### PR TITLE
test: stop leaking temp dirs from mkdtemp fixtures

### DIFF
--- a/apps/mapgen-studio/test/civ7Resources/catalog.test.ts
+++ b/apps/mapgen-studio/test/civ7Resources/catalog.test.ts
@@ -1,7 +1,6 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { mkdtemp } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
 import { loadCiv7SetupCatalog } from "../../src/server/civ7Resources/catalog";
@@ -9,39 +8,43 @@ import { loadCiv7SetupCatalog } from "../../src/server/civ7Resources/catalog";
 describe("Civ7 setup catalog", () => {
   it("extracts setup options from official resource XML rows", async () => {
     const repoRoot = await mkdtemp(join(tmpdir(), "studio-civ7-catalog-"));
-    const resourceDir = join(repoRoot, ".civ7", "outputs", "resources", "Base", "modules", "base-standard", "data");
-    await mkdir(resourceDir, { recursive: true });
-    await writeFile(
-      join(resourceDir, "leaders.xml"),
-      `<Database><Leaders>
-        <Row LeaderType="LEADER_ALEXANDER" Name="LOC_LEADER_ALEXANDER_NAME" IsMajorLeader="true"/>
-        <Row LeaderType="LEADER_MINOR_CIV_DEFAULT" Name="LOC_MINOR"/>
-      </Leaders></Database>`,
-    );
-    await writeFile(
-      join(resourceDir, "civilizations.xml"),
-      `<Database><Civilizations>
-        <Row CivilizationType="CIVILIZATION_GREECE" Name="LOC_CIVILIZATION_GREECE_NAME" StartingCivilizationLevelType="CIVILIZATION_LEVEL_FULL_CIV"/>
-        <Row CivilizationType="CIVILIZATION_INDEPENDENT" Name="LOC_CIVILIZATION_INDEPENDENT_NAME" StartingCivilizationLevelType="CIVILIZATION_LEVEL_INDEPENDENT"/>
-      </Civilizations></Database>`,
-    );
-    await writeFile(
-      join(resourceDir, "difficulties.xml"),
-      `<Database><Difficulties><Row DifficultyType="DIFFICULTY_CUSTOM" Name="LOC_DIFFICULTY_CUSTOM_NAME"/></Difficulties></Database>`,
-    );
-    await writeFile(
-      join(resourceDir, "game-speeds.xml"),
-      `<Database><GameSpeeds><Row><GameSpeedType>GAMESPEED_STANDARD</GameSpeedType><Name>LOC_GAMESPEED_STANDARD_NAME</Name></Row></GameSpeeds></Database>`,
-    );
+    try {
+      const resourceDir = join(repoRoot, ".civ7", "outputs", "resources", "Base", "modules", "base-standard", "data");
+      await mkdir(resourceDir, { recursive: true });
+      await writeFile(
+        join(resourceDir, "leaders.xml"),
+        `<Database><Leaders>
+          <Row LeaderType="LEADER_ALEXANDER" Name="LOC_LEADER_ALEXANDER_NAME" IsMajorLeader="true"/>
+          <Row LeaderType="LEADER_MINOR_CIV_DEFAULT" Name="LOC_MINOR"/>
+        </Leaders></Database>`,
+      );
+      await writeFile(
+        join(resourceDir, "civilizations.xml"),
+        `<Database><Civilizations>
+          <Row CivilizationType="CIVILIZATION_GREECE" Name="LOC_CIVILIZATION_GREECE_NAME" StartingCivilizationLevelType="CIVILIZATION_LEVEL_FULL_CIV"/>
+          <Row CivilizationType="CIVILIZATION_INDEPENDENT" Name="LOC_CIVILIZATION_INDEPENDENT_NAME" StartingCivilizationLevelType="CIVILIZATION_LEVEL_INDEPENDENT"/>
+        </Civilizations></Database>`,
+      );
+      await writeFile(
+        join(resourceDir, "difficulties.xml"),
+        `<Database><Difficulties><Row DifficultyType="DIFFICULTY_CUSTOM" Name="LOC_DIFFICULTY_CUSTOM_NAME"/></Difficulties></Database>`,
+      );
+      await writeFile(
+        join(resourceDir, "game-speeds.xml"),
+        `<Database><GameSpeeds><Row><GameSpeedType>GAMESPEED_STANDARD</GameSpeedType><Name>LOC_GAMESPEED_STANDARD_NAME</Name></Row></GameSpeeds></Database>`,
+      );
 
-    const catalog = await loadCiv7SetupCatalog({
-      repoRoot,
-      appResourcesRoot: join(repoRoot, "missing-app-resources"),
-    });
+      const catalog = await loadCiv7SetupCatalog({
+        repoRoot,
+        appResourcesRoot: join(repoRoot, "missing-app-resources"),
+      });
 
-    expect(catalog.leaders.map((option) => option.value)).toEqual(["LEADER_ALEXANDER"]);
-    expect(catalog.civilizations.map((option) => option.value)).toEqual(["CIVILIZATION_GREECE"]);
-    expect(catalog.difficulties.map((option) => option.value)).toEqual(["DIFFICULTY_CUSTOM"]);
-    expect(catalog.gameSpeeds.map((option) => option.value)).toEqual(["GAMESPEED_STANDARD"]);
+      expect(catalog.leaders.map((option) => option.value)).toEqual(["LEADER_ALEXANDER"]);
+      expect(catalog.civilizations.map((option) => option.value)).toEqual(["CIVILIZATION_GREECE"]);
+      expect(catalog.difficulties.map((option) => option.value)).toEqual(["DIFFICULTY_CUSTOM"]);
+      expect(catalog.gameSpeeds.map((option) => option.value)).toEqual(["GAMESPEED_STANDARD"]);
+    } finally {
+      await rm(repoRoot, { force: true, recursive: true });
+    }
   });
 });

