### PR TITLE
feat(agents): add graphite-stack-drain skill

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -18,6 +18,7 @@ discipline; they should not duplicate the packet as a parallel spec.
 | `civ7-systematic-workstream` | Running a systematic, evidence-grounded domain workstream that needs full corpus extraction, expected ranges, architecture-aligned strategies, local statistics, runtime proof, peer review, and clean Graphite closure. |
 | `civ7-operational-debugging` | Debugging build/deploy/log/in-game evidence across generated mod output, deployed Civ7 Mods folders, official resources, and proof boundaries. |
 | `dra-structural-watcher` | Running or setting up a separate watcher DRA for OpenSpec workstreams: heartbeat/cron monitoring, NOTE-TO-DRA scans, correction logs, closure-drift checks, and branch/stack watcher passes without owning implementation. |
+| `graphite-stack-drain` | Managing complex Graphite stack/worktree cleanup: deterministic stack census, source/sink accounting, folding over-atomized stacks, targeted restacks, submit/merge drains, and safe branch/worktree retirement. |
 
 ## Operating Rules
 

--- a/.agents/skills/graphite-stack-drain/SKILL.md
+++ b/.agents/skills/graphite-stack-drain/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: graphite-stack-drain
+description: |
+  Use when managing complex Graphite stacks, worktrees, branch accounting, folding/consolidation, restacking, submit/merge drain loops, and cleanup across local stack topologies. This skill is generic: it is for Git + Graphite repositories, not Civ7-specific product decisions.
+---
+
+# Graphite Stack Drain
+
+## Purpose
+
+Use this skill when the problem is not "make one code change", but "make the
+Graphite topology sane": many worktrees, stale or superseded source stacks,
+local-only stacks, over-atomized branch chains, partial adoption/recovery
+branches, PR/status confusion, or risky cleanup after merges.
+
+The skill's job is to keep three things separate:
+
+- **Facts**: Git refs, worktrees, Graphite cache parentage, Graphite restack
+  markers, origin refs, and PR/submission diagnostics.
+- **Accounting**: explicit operator-authored moves such as "this source branch
+  was adopted by that sink branch", "this work was superseded", or "this branch
+  is excluded by decision".
+- **Actions**: submit, merge, sync, fold, restack, rename, delete, or remove a
+  worktree.
+
+Do not use this skill as a general Git tutorial, a product-domain authority, or
+a reason to perform global restacks. It composes with repo-specific Graphite
+docs and domain skills.
+
+## Core Invariants
+
+<invariants>
+<invariant name="deterministic-census-first">Capture Graphite/Git/worktree state before mutating stack topology. Do not rely on bottom-anchored ASCII diagrams as the only source of truth.</invariant>
+<invariant name="dirty-worktrees-gate-mutation">Dirty or ownership-ambiguous worktrees block sync, restack, fold, submit, delete, and cleanup unless changes are committed, parked, or explicitly excluded.</invariant>
+<invariant name="facts-are-not-accounting">PR state, patch overlap, and Git reachability are diagnostics. They do not become source/sink accounting unless an operator records a move.</invariant>
+<invariant name="source-and-sink-labels-differ">Label the source as adopted/superseded/excluded/reference. Label the destination as the adoption sink. Do not mark only the destination as "accounted".</invariant>
+<invariant name="sync-no-restack-default">In multi-worktree or multi-agent repos, default to `gt sync --no-restack`; run targeted restacks only for stacks you intend to keep or submit.</invariant>
+<invariant name="native-drain-first">For submit-ready stacks, use Graphite publish/merge/sync/prune behavior before manual deletion. Manual deletion is an allowlisted cleanup path, not the normal drain loop.</invariant>
+<invariant name="fold-large-local-only-stacks">For very large local-only stacks, consolidate into semantic survivor branches before publishing, then run a targeted submit-readiness restack.</invariant>
+<invariant name="retire-only-after-disposition">Do not delete source branches because they look old. Delete after merge, explicit supersession/adoption, exclusion, or terminal reference disposition is recorded.</invariant>
+</invariants>
+
+## Standard Workflow
+
+1. **Frame the stack problem**: name the target stacks, non-target owner lanes,
+   cleanup goal, and stop conditions.
+2. **Run a stack census**: capture worktrees, dirty state, Graphite cache
+   parentage, displayed restack markers, branch refs, origin refs, and PR
+   diagnostics.
+3. **Classify topology**: root stacks, splits, leaves, subtree leaves, local-only
+   chains, submitted/open stacks, merged/closed/pruned candidates, and
+   untracked branches.
+4. **Compose accounting**: record explicit source-to-sink moves or terminal
+   dispositions; keep accounting sparse and intentional.
+5. **Choose the lane**:
+   - submit-ready support stack: drain through Graphite;
+   - stale source stack: adopt/supersede/exclude, then retire after sinks land;
+   - large local-only stack: fold into semantic survivor branches before submit;
+   - live owner stack: restack only with owner-aware look-ahead.
+6. **Execute with Graphite-native commands**: fold, rename, targeted restack,
+   submit, merge, sync, delete.
+7. **Close cleanly**: clean worktrees, refreshed census, updated accounting,
+   no stale branches left unexplained.
+
+## Reference Map
+
+| Reference | Open When |
+| --- | --- |
+| `references/state-model.md` | You need the vocabulary for facts, accounting, actions, and states. |
+| `references/deterministic-inspection.md` | You need a repeatable snapshot or need to reconcile `gt ls` with Graphite metadata. |
+| `references/drain-loop.md` | A stack is ready to submit/merge/prune through Graphite. |
+| `references/folding-and-consolidation.md` | A local-only stack is too large or too atomized to submit as-is. |
+| `references/restack-planning.md` | A stack needs restack and conflicts may require semantic resolution. |
+| `references/cleanup-and-retirement.md` | You need to remove worktrees, delete Graphite branches, or retire source stacks. |
+| `references/worktree-hygiene.md` | Worktree occupancy, dirtiness, or removal is part of the cleanup decision. |
+| `references/adversarial-review-lanes.md` | A large drain/restack needs independent review for accuracy, clarity, quality, and operational usefulness. |
+| `references/failure-patterns.md` | The work is getting confusing, circular, or overly manual. |
+
+## Script Map
+
+Scripts are intentionally small, JSON-first helpers. They are not a replacement
+for the richer repo-local visualizer if one exists.
+
+| Script | Purpose |
+| --- | --- |
+| `scripts/graphite-stack-census.mjs` | Read Git + Graphite cache facts and emit stack/root/split/leaf/worktree JSON. |
+| `scripts/patch-overlap.mjs` | Compare two branches for ahead/behind, patch-equivalent commits, and file overlap. |
+| `scripts/accounting-compose.mjs` | Validate a sparse accounting ledger and project source/sink labels onto a census. |
+
+## Command Defaults
+
+```bash
+# Safe refresh in a parallel repo
+gt sync --no-restack --no-interactive
+
+# Submit-ready drain loop
+gt ss --publish --ai --stack --no-interactive
+gt merge --no-interactive
+gt sync --no-restack --no-interactive
+
+# Targeted restack only for the stack you intend to keep
+gt restack --branch <top-branch> --downstack --no-interactive
+
+# Fold the current branch into its parent
+gt branch fold --no-interactive
+```
+
+## Quality Bar
+
+Before making a closure claim, you should be able to answer:
+
+- Which current facts came from Git, Graphite cache, `gt log short`, origin, PR
+  diagnostics, or worktree status?
+- Which accounting moves are operator-authored, and where are they recorded?
+- Which branches are submit-ready, cleanup-ready, restack-needed, or explicitly
+  out of scope?
+- Which worktrees were removed or preserved, and why?
+- Which stacks were intentionally not restacked because they are live owner
+  lanes or retirement targets?
+
+## Skills Used With This Skill
+
+- `graphite`: command-level Graphite behavior and repo-specific Graphite docs.
+- `git-worktrees`: worktree creation/removal, branch occupancy, and dirtiness.
+- `framing-design` or equivalent: hard core, exterior, stop conditions.
+- `team-design` or equivalent: adversarial review lanes for large restacks.
+- Repo-specific product/domain skills: only when conflict resolution needs
+  domain ownership, not for generic stack mechanics.

