### PR TITLE
docs(cli): cli-command-taxonomy workstream record, corpus ledger, target grammar

### DIFF
--- a/docs/projects/cli-command-taxonomy/corpus.md
+++ b/docs/projects/cli-command-taxonomy/corpus.md
@@ -1,0 +1,150 @@
+# Command Corpus Ledger — `game` mount
+
+Point-in-time corpus of the `civ7 game` CLI surface (greps and counts taken
+2026-06-11 against this stack). Decisions reference the decision log in
+`workstream-record.md` (D1–D7). Governing grammar:
+`docs/projects/civ7-live-play-support/topics/command-surface-design.md`.
+
+Column key:
+
+- **Layer**: which control layer the command speaks (direct-control socket,
+  control-oRPC service, GameInfo reads, filesystem).
+- **State**: which Civ7 tuner scripting state it targets (App UI, Tuner,
+  offline).
+- **Consumer**: who depends on it (play-agent, maintainer, proof-tooling,
+  RHQ).
+- **Refs**: doc-reference blast radius (grep count across `docs/` at corpus
+  time; approximate, point-in-time).
+- **Decision**: taxonomy disposition (D1–D7).
+
+## Flat Tier (session-control singletons)
+
+| Id | Summary | Layer | State | Consumer | Refs | Decision |
+| --- | --- | --- | --- | --- | --- | --- |
+| `game status` | control-oRPC readiness | control-oRPC | App UI + Tuner | play-agent | 91 | stays flat (D1) |
+| `game health` | direct-control socket + Tuner canary | direct-control | App UI + Tuner | maintainer | 16 | stays flat (D1) |
+| `game watch` | direct-control HUD observer | direct-control | App UI | play-agent (passive) | 59 | stays flat (D1); future play-grammar candidate |
+| `game restart` | direct-control `Network.restartGame` mutation | direct-control | App UI | maintainer / autoplay-reset | 20+ | stays flat (D1); NOTE: restart rerolls the map seed — live-verified 2026-06-11 |
+| `game visibility` | direct-control read or disposable reveal mutation | direct-control | App UI | proof-tooling | 9 | MOVES to `game map visibility` (D5, FULL migration); old id removed, repo refs retargeted |
+| `game inspect` | direct-control reflection | direct-control | App UI + Tuner | maintainer | 17 | stays flat (D1) |
+| `game map` | control-oRPC `world.*` reads | control-oRPC | App UI | play-agent map awareness | 148 | becomes noun topic (D2); flag-multiplex preserved as topic index |
+| `game operation` | direct-control mutation gateway escape hatch | direct-control | Tuner | play-agent | 14 | stays flat (D1, per design doc: generic escape hatch) |
+| `game exec` | direct-control raw JS | direct-control | App UI + Tuner | maintainer / proof | 43 | stays flat (D1) |
+| `game autoplay` | direct-control Autoplay state machine | direct-control | Tuner | play-agent / maintainer | 43 | stays flat (D1) |
+| `game gameinfo` | direct-control GameInfo reads | direct-control | Tuner | maintainer / proof | 12 | stays flat (D1); GameInfo is already the NATIVE Civ7 noun |
+| `game catalog` | direct-control capability reflection | direct-control | App UI + Tuner | maintainer / proof | 9 | stays flat (D1) |
+| `game ai loaded-levers` | GameInfo AI policy reads | direct-control (GameInfo) | Tuner | proof / RHQ | — | stays nested under `ai` (D1) |
+| `game local-data inspect` | filesystem forensics (SQLite, saves, logs) | filesystem | offline | maintainer | 0 | stays nested under `local-data` (D1) |
+
+## In-Flight (this stack, pre-merge — no aliases needed)
+
+| Id | Summary | Layer | State | Consumer | Decision |
+| --- | --- | --- | --- | --- | --- |
+| `game map starts` | direct-control founder-unit-derived start-position read | direct-control | Tuner | proof-tooling | D3 (renamed from unmerged `game starts`) |
+| `game play screen dismiss` | direct-control App UI display-queue cinematic dismissal | direct-control | App UI | play-agent | D4 (renamed from unmerged `game dismiss-cinematics`) |
+| `game play screen show` | read-only display-queue screen listing (selector count + titles) | direct-control exec (read-only) | App UI | play-agent | D4 (new phase-verb sibling) |
+
+## Play Tier (`game play/*`, 43 commands — out of scope, D7)
+
+Migration of these into the unit/city/progress/notifications/trade/turn
+grammar is owned by the command-surface-design roadmap, not this workstream.
+One-liners for corpus completeness:
+
+| Id | Summary |
+| --- | --- |
+| `game play advisor-warning` | Validate or acknowledge an advisor warning blocker |
+| `game play assign-worker` | Validate or assign a city growth worker |
+| `game play battlefield-scan` | Read a tactical battlefield lens around one or more origins |
+| `game play build-production` | Validate or choose city production |
+| `game play buy-attribute` | Validate or buy an attribute tree node |
+| `game play change-tradition` | Validate or change an active tradition |
+| `game play choose-celebration` | Validate or choose a celebration bonus |
+| `game play choose-culture` | Validate or choose a culture tree node |
+| `game play choose-government` | Validate or choose a government |
+| `game play choose-narrative` | Validate or choose a narrative story direction |
+| `game play choose-tech` | Validate or choose a technology node |
+| `game play civilian-route-triage` | Read civilian route risk from settlement, battlefield, and destination lenses |
+| `game play consider-attributes` | Validate or close out attribute assignment review |
+| `game play consider-town-project` | Validate or close out town project review |
+| `game play consider-traditions` | Validate or close out tradition assignment review |
+| `game play destination-analysis` | Read tactical pressure around an intended destination |
+| `game play dismiss-notification-queue` | Bulk dismiss reviewed informational notifications from the live queue |
+| `game play dismiss-notification` | Inspect or dismiss a reviewed notification |
+| `game play end-turn` | Check or send Civ7 end turn |
+| `game play expand-city` | Validate or send a city expansion placement |
+| `game play formation-snapshot` | Read ready-unit formation, escort, and civilian-screen context |
+| `game play front-summary` | Read a composed front and formation summary without sending operations |
+| `game play notification-queue` | Read and schedule the current notification decision queue |
+| `game play notifications` | Read live play blockers with operation hints |
+| `game play priorities` | Read a turn-priority dashboard without sending operations |
+| `game play progress-dashboard` | Read local victory, legacy, age, and reward progress |
+| `game play promotion-readiness` | Read promotion spend readiness for the selected or first ready unit |
+| `game play ready-city` | Read the selected or blocking city with legal closeout operations |
+| `game play ready-unit` | Read the selected or first ready unit with legal operations |
+| `game play rehydrate` | Read the live session after restart or reconnect |
+| `game play resettle-unit` | Validate or send a population resettle command |
+| `game play respond-diplomacy` | Validate or send a diplomacy response |
+| `game play respond-first-meet` | Validate or send a first-meet diplomacy greeting |
+| `game play set-culture-target` | Validate or set a culture tree target node |
+| `game play set-tech-target` | Validate or set a technology tree target node |
+| `game play set-town-focus` | Validate or change a town focus project |
+| `game play settlement-recommendations` | Read official settlement recommendation hints |
+| `game play target-candidates` | Read strategic target candidates from live city and unit summaries |
+| `game play topics` | List live-play topic families and reference shortcuts |
+| `game play traditions` | Read current tradition slots and available policy actions |
+| `game play unit-move-preview` | Read official unit movement, target, path, and queued-destination preview |
+| `game play unit-target` | Resolve a unit plot target through the official right-click action order |
+| `game play upgrade-unit` | Validate or send a unit upgrade command |
+
+### Design-Doc Accuracy Table
+
+Status of the command-surface-design.md Compatibility Path table against the
+current corpus (none of the designed play-agent paths exist yet; the design
+doc remains the owner of this migration, D7):
+
+| Existing command | Designed play-agent path | Corpus status |
+| --- | --- | --- |
+| `game play priorities` | `game play todo` | exists as `priorities`; `todo` not implemented |
+| `game play ready-unit` | `game play unit show unit:next` | exists as `ready-unit`; `unit` noun not implemented |
+| `game play unit-target` | `game play unit targets` / `unit send target` | exists as `unit-target`; split not implemented |
+| `game play operation` | `game play unit/city/player operation` | generic `game operation` is the live escape hatch (flat tier) |
+| `game play notifications` | `game play notifications list` | exists as flat `notifications` read |
+| `game play notification-queue` | `game play notifications schedule` | exists as `notification-queue` |
+| `game play dismiss-notification-queue` | `game play notifications dismiss-reviewed` | exists as `dismiss-notification-queue` |
+| `game play ready-city` | `game play city show city:ready` | exists as `ready-city`; `city` noun not implemented |
+| `game play build-production` | `game play city production send` | exists as `build-production` |
+| `game play choose-tech` / `choose-culture` | `game play progress tech send` / `progress culture send` | exist as flat choosers; `progress` noun not implemented |
+| `game play civilian-route-triage` | `game play trade preview` or `unit preview route` | exists as `civilian-route-triage`; `trade` noun not implemented |
+| — (new, this stack) | `game play screen show|dismiss` | IMPLEMENTED (D4) — first play noun landed in the designed grammar |
+
+## Rivers-Branch Planned Arrivals (not on `main` — designated only, D6)
+
+| Planned command | Designated home | Notes |
+| --- | --- | --- |
+| `camera` | `game view camera` | presentation/capture noun; camera read/positioning |
+| `screenshot` | `game view screenshot` | native screenshot capture |
+| `appshot` | `game view appshot` | app-window capture proof tooling |
+
+`game view` is reserved; nothing lands there in this workstream.
+
+## oclif Conventions Found
+
+- Directory = topic: `commands/game/play/` makes `game play` a topic;
+  `topicSeparator: " "` gives space-separated ids while manifest keys stay
+  colon-separated (`game:play:end-turn`).
+- Command-file + topic-dir coexistence is valid: `game/map.ts` beside
+  `game/map/` emits both `game:map` (runnable index) and `game:map:*`
+  subcommands (verified via manifest build in slice 2). `game/map/index.ts`
+  is the equivalent long-term shape (slice 4).
+- Aliases: declared as `static aliases = ['link:push']` (colon-separated
+  ids); the only aliases in the repo today are `mod git *` → `link:*`. They
+  work across topics (verified during this workstream; D5 ultimately chose
+  full migration instead). There are no aliases or hidden
+  commands in the `game` mount before this workstream.
+- Mutation gating: the established read-first pattern gates mutations behind
+  explicit flags — `--send` (play commands), `--disposable` (visibility
+  reveal), `--reveal`, `--dry-run` (exec). New subcommands preserve these
+  contracts verbatim.
+- Each command declares `static id` matching its path-derived id (decorative
+  but consistent); class names concatenate the id segments
+  (`GameMapStarts`, `GamePlayScreenDismiss`).