--- a/packages/civ7-direct-control/test/runtime-and-catalog.test.ts
+++ b/packages/civ7-direct-control/test/runtime-and-catalog.test.ts
@@ -467,41 +467,49 @@ describe("Civ7 runtime inspection and capability catalog support", () => {
 
   test("waits for markers when Civ rewrites the log at the same byte length", async () => {
     const dir = await mkdtemp(join(tmpdir(), "civ7-direct-control-log-"));
-    const logPath = join(dir, "Scripting.log");
-    await writeFile(logPath, "old log padding\n");
-    const snapshot = await snapshotFile(logPath);
-    await writeFile(logPath, "fresh\nmarker\n".padEnd(snapshot.size, " "));
-    await utimes(logPath, new Date(snapshot.mtimeMs + 1_000), new Date(snapshot.mtimeMs + 1_000));
+    try {
+      const logPath = join(dir, "Scripting.log");
+      await writeFile(logPath, "old log padding\n");
+      const snapshot = await snapshotFile(logPath);
+      await writeFile(logPath, "fresh\nmarker\n".padEnd(snapshot.size, " "));
+      await utimes(logPath, new Date(snapshot.mtimeMs + 1_000), new Date(snapshot.mtimeMs + 1_000));
 
-    const proof = await waitForFreshLogMarkers({
-      logPath,
-      snapshot,
-      markers: ["fresh", "marker"],
-      timeoutMs: 100,
-      pollIntervalMs: 10,
-    });
+      const proof = await waitForFreshLogMarkers({
+        logPath,
+        snapshot,
+        markers: ["fresh", "marker"],
+        timeoutMs: 100,
+        pollIntervalMs: 10,
+      });
 
-    expect(proof.matched).toEqual(["fresh", "marker"]);
+      expect(proof.matched).toEqual(["fresh", "marker"]);
+    } finally {
+      await rm(dir, { force: true, recursive: true });
+    }
   });
 
   test("waits for markers when Civ rewrites the log beyond the old offset", async () => {
     const dir = await mkdtemp(join(tmpdir(), "civ7-direct-control-log-"));
-    const logPath = join(dir, "Scripting.log");
-    await writeFile(logPath, `old\n${"x".repeat(160)}\n`);
-    const snapshot = await snapshotFile(logPath);
-    await writeFile(logPath, `fresh\nmarker\n${"y".repeat(snapshot.size + 40)}\n`);
-    await utimes(logPath, new Date(snapshot.mtimeMs + 1_000), new Date(snapshot.mtimeMs + 1_000));
+    try {
+      const logPath = join(dir, "Scripting.log");
+      await writeFile(logPath, `old\n${"x".repeat(160)}\n`);
+      const snapshot = await snapshotFile(logPath);
+      await writeFile(logPath, `fresh\nmarker\n${"y".repeat(snapshot.size + 40)}\n`);
+      await utimes(logPath, new Date(snapshot.mtimeMs + 1_000), new Date(snapshot.mtimeMs + 1_000));
 
-    const proof = await waitForFreshLogMarkers({
-      logPath,
-      snapshot,
-      markers: ["fresh", "marker"],
-      timeoutMs: 100,
-      pollIntervalMs: 10,
-    });
+      const proof = await waitForFreshLogMarkers({
+        logPath,
+        snapshot,
+        markers: ["fresh", "marker"],
+        timeoutMs: 100,
+        pollIntervalMs: 10,
+      });
 
-    expect(proof.startOffset).toBe(0);
-    expect(proof.matched).toEqual(["fresh", "marker"]);
+      expect(proof.startOffset).toBe(0);
+      expect(proof.matched).toEqual(["fresh", "marker"]);
+    } finally {
+      await rm(dir, { force: true, recursive: true });
+    }
   });
 });
 