--- a/.agents/skills/graphite-stack-drain/assets/accounting-ledger-template.json
+++ b/.agents/skills/graphite-stack-drain/assets/accounting-ledger-template.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "graphite-stack-drain.accounting.v1",
+  "moves": [
+    {
+      "id": "example-adopt",
+      "state": "done",
+      "kind": "adopt",
+      "source": {
+        "kind": "branch",
+        "branch": "codex/source-branch"
+      },
+      "sink": {
+        "kind": "branch",
+        "branch": "codex/sink-branch"
+      },
+      "method": "semantic",
+      "anchors": {
+        "fromHead": "source-head-sha",
+        "toHead": "sink-head-sha",
+        "capturedAt": "snapshot:/tmp/graphite-stack-snapshot.json"
+      },
+      "note": "Accepted intent from the source is represented in the sink."
+    }
+  ]
+}

--- a/.agents/skills/graphite-stack-drain/references/adversarial-review-lanes.md
+++ b/.agents/skills/graphite-stack-drain/references/adversarial-review-lanes.md
@@ -1,0 +1,101 @@
+# Adversarial Review Lanes
+
+Use review lanes before turning a messy stack situation into mutation. The goal
+is not to create bureaucracy; it is to prevent the familiar failure modes:
+partial accounting, stale source deletion, wrong restack target, hidden dirty
+worktree, or visualizing noisy labels as if they were decisions.
+
+## Lane 1: Accuracy
+
+Question:
+
+> What concrete state claim could be false, stale, or inferred from the wrong
+> layer?
+
+Check:
+
+- Graphite cache parentage vs `gt log short`;
+- local refs vs origin refs;
+- PR state vs patch overlap;
+- current worktree state vs prior snapshot;
+- whether leaves are single branches or tops of mini-stacks.
+
+Output:
+
+- corrected facts;
+- ambiguous facts that need another command;
+- any claim that must be downgraded from "done" to "diagnostic".
+
+## Lane 2: Operational Usefulness
+
+Question:
+
+> Does this classification tell us what to do next?
+
+Check:
+
+- ready-to-land support stacks;
+- accounted source stacks ready to retire after sink durability;
+- live stacks that should not be globally restacked;
+- over-atomized stacks that should be folded before submit;
+- branches that are just pinned by worktrees.
+
+Output:
+
+- one recommended next domino;
+- stop conditions;
+- commands that should not be run globally.
+
+## Lane 3: Clarity
+
+Question:
+
+> Would another operator understand this map without knowing the conversation?
+
+Check:
+
+- semantic stack names instead of opaque branch-only labels;
+- timeline and base/parent context;
+- source vs sink labels;
+- accounting moves separate from PR diagnostics;
+- defaults hidden unless diagnostic view requires them.
+
+Output:
+
+- renamed stack/segment labels;
+- labels to remove because they restate defaults;
+- labels to split because they conflate state and decision.
+
+## Lane 4: Quality
+
+Question:
+
+> Does this workflow preserve the intended work while reducing topology?
+
+Check:
+
+- whether adopted behavior is actually present in the sink;
+- whether excluded source changes were intentionally dropped;
+- whether folding crosses review-worthy boundaries;
+- whether restack conflicts indicate a deeper semantic integration issue;
+- whether validation/proof claims are scoped to what actually ran.
+
+Output:
+
+- accepted risk;
+- required validation;
+- blocker list;
+- whether to continue, pause, or reframe.
+
+## Ready-To-Send Auditor Prompt
+
+Use this with a peer agent when available:
+
+```text
+You are part of a team helping manage a Graphite stack/worktree drain. Do not
+edit files. Adversarially audit one lane: accuracy, operational usefulness,
+clarity, or quality. Inspect deterministic topology captures, Graphite metadata,
+Git refs, worktrees, branch history, accounting overlays, and relevant docs.
+Return concise findings with exact file paths/branch names, state which claims
+are concrete facts vs accounting decisions, and recommend the next safe action.
+```