--- a/docs/projects/cli-command-taxonomy/target-grammar.md
+++ b/docs/projects/cli-command-taxonomy/target-grammar.md
@@ -1,0 +1,86 @@
+# Target Grammar — `civ7 game` mount
+
+The full target tree for the `game` mount after this workstream's slices.
+Decisions D1–D7 in `workstream-record.md`; grammar authority is
+`docs/projects/civ7-live-play-support/topics/command-surface-design.md`
+(noun-first, phase verbs `show|targets|preview|check|send`; native control
+first; no casual breaking renames).
+
+## Tree
+
+```text
+game                                  # the mount itself is the session noun (D1)
+├── status                            # flat session tier (D1) — control-oRPC readiness
+├── health                            # flat — socket + Tuner canary
+├── watch                             # flat — HUD observer (future play-grammar candidate)
+├── restart                           # flat — Network.restartGame (rerolls map seed)
+├── autoplay                          # flat — Autoplay state machine
+├── exec                              # flat — raw JS escape hatch
+├── inspect                           # flat — reflection
+├── operation                         # flat — mutation gateway escape hatch (per design doc)
+├── catalog                           # flat — capability reflection
+├── gameinfo                          # flat — GameInfo is already the native noun
+├── ai
+│   └── loaded-levers                 # GameInfo AI policy reads
+├── local-data
+│   └── inspect                       # offline filesystem forensics
+├── map                               # noun topic (D2)
+│   ├── (index)                       # current flag-multiplex preserved verbatim
+│   │                                 #   --summary | --plot x,y | --bounds x,y,w,h
+│   ├── summary                       # thin delegation: world.current
+│   ├── plot                          # thin delegation: world.plot
+│   ├── grid                          # thin delegation: world.grid
+│   ├── starts                        # founder-unit-derived start positions (D3)
+│   └── visibility                    # moved from `game visibility` (D5)
+│                                     #   FULL migration: old id removed, refs retargeted
+├── play                              # play-agent grammar (design-doc owned)
+│   ├── screen                        # NEW play noun (D4)
+│   │   ├── show                      # read-only: mounted display-queue screens
+│   │   └── dismiss                   # drain cinematic moments (DisplayQueueManager)
+│   ├── <43 existing flat commands>   # unchanged here; migration owned by
+│   │                                 #   command-surface-design.md (D7):
+│   │                                 #   unit/city/progress/notifications/trade/turn
+│   └── (designed nouns, future)      # unit, city, notifications, progress,
+│                                     #   trade, objective, map, turn — see design doc
+└── view                              # RESERVED presentation/capture noun (D6)
+    ├── camera                        # rivers-branch arrival (not on main)
+    ├── screenshot                    # rivers-branch arrival (not on main)
+    └── appshot                       # rivers-branch arrival (not on main)
+```
+
+## Tier Contracts
+
+- **Flat session tier (D1).** Singletons that operate the session itself.
+  They keep their ids forever-stable; no umbrella topics (`game session`,
+  `game native`) are introduced. New session-control commands must argue for
+  flatness explicitly (default is a noun home).
+- **`game map` (D2/D3/D5).** Read-only world state. The index command is the
+  compatibility surface — its flags never change semantics. Subcommands are
+  thin delegations over the same control-oRPC/direct-control calls with
+  focused flags. The only mutation under `map` is `visibility --reveal`,
+  which keeps its `--disposable` gate verbatim.
+- **`game play` (D4/D7).** The play-agent grammar. `screen` is the first
+  noun landed in the designed shape: `show` (read) / `dismiss` (mutation by
+  official close handler). All further noun gathering (unit, city, progress,
+  notifications, trade, turn) follows the design doc's Priority Refactors —
+  out of scope here, cross-linked as the D7 boundary.
+- **`game view` (D6).** Reserved for presentation/capture commands arriving
+  from the rivers branch (`camera`, `screenshot`, `appshot`). Nothing may
+  squat on `view` in the meantime.
+
+## Invariants
+
+1. Pre-existing invocations on `main` keep working except where a decision
+   record says otherwise: flat ids unchanged, `game map` flag-multiplex
+   unchanged. `game visibility` is a recorded FULL migration to
+   `game map visibility` (D5): old id removed, all repo references
+   retargeted in the same slice.
+2. Pre-merge commands may be renamed in place (D3/D4); merged commands move
+   only with an explicit decision-logged migration that retargets every
+   in-repo reference (D5) — removal is never silent.
+3. New wrappers call `@civ7/direct-control` / `@civ7/control-orpc`; no
+   caller-local runtime control. Read-only commands may compose one exec
+   from exported selector/constant primitives (e.g. `game play screen
+   show`).
+4. Mutations stay flag-gated (`--send`, `--disposable`, `--reveal`) and
+   keep the design doc's preview/check/send phase contract as nouns gather.