--- a/packages/civ7-direct-control/test/session.test.ts
+++ b/packages/civ7-direct-control/test/session.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "node:net";
@@ -352,20 +352,24 @@ describe("Civ7 direct control session framing", () => {
 
   test("waits for fresh ordered log markers", async () => {
     const dir = await mkdtemp(join(tmpdir(), "civ7-direct-control-log-"));
-    const logPath = join(dir, "Scripting.log");
-    await writeFile(logPath, "old\n");
-    const snapshot = await snapshotFile(logPath);
-    await writeFile(logPath, "old\nCreating Context -  MapGeneration\nDestroying Context -  MapGeneration\n");
+    try {
+      const logPath = join(dir, "Scripting.log");
+      await writeFile(logPath, "old\n");
+      const snapshot = await snapshotFile(logPath);
+      await writeFile(logPath, "old\nCreating Context -  MapGeneration\nDestroying Context -  MapGeneration\n");
 
-    const proof = await waitForFreshLogMarkers({
-      logPath,
-      snapshot,
-      markers: ["Creating Context -  MapGeneration", "Destroying Context -  MapGeneration"],
-      timeoutMs: 100,
-      pollIntervalMs: 10,
-    });
+      const proof = await waitForFreshLogMarkers({
+        logPath,
+        snapshot,
+        markers: ["Creating Context -  MapGeneration", "Destroying Context -  MapGeneration"],
+        timeoutMs: 100,
+        pollIntervalMs: 10,
+      });
 
-    expect(proof.matched).toEqual(["Creating Context -  MapGeneration", "Destroying Context -  MapGeneration"]);
+      expect(proof.matched).toEqual(["Creating Context -  MapGeneration", "Destroying Context -  MapGeneration"]);
+    } finally {
+      await rm(dir, { force: true, recursive: true });
+    }
   });
 });
 

--- a/packages/sdk/test/mod-build.test.ts
+++ b/packages/sdk/test/mod-build.test.ts
@@ -22,12 +22,16 @@ test('Mod.build writes modinfo referencing builder files', async () => {
   const mod = new Mod({ id: 'my-mod' });
   mod.add(new FileBuilder());
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'mod-build-'));
-  mod.build(tmp);
-  await new Promise(r => setTimeout(r, 50));
-  const modinfoPath = join(tmp, 'my-mod.modinfo');
-  const xml = fs.readFileSync(modinfoPath, 'utf-8');
-  expect(xml).toContain('<UpdateDatabase>');
-  expect(xml).toContain('<Item>foo/bar.xml</Item>');
-  const builderFile = fs.readFileSync(join(tmp, 'foo', 'bar.xml'), 'utf-8');
-  expect(builderFile).toContain('<Test');
+  try {
+    mod.build(tmp);
+    await new Promise(r => setTimeout(r, 50));
+    const modinfoPath = join(tmp, 'my-mod.modinfo');
+    const xml = fs.readFileSync(modinfoPath, 'utf-8');
+    expect(xml).toContain('<UpdateDatabase>');
+    expect(xml).toContain('<Item>foo/bar.xml</Item>');
+    const builderFile = fs.readFileSync(join(tmp, 'foo', 'bar.xml'), 'utf-8');
+    expect(builderFile).toContain('<Test');
+  } finally {
+    fs.rmSync(tmp, { force: true, recursive: true });
+  }
 });

--- a/packages/sdk/test/mod.test.ts
+++ b/packages/sdk/test/mod.test.ts
@@ -28,9 +28,13 @@ test('Mod.add invokes build for each builder', () => {
   mod.add(new SingleBuilder());
   mod.add([new ArrayBuilder(), new ArrayBuilder()]);
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'mod-test-'));
-  mod.build(tmp);
-  expect(single).toBe(1);
-  expect(array).toBe(2);
+  try {
+    mod.build(tmp);
+    expect(single).toBe(1);
+    expect(array).toBe(2);
+  } finally {
+    fs.rmSync(tmp, { force: true, recursive: true });
+  }
 });
 
 test('Mod.addFiles invokes write for each file', () => {
@@ -47,6 +51,10 @@ test('Mod.addFiles invokes write for each file', () => {
   mod.addFiles(new FileStub());
   mod.addFiles([new FileStub(), new FileStub()]);
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'mod-test-'));
-  mod.build(tmp);
-  expect(count).toBe(3);
+  try {
+    mod.build(tmp);
+    expect(count).toBe(3);
+  } finally {
+    fs.rmSync(tmp, { force: true, recursive: true });
+  }
 });


### PR DESCRIPTION
Every mkdtemp fixture now removes its directory in a finally block.
Leak census (observed in /tmp): civ7-direct-control-log-* (35 dirs from
runtime-and-catalog + session log-marker tests), studio-civ7-catalog-*
(10 dirs from the studio setup-catalog test), mod-build-*/mod-test-*
(sdk Mod.build tests). Verified: full affected suites leave zero
directories behind.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>