### PR TITLE
docs(agents): restore civ7-orpc-control-architecture skill, updated to the implemented layer

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -17,6 +17,7 @@ discipline; they should not duplicate the packet as a parallel spec.
 | `civ7-open-spec-workstream` | Running a bounded spec/workstream phase from authority grounding through implementation, verification, downstream realignment, and handoff. |
 | `civ7-systematic-workstream` | Running a systematic, evidence-grounded domain workstream that needs full corpus extraction, expected ranges, architecture-aligned strategies, local statistics, runtime proof, peer review, and clean Graphite closure. |
 | `civ7-operational-debugging` | Debugging build/deploy/log/in-game evidence across generated mod output, deployed Civ7 Mods folders, official resources, and proof boundaries. |
+| `civ7-orpc-control-architecture` | Designing or reviewing oRPC/Effect procedure, router, middleware, and context surfaces for Civ7 direct-control, CLI game/play commands, Studio endpoints, and live-play support refactors (`@civ7/control-orpc`). |
 | `dra-structural-watcher` | Running or setting up a separate watcher DRA for OpenSpec workstreams: heartbeat/cron monitoring, NOTE-TO-DRA scans, correction logs, closure-drift checks, and branch/stack watcher passes without owning implementation. |
 | `graphite-stack-drain` | Managing complex Graphite stack/worktree cleanup: deterministic stack census, source/sink accounting, folding over-atomized stacks, targeted restacks, submit/merge drains, and safe branch/worktree retirement. |
 