--- a/.agents/skills/graphite-stack-drain/references/cleanup-and-retirement.md
+++ b/.agents/skills/graphite-stack-drain/references/cleanup-and-retirement.md
@@ -1,0 +1,78 @@
+# Cleanup And Retirement
+
+Cleanup is a Graphite operation plus an accounting decision. Do not delete
+branches just because the terminal graph looks cluttered.
+
+## Cleanup Classes
+
+| Class | Native treatment |
+| --- | --- |
+| Merged through Graphite | `gt sync --no-restack` should prune or prompt cleanup. |
+| Submitted/open PR | Do not delete; merge/close through Graphite/GitHub first. |
+| Local-only support stack | Submit/merge/drain if it should land; delete only if explicitly abandoned. |
+| Source stack adopted elsewhere | Retire after sink lands or after local-only supersession is explicitly accepted. |
+| Reference-only branch | Keep as reference or delete with a durable note that no product work remains. |
+| Untracked branch | Track if part of a stack; otherwise treat as plain Git branch with care. |
+| Worktree pinning branch | Remove or repoint the worktree before branch deletion. |
+
+## Worktree Removal
+
+Before removing a worktree:
+
+```bash
+git -C <worktree> status --short --branch
+git worktree list --porcelain
+```
+
+If clean and disposable:
+
+```bash
+git worktree remove <worktree>
+```
+
+Use `--force` only when you have already verified that no useful uncommitted
+state exists and the refusal is mechanical, such as submodule metadata.
+
+## Graphite Branch Deletion
+
+Prefer Graphite:
+
+```bash
+gt delete <branch> --no-interactive
+```
+
+Use `--force`, `--upstack`, or `--downstack` only from an explicit allowlist.
+Remember: deleting a branch also deletes local Graphite metadata and may restack
+children onto the parent.
+
+## Retiring Source Stacks
+
+A source stack is cleanup-ready only when every relevant branch or slice is:
+
+- merged as-is;
+- adopted by a sink;
+- superseded by a named branch/stack;
+- excluded by decision; or
+- retained as reference-only with a reason.
+
+If any known source branch remains `needs-adoption`, the source stack is not
+ready to retire.
+
+## Avoid These Labels
+
+Avoid ambiguous terminal labels:
+
+- `parked`
+- `cleanup candidate`
+- `retain`
+- `split or retire`
+- `accounted`
+
+Use concrete labels instead:
+
+- `source adopted: semantic`
+- `source superseded`
+- `source excluded`
+- `sink adopts: cherry-pick`
+- `merged through Graphite`
+- `delete allowlisted`

--- a/.agents/skills/graphite-stack-drain/references/deterministic-inspection.md
+++ b/.agents/skills/graphite-stack-drain/references/deterministic-inspection.md
@@ -1,0 +1,77 @@
+# Deterministic Inspection
+
+Run inspection before stack mutation and after each major cleanup/drain phase.
+
+## Minimum Capture
+
+```bash
+git status --short --branch
+git worktree list --porcelain
+gt sync --no-restack --no-interactive
+gt log short --no-interactive
+node .agents/skills/graphite-stack-drain/scripts/graphite-stack-census.mjs \
+  --repo-root "$PWD" \
+  --output /tmp/graphite-stack-census.json
+```
+
+The census script reads:
+
+- Git common dir and top-level path.
+- `.git/.graphite_cache_persist` for Graphite branch metadata and parentage.
+- `.git/.graphite_pr_info` when available.
+- Local and origin refs.
+- Worktree occupancy and dirtiness.
+- `gt log short --no-interactive` only for Graphite's displayed
+  `needs restack` marker.
+
+## Why Not Parse `gt ls` As Topology?
+
+`gt ls` is useful for humans and for Graphite's displayed restack marker, but
+its bottom-anchored ASCII drawing can make separate root stacks look like one
+giant nested stack. Use Graphite cache parentage as the topology source, then
+use `gt ls` as display evidence.
+
+## Root Stack Terms
+
+- **Root stack**: a Graphite-tracked branch whose parent is trunk, usually
+  `main`. Traverse its children to get the stack/subtree.
+- **Split**: a branch with more than one Graphite child.
+- **Leaf**: a branch with no Graphite children.
+- **Subtree leaf**: a terminal branch inside a root stack's subtree. Do not call
+  a whole visible mini-stack a leaf.
+- **Outside root model**: a cached branch that is not reachable from a trunk
+  child; investigate before cleanup.
+
+## Inspection Questions
+
+Answer these before mutation:
+
+1. Which worktrees are dirty, detached, or occupying branches we want to delete?
+2. Which root stacks are live owner lanes, support stacks, source stacks,
+   recovery/adoption sinks, or tooling lanes?
+3. Which branches have PR evidence, remote refs, local-only status, or restack
+   markers?
+4. Which splits/leaves are real subtrees versus merely display artifacts?
+5. Which source branches have explicit accounting moves, and which are still
+   unaccounted?
+
+## Patch Overlap Checks
+
+Use patch overlap when stacks look parallel or one may have superseded another:
+
+```bash
+node .agents/skills/graphite-stack-drain/scripts/patch-overlap.mjs \
+  --repo-root "$PWD" \
+  --left <branch-a> \
+  --right <branch-b> \
+  --output /tmp/patch-overlap.json
+```
+
+Interpretation:
+
+- High patch equivalence suggests mechanical duplication or replay.
+- High file overlap with low patch equivalence suggests semantic conflict or
+  independent implementation.
+- Commit timing helps decide whether one stack took over from another.
+
+Patch overlap is evidence. It is not automatic accounting.

--- a/.agents/skills/graphite-stack-drain/references/drain-loop.md
+++ b/.agents/skills/graphite-stack-drain/references/drain-loop.md
@@ -1,0 +1,62 @@
+# Stack Drain Loop
+
+Use the drain loop for a stack that is submit-ready or close to submit-ready.
+Do not use it to force-clean live owner stacks or source stacks that were only
+semantically adopted elsewhere.
+
+## Preconditions
+
+```bash
+git status --short --branch
+git branch --show-current
+git worktree list --porcelain
+gt sync --no-restack --no-interactive
+gt ls --no-interactive
+gt submit --dry-run --stack --branch <top-branch> --no-interactive
+```
+
+Resolve dirty worktrees and restack blockers before claiming the stack is
+submit-ready.
+
+## Canonical Loop
+
+The RAWR loop is:
+
+```bash
+gt ss --publish --ai --stack --no-interactive
+gt merge --no-interactive
+gt sync --no-restack --no-interactive
+gt ls --no-interactive
+```
+
+Repeat until the intended branches are merged and Graphite has pruned merged
+local branches.
+
+## What Not To Do During A Drain
+
+- Do not restack after every single lower branch merge just because the stack is
+  changing. Let Graphite merge/prune and then inspect.
+- Do not run plain `gt sync` in a multi-worktree repo unless you intentionally
+  want opportunistic restacks.
+- Do not use manual `git branch -D` as the normal cleanup path.
+- Do not globally restack unrelated stacks to "make the world current".
+
+## Batching
+
+If Graphite or review policy limits stack size:
+
+1. Submit a bounded batch from the lower part of the stack or from the current
+   top, according to Graphite's command behavior and repo convention.
+2. Merge the submitted batch.
+3. `gt sync --no-restack`.
+4. Re-inspect before the next batch.
+
+For very large local-only stacks, prefer folding/consolidation before creating
+hundreds of PRs.
+
+## Exit Criteria
+
+- The intended stack branches are merged or have explicit terminal disposition.
+- `gt ls` no longer shows stale merged branches that Graphite can prune.
+- No relevant worktree remains dirty or pinned to a branch we intended to clean.
+- The accounting ledger no longer marks those source branches as pending.

