### PR TITLE
feat(cli): game map starts + game play screen dismiss/show

### DIFF
--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -661,6 +661,16 @@ export {
   getCiv7UnitSummary,
 };
 export {
+  CIV7_START_POSITIONS_METHOD,
+  Civ7StartPositionPlayerSchema,
+  Civ7StartPositionsResultSchema,
+  readCiv7StartPositions,
+} from "./play/start-positions.js";
+export type {
+  Civ7StartPositionPlayer,
+  Civ7StartPositionsResult,
+} from "./play/start-positions.js";
+export {
   callCiv7PlayerSummaryProcedure,
   Civ7PlayerSummaryProcedureDescriptor,
   Civ7PlayerSummaryProcedureSchemaArtifacts,

--- a/packages/civ7-direct-control/src/play/start-positions.ts
+++ b/packages/civ7-direct-control/src/play/start-positions.ts
@@ -1,0 +1,128 @@
+import { Type } from "typebox";
+
+import { Civ7RuntimeProbeSchema, probeHelperSource } from "../runtime/probe.js";
+import { jsonPayloadFromCommandResult } from "../session/command-result.js";
+import { executeCiv7TunerCommand } from "../session/execute.js";
+import { Civ7MapLocationSchema } from "./map/types.js";
+
+import type { Civ7RuntimeProbe } from "../runtime/probe.js";
+import type {
+  Civ7CommandResult,
+  Civ7DirectControlOptions,
+  Civ7TunerState,
+} from "../session/types.js";
+import type { Civ7MapLocation } from "./map/types.js";
+
+// Live-verified against a running Civ7 game on 2026-06-11
+// (docs/projects/placement-realignment/evidence/milestone-b-2026-06-11.md, placement stack):
+// the engine exposes NO start-plot getter on the player prototype — a live probe of the
+// prototype found zero /[Ss]tart/ members. The turn-1 founder-unit position IS the start
+// plot, but only before units move, so this read is named "founder-unit-derived" and always
+// reports Game.turn so callers can judge validity themselves.
+
+export const CIV7_START_POSITIONS_METHOD = "founder-unit-derived" as const;
+
+export type Civ7StartPositionPlayer = Readonly<{
+  id: number;
+  isHuman: boolean;
+  civilizationType: string | number | null;
+  leaderType: string | number | null;
+  unitCount: number;
+  firstUnitPlot: Civ7MapLocation | null;
+}>;
+
+export const Civ7StartPositionPlayerSchema = Type.Object({
+  id: Type.Integer({ minimum: 0, maximum: 1024 }),
+  isHuman: Type.Boolean(),
+  civilizationType: Type.Union([Type.String(), Type.Number(), Type.Null()]),
+  leaderType: Type.Union([Type.String(), Type.Number(), Type.Null()]),
+  unitCount: Type.Integer({ minimum: 0 }),
+  firstUnitPlot: Type.Union([Civ7MapLocationSchema, Type.Null()]),
+}, { additionalProperties: false });
+
+const civ7TunerStateSchema = Type.Object({
+  id: Type.String(),
+  name: Type.String(),
+}, { additionalProperties: false });
+
+export const Civ7StartPositionsResultSchema = Type.Object({
+  host: Type.String(),
+  port: Type.Number(),
+  state: civ7TunerStateSchema,
+  method: Type.Literal(CIV7_START_POSITIONS_METHOD),
+  turn: Civ7RuntimeProbeSchema(Type.Number()),
+  players: Civ7RuntimeProbeSchema(Type.Array(Civ7StartPositionPlayerSchema)),
+  notes: Type.Array(Type.String()),
+}, { additionalProperties: false });
+
+export type Civ7StartPositionsResult = Readonly<{
+  host: string;
+  port: number;
+  state: Civ7TunerState;
+  method: typeof CIV7_START_POSITIONS_METHOD;
+  turn: Civ7RuntimeProbe<number>;
+  players: Civ7RuntimeProbe<ReadonlyArray<Civ7StartPositionPlayer>>;
+  notes: ReadonlyArray<string>;
+}>;
+
+type StartPositionsReadDependencies = Readonly<{
+  executeTunerCommand: (
+    options: Civ7DirectControlOptions & Readonly<{ command: string }>,
+  ) => Promise<Civ7CommandResult>;
+  parseStartPositions: (result: Civ7CommandResult, label: string) => Civ7StartPositionsResult;
+  probeHelperSource: () => string;
+}>;
+
+export async function readCiv7StartPositions(
+  options: Civ7DirectControlOptions = {},
+  dependencies: StartPositionsReadDependencies = defaultStartPositionsReadDependencies,
+): Promise<Civ7StartPositionsResult> {
+  const result = await dependencies.executeTunerCommand({
+    ...options,
+    command: buildStartPositionsCommand(dependencies),
+  });
+  return dependencies.parseStartPositions(result, "Civ7 start positions");
+}
+
+export function buildStartPositionsCommand(
+  dependencies: Pick<StartPositionsReadDependencies, "probeHelperSource">,
+): string {
+  // CAVEAT (live-verified): there is no start-plot getter anywhere on the player prototype
+  // (probed live: zero /[Ss]tart/ members). The founder unit's current location is only the
+  // start plot while units have not moved — in practice on turn 1. Game.turn is reported so
+  // callers can judge how trustworthy firstUnitPlot is as a start position.
+  return `(() => {
+    ${dependencies.probeHelperSource()}
+    const readStartPositions = () => {
+      const turn = probe(() => Game.turn);
+      const players = probe(() => Players.getAliveMajorIds().map(id => {
+        const p = Players.get(id);
+        const units = p?.Units?.getUnits?.() ?? [];
+        return {
+          id,
+          isHuman: !!p?.isHuman,
+          civilizationType: p?.civilizationType ?? null,
+          leaderType: p?.leaderType ?? null,
+          unitCount: units.length,
+          firstUnitPlot: units[0]?.location ?? null,
+        };
+      }));
+      return { method: ${JSON.stringify(CIV7_START_POSITIONS_METHOD)}, turn, players };
+    };
+    return JSON.stringify(readStartPositions());
+  })()`;
+}
+
+const CIV7_START_POSITIONS_NOTES: ReadonlyArray<string> = [
+  "The engine exposes no start-plot getter on the player prototype (live probe found zero /[Ss]tart/ members), so start positions are founder-unit-derived.",
+  "firstUnitPlot is the founder unit's CURRENT location: it equals the start plot only before units move (turn 1 in practice). Use the reported turn to judge validity.",
+];
+
+const defaultStartPositionsReadDependencies: StartPositionsReadDependencies = {
+  executeTunerCommand: executeCiv7TunerCommand,
+  parseStartPositions: (result, label) => ({
+    ...jsonPayloadFromCommandResult<Omit<Civ7StartPositionsResult, "notes">>(result, label),
+    notes: CIV7_START_POSITIONS_NOTES,
+  }),
+  probeHelperSource,
+};

--- a/packages/civ7-direct-control/test/start-positions.test.ts
+++ b/packages/civ7-direct-control/test/start-positions.test.ts
@@ -1,0 +1,166 @@
+import { once } from "node:events";
+import { type AddressInfo, createServer, type Socket } from "node:net";
+import { describe, expect, test } from "vitest";
+import { Value } from "typebox/value";
+
+import {
+  Civ7StartPositionsResultSchema,
+  encodeCiv7TunerRequest,
+  parseCiv7TunerFrame,
+  readCiv7StartPositions,
+} from "../src/index";
+
+type FakeTunerServer = {
+  received: string[];
+  address(): AddressInfo;
+  close(): Promise<void>;
+};
+
+describe("start-position readback", () => {
+  test("reads founder-unit-derived start positions in one tuner exec without sending operations", async () => {
+    const server = await startStartPositionsTunerServer(startPositionsPayload(1));
+    try {
+      const { port } = server.address();
+      const result = await readCiv7StartPositions({ host: "127.0.0.1", port, timeoutMs: 1_000 });
+
+      expect(result.method).toBe("founder-unit-derived");
+      expect(result.turn).toEqual({ ok: true, value: 1 });
+      expect(result.players).toEqual({
+        ok: true,
+        value: [
+          {
+            id: 0,
+            isHuman: true,
+            civilizationType: "CIVILIZATION_AKSUM",
+            leaderType: "LEADER_AMINA",
+            unitCount: 2,
+            firstUnitPlot: { x: 17, y: 20 },
+          },
+          {
+            id: 1,
+            isHuman: false,
+            civilizationType: "CIVILIZATION_ROME",
+            leaderType: "LEADER_AUGUSTUS",
+            unitCount: 2,
+            firstUnitPlot: { x: 41, y: 9 },
+          },
+        ],
+      });
+      expect(result.state).toEqual({ id: "1", name: "Tuner" });
+      expect(result.notes.join("\n")).toContain("founder-unit-derived");
+      expect(result.notes.join("\n")).toContain("before units move");
+      expect(Value.Check(Civ7StartPositionsResultSchema, result)).toBe(true);
+
+      const commands = server.received.filter((message) => message.startsWith("CMD:"));
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toContain("CMD:1:");
+      expect(commands[0]).toContain("Players.getAliveMajorIds()");
+      expect(commands[0]).toContain("Game.turn");
+      expect(commands[0]).toContain("firstUnitPlot");
+      expect(commands[0]).not.toContain("sendRequest");
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("reports the current turn so callers can judge founder-unit-plot validity", async () => {
+    const server = await startStartPositionsTunerServer(startPositionsPayload(37));
+    try {
+      const { port } = server.address();
+      const result = await readCiv7StartPositions({ host: "127.0.0.1", port, timeoutMs: 1_000 });
+      expect(result.turn).toEqual({ ok: true, value: 37 });
+      expect(Value.Check(Civ7StartPositionsResultSchema, result)).toBe(true);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("rejects extra fields in the result schema", () => {
+    const result = {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "1", name: "Tuner" },
+      ...startPositionsPayload(1),
+      notes: ["..."],
+    };
+    expect(Value.Check(Civ7StartPositionsResultSchema, result)).toBe(true);
+    expect(Value.Check(Civ7StartPositionsResultSchema, {
+      ...result,
+      startPlots: [],
+    })).toBe(false);
+    expect(Value.Check(Civ7StartPositionsResultSchema, {
+      ...result,
+      method: "engine-start-plot",
+    })).toBe(false);
+  });
+});
+
+function startPositionsPayload(turn: number) {
+  return {
+    method: "founder-unit-derived",
+    turn: { ok: true, value: turn },
+    players: {
+      ok: true,
+      value: [
+        {
+          id: 0,
+          isHuman: true,
+          civilizationType: "CIVILIZATION_AKSUM",
+          leaderType: "LEADER_AMINA",
+          unitCount: 2,
+          firstUnitPlot: { x: 17, y: 20 },
+        },
+        {
+          id: 1,
+          isHuman: false,
+          civilizationType: "CIVILIZATION_ROME",
+          leaderType: "LEADER_AUGUSTUS",
+          unitCount: 2,
+          firstUnitPlot: { x: 41, y: 9 },
+        },
+      ],
+    },
+  };
+}
+
+async function startStartPositionsTunerServer(payload: unknown): Promise<FakeTunerServer> {
+  const received: string[] = [];
+  const sockets = new Set<Socket>();
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    let buffer = Buffer.alloc(0);
+    socket.on("data", (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      for (;;) {
+        const parsed = parseCiv7TunerFrame(buffer);
+        if (!parsed) return;
+        buffer = buffer.subarray(parsed.bytesRead);
+        const message = parsed.frame.parts.join("\0");
+        received.push(message);
+        const respond = (parts: string[]) => {
+          socket.write(encodeCiv7TunerRequest(parsed.frame.listenerId, parts.join("\0")));
+        };
+        if (message === "LSQ:") {
+          respond(["65535", "App UI", "1", "Tuner"]);
+        } else if (message.includes("readStartPositions")) {
+          respond([JSON.stringify(payload)]);
+        } else {
+          respond(["null"]);
+        }
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return {
+    received,
+    address: () => server.address() as AddressInfo,
+    close: async () => {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -83,8 +83,14 @@
       "game:local-data": {
         "description": "Inspect local Civ7 SQLite, save, and log evidence"
       },
+      "game:map": {
+        "description": "Read current world, plot, grid, start, and visibility map state"
+      },
       "game:play": {
         "description": "Turn-by-turn live-play shortcuts over direct-control"
+      },
+      "game:play:screen": {
+        "description": "Inspect and dismiss App UI display-queue screens (cinematic moments)"
       },
       "mod": {
         "description": "Manage Civilization VII mods"

--- a/packages/cli/src/commands/game/map/starts.ts
+++ b/packages/cli/src/commands/game/map/starts.ts
@@ -1,0 +1,69 @@
+import { Command, Flags } from '@oclif/core';
+import { readCiv7StartPositions } from '@civ7/direct-control';
+
+export default class GameMapStarts extends Command {
+  static id = 'game map starts';
+  static summary = 'Read founder-unit-derived start positions for alive major players';
+  static description =
+    'Reads per-player start positions through @civ7/direct-control in one tuner exec. ' +
+    'The engine exposes no start-plot getter on the player prototype, so the founder unit\'s ' +
+    'current location stands in for the start plot — valid only before units move (turn 1 in ' +
+    'practice). The current game turn is always reported so the readback can be judged.';
+
+  static examples = [
+    '<%= config.bin %> game map starts',
+    '<%= config.bin %> game map starts --json',
+  ];
+
+  static flags = {
+    host: Flags.string({
+      description: 'Civ7 tuner socket host',
+    }),
+    port: Flags.integer({
+      description: 'Civ7 tuner socket port',
+    }),
+    'timeout-ms': Flags.integer({
+      description: 'Socket timeout',
+      default: 45_000,
+    }),
+    json: Flags.boolean({
+      description: 'Emit machine-readable JSON',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(GameMapStarts);
+    const result = await readCiv7StartPositions({
+      host: flags.host,
+      port: flags.port,
+      timeoutMs: flags['timeout-ms'],
+    });
+
+    if (flags.json) {
+      this.log(JSON.stringify({ ok: true, result }));
+      return;
+    }
+
+    const turn = result.turn.ok ? result.turn.value : null;
+    this.log(`method: ${result.method} (turn ${turn ?? 'unknown'})`);
+    if (!result.players.ok) {
+      this.error(`start-position read failed: ${result.players.error}`);
+    }
+    this.log('player  human  plot      units');
+    for (const player of result.players.value) {
+      const plot = player.firstUnitPlot
+        ? `${player.firstUnitPlot.x},${player.firstUnitPlot.y}`
+        : '-';
+      this.log(
+        `${String(player.id).padEnd(6)}  ${(player.isHuman ? 'yes' : 'no').padEnd(5)}  ${plot.padEnd(8)}  ${player.unitCount}`,
+      );
+    }
+    if (turn === null || turn > 1) {
+      this.log(
+        'caveat: founder-unit-derived plots equal start plots only before units move; ' +
+          `turn is ${turn ?? 'unknown'}, so treat plots as current unit positions, not proven starts.`,
+      );
+    }
+  }
+}

--- a/packages/cli/src/commands/game/play/screen/dismiss.ts
+++ b/packages/cli/src/commands/game/play/screen/dismiss.ts
@@ -1,0 +1,103 @@
+import { Command, Flags } from '@oclif/core';
+import {
+  DEFAULT_CIV7_CINEMATIC_MAX_DISMISSALS,
+  DEFAULT_CIV7_CINEMATIC_SETTLE_MS,
+  dismissCiv7CinematicMoments,
+} from '@civ7/direct-control';
+
+export default class GamePlayScreenDismiss extends Command {
+  static id = 'game play screen dismiss';
+  static summary = 'Dismiss queued Civ7 cinematic-moment screens';
+  static description =
+    'Drains map-reveal / wonder-discovery cinematic moments (App UI DisplayQueueManager screens) ' +
+    'through @civ7/direct-control. One screen mounts at a time; each is closed via its official ' +
+    'close button and the next mounts after a settle beat. Finishes with a DOM-clear verification ' +
+    'and an optional Camera.lookAtPlot restore.';
+
+  static examples = [
+    '<%= config.bin %> game play screen dismiss',
+    '<%= config.bin %> game play screen dismiss --max 5 --settle-ms 2500',
+    '<%= config.bin %> game play screen dismiss --look-at 31,7 --json',
+  ];
+
+  static flags = {
+    host: Flags.string({
+      description: 'Civ7 tuner socket host',
+    }),
+    port: Flags.integer({
+      description: 'Civ7 tuner socket port',
+    }),
+    max: Flags.integer({
+      description: 'Maximum number of cinematic moments to dismiss',
+      default: DEFAULT_CIV7_CINEMATIC_MAX_DISMISSALS,
+    }),
+    'settle-ms': Flags.integer({
+      description: 'Wait between dismissals so the next queued cinematic can mount',
+      default: DEFAULT_CIV7_CINEMATIC_SETTLE_MS,
+    }),
+    'look-at': Flags.string({
+      description: 'Optional camera restore plot as x,y (Camera.lookAtPlot after draining)',
+    }),
+    'timeout-ms': Flags.integer({
+      description: 'Socket timeout',
+      default: 45_000,
+    }),
+    json: Flags.boolean({
+      description: 'Emit machine-readable JSON',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(GamePlayScreenDismiss);
+    const restoreCameraPlot = flags['look-at'] === undefined
+      ? undefined
+      : this.parseLookAt(flags['look-at']);
+
+    const result = await dismissCiv7CinematicMoments(
+      {
+        maxDismissals: flags.max,
+        settleMs: flags['settle-ms'],
+        ...(restoreCameraPlot ? { restoreCameraPlot } : {}),
+      },
+      {
+        host: flags.host,
+        port: flags.port,
+        timeoutMs: flags['timeout-ms'],
+      },
+    );
+
+    if (flags.json) {
+      this.log(JSON.stringify({ ok: true, result }));
+      return;
+    }
+
+    for (const row of result.dismissals) {
+      this.log(`dismissed[${row.iteration}]: ${row.title ?? '<untitled cinematic>'}`);
+    }
+    if (result.dismissals.length === 0) {
+      this.log('no cinematic moments were mounted');
+    }
+    this.log(
+      result.drained
+        ? `drained: yes (0 cinematic-moment DOM nodes after ${result.iterations} probe${result.iterations === 1 ? '' : 's'})`
+        : `drained: no (${result.domClearCount} cinematic-moment DOM nodes remain after ${result.iterations} probe${result.iterations === 1 ? '' : 's'})`,
+    );
+    if (result.cameraRestore) {
+      const { plot, lookAt } = result.cameraRestore;
+      this.log(
+        lookAt.ok
+          ? `camera: restored via Camera.lookAtPlot(${plot.x}, ${plot.y})`
+          : `camera: Camera.lookAtPlot(${plot.x}, ${plot.y}) failed: ${lookAt.error}`,
+      );
+    }
+  }
+
+  private parseLookAt(value: string): { x: number; y: number } {
+    const match = /^\s*(\d+)\s*,\s*(\d+)\s*$/.exec(value);
+    if (!match) {
+      this.error(`--look-at must be x,y (got "${value}")`);
+    }
+    return { x: Number(match[1]), y: Number(match[2]) };
+  }
+}

--- a/packages/cli/src/commands/game/play/screen/show.ts
+++ b/packages/cli/src/commands/game/play/screen/show.ts
@@ -1,0 +1,127 @@
+import { Command, Flags } from '@oclif/core';
+import {
+  CIV7_CINEMATIC_CLOSE_BUTTON_SELECTOR,
+  CIV7_CINEMATIC_MOMENT_SELECTOR,
+  CIV7_CINEMATIC_TITLE_SELECTOR,
+  executeCiv7AppUiCommand,
+} from '@civ7/direct-control';
+
+// Native primitive provenance (same as `game play screen dismiss`): map-reveal /
+// wonder-discovery cinematic moments are DisplayQueueManager screens in the App UI
+// scripting state. One mounts at a time. Official handler:
+// .civ7/outputs/resources/Base/modules/base-standard/ui/cinematic/cinematic-manager.chunk.js
+// — DisplayQueueManager.close(...) (~line 198). This command is the read-only sibling:
+// one App UI exec that lists the active cinematic/display screens (selector count +
+// titles) using the selector constants exported by @civ7/direct-control, without
+// dispatching any close events.
+
+type ScreenShowPayload = Readonly<{
+  selectorCount: number;
+  screens: ReadonlyArray<{ title: string | null; closeButtonPresent: boolean }>;
+}>;
+
+export default class GamePlayScreenShow extends Command {
+  static id = 'game play screen show';
+  static summary = 'Show active Civ7 cinematic/display screens (read-only)';
+  static description =
+    'Lists mounted cinematic-moment screens (App UI DisplayQueueManager) in one read-only App UI ' +
+    'exec: selector match count plus the title and close-button presence of any mounted screen. ' +
+    'Uses the same live-verified selectors as `game play screen dismiss` and performs no dismissal.';
+
+  static examples = [
+    '<%= config.bin %> game play screen show',
+    '<%= config.bin %> game play screen show --json',
+  ];
+
+  static flags = {
+    host: Flags.string({
+      description: 'Civ7 tuner socket host',
+    }),
+    port: Flags.integer({
+      description: 'Civ7 tuner socket port',
+    }),
+    'timeout-ms': Flags.integer({
+      description: 'Socket timeout',
+      default: 45_000,
+    }),
+    json: Flags.boolean({
+      description: 'Emit machine-readable JSON',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(GamePlayScreenShow);
+    const result = await executeCiv7AppUiCommand({
+      host: flags.host,
+      port: flags.port,
+      timeoutMs: flags['timeout-ms'],
+      command: buildScreenShowCommand(),
+    });
+
+    const payload = parseScreenShowPayload(result.output);
+
+    if (flags.json) {
+      this.log(
+        JSON.stringify({
+          ok: true,
+          result: {
+            host: result.host,
+            port: result.port,
+            state: result.state,
+            ...payload,
+          },
+        }),
+      );
+      return;
+    }
+
+    this.log(`cinematic-moment DOM nodes: ${payload.selectorCount}`);
+    if (payload.screens.length === 0) {
+      this.log('screens: none mounted');
+      return;
+    }
+    for (const screen of payload.screens) {
+      this.log(
+        `screen: ${screen.title ?? '<untitled cinematic>'} (close button ${screen.closeButtonPresent ? 'present' : 'missing'})`,
+      );
+    }
+  }
+}
+
+export function buildScreenShowCommand(): string {
+  // Read-only probe: same selectors as the dismissal primitive, no synthetic events.
+  return `(() => {
+    const readScreenShow = () => {
+      const selectorCount = document.querySelectorAll(${JSON.stringify(CIV7_CINEMATIC_MOMENT_SELECTOR)}).length;
+      const closeButton = document.querySelector(${JSON.stringify(CIV7_CINEMATIC_CLOSE_BUTTON_SELECTOR)});
+      const title = document.querySelector(${JSON.stringify(CIV7_CINEMATIC_TITLE_SELECTOR)})?.textContent ?? null;
+      const screens = closeButton || title !== null
+        ? [{ title, closeButtonPresent: Boolean(closeButton) }]
+        : [];
+      return { selectorCount, screens };
+    };
+    return JSON.stringify(readScreenShow());
+  })()`;
+}
+
+function parseScreenShowPayload(output: ReadonlyArray<string>): ScreenShowPayload {
+  const raw = output[0] ?? '{}';
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`game play screen show returned invalid JSON: ${output.join('\n') || '<empty>'}`, {
+      cause: err,
+    });
+  }
+  const payload = parsed as { selectorCount?: unknown; screens?: unknown };
+  const selectorCount = typeof payload.selectorCount === 'number' ? payload.selectorCount : 0;
+  const screens = Array.isArray(payload.screens)
+    ? payload.screens.map((screen: { title?: unknown; closeButtonPresent?: unknown }) => ({
+        title: typeof screen.title === 'string' ? screen.title : null,
+        closeButtonPresent: screen.closeButtonPresent === true,
+      }))
+    : [];
+  return { selectorCount, screens };
+}

--- a/packages/cli/test/commands/game.map.starts.test.ts
+++ b/packages/cli/test/commands/game.map.starts.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test, vi } from 'vitest';
+import GameMapStarts from '../../src/commands/game/map/starts';
+import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
+
+describe('game map starts', () => {
+  test('prints a player table from one founder-unit-derived tuner read', async () => {
+    const server = await startStartPositionsTunerServer(startPositionsPayload(1));
+    try {
+      const { writes } = await runCommand(server, []);
+      expect(writes[0]).toBe('method: founder-unit-derived (turn 1)');
+      expect(writes[1]).toBe('player  human  plot      units');
+      expect(writes[2]).toContain('0');
+      expect(writes[2]).toContain('yes');
+      expect(writes[2]).toContain('17,20');
+      expect(writes[3]).toContain('1');
+      expect(writes[3]).toContain('no');
+      expect(writes[3]).toContain('41,9');
+      expect(writes.some((line) => line.startsWith('caveat:'))).toBe(false);
+
+      const commands = server.received.filter((message) => message.startsWith('CMD:'));
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toContain('CMD:1:');
+      expect(commands[0]).toContain('Players.getAliveMajorIds()');
+      expect(commands[0]).toContain('Game.turn');
+      expect(commands[0]).not.toContain('sendRequest');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('prints a validity caveat when the turn is past 1', async () => {
+    const server = await startStartPositionsTunerServer(startPositionsPayload(37));
+    try {
+      const { writes } = await runCommand(server, []);
+      expect(writes[0]).toBe('method: founder-unit-derived (turn 37)');
+      const caveat = writes.find((line) => line.startsWith('caveat:'));
+      expect(caveat).toBeDefined();
+      expect(caveat).toContain('before units move');
+      expect(caveat).toContain('turn is 37');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('emits machine-readable output with --json', async () => {
+    const server = await startStartPositionsTunerServer(startPositionsPayload(1));
+    try {
+      const { writes } = await runCommand(server, ['--json']);
+      const payload = JSON.parse(writes.join('')) as {
+        ok: boolean;
+        result: {
+          method: string;
+          turn: { ok: boolean; value?: number };
+          players: { ok: boolean; value?: Array<{ id: number; firstUnitPlot: { x: number; y: number } | null }> };
+          notes: string[];
+        };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.result.method).toBe('founder-unit-derived');
+      expect(payload.result.turn).toEqual({ ok: true, value: 1 });
+      expect(payload.result.players.value).toHaveLength(2);
+      expect(payload.result.players.value?.[0]?.firstUnitPlot).toEqual({ x: 17, y: 20 });
+      expect(payload.result.notes.join('\n')).toContain('founder-unit-derived');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+function startPositionsPayload(turn: number) {
+  return {
+    method: 'founder-unit-derived',
+    turn: { ok: true, value: turn },
+    players: {
+      ok: true,
+      value: [
+        {
+          id: 0,
+          isHuman: true,
+          civilizationType: 'CIVILIZATION_AKSUM',
+          leaderType: 'LEADER_AMINA',
+          unitCount: 2,
+          firstUnitPlot: { x: 17, y: 20 },
+        },
+        {
+          id: 1,
+          isHuman: false,
+          civilizationType: 'CIVILIZATION_ROME',
+          leaderType: 'LEADER_AUGUSTUS',
+          unitCount: 3,
+          firstUnitPlot: { x: 41, y: 9 },
+        },
+      ],
+    },
+  };
+}
+
+async function startStartPositionsTunerServer(payload: unknown): Promise<FakeTunerServer> {
+  return startFakeTunerServer({
+    handle({ message }) {
+      if (message.includes('readStartPositions')) {
+        return [JSON.stringify(payload)];
+      }
+      return undefined;
+    },
+  });
+}
+
+async function runCommand(server: FakeTunerServer, args: string[]): Promise<{ writes: string[] }> {
+  const writes: string[] = [];
+  const log = vi.spyOn(GameMapStarts.prototype, 'log').mockImplementation(function (this: unknown, message?: string) {
+    if (message !== undefined) writes.push(message);
+    return undefined as never;
+  });
+  try {
+    const { port } = server.address();
+    await GameMapStarts.run(['--host', '127.0.0.1', '--port', String(port), ...args]);
+    return { writes };
+  } finally {
+    log.mockRestore();
+  }
+}

--- a/packages/cli/test/commands/game.play.screen.dismiss.test.ts
+++ b/packages/cli/test/commands/game.play.screen.dismiss.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test, vi } from 'vitest';
+import GamePlayScreenDismiss from '../../src/commands/game/play/screen/dismiss';
+import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
+
+type CinematicProbePayload = {
+  cinematicPresent: boolean;
+  dismissedTitle: string | null;
+  activate: { ok: boolean; value?: boolean } | null;
+  click: { ok: boolean; value?: boolean } | null;
+  remainingSelectorCount: number;
+};
+
+describe('game play screen dismiss', () => {
+  test('drains queued cinematic moments and reports titles plus a drained verdict', async () => {
+    const { server } = await startCinematicTunerServer({
+      probes: [presentProbe('Zhangjiajie'), presentProbe('Iguazú Falls'), absentProbe()],
+      domClearCount: 0,
+    });
+    try {
+      const { writes } = await runCommand(server, ['--settle-ms', '0']);
+      expect(writes).toEqual([
+        'dismissed[1]: Zhangjiajie',
+        'dismissed[2]: Iguazú Falls',
+        'drained: yes (0 cinematic-moment DOM nodes after 3 probes)',
+      ]);
+      expect(server.received.filter((message) => message.includes('dismissCinematicMoment'))).toHaveLength(3);
+      expect(server.received.filter((message) => message.includes('readCinematicDrainCheck'))).toHaveLength(1);
+      expect(server.received.some((message) => message.includes('restoreCinematicCamera'))).toBe(false);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('respects --max and reports an undrained verdict', async () => {
+    const { server } = await startCinematicTunerServer({
+      probes: [],
+      fallbackProbe: presentProbe('Uluru'),
+      domClearCount: 2,
+    });
+    try {
+      const { writes } = await runCommand(server, ['--max', '2', '--settle-ms', '0']);
+      expect(writes).toEqual([
+        'dismissed[1]: Uluru',
+        'dismissed[2]: Uluru',
+        'drained: no (2 cinematic-moment DOM nodes remain after 2 probes)',
+      ]);
+      expect(server.received.filter((message) => message.includes('dismissCinematicMoment'))).toHaveLength(2);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('supports --look-at camera restore and --json output', async () => {
+    const { server } = await startCinematicTunerServer({
+      probes: [absentProbe()],
+      domClearCount: 0,
+    });
+    try {
+      const { writes } = await runCommand(server, ['--settle-ms', '0', '--look-at', '31,7', '--json']);
+      const payload = JSON.parse(writes.join('')) as {
+        ok: boolean;
+        result: {
+          dismissals: unknown[];
+          drained: boolean;
+          iterations: number;
+          domClearCount: number;
+          cameraRestore: { plot: { x: number; y: number }; lookAt: { ok: boolean; value?: boolean } } | null;
+        };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.result.dismissals).toEqual([]);
+      expect(payload.result.drained).toBe(true);
+      expect(payload.result.cameraRestore).toEqual({
+        plot: { x: 31, y: 7 },
+        lookAt: { ok: true, value: true },
+      });
+      const cameraCommands = server.received.filter((message) => message.includes('restoreCinematicCamera'));
+      expect(cameraCommands).toHaveLength(1);
+      expect(cameraCommands[0]).toContain('Camera.lookAtPlot(plot.x, plot.y)');
+      expect(cameraCommands[0]).toContain('"x":31');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('reports the zero-cinematic fast path in human output', async () => {
+    const { server } = await startCinematicTunerServer({
+      probes: [absentProbe()],
+      domClearCount: 0,
+    });
+    try {
+      const { writes } = await runCommand(server, ['--settle-ms', '0']);
+      expect(writes).toEqual([
+        'no cinematic moments were mounted',
+        'drained: yes (0 cinematic-moment DOM nodes after 1 probe)',
+      ]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('rejects a malformed --look-at value without opening a socket', async () => {
+    const { server } = await startCinematicTunerServer({ probes: [], domClearCount: 0 });
+    try {
+      await expect(runCommand(server, ['--look-at', 'not-a-plot'])).rejects.toThrow(/--look-at must be x,y/);
+      expect(server.received).toHaveLength(0);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+function presentProbe(title: string): CinematicProbePayload {
+  return {
+    cinematicPresent: true,
+    dismissedTitle: title,
+    activate: { ok: true, value: true },
+    click: { ok: true, value: true },
+    remainingSelectorCount: 4,
+  };
+}
+
+function absentProbe(): CinematicProbePayload {
+  return {
+    cinematicPresent: false,
+    dismissedTitle: null,
+    activate: null,
+    click: null,
+    remainingSelectorCount: 0,
+  };
+}
+
+async function startCinematicTunerServer(options: {
+  probes: CinematicProbePayload[];
+  fallbackProbe?: CinematicProbePayload;
+  domClearCount: number;
+}): Promise<{ server: FakeTunerServer }> {
+  const probes = [...options.probes];
+  const server = await startFakeTunerServer({
+    handle({ message }) {
+      if (message.includes('dismissCinematicMoment')) {
+        return [JSON.stringify(probes.shift() ?? options.fallbackProbe ?? absentProbe())];
+      }
+      if (message.includes('readCinematicDrainCheck')) {
+        return [JSON.stringify({ domClearCount: options.domClearCount })];
+      }
+      if (message.includes('restoreCinematicCamera')) {
+        return [JSON.stringify({ lookAt: { ok: true, value: true } })];
+      }
+      return undefined;
+    },
+  });
+  return { server };
+}
+
+async function runCommand(server: FakeTunerServer, args: string[]): Promise<{ writes: string[] }> {
+  const writes: string[] = [];
+  const log = vi.spyOn(GamePlayScreenDismiss.prototype, 'log').mockImplementation(function (this: unknown, message?: string) {
+    if (message !== undefined) writes.push(message);
+    return undefined as never;
+  });
+  try {
+    const { port } = server.address();
+    await GamePlayScreenDismiss.run(['--host', '127.0.0.1', '--port', String(port), ...args]);
+    return { writes };
+  } finally {
+    log.mockRestore();
+  }
+}

--- a/packages/cli/test/commands/game.play.screen.show.test.ts
+++ b/packages/cli/test/commands/game.play.screen.show.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test, vi } from 'vitest';
+import GamePlayScreenShow from '../../src/commands/game/play/screen/show';
+import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
+
+type ScreenShowPayload = {
+  selectorCount: number;
+  screens: Array<{ title: string | null; closeButtonPresent: boolean }>;
+};
+
+describe('game play screen show', () => {
+  test('lists the mounted cinematic screen from one read-only App UI exec', async () => {
+    const server = await startScreenShowTunerServer({
+      selectorCount: 4,
+      screens: [{ title: 'Zhangjiajie', closeButtonPresent: true }],
+    });
+    try {
+      const { writes } = await runCommand(server, []);
+      expect(writes).toEqual([
+        'cinematic-moment DOM nodes: 4',
+        'screen: Zhangjiajie (close button present)',
+      ]);
+
+      const commands = server.received.filter((message) => message.startsWith('CMD:'));
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toContain('readScreenShow');
+      expect(commands[0]).toContain('cinematic-moment__close-button');
+      expect(commands[0]).toContain('cinematic-moment_title-header');
+      expect(commands[0]).toContain('[class*=cinematic-moment]');
+      // Read-only: no synthetic close events or clicks anywhere in the exec.
+      expect(commands[0]).not.toContain('action-activate');
+      expect(commands[0]).not.toContain('.click()');
+      expect(commands[0]).not.toContain('dispatchEvent');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('reports an empty screen list when nothing is mounted', async () => {
+    const server = await startScreenShowTunerServer({ selectorCount: 0, screens: [] });
+    try {
+      const { writes } = await runCommand(server, []);
+      expect(writes).toEqual([
+        'cinematic-moment DOM nodes: 0',
+        'screens: none mounted',
+      ]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('emits machine-readable output with --json', async () => {
+    const server = await startScreenShowTunerServer({
+      selectorCount: 4,
+      screens: [{ title: null, closeButtonPresent: true }],
+    });
+    try {
+      const { writes } = await runCommand(server, ['--json']);
+      const payload = JSON.parse(writes.join('')) as {
+        ok: boolean;
+        result: ScreenShowPayload & { host: string; port: number; state: { id: string; name: string } };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.result.selectorCount).toBe(4);
+      expect(payload.result.screens).toEqual([{ title: null, closeButtonPresent: true }]);
+      expect(payload.result.state.name).toBe('App UI');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+async function startScreenShowTunerServer(payload: ScreenShowPayload): Promise<FakeTunerServer> {
+  return startFakeTunerServer({
+    handle({ message }) {
+      if (message.includes('readScreenShow')) {
+        return [JSON.stringify(payload)];
+      }
+      return undefined;
+    },
+  });
+}
+
+async function runCommand(server: FakeTunerServer, args: string[]): Promise<{ writes: string[] }> {
+  const writes: string[] = [];
+  const log = vi.spyOn(GamePlayScreenShow.prototype, 'log').mockImplementation(function (this: unknown, message?: string) {
+    if (message !== undefined) writes.push(message);
+    return undefined as never;
+  });
+  try {
+    const { port } = server.address();
+    await GamePlayScreenShow.run(['--host', '127.0.0.1', '--port', String(port), ...args]);
+    return { writes };
+  } finally {
+    log.mockRestore();
+  }
+}


### PR DESCRIPTION
Surface the cinematic-moment dismissal primitive on the CLI and close
the named start-position readback gap from the final-surface parity
proof ("starts: direct-control-readback-limitation — no start-position
wrapper"), landing both commands at their taxonomy homes per the
command-surface-design grammar (noun-first, phase verbs; docs/projects/
civ7-live-play-support/topics/command-surface-design.md) and the CLI
command-taxonomy decision log (D2/D3/D4 in
docs/projects/cli-command-taxonomy/workstream-record.md).

civ7 game play screen dismiss (taxonomy retarget of the pre-merge
game dismiss-cinematics; no alias needed, the id never shipped) drives
dismissCiv7CinematicMoments with --max / --settle-ms / --look-at
(optional Camera.lookAtPlot restore) / --json plus the usual
--host/--port/--timeout-ms plumbing. Human output prints one line per
dismissed cinematic title and a drained verdict from the final
DOM-clear verification. "screen" is a new play noun whose native
primitive is the App UI DisplayQueueManager cinematic-moment screen.

civ7 game play screen show is the read-only phase-verb sibling: one
App UI exec listing mounted cinematic/display screens (selector match
count + title + close-button presence) using the selector constants
exported by @civ7/direct-control — no synthetic close events.

civ7 game map starts (taxonomy retarget of the pre-merge game starts)
reads start positions through readCiv7StartPositions in one
Tuner-state exec: Players.getAliveMajorIds() mapped to { id, isHuman,
civilizationType, leaderType, unitCount, firstUnitPlot }.
LIVE-VERIFIED caveat (2026-06-11): the engine exposes NO start-plot
getter on the player prototype (probed live: zero /[Ss]tart/ members).
The turn-1 founder-unit position IS the start plot, but only before
units move, so the read is named "founder-unit-derived" and always
reports Game.turn so callers can judge validity. The command prints a
player id / human / plot / unitCount table, appends a caveat line
whenever turn > 1, and supports --json.

oclif note: game/map.ts (command) and game/map/ (topic dir) coexist —
the manifest emits both game:map and game:map:starts, so the existing
flag-multiplexed game map invocation is unchanged.

Evidence: docs/projects/placement-realignment/evidence/milestone-b-2026-06-11.md
(placement stack, not on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