--- a/.agents/skills/civ7-orpc-control-architecture/SKILL.md
+++ b/.agents/skills/civ7-orpc-control-architecture/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: civ7-orpc-control-architecture
+description: |
+  Use in the Civ7 Modding Tools repo before designing, refactoring, or reviewing oRPC/ORPC surfaces for Civ7 direct-control, CLI game/play commands, Studio Civ7 endpoints, tuner control procedures, in-process procedure routing, context/middleware policy, OpenAPI/RPC exposure, or contract-first control APIs. Trigger phrases include "ORPC direct-control", "oRPC game command", "direct-control router", "procedure map for Civ7 control", "Civ7 control API", "middleware for verification", and "context for Civ7 runtime".
+---
+
+# Civ7 ORPC Control Architecture
+
+## Purpose
+
+Use this skill before adding or reshaping oRPC surfaces for Civ7 play/control
+support. The frame is: oRPC is a typed procedure/router/context layer over
+repo-owned control capabilities; it is not the authority for Civ7 runtime
+behavior and it is not a replacement transport for `@civ7/direct-control`.
+
+This layer is IMPLEMENTED: `@civ7/control-orpc`
+(`packages/civ7-control-orpc`) is the native oRPC+Effect procedure
+composition over direct-control atoms — contract-first TypeBox schemas
+(`toStandardSchema`), `effect-orpc`'s `implementEffect` with a shared
+`ManagedRuntime`, procedures written as Effect generators, a typed error map,
+and correlation/safe-error middleware. New control surfaces extend that
+package; do not start a parallel oRPC layer or hand-roll orchestration in
+plain async.
+
+## When To Use
+
+- Designing an oRPC contract, router, procedure, handler, or server-side client
+  for Civ7 runtime control.
+- Refactoring CLI game/play commands or Studio Civ7 endpoints toward shared
+  procedures with the right caller boundary.
+- Moving verification, approval, relationship-label policy, readiness, or proof
+  boundaries into typed middleware/context.
+- Reviewing whether a proposed ORPC slice preserves direct-control package
+  ownership and active live-play safety.
+
+## Non-Goals
+
+- Do not expose arbitrary `game exec` JavaScript as an oRPC procedure.
+- Do not move raw tuner socket framing, reconnect polling, App UI/Tuner state
+  discovery, or generated command strings into caller-local code.
+- Do not make HTTP/OpenAPI shape the product authority. Transports mount at the
+  edge after the shared procedure/router core is coherent.
+- Do not treat oRPC tests, TypeScript checks, or generated schemas as in-game
+  proof.
+
+## Default Workflow
+
+1. **Ground authority.** Read root `AGENTS.md`, the closest package router, and
+   the Civ7 architecture/product authority skills.
+2. **Name the capability.** Identify the repo-owned behavior: runtime read,
+   mutating operation, live-play decision view, Studio endpoint, or CLI command
+   orchestration.
+3. **Choose the procedure atom.** Procedures should be the smallest complete
+   behavior with a stable input, output, risk level, and proof boundary.
+4. **Place context.** Put dependencies in context: direct-control facade,
+   endpoint defaults, timeout, logger/proof sink, clock, approval policy, live
+   session policy, and test doubles.
+5. **Place middleware.** Use middleware for reusable policy: readiness,
+   approval, validator-first mutation gates, proof recording, relationship-label
+   authority, error normalization, bounded polling, and live-mutation guards.
+6. **Compose routers by operational surface.** Extend the existing
+   `src/modules/*` families (`attention`, `city`, `diplomacy`, `display`,
+   `government`, `narrative`, `notifications`, `progression`, `readiness`,
+   `strategy`, `turn`, `unit`, `world`, ...) over broad `control.call`
+   routers; a new family mirrors the module template
+   (`contract.ts` + `router.ts` + `procedures/`).
+7. **Choose the caller boundary deliberately.** CLI/tests use the in-process
+   typed client: `createCiv7ControlOrpcServerClient({ directControl:
+   liveCiv7ControlOrpcDirectControlFacade, endpointDefaults })` (live facade
+   from `@civ7/control-orpc/runtime`). Studio browser clients should call
+   the same router over HTTP through `RPCHandler`/`RPCLink`; Studio server
+   code may call in-process when no browser boundary is crossed. OpenAPI
+   remains for external/documented consumers, not the Civ7 Studio control
+   loop.
+8. **Verify in layers.** Run no-network procedure tests, CLI/Studio integration
+   tests for changed callers, direct-control checks/builds, and live read-only
+   smoke when a claim depends on the running game.
+
+## Reference Map
+
+| Reference | Path | Open When |
+|---|---|---|
+| ORPC server shape | `references/orpc-server-shape.md` | You need the exact official oRPC concepts to apply: procedure, router, middleware, context, server-side calls, tests. |
+| Civ7 procedure map | `references/civ7-procedure-map.md` | You are mapping direct-control/CLI/Studio behavior into procedure/router/context/middleware atoms. |
+| Migration gates | `references/migration-gates.md` | You are planning an incremental slice or deciding what tests/proof must pass before handoff. |
+| Failure patterns | `references/failure-patterns.md` | A proposed oRPC refactor smells like a wrapper, broad transport, unsafe mutation, or relationship-authority leak. |
+
+## Asset Map
+
+| Asset | Path | Use When |
+|---|---|---|
+| Procedure slice preflight | `assets/procedure-slice-preflight.md` | Copy into a project/spec note before implementing an ORPC control slice. |
+
+## Core Invariants
+
+<invariants>
+<invariant name="direct-control-owns-runtime">`@civ7/direct-control` owns tuner socket framing, state discovery, reconnect polling, runtime wrappers, approval enforcement, and capability catalog evidence. Its functions stay plain-async WIRE ATOMS (ideally one exec each).</invariant>
+<invariant name="orchestration-lives-in-effect-layer">Multi-step async flows over the atoms (state machines, drain/poll loops, suspend/resume lifecycles, retries, schedules) are Effect procedures in `@civ7/control-orpc` — use `Effect.acquireUseRelease`/`Effect.ensuring` for guaranteed cleanup and `Effect.iterate`/`Schedule` for loops, never hand-rolled try/finally orchestrators inside direct-control (live lesson: D10, cli-command-taxonomy workstream).</invariant>
+<invariant name="orpc-is-procedure-composition">oRPC organizes typed procedures, routers, context, middleware, and optional edge handlers. It does not redefine Civ7 runtime truth.</invariant>
+<invariant name="shared-core-caller-boundary">Design the shared procedure/router core first. CLI and tests can call it in-process; Studio browser clients cross the web boundary with RPC over HTTP (`RPCHandler`/`RPCLink`).</invariant>
+<invariant name="middleware-guards-mutations">Mutating procedures require explicit approval, validator evidence where available, and postcondition/proof classification through shared middleware or shared procedure helpers.</invariant>
+<invariant name="context-not-globals">Provision runtime dependencies through typed context. Do not smuggle host/port/session/approval/logger state through globals or ad hoc command flags inside handlers.</invariant>
+<invariant name="relationship-authority-is-structural">Owner mismatch, contact, proximity, or attack legality is not hostile/enemy/opponent/threat/non-friendly proof without official relationship, team, war, suzerain, or equivalent validator evidence.</invariant>
+<invariant name="proof-boundaries-stay-labeled">Unit tests, oRPC procedure calls, handler tests, CLI tests, package builds, and live game smoke prove different things. Close claims with the strongest evidence actually collected.</invariant>
+</invariants>
+
+## Quick Start
+
+1. Open `references/orpc-server-shape.md`.
+2. Open `references/civ7-procedure-map.md` for the affected surface.
+3. Copy `assets/procedure-slice-preflight.md` into the project note if the slice
+   will be implemented.
+4. Run `references/migration-gates.md` before handoff.
+5. Check `references/failure-patterns.md` during review.