--- a/.agents/skills/graphite-stack-drain/references/failure-patterns.md
+++ b/.agents/skills/graphite-stack-drain/references/failure-patterns.md
@@ -1,0 +1,52 @@
+# Failure Patterns
+
+These patterns repeatedly cause Graphite cleanup work to become confusing or
+dangerous.
+
+## Topology Mistakes
+
+- Treating `gt ls` ASCII layout as authoritative ancestry.
+- Calling a whole subtree a "leaf" because the visual is compressed.
+- Counting only an ancestor spine instead of the full root subtree.
+- Ignoring worktree occupancy before deleting Graphite branches.
+- Assuming Git reachability proves squash-merged work was not represented.
+
+## State Model Mistakes
+
+- Treating PR state as accounting state.
+- Marking the sink as "accounted" while the source remains unlabeled.
+- Showing both default and inverse labels, such as "local" and "not remote",
+  until labels become noise.
+- Using "merged" for semantic supersession.
+- Letting "reference" or "retain" become a terminal state without a concrete
+  next action.
+
+## Execution Mistakes
+
+- Restacking unrelated live stacks while trying to clean one stack.
+- Running broad `gt sync` in a multi-worktree repo when `--no-restack` is the
+  intended safe refresh.
+- Creating a recovery/adoption sink without a ledger of what it adopted.
+- Deleting source branches before the sink landed or before explicit
+  local-only supersession was accepted.
+- Fixing product code while the active task is stack hygiene.
+- Leaving obsolete scripts or "v1" paths alongside the new workflow.
+
+## Recovery Signals
+
+Stop and reframe when:
+
+- every answer introduces a new stack or branch name but not a disposition;
+- the same conflict resolution repeats across many branches;
+- a branch is dirty and nobody can name its owner;
+- inspection output disagrees with what Graphite displays;
+- the next action would delete metadata from a branch without an allowlist;
+- the stack is too large to submit and no consolidation map exists.
+
+## Better Defaults
+
+- Say "source stack", "adoption sink", "submit-ready", "cleanup-ready", or
+  "restack-needed"; avoid vague temporal names like "old stack".
+- Use semantic names next to raw branch names.
+- Keep live owner lanes separate until intentionally restacked.
+- Prefer broad-stroke simplification first, details at the end.

--- a/.agents/skills/graphite-stack-drain/references/folding-and-consolidation.md
+++ b/.agents/skills/graphite-stack-drain/references/folding-and-consolidation.md
@@ -1,0 +1,97 @@
+# Folding And Consolidation
+
+Use folding when a local-only stack is too atomized to submit or review branch
+by branch. Folding is not the default answer for ordinary stacks.
+
+## When Folding Is Appropriate
+
+- The stack is local-only or not yet PR-associated.
+- Branches are micro-slices of one semantic body of work.
+- The branch count would create an impractical number of PRs.
+- The stack itself remains the intended work carrier.
+- You can preserve a branch-map from old branch ranges to survivor branches.
+
+Do not fold:
+
+- submitted/open PRs unless PR association loss is accepted;
+- branches whose messages/history are needed for review;
+- mixed owner lanes where folding would hide domain boundaries;
+- branches you intend to retire rather than carry forward.
+
+## Semantic Groups
+
+A semantic group is a contiguous run of branches that can be reviewed as one
+branch without hiding an important contract, runtime boundary, proof boundary,
+or ownership decision.
+
+For each group, record:
+
+- original branch range;
+- survivor branch;
+- semantic name;
+- intended final branch name;
+- proof/review boundaries preserved or intentionally collapsed.
+
+## Fold Mechanics
+
+Graphite `gt branch fold`:
+
+- folds the current branch into its parent;
+- updates descendant dependencies and restacks;
+- does not touch GitHub or remote branches;
+- has no range argument;
+- has no `--no-restack` mode.
+
+Practical implication: fold top-down inside a semantic group when possible so
+early folds have fewer descendants. After a group is folded, rename the survivor
+branch before submit:
+
+```bash
+gt checkout <top-branch-in-group>
+gt branch fold --no-interactive
+gt branch rename <semantic-survivor-name> --no-interactive
+```
+
+Confirm exact command names and aliases with `gt branch fold --help` and
+`gt branch rename --help` in the installed Graphite version.
+
+## Restack Timing
+
+The usual consolidation order is:
+
+1. Run deterministic census.
+2. Fold semantic groups in place.
+3. Rename survivor branches before PR creation.
+4. Run one explicit targeted submit-readiness restack from the consolidated
+   top branch:
+
+   ```bash
+   gt restack --branch <consolidated-top> --downstack --no-interactive
+   ```
+
+Do not run a full pre-fold restack solely because an old root says it needs
+restack. If the first guarded fold shows the stale stack cannot be folded
+coherently, stop and reframe.
+
+## Branch Map Template
+
+```json
+{
+  "schemaVersion": "graphite-stack-fold-map/v1",
+  "groups": [
+    {
+      "id": "control-orpc-client",
+      "survivor": "codex/control-orpc-client-runtime",
+      "originalBranches": [
+        "branch-a",
+        "branch-b"
+      ],
+      "method": "fold",
+      "status": "planned"
+    }
+  ]
+}
+```
+
+Keep the map close to the workstream record or accounting ledger. It is the
+reviewer's bridge between old local topology and new semantic PRs.

--- a/.agents/skills/graphite-stack-drain/references/restack-planning.md
+++ b/.agents/skills/graphite-stack-drain/references/restack-planning.md
@@ -1,0 +1,71 @@
+# Restack Planning
+
+Treat a meaningful restack as a look-ahead workstream, not a reflex command.
+
+## When To Restack
+
+Restack when:
+
+- a kept stack must absorb updated trunk/main;
+- Graphite submit requires it;
+- a mid-stack edit changed descendants;
+- folding/consolidation is complete and the stack is submit-ready;
+- an owner lane intentionally wants to rebase over newly landed work.
+
+Avoid restack when:
+
+- the stack is a retired source route;
+- the worktree is dirty;
+- the stack belongs to another active owner;
+- you do not know whether source branches are adopted, superseded, or live;
+- the target stack is huge and should be folded first.
+
+## Look-Ahead Checklist
+
+Before `gt restack`:
+
+1. Refresh census with `gt sync --no-restack` and the census script.
+2. Identify the exact stack top and direction (`--downstack` or `--upstack`).
+3. Check dirty worktrees and branch occupancy.
+4. Compare file overlap between the stack and updated trunk or neighboring
+   stacks.
+5. Use patch-overlap for suspected parallel implementations.
+6. Read the relevant commit messages/docs/specs for files likely to conflict.
+7. Name semantic authorities for conflicts: which side owns behavior, schema,
+   domain boundary, tooling, or proof records?
+
+## Conflict Resolution Rules
+
+- Do not resolve by "ours/theirs" unless the conflict is truly mechanical.
+- Preserve intentional behavior from the owning workstream.
+- Translate stale config or API shapes into the current authoritative boundary.
+- Do not reintroduce deprecated files or fields merely because incoming commits
+  touched them.
+- If a conflict repeatedly applies the same transformation, consider whether
+  folding or a scripted rewrite is more efficient.
+- If a branch adds code to an intentionally phased-out surface, either move it
+  to the new owner immediately or record an explicit follow-up for that owner.
+
+## Command Pattern
+
+```bash
+gt sync --no-restack --no-interactive
+gt restack --branch <intended-top> --downstack --no-interactive
+```
+
+If conflicts occur:
+
+1. Resolve the current conflict semantically.
+2. Run focused validation for the touched surface when practical.
+3. Continue the Graphite rebase.
+4. Stop if conflicts reveal a wrong strategy, hidden owner lane, or stale source
+   stack that should be folded or retired instead.
+
+## Closure
+
+After restack:
+
+- `git status --short --branch` is clean.
+- `gt ls --no-interactive` shows expected restack state.
+- Any conflict resolutions are documented in the workstream record or PR body.
+- No unrelated stack was restacked opportunistically.

