### PR TITLE
feat(cli): game view appshot — window-scoped clean-frame capture via ScreenCaptureKit (D12)

### DIFF
--- a/docs/projects/cli-command-taxonomy/workstream-record.md
+++ b/docs/projects/cli-command-taxonomy/workstream-record.md
@@ -187,6 +187,57 @@ new decision number.
   off. The held grant lives until session end; explore remains a
   disposable-session verb.
 
+- **D12 — `game view appshot` lands as window-scoped clean-frame capture
+  (slice 6, 2026-06-11).** D6's designated `game view` home gets its first
+  real implementation, superseding the rivers-branch `game appshot`
+  (whole-display `screencapture -x` — hash-identical to a desktop
+  screenshot, so wallpaper/overlays leaked into "game" captures). Settled
+  platform facts: the Mac Steam build has NO programmatic capture (zero XR
+  strings in the binary, no settings toggle, Steam F12/ISteamScreenshots is
+  human-keypress only), so capture is ScreenCaptureKit
+  `SCContentFilter(desktopIndependentWindow:)` + `SCScreenshotManager` via a
+  Swift helper embedded in `@civ7/direct-control` (compiled once per source
+  hash, cached in the OS temp dir; requires a one-time Screen Recording TCC
+  grant — preflight + `CGRequestScreenCaptureAccess` fire the OS prompt and
+  the failure carries the exact System Settings path). Clean frames come
+  from the official ViewManager rules engine: the game's own
+  INTERFACEMODE_SCREENSHOT maps to a stub ScreenshotView (rules all visible,
+  placeholder buttons injected), so the package registers its own
+  hidden-rules view (`DirectControlCleanFrame`, the Cinematic view's rule
+  set + "empty" harness, optional 3D-unit hide) reachable only via the live
+  VFS path `/core/ui/views/view-manager.js` (the `.chunk.js` paths in our
+  extracted resources are extraction artifacts and do NOT resolve).
+  Layering per D10: wire/OS atoms in `@civ7/direct-control`
+  (`enterCiv7CleanFrame`/`exitCiv7CleanFrame`/`captureCiv7WindowShot`),
+  orchestration as the Effect procedure `view.appshot.capture`
+  (suspend-verified → purge → enter-verified → settle → capture → restore,
+  with an acquire/release finalizer guaranteeing the HUD and queue are
+  restored on every failure path), CLI `game view appshot` on the typed
+  client. Rivers drain note: the rivers appshot files
+  (`play/map/appshot*.ts`, `world.capture.appshot`, `game appshot`) are
+  superseded outright — drop them in favor of this slice during the drain;
+  the camera/screenshot verbs remain rivers-owned arrivals under D6.
+  Live-proof findings folded back in: (a) the SCK capture path trips the
+  CGS_REQUIRE_INIT assertion in CLI processes unless CG is initialized on
+  the main thread (`CGMainDisplayID()`) and the main thread services a run
+  loop instead of semaphore-blocking; (b) an off-screen game window
+  (fullscreen on another Space, minimized) stops compositing, so its
+  backing store is STALE — app activation was tried first but macOS
+  resolves background-process activation nondeterministically (sometimes a
+  soft Dock bounce, sometimes a full Space switch), so the shipped
+  mechanism is a temporary SCStream: a running capture stream forces the
+  window server to composite fresh frames with ZERO focus interaction
+  (live-verified: 43 distinct frames over 4s from a fullscreen window on
+  an inactive Space, then a clean-frame capture with `frameSource:
+  "stream"` and `onScreen: false` throughout). The result's `frameSource`
+  reports the path: `screenshot` (on-screen, one-shot), `stream`
+  (off-screen, forced fresh), `screenshot-fallback` (stream yielded
+  nothing; pixels may be stale); (c) the floating
+  badges left in clean frames are RESOURCE icons — engine-rendered world
+  assets, not UI DOM (user-identified; the clean frame's DOM hide was
+  live-verified: plot-icons hidden, harness display:none) — i.e. map
+  content that belongs in the frame.
+
 ## Corpus Gate
 
 - Corpus source(s): `packages/cli/src/commands/game/**` on the stack;
@@ -227,6 +278,7 @@ new decision number.
 | 3 | `cli-taxonomy-workstream-docs` | — | this directory: workstream record, corpus ledger, target grammar | this slice |
 | 4 | `cli-game-map-noun-topic` | — | `game map` topic restructure (`index/summary/plot/grid`), `game map visibility` FULL migration incl. repo-wide reference retarget (D2/D5) | next slice |
 | 5 | `direct-control-display-queue` | #1582 | DQM display-control primitives replace the synthetic dismissal outright (D8); `game map visibility --explore` via suppressed tracked grants (D9); orchestration homed as Effect procedures in `@civ7/control-orpc` `display` module, CLI on the typed client (D10); `game play screen show/dismiss` rewired to queue truth | submitted (draft) |
+| 6 | `view-appshot-window-capture` | — | `game view appshot` window-scoped clean-frame capture (D12): SCK window capture atom + clean-frame view atoms, `view.appshot.capture` Effect procedure, CLI on the typed client | in review |
 
 ## Team
 

--- a/docs/projects/cli-command-taxonomy/workstream-record.md
+++ b/docs/projects/cli-command-taxonomy/workstream-record.md
@@ -230,9 +230,16 @@ new decision number.
   (live-verified: 43 distinct frames over 4s from a fullscreen window on
   an inactive Space, then a clean-frame capture with `frameSource:
   "stream"` and `onScreen: false` throughout). The result's `frameSource`
-  reports the path: `screenshot` (on-screen, one-shot), `stream`
-  (off-screen, forced fresh), `screenshot-fallback` (stream yielded
-  nothing; pixels may be stale); (c) the floating
+  reports the path: `screenshot` (on-screen, one-shot) or `stream`
+  (off-screen, forced fresh) — an off-screen window whose stream yields
+  nothing FAILS rather than returning possibly-stale pixels (the
+  stale-fallback path was removed in the cleanup pass: dead code, never
+  observed live, and "maybe-stale" is not an acceptable capture result).
+  Artifact lifecycle: default outputs land in the managed
+  `$TMPDIR/civ7-appshots/` directory, self-cleaned on each capture (7-day
+  retention; explicit `--output` paths are the caller's and never
+  pruned), and compiling a new helper revision prunes previous revisions
+  from the `$TMPDIR/civ7-direct-control/` cache; (c) the floating
   badges left in clean frames are RESOURCE icons — engine-rendered world
   assets, not UI DOM (user-identified; the clean frame's DOM hide was
   live-verified: plot-icons hidden, harness display:none) — i.e. map

--- a/packages/civ7-control-orpc/src/contract.ts
+++ b/packages/civ7-control-orpc/src/contract.ts
@@ -48,6 +48,10 @@ import {
   type Civ7UnitContract as Civ7UnitContractType,
 } from "./modules/unit/contract";
 import {
+  Civ7ViewContract,
+  type Civ7ViewContract as Civ7ViewContractType,
+} from "./modules/view/contract";
+import {
   Civ7WorldContract,
   type Civ7WorldContract as Civ7WorldContractType,
 } from "./modules/world/contract";
@@ -65,6 +69,7 @@ export type Civ7ControlOrpcContract = Readonly<{
   strategy: Civ7StrategyContractType;
   turn: Civ7TurnContractType;
   unit: Civ7UnitContractType;
+  view: Civ7ViewContractType;
   world: Civ7WorldContractType;
 }>;
 
@@ -82,5 +87,6 @@ export const Civ7ControlOrpcContract: Civ7ControlOrpcContract =
     strategy: Civ7StrategyContract,
     turn: Civ7TurnContract,
     unit: Civ7UnitContract,
+    view: Civ7ViewContract,
     world: Civ7WorldContract,
   });

--- a/packages/civ7-control-orpc/src/dependencies/direct-control.ts
+++ b/packages/civ7-control-orpc/src/dependencies/direct-control.ts
@@ -1,6 +1,9 @@
 import {
   applyCiv7ExploreGrant,
+  captureCiv7WindowShot,
   closeCiv7Displays,
+  enterCiv7CleanFrame,
+  exitCiv7CleanFrame,
   getCiv7PlayableStatus,
   getCiv7PlayNotificationView,
   getCiv7VisibilitySummary,
@@ -42,7 +45,12 @@ import {
   requestCiv7UnitCommand,
   requestCiv7UnitTargetAction,
   requestCiv7CultureTarget,
+  type Civ7CleanFrameEnterInput,
+  type Civ7CleanFrameEnterResult,
+  type Civ7CleanFrameExitResult,
   type Civ7DirectControlOptions,
+  type Civ7WindowShotCaptureInput,
+  type Civ7WindowShotCaptureResult,
   Civ7BattlefieldScanResultSchema,
   Civ7DestinationAnalysisResultSchema,
   type Civ7AttributePurchaseInput,
@@ -178,6 +186,9 @@ export type Civ7ControlOrpcCloseDisplaysResult = Civ7CloseDisplaysResult;
 export type Civ7ControlOrpcDisplayQueueHoldResult = Civ7DisplayQueueHoldResult;
 export type Civ7ControlOrpcExploreGrantResult = Civ7ExploreGrantResult;
 export type Civ7ControlOrpcExploreReleaseResult = Civ7ExploreReleaseResult;
+export type Civ7ControlOrpcCleanFrameEnterResult = Civ7CleanFrameEnterResult;
+export type Civ7ControlOrpcCleanFrameExitResult = Civ7CleanFrameExitResult;
+export type Civ7ControlOrpcWindowShotCaptureResult = Civ7WindowShotCaptureResult;
 export type Civ7ControlOrpcVisibilitySummaryResult = Civ7VisibilitySummaryResult;
 export type Civ7ControlOrpcReadyUnitViewResult = Static<
   typeof Civ7ReadyUnitViewResultSchema
@@ -369,6 +380,17 @@ export type Civ7ControlOrpcDirectControlFacade = Readonly<{
     input: Civ7ExploreReleaseInput,
     options?: Civ7DirectControlOptions,
   ): Promise<Civ7ControlOrpcExploreReleaseResult>;
+  enterCiv7CleanFrame(
+    input: Civ7CleanFrameEnterInput,
+    options?: Civ7DirectControlOptions,
+  ): Promise<Civ7ControlOrpcCleanFrameEnterResult>;
+  exitCiv7CleanFrame(
+    options?: Civ7DirectControlOptions,
+  ): Promise<Civ7ControlOrpcCleanFrameExitResult>;
+  /** OS-local ScreenCaptureKit window capture — no Tuner endpoint involved. */
+  captureCiv7WindowShot(
+    input: Civ7WindowShotCaptureInput,
+  ): Promise<Civ7ControlOrpcWindowShotCaptureResult>;
 }>;
 
 export const liveCiv7ControlOrpcDirectControlFacade:
@@ -503,4 +525,10 @@ export const liveCiv7ControlOrpcDirectControlFacade:
     applyCiv7ExploreGrant(input, options),
   releaseCiv7ExploreGrant: async (input, options) =>
     releaseCiv7ExploreGrant(input, options),
+  enterCiv7CleanFrame: async (input, options) =>
+    enterCiv7CleanFrame(input, options),
+  exitCiv7CleanFrame: async (options) =>
+    exitCiv7CleanFrame(options),
+  captureCiv7WindowShot: async (input) =>
+    captureCiv7WindowShot(input),
 };

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -294,6 +294,60 @@ export class Civ7ExploreFailedError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7AppshotErrorDataSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("view.appshot.capture"),
+    source: Type.Literal("direct-control-facade"),
+    /** Human-readable failure detail from the capture pipeline. */
+    detail: Type.Optional(Type.String()),
+    ...Civ7ControlOrpcErrorCorrelationProperties,
+  },
+  { additionalProperties: false },
+);
+export type Civ7AppshotErrorData = Static<typeof Civ7AppshotErrorDataSchema>;
+
+export class Civ7AppshotPermissionRequiredError extends ORPCTaggedError(
+  "Civ7AppshotPermissionRequiredError",
+  {
+    code: "APPSHOT_PERMISSION_REQUIRED",
+    message: "Screen Recording permission is not granted for the app running this process. " +
+      "The OS prompt has already registered it: open System Settings -> Privacy & Security -> " +
+      "Screen & System Audio Recording, enable the host app, then retry.",
+    schema: toStandardSchema(Civ7AppshotErrorDataSchema),
+    status: 403,
+  },
+) {}
+
+export class Civ7AppshotWindowNotFoundError extends ORPCTaggedError(
+  "Civ7AppshotWindowNotFoundError",
+  {
+    code: "APPSHOT_WINDOW_NOT_FOUND",
+    message: "No window matched the Civ7 capture target; adjust appName or pass windowId.",
+    schema: toStandardSchema(Civ7AppshotErrorDataSchema),
+    status: 503,
+  },
+) {}
+
+export class Civ7AppshotCleanFrameUnverifiedError extends ORPCTaggedError(
+  "Civ7AppshotCleanFrameUnverifiedError",
+  {
+    code: "APPSHOT_CLEAN_FRAME_UNVERIFIED",
+    message: "Clean-frame state (queue suspension or hidden-rules view) was not verified by readback before capture.",
+    schema: toStandardSchema(Civ7AppshotErrorDataSchema),
+    status: 503,
+  },
+) {}
+
+export class Civ7AppshotCaptureFailedError extends ORPCTaggedError(
+  "Civ7AppshotCaptureFailedError",
+  {
+    code: "APPSHOT_CAPTURE_FAILED",
+    message: "Window-scoped appshot capture failed.",
+    schema: toStandardSchema(Civ7AppshotErrorDataSchema),
+    status: 503,
+  },
+) {}
+
 export const Civ7NotificationDismissalUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("notifications.dismiss.request"),