--- a/.agents/skills/civ7-orpc-control-architecture/assets/procedure-slice-preflight.md
+++ b/.agents/skills/civ7-orpc-control-architecture/assets/procedure-slice-preflight.md
@@ -1,0 +1,51 @@
+# Civ7 ORPC Procedure Slice Preflight
+
+## Frame
+
+- Capability:
+- Owning package/module:
+- Current CLI/Studio callers:
+- Procedure atom:
+- Router:
+- Risk class:
+- Proof boundary:
+
+## Selection
+
+- In:
+- Foreground:
+- Exterior:
+- Would force a reframe:
+
+## Context
+
+- Required direct-control dependencies:
+- Endpoint/session fields:
+- Approval fields:
+- Logger/evidence fields:
+- Test doubles:
+
+## Middleware
+
+- Readiness:
+- Approval:
+- Validator/preflight:
+- Postcondition/proof:
+- Relationship authority:
+- Error normalization:
+
+## Verification Gates
+
+- Direct-control:
+- CLI/Studio:
+- ORPC no-network:
+- Contract snapshot:
+- Live read-only smoke:
+- Live mutation smoke, if explicitly authorized:
+
+## Handoff Claim
+
+- Implemented:
+- Verified:
+- Not verified:
+- Deferred:

--- a/.agents/skills/civ7-orpc-control-architecture/references/civ7-procedure-map.md
+++ b/.agents/skills/civ7-orpc-control-architecture/references/civ7-procedure-map.md
@@ -1,0 +1,89 @@
+# Civ7 Procedure Map
+
+## Owning Boundaries
+
+- `@civ7/direct-control` owns Civ7 runtime control wrappers, tuner/App UI state
+  selection, socket framing, reconnect behavior, official runtime reads, approval
+  enforcement, and postcondition/proof helpers. Keep its functions wire ATOMS
+  (one exec each, plain async, dependency-injected for tests).
+- `@civ7/control-orpc` (`packages/civ7-control-orpc`) owns procedure
+  composition AND orchestration: contracts, routers, typed errors, middleware,
+  and any multi-step flow over the atoms, written as Effect procedures
+  (`implementEffect` from `effect-orpc`, shared `ManagedRuntime`). The
+  direct-control facade (`Civ7ControlOrpcDirectControlFacade` in
+  `src/dependencies/direct-control.ts`, live implementation exported from
+  `@civ7/control-orpc/runtime`) is the only path from procedures to the atoms;
+  adding a facade member also requires the `src/game-ui.ts` facade to satisfy
+  the type (not-supported stubs are acceptable there).
+- CLI owns command names, flags, examples, compact/full output, and shell-facing
+  orchestration. It consumes procedures via
+  `createCiv7ControlOrpcServerClient` — it must not import orchestration from
+  direct-control or hand-roll fetch/exec flows.
+- Studio/app endpoints own app-specific routing and presentation, but should
+  consume the same shared procedure router instead of growing parallel Civ7
+  control routers. Browser clients should reach that router through a server
+  HTTP `RPCHandler` and client `RPCLink`; Studio server-side code may use
+  in-process calls when no browser boundary is involved.
+
+## Procedure Families
+
+These module families exist under `packages/civ7-control-orpc/src/modules/`
+(each is `contract.ts` + `router.ts` + `procedures/`); extend them or mirror
+the template for a new family.
+
+| Module | Covers | Notes |
+|---|---|---|
+| `readiness` | direct-control/tuner/playable readiness | Read-only diagnostics. |
+| `world` | world/grid/current reads | Bound inputs to avoid accidental huge reads. |
+| `display` | `display.queue.current`, `display.queue.close`, `display.explore.request` | DisplayQueueManager substrate; explore is the reference Effect orchestration (acquire/release suspend→grant→drain→resume→release). |
+| `notifications` | read/dismiss flows | Separate exact closeout, bulk scheduling, and popup closeout. |
+| `attention` | attention priorities | Read-only planning evidence. |
+| `city` | production, population, town focus, expansion | Keep validators and postconditions close to the procedure. |
+| `unit` | unit commands/targets/operations | Relationship labels remain neutral unless official proof exists. |
+| `diplomacy` | diplomacy/first-meet responses | Mutations need proof classification. |
+| `government` / `narrative` / `progression` | choice surfaces | Choice sends need postcondition classification; options are read-only. |
+| `strategy` | fronts, priorities, dashboards | Read-only planning evidence; never mutation authority. |
+| `turn` | turn flow | High-risk; explicit policy context. |
+
+Procedure keys are dot-paths (`display.explore.request`), each with meta
+(`family`, risk class) and entries in the shared error map
+(`civ7ControlOrpcErrorMap` in `src/errors.ts` — typed `ORPCTaggedError`
+classes with TypeBox data schemas carrying
+`{procedureKey, source, correlationId?}`).
+
+## Context Shape
+
+The implemented context (`Civ7ControlOrpcContext` in `src/context.ts`) carries
+the direct-control facade, endpoint defaults
+(`{ host?, port?, timeoutMs? }`), and optional correlation
+(`{ correlationId? }`, validated by the correlation middleware and echoed in
+error data). Procedures read it as `context.directControl`,
+`context.endpointDefaults`, and `civ7ControlOrpcErrorCorrelationData(context)`.
+Approval/risk policy lives in `src/policy` and procedure meta rather than
+free-form context fields.
+
+Do not require HTTP headers, cookies, or framework request objects for the core
+procedure context or in-process CLI/test calls. Add request-specific values only
+in edge handlers, including the Studio `RPCHandler` bridge when the browser
+client calls through `RPCLink`.
+
+## Middleware
+
+Implemented (in `src/middleware/`): correlation-id validation and safe-error
+normalization apply to every procedure; the mutation proof-boundary middleware
+(`civ7ControlOrpcMutationProcedure`) is OPT-IN per procedure and requires a
+`postcondition/status/nextSteps` output shape — use it when the mutation's
+contract carries those fields, skip it (with meta `risk: "mutation"` still
+set) when the output is a domain-specific report.
+
+Still-candidate policy for future middleware: readiness assertions per state
+surface, validator-first dry runs, relationship-label authority (blocks
+hostile/enemy/opponent/threat labels without official
+relationship/team/war/suzerain evidence), and evidence sinks.
+
+## Atomicity Rule
+
+A procedure atom is complete when it has stable input, stable output,
+risk/approval policy, proof boundary, and tests. If a procedure requires callers
+to remember a hidden preflight or postcondition step, the atom is too small or
+the middleware composition is incomplete.