--- a/docs/projects/cli-command-taxonomy/workstream-record.md
+++ b/docs/projects/cli-command-taxonomy/workstream-record.md
@@ -1,0 +1,166 @@
+# Systematic Workstream Record — CLI Command Taxonomy (game mount)
+
+## Frame
+
+- Objective: extend the noun-first / phase-verb grammar that
+  `docs/projects/civ7-live-play-support/topics/command-surface-design.md`
+  established for `game play` to the whole `game` mount, so every command lives
+  at a taxonomy home a play agent can predict from the noun it is thinking
+  about.
+- Future state: `game` carries a flat session-control tier plus real noun
+  topics (`map`, `play` incl. the new `screen` noun, reserved `view`). Flat
+  ids and the `game map` flag-multiplex stay unchanged; decision-logged FULL
+  migrations (D5) remove an old id outright and retarget every repo
+  reference in the same slice — never silently.
+- Non-goals: migrating the 43 `game play/*` commands into the
+  unit/city/progress/notifications/trade/turn grammar (owned by the
+  command-surface-design roadmap, see D7); implementing the rivers-branch
+  `camera`/`screenshot`/`appshot` arrivals (designated only, see D6).
+- Hard core: the command-surface-design grammar (noun-first, phase verbs
+  `show|targets|preview|check|send`; native control first; mutations gated
+  behind explicit flags) and its compatibility rule — "Do not remove existing
+  commands casually" and "Do not add aliases as a substitute for fixing the
+  command model".
+- Exterior: the `game play/*` noun migration (D7); presentation/capture
+  commands not yet on `main` (D6); any direct-control or control-oRPC service
+  changes (this workstream moves CLI surface only).
+- Falsifier: any existing documented invocation breaking WITHOUT a
+  decision-logged migration that retargets its references (`game map
+  --summary` and the flat session commands are unchanged; `game visibility`
+  is the one recorded full migration), or the oclif manifest failing to
+  emit both a topic index command and its subcommands.
+- Redesign trigger: oclif rejecting command-file + topic-dir coexistence or
+  cross-topic aliases (verified working — see Status notes), or a consumer
+  inventory showing clustering value for the flat session tier (would reopen
+  D1).
+
+## Status
+
+- Last updated: 2026-06-11
+- Current gate: slice 4 (map noun gathering) implemented; stack submitted as
+  drafts.
+- Next gate: review + merge of PRs #1576/#1577 and the slice 3/4 PRs; then the
+  D7 play-grammar migration proceeds under command-surface-design ownership.
+- Blocked by: nothing; pre-merge amendment of slice 2 means no alias debt for
+  `game map starts` / `game play screen dismiss`.
+- Stop condition: all four slices merged with the manifest showing the target
+  ids and zero broken legacy invocations.
+- Verified findings:
+  - oclif command-file + topic-dir coexistence works: `game/map.ts` beside
+    `game/map/` emitted both `game:map` and `game:map:starts` in the manifest
+    (slice 2). Slice 4 still restructures to `game/map/index.ts` for the
+    long-term topic shape.
+  - Cross-topic aliases verified working (`static aliases` with
+    colon-separated ids, mirroring `mod git push` → `link:push`) BEFORE the
+    D5 override chose full migration; recorded as a usable mechanism, not
+    used by this stack.
+
+## Repo State
+
+- Worktree: `wt-direct-control-live-ui`
+- Branches (Graphite stack, bottom → top):
+  1. `direct-control-cinematic-dismissal` (PR #1576) — dismissal primitive.
+  2. `cli-game-dismiss-cinematics-and-starts` (PR #1577, amended in place) —
+     `game map starts`, `game play screen dismiss|show`.
+  3. `cli-taxonomy-workstream-docs` — this directory.
+  4. `cli-game-map-noun-topic` — `game map` topic restructure + visibility
+     move.
+- Protected paths: `packages/cli/src/commands/game/play/*` behavior (D7
+  boundary); `game map` index flag-multiplex behavior (D2 compatibility).
+- Generated/read-only paths: `packages/cli/oclif.manifest.json` (build
+  output, untracked).
+
+## Decision Log
+
+Decisions D1–D7 are settled. Do not relitigate; record deviations here with a
+new decision number.
+
+- **D1 — session tier stays flat.** The `game` mount itself is the session
+  noun. Session-control singletons stay FLAT: `status`, `health`, `restart`,
+  `autoplay`, `exec`, `inspect`, `operation`, `watch`, `catalog`, `gameinfo`,
+  `ai loaded-levers`, `local-data inspect`. Rationale: `gameinfo` is already
+  the NATIVE Civ7 noun (GameInfo); `status`/`health`/`restart` have a huge
+  reference blast radius (91/16/20+ doc references) and no clustering value;
+  the design doc forbids aliases as a substitute for model fixes — and
+  equally, renames without consumer value. No `game session` / `game native`
+  umbrella topics.
+- **D2 — `game map` becomes a real noun topic.** Subcommands `summary`,
+  `plot`, `grid`, `starts`, `visibility`. The current `game map`
+  flag-multiplex (`--summary/--plot/--bounds`) is preserved as the topic
+  INDEX command (oclif: `game/map/index.ts`) so every existing invocation
+  keeps working unchanged; the new subcommands are thin delegations over the
+  same service calls with focused flags.
+- **D3 — `game starts` renames to `game map starts`.** Amended into slice 2;
+  the command was unmerged, so no alias is needed.
+- **D4 — `game dismiss-cinematics` renames to `game play screen dismiss`.**
+  Amended into slice 2. Added sibling `game play screen show` (read-only: one
+  App UI exec listing active cinematic/display screens — selector count +
+  titles via the same selectors as the dismissal primitive; reuses exported
+  selector constants from `@civ7/direct-control` rather than duplicating
+  strings). `screen` is a new play noun; native primitive =
+  DisplayQueueManager cinematic-moment screens (provenance comments per
+  slice 1).
+- **D5 — `game visibility` moves to `game map visibility`, FULL MIGRATION
+  (user decision 2026-06-11, supersedes the initial alias plan).** No alias,
+  no deprecated stub: the old id is removed outright and every repo
+  reference (docs/, scripts/, .agents/) is retargeted to
+  `game map visibility` in the same slice. (For the record: cross-topic
+  oclif aliases were verified working via the `mod/git` → `link:*` pattern
+  before the override — usable if a future migration ever needs one.)
+- **D6 — rivers-branch arrivals get a designated home.** Planned arrivals
+  (`camera`, `screenshot`, `appshot` — NOT on `main`) are DESIGNATED to land
+  as `game view camera|screenshot|appshot` (a presentation/capture noun).
+  Documented only; not implemented here.
+- **D7 — `game play/*` noun migration is out of scope.** The 43 `game play/*`
+  commands' migration to the unit/city/progress/notifications/trade/turn
+  grammar is OWNED by the existing command-surface-design.md roadmap. This
+  workstream records the boundary and cross-links; see
+  `docs/projects/civ7-live-play-support/topics/command-surface-design.md`
+  (Priority Refactors, Compatibility Path).
+
+## Corpus Gate
+
+- Corpus source(s): `packages/cli/src/commands/game/**` on the stack;
+  `corpus.md` in this directory (command corpus ledger).
+- Corpus shape: action surfaces (CLI command ids) + consumer/reference
+  effect matrix.
+- Coverage ledger: see `corpus.md` — every flat-tier command has a row with
+  id/summary/layer/state/consumer/refs/decision; play tier covered by
+  one-liners + the design-doc accuracy table.
+- Open uncertainty: reference counts are point-in-time greps (2026-06-11);
+  rivers-branch arrival shapes may drift before they reach `main`.
+
+## Proof Gates
+
+- Local stats: `turbo run test --filter=@mateicanavra/civ7-cli
+  --filter=@civ7/direct-control` green; root `bun run check-types` green.
+- Generated/deploy proof: oclif manifest contains `game:map`,
+  `game:map:starts`, `game:map:summary|plot|grid|visibility`,
+  `game:play:screen:dismiss|show`; does NOT contain `game:starts` or
+  `game:dismiss-cinematics` — and after the D5 override, no
+  `game:visibility` id or alias at all.
+- Runtime proof: none required — no live-game socket use in this workstream;
+  all command behavior is fake-tuner-server tested. The underlying
+  primitives carry their own live verification (cinematic dismissal and
+  founder-unit starts live-verified 2026-06-11; `restart` rerolls the map
+  seed, live-verified 2026-06-11).
+- Product proof: `--help` exits 0 without sockets for `game map`,
+  `game map summary`, `game map starts`, `game play screen dismiss`.
+- Closure boundary: D6 (view noun) and D7 (play migration) intentionally
+  remain open; they are exterior, not debt.
+
+## Slice Ledger
+
+| Slice | Branch | PR | Content | State |
+| --- | --- | --- | --- | --- |
+| 1 | `direct-control-cinematic-dismissal` | #1576 | cinematic-moment dismissal primitive (`@civ7/direct-control`) | submitted (draft) |
+| 2 | `cli-game-dismiss-cinematics-and-starts` | #1577 | `game map starts`, `game play screen dismiss`, `game play screen show` (amended in place to taxonomy homes per D2/D3/D4) | submitted (draft, amended) |
+| 3 | `cli-taxonomy-workstream-docs` | — | this directory: workstream record, corpus ledger, target grammar | this slice |
+| 4 | `cli-game-map-noun-topic` | — | `game map` topic restructure (`index/summary/plot/grid`), `game map visibility` FULL migration incl. repo-wide reference retarget (D2/D5) | next slice |
+
+## Team
+
+- Owner: Matei (tools@matei.work)
+- Evidence agents: fake-tuner-server CLI tests; oclif manifest grep.
+- Review agents: PR review on the Graphite stack.
+- Open findings: none.


### PR DESCRIPTION
Record the command-taxonomy workstream for the `game` mount: a
systematic-workstream record with the settled decision log (D1-D7:
flat session tier, `game map` noun topic, pre-merge renames of
`game starts` -> `game map starts` and `game dismiss-cinematics` ->
`game play screen dismiss` + new `show` sibling, `game visibility`
move with alias, `game view` reservation for rivers-branch arrivals,
and the D7 boundary leaving the 43 `game play/*` commands to the
command-surface-design roadmap), the full command corpus ledger
(flat-tier rows with layer/state/consumer/refs/decision, play-tier
one-liners, design-doc accuracy table, oclif conventions found), and
the target grammar tree for the whole mount.

References:
- Project: Civ7 Modding Tools
- Docs: docs/projects/civ7-live-play-support/topics/command-surface-design.md
- Docs: docs/process/GRAPHITE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