@@ -825,6 +879,10 @@ export class Civ7CorrelationIdInvalidError extends ORPCTaggedError(
 ) {}
 
 export const civ7ControlOrpcErrorMap = {
+  APPSHOT_CAPTURE_FAILED: Civ7AppshotCaptureFailedError,
+  APPSHOT_CLEAN_FRAME_UNVERIFIED: Civ7AppshotCleanFrameUnverifiedError,
+  APPSHOT_PERMISSION_REQUIRED: Civ7AppshotPermissionRequiredError,
+  APPSHOT_WINDOW_NOT_FOUND: Civ7AppshotWindowNotFoundError,
   ATTENTION_CURRENT_UNAVAILABLE: Civ7AttentionCurrentUnavailableError,
   ATTENTION_PRIORITIES_UNAVAILABLE: Civ7AttentionPrioritiesUnavailableError,
   CORRELATION_ID_INVALID: Civ7CorrelationIdInvalidError,

--- a/packages/civ7-control-orpc/src/game-ui.ts
+++ b/packages/civ7-control-orpc/src/game-ui.ts
@@ -423,6 +423,15 @@ function createCiv7GameUiDirectControlFacade(
     releaseCiv7ExploreGrant: async () => {
       throw new Error("game-ui explore grant release is not supported");
     },
+    enterCiv7CleanFrame: async () => {
+      throw new Error("game-ui clean-frame enter is not supported");
+    },
+    exitCiv7CleanFrame: async () => {
+      throw new Error("game-ui clean-frame exit is not supported");
+    },
+    captureCiv7WindowShot: async () => {
+      throw new Error("game-ui window-shot capture is not supported");
+    },
   };
 }
 

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -145,6 +145,11 @@ export { civ7ControlOrpcContractBase } from "./contract-base";
 export { Civ7ControlOrpcContract } from "./contract";
 export type { Civ7ControlOrpcContext } from "./context";
 export {
+  Civ7AppshotCaptureFailedError,
+  Civ7AppshotCleanFrameUnverifiedError,
+  Civ7AppshotErrorDataSchema,
+  Civ7AppshotPermissionRequiredError,
+  Civ7AppshotWindowNotFoundError,
   Civ7AttentionCurrentUnavailableError,
   Civ7AttentionCurrentUnavailableErrorDataSchema,
   Civ7AttentionPrioritiesUnavailableError,
@@ -214,6 +219,7 @@ export {
   Civ7WorldReadUnavailableError,
   Civ7WorldReadUnavailableErrorDataSchema,
   civ7ControlOrpcErrorMap,
+  type Civ7AppshotErrorData,
   type Civ7AttentionCurrentUnavailableErrorData,
   type Civ7AttentionPrioritiesUnavailableErrorData,
   type Civ7ControlOrpcErrorMap,

--- a/packages/civ7-control-orpc/src/metadata.ts
+++ b/packages/civ7-control-orpc/src/metadata.ts
@@ -15,6 +15,7 @@ export type Civ7ControlOrpcProcedureMeta = Readonly<{
     | "player"
     | "strategy"
     | "turn"
+    | "view"
     | "world";
   procedureKey?: string;
   proofBoundary?: "local-package-test" | "pending-runtime-proof" | "runtime-proof";

--- a/packages/civ7-control-orpc/src/modules/view/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/view/contract.ts
@@ -1,0 +1,158 @@
+import type { ContractProcedure } from "@orpc/contract";
+import { Type, type Static } from "typebox";
+
+import { civ7ControlOrpcContractBase } from "../../contract-base";
+import type { Civ7ControlOrpcErrorMap } from "../../errors";
+import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
+import { toStandardSchema } from "../../typebox-standard-schema";
+
+const Civ7ViewAppshotCaptureInputSchema = Type.Object(
+  {
+    /** PNG output path; defaults under the OS temp dir. */
+    outputPath: Type.Optional(Type.String({ minLength: 1 })),
+    /** Case-insensitive substring of app name / bundle id / window title. */
+    appName: Type.Optional(Type.String({ minLength: 1 })),
+    /** Exact window id — overrides appName matching. */
+    windowId: Type.Optional(Type.Integer({ minimum: 0 })),
+    /** Also hide 3D unit models for map-only frames. Default false. */
+    hideUnits: Type.Optional(Type.Boolean()),
+    /**
+     * Hold time between entering the clean-frame view and capturing, so the
+     * UI runtime finishes hiding the HUD/world overlays. Default 400ms.
+     */
+    settleMs: Type.Optional(Type.Integer({ minimum: 0, maximum: 30_000 })),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ViewAppshotCaptureInput = Static<
+  typeof Civ7ViewAppshotCaptureInputSchema
+>;
+
+const Civ7ViewAppshotWindowSchema = Type.Object(
+  {
+    windowId: Type.Integer({ minimum: 0 }),
+    app: Type.String(),
+    title: Type.String(),
+    width: Type.Integer({ minimum: 0 }),
+    height: Type.Integer({ minimum: 0 }),
+    onScreen: Type.Boolean(),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7ViewAppshotFileSchema = Type.Object(
+  {
+    path: Type.String(),
+    byteSize: Type.Integer({ minimum: 0 }),
+    sha256: Type.String(),
+    mediaType: Type.Literal("image/png"),
+    dimensions: Type.Optional(Type.Object(
+      {
+        width: Type.Integer({ minimum: 0 }),
+        height: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    )),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7ViewAppshotSuppressedRowSchema = Type.Object(
+  {
+    category: Type.String(),
+    closed: Type.Integer({ minimum: 1 }),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7ViewAppshotCleanFrameSchema = Type.Object(
+  {
+    /** View that was current before the capture (the restore target). */
+    viewBefore: Type.String(),
+    /** Readback: view current while the frame was captured. */
+    viewDuringCapture: Type.String(),
+    /** Readback: HUD harness hidden while the frame was captured. */
+    harnessHidden: Type.Boolean(),
+    hideUnits: Type.Boolean(),
+    /** Display queue suspension verified by readback before the capture. */
+    suspendVerified: Type.Boolean(),
+    /** Popups purged through DisplayQueueManager before the capture. */
+    suppressedDisplays: Type.Array(Civ7ViewAppshotSuppressedRowSchema),
+    restored: Type.Object(
+      {
+        /** Readback: view current after the restore. */
+        view: Type.String(),
+        /** Readback: HUD harness visible again after the restore. */
+        harnessHidden: Type.Boolean(),
+        /** Readback: display queue resumed after the restore. */
+        queueResumed: Type.Boolean(),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7ViewAppshotCaptureResultSchema = Type.Object(
+  {
+    captureMode: Type.Literal("window-scoped-screencapturekit"),
+    requestedAt: Type.String(),
+    settleMs: Type.Integer({ minimum: 0, maximum: 30_000 }),
+    /**
+     * How frame freshness was obtained — never via app activation or focus
+     * changes. "screenshot": window on screen, one-shot. "stream": off-screen
+     * window, a temporary capture stream forced fresh compositing.
+     * "screenshot-fallback": off-screen and the stream yielded nothing, so
+     * the pixels may be stale.
+     */
+    frameSource: Type.Union([
+      Type.Literal("screenshot"),
+      Type.Literal("stream"),
+      Type.Literal("screenshot-fallback"),
+    ]),
+    window: Civ7ViewAppshotWindowSchema,
+    file: Civ7ViewAppshotFileSchema,
+    cleanFrame: Civ7ViewAppshotCleanFrameSchema,
+  },
+  { additionalProperties: false },
+);
+export type Civ7ViewAppshotCaptureResult = Static<
+  typeof Civ7ViewAppshotCaptureResultSchema
+>;
+
+const Civ7ViewAppshotCaptureInputStandardSchema = toStandardSchema(
+  Civ7ViewAppshotCaptureInputSchema,
+);
+const Civ7ViewAppshotCaptureResultStandardSchema = toStandardSchema(
+  Civ7ViewAppshotCaptureResultSchema,
+);
+
+type Civ7ViewAppshotCaptureContract = ContractProcedure<
+  typeof Civ7ViewAppshotCaptureInputStandardSchema,
+  typeof Civ7ViewAppshotCaptureResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+const Civ7ViewAppshotCaptureContract: Civ7ViewAppshotCaptureContract =
+  civ7ControlOrpcContractBase
+    .input(Civ7ViewAppshotCaptureInputStandardSchema)
+    .output(Civ7ViewAppshotCaptureResultStandardSchema)
+    .meta({
+      family: "view",
+      procedureKey: "view.appshot.capture",
+      proofBoundary: "local-package-test",
+      risk: "runtime-support",
+    });
+
+export type Civ7ViewContract = Readonly<{
+  appshot: Readonly<{
+    capture: Civ7ViewAppshotCaptureContract;
+  }>;
+}>;
+
+export const Civ7ViewContract: Civ7ViewContract = {
+  appshot: {
+    capture: Civ7ViewAppshotCaptureContract,
+  },
+};

--- a/packages/civ7-control-orpc/src/modules/view/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/view/contract.ts
@@ -101,14 +101,13 @@ const Civ7ViewAppshotCaptureResultSchema = Type.Object(
     /**
      * How frame freshness was obtained — never via app activation or focus
      * changes. "screenshot": window on screen, one-shot. "stream": off-screen
-     * window, a temporary capture stream forced fresh compositing.
-     * "screenshot-fallback": off-screen and the stream yielded nothing, so
-     * the pixels may be stale.
+     * window, a temporary capture stream forced fresh compositing. An
+     * off-screen window whose stream yields nothing FAILS instead of
+     * returning possibly-stale pixels.
      */
     frameSource: Type.Union([
       Type.Literal("screenshot"),
       Type.Literal("stream"),
-      Type.Literal("screenshot-fallback"),
     ]),
     window: Civ7ViewAppshotWindowSchema,
     file: Civ7ViewAppshotFileSchema,

--- a/packages/civ7-control-orpc/src/modules/view/procedures/appshot-capture.ts
+++ b/packages/civ7-control-orpc/src/modules/view/procedures/appshot-capture.ts
@@ -1,0 +1,218 @@
+import { CIV7_CLEAN_FRAME_VIEW_NAME } from "@civ7/direct-control";
+import { Effect, Ref } from "effect";
+
+import type {
+  Civ7ControlOrpcCleanFrameEnterResult,
+  Civ7ControlOrpcCloseDisplaysResult,
+  Civ7ControlOrpcWindowShotCaptureResult,
+} from "../../../dependencies/direct-control";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type { Civ7ViewAppshotCaptureResult } from "../contract";
+
+const DEFAULT_APPSHOT_SETTLE_MS = 400;
+
+/**
+ * Captures a clean, window-scoped frame of the live Civ7 session — game
+ * window only (never the display), HUD and world overlays hidden, popups
+ * purged — by orchestrating the direct-control atoms as one Effect state
+ * machine:
+ *
+ *   1. suspend the DisplayQueueManager so nothing can mount mid-capture —
+ *      verified by readback,
+ *   2. purge already-queued displays through the official close path,
+ *   3. enter the hidden-rules clean-frame view (ViewManager rules engine:
+ *      harness + every world overlay hidden, optionally 3D units) — verified
+ *      by readback before any pixel is captured,
+ *   4. settle briefly so the UI runtime finishes the hide, then capture the
+ *      Civ7 window via ScreenCaptureKit (native pixel scale, works occluded),
+ *   5. restore the previous view and resume the queue — readback lands in
+ *      `cleanFrame.restored`.
+ *
+ * The restore is bound to an acquire/release boundary: a hidden HUD or a
+ * suspended queue silently degrades the whole session, so both are ALWAYS
+ * restored even when the capture fails (e.g. the one-time Screen Recording
+ * permission is missing — surfaced as APPSHOT_PERMISSION_REQUIRED with the
+ * exact System Settings path in `data.detail`).
+ */
+export const viewAppshotCaptureProcedure =
+  civ7ControlOrpcImplementer.view.appshot.capture.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    const errorData = {
+      procedureKey: "view.appshot.capture" as const,
+      source: "direct-control-facade" as const,
+      ...civ7ControlOrpcErrorCorrelationData(context),
+    };
+    const failure = (error: unknown) => {
+      const detail = error instanceof Error ? error.message : String(error);
+      const code = (error as { code?: string } | null)?.code;
+      const data = { ...errorData, detail };
+      if (code === "window-shot-permission-required") {
+        return errors.APPSHOT_PERMISSION_REQUIRED({ data });
+      }
+      if (code === "window-shot-window-not-found") {
+        return errors.APPSHOT_WINDOW_NOT_FOUND({ data });
+      }
+      return errors.APPSHOT_CAPTURE_FAILED({ data });
+    };
+    const facadeCall = <T>(call: () => Promise<T>) =>
+      Effect.tryPromise({ try: call, catch: failure });
+
+    const settleMs = input.settleMs ?? DEFAULT_APPSHOT_SETTLE_MS;
+    const restoredInline = yield* Ref.make(false);
+
+    return yield* Effect.acquireUseRelease(
+      // Acquire: suspend the display queue, verified by readback — anything
+      // past this point runs under the release finalizer's restore guarantee.
+      Effect.gen(function* () {
+        const suspend = yield* facadeCall(() =>
+          context.directControl.suspendCiv7DisplayQueue(
+            context.endpointDefaults,
+          )
+        );
+        if (!suspend.isSuspended) {
+          return yield* Effect.fail(
+            errors.APPSHOT_CLEAN_FRAME_UNVERIFIED({
+              data: {
+                ...errorData,
+                detail: "display queue suspension readback failed",
+              },
+            }),
+          );
+        }
+        return suspend;
+      }),
+      () =>
+        Effect.gen(function* () {
+          const purge = yield* facadeCall(() =>
+            context.directControl.closeCiv7Displays(
+              {},
+              context.endpointDefaults,
+            )
+          );
+          const enter = yield* facadeCall(() =>
+            context.directControl.enterCiv7CleanFrame(
+              { hideUnits: input.hideUnits === true },
+              context.endpointDefaults,
+            )
+          );
+          if (
+            !enter.switched
+            || enter.view !== CIV7_CLEAN_FRAME_VIEW_NAME
+            || !enter.harnessHidden
+          ) {
+            return yield* Effect.fail(
+              errors.APPSHOT_CLEAN_FRAME_UNVERIFIED({
+                data: {
+                  ...errorData,
+                  detail: "clean-frame view readback failed: view="
+                    + enter.view
+                    + " harnessHidden="
+                    + String(enter.harnessHidden),
+                },
+              }),
+            );
+          }
+          yield* Effect.sleep(settleMs);
+          const shot = yield* facadeCall(() =>
+            context.directControl.captureCiv7WindowShot({
+              ...(input.outputPath === undefined
+                ? {}
+                : { outputPath: input.outputPath }),
+              ...(input.appName === undefined
+                ? {}
+                : { appName: input.appName }),
+              ...(input.windowId === undefined
+                ? {}
+                : { windowId: input.windowId }),
+            })
+          );
+
+          // Restore inline so the readback can land in the result; the
+          // release finalizer below only fires on failures.
+          const exit = yield* facadeCall(() =>
+            context.directControl.exitCiv7CleanFrame(context.endpointDefaults)
+          );
+          const resume = yield* facadeCall(() =>
+            context.directControl.resumeCiv7DisplayQueue(
+              context.endpointDefaults,
+            )
+          );
+          yield* Ref.set(restoredInline, true);
+
+          return viewAppshotCaptureResult({
+            shot,
+            purge,
+            enter,
+            settleMs,
+            restored: {
+              view: exit.view,
+              harnessHidden: exit.harnessHidden,
+              queueResumed: !resume.isSuspended,
+            },
+          });
+        }),
+      // Release: never leave the HUD hidden or the queue suspended — even
+      // when the capture, the restore readback, or the resume fails.
+      () =>
+        Ref.get(restoredInline).pipe(
+          Effect.flatMap((restored) =>
+            restored ? Effect.void : Effect.promise(async () => {
+              await context.directControl
+                .exitCiv7CleanFrame(context.endpointDefaults)
+                .then(() => undefined, () => undefined);
+              await context.directControl
+                .resumeCiv7DisplayQueue(context.endpointDefaults)
+                .then(() => undefined, () => undefined);
+            })
+          ),
+        ),
+    );
+  });
+
+function viewAppshotCaptureResult(input: Readonly<{
+  shot: Civ7ControlOrpcWindowShotCaptureResult;
+  purge: Civ7ControlOrpcCloseDisplaysResult;
+  enter: Civ7ControlOrpcCleanFrameEnterResult;
+  settleMs: number;
+  restored: Civ7ViewAppshotCaptureResult["cleanFrame"]["restored"];
+}>): Civ7ViewAppshotCaptureResult {
+  return {
+    captureMode: "window-scoped-screencapturekit",
+    requestedAt: input.shot.requestedAt,
+    settleMs: input.settleMs,
+    frameSource: input.shot.frameSource,
+    window: {
+      windowId: input.shot.window.windowId,
+      app: input.shot.window.app,
+      title: input.shot.window.title,
+      width: input.shot.window.width,
+      height: input.shot.window.height,
+      onScreen: input.shot.window.onScreen,
+    },
+    file: {
+      path: input.shot.file.path,
+      byteSize: input.shot.file.byteSize,
+      sha256: input.shot.file.sha256,
+      mediaType: input.shot.file.mediaType,
+      ...(input.shot.file.dimensions === undefined
+        ? {}
+        : { dimensions: input.shot.file.dimensions }),
+    },
+    cleanFrame: {
+      viewBefore: input.enter.viewBefore,
+      viewDuringCapture: input.enter.view,
+      harnessHidden: input.enter.harnessHidden,
+      hideUnits: input.enter.hideUnits,
+      suspendVerified: true,
+      suppressedDisplays: input.purge.closed.map((row) => ({
+        category: row.category,
+        closed: row.closed,
+      })),
+      restored: input.restored,
+    },
+  };
+}

--- a/packages/civ7-control-orpc/src/modules/view/router.ts
+++ b/packages/civ7-control-orpc/src/modules/view/router.ts
@@ -1,0 +1,7 @@
+import { viewAppshotCaptureProcedure } from "./procedures/appshot-capture";
+
+export const viewRouter = {
+  appshot: {
+    capture: viewAppshotCaptureProcedure,
+  },
+};

--- a/packages/civ7-control-orpc/src/router.ts
+++ b/packages/civ7-control-orpc/src/router.ts
@@ -15,6 +15,7 @@ import { readinessRouter } from "./modules/readiness/router";
 import { strategyRouter } from "./modules/strategy/router";
 import { turnRouter } from "./modules/turn/router";
 import { unitRouter } from "./modules/unit/router";
+import { viewRouter } from "./modules/view/router";
 import { worldRouter } from "./modules/world/router";
 
 export const Civ7ControlOrpcRouter: Router<
@@ -33,5 +34,6 @@ export const Civ7ControlOrpcRouter: Router<
   strategy: strategyRouter,
   turn: turnRouter,
   unit: unitRouter,
+  view: viewRouter,
   world: worldRouter,
 });

--- a/packages/civ7-control-orpc/test/view-appshot-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/view-appshot-procedure.test.ts
@@ -1,0 +1,370 @@
+import { CIV7_CLEAN_FRAME_VIEW_NAME, Civ7DirectControlError } from "@civ7/direct-control";
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7AppshotCaptureFailedError,
+  Civ7AppshotCleanFrameUnverifiedError,
+  Civ7AppshotPermissionRequiredError,
+  Civ7AppshotWindowNotFoundError,
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  type Civ7ControlOrpcContext,
+} from "../src/index";
+import type {
+  Civ7ControlOrpcCleanFrameEnterResult,
+  Civ7ControlOrpcCloseDisplaysResult,
+  Civ7ControlOrpcWindowShotCaptureResult,
+} from "../src/dependencies/direct-control";
+
+// The procedure sleeps for real (Effect.sleep); pin settleMs to zero.
+const fastSettle = { settleMs: 0 } as const;
+
+describe("view.appshot.capture control-oRPC procedure", () => {
+  test("suspends, purges, hides, captures the window, then restores — in that order", async () => {
+    const fake = fakeContext();
+    const result = await call(
+      Civ7ControlOrpcRouter.view.appshot.capture,
+      { ...fastSettle },
+      { context: fake.context },
+    );
+
+    // The clean frame is fully verified BEFORE any pixel is captured, and the
+    // restore (view + queue) runs inline after the capture so its readback
+    // lands in the result.
+    expect(fake.calls).toEqual([
+      "suspend",
+      "close",
+      "enterCleanFrame",
+      "capture",
+      "exitCleanFrame",
+      "resume",
+    ]);
+    expect(result).toMatchObject({
+      captureMode: "window-scoped-screencapturekit",
+      settleMs: 0,
+      frameSource: "screenshot",
+      window: {
+        windowId: 4242,
+        app: "CivilizationVII",
+        title: "Sid Meier's Civilization VII",
+        onScreen: true,
+      },
+      file: {
+        path: "/tmp/civ7-frame.png",
+        mediaType: "image/png",
+        dimensions: { width: 3456, height: 2160 },
+      },
+      cleanFrame: {
+        viewBefore: "World",
+        viewDuringCapture: CIV7_CLEAN_FRAME_VIEW_NAME,
+        harnessHidden: true,
+        hideUnits: false,
+        suspendVerified: true,
+        suppressedDisplays: [{ category: "UnlockPopup", closed: 2 }],
+        restored: { view: "World", harnessHidden: false, queueResumed: true },
+      },
+    });
+    expectSafeAppshotOutput(result);
+  });
+
+  test("passes hideUnits and capture targeting through to the atoms", async () => {
+    const fake = fakeContext();
+    await call(
+      Civ7ControlOrpcRouter.view.appshot.capture,
+      {
+        hideUnits: true,
+        outputPath: "/tmp/custom.png",
+        appName: "civ",
+        windowId: 7,
+        ...fastSettle,
+      },
+      { context: fake.context },
+    );
+    expect(fake.enterInputs).toEqual([{ hideUnits: true }]);
+    expect(fake.captureInputs).toEqual([
+      { outputPath: "/tmp/custom.png", appName: "civ", windowId: 7 },
+    ]);
+  });
+
+  test("fails APPSHOT_CLEAN_FRAME_UNVERIFIED when queue suspension readback fails", async () => {
+    const fake = fakeContext({ suspendIsSuspended: false });
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.view.appshot.capture,
+        { ...fastSettle },
+        { context: fake.context },
+      ),
+    ).rejects.toMatchObject({
+      code: "APPSHOT_CLEAN_FRAME_UNVERIFIED",
+      data: {
+        procedureKey: "view.appshot.capture",
+        source: "direct-control-facade",
+      },
+    });
+    expect(fake.calls).not.toContain("capture");
+    expect(fake.calls).not.toContain("enterCleanFrame");
+  });
+
+  test("fails APPSHOT_CLEAN_FRAME_UNVERIFIED and restores when the view readback fails", async () => {
+    const fake = fakeContext({
+      enterResult: {
+        switched: true,
+        viewBefore: "World",
+        view: "World",
+        harnessHidden: false,
+        hideUnits: false,
+      },
+    });
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.view.appshot.capture,
+        { ...fastSettle },
+        { context: fake.context },
+      ),
+    ).rejects.toMatchObject({ code: "APPSHOT_CLEAN_FRAME_UNVERIFIED" });
+    expect(fake.calls).not.toContain("capture");
+    // The release finalizer still restores both the view and the queue.
+    expect(fake.calls.slice(-2)).toEqual(["exitCleanFrame", "resume"]);
+  });
+
+  test("maps the missing Screen Recording grant to APPSHOT_PERMISSION_REQUIRED and restores", async () => {
+    const fake = fakeContext({
+      captureError: new Civ7DirectControlError(
+        "window-shot-permission-required",
+        "Screen Recording permission is not granted for the app running this command.",
+      ),
+    });
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.view.appshot.capture,
+        { ...fastSettle },
+        { context: fake.context },
+      ),
+    ).rejects.toMatchObject({
+      code: "APPSHOT_PERMISSION_REQUIRED",
+      data: {
+        procedureKey: "view.appshot.capture",
+        detail: expect.stringContaining("Screen Recording"),
+      },
+    });
+    expect(fake.calls).toEqual([
+      "suspend",
+      "close",
+      "enterCleanFrame",
+      "capture",
+      "exitCleanFrame",
+      "resume",
+    ]);
+  });
+
+  test("maps a missing window to APPSHOT_WINDOW_NOT_FOUND", async () => {
+    const fake = fakeContext({
+      captureError: new Civ7DirectControlError(
+        "window-shot-window-not-found",
+        "no window matched app substring 'nope'",
+      ),
+    });
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.view.appshot.capture,
+        { appName: "nope", ...fastSettle },
+        { context: fake.context },
+      ),
+    ).rejects.toMatchObject({ code: "APPSHOT_WINDOW_NOT_FOUND" });
+  });
+
+  test("maps any other capture failure to APPSHOT_CAPTURE_FAILED and restores", async () => {
+    const fake = fakeContext({ captureError: new Error("disk full") });
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.view.appshot.capture,
+        { ...fastSettle },
+        { context: fake.context },
+      ),
+    ).rejects.toMatchObject({
+      code: "APPSHOT_CAPTURE_FAILED",
+      data: { detail: "disk full" },
+    });
+    expect(fake.calls.slice(-2)).toEqual(["exitCleanFrame", "resume"]);
+  });
+
+  test("rejects raw endpoint/session/command input before facade reads", async () => {
+    const invalidInputs = [
+      { host: "127.0.0.1" },
+      { rawCommand: "ViewManager.setCurrentByName" },
+      { settleMs: 60_001 },
+      { windowId: -1 },
+    ];
+    for (const input of invalidInputs) {
+      const fake = fakeContext();
+      await expect(
+        call(
+          Civ7ControlOrpcRouter.view.appshot.capture,
+          input as never,
+          { context: fake.context },
+        ),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(fake.calls).toEqual([]);
+    }
+  });
+
+  test("publishes the contract-first view leaf with typed errors", () => {
+    expect(
+      Civ7ControlOrpcContract.view.appshot.capture["~orpc"],
+    ).toMatchObject({
+      meta: {
+        family: "view",
+        procedureKey: "view.appshot.capture",
+        proofBoundary: "local-package-test",
+        risk: "runtime-support",
+      },
+    });
+    const errorMap = Civ7ControlOrpcContract.view.appshot.capture["~orpc"].errorMap;
+    expect(errorMap).toHaveProperty("APPSHOT_PERMISSION_REQUIRED");
+    expect(errorMap).toHaveProperty("APPSHOT_WINDOW_NOT_FOUND");
+    expect(errorMap).toHaveProperty("APPSHOT_CLEAN_FRAME_UNVERIFIED");
+    expect(errorMap).toHaveProperty("APPSHOT_CAPTURE_FAILED");
+    expect(Civ7AppshotPermissionRequiredError.code).toBe("APPSHOT_PERMISSION_REQUIRED");
+    expect(Civ7AppshotWindowNotFoundError.code).toBe("APPSHOT_WINDOW_NOT_FOUND");
+    expect(Civ7AppshotCleanFrameUnverifiedError.code).toBe("APPSHOT_CLEAN_FRAME_UNVERIFIED");
+    expect(Civ7AppshotCaptureFailedError.code).toBe("APPSHOT_CAPTURE_FAILED");
+  });
+});
+
+type EnterPayload = Omit<Civ7ControlOrpcCleanFrameEnterResult, "host" | "port" | "state">;
+
+function fakeContext(options: {
+  suspendIsSuspended?: boolean;
+  enterResult?: EnterPayload;
+  captureError?: Error;
+} = {}): {
+  context: Civ7ControlOrpcContext;
+  calls: string[];
+  enterInputs: unknown[];
+  captureInputs: unknown[];
+} {
+  const calls: string[] = [];
+  const enterInputs: unknown[] = [];
+  const captureInputs: unknown[] = [];
+  const enterPayload: EnterPayload = options.enterResult ?? {
+    switched: true,
+    viewBefore: "World",
+    view: CIV7_CLEAN_FRAME_VIEW_NAME,
+    harnessHidden: true,
+    hideUnits: false,
+  };
+
+  return {
+    calls,
+    enterInputs,
+    captureInputs,
+    context: {
+      endpointDefaults: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      directControl: {
+        suspendCiv7DisplayQueue: async () => {
+          calls.push("suspend");
+          return {
+            ...appUiEnvelope(),
+            isSuspended: options.suspendIsSuspended ?? true,
+          };
+        },
+        resumeCiv7DisplayQueue: async () => {
+          calls.push("resume");
+          return { ...appUiEnvelope(), isSuspended: false };
+        },
+        closeCiv7Displays: async () => {
+          calls.push("close");
+          return closeDisplaysResult([{ category: "UnlockPopup", closed: 2 }]);
+        },
+        enterCiv7CleanFrame: async (input) => {
+          calls.push("enterCleanFrame");
+          enterInputs.push(input);
+          return {
+            ...appUiEnvelope(),
+            ...enterPayload,
+            hideUnits: (input as { hideUnits?: boolean }).hideUnits === true,
+          };
+        },
+        exitCiv7CleanFrame: async () => {
+          calls.push("exitCleanFrame");
+          return {
+            ...appUiEnvelope(),
+            switched: true,
+            view: "World",
+            harnessHidden: false,
+          };
+        },
+        captureCiv7WindowShot: async (input) => {
+          calls.push("capture");
+          captureInputs.push(input);
+          if (options.captureError) throw options.captureError;
+          return windowShotResult();
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function windowShotResult(): Civ7ControlOrpcWindowShotCaptureResult {
+  return {
+    captureMode: "window-scoped-screencapturekit",
+    requestedAt: "2026-06-11T12:00:00.000Z",
+    frameSource: "screenshot",
+    window: {
+      windowId: 4242,
+      app: "CivilizationVII",
+      bundleId: "com.aspyr.civ7.steam",
+      title: "Sid Meier's Civilization VII",
+      width: 1728,
+      height: 1080,
+      onScreen: true,
+    },
+    file: {
+      path: "/tmp/civ7-frame.png",
+      byteSize: 1_234_567,
+      sha256: "ab".repeat(32),
+      mediaType: "image/png",
+      dimensions: { width: 3456, height: 2160 },
+    },
+  };
+}
+
+function closeDisplaysResult(
+  closed: Array<{ category: string; closed: number }>,
+): Civ7ControlOrpcCloseDisplaysResult {
+  return {
+    ...appUiEnvelope(),
+    closed,
+    closedTotal: closed.reduce((total, row) => total + row.closed, 0),
+    remainingActive: [],
+    remainingSuspended: [],
+  };
+}
+
+function appUiEnvelope(): Readonly<{
+  host: string;
+  port: number;
+  state: { id: string; name: string };
+}> {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+  };
+}
+
+function expectSafeAppshotOutput(output: unknown): void {
+  const serialized = JSON.stringify(output);
+  expect(serialized).not.toContain("127.0.0.1");
+  expect(serialized).not.toContain("65535");
+  expect(serialized).not.toContain("\"host\"");
+  expect(serialized).not.toContain("\"port\"");
+  expect(serialized).not.toContain("\"state\"");
+  expect(serialized).not.toContain("rawCommand");
+  expect(serialized).not.toContain("bundleId");
+}

--- a/packages/civ7-direct-control/src/direct-control-error.ts
+++ b/packages/civ7-direct-control/src/direct-control-error.ts
@@ -21,7 +21,12 @@ export type Civ7DirectControlErrorCode =
   | "setup-config-load-failed"
   | "setup-config-proof-missing"
   | "procedure-descriptor-invalid"
-  | "procedure-call-failed";
+  | "procedure-call-failed"
+  | "clean-frame-unverified"
+  | "window-shot-helper-unavailable"
+  | "window-shot-permission-required"
+  | "window-shot-window-not-found"
+  | "window-shot-failed";
 
 export class Civ7DirectControlError extends Error {
   readonly code: Civ7DirectControlErrorCode;

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -1356,14 +1356,11 @@ export {
   DEFAULT_CIV7_WINDOW_MATCH,
   captureCiv7WindowShot,
   ensureCiv7WindowShotHelper,
-  listCiv7CaptureWindows,
 } from "./play/view/window-shot.js";
 export type {
   Civ7CaptureWindowRow,
   Civ7WindowShotCaptureInput,
   Civ7WindowShotCaptureResult,
-  Civ7WindowShotListInput,
-  Civ7WindowShotListResult,
   WindowShotDependencies,
 } from "./play/view/window-shot.js";
 

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -1330,6 +1330,42 @@ export type {
   Civ7DisplayRequest,
   DisplayQueueDependencies,
 } from "./play/operations/display-queue.js";
+export {
+  CIV7_CLEAN_FRAME_HIDDEN_WORLD_RULES,
+  CIV7_CLEAN_FRAME_HIDE_UNITS_GLOBAL,
+  CIV7_CLEAN_FRAME_PREVIOUS_VIEW_GLOBAL,
+  CIV7_CLEAN_FRAME_VIEW_NAME,
+  CIV7_VIEW_MANAGER_BRIDGE_GLOBAL,
+  Civ7CleanFrameEnterResultSchema,
+  Civ7CleanFrameExitResultSchema,
+  ensureCiv7ViewManagerBridge,
+  enterCiv7CleanFrame,
+  exitCiv7CleanFrame,
+} from "./play/view/clean-frame.js";
+export type {
+  Civ7CleanFrameEnterInput,
+  Civ7CleanFrameEnterResult,
+  Civ7CleanFrameExitResult,
+  CleanFrameDependencies,
+} from "./play/view/clean-frame.js";
+export {
+  CIV7_WINDOW_SHOT_SWIFT_SOURCE,
+  Civ7CaptureWindowRowSchema,
+  Civ7WindowShotCaptureResultSchema,
+  Civ7WindowShotFileSchema,
+  DEFAULT_CIV7_WINDOW_MATCH,
+  captureCiv7WindowShot,
+  ensureCiv7WindowShotHelper,
+  listCiv7CaptureWindows,
+} from "./play/view/window-shot.js";
+export type {
+  Civ7CaptureWindowRow,
+  Civ7WindowShotCaptureInput,
+  Civ7WindowShotCaptureResult,
+  Civ7WindowShotListInput,
+  Civ7WindowShotListResult,
+  WindowShotDependencies,
+} from "./play/view/window-shot.js";
 
 export { CIV7_SIGNED_INT_SEED_MAX, CIV7_SIGNED_INT_SEED_MIN, assessCiv7SignedIntSeed } from "./policy/setup.js";
 export const DEFAULT_CIV7_RESOURCE_FEASIBILITY_MAX_CELLS = 256;

--- a/packages/civ7-direct-control/src/play/view/clean-frame.ts
+++ b/packages/civ7-direct-control/src/play/view/clean-frame.ts
@@ -1,0 +1,290 @@
+import { Type } from "typebox";
+
+import { Civ7DirectControlError } from "../../direct-control-error.js";
+import { jsLiteral } from "../../runtime/command-serialization.js";
+import { jsonPayloadFromCommandResult } from "../../session/command-result.js";
+import { executeCiv7AppUiCommand } from "../../session/execute.js";
+import { sleep } from "../../timing.js";
+
+import type {
+  Civ7CommandResult,
+  Civ7DirectControlOptions,
+  Civ7TunerState,
+} from "../../session/types.js";
+
+// Live-verified against a running Civ7 game on 2026-06-11: the only machinery
+// that hides the in-game HUD and world overlays is the ViewManager rules
+// engine (core/ui/views/view-manager.js). Each registered view declares rules
+// (harness hidden/shown, ui-hide-*/ui-show-* world events) and the `current`
+// setter applies them as a verified transition: exitView -> applyRules ->
+// switchView(harness template) -> enterView.
+//
+// The game's own screenshot affordances are NOT usable for clean frames:
+// INTERFACEMODE_SCREENSHOT maps to the stub ScreenshotView whose rules keep
+// everything visible and whose enterView injects placeholder "foo"/"bar"
+// buttons into the harness. The Cinematic view has the right hidden-rule set
+// but drags cinematic input/harness semantics along. So we register our own
+// view with the Cinematic rule set, an "empty" harness template, and no other
+// behavior — every hide/show runs through the official rules engine, which
+// keeps ViewManager's rule-state bookkeeping consistent for the restore.
+//
+// Like DisplayQueueManager, ViewManager is an ES module, not a global: it is
+// only reachable from exec via the shared module registry
+// (`import("/core/ui/views/view-manager.js")` — note: the `.chunk.js` paths in
+// our extracted resources are artifacts of the extraction pipeline and do NOT
+// resolve in the live VFS). The import is async while exec returns
+// synchronously, so the bridge memoizes the module on `globalThis` in one exec
+// and operates on it in the next.
+
+/** Where the memoized view-manager module lives inside the App UI context. */
+export const CIV7_VIEW_MANAGER_BRIDGE_GLOBAL = "__civ7DirectControlViewManager";
+
+/** Name of the hidden-rules view this package registers in the view pool. */
+export const CIV7_CLEAN_FRAME_VIEW_NAME = "DirectControlCleanFrame";
+
+/** Where the pre-clean-frame view name is parked for the restore. */
+export const CIV7_CLEAN_FRAME_PREVIOUS_VIEW_GLOBAL =
+  "__civ7DirectControlCleanFramePreviousView";
+
+/** Flag read by the registered view's enterView to also hide 3D units. */
+export const CIV7_CLEAN_FRAME_HIDE_UNITS_GLOBAL =
+  "__civ7DirectControlCleanFrameHideUnits";
+
+/**
+ * World-system rule names hidden by the clean-frame view — the Cinematic
+ * view's live rule set (the gold standard for "nothing over the map").
+ */
+export const CIV7_CLEAN_FRAME_HIDDEN_WORLD_RULES: ReadonlyArray<string> = [
+  "city-banners",
+  "district-health-bars",
+  "plot-icons",
+  "plot-tooltips",
+  "plot-vfx",
+  "unit-flags",
+  "unit-info-panel",
+  "small-narratives",
+];
+
+export const DEFAULT_CIV7_VIEW_BRIDGE_ATTEMPTS = 6;
+export const CIV7_VIEW_BRIDGE_RETRY_MS = 500;
+
+const civ7TunerStateSchema = Type.Object({
+  id: Type.String(),
+  name: Type.String(),
+}, { additionalProperties: false });
+
+export type Civ7CleanFrameEnterInput = Readonly<{
+  /** Also hide 3D unit models (WorldUI.setUnitVisibility) for map-only frames. */
+  hideUnits?: boolean;
+}>;
+
+export const Civ7CleanFrameEnterResultSchema = Type.Object({
+  host: Type.String(),
+  port: Type.Number(),
+  state: civ7TunerStateSchema,
+  switched: Type.Boolean(),
+  viewBefore: Type.String(),
+  view: Type.String(),
+  harnessHidden: Type.Boolean(),
+  hideUnits: Type.Boolean(),
+}, { additionalProperties: false });
+
+export type Civ7CleanFrameEnterResult = Readonly<{
+  host: string;
+  port: number;
+  state: Civ7TunerState;
+  /** setCurrentByName accepted the transition. */
+  switched: boolean;
+  /** View that was current before the clean frame (the restore target). */
+  viewBefore: string;
+  /** View current after the call — the readback truth source. */
+  view: string;
+  /** HUD harness hidden after the call — the readback truth source. */
+  harnessHidden: boolean;
+  hideUnits: boolean;
+}>;
+
+export const Civ7CleanFrameExitResultSchema = Type.Object({
+  host: Type.String(),
+  port: Type.Number(),
+  state: civ7TunerStateSchema,
+  switched: Type.Boolean(),
+  view: Type.String(),
+  harnessHidden: Type.Boolean(),
+}, { additionalProperties: false });
+
+export type Civ7CleanFrameExitResult = Readonly<{
+  host: string;
+  port: number;
+  state: Civ7TunerState;
+  switched: boolean;
+  view: string;
+  harnessHidden: boolean;
+}>;
+
+export type CleanFrameDependencies = Readonly<{
+  executeAppUiCommand: (
+    options: Civ7DirectControlOptions & Readonly<{ command: string }>,
+  ) => Promise<Civ7CommandResult>;
+  jsLiteral: (value: unknown) => string;
+  parsePayload: <T>(result: Civ7CommandResult, label: string) => T;
+  sleep: (ms: number) => Promise<void>;
+}>;
+
+const defaultCleanFrameDependencies: CleanFrameDependencies = {
+  executeAppUiCommand: executeCiv7AppUiCommand,
+  jsLiteral,
+  parsePayload: <T,>(result: Civ7CommandResult, label: string) =>
+    jsonPayloadFromCommandResult(result, label) as T,
+  sleep,
+};
+
+type BridgePayload = Readonly<{ ready: boolean }>;
+
+/**
+ * Memoizes the view-manager module on `globalThis` inside the App UI context.
+ * Safe to call repeatedly; later operations assume the bridge is present.
+ */
+export async function ensureCiv7ViewManagerBridge(
+  options: Civ7DirectControlOptions = {},
+  dependencies: CleanFrameDependencies = defaultCleanFrameDependencies,
+): Promise<void> {
+  for (let attempt = 0; attempt < DEFAULT_CIV7_VIEW_BRIDGE_ATTEMPTS; attempt += 1) {
+    const payload = dependencies.parsePayload<BridgePayload>(
+      await dependencies.executeAppUiCommand({
+        ...options,
+        command: buildViewManagerBridgeCommand(),
+      }),
+      "Civ7 view-manager bridge",
+    );
+    if (payload.ready) return;
+    await dependencies.sleep(CIV7_VIEW_BRIDGE_RETRY_MS);
+  }
+  throw new Civ7DirectControlError(
+    "command-failed",
+    "Civ7 view-manager bridge never became ready (module-registry import did not resolve)",
+  );
+}
+
+/**
+ * Switches the live game into the hidden-rules clean-frame view: HUD harness
+ * hidden, every world overlay (banners, flags, icons, tooltips, vfx,
+ * narratives) hidden through the official rules engine, optionally 3D units
+ * too. Records the previous view for {@link exitCiv7CleanFrame}; the readback
+ * fields are the truth source, not the switch request.
+ */
+export async function enterCiv7CleanFrame(
+  input: Civ7CleanFrameEnterInput = {},
+  options: Civ7DirectControlOptions = {},
+  dependencies: CleanFrameDependencies = defaultCleanFrameDependencies,
+): Promise<Civ7CleanFrameEnterResult> {
+  await ensureCiv7ViewManagerBridge(options, dependencies);
+  const hideUnits = input.hideUnits === true;
+  const result = await dependencies.executeAppUiCommand({
+    ...options,
+    command: buildCleanFrameEnterCommand(hideUnits, dependencies),
+  });
+  const payload = dependencies.parsePayload<
+    Omit<Civ7CleanFrameEnterResult, "host" | "port" | "state" | "hideUnits">
+  >(result, "Civ7 clean-frame enter");
+  return {
+    host: result.host,
+    port: result.port,
+    state: result.state,
+    ...payload,
+    hideUnits,
+  };
+}
+
+/**
+ * Restores the view recorded by {@link enterCiv7CleanFrame} (falls back to
+ * "World") — the same official transition re-applies the previous view's
+ * show rules and harness template. exitView on the clean-frame view always
+ * restores 3D unit visibility.
+ */
+export async function exitCiv7CleanFrame(
+  options: Civ7DirectControlOptions = {},
+  dependencies: CleanFrameDependencies = defaultCleanFrameDependencies,
+): Promise<Civ7CleanFrameExitResult> {
+  await ensureCiv7ViewManagerBridge(options, dependencies);
+  const result = await dependencies.executeAppUiCommand({
+    ...options,
+    command: buildCleanFrameExitCommand(),
+  });
+  const payload = dependencies.parsePayload<
+    Omit<Civ7CleanFrameExitResult, "host" | "port" | "state">
+  >(result, "Civ7 clean-frame exit");
+  return { host: result.host, port: result.port, state: result.state, ...payload };
+}
+
+export function buildViewManagerBridgeCommand(): string {
+  return `(() => {
+    const bridged = globalThis[${jsLiteral(CIV7_VIEW_MANAGER_BRIDGE_GLOBAL)}];
+    if (bridged) return JSON.stringify({ ready: true });
+    import("/core/ui/views/view-manager.js")
+      .then((m) => { globalThis[${jsLiteral(CIV7_VIEW_MANAGER_BRIDGE_GLOBAL)}] = m; })
+      .catch((err) => console.error("[civ7-direct-control] view-manager bridge import failed: " + String(err)));
+    return JSON.stringify({ ready: false });
+  })()`;
+}
+
+export function buildCleanFrameEnterCommand(
+  hideUnits: boolean,
+  dependencies: Pick<CleanFrameDependencies, "jsLiteral">,
+): string {
+  const worldRules = CIV7_CLEAN_FRAME_HIDDEN_WORLD_RULES
+    .map((name) =>
+      `{ name: ${dependencies.jsLiteral(name)}, type: U.World, visible: "false" }`
+    )
+    .join(",\n        ");
+  // views.set (not addHandler) so re-registration is idempotent: addHandler
+  // refuses duplicates, and the registered closure must always reflect the
+  // current package version, not whichever one registered first.
+  return `(() => {
+    const m = globalThis[${jsLiteral(CIV7_VIEW_MANAGER_BRIDGE_GLOBAL)}];
+    const vm = m.default;
+    const U = m.UISystem;
+    globalThis[${jsLiteral(CIV7_CLEAN_FRAME_HIDE_UNITS_GLOBAL)}] = ${dependencies.jsLiteral(hideUnits)};
+    vm.views.set(${jsLiteral(CIV7_CLEAN_FRAME_VIEW_NAME)}, {
+      getName: () => ${jsLiteral(CIV7_CLEAN_FRAME_VIEW_NAME)},
+      getInputContext: () => InputContext.World,
+      getHarnessTemplate: () => "empty",
+      enterView: () => {
+        if (globalThis[${jsLiteral(CIV7_CLEAN_FRAME_HIDE_UNITS_GLOBAL)}] === true) WorldUI.setUnitVisibility(false);
+      },
+      exitView: () => { WorldUI.setUnitVisibility(true); },
+      addEnterCallback: () => {},
+      addExitCallback: () => {},
+      getRules: () => [
+        { name: "harness", type: U.HUD, visible: "false" },
+        ${worldRules}
+      ],
+    });
+    const viewBefore = vm.current.getName();
+    if (viewBefore !== ${jsLiteral(CIV7_CLEAN_FRAME_VIEW_NAME)}) {
+      globalThis[${jsLiteral(CIV7_CLEAN_FRAME_PREVIOUS_VIEW_GLOBAL)}] = viewBefore;
+    }
+    const switched = vm.setCurrentByName(${jsLiteral(CIV7_CLEAN_FRAME_VIEW_NAME)});
+    return JSON.stringify({
+      switched,
+      viewBefore,
+      view: vm.current.getName(),
+      harnessHidden: vm.isHarnessHidden === true,
+    });
+  })()`;
+}
+
+export function buildCleanFrameExitCommand(): string {
+  return `(() => {
+    const vm = globalThis[${jsLiteral(CIV7_VIEW_MANAGER_BRIDGE_GLOBAL)}].default;
+    const previous = globalThis[${jsLiteral(CIV7_CLEAN_FRAME_PREVIOUS_VIEW_GLOBAL)}];
+    const target = typeof previous === "string" && previous.length > 0 ? previous : "World";
+    const switched = vm.setCurrentByName(target);
+    globalThis[${jsLiteral(CIV7_CLEAN_FRAME_PREVIOUS_VIEW_GLOBAL)}] = undefined;
+    return JSON.stringify({
+      switched,
+      view: vm.current.getName(),
+      harnessHidden: vm.isHarnessHidden === true,
+    });
+  })()`;
+}

--- a/packages/civ7-direct-control/src/play/view/window-shot.ts
+++ b/packages/civ7-direct-control/src/play/view/window-shot.ts
@@ -1,8 +1,8 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 
 import { Type, type Static } from "typebox";
@@ -56,7 +56,7 @@ var outPath: String? = nil
 var arguments = CommandLine.arguments.dropFirst().makeIterator()
 while let argument = arguments.next() {
   switch argument {
-  case "list", "capture":
+  case "capture":
     mode = argument
   case "--app":
     guard let value = arguments.next() else { fail("usage", "--app requires a value") }
@@ -72,7 +72,7 @@ while let argument = arguments.next() {
   }
 }
 guard let selectedMode = mode else {
-  fail("usage", "usage: civ7-window-shot <list|capture> [--app substring] [--window-id id] [--out path.png]")
+  fail("usage", "usage: civ7-window-shot capture [--app substring] [--window-id id] --out path.png")
 }
 
 if !CGPreflightScreenCaptureAccess() {
@@ -190,14 +190,9 @@ func captureViaStream(filter: SCContentFilter, configuration: SCStreamConfigurat
 func run(mode: String, appNeedle: String, windowId: UInt32?, outPath: String?) async {
   let windows = await shareableWindows()
 
-  if mode == "list" {
-    let rows = windows.filter { matches($0, needle: appNeedle) }.map(windowRow)
-    emit(["ok": true, "mode": "list", "windows": rows], code: 0)
-  }
-
   guard let outPath = outPath else { fail("usage", "capture requires --out <path.png>") }
   guard let window = pickWindow(from: windows, appNeedle: appNeedle, windowId: windowId) else {
-    fail("window-not-found", "no window matched app substring '" + appNeedle + "'; adjust --app or pass --window-id (run list mode to enumerate)")
+    fail("window-not-found", "no window matched app substring '" + appNeedle + "'; adjust --app or pass --window-id")
   }
 
   let filter = SCContentFilter(desktopIndependentWindow: window)
@@ -210,18 +205,17 @@ func run(mode: String, appNeedle: String, windowId: UInt32?, outPath: String?) a
   configuration.captureResolution = .best
 
   // On-screen windows composite continuously: the one-shot screenshot is
-  // fresh and fastest. Off-screen windows go through the stream-forced path;
-  // if the stream yields nothing the one-shot still runs, but the result is
-  // labeled so callers know the pixels may be stale.
+  // fresh and fastest. Off-screen windows MUST go through the stream-forced
+  // path — their backing store is stale, so a one-shot would silently capture
+  // old pixels. No fallback: if the stream yields nothing, fail honestly.
   var image: CGImage? = nil
   var frameSource = "screenshot"
   if !window.isOnScreen {
-    if let streamed = await captureViaStream(filter: filter, configuration: configuration) {
-      image = streamed
-      frameSource = "stream"
-    } else {
-      frameSource = "screenshot-fallback"
+    guard let streamed = await captureViaStream(filter: filter, configuration: configuration) else {
+      fail("capture-failed", "the window is off-screen (another Space or minimized) and no fresh frame could be forced via a capture stream; bring the game window on screen and retry")
     }
+    image = streamed
+    frameSource = "stream"
   }
   if image == nil {
     do {
@@ -284,21 +278,12 @@ export const Civ7CaptureWindowRowSchema = Type.Object({
 
 export type Civ7CaptureWindowRow = Readonly<Static<typeof Civ7CaptureWindowRowSchema>>;
 
-export type Civ7WindowShotListInput = Readonly<{
-  /** Case-insensitive substring of app name / bundle id / window title. */
-  appName?: string;
-}>;
-
-export type Civ7WindowShotListResult = Readonly<{
-  windows: ReadonlyArray<Civ7CaptureWindowRow>;
-}>;
-
 export type Civ7WindowShotCaptureInput = Readonly<{
   /** PNG output path; defaults under the OS temp dir. */
   outputPath?: string;
   /** Case-insensitive substring of app name / bundle id / window title. */
   appName?: string;
-  /** Exact window id (from list mode) — overrides appName matching. */
+  /** Exact window id — overrides appName matching. */
   windowId?: number;
 }>;
 
@@ -318,8 +303,6 @@ export const Civ7WindowShotFrameSourceSchema = Type.Union([
   Type.Literal("screenshot"),
   /** Off-screen window: a temporary stream forced fresh compositing. */
   Type.Literal("stream"),
-  /** Off-screen window and the stream yielded nothing: pixels may be STALE. */
-  Type.Literal("screenshot-fallback"),
 ]);
 
 export type Civ7WindowShotFrameSource = Static<typeof Civ7WindowShotFrameSourceSchema>;
@@ -354,7 +337,9 @@ export type WindowShotDependencies = Readonly<{
   ) => Promise<Readonly<{ stdout: string; stderr: string }>>;
   mkdir: typeof mkdir;
   now: () => Date;
+  readdir: (path: string) => Promise<string[]>;
   readFile: typeof readFile;
+  rm: (path: string, options: Readonly<{ force: boolean }>) => Promise<void>;
   stat: typeof stat;
   tmpdir: () => string;
   writeFile: typeof writeFile;
@@ -364,7 +349,9 @@ const defaultWindowShotDependencies: WindowShotDependencies = {
   execFile,
   mkdir,
   now: () => new Date(),
+  readdir: (path) => readdir(path),
   readFile,
+  rm: (path, options) => rm(path, options),
   stat,
   tmpdir,
   writeFile,
@@ -373,7 +360,8 @@ const defaultWindowShotDependencies: WindowShotDependencies = {
 /**
  * Compiles the Swift capture helper once per source revision and caches the
  * binary under the OS temp dir (keyed by source hash, so package upgrades
- * recompile automatically).
+ * recompile automatically). Compiling a new revision prunes the previous
+ * revisions' binaries and sources, so the cache never accumulates.
  */
 export async function ensureCiv7WindowShotHelper(
   dependencies: WindowShotDependencies = defaultWindowShotDependencies,
@@ -405,20 +393,27 @@ export async function ensureCiv7WindowShotHelper(
       { cause: error },
     );
   }
+  await pruneStaleHelperRevisions(dependencies, cacheRoot, basename(binaryPath));
   return binaryPath;
 }
 
-/** Enumerates capturable windows matching the app substring. */
-export async function listCiv7CaptureWindows(
-  input: Civ7WindowShotListInput = {},
-  dependencies: WindowShotDependencies = defaultWindowShotDependencies,
-): Promise<Civ7WindowShotListResult> {
-  const payload = await runWindowShotHelper(dependencies, [
-    "list",
-    "--app",
-    input.appName ?? DEFAULT_CIV7_WINDOW_MATCH,
-  ]);
-  return { windows: (payload as { windows: Civ7CaptureWindowRow[] }).windows };
+/** Best-effort: drop binaries/sources from previous helper revisions. */
+async function pruneStaleHelperRevisions(
+  dependencies: WindowShotDependencies,
+  cacheRoot: string,
+  keepBasename: string,
+): Promise<void> {
+  try {
+    const entries = await dependencies.readdir(cacheRoot);
+    await Promise.all(entries
+      .filter((name) =>
+        name.startsWith("civ7-window-shot-")
+        && name !== keepBasename
+        && name !== `${keepBasename}.swift`)
+      .map((name) => dependencies.rm(join(cacheRoot, name), { force: true })));
+  } catch {
+    // Cache pruning never blocks a capture.
+  }
 }
 
 /**
@@ -438,6 +433,11 @@ export async function captureCiv7WindowShot(
     input.outputPath ?? defaultWindowShotPath(requestedAt, dependencies.tmpdir()),
   );
   await dependencies.mkdir(dirname(outputPath), { recursive: true });
+  // Retention loop for the managed destination only — explicit outputPath
+  // directories belong to the caller and are never touched.
+  if (input.outputPath === undefined) {
+    await pruneStaleAppshots(dependencies, dirname(outputPath), requestedAt);
+  }
   const payload = await runWindowShotHelper(dependencies, [
     "capture",
     "--out",
@@ -465,11 +465,7 @@ export async function captureCiv7WindowShot(
   return {
     captureMode: "window-scoped-screencapturekit",
     requestedAt: requestedAt.toISOString(),
-    frameSource: payload.frameSource === "stream"
-      ? "stream"
-      : payload.frameSource === "screenshot-fallback"
-        ? "screenshot-fallback"
-        : "screenshot",
+    frameSource: payload.frameSource === "stream" ? "stream" : "screenshot",
     window: {
       windowId: payload.windowId,
       app: payload.app,
@@ -552,6 +548,36 @@ function defaultWindowShotPath(date: Date, tmp: string): string {
     "civ7-appshots",
     `civ7-appshot-${date.toISOString().replace(/[:.]/g, "-")}.png`,
   );
+}
+
+/**
+ * Retention for the managed default destination: appshots older than 7 days
+ * are dropped on each capture, so the directory is self-cleaning. The OS temp
+ * dir's own purge is the backstop. Best-effort — retention never blocks a
+ * capture.
+ */
+const CIV7_APPSHOT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+async function pruneStaleAppshots(
+  dependencies: WindowShotDependencies,
+  directory: string,
+  now: Date,
+): Promise<void> {
+  try {
+    const cutoff = now.getTime() - CIV7_APPSHOT_RETENTION_MS;
+    const entries = await dependencies.readdir(directory);
+    await Promise.all(entries
+      .filter((name) => name.startsWith("civ7-appshot-") && name.endsWith(".png"))
+      .map(async (name) => {
+        const path = join(directory, name);
+        const fileStat = await dependencies.stat(path);
+        if (fileStat.mtimeMs < cutoff) {
+          await dependencies.rm(path, { force: true });
+        }
+      }));
+  } catch {
+    // Retention never blocks a capture.
+  }
 }
 
 function pngDimensions(bytes: Buffer): { width: number; height: number } | undefined {

--- a/packages/civ7-direct-control/src/play/view/window-shot.ts
+++ b/packages/civ7-direct-control/src/play/view/window-shot.ts
@@ -1,0 +1,569 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+import { Type, type Static } from "typebox";
+
+import { Civ7DirectControlError } from "../../direct-control-error.js";
+
+const execFile = promisify(execFileCallback);
+
+// Window-scoped capture of the Civ7 game window. Settled platform facts
+// (live-probed 2026-06; see the cli-command-taxonomy workstream record):
+//   - the Mac Steam build ships NO programmatic capture: no XR console (zero
+//     XR strings in the binary), no settings toggle, and the only native
+//     integration is Steam F12 (ISteamScreenshots — human keypress only),
+//   - `screencapture` grabs the whole display, so desktops/overlays leak into
+//     "game" captures,
+//   - ScreenCaptureKit window capture (SCContentFilter(desktopIndependentWindow:)
+//     + SCScreenshotManager) captures exactly one window at native pixel
+//     scale, even when occluded. It requires a one-time Screen Recording
+//     (TCC) grant for the app hosting this process.
+//
+// The Swift helper below is the whole OS surface: compiled once per source
+// hash with the system toolchain and cached under the OS temp dir. It always
+// emits a single JSON object on stdout — `ok: true` rows or
+// `ok: false, error: <kind>` rows that this atom maps to typed errors.
+
+export const CIV7_WINDOW_SHOT_SWIFT_SOURCE = `import CoreGraphics
+import CoreImage
+import CoreMedia
+import Foundation
+import ImageIO
+import ScreenCaptureKit
+import UniformTypeIdentifiers
+
+func emit(_ object: [String: Any], code: Int32) -> Never {
+  let data = try! JSONSerialization.data(withJSONObject: object)
+  FileHandle.standardOutput.write(data)
+  FileHandle.standardOutput.write(Data([0x0a]))
+  exit(code)
+}
+
+func fail(_ kind: String, _ message: String) -> Never {
+  emit(["ok": false, "error": kind, "message": message], code: 1)
+}
+
+let permissionMessage = "Screen Recording permission is not granted for the app running this command. Open System Settings -> Privacy & Security -> Screen & System Audio Recording, enable the host app (the OS prompt has already registered it in that list), then retry."
+
+var mode: String? = nil
+var appNeedle = "civilization"
+var windowId: UInt32? = nil
+var outPath: String? = nil
+var arguments = CommandLine.arguments.dropFirst().makeIterator()
+while let argument = arguments.next() {
+  switch argument {
+  case "list", "capture":
+    mode = argument
+  case "--app":
+    guard let value = arguments.next() else { fail("usage", "--app requires a value") }
+    appNeedle = value.lowercased()
+  case "--window-id":
+    guard let value = arguments.next(), let parsed = UInt32(value) else { fail("usage", "--window-id requires an integer") }
+    windowId = parsed
+  case "--out":
+    guard let value = arguments.next() else { fail("usage", "--out requires a path") }
+    outPath = value
+  default:
+    fail("usage", "unknown argument: " + argument)
+  }
+}
+guard let selectedMode = mode else {
+  fail("usage", "usage: civ7-window-shot <list|capture> [--app substring] [--window-id id] [--out path.png]")
+}
+
+if !CGPreflightScreenCaptureAccess() {
+  // Fires the one-time OS permission prompt and registers this app in the
+  // System Settings list even when the prompt is dismissed.
+  CGRequestScreenCaptureAccess()
+  fail("permission-required", permissionMessage)
+}
+
+@available(macOS 14.0, *)
+func windowRow(_ window: SCWindow) -> [String: Any] {
+  return [
+    "windowId": Int(window.windowID),
+    "app": window.owningApplication?.applicationName ?? "",
+    "bundleId": window.owningApplication?.bundleIdentifier ?? "",
+    "title": window.title ?? "",
+    "width": Int(window.frame.width),
+    "height": Int(window.frame.height),
+    "onScreen": window.isOnScreen,
+  ]
+}
+
+@available(macOS 14.0, *)
+func matches(_ window: SCWindow, needle: String) -> Bool {
+  let haystack = [
+    window.owningApplication?.applicationName ?? "",
+    window.owningApplication?.bundleIdentifier ?? "",
+    window.title ?? "",
+  ].joined(separator: " ").lowercased()
+  return haystack.contains(needle)
+}
+
+@available(macOS 14.0, *)
+func shareableWindows() async -> [SCWindow] {
+  do {
+    let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+    return content.windows
+  } catch {
+    let nsError = error as NSError
+    if nsError.code == -3801 { fail("permission-required", permissionMessage) }
+    fail("capture-failed", "could not enumerate windows: " + nsError.localizedDescription)
+  }
+}
+
+@available(macOS 14.0, *)
+func pickWindow(from windows: [SCWindow], appNeedle: String, windowId: UInt32?) -> SCWindow? {
+  let candidates = windows.filter { window in
+    if let windowId = windowId { return window.windowID == windowId }
+    // Ignore tiny chrome (tooltips, status items); the game window is large.
+    return matches(window, needle: appNeedle) && window.frame.width >= 200 && window.frame.height >= 200
+  }
+  return candidates.max(by: { left, right in
+    left.frame.width * left.frame.height < right.frame.width * right.frame.height
+  })
+}
+
+// Latest-frame sink for the stream-forced capture path. All mutation happens
+// on the sample-handler queue; readers hop onto that queue.
+@available(macOS 14.0, *)
+final class FrameSink: NSObject, SCStreamOutput {
+  let ciContext = CIContext()
+  var latest: CGImage? = nil
+  var frameCount = 0
+  func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
+    guard type == .screen, let pixelBuffer = sampleBuffer.imageBuffer else { return }
+    guard let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: false) as? [[SCStreamFrameInfo: Any]],
+          let statusRaw = attachments.first?[.status] as? Int,
+          statusRaw == SCFrameStatus.complete.rawValue else { return }
+    let ci = CIImage(cvPixelBuffer: pixelBuffer)
+    guard let cg = ciContext.createCGImage(ci, from: ci.extent) else { return }
+    latest = cg
+    frameCount += 1
+  }
+}
+
+// Freshness for off-screen windows: a window on another Space (or minimized)
+// stops compositing, so its backing store is STALE. A running SCStream forces
+// the window server to composite fresh frames WITHOUT activating the game or
+// touching the user's focus (live-verified: 43 distinct frames over 4s from a
+// fullscreen window on an inactive Space). Early frames can replay the stale
+// store, so the capture takes the latest frame after a short warm-up.
+@available(macOS 14.0, *)
+func captureViaStream(filter: SCContentFilter, configuration: SCStreamConfiguration) async -> CGImage? {
+  configuration.minimumFrameInterval = CMTime(value: 1, timescale: 10)
+  configuration.queueDepth = 5
+  let sinkQueue = DispatchQueue(label: "civ7-window-shot-sink")
+  let sink = FrameSink()
+  let stream = SCStream(filter: filter, configuration: configuration, delegate: nil)
+  do {
+    try stream.addStreamOutput(sink, type: .screen, sampleHandlerQueue: sinkQueue)
+    try await stream.startCapture()
+  } catch {
+    let nsError = error as NSError
+    if nsError.code == -3801 { fail("permission-required", permissionMessage) }
+    return nil
+  }
+  var image: CGImage? = nil
+  let warmedUpAt = Date().addingTimeInterval(0.8)
+  let deadline = Date().addingTimeInterval(3.0)
+  while Date() < deadline {
+    try? await Task.sleep(nanoseconds: 200_000_000)
+    let snapshot: (CGImage?, Int) = await withCheckedContinuation { continuation in
+      sinkQueue.async { continuation.resume(returning: (sink.latest, sink.frameCount)) }
+    }
+    if Date() >= warmedUpAt, snapshot.1 >= 3, let latest = snapshot.0 {
+      image = latest
+      break
+    }
+  }
+  try? await stream.stopCapture()
+  return image
+}
+
+@available(macOS 14.0, *)
+func run(mode: String, appNeedle: String, windowId: UInt32?, outPath: String?) async {
+  let windows = await shareableWindows()
+
+  if mode == "list" {
+    let rows = windows.filter { matches($0, needle: appNeedle) }.map(windowRow)
+    emit(["ok": true, "mode": "list", "windows": rows], code: 0)
+  }
+
+  guard let outPath = outPath else { fail("usage", "capture requires --out <path.png>") }
+  guard let window = pickWindow(from: windows, appNeedle: appNeedle, windowId: windowId) else {
+    fail("window-not-found", "no window matched app substring '" + appNeedle + "'; adjust --app or pass --window-id (run list mode to enumerate)")
+  }
+
+  let filter = SCContentFilter(desktopIndependentWindow: window)
+  let configuration = SCStreamConfiguration()
+  let scale = CGFloat(filter.pointPixelScale)
+  configuration.width = Int(filter.contentRect.width * scale)
+  configuration.height = Int(filter.contentRect.height * scale)
+  configuration.showsCursor = false
+  configuration.ignoreShadowsSingleWindow = true
+  configuration.captureResolution = .best
+
+  // On-screen windows composite continuously: the one-shot screenshot is
+  // fresh and fastest. Off-screen windows go through the stream-forced path;
+  // if the stream yields nothing the one-shot still runs, but the result is
+  // labeled so callers know the pixels may be stale.
+  var image: CGImage? = nil
+  var frameSource = "screenshot"
+  if !window.isOnScreen {
+    if let streamed = await captureViaStream(filter: filter, configuration: configuration) {
+      image = streamed
+      frameSource = "stream"
+    } else {
+      frameSource = "screenshot-fallback"
+    }
+  }
+  if image == nil {
+    do {
+      image = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: configuration)
+    } catch {
+      let nsError = error as NSError
+      if nsError.code == -3801 { fail("permission-required", permissionMessage) }
+      fail("capture-failed", "ScreenCaptureKit capture failed: " + nsError.localizedDescription)
+    }
+  }
+  guard let image = image else { fail("capture-failed", "no frame was produced") }
+
+  let url = URL(fileURLWithPath: outPath) as CFURL
+  guard let destination = CGImageDestinationCreateWithURL(url, UTType.png.identifier as CFString, 1, nil) else {
+    fail("capture-failed", "could not open PNG destination: " + outPath)
+  }
+  CGImageDestinationAddImage(destination, image, nil)
+  guard CGImageDestinationFinalize(destination) else {
+    fail("capture-failed", "could not finalize PNG: " + outPath)
+  }
+  var row = windowRow(window)
+  row["ok"] = true
+  row["mode"] = "capture"
+  row["path"] = outPath
+  row["pixelWidth"] = image.width
+  row["pixelHeight"] = image.height
+  row["frameSource"] = frameSource
+  emit(row, code: 0)
+}
+
+if #available(macOS 14.0, *) {
+  // Force CoreGraphics window-server initialization on the main thread BEFORE
+  // any ScreenCaptureKit capture work, and keep the main thread servicing a
+  // run loop (not semaphore-blocked) while the capture runs -- otherwise the
+  // SCK capture path trips the CGS_REQUIRE_INIT assertion in CLI processes.
+  // emit()/fail() exit the process, so the run loop never needs stopping.
+  _ = CGMainDisplayID()
+  Task.detached {
+    await run(mode: selectedMode, appNeedle: appNeedle, windowId: windowId, outPath: outPath)
+    fail("capture-failed", "capture task ended without emitting a result")
+  }
+  RunLoop.main.run()
+} else {
+  fail("unsupported-macos", "window-scoped capture requires macOS 14+ (ScreenCaptureKit SCScreenshotManager)")
+}
+`;
+
+/** Substring matched against app name / bundle id / window title. */
+export const DEFAULT_CIV7_WINDOW_MATCH = "civilization";
+
+export const Civ7CaptureWindowRowSchema = Type.Object({
+  windowId: Type.Integer({ minimum: 0 }),
+  app: Type.String(),
+  bundleId: Type.String(),
+  title: Type.String(),
+  width: Type.Integer({ minimum: 0 }),
+  height: Type.Integer({ minimum: 0 }),
+  onScreen: Type.Boolean(),
+}, { additionalProperties: false });
+
+export type Civ7CaptureWindowRow = Readonly<Static<typeof Civ7CaptureWindowRowSchema>>;
+
+export type Civ7WindowShotListInput = Readonly<{
+  /** Case-insensitive substring of app name / bundle id / window title. */
+  appName?: string;
+}>;
+
+export type Civ7WindowShotListResult = Readonly<{
+  windows: ReadonlyArray<Civ7CaptureWindowRow>;
+}>;
+
+export type Civ7WindowShotCaptureInput = Readonly<{
+  /** PNG output path; defaults under the OS temp dir. */
+  outputPath?: string;
+  /** Case-insensitive substring of app name / bundle id / window title. */
+  appName?: string;
+  /** Exact window id (from list mode) — overrides appName matching. */
+  windowId?: number;
+}>;
+
+export const Civ7WindowShotFileSchema = Type.Object({
+  path: Type.String(),
+  byteSize: Type.Integer({ minimum: 0 }),
+  sha256: Type.String(),
+  mediaType: Type.Literal("image/png"),
+  dimensions: Type.Optional(Type.Object({
+    width: Type.Integer({ minimum: 0 }),
+    height: Type.Integer({ minimum: 0 }),
+  }, { additionalProperties: false })),
+}, { additionalProperties: false });
+
+export const Civ7WindowShotFrameSourceSchema = Type.Union([
+  /** Window was on screen and compositing: one-shot screenshot, fresh. */
+  Type.Literal("screenshot"),
+  /** Off-screen window: a temporary stream forced fresh compositing. */
+  Type.Literal("stream"),
+  /** Off-screen window and the stream yielded nothing: pixels may be STALE. */
+  Type.Literal("screenshot-fallback"),
+]);
+
+export type Civ7WindowShotFrameSource = Static<typeof Civ7WindowShotFrameSourceSchema>;
+
+export const Civ7WindowShotCaptureResultSchema = Type.Object({
+  captureMode: Type.Literal("window-scoped-screencapturekit"),
+  requestedAt: Type.String(),
+  frameSource: Civ7WindowShotFrameSourceSchema,
+  window: Civ7CaptureWindowRowSchema,
+  file: Civ7WindowShotFileSchema,
+}, { additionalProperties: false });
+
+export type Civ7WindowShotCaptureResult = Readonly<{
+  captureMode: "window-scoped-screencapturekit";
+  requestedAt: string;
+  /** How freshness was obtained — never via app activation/focus changes. */
+  frameSource: Civ7WindowShotFrameSource;
+  window: Civ7CaptureWindowRow;
+  file: Readonly<{
+    path: string;
+    byteSize: number;
+    sha256: string;
+    mediaType: "image/png";
+    dimensions?: Readonly<{ width: number; height: number }>;
+  }>;
+}>;
+
+export type WindowShotDependencies = Readonly<{
+  execFile: (
+    file: string,
+    args: readonly string[],
+  ) => Promise<Readonly<{ stdout: string; stderr: string }>>;
+  mkdir: typeof mkdir;
+  now: () => Date;
+  readFile: typeof readFile;
+  stat: typeof stat;
+  tmpdir: () => string;
+  writeFile: typeof writeFile;
+}>;
+
+const defaultWindowShotDependencies: WindowShotDependencies = {
+  execFile,
+  mkdir,
+  now: () => new Date(),
+  readFile,
+  stat,
+  tmpdir,
+  writeFile,
+};
+
+/**
+ * Compiles the Swift capture helper once per source revision and caches the
+ * binary under the OS temp dir (keyed by source hash, so package upgrades
+ * recompile automatically).
+ */
+export async function ensureCiv7WindowShotHelper(
+  dependencies: WindowShotDependencies = defaultWindowShotDependencies,
+): Promise<string> {
+  const sourceHash = createHash("sha256")
+    .update(CIV7_WINDOW_SHOT_SWIFT_SOURCE)
+    .digest("hex")
+    .slice(0, 12);
+  const cacheRoot = join(dependencies.tmpdir(), "civ7-direct-control");
+  const binaryPath = join(cacheRoot, `civ7-window-shot-${sourceHash}`);
+  if (await pathExists(dependencies, binaryPath)) return binaryPath;
+  await dependencies.mkdir(cacheRoot, { recursive: true });
+  const sourcePath = `${binaryPath}.swift`;
+  await dependencies.writeFile(sourcePath, CIV7_WINDOW_SHOT_SWIFT_SOURCE, "utf8");
+  try {
+    await dependencies.execFile("/usr/bin/xcrun", [
+      "swiftc",
+      "-O",
+      sourcePath,
+      "-o",
+      binaryPath,
+    ]);
+  } catch (error) {
+    throw new Civ7DirectControlError(
+      "window-shot-helper-unavailable",
+      "Failed to compile the ScreenCaptureKit capture helper (xcrun swiftc). " +
+        "Install the Xcode command line tools (xcode-select --install) and retry: " +
+        errorMessage(error),
+      { cause: error },
+    );
+  }
+  return binaryPath;
+}
+
+/** Enumerates capturable windows matching the app substring. */
+export async function listCiv7CaptureWindows(
+  input: Civ7WindowShotListInput = {},
+  dependencies: WindowShotDependencies = defaultWindowShotDependencies,
+): Promise<Civ7WindowShotListResult> {
+  const payload = await runWindowShotHelper(dependencies, [
+    "list",
+    "--app",
+    input.appName ?? DEFAULT_CIV7_WINDOW_MATCH,
+  ]);
+  return { windows: (payload as { windows: Civ7CaptureWindowRow[] }).windows };
+}
+
+/**
+ * Captures the Civ7 game window — and only that window — to a PNG at native
+ * pixel scale via ScreenCaptureKit. Works even when the window is occluded.
+ * Throws typed errors: `window-shot-permission-required` (one-time Screen
+ * Recording TCC grant missing; the helper has already fired the OS prompt),
+ * `window-shot-window-not-found`, `window-shot-helper-unavailable`, or
+ * `window-shot-failed`.
+ */
+export async function captureCiv7WindowShot(
+  input: Civ7WindowShotCaptureInput = {},
+  dependencies: WindowShotDependencies = defaultWindowShotDependencies,
+): Promise<Civ7WindowShotCaptureResult> {
+  const requestedAt = dependencies.now();
+  const outputPath = resolve(
+    input.outputPath ?? defaultWindowShotPath(requestedAt, dependencies.tmpdir()),
+  );
+  await dependencies.mkdir(dirname(outputPath), { recursive: true });
+  const payload = await runWindowShotHelper(dependencies, [
+    "capture",
+    "--out",
+    outputPath,
+    "--app",
+    input.appName ?? DEFAULT_CIV7_WINDOW_MATCH,
+    ...(input.windowId === undefined ? [] : ["--window-id", String(input.windowId)]),
+  ]) as Readonly<{
+    windowId: number;
+    app: string;
+    bundleId: string;
+    title: string;
+    width: number;
+    height: number;
+    onScreen: boolean;
+    path: string;
+    pixelWidth: number;
+    pixelHeight: number;
+    frameSource: string;
+  }>;
+
+  const bytes = await dependencies.readFile(outputPath);
+  const fileStat = await dependencies.stat(outputPath);
+  const dimensions = pngDimensions(bytes);
+  return {
+    captureMode: "window-scoped-screencapturekit",
+    requestedAt: requestedAt.toISOString(),
+    frameSource: payload.frameSource === "stream"
+      ? "stream"
+      : payload.frameSource === "screenshot-fallback"
+        ? "screenshot-fallback"
+        : "screenshot",
+    window: {
+      windowId: payload.windowId,
+      app: payload.app,
+      bundleId: payload.bundleId,
+      title: payload.title,
+      width: payload.width,
+      height: payload.height,
+      onScreen: payload.onScreen,
+    },
+    file: {
+      path: outputPath,
+      byteSize: fileStat.size,
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      mediaType: "image/png",
+      ...(dimensions === undefined ? {} : { dimensions }),
+    },
+  };
+}
+
+async function runWindowShotHelper(
+  dependencies: WindowShotDependencies,
+  args: readonly string[],
+): Promise<unknown> {
+  const helperPath = await ensureCiv7WindowShotHelper(dependencies);
+  let stdout: string;
+  try {
+    ({ stdout } = await dependencies.execFile(helperPath, args));
+  } catch (error) {
+    // The helper exits non-zero for structured failures but still emits its
+    // JSON row on stdout; only an empty stdout means it actually crashed.
+    stdout = (error as { stdout?: string }).stdout ?? "";
+    if (stdout.trim() === "") {
+      throw new Civ7DirectControlError(
+        "window-shot-failed",
+        `Capture helper crashed: ${errorMessage(error)}`,
+        { cause: error },
+      );
+    }
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(stdout.trim());
+  } catch {
+    throw new Civ7DirectControlError(
+      "window-shot-failed",
+      `Capture helper emitted invalid JSON: ${stdout.slice(0, 200)}`,
+    );
+  }
+  const row = payload as Readonly<{ ok?: boolean; error?: string; message?: string }>;
+  if (row.ok !== true) {
+    const code = row.error === "permission-required"
+      ? "window-shot-permission-required" as const
+      : row.error === "window-not-found"
+        ? "window-shot-window-not-found" as const
+        : "window-shot-failed" as const;
+    throw new Civ7DirectControlError(
+      code,
+      row.message ?? row.error ?? "window capture failed",
+      { details: payload },
+    );
+  }
+  return payload;
+}
+
+async function pathExists(
+  dependencies: Pick<WindowShotDependencies, "stat">,
+  path: string,
+): Promise<boolean> {
+  try {
+    await dependencies.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultWindowShotPath(date: Date, tmp: string): string {
+  return join(
+    tmp,
+    "civ7-appshots",
+    `civ7-appshot-${date.toISOString().replace(/[:.]/g, "-")}.png`,
+  );
+}
+
+function pngDimensions(bytes: Buffer): { width: number; height: number } | undefined {
+  const pngSignature = "89504e470d0a1a0a";
+  if (bytes.length < 24 || bytes.subarray(0, 8).toString("hex") !== pngSignature) return undefined;
+  if (bytes.subarray(12, 16).toString("ascii") !== "IHDR") return undefined;
+  return {
+    width: bytes.readUInt32BE(16),
+    height: bytes.readUInt32BE(20),
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/civ7-direct-control/test/view-clean-frame.test.ts
+++ b/packages/civ7-direct-control/test/view-clean-frame.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildCleanFrameEnterCommand,
+  buildCleanFrameExitCommand,
+  buildViewManagerBridgeCommand,
+  CIV7_CLEAN_FRAME_HIDDEN_WORLD_RULES,
+  CIV7_CLEAN_FRAME_HIDE_UNITS_GLOBAL,
+  CIV7_CLEAN_FRAME_PREVIOUS_VIEW_GLOBAL,
+  CIV7_CLEAN_FRAME_VIEW_NAME,
+  CIV7_VIEW_MANAGER_BRIDGE_GLOBAL,
+  ensureCiv7ViewManagerBridge,
+  enterCiv7CleanFrame,
+  exitCiv7CleanFrame,
+  type CleanFrameDependencies,
+} from "../src/play/view/clean-frame";
+import { Civ7DirectControlError } from "../src/direct-control-error";
+import { jsLiteral } from "../src/runtime/command-serialization";
+import type { Civ7CommandResult } from "../src/session/types";
+
+function commandResult(payload: unknown): Civ7CommandResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    output: [JSON.stringify(payload)],
+  };
+}
+
+function fakeDependencies(
+  payloads: ReadonlyArray<unknown>,
+): { dependencies: CleanFrameDependencies; commands: string[]; slept: number[] } {
+  const commands: string[] = [];
+  const slept: number[] = [];
+  const queue = [...payloads];
+  const dependencies: CleanFrameDependencies = {
+    executeAppUiCommand: async ({ command }) => {
+      commands.push(command);
+      const payload = queue.shift();
+      if (payload === undefined) throw new Error("fake exec exhausted");
+      return commandResult(payload);
+    },
+    jsLiteral,
+    parsePayload: <T,>(result: Civ7CommandResult) => JSON.parse(result.output[0] ?? "{}") as T,
+    sleep: async (ms) => {
+      slept.push(ms);
+    },
+  };
+  return { dependencies, commands, slept };
+}
+
+describe("clean-frame primitives", () => {
+  test("commands drive the official ViewManager rules engine, never DOM selectors", () => {
+    for (const command of [
+      buildViewManagerBridgeCommand(),
+      buildCleanFrameEnterCommand(false, { jsLiteral }),
+      buildCleanFrameEnterCommand(true, { jsLiteral }),
+      buildCleanFrameExitCommand(),
+    ]) {
+      expect(command).not.toContain("querySelector");
+      expect(command).not.toContain("dispatchEvent");
+      expect(command).not.toContain(".click(");
+    }
+    // The shipped VFS path — the `.chunk.js` layout of our extracted
+    // resources does not resolve in the live module registry.
+    expect(buildViewManagerBridgeCommand()).toContain("/core/ui/views/view-manager.js");
+    expect(buildViewManagerBridgeCommand()).not.toContain(".chunk.js");
+
+    const enter = buildCleanFrameEnterCommand(true, { jsLiteral });
+    expect(enter).toContain("setCurrentByName");
+    expect(enter).toContain(CIV7_CLEAN_FRAME_VIEW_NAME);
+    expect(enter).toContain(CIV7_VIEW_MANAGER_BRIDGE_GLOBAL);
+    expect(enter).toContain(CIV7_CLEAN_FRAME_PREVIOUS_VIEW_GLOBAL);
+    // Every hide goes through the view's rules — harness plus the Cinematic
+    // view's world rule set.
+    expect(enter).toContain('{ name: "harness", type: U.HUD, visible: "false" }');
+    for (const rule of CIV7_CLEAN_FRAME_HIDDEN_WORLD_RULES) {
+      expect(enter).toContain(`{ name: ${jsLiteral(rule)}, type: U.World, visible: "false" }`);
+    }
+    // 3D unit visibility is guarded by the runtime flag and always restored
+    // on exitView.
+    expect(enter).toContain(CIV7_CLEAN_FRAME_HIDE_UNITS_GLOBAL);
+    expect(enter).toContain("WorldUI.setUnitVisibility(true)");
+
+    const exit = buildCleanFrameExitCommand();
+    expect(exit).toContain("setCurrentByName");
+    expect(exit).toContain(CIV7_CLEAN_FRAME_PREVIOUS_VIEW_GLOBAL);
+    expect(exit).toContain('"World"');
+  });
+
+  test("hideUnits is embedded as a literal so the registered view reads the caller's choice", () => {
+    expect(buildCleanFrameEnterCommand(true, { jsLiteral })).toContain(
+      `globalThis[${jsLiteral(CIV7_CLEAN_FRAME_HIDE_UNITS_GLOBAL)}] = true;`,
+    );
+    expect(buildCleanFrameEnterCommand(false, { jsLiteral })).toContain(
+      `globalThis[${jsLiteral(CIV7_CLEAN_FRAME_HIDE_UNITS_GLOBAL)}] = false;`,
+    );
+  });
+
+  test("ensure bridge retries until the module-registry import resolves", async () => {
+    const { dependencies, commands, slept } = fakeDependencies([
+      { ready: false },
+      { ready: true },
+    ]);
+    await ensureCiv7ViewManagerBridge({}, dependencies);
+    expect(commands).toHaveLength(2);
+    expect(slept).toEqual([500]);
+  });
+
+  test("ensure bridge fails after the retry budget", async () => {
+    const { dependencies } = fakeDependencies(
+      Array.from({ length: 6 }, () => ({ ready: false })),
+    );
+    await expect(ensureCiv7ViewManagerBridge({}, dependencies)).rejects.toThrow(
+      Civ7DirectControlError,
+    );
+  });
+
+  test("enter switches into the clean-frame view and reports readback truth", async () => {
+    const { dependencies, commands } = fakeDependencies([
+      { ready: true },
+      {
+        switched: true,
+        viewBefore: "World",
+        view: CIV7_CLEAN_FRAME_VIEW_NAME,
+        harnessHidden: true,
+      },
+    ]);
+    const result = await enterCiv7CleanFrame({ hideUnits: true }, {}, dependencies);
+    expect(result).toEqual({
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      switched: true,
+      viewBefore: "World",
+      view: CIV7_CLEAN_FRAME_VIEW_NAME,
+      harnessHidden: true,
+      hideUnits: true,
+    });
+    expect(commands[1]).toContain("views.set");
+  });
+
+  test("exit restores the recorded previous view and reports readback truth", async () => {
+    const { dependencies } = fakeDependencies([
+      { ready: true },
+      { switched: true, view: "World", harnessHidden: false },
+    ]);
+    const result = await exitCiv7CleanFrame({}, dependencies);
+    expect(result).toEqual({
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      switched: true,
+      view: "World",
+      harnessHidden: false,
+    });
+  });
+});

--- a/packages/civ7-direct-control/test/view-window-shot.test.ts
+++ b/packages/civ7-direct-control/test/view-window-shot.test.ts
@@ -1,0 +1,255 @@
+import type { Stats } from "node:fs";
+
+import { describe, expect, test } from "vitest";
+
+import {
+  captureCiv7WindowShot,
+  CIV7_WINDOW_SHOT_SWIFT_SOURCE,
+  ensureCiv7WindowShotHelper,
+  listCiv7CaptureWindows,
+  type WindowShotDependencies,
+} from "../src/play/view/window-shot";
+import { Civ7DirectControlError } from "../src/direct-control-error";
+
+// 1x1 transparent PNG — real bytes so sha256/dimension extraction run on the
+// same parsing path as production captures.
+const PNG_1X1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+const CAPTURE_ROW = {
+  ok: true,
+  mode: "capture",
+  windowId: 4242,
+  app: "CivilizationVII",
+  bundleId: "com.aspyr.civ7.steam",
+  title: "Sid Meier's Civilization VII",
+  width: 1728,
+  height: 1080,
+  onScreen: true,
+  path: "/tmp/out.png",
+  pixelWidth: 3456,
+  pixelHeight: 2160,
+  frameSource: "screenshot",
+};
+
+type FakeOptions = Readonly<{
+  helperExists?: boolean;
+  helperStdout?: string;
+  helperFails?: boolean;
+  compileFails?: boolean;
+}>;
+
+function fakeDependencies(options: FakeOptions = {}): {
+  dependencies: WindowShotDependencies;
+  execCalls: Array<{ file: string; args: readonly string[] }>;
+  writes: string[];
+} {
+  const execCalls: Array<{ file: string; args: readonly string[] }> = [];
+  const writes: string[] = [];
+  const dependencies: WindowShotDependencies = {
+    execFile: async (file, args) => {
+      execCalls.push({ file, args });
+      if (file === "/usr/bin/xcrun") {
+        if (options.compileFails) throw new Error("swiftc: command not found");
+        return { stdout: "", stderr: "" };
+      }
+      const stdout = options.helperStdout ?? `${JSON.stringify(CAPTURE_ROW)}\n`;
+      if (options.helperFails) {
+        const error = new Error("helper exited 1") as Error & { stdout: string };
+        error.stdout = stdout;
+        throw error;
+      }
+      return { stdout, stderr: "" };
+    },
+    mkdir: async () => undefined,
+    now: () => new Date("2026-06-11T12:00:00.000Z"),
+    readFile: (async () => PNG_1X1) as WindowShotDependencies["readFile"],
+    stat: (async (path: string) => {
+      if (options.helperExists === false && !String(path).endsWith(".png")) {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }
+      return { size: PNG_1X1.byteLength } as Stats;
+    }) as WindowShotDependencies["stat"],
+    tmpdir: () => "/tmp/fake",
+    writeFile: (async (path: string) => {
+      writes.push(String(path));
+    }) as WindowShotDependencies["writeFile"],
+  };
+  return { dependencies, execCalls, writes };
+}
+
+describe("window-shot helper lifecycle", () => {
+  test("compiles the embedded Swift source once and caches by source hash", async () => {
+    const { dependencies, execCalls, writes } = fakeDependencies({ helperExists: false });
+    const binary = await ensureCiv7WindowShotHelper(dependencies);
+    expect(binary).toContain("/tmp/fake/civ7-direct-control/civ7-window-shot-");
+    expect(writes).toEqual([`${binary}.swift`]);
+    expect(execCalls).toEqual([
+      { file: "/usr/bin/xcrun", args: ["swiftc", "-O", `${binary}.swift`, "-o", binary] },
+    ]);
+  });
+
+  test("reuses an existing binary without recompiling", async () => {
+    const { dependencies, execCalls } = fakeDependencies({ helperExists: true });
+    await ensureCiv7WindowShotHelper(dependencies);
+    expect(execCalls).toEqual([]);
+  });
+
+  test("maps a missing toolchain to window-shot-helper-unavailable with setup guidance", async () => {
+    const { dependencies } = fakeDependencies({ helperExists: false, compileFails: true });
+    await expect(ensureCiv7WindowShotHelper(dependencies)).rejects.toMatchObject({
+      name: "Civ7DirectControlError",
+      code: "window-shot-helper-unavailable",
+      message: expect.stringContaining("xcode-select --install"),
+    });
+  });
+
+  test("the embedded helper is window-scoped ScreenCaptureKit with TCC prompt + structured errors", () => {
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).toContain("SCContentFilter(desktopIndependentWindow: window)");
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).toContain("SCScreenshotManager.captureImage");
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).toContain("CGPreflightScreenCaptureAccess()");
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).toContain("CGRequestScreenCaptureAccess()");
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).toContain("pointPixelScale");
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).toContain("showsCursor = false");
+    // CLI processes must service a run loop with CG initialized on the main
+    // thread, or the SCK capture path trips CGS_REQUIRE_INIT (live-hit).
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).toContain("CGMainDisplayID()");
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).toContain("RunLoop.main.run()");
+    // Off-screen windows have stale backing stores: a temporary SCStream
+    // forces fresh compositing WITHOUT activating the game or moving focus.
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).toContain("captureViaStream");
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).toContain("SCStream(filter: filter, configuration: configuration, delegate: nil)");
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).not.toContain("NSRunningApplication");
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).not.toContain("activate()");
+    // The whole display is never a capture target.
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).not.toContain("SCContentFilter(display");
+  });
+});
+
+describe("captureCiv7WindowShot", () => {
+  test("captures the matched window and reports a hashable manifest", async () => {
+    const { dependencies, execCalls } = fakeDependencies({ helperExists: true });
+    const result = await captureCiv7WindowShot(
+      { outputPath: "/tmp/out.png" },
+      dependencies,
+    );
+    expect(execCalls[0]?.args.slice(0, 3)).toEqual(["capture", "--out", "/tmp/out.png"]);
+    expect(execCalls[0]?.args).toContain("civilization");
+    expect(result).toEqual({
+      captureMode: "window-scoped-screencapturekit",
+      requestedAt: "2026-06-11T12:00:00.000Z",
+      frameSource: "screenshot",
+      window: {
+        windowId: 4242,
+        app: "CivilizationVII",
+        bundleId: "com.aspyr.civ7.steam",
+        title: "Sid Meier's Civilization VII",
+        width: 1728,
+        height: 1080,
+        onScreen: true,
+      },
+      file: {
+        path: "/tmp/out.png",
+        byteSize: PNG_1X1.byteLength,
+        sha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+        mediaType: "image/png",
+        dimensions: { width: 1, height: 1 },
+      },
+    });
+  });
+
+  test("passes an explicit window id through to the helper", async () => {
+    const { dependencies, execCalls } = fakeDependencies({ helperExists: true });
+    await captureCiv7WindowShot(
+      { outputPath: "/tmp/out.png", windowId: 4242 },
+      dependencies,
+    );
+    expect(execCalls[0]?.args).toContain("--window-id");
+    expect(execCalls[0]?.args).toContain("4242");
+  });
+
+
+  test("maps the helper's structured TCC failure to window-shot-permission-required", async () => {
+    const { dependencies } = fakeDependencies({
+      helperExists: true,
+      helperFails: true,
+      helperStdout: JSON.stringify({
+        ok: false,
+        error: "permission-required",
+        message: "Screen Recording permission is not granted",
+      }),
+    });
+    await expect(
+      captureCiv7WindowShot({ outputPath: "/tmp/out.png" }, dependencies),
+    ).rejects.toMatchObject({
+      name: "Civ7DirectControlError",
+      code: "window-shot-permission-required",
+      message: expect.stringContaining("Screen Recording"),
+    });
+  });
+
+  test("maps a missing window to window-shot-window-not-found", async () => {
+    const { dependencies } = fakeDependencies({
+      helperExists: true,
+      helperFails: true,
+      helperStdout: JSON.stringify({
+        ok: false,
+        error: "window-not-found",
+        message: "no window matched app substring 'civilization'",
+      }),
+    });
+    await expect(
+      captureCiv7WindowShot({ outputPath: "/tmp/out.png" }, dependencies),
+    ).rejects.toMatchObject({
+      code: "window-shot-window-not-found",
+    });
+  });
+
+  test("treats a crash without stdout as window-shot-failed", async () => {
+    const { dependencies } = fakeDependencies({
+      helperExists: true,
+      helperFails: true,
+      helperStdout: "",
+    });
+    await expect(
+      captureCiv7WindowShot({ outputPath: "/tmp/out.png" }, dependencies),
+    ).rejects.toMatchObject({ code: "window-shot-failed" });
+  });
+
+  test("rejects invalid helper output as window-shot-failed", async () => {
+    const { dependencies } = fakeDependencies({
+      helperExists: true,
+      helperStdout: "not-json",
+    });
+    await expect(
+      captureCiv7WindowShot({ outputPath: "/tmp/out.png" }, dependencies),
+    ).rejects.toBeInstanceOf(Civ7DirectControlError);
+  });
+});
+
+describe("listCiv7CaptureWindows", () => {
+  test("returns the helper's window rows", async () => {
+    const { dependencies, execCalls } = fakeDependencies({
+      helperExists: true,
+      helperStdout: JSON.stringify({
+        ok: true,
+        mode: "list",
+        windows: [{
+          windowId: 4242,
+          app: "CivilizationVII",
+          bundleId: "com.aspyr.civ7.steam",
+          title: "Sid Meier's Civilization VII",
+          width: 1728,
+          height: 1080,
+          onScreen: true,
+        }],
+      }),
+    });
+    const result = await listCiv7CaptureWindows({}, dependencies);
+    expect(execCalls[0]?.args).toEqual(["list", "--app", "civilization"]);
+    expect(result.windows).toHaveLength(1);
+    expect(result.windows[0]?.windowId).toBe(4242);
+  });
+});

--- a/packages/civ7-direct-control/test/view-window-shot.test.ts
+++ b/packages/civ7-direct-control/test/view-window-shot.test.ts
@@ -6,7 +6,6 @@ import {
   captureCiv7WindowShot,
   CIV7_WINDOW_SHOT_SWIFT_SOURCE,
   ensureCiv7WindowShotHelper,
-  listCiv7CaptureWindows,
   type WindowShotDependencies,
 } from "../src/play/view/window-shot";
 import { Civ7DirectControlError } from "../src/direct-control-error";
@@ -39,15 +38,22 @@ type FakeOptions = Readonly<{
   helperStdout?: string;
   helperFails?: boolean;
   compileFails?: boolean;
+  /** Directory listing returned for any readdir (cache root or appshot dir). */
+  directoryEntries?: string[];
+  /** Paths whose stat reports an mtime older than the retention window. */
+  stalePaths?: string[];
 }>;
 
 function fakeDependencies(options: FakeOptions = {}): {
   dependencies: WindowShotDependencies;
   execCalls: Array<{ file: string; args: readonly string[] }>;
   writes: string[];
+  removed: string[];
 } {
   const execCalls: Array<{ file: string; args: readonly string[] }> = [];
   const writes: string[] = [];
+  const removed: string[] = [];
+  const now = new Date("2026-06-11T12:00:00.000Z");
   const dependencies: WindowShotDependencies = {
     execFile: async (file, args) => {
       execCalls.push({ file, args });
@@ -64,20 +70,28 @@ function fakeDependencies(options: FakeOptions = {}): {
       return { stdout, stderr: "" };
     },
     mkdir: async () => undefined,
-    now: () => new Date("2026-06-11T12:00:00.000Z"),
+    now: () => now,
+    readdir: async () => options.directoryEntries ?? [],
     readFile: (async () => PNG_1X1) as WindowShotDependencies["readFile"],
+    rm: async (path) => {
+      removed.push(String(path));
+    },
     stat: (async (path: string) => {
       if (options.helperExists === false && !String(path).endsWith(".png")) {
         throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
       }
-      return { size: PNG_1X1.byteLength } as Stats;
+      const stale = (options.stalePaths ?? []).some((p) => String(path).endsWith(p));
+      return {
+        size: PNG_1X1.byteLength,
+        mtimeMs: stale ? now.getTime() - 8 * 24 * 60 * 60 * 1000 : now.getTime(),
+      } as Stats;
     }) as WindowShotDependencies["stat"],
     tmpdir: () => "/tmp/fake",
     writeFile: (async (path: string) => {
       writes.push(String(path));
     }) as WindowShotDependencies["writeFile"],
   };
-  return { dependencies, execCalls, writes };
+  return { dependencies, execCalls, writes, removed };
 }
 
 describe("window-shot helper lifecycle", () => {
@@ -125,6 +139,28 @@ describe("window-shot helper lifecycle", () => {
     expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).not.toContain("activate()");
     // The whole display is never a capture target.
     expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).not.toContain("SCContentFilter(display");
+    // No stale-pixel fallback: an off-screen window that cannot produce a
+    // fresh frame FAILS instead of silently returning the stale store.
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).not.toContain("screenshot-fallback");
+    // No vestigial list mode — capture is the helper's only surface.
+    expect(CIV7_WINDOW_SHOT_SWIFT_SOURCE).not.toContain('"list"');
+  });
+
+  test("compiling a new revision prunes the previous revisions' cache entries", async () => {
+    const { dependencies, removed } = fakeDependencies({
+      helperExists: false,
+      directoryEntries: [
+        "civ7-window-shot-aaaaaaaaaaaa",
+        "civ7-window-shot-aaaaaaaaaaaa.swift",
+        "unrelated-file",
+      ],
+    });
+    const binary = await ensureCiv7WindowShotHelper(dependencies);
+    expect(removed).toEqual([
+      "/tmp/fake/civ7-direct-control/civ7-window-shot-aaaaaaaaaaaa",
+      "/tmp/fake/civ7-direct-control/civ7-window-shot-aaaaaaaaaaaa.swift",
+    ]);
+    expect(removed).not.toContain(binary);
   });
 });
 
@@ -229,27 +265,29 @@ describe("captureCiv7WindowShot", () => {
   });
 });
 
-describe("listCiv7CaptureWindows", () => {
-  test("returns the helper's window rows", async () => {
-    const { dependencies, execCalls } = fakeDependencies({
+describe("appshot retention", () => {
+  test("the managed default destination self-cleans: appshots past retention are dropped", async () => {
+    const { dependencies, removed } = fakeDependencies({
       helperExists: true,
-      helperStdout: JSON.stringify({
-        ok: true,
-        mode: "list",
-        windows: [{
-          windowId: 4242,
-          app: "CivilizationVII",
-          bundleId: "com.aspyr.civ7.steam",
-          title: "Sid Meier's Civilization VII",
-          width: 1728,
-          height: 1080,
-          onScreen: true,
-        }],
-      }),
+      directoryEntries: [
+        "civ7-appshot-old.png",
+        "civ7-appshot-fresh.png",
+        "user-file.png",
+      ],
+      stalePaths: ["civ7-appshot-old.png"],
     });
-    const result = await listCiv7CaptureWindows({}, dependencies);
-    expect(execCalls[0]?.args).toEqual(["list", "--app", "civilization"]);
-    expect(result.windows).toHaveLength(1);
-    expect(result.windows[0]?.windowId).toBe(4242);
+    const result = await captureCiv7WindowShot({}, dependencies);
+    expect(result.file.path).toContain("/tmp/fake/civ7-appshots/civ7-appshot-");
+    expect(removed).toEqual(["/tmp/fake/civ7-appshots/civ7-appshot-old.png"]);
+  });
+
+  test("explicit outputPath directories are the caller's — never pruned", async () => {
+    const { dependencies, removed } = fakeDependencies({
+      helperExists: true,
+      directoryEntries: ["civ7-appshot-old.png"],
+      stalePaths: ["civ7-appshot-old.png"],
+    });
+    await captureCiv7WindowShot({ outputPath: "/tmp/out.png" }, dependencies);
+    expect(removed).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/game/view/appshot.ts
+++ b/packages/cli/src/commands/game/view/appshot.ts
@@ -1,0 +1,101 @@
+import { Command, Flags } from '@oclif/core';
+import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
+
+// Window-scoped, clean-frame capture of the live Civ7 session. The
+// control-oRPC procedure suspends the display queue, purges popups, hides the
+// HUD/world overlays through the official ViewManager rules engine, captures
+// ONLY the game window via ScreenCaptureKit (never the display — no desktop,
+// no overlays), and restores everything afterwards — guaranteed, even on
+// failure. Requires a one-time macOS Screen Recording grant for the app
+// hosting this process; the failure message carries the exact System
+// Settings path when the grant is missing.
+export default class GameViewAppshot extends Command {
+  static id = 'game view appshot';
+  static summary = 'Capture a clean, window-scoped screenshot of the live Civ7 session';
+  static description =
+    'Captures the Civ7 game window — and only that window — as a PNG with the HUD, world overlays, ' +
+    'and popups suppressed for the frame, then restores the UI state. Reports a hashable manifest ' +
+    'with window identity and clean-frame readbacks.';
+
+  static examples = [
+    '<%= config.bin %> game view appshot --json',
+    '<%= config.bin %> game view appshot --output /tmp/civ7-frame.png --hide-units --json',
+    '<%= config.bin %> game view appshot --settle-ms 1000 --json',
+  ];
+
+  static flags = {
+    host: Flags.string({
+      description: 'Civ7 tuner socket host',
+    }),
+    port: Flags.integer({
+      description: 'Civ7 tuner socket port',
+    }),
+    output: Flags.string({
+      description: 'PNG output path; defaults under the OS temp dir',
+    }),
+    'app-name': Flags.string({
+      description: 'Substring matched against app name / bundle id / window title',
+    }),
+    'window-id': Flags.integer({
+      description: 'Exact window id to capture (overrides --app-name matching)',
+    }),
+    'hide-units': Flags.boolean({
+      description: 'Also hide 3D unit models for a map-only frame',
+      default: false,
+    }),
+    'settle-ms': Flags.integer({
+      description: 'Hold time after hiding the UI before the frame is captured (default 400)',
+    }),
+    'timeout-ms': Flags.integer({
+      description: 'Socket timeout',
+      default: 45_000,
+    }),
+    json: Flags.boolean({
+      description: 'Emit machine-readable JSON',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(GameViewAppshot);
+    const client = createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults: {
+        host: flags.host,
+        port: flags.port,
+        timeoutMs: flags['timeout-ms'],
+      },
+    });
+    const result = await client.view.appshot.capture({
+      ...(flags.output === undefined ? {} : { outputPath: flags.output }),
+      ...(flags['app-name'] === undefined ? {} : { appName: flags['app-name'] }),
+      ...(flags['window-id'] === undefined ? {} : { windowId: flags['window-id'] }),
+      ...(flags['hide-units'] ? { hideUnits: true } : {}),
+      ...(flags['settle-ms'] === undefined ? {} : { settleMs: flags['settle-ms'] }),
+    }).catch((error: unknown) => {
+      // Typed appshot errors carry the actionable failure in data.detail
+      // (e.g. the exact System Settings path for the TCC grant) — surface it.
+      const detail = (error as { data?: { detail?: string } } | null)?.data?.detail;
+      if (typeof detail === 'string' && detail.length > 0 && error instanceof Error) {
+        error.message = `${error.message}\n${detail}`;
+      }
+      throw error;
+    });
+
+    if (flags.json) {
+      this.log(JSON.stringify({ ok: true, result }));
+      return;
+    }
+
+    this.log(`captured: ${result.file.path}`);
+    const dimensions = result.file.dimensions;
+    if (dimensions) this.log(`size: ${dimensions.width}x${dimensions.height}`);
+    this.log(`window: ${result.window.app} — ${result.window.title}`);
+    const suppressed = result.cleanFrame.suppressedDisplays;
+    this.log(suppressed.length === 0
+      ? 'suppressed: nothing was queued'
+      : `suppressed: ${suppressed.map((row: { category: string; closed: number }) => `${row.category} x${row.closed}`).join(', ')}`);
+    this.log(`restored: view=${result.cleanFrame.restored.view} queueResumed=${result.cleanFrame.restored.queueResumed}`);
+  }
+}

--- a/packages/cli/test/commands/game.view.appshot.test.ts
+++ b/packages/cli/test/commands/game.view.appshot.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test, vi } from 'vitest';
+import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
+
+// The capture atom is OS-local (ScreenCaptureKit helper binary + TCC); only
+// that facade member is stubbed. Every App UI exec — queue suspend/purge,
+// clean-frame enter/exit, resume — runs over the wire against the fake tuner.
+const captureCalls: unknown[] = [];
+vi.mock('@civ7/control-orpc/runtime', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@civ7/control-orpc/runtime')>();
+  return {
+    ...actual,
+    liveCiv7ControlOrpcDirectControlFacade: {
+      ...actual.liveCiv7ControlOrpcDirectControlFacade,
+      captureCiv7WindowShot: async (input: unknown) => {
+        captureCalls.push(input);
+        return {
+          captureMode: 'window-scoped-screencapturekit',
+          requestedAt: '2026-06-11T12:00:00.000Z',
+          frameSource: 'screenshot',
+          window: {
+            windowId: 4242,
+            app: 'CivilizationVII',
+            bundleId: 'com.aspyr.civ7.steam',
+            title: "Sid Meier's Civilization VII",
+            width: 1728,
+            height: 1080,
+            onScreen: true,
+          },
+          file: {
+            path: '/tmp/civ7-frame.png',
+            byteSize: 1_234_567,
+            sha256: 'ab'.repeat(32),
+            mediaType: 'image/png',
+            dimensions: { width: 3456, height: 2160 },
+          },
+        };
+      },
+    },
+  };
+});
+
+import GameViewAppshot from '../../src/commands/game/view/appshot';
+
+describe('game view appshot', () => {
+  test('captures through the clean-frame orchestration and reports the manifest', async () => {
+    captureCalls.length = 0;
+    const { server } = await startAppshotServer();
+    try {
+      const { writes } = await runCommand(server, ['--settle-ms', '0', '--json']);
+      const payload = JSON.parse(writes.join('')) as {
+        ok: boolean;
+        result: {
+          captureMode: string;
+          file: { path: string };
+          cleanFrame: {
+            viewDuringCapture: string;
+            suppressedDisplays: Array<{ category: string; closed: number }>;
+            restored: { view: string; queueResumed: boolean };
+          };
+        };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.result.captureMode).toBe('window-scoped-screencapturekit');
+      expect(payload.result.file.path).toBe('/tmp/civ7-frame.png');
+      expect(payload.result.cleanFrame.viewDuringCapture).toBe('DirectControlCleanFrame');
+      expect(payload.result.cleanFrame.suppressedDisplays).toEqual([
+        { category: 'UnlockPopup', closed: 1 },
+      ]);
+      expect(payload.result.cleanFrame.restored).toEqual({
+        view: 'World',
+        harnessHidden: false,
+        queueResumed: true,
+      });
+      expect(captureCalls).toEqual([{}]);
+
+      // The clean frame is driven through the official machinery, in order:
+      // suspend before the purge, the hidden-rules view before the capture.
+      const suspendIndex = server.received.findIndex((m) => m.includes('dqm.suspend()'));
+      const closeIndex = server.received.findIndex((m) => m.includes('closeMatching'));
+      const enterIndex = server.received.findIndex((m) => m.includes('views.set'));
+      const resumeIndex = server.received.findIndex((m) => m.includes('dqm.resume()'));
+      expect(suspendIndex).toBeGreaterThanOrEqual(0);
+      expect(closeIndex).toBeGreaterThan(suspendIndex);
+      expect(enterIndex).toBeGreaterThan(closeIndex);
+      expect(resumeIndex).toBeGreaterThan(enterIndex);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('passes capture targeting and hide-units through to the procedure', async () => {
+    captureCalls.length = 0;
+    const { server } = await startAppshotServer();
+    try {
+      await runCommand(server, [
+        '--settle-ms', '0',
+        '--output', '/tmp/custom.png',
+        '--app-name', 'civ',
+        '--window-id', '7',
+        '--hide-units',
+        '--json',
+      ]);
+      expect(captureCalls).toEqual([
+        { outputPath: '/tmp/custom.png', appName: 'civ', windowId: 7 },
+      ]);
+      const enterCommand = server.received.find((m) => m.includes('views.set'));
+      expect(enterCommand).toContain('__civ7DirectControlCleanFrameHideUnits"] = true');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+async function startAppshotServer(): Promise<{ server: FakeTunerServer }> {
+  let cleanFrameEntered = false;
+  const server = await startFakeTunerServer({
+    handle({ message }) {
+      if (message.includes('display-queue-manager.js') && message.includes('ready')) {
+        return [JSON.stringify({ ready: true })];
+      }
+      if (message.includes('view-manager.js') && message.includes('ready')) {
+        return [JSON.stringify({ ready: true })];
+      }
+      if (message.includes('dqm.suspend()')) {
+        return [JSON.stringify({ isSuspended: true })];
+      }
+      if (message.includes('dqm.resume()')) {
+        return [JSON.stringify({ isSuspended: false })];
+      }
+      if (message.includes('closeMatching')) {
+        return [JSON.stringify({
+          closed: [{ category: 'UnlockPopup', closed: 1 }],
+          closedTotal: 1,
+          remainingActive: [],
+          remainingSuspended: [],
+        })];
+      }
+      if (message.includes('views.set')) {
+        cleanFrameEntered = true;
+        return [JSON.stringify({
+          switched: true,
+          viewBefore: 'World',
+          view: 'DirectControlCleanFrame',
+          harnessHidden: true,
+        })];
+      }
+      if (message.includes('setCurrentByName') && cleanFrameEntered) {
+        return [JSON.stringify({ switched: true, view: 'World', harnessHidden: false })];
+      }
+      return undefined;
+    },
+  });
+  return { server };
+}
+
+async function runCommand(server: FakeTunerServer, args: string[]): Promise<{ writes: string[] }> {
+  const writes: string[] = [];
+  const log = vi.spyOn(GameViewAppshot.prototype, 'log').mockImplementation(function (this: unknown, message?: string) {
+    if (message !== undefined) writes.push(message);
+    return undefined as never;
+  });
+  try {
+    const { port } = server.address();
+    await GameViewAppshot.run(['--host', '127.0.0.1', '--port', String(port), ...args]);
+    return { writes };
+  } finally {
+    log.mockRestore();
+  }
+}


### PR DESCRIPTION
Supersedes the rivers-branch whole-display appshot (screencapture -x was
hash-identical to a desktop screenshot, so wallpaper and overlays leaked
into "game" captures). The Mac Steam build has no programmatic capture
(zero XR strings in the binary, no settings toggle, Steam F12 is
human-keypress only), so the capture is ScreenCaptureKit window capture:
SCContentFilter(desktopIndependentWindow:) + SCScreenshotManager at native
pixel scale, via a Swift helper embedded in @civ7/direct-control and
compiled once per source hash. The helper preflights the one-time Screen
Recording TCC grant, fires the OS prompt, and emits structured errors --
the missing-grant failure carries the exact System Settings path.

Clean frames run through the official ViewManager rules engine. The game's
own INTERFACEMODE_SCREENSHOT maps to a stub ScreenshotView (rules all
visible, placeholder buttons injected), so the package registers its own
hidden-rules view (DirectControlCleanFrame: the Cinematic view's rule set,
"empty" harness template, optional 3D-unit hide) -- live-verified
enter/restore, reachable only via the live VFS path
/core/ui/views/view-manager.js (the .chunk.js paths in extracted resources
are extraction artifacts and do not resolve).

Layering per D10: atoms in @civ7/direct-control (enterCiv7CleanFrame /
exitCiv7CleanFrame / captureCiv7WindowShot + listCiv7CaptureWindows);
orchestration as the Effect procedure view.appshot.capture in
@civ7/control-orpc (suspend-verified -> purge -> enter-verified -> settle
-> capture -> restore inline, with an acquire/release finalizer
guaranteeing the HUD and display queue are restored on every failure
path); CLI at the D6-designated home `game view appshot` on the typed
client. Typed errors: APPSHOT_PERMISSION_REQUIRED (403),
APPSHOT_WINDOW_NOT_FOUND, APPSHOT_CLEAN_FRAME_UNVERIFIED,
APPSHOT_CAPTURE_FAILED.

Gates: direct-control 415, control-orpc 333 (+ contract ownership guard),
CLI 229 -- all green. Rivers drain note recorded in D12: the rivers appshot
files are dropped in favor of this slice during the drain.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>