--- a/.agents/skills/civ7-orpc-control-architecture/references/failure-patterns.md
+++ b/.agents/skills/civ7-orpc-control-architecture/references/failure-patterns.md
@@ -1,0 +1,82 @@
+# Failure Patterns
+
+## Generic Router Wrapper
+
+**Symptom:** a router exposes `control.call`, `operation.any`, or raw command
+strings.
+
+**Why It Fails:** it preserves the current command/transport tangle and removes
+procedure identity. Policy and tests cannot attach to meaningful atoms.
+
+**Fix:** name stable procedure keys by capability, risk, and proof boundary.
+
+## Runtime Authority Leak
+
+**Symptom:** oRPC handlers open sockets, select tuner states, or build raw
+App UI/Tuner scripts outside `@civ7/direct-control`.
+
+**Why It Fails:** callers become runtime transport owners and the repo loses the
+central package boundary.
+
+**Fix:** keep handlers thin over direct-control facades or extracted package
+modules.
+
+## Orchestration In The Atom Layer
+
+**Symptom:** a direct-control function grows a multi-step async flow — a
+suspend/resume lifecycle, a drain/poll loop, retries, a hand-rolled
+try/finally state machine over several execs.
+
+**Why It Fails:** it bypasses the Effect layer the repo standardized on, so
+cleanup guarantees, schedules, typed errors, and procedure-level tests are
+reimplemented ad hoc — and CLI callers end up importing orchestration from
+the wrong package (live lesson: the explore orchestrator was first built in
+direct-control and had to be migrated; D10 in the cli-command-taxonomy
+workstream record).
+
+**Fix:** keep direct-control functions one-exec wire atoms; home the flow in
+`@civ7/control-orpc` as an Effect procedure (`Effect.acquireUseRelease` for
+guaranteed cleanup, `Effect.iterate`/`Schedule` for loops) and route the CLI
+through the typed server client.
+
+## Middleware As Approval Laundering
+
+**Symptom:** middleware auto-adds approval or turns missing approval into a
+default reason.
+
+**Why It Fails:** mutation risk becomes invisible at the call site.
+
+**Fix:** middleware may validate and record approval; it must not invent it.
+
+## Transport-First Drift
+
+**Symptom:** REST path aesthetics, RPC URL shape, or frontend route convenience
+drive procedure shape before the shared behavior is stable.
+
+**Why It Fails:** the external transport becomes product authority.
+
+**Fix:** design the shared router/procedure core first; then expose it through
+the caller boundary that fits the caller. CLI/tests can call in-process. Studio
+browser clients should use HTTP `RPCHandler`/`RPCLink`. OpenAPI should be a
+separate external/documented edge.
+
+## Relationship Label Regression
+
+**Symptom:** a planning or battlefield procedure emits hostile/enemy/opponent/
+threat/non-friendly because owner ids differ, units are near us, or an attack
+operation appears legal.
+
+**Why It Fails:** those facts are contact/validator evidence, not relationship
+proof.
+
+**Fix:** enforce neutral labels in procedure output or middleware until official
+relationship, team, war, suzerain, or equivalent validator evidence exists.
+
+## Proof Inflation
+
+**Symptom:** a passing ORPC test or CLI test is described as in-game verified.
+
+**Why It Fails:** procedure tests prove local behavior, not Civ7 runtime state.
+
+**Fix:** close with evidence-scoped labels and require live smoke for live-game
+claims.