--- a/.agents/skills/graphite-stack-drain/references/state-model.md
+++ b/.agents/skills/graphite-stack-drain/references/state-model.md
@@ -1,0 +1,84 @@
+# State Model
+
+This skill uses a small state model so operators do not mix together Git facts,
+Graphite facts, PR facts, human accounting, and action plans.
+
+## Baseline Facts
+
+Baseline facts are observed, not decided.
+
+| Axis | Meaning | Source |
+| --- | --- | --- |
+| Git local | Local branch exists and points at a commit. | `git for-each-ref refs/heads` |
+| Git remote | Matching remote branch exists. | `git for-each-ref refs/remotes/origin` |
+| Worktree occupancy | A worktree has this branch checked out or detached at a head. | `git worktree list --porcelain` |
+| Worktree dirtiness | Checked-out files differ from HEAD. | `git status --short --branch --porcelain=v1` |
+| Graphite local tracking | Branch exists in Graphite cache/metadata. | `.git/.graphite_cache_persist` |
+| Graphite parentage | Parent/children according to Graphite metadata. | Graphite cache branch metadata |
+| Graphite restack display | Branch is marked by Graphite as needing restack. | `gt log short --no-interactive` |
+| PR/submission | PR numbers, states, remote submission evidence. | Graphite PR cache, GitHub/Graphite APIs if available |
+
+Display smart defaults. In a local stack view, "local branch exists" and
+"Graphite-tracked locally" are usually default facts and do not need labels
+unless absent. Show labels for meaningful deltas: dirty, detached, remote,
+submitted/open PR, merged/closed PR, needs restack, untracked, or local-only.
+
+## Accounting Overlay
+
+Accounting is sparse and operator-authored. It records moves that matter for
+cleanup or integration; it does not mirror every fact.
+
+### Source-side states
+
+| State | Meaning |
+| --- | --- |
+| `needs-adoption` | Known source work must be handled before cleanup. |
+| `adopted` | Source work was incorporated into a sink. |
+| `superseded` | Source work is intentionally replaced by another branch/stack. |
+| `excluded` | Source work is intentionally not carried forward. |
+| `reference-only` | Source remains useful as historical/context evidence, not as a merge target. |
+
+### Sink-side states
+
+| State | Meaning |
+| --- | --- |
+| `adoption-sink` | Destination branch/stack/mainline that receives accepted source intent. |
+
+Do not use persistent half-states for partial adoption. If only part of a
+source has moved, split the source into smaller branch or stack-slice endpoints
+and record separate `needs-adoption`, `adopted`, `superseded`, or `excluded`
+states for those slices.
+
+Use explicit methods when known:
+
+- `as-is`: source landed without semantic rewrite.
+- `cherry-pick`: a commit or patch was replayed mechanically.
+- `semantic`: behavior/intent was reimplemented or translated.
+- `merge`: landed through the normal Graphite PR/merge path.
+- `drop`: excluded intentionally.
+
+## Actions
+
+Actions are commands or decisions, not states.
+
+| Action | When |
+| --- | --- |
+| `submit` | Branch/stack is ready to create/update PRs. |
+| `merge` | Submitted PRs are ready to merge through Graphite. |
+| `sync-no-restack` | Refresh remote/PR/prune state without opportunistic global restack. |
+| `restack-targeted` | A kept stack must rebase onto updated trunk or parent. |
+| `fold` | A branch should be absorbed into its parent. |
+| `rename-before-submit` | A survivor branch needs a semantic name before PR creation. |
+| `delete-graphite-branch` | A local branch and Graphite metadata are terminally retired. |
+| `remove-worktree` | A checked-out worktree is stale or disposable and blocks cleanup. |
+
+## Forbidden Conflations
+
+- "Merged PR" is not the same as "source adopted" unless the merged PR is the
+  accepted source of record.
+- "Patch equivalent" is evidence, not disposition.
+- "Local-only" is not bad by itself; it only becomes actionable after you know
+  whether the branch is live, submit-ready, superseded, or disposable.
+- "Needs restack" does not mean "safe to restack globally".
+- "Leaf" must mean terminal branch in the Graphite parent tree. If a visible
+  terminal item represents a subtree or mini-stack, name it as a subtree.

--- a/.agents/skills/graphite-stack-drain/references/worktree-hygiene.md
+++ b/.agents/skills/graphite-stack-drain/references/worktree-hygiene.md
@@ -1,0 +1,62 @@
+# Worktree Hygiene
+
+Worktrees are often the difference between a clean Graphite drain and a
+confusing local state explosion.
+
+## Facts
+
+- A worktree is a checkout, not branch ownership.
+- A branch can be checked out in only one worktree at a time.
+- Removing a worktree removes the directory, not the branch or Graphite
+  metadata.
+- Dirty worktrees can hide user work, generated artifacts, conflict leftovers,
+  or another agent's active lane.
+
+## Pre-Mutation Gate
+
+Before any Graphite mutation:
+
+```bash
+git worktree list --porcelain
+git status --short --branch
+```
+
+For every in-scope worktree, answer:
+
+- Which branch is checked out?
+- Is it dirty?
+- Is it detached?
+- Is it part of the target stack, a protected adjacent owner lane, or unrelated
+  clutter?
+- Would it pin a branch Graphite wants to prune/delete?
+
+## Cleanup Choices
+
+| Situation | Action |
+| --- | --- |
+| Clean disposable worktree on an already-retired branch | `git worktree remove <path>` |
+| Dirty worktree with relevant WIP | Commit, stash with explicit message, or hand off before mutation. |
+| Dirty generated artifacts only | Prefer regenerate/clean through repo scripts or stash if owner accepts. |
+| Worktree owned by another active lane | Do not remove; coordinate. |
+| Branch deletion blocked by checkout | Remove/move the worktree only after dirty/ownership checks. |
+
+Use `git worktree remove --force` only when you have already inspected dirty
+state and know no wanted work will be lost.
+
+## Closure
+
+At the end of a drain or cleanup:
+
+```bash
+git worktree list --porcelain
+git status --short --branch
+gt log short --no-interactive
+```
+
+Report:
+
+- remaining worktrees and dirty counts;
+- branches merged/drained;
+- branches intentionally kept live;
+- branches retired/deleted;
+- any branch still pinned by a worktree.