--- a/.agents/skills/civ7-orpc-control-architecture/references/migration-gates.md
+++ b/.agents/skills/civ7-orpc-control-architecture/references/migration-gates.md
@@ -1,0 +1,62 @@
+# Migration Gates
+
+## Incremental Path
+
+1. **Inventory the current wrapper.** Name the direct-control function, CLI
+   command, tests, docs, risk class, and live proof boundary.
+2. **Extract a procedure atom without changing callers.** Add schemas/context
+   and no-network tests around existing direct-control behavior.
+3. **Route one caller through the procedure.** Prefer one CLI command or one
+   Studio endpoint. Keep output contract stable unless the product change is
+   intentional and documented.
+4. **Centralize repeated policy.** Only after at least two procedure atoms share
+   the same guard should it become middleware.
+5. **Add edge handlers last.** Mount RPC/OpenAPI only after in-process callers
+   and tests prove the router shape.
+
+## Required Gates By Slice
+
+For any direct-control package change:
+
+- `bun run --cwd packages/civ7-direct-control check`
+- package tests if present or touched
+- build/export verification when CLI imports changed symbols
+
+For any CLI game/play command change:
+
+- focused CLI tests for the changed command and adjacent scheduler/priority
+  behavior
+- `bun run --cwd packages/cli check`
+- broader `game.play.test.ts` gate when shared output, notification scheduling,
+  postconditions, or relationship labels are affected
+
+For any `@civ7/control-orpc` contract/router/procedure change:
+
+- `bun run --cwd packages/civ7-control-orpc check` (includes the contract
+  ownership guard), `build`, and `test`
+- no-network procedure tests with a fake direct-control facade (see
+  `test/display-explore-procedure.test.ts` for the lifecycle-ordering
+  pattern: assert the facade call sequence, the failure paths, and that
+  cleanup ran)
+- contract meta + error-map coverage for every new procedure key
+- dependency review for new `@orpc/*` / `effect` packages
+
+For live-game claims:
+
+- read-only smoke before mutation guidance
+- mutation smoke only when explicitly authorized and scoped to the current
+  player/game state
+- final claim labeled as unit-tested, type-checked, built, CLI-verified,
+  live-read, or live-mutated
+
+## Stop Conditions
+
+Stop and ask or nudge the owning thread if:
+
+- a caller imports a new direct-control symbol that package exports/builds do
+  not expose;
+- middleware hides mutation approval instead of requiring it;
+- a router exposes broad arbitrary runtime execution;
+- a relationship/city-state label becomes hostile/enemy/opponent/threat without
+  official proof;
+- tests prove only TypeScript shape but the handoff claims live game behavior.

--- a/.agents/skills/civ7-orpc-control-architecture/references/orpc-server-shape.md
+++ b/.agents/skills/civ7-orpc-control-architecture/references/orpc-server-shape.md
@@ -1,0 +1,92 @@
+# ORPC Server Shape
+
+## Version And Source Posture
+
+Official docs were checked on 2026-06-02. The current npm version observed for
+`@orpc/server`, `@orpc/client`, and `@orpc/openapi` was `1.14.4`.
+Re-check versions and official docs before implementation because oRPC moves
+quickly.
+
+Primary official docs:
+
+- Procedure: https://orpc.dev/docs/procedure
+- Router: https://orpc.dev/docs/router
+- Middleware: https://orpc.dev/docs/middleware
+- Context: https://orpc.dev/docs/context
+- RPC handler: https://orpc.dev/docs/rpc-handler
+- RPC link: https://orpc.dev/docs/client/rpc-link
+- Server-side clients: https://orpc.dev/docs/client/server-side
+- Testing and mocking: https://orpc.dev/docs/advanced/testing-mocking
+
+## Concepts To Apply
+
+**Procedure:** a typed function-like unit with optional input/output validation,
+middleware, dependency injection, handler logic, and callable/server-action
+helpers. Only `.handler` is required, but Civ7 control procedures should usually
+declare input/output shape explicitly to keep command/API drift visible.
+
+**Router:** a plain, nestable object of procedures. Routers can be wrapped with
+middleware, but do not apply the same middleware at router and procedure levels
+without checking for duplicate execution.
+
+**Middleware:** reusable code that calls `next`, can run before/after a handler,
+can inject or guard context, can inspect typed input, can modify output, and can
+be concatenated/mapped. This is the right place for repeated Civ7 policy:
+readiness, approval, validator-first mutation, proof collection, relationship
+label authority, and error normalization.
+
+**Context:** type-safe dependency injection. Initial context is passed by the
+caller/handler invocation; execution context is computed during procedure
+execution, usually via middleware. For Civ7, use context for direct-control
+facades, endpoint defaults, live-session policy, approval metadata, logger/proof
+sinks, clocks, and fakes.
+
+**Server-side clients:** oRPC supports local procedure invocation without a
+network proxy using `.callable`, `call`, and `createRouterClient`. This is the
+default migration target for CLI, tests, and Studio server-side code that does
+not cross a browser/network boundary.
+
+**RPC HTTP boundary:** oRPC also supports `RPCHandler` plus `RPCLink` over
+HTTP/Fetch. This is the natural Studio browser-to-server boundary: the browser
+gets a typed client, the server keeps the same router/procedure policy, and the
+runtime direct-control surface stays server-side.
+
+**Testing/mocking:** official docs support direct procedure invocation in tests
+and alternative implementations through the implementer. Use this to test
+procedure atoms with fake direct-control dependencies before wiring CLI/Studio
+callers.
+
+## In-Repo Implementation (effect-orpc)
+
+`packages/civ7-control-orpc` realizes these concepts through `effect-orpc`,
+which lets procedures be Effect programs instead of plain async handlers:
+
+- **Implementer:** `src/procedure.ts` builds
+  `implementEffect(Civ7ControlOrpcContract, civ7ControlOrpcEffectRuntime)
+  .$context<...>()` over a shared `ManagedRuntime` (currently
+  `Layer.empty` — note this means a `TestClock` cannot be injected in tests
+  without restructuring the implementer; time-driven tests run on the real
+  clock at schema-minimum intervals).
+- **Procedures:** `civ7ControlOrpcImplementer.<key>.effect(function* ({
+  context, errors, input }) { ... })` — facade calls wrapped in
+  `Effect.tryPromise({ try, catch: () => errors.SOME_CODE({ data }) })`.
+- **Contracts:** contract-first TypeBox schemas bridged via
+  `toStandardSchema` (`src/typebox-standard-schema.ts`); typed error classes
+  via `ORPCTaggedError` registered in `civ7ControlOrpcErrorMap`.
+- **Lifecycles:** multi-step flows use `Effect.acquireUseRelease` /
+  `Effect.ensuring` for guaranteed cleanup and `Effect.iterate` /
+  `Schedule` for loops (reference implementation:
+  `src/modules/display/procedures/explore-request.ts`).
+- **Effect's library is in-bounds:** queues, schedules, PubSub, `Ref`,
+  fibers — prefer them over hand-rolled async coordination when orchestration
+  grows.
+
+## Civ7 Implication
+
+Start with the shared router/procedure core, then choose the caller boundary.
+CLI and tests should normally use server-side/in-process calls
+(`createCiv7ControlOrpcServerClient`). Studio browser clients should call the
+same router through an HTTP `RPCHandler`/`RPCLink` boundary. Keep
+`OpenAPIHandler` separate for external/documented consumers where
+REST/OpenAPI compatibility matters more than native TypeScript RPC
+ergonomics.


### PR DESCRIPTION
The skill was authored 2026-06-02 (commit d3d49b48f) but never reached main —
it survived only via a Codex snapshot ref (now pinned locally as tag
archive/civ7-orpc-skill). Restored verbatim, then updated to current reality:

- the layer is implemented as @civ7/control-orpc (effect-orpc implementEffect,
  contract-first TypeBox via toStandardSchema, typed error map,
  correlation/safe-error middleware, module families under src/modules/)
- direct-control stays plain-async wire atoms; orchestration (state machines,
  drain loops, suspend/resume lifecycles) is Effect procedures in control-orpc
  (new invariant + failure pattern; live lesson D10 in the cli-command-taxonomy
  workstream record)
- CLI consumption pattern: createCiv7ControlOrpcServerClient with the live
  facade from @civ7/control-orpc/runtime
- procedure map, context shape, middleware, and migration gates refreshed to
  the implemented package surfaces
- README skill index row re-added

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>