--- a/.agents/skills/graphite-stack-drain/scripts/accounting-compose.mjs
+++ b/.agents/skills/graphite-stack-drain/scripts/accounting-compose.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const moveStates = new Set(["planned", "done"]);
+const moveKinds = new Set(["adopt", "supersede", "exclude", "reference"]);
+const methods = new Set(["as-is", "merge", "cherry-pick", "semantic", "drop"]);
+const endpointKinds = new Set(["branch", "stack-slice", "main", "pr", "external"]);
+
+function parseArgs(argv) {
+  const args = { census: undefined, ledger: undefined, output: undefined };
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--census") args.census = argv[++index];
+    else if (arg === "--ledger") args.ledger = argv[++index];
+    else if (arg === "--output") args.output = argv[++index];
+    else if (arg === "--help" || arg === "-h") {
+      console.log("Usage: accounting-compose.mjs --census census.json --ledger ledger.json [--output PATH]");
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!args.census || !args.ledger) throw new Error("--census and --ledger are required");
+  return args;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(resolve(path), "utf8"));
+}
+
+function assertEndpoint(endpoint, label) {
+  if (!endpoint || typeof endpoint !== "object") throw new Error(`${label} endpoint is missing`);
+  if (!endpointKinds.has(endpoint.kind)) throw new Error(`${label} endpoint has invalid kind: ${endpoint.kind}`);
+  if (endpoint.kind === "branch" && typeof endpoint.branch !== "string") {
+    throw new Error(`${label} branch endpoint requires branch`);
+  }
+  if (endpoint.kind === "stack-slice") {
+    if (typeof endpoint.root !== "string") throw new Error(`${label} stack-slice requires root`);
+    if (endpoint.branches !== undefined && !Array.isArray(endpoint.branches)) {
+      throw new Error(`${label} stack-slice branches must be an array`);
+    }
+  }
+  if (endpoint.kind === "pr" && typeof endpoint.number !== "number") {
+    throw new Error(`${label} pr endpoint requires numeric number`);
+  }
+}
+
+function validateMove(move, index) {
+  const label = `moves[${index}]`;
+  if (!move || typeof move !== "object") throw new Error(`${label} is not an object`);
+  if (typeof move.id !== "string") throw new Error(`${label}.id is required`);
+  if (!moveStates.has(move.state)) throw new Error(`${label}.state is invalid: ${move.state}`);
+  if (!moveKinds.has(move.kind)) throw new Error(`${label}.kind is invalid: ${move.kind}`);
+  if (move.method !== undefined && !methods.has(move.method)) throw new Error(`${label}.method is invalid: ${move.method}`);
+  assertEndpoint(move.source, `${label}.source`);
+  if (move.sink !== undefined) assertEndpoint(move.sink, `${label}.sink`);
+  if (move.kind === "adopt" && !move.sink) throw new Error(`${label} adopt move requires a sink`);
+  return move;
+}
+
+function endpointBranches(endpoint) {
+  if (endpoint.kind === "branch") return [endpoint.branch];
+  if (endpoint.kind === "stack-slice") return Array.isArray(endpoint.branches) ? endpoint.branches : [endpoint.root];
+  if (endpoint.kind === "main") return ["main"];
+  return [];
+}
+
+function labelFor(move, role) {
+  if (role === "sink") return `${move.state}:sink:${move.kind}${move.method ? `:${move.method}` : ""}`;
+  return `${move.state}:source:${move.kind}${move.method ? `:${move.method}` : ""}`;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const census = readJson(args.census);
+  const ledger = readJson(args.ledger);
+  if (!Array.isArray(ledger.moves)) throw new Error("ledger.moves must be an array");
+  const moves = ledger.moves.map(validateMove);
+  const labelsByBranch = new Map();
+  const add = (branch, entry) => {
+    if (!labelsByBranch.has(branch)) labelsByBranch.set(branch, []);
+    labelsByBranch.get(branch).push(entry);
+  };
+  for (const move of moves) {
+    for (const branch of endpointBranches(move.source)) add(branch, { role: "source", moveId: move.id, label: labelFor(move, "source") });
+    if (move.sink) {
+      for (const branch of endpointBranches(move.sink)) add(branch, { role: "sink", moveId: move.id, label: labelFor(move, "sink") });
+    }
+  }
+  const branches = Array.isArray(census.branches)
+    ? census.branches.map((branch) => ({
+        ...branch,
+        accounting: labelsByBranch.get(branch.branch) ?? [],
+      }))
+    : [];
+  const result = {
+    schemaVersion: "graphite-stack-accounting-composed/v1",
+    generatedAt: new Date().toISOString(),
+    censusSchemaVersion: census.schemaVersion,
+    ledgerSchemaVersion: ledger.schemaVersion,
+    totals: {
+      moves: moves.length,
+      branchesWithAccounting: [...labelsByBranch.keys()].length,
+    },
+    moves,
+    branches,
+  };
+  const json = `${JSON.stringify(result, null, 2)}\n`;
+  if (args.output) writeFileSync(resolve(args.output), json);
+  else process.stdout.write(json);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/.agents/skills/graphite-stack-drain/scripts/graphite-stack-census.mjs
+++ b/.agents/skills/graphite-stack-drain/scripts/graphite-stack-census.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function parseArgs(argv) {
+  const args = { repoRoot: process.cwd(), output: undefined };
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--repo-root") args.repoRoot = argv[++index];
+    else if (arg === "--output") args.output = argv[++index];
+    else if (arg === "--help" || arg === "-h") {
+      console.log("Usage: graphite-stack-census.mjs [--repo-root PATH] [--output PATH]");
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function run(command, args, cwd) {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function tryRun(command, args, cwd) {
+  try {
+    return run(command, args, cwd);
+  } catch (error) {
+    return "";
+  }
+}
+
+function parseWorktrees(stdout) {
+  const worktrees = [];
+  let current;
+  const flush = () => {
+    if (current?.path) worktrees.push(current);
+    current = undefined;
+  };
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line) {
+      flush();
+      continue;
+    }
+    if (line.startsWith("worktree ")) {
+      flush();
+      current = { path: line.slice("worktree ".length), detached: false };
+    } else if (current && line.startsWith("HEAD ")) {
+      current.head = line.slice("HEAD ".length);
+    } else if (current && line.startsWith("branch ")) {
+      current.branch = line.slice("branch ".length).replace(/^refs\/heads\//, "");
+    } else if (current && line === "detached") {
+      current.detached = true;
+    }
+  }
+  flush();
+  return worktrees;
+}
+
+function parseStatus(stdout) {
+  const entries = [];
+  let branchLine;
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line) continue;
+    if (line.startsWith("## ")) branchLine = line;
+    else entries.push({ index: line.slice(0, 1), worktree: line.slice(1, 2), path: line.slice(3) });
+  }
+  return { branchLine, dirtyFileCount: entries.length, entries };
+}
+
+function parseRefs(stdout) {
+  const refs = new Map();
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line) continue;
+    const [name, object] = line.split("\t");
+    if (name && object) refs.set(name, object);
+  }
+  return refs;
+}
+
+function parseNeedsRestack(stdout) {
+  const branches = new Set();
+  const ansiPattern = /\x1b\[[0-9;]*m/g;
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.replace(ansiPattern, "");
+    if (!line.includes("(needs restack)")) continue;
+    const before = line.split("(needs restack)", 1)[0]?.trim();
+    const branch = before?.split(/\s+/).at(-1);
+    if (branch) branches.add(branch);
+  }
+  return [...branches].sort();
+}
+
+function parseGraphiteCache(commonDir) {
+  const cachePath = resolve(commonDir, ".graphite_cache_persist");
+  if (!existsSync(cachePath)) {
+    throw new Error(`Graphite cache not found: ${cachePath}`);
+  }
+  const parsed = JSON.parse(readFileSync(cachePath, "utf8"));
+  if (!Array.isArray(parsed.branches)) {
+    throw new Error("Unsupported Graphite cache shape: missing branches array");
+  }
+  const branches = new Map();
+  for (const entry of parsed.branches) {
+    if (!Array.isArray(entry) || typeof entry[0] !== "string" || typeof entry[1] !== "object") {
+      throw new Error("Unsupported Graphite cache branch entry shape");
+    }
+    branches.set(entry[0], entry[1] ?? {});
+  }
+  return { sha: typeof parsed.sha === "string" ? parsed.sha : undefined, branches };
+}
+
+function readPrInfo(commonDir) {
+  const prPath = resolve(commonDir, ".graphite_pr_info");
+  if (!existsSync(prPath)) return undefined;
+  try {
+    return JSON.parse(readFileSync(prPath, "utf8"));
+  } catch {
+    return { parseError: true };
+  }
+}
+
+function buildChildren(branches) {
+  const children = new Map();
+  const parent = new Map();
+  for (const [branch, meta] of branches) {
+    if (!children.has(branch)) children.set(branch, new Set());
+    if (typeof meta.parentBranchName === "string") {
+      parent.set(branch, meta.parentBranchName);
+      if (!children.has(meta.parentBranchName)) children.set(meta.parentBranchName, new Set());
+      children.get(meta.parentBranchName).add(branch);
+    }
+  }
+  return {
+    parent,
+    children: new Map([...children].map(([key, value]) => [key, [...value].sort()])),
+  };
+}
+
+function traverse(root, children) {
+  const nodes = [];
+  const stack = [root];
+  const seen = new Set();
+  while (stack.length > 0) {
+    const branch = stack.pop();
+    if (!branch || seen.has(branch)) continue;
+    seen.add(branch);
+    nodes.push(branch);
+    for (const child of [...(children.get(branch) ?? [])].reverse()) stack.push(child);
+  }
+  return nodes;
+}
+
+function summarizeRoot(root, children) {
+  const nodes = traverse(root, children);
+  const splits = nodes.filter((branch) => (children.get(branch) ?? []).length > 1);
+  const leaves = nodes.filter((branch) => (children.get(branch) ?? []).length === 0);
+  return {
+    root,
+    branchCount: nodes.length,
+    splitCount: splits.length,
+    leafCount: leaves.length,
+    splits: splits.map((branch) => ({ branch, children: children.get(branch) ?? [] })),
+    leaves,
+    nodes,
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const repoRoot = resolve(args.repoRoot);
+  const topLevel = run("git", ["rev-parse", "--show-toplevel"], repoRoot).trim();
+  const commonDirRaw = run("git", ["rev-parse", "--git-common-dir"], topLevel).trim();
+  const commonDir = resolve(topLevel, commonDirRaw);
+  const head = run("git", ["rev-parse", "HEAD"], topLevel).trim();
+  const currentBranch = run("git", ["branch", "--show-current"], topLevel).trim();
+  const cache = parseGraphiteCache(commonDir);
+  const prInfo = readPrInfo(commonDir);
+  const graph = buildChildren(cache.branches);
+  const localRefs = parseRefs(run("git", ["for-each-ref", "refs/heads", "--format=%(refname:short)%09%(objectname)"], topLevel));
+  const remoteRefs = parseRefs(tryRun("git", ["for-each-ref", "refs/remotes/origin", "--format=%(refname:short)%09%(objectname)"], topLevel));
+  const worktrees = parseWorktrees(run("git", ["worktree", "list", "--porcelain"], topLevel)).map((worktree) => ({
+    ...worktree,
+    status: existsSync(worktree.path) ? parseStatus(tryRun("git", ["status", "--short", "--branch", "--porcelain=v1"], worktree.path)) : undefined,
+  }));
+  const worktreesByBranch = new Map();
+  for (const worktree of worktrees) {
+    if (!worktree.branch) continue;
+    if (!worktreesByBranch.has(worktree.branch)) worktreesByBranch.set(worktree.branch, []);
+    worktreesByBranch.get(worktree.branch).push(worktree.path);
+  }
+  const needsRestack = parseNeedsRestack(tryRun("gt", ["log", "short", "--no-interactive"], topLevel));
+  const needsRestackSet = new Set(needsRestack);
+  const trunk = cache.branches.has("main") ? "main" : currentBranch;
+  const rootNames = (graph.children.get(trunk) ?? []).filter((branch) => cache.branches.has(branch));
+  const roots = rootNames.map((root) => summarizeRoot(root, graph.children));
+  const covered = new Set([trunk]);
+  for (const root of roots) for (const node of root.nodes) covered.add(node);
+  const outsideRootModel = [...cache.branches.keys()].filter((branch) => !covered.has(branch)).sort();
+  const branches = [...cache.branches.entries()]
+    .map(([branch, meta]) => ({
+      branch,
+      head: localRefs.get(branch) ?? meta.branchRevision,
+      local: localRefs.has(branch),
+      remote: remoteRefs.has(`origin/${branch}`),
+      graphiteTracked: true,
+      graphiteValidation: meta.validationResult,
+      parent: graph.parent.get(branch),
+      children: graph.children.get(branch) ?? [],
+      needsRestack: needsRestackSet.has(branch),
+      worktrees: worktreesByBranch.get(branch) ?? [],
+    }))
+    .sort((a, b) => a.branch.localeCompare(b.branch));
+
+  const result = {
+    schemaVersion: "graphite-stack-census/v1",
+    generatedAt: new Date().toISOString(),
+    repo: { topLevel, commonDir, head, currentBranch, graphiteCacheSha: cache.sha },
+    totals: {
+      graphiteBranches: cache.branches.size,
+      localBranches: localRefs.size,
+      remoteBranches: remoteRefs.size,
+      worktrees: worktrees.length,
+      dirtyWorktrees: worktrees.filter((worktree) => (worktree.status?.dirtyFileCount ?? 0) > 0).length,
+      rootStacks: roots.length,
+      outsideRootModel: outsideRootModel.length,
+      needsRestack: needsRestack.length,
+    },
+    roots,
+    outsideRootModel,
+    needsRestack,
+    branches,
+    worktrees,
+    prInfo,
+  };
+
+  const json = `${JSON.stringify(result, null, 2)}\n`;
+  if (args.output) {
+    const output = resolve(args.output);
+    writeFileSync(output, json);
+    console.error(`Wrote ${output}`);
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/.agents/skills/graphite-stack-drain/scripts/patch-overlap.mjs
+++ b/.agents/skills/graphite-stack-drain/scripts/patch-overlap.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function parseArgs(argv) {
+  const args = { repoRoot: process.cwd(), output: undefined, left: undefined, right: undefined };
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--repo-root") args.repoRoot = argv[++index];
+    else if (arg === "--left") args.left = argv[++index];
+    else if (arg === "--right") args.right = argv[++index];
+    else if (arg === "--output") args.output = argv[++index];
+    else if (arg === "--help" || arg === "-h") {
+      console.log("Usage: patch-overlap.mjs --left BRANCH --right BRANCH [--repo-root PATH] [--output PATH]");
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!args.left || !args.right) throw new Error("--left and --right are required");
+  return args;
+}
+
+function run(command, args, cwd) {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function lines(stdout) {
+  return stdout.split(/\r?\n/).filter(Boolean);
+}
+
+function cherry(upstream, head, cwd) {
+  return lines(run("git", ["cherry", "-v", upstream, head], cwd)).map((line) => ({
+    equivalent: line.startsWith("-"),
+    sha: line.slice(2, 42),
+    subject: line.slice(43),
+  }));
+}
+
+function changedFiles(base, branch, cwd) {
+  return new Set(lines(run("git", ["diff", "--name-only", `${base}..${branch}`], cwd)));
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const repoRoot = resolve(args.repoRoot);
+  const mergeBase = run("git", ["merge-base", args.left, args.right], repoRoot).trim();
+  const [leftAhead, rightAhead] = run("git", ["rev-list", "--left-right", "--count", `${args.left}...${args.right}`], repoRoot)
+    .trim()
+    .split(/\s+/)
+    .map((value) => Number.parseInt(value, 10));
+  const leftFiles = changedFiles(mergeBase, args.left, repoRoot);
+  const rightFiles = changedFiles(mergeBase, args.right, repoRoot);
+  const overlappingFiles = [...leftFiles].filter((file) => rightFiles.has(file)).sort();
+  const leftCherry = cherry(args.right, args.left, repoRoot);
+  const rightCherry = cherry(args.left, args.right, repoRoot);
+  const result = {
+    schemaVersion: "graphite-stack-patch-overlap/v1",
+    generatedAt: new Date().toISOString(),
+    repoRoot,
+    left: args.left,
+    right: args.right,
+    mergeBase,
+    aheadBehind: { leftAhead, rightAhead },
+    patchEquivalent: {
+      leftEquivalentToRight: leftCherry.filter((commit) => commit.equivalent).length,
+      rightEquivalentToLeft: rightCherry.filter((commit) => commit.equivalent).length,
+    },
+    commits: {
+      leftOnly: leftCherry,
+      rightOnly: rightCherry,
+    },
+    files: {
+      leftChanged: leftFiles.size,
+      rightChanged: rightFiles.size,
+      overlapCount: overlappingFiles.length,
+      overlappingFiles,
+    },
+  };
+  const json = `${JSON.stringify(result, null, 2)}\n`;
+  if (args.output) {
+    writeFileSync(resolve(args.output), json);
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}


### PR DESCRIPTION
Adds a new `graphite-stack-drain` agent skill for managing complex Graphite stack and worktree cleanup operations.

The skill provides a structured approach to Graphite topology problems — situations where the goal is not making a code change but making the stack state sane. It separates three concerns: **facts** (Git refs, worktrees, Graphite cache parentage, PR diagnostics), **accounting** (explicit operator-authored source/sink moves and terminal dispositions), and **actions** (submit, merge, fold, restack, delete, retire).

Core reference documents cover:
- **State model**: vocabulary for facts, accounting overlay states (`needs-adoption`, `adopted`, `superseded`, `excluded`, `reference-only`), and forbidden conflations between PR state, patch equivalence, and accounting decisions
- **Deterministic inspection**: repeatable census procedure using Graphite cache parentage as the topology source rather than `gt ls` ASCII layout
- **Drain loop**: canonical RAWR loop (`gt ss → gt merge → gt sync --no-restack`) with explicit guards against global restacks and manual branch deletion as a normal path
- **Folding and consolidation**: when and how to collapse over-atomized local-only stacks into semantic survivor branches before publishing
- **Restack planning**: look-ahead checklist and semantic conflict resolution rules
- **Cleanup and retirement**: branch deletion classes, worktree removal gates, and concrete terminal labels replacing ambiguous ones like `parked` or `retain`
- **Worktree hygiene**: pre-mutation gate requiring dirty/ownership checks before any topology mutation
- **Adversarial review lanes**: four review lanes (accuracy, operational usefulness, clarity, quality) with a ready-to-send auditor prompt for peer agent review
- **Failure patterns**: recurring topology, state model, and execution mistakes with recovery signals

Three helper scripts are included:
- `graphite-stack-census.mjs`: reads Git and Graphite cache facts and emits structured JSON covering stack roots, splits, leaves, worktree occupancy, dirty state, restack markers, and PR info
- `patch-overlap.mjs`: compares two branches for ahead/behind counts, patch-equivalent commits, and file overlap to support adoption accounting decisions
- `accounting-compose.mjs`: validates a sparse accounting ledger and projects source/sink labels onto a census snapshot

An accounting ledger template is provided as a starting point for recording source-to-sink moves with SHA anchors and disposition methods.