### PR TITLE
feat(mapgen-studio): dependency-ranked DAG layout, compact chrome, centered stats bar

### DIFF
--- a/apps/mapgen-studio/src/App.tsx
+++ b/apps/mapgen-studio/src/App.tsx
@@ -91,7 +91,7 @@ import {
 import { DeckCanvas, type DeckCanvasApi } from "./features/viz/DeckCanvas";
 import { useVizState } from "./features/viz/useVizState";
 import { createStudioRecipeDagClient, type RecipeDagResult } from "./features/recipeDag/client";
-import { RecipeDagView } from "./features/recipeDag/RecipeDagView";
+import { RecipeDagStatsBar, RecipeDagView } from "./features/recipeDag/RecipeDagView";
 import {
   findVariantIdForEra,
   findVariantKeyForEra,
@@ -2821,7 +2821,7 @@ function AppContent(props: AppContentProps) {
       selectedStageId={selectedStageId || null}
       onToggleStage={handleRecipeDagStageToggle}
       onSelectStage={setSelectedStageId}
-      topInset={panelTop}
+      topInset={panelTop + 84}
     />
   );
 
@@ -2893,6 +2893,13 @@ function AppContent(props: AppContentProps) {
       setupOptions={setupControlOptions}
       onSetupConfigChange={setSetupConfig}
       onSavedConfigChange={handleSavedSetupConfigChange}
+      statsAccessory={activeStudioView === "dag" ? (
+        <RecipeDagStatsBar
+          dag={recipeDagState.recipeId === recipeSettings.recipe ? recipeDagState.dag : null}
+          recipeId={recipeSettings.recipe}
+          lightMode={isLightMode}
+        />
+      ) : null}
       onHeaderHeightChange={handleHeaderHeightChange}
     />
   );

--- a/apps/mapgen-studio/src/features/recipeDag/RecipeDagView.tsx
+++ b/apps/mapgen-studio/src/features/recipeDag/RecipeDagView.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { AlertTriangle, Boxes, ChevronDown, GitBranch, Loader2 } from "lucide-react";
 
 import type { RecipeDagResult } from "./client";
+import { buildRecipeDagLayout, pointsToPath } from "./layout";
 
 type RecipeDagLoadStatus = "idle" | "loading" | "ready" | "error";
 
@@ -18,28 +19,6 @@ export interface RecipeDagViewProps {
   topInset: number;
 }
 
-type StagePosition = Readonly<{
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}>;
-
-type StageEdgeGroup = Readonly<{
-  id: string;
-  fromStageId: string;
-  toStageId: string;
-  artifacts: readonly string[];
-}>;
-
-const STAGE_WIDTH = 232;
-const STAGE_HEIGHT = 116;
-const STAGE_GAP_X = 86;
-const PHASE_GAP_Y = 218;
-const GRAPH_PAD_X = 72;
-const GRAPH_PAD_TOP = 98;
-const GRAPH_PAD_BOTTOM = 112;
-
 export function RecipeDagView(props: RecipeDagViewProps) {
   const {
     recipeId,
@@ -54,34 +33,25 @@ export function RecipeDagView(props: RecipeDagViewProps) {
     topInset,
   } = props;
   const palette = useMemo(() => createPalette(lightMode), [lightMode]);
-  const layout = useMemo(() => (dag ? buildLayout(dag) : null), [dag]);
+  const layout = useMemo(() => (dag ? buildRecipeDagLayout(dag) : null), [dag]);
+  const neighborStageIds = useMemo(() => {
+    if (!selectedStageId || !layout) return null;
+    const ids = new Set([selectedStageId]);
+    for (const edge of layout.edgeGroups) {
+      if (edge.fromStageId === selectedStageId) ids.add(edge.toStageId);
+      if (edge.toStageId === selectedStageId) ids.add(edge.fromStageId);
+    }
+    return ids;
+  }, [layout, selectedStageId]);
 
   return (
     <section
       className={`absolute inset-0 overflow-hidden ${palette.surface}`}
       style={{ paddingTop: topInset }}
-      aria-label="Recipe dependency graph"
+      aria-label={`Recipe dependency graph for ${recipeId}`}
     >
       <div className={`absolute inset-0 pointer-events-none ${palette.grid}`} aria-hidden="true" />
       <div className="relative flex h-full min-h-0 flex-col">
-        <div className={`mx-4 mb-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3 backdrop-blur-sm ${palette.panel}`}>
-          <div className="min-w-0">
-            <div className={`flex items-center gap-2 text-[11px] font-semibold uppercase ${palette.kicker}`}>
-              <GitBranch className="h-4 w-4" />
-              Recipe DAG
-            </div>
-            <h2 className={`mt-1 truncate text-[18px] font-semibold ${palette.heading}`}>
-              {dag?.title ?? recipeId}
-            </h2>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Metric label="Phases" value={dag?.phases.length ?? 0} lightMode={lightMode} />
-            <Metric label="Stages" value={dag?.stages.length ?? 0} lightMode={lightMode} />
-            <Metric label="Artifact edges" value={dag?.edges.length ?? 0} lightMode={lightMode} />
-            <Metric label="Diagnostics" value={dag?.diagnostics.length ?? 0} lightMode={lightMode} tone={dag?.diagnostics.length ? "warn" : "normal"} />
-          </div>
-        </div>
-
         <div className="relative min-h-0 flex-1 overflow-auto px-4 pb-4">
           {status === "loading" || status === "idle" ? (
             <CenteredState
@@ -127,20 +97,51 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                     <path d="M0,0 L0,6 L8,3 z" fill={palette.edge} />
                   </marker>
                 </defs>
-                {layout.phaseBands.map((phase) => (
+                {layout.rankColumns.map((column) => (
+                  <g key={column.rank}>
+                    <line
+                      x1={column.x + 124}
+                      y1={48}
+                      x2={column.x + 124}
+                      y2={layout.height - 58}
+                      stroke={palette.rankLine}
+                      strokeWidth="1"
+                      strokeDasharray="3 8"
+                    />
+                    <text
+                      x={column.x}
+                      y={28}
+                      fill={palette.phaseText}
+                      fontSize="10"
+                      fontWeight="700"
+                    >
+                      {column.label}
+                    </text>
+                  </g>
+                ))}
+                {layout.phaseBands.map((phase, index) => (
                   <g key={phase.id}>
                     <rect
                       x={32}
-                      y={phase.y - 52}
+                      y={phase.y}
                       width={layout.width - 64}
-                      height={PHASE_GAP_Y - 30}
+                      height={phase.height}
                       rx={8}
-                      fill={palette.phaseFill}
+                      fill={palette.phaseFills[index % palette.phaseFills.length]}
                       stroke={palette.phaseStroke}
+                    />
+                    <rect
+                      x={32}
+                      y={phase.y}
+                      width={4}
+                      height={phase.height}
+                      rx={2}
+                      fill={palette.phaseAccents[index % palette.phaseAccents.length]}
+                      opacity="0.9"
                     />
                     <text
                       x={52}
-                      y={phase.y - 24}
+                      y={phase.y + 26}
                       fill={palette.phaseText}
                       fontSize="12"
                       fontWeight="700"
@@ -149,25 +150,30 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                     </text>
                   </g>
                 ))}
-                {layout.edgeGroups.map((edge, index) => {
-                  const from = layout.positions.get(edge.fromStageId);
-                  const to = layout.positions.get(edge.toStageId);
-                  if (!from || !to) return null;
-                  const x1 = from.x + from.width;
-                  const y1 = from.y + 42 + (index % 4) * 10;
-                  const x2 = to.x;
-                  const y2 = to.y + 42 + (index % 4) * 10;
-                  const dx = Math.max(42, Math.abs(x2 - x1) * 0.42);
+                {layout.edgeGroups.map((edge) => {
+                  if (!edge.points.length) return null;
+                  const related = !selectedStageId || edge.fromStageId === selectedStageId || edge.toStageId === selectedStageId;
                   return (
                     <g key={edge.id}>
                       <path
-                        d={`M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`}
+                        d={pointsToPath(edge.points)}
                         fill="none"
                         stroke={palette.edge}
-                        strokeWidth="2"
+                        strokeWidth={related ? "2.4" : "1.4"}
                         markerEnd="url(#recipe-dag-arrow)"
-                        opacity="0.76"
+                        opacity={related ? "0.82" : "0.22"}
                       />
+                      <text
+                        x={edge.labelX}
+                        y={edge.labelY - 5}
+                        fill={palette.edgeLabel}
+                        fontSize="9"
+                        fontWeight="700"
+                        textAnchor="middle"
+                        opacity={related ? "0.9" : "0.25"}
+                      >
+                        {edge.label}
+                      </text>
                       <title>{`${edge.fromStageId} provides ${edge.artifacts.join(", ")} to ${edge.toStageId}`}</title>
                     </g>
                   );
@@ -179,10 +185,11 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                 if (!position) return null;
                 const expanded = expandedStageIds.has(stage.stageId);
                 const selected = selectedStageId === stage.stageId;
+                const dimmed = Boolean(neighborStageIds && !neighborStageIds.has(stage.stageId));
                 return (
                   <article
                     key={stage.stageId}
-                    className={`absolute overflow-hidden rounded-lg border shadow-sm ${selected ? palette.stageSelected : palette.stage}`}
+                    className={`absolute overflow-hidden rounded-lg border shadow-sm transition-opacity ${selected ? palette.stageSelected : palette.stage} ${dimmed ? "opacity-45" : "opacity-100"}`}
                     style={{
                       left: position.x,
                       top: position.y,
@@ -202,7 +209,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                       <span className="min-w-0 flex-1">
                         <span className={`block truncate text-[13px] font-semibold ${palette.heading}`}>{stage.stageId}</span>
                         <span className={`mt-0.5 block truncate text-[11px] ${palette.body}`}>
-                          {stage.steps.length} steps, {stage.artifactProvides.length} provides, {stage.artifactRequires.length} requires
+                          Runs {stage.steps.length} {stage.steps.length === 1 ? "step" : "steps"}; creates {stage.artifactProvides.length}; needs {stage.artifactRequires.length}
                         </span>
                       </span>
                       <ChevronDown className={`mt-0.5 h-4 w-4 shrink-0 transition-transform ${expanded ? "rotate-180" : ""} ${palette.icon}`} />
@@ -220,11 +227,11 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                           {stage.steps.map((step) => (
                             <li key={step.fullStepId} className={`rounded border px-2 py-1.5 ${palette.step}`}>
                               <div className={`truncate text-[11px] font-medium ${palette.heading}`}>
-                                {step.orderInStage + 1}. {step.stepId}
+                                Step {step.orderInStage + 1}: {step.stepId}
                               </div>
-                              <div className={`mt-1 truncate text-[10px] ${palette.body}`}>{step.phase}</div>
-                              <ArtifactList label="Requires" values={step.artifactRequires.map((artifact) => artifact.id)} lightMode={lightMode} />
-                              <ArtifactList label="Provides" values={step.artifactProvides.map((artifact) => artifact.id)} lightMode={lightMode} />
+                              <div className={`mt-1 truncate text-[10px] ${palette.body}`}>Phase: {step.phase}</div>
+                              <ArtifactList label="Needs" values={step.artifactRequires.map((artifact) => artifact.id)} lightMode={lightMode} />
+                              <ArtifactList label="Creates" values={step.artifactProvides.map((artifact) => artifact.id)} lightMode={lightMode} />
                             </li>
                           ))}
                         </ol>
@@ -257,58 +264,20 @@ export function RecipeDagView(props: RecipeDagViewProps) {
   );
 }
 
-function buildLayout(dag: RecipeDagResult): {
-  width: number;
-  height: number;
-  positions: Map<string, StagePosition>;
-  phaseBands: readonly { id: string; y: number }[];
-  edgeGroups: readonly StageEdgeGroup[];
-} {
-  const phaseIndexById = new Map(dag.phases.map((phase, index) => [phase.id, index]));
-  const positions = new Map<string, StagePosition>();
-  for (const stage of dag.stages) {
-    const phaseId = stage.phases[0] ?? dag.phases[0]?.id ?? "unphased";
-    const phaseIndex = phaseIndexById.get(phaseId) ?? 0;
-    positions.set(stage.stageId, {
-      x: GRAPH_PAD_X + stage.order * (STAGE_WIDTH + STAGE_GAP_X),
-      y: GRAPH_PAD_TOP + phaseIndex * PHASE_GAP_Y,
-      width: STAGE_WIDTH,
-      height: STAGE_HEIGHT,
-    });
-  }
-  const width = Math.max(980, GRAPH_PAD_X * 2 + dag.stages.length * STAGE_WIDTH + Math.max(0, dag.stages.length - 1) * STAGE_GAP_X);
-  const height = Math.max(520, GRAPH_PAD_TOP + Math.max(1, dag.phases.length) * PHASE_GAP_Y + GRAPH_PAD_BOTTOM);
-  return {
-    width,
-    height,
-    positions,
-    phaseBands: dag.phases.map((phase) => ({
-      id: phase.id,
-      y: GRAPH_PAD_TOP + (phaseIndexById.get(phase.id) ?? 0) * PHASE_GAP_Y,
-    })),
-    edgeGroups: groupStageEdges(dag),
-  };
-}
-
-function groupStageEdges(dag: RecipeDagResult): StageEdgeGroup[] {
-  const groups = new Map<string, { fromStageId: string; toStageId: string; artifacts: Set<string> }>();
-  for (const edge of dag.edges) {
-    if (edge.internal) continue;
-    const key = `${edge.from.stageId}->${edge.to.stageId}`;
-    const existing = groups.get(key) ?? {
-      fromStageId: edge.from.stageId,
-      toStageId: edge.to.stageId,
-      artifacts: new Set<string>(),
-    };
-    existing.artifacts.add(edge.artifact.id);
-    groups.set(key, existing);
-  }
-  return Array.from(groups.entries()).map(([id, group]) => ({
-    id,
-    fromStageId: group.fromStageId,
-    toStageId: group.toStageId,
-    artifacts: Array.from(group.artifacts).sort(),
-  }));
+export function RecipeDagStatsBar(props: { dag: RecipeDagResult | null; recipeId: string; lightMode: boolean }) {
+  const palette = createPalette(props.lightMode);
+  return (
+    <div className={`flex max-w-[min(760px,calc(100vw-260px))] items-center gap-2 rounded-lg border px-2 py-1 backdrop-blur-md ${palette.panel}`}>
+      <div className={`hidden min-w-0 items-center gap-1.5 px-2 text-[11px] font-semibold uppercase md:flex ${palette.kicker}`}>
+        <GitBranch className="h-3.5 w-3.5" />
+        <span className="truncate">{props.dag?.title ?? props.recipeId}</span>
+      </div>
+      <Metric label="Phases" value={props.dag?.phases.length ?? 0} lightMode={props.lightMode} />
+      <Metric label="Stages" value={props.dag?.stages.length ?? 0} lightMode={props.lightMode} />
+      <Metric label="Edges" value={props.dag?.edges.length ?? 0} lightMode={props.lightMode} />
+      <Metric label="Issues" value={props.dag?.diagnostics.length ?? 0} lightMode={props.lightMode} tone={props.dag?.diagnostics.length ? "warn" : "normal"} />
+    </div>
+  );
 }
 
 function Metric(props: { label: string; value: number; lightMode: boolean; tone?: "normal" | "warn" }) {
@@ -321,9 +290,9 @@ function Metric(props: { label: string; value: number; lightMode: boolean; tone?
       ? "border-amber-500/40 bg-amber-500/10 text-amber-200"
       : "border-[#2a2a32] bg-[#111116] text-[#e8e8ed]";
   return (
-    <div className={`min-w-[86px] rounded border px-2 py-1 text-right ${className}`}>
-      <div className="text-[15px] font-semibold leading-5">{props.value}</div>
-      <div className="text-[10px] uppercase">{props.label}</div>
+    <div className={`min-w-[64px] rounded border px-2 py-1 text-right ${className}`}>
+      <div className="text-[13px] font-semibold leading-4">{props.value}</div>
+      <div className="text-[9px] uppercase">{props.label}</div>
     </div>
   );
 }
@@ -386,7 +355,7 @@ function createPalette(lightMode: boolean) {
     return {
       surface: "bg-[#f5f5f7]",
       grid: "bg-[linear-gradient(rgba(0,0,0,0.045)_1px,transparent_1px),linear-gradient(90deg,rgba(0,0,0,0.045)_1px,transparent_1px)] bg-[length:48px_48px]",
-      panel: "border-gray-200 bg-white/95",
+      panel: "border-white/80 bg-white/78",
       stage: "border-gray-200 bg-white",
       stageSelected: "border-cyan-500 bg-white ring-2 ring-cyan-500/30",
       step: "border-gray-200 bg-gray-50",
@@ -397,15 +366,23 @@ function createPalette(lightMode: boolean) {
       kicker: "text-cyan-700",
       icon: "text-cyan-700",
       edge: "#0891b2",
-      phaseFill: "rgba(255,255,255,0.68)",
-      phaseStroke: "rgba(148,163,184,0.55)",
-      phaseText: "#475569",
+      edgeLabel: "#0e7490",
+      rankLine: "rgba(71,85,105,0.22)",
+      phaseFills: [
+        "rgba(236,253,245,0.68)",
+        "rgba(239,246,255,0.68)",
+        "rgba(255,247,237,0.66)",
+        "rgba(245,243,255,0.64)",
+      ],
+      phaseAccents: ["#059669", "#2563eb", "#d97706", "#7c3aed"],
+      phaseStroke: "rgba(100,116,139,0.42)",
+      phaseText: "#334155",
     } as const;
   }
   return {
     surface: "bg-[#0a0a12]",
     grid: "bg-[linear-gradient(rgba(255,255,255,0.035)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.035)_1px,transparent_1px)] bg-[length:48px_48px]",
-    panel: "border-[#2a2a32] bg-[#141418]/95",
+    panel: "border-white/10 bg-[#141418]/72",
     stage: "border-[#2a2a32] bg-[#101014]",
     stageSelected: "border-cyan-400 bg-[#101014] ring-2 ring-cyan-400/30",
     step: "border-[#30303a] bg-[#15151a]",
@@ -416,8 +393,16 @@ function createPalette(lightMode: boolean) {
     kicker: "text-cyan-300",
     icon: "text-cyan-300",
     edge: "#22d3ee",
-    phaseFill: "rgba(20,20,24,0.68)",
-    phaseStroke: "rgba(68,68,78,0.82)",
-    phaseText: "#a9a9b5",
+    edgeLabel: "#67e8f9",
+    rankLine: "rgba(148,163,184,0.16)",
+    phaseFills: [
+      "rgba(6,78,59,0.20)",
+      "rgba(30,64,175,0.18)",
+      "rgba(146,64,14,0.18)",
+      "rgba(91,33,182,0.17)",
+    ],
+    phaseAccents: ["#34d399", "#60a5fa", "#f59e0b", "#a78bfa"],
+    phaseStroke: "rgba(100,116,139,0.42)",
+    phaseText: "#d4d4dc",
   } as const;
 }

--- a/apps/mapgen-studio/src/features/recipeDag/layout.ts
+++ b/apps/mapgen-studio/src/features/recipeDag/layout.ts
@@ -1,0 +1,315 @@
+import type { RecipeDagResult } from "./client";
+
+export type DagPoint = Readonly<{
+  x: number;
+  y: number;
+}>;
+
+export type StagePosition = Readonly<{
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rank: number;
+  phaseId: string;
+}>;
+
+export type StageEdgeGroup = Readonly<{
+  id: string;
+  fromStageId: string;
+  toStageId: string;
+  artifacts: readonly string[];
+}>;
+
+export type RoutedStageEdgeGroup = StageEdgeGroup &
+  Readonly<{
+    points: readonly DagPoint[];
+    label: string;
+    labelX: number;
+    labelY: number;
+  }>;
+
+export type PhaseBand = Readonly<{
+  id: string;
+  y: number;
+  height: number;
+}>;
+
+export type RankColumn = Readonly<{
+  rank: number;
+  x: number;
+  label: string;
+}>;
+
+export type RecipeDagLayout = Readonly<{
+  width: number;
+  height: number;
+  positions: ReadonlyMap<string, StagePosition>;
+  phaseBands: readonly PhaseBand[];
+  rankColumns: readonly RankColumn[];
+  edgeGroups: readonly RoutedStageEdgeGroup[];
+}>;
+
+const STAGE_WIDTH = 248;
+const STAGE_HEIGHT = 122;
+const RANK_GAP_X = 122;
+const GRAPH_PAD_X = 80;
+const GRAPH_PAD_TOP = 96;
+const GRAPH_PAD_BOTTOM = 110;
+const PHASE_TITLE_HEIGHT = 42;
+const PHASE_MIN_HEIGHT = 188;
+const STAGE_GAP_Y = 28;
+const EDGE_STEM = 34;
+
+export function buildRecipeDagLayout(dag: RecipeDagResult): RecipeDagLayout {
+  const edgeGroups = groupStageEdges(dag);
+  const phaseIndexById = new Map(dag.phases.map((phase, index) => [phase.id, index]));
+  const rankByStageId = assignDependencyRanks(dag, edgeGroups);
+  const rankCount = Math.max(1, Math.max(...Array.from(rankByStageId.values()), 0) + 1);
+  const phaseMetrics = measurePhaseLanes(dag, phaseIndexById, rankByStageId);
+  const positions = positionStages(dag, phaseMetrics, phaseIndexById, rankByStageId);
+  const width = Math.max(1040, GRAPH_PAD_X * 2 + rankCount * STAGE_WIDTH + Math.max(0, rankCount - 1) * RANK_GAP_X);
+  const height = Math.max(560, GRAPH_PAD_TOP + phaseMetrics.totalHeight + GRAPH_PAD_BOTTOM);
+  const rankColumns = Array.from({ length: rankCount }, (_, rank) => ({
+    rank,
+    x: GRAPH_PAD_X + rank * (STAGE_WIDTH + RANK_GAP_X),
+    label: rank === 0 ? "Sources" : `D${rank}`,
+  }));
+
+  return {
+    width,
+    height,
+    positions,
+    phaseBands: dag.phases.map((phase) => {
+      const metrics = phaseMetrics.byPhaseId.get(phase.id);
+      return {
+        id: phase.id,
+        y: metrics?.y ?? GRAPH_PAD_TOP,
+        height: metrics?.height ?? PHASE_MIN_HEIGHT,
+      };
+    }),
+    rankColumns,
+    edgeGroups: routeEdges(edgeGroups, positions),
+  };
+}
+
+export function groupStageEdges(dag: RecipeDagResult): StageEdgeGroup[] {
+  const groups = new Map<string, { fromStageId: string; toStageId: string; artifacts: Set<string> }>();
+  for (const edge of dag.edges) {
+    if (edge.internal) continue;
+    const key = `${edge.from.stageId}->${edge.to.stageId}`;
+    const existing = groups.get(key) ?? {
+      fromStageId: edge.from.stageId,
+      toStageId: edge.to.stageId,
+      artifacts: new Set<string>(),
+    };
+    existing.artifacts.add(edge.artifact.id);
+    groups.set(key, existing);
+  }
+  return Array.from(groups.entries()).map(([id, group]) => ({
+    id,
+    fromStageId: group.fromStageId,
+    toStageId: group.toStageId,
+    artifacts: Array.from(group.artifacts).sort(),
+  }));
+}
+
+function assignDependencyRanks(
+  dag: RecipeDagResult,
+  edgeGroups: readonly StageEdgeGroup[]
+): ReadonlyMap<string, number> {
+  const rankByStageId = new Map(dag.stages.map((stage) => [stage.stageId, 0]));
+  const stageOrderById = new Map(dag.stages.map((stage) => [stage.stageId, stage.order]));
+  const incomingByStageId = new Map<string, StageEdgeGroup[]>();
+  for (const edge of edgeGroups) {
+    const incoming = incomingByStageId.get(edge.toStageId) ?? [];
+    incoming.push(edge);
+    incomingByStageId.set(edge.toStageId, incoming);
+  }
+
+  for (const stage of [...dag.stages].sort((a, b) => a.order - b.order)) {
+    const incoming = incomingByStageId.get(stage.stageId) ?? [];
+    let rank = rankByStageId.get(stage.stageId) ?? 0;
+    for (const edge of incoming) {
+      const fromOrder = stageOrderById.get(edge.fromStageId) ?? -1;
+      if (fromOrder > stage.order) continue;
+      rank = Math.max(rank, (rankByStageId.get(edge.fromStageId) ?? 0) + 1);
+    }
+    rankByStageId.set(stage.stageId, rank);
+  }
+
+  return rankByStageId;
+}
+
+function measurePhaseLanes(
+  dag: RecipeDagResult,
+  phaseIndexById: ReadonlyMap<string, number>,
+  rankByStageId: ReadonlyMap<string, number>
+): {
+  totalHeight: number;
+  byPhaseId: ReadonlyMap<string, { y: number; height: number; maxSlotCount: number }>;
+} {
+  const slotCountByPhaseRank = new Map<string, number>();
+  for (const stage of dag.stages) {
+    const phaseId = resolveStagePhaseId(dag, phaseIndexById, stage.phases);
+    const rank = rankByStageId.get(stage.stageId) ?? 0;
+    const key = `${phaseId}:${rank}`;
+    slotCountByPhaseRank.set(key, (slotCountByPhaseRank.get(key) ?? 0) + 1);
+  }
+
+  const byPhaseId = new Map<string, { y: number; height: number; maxSlotCount: number }>();
+  let cursor = GRAPH_PAD_TOP;
+  for (const phase of dag.phases) {
+    let maxSlotCount = 1;
+    for (const [key, count] of slotCountByPhaseRank) {
+      if (key.startsWith(`${phase.id}:`)) maxSlotCount = Math.max(maxSlotCount, count);
+    }
+    const height = Math.max(PHASE_MIN_HEIGHT, PHASE_TITLE_HEIGHT + maxSlotCount * STAGE_HEIGHT + Math.max(0, maxSlotCount - 1) * STAGE_GAP_Y + 26);
+    byPhaseId.set(phase.id, { y: cursor, height, maxSlotCount });
+    cursor += height + 28;
+  }
+
+  return {
+    totalHeight: Math.max(PHASE_MIN_HEIGHT, cursor - GRAPH_PAD_TOP),
+    byPhaseId,
+  };
+}
+
+function positionStages(
+  dag: RecipeDagResult,
+  phaseMetrics: ReturnType<typeof measurePhaseLanes>,
+  phaseIndexById: ReadonlyMap<string, number>,
+  rankByStageId: ReadonlyMap<string, number>
+): ReadonlyMap<string, StagePosition> {
+  const positions = new Map<string, StagePosition>();
+  const stagesByPhaseRank = new Map<string, typeof dag.stages>();
+  for (const stage of dag.stages) {
+    const phaseId = resolveStagePhaseId(dag, phaseIndexById, stage.phases);
+    const rank = rankByStageId.get(stage.stageId) ?? 0;
+    const key = `${phaseId}:${rank}`;
+    stagesByPhaseRank.set(key, [...(stagesByPhaseRank.get(key) ?? []), stage]);
+  }
+
+  for (const [key, stages] of stagesByPhaseRank) {
+    const [phaseId, rankText] = key.split(":");
+    const rank = Number(rankText);
+    const phase = phaseMetrics.byPhaseId.get(phaseId);
+    const sortedStages = [...stages].sort((a, b) => a.order - b.order);
+    sortedStages.forEach((stage, slot) => {
+      positions.set(stage.stageId, {
+        x: GRAPH_PAD_X + rank * (STAGE_WIDTH + RANK_GAP_X),
+        y: (phase?.y ?? GRAPH_PAD_TOP) + PHASE_TITLE_HEIGHT + slot * (STAGE_HEIGHT + STAGE_GAP_Y),
+        width: STAGE_WIDTH,
+        height: STAGE_HEIGHT,
+        rank,
+        phaseId,
+      });
+    });
+  }
+
+  return positions;
+}
+
+function routeEdges(
+  edgeGroups: readonly StageEdgeGroup[],
+  positions: ReadonlyMap<string, StagePosition>
+): RoutedStageEdgeGroup[] {
+  const outboundIndex = indexEdgesByEndpoint(edgeGroups, "fromStageId");
+  const inboundIndex = indexEdgesByEndpoint(edgeGroups, "toStageId");
+
+  return edgeGroups.map((edge) => {
+    const from = positions.get(edge.fromStageId);
+    const to = positions.get(edge.toStageId);
+    if (!from || !to) {
+      return {
+        ...edge,
+        points: [],
+        label: formatEdgeLabel(edge.artifacts),
+        labelX: 0,
+        labelY: 0,
+      };
+    }
+
+    const outOffset = anchorOffset(outboundIndex.get(edge.fromStageId) ?? [], edge.id, from.height);
+    const inOffset = anchorOffset(inboundIndex.get(edge.toStageId) ?? [], edge.id, to.height);
+    const start = { x: from.x + from.width, y: from.y + outOffset };
+    const end = { x: to.x, y: to.y + inOffset };
+    const forward = end.x > start.x;
+    const midX = forward ? start.x + Math.max(EDGE_STEM * 2, (end.x - start.x) / 2) : start.x + EDGE_STEM * 1.6;
+    const points = forward
+      ? [
+          start,
+          { x: start.x + EDGE_STEM, y: start.y },
+          { x: midX, y: start.y },
+          { x: midX, y: end.y },
+          { x: end.x - EDGE_STEM, y: end.y },
+          end,
+        ]
+      : [
+          start,
+          { x: start.x + EDGE_STEM, y: start.y },
+          { x: start.x + EDGE_STEM, y: Math.max(start.y, end.y) + 42 },
+          { x: end.x - EDGE_STEM, y: Math.max(start.y, end.y) + 42 },
+          { x: end.x - EDGE_STEM, y: end.y },
+          end,
+        ];
+
+    return {
+      ...edge,
+      points,
+      label: formatEdgeLabel(edge.artifacts),
+      labelX: forward ? midX : (start.x + end.x) / 2,
+      labelY: (start.y + end.y) / 2,
+    };
+  });
+}
+
+function indexEdgesByEndpoint(
+  edgeGroups: readonly StageEdgeGroup[],
+  endpoint: "fromStageId" | "toStageId"
+): ReadonlyMap<string, readonly StageEdgeGroup[]> {
+  const byEndpoint = new Map<string, StageEdgeGroup[]>();
+  for (const edge of edgeGroups) {
+    const edges = byEndpoint.get(edge[endpoint]) ?? [];
+    edges.push(edge);
+    byEndpoint.set(edge[endpoint], edges);
+  }
+  for (const [stageId, edges] of byEndpoint) {
+    byEndpoint.set(
+      stageId,
+      [...edges].sort((a, b) => a.id.localeCompare(b.id))
+    );
+  }
+  return byEndpoint;
+}
+
+function anchorOffset(edges: readonly StageEdgeGroup[], edgeId: string, height: number): number {
+  const index = Math.max(0, edges.findIndex((edge) => edge.id === edgeId));
+  const count = Math.max(1, edges.length);
+  const top = 38;
+  const bottom = height - 28;
+  return top + ((bottom - top) * (index + 1)) / (count + 1);
+}
+
+function formatEdgeLabel(artifacts: readonly string[]): string {
+  if (artifacts.length === 0) return "artifact";
+  if (artifacts.length === 1) return artifacts[0] ?? "artifact";
+  return `${artifacts[0]} +${artifacts.length - 1}`;
+}
+
+function resolveStagePhaseId(
+  dag: RecipeDagResult,
+  phaseIndexById: ReadonlyMap<string, number>,
+  stagePhases: readonly string[]
+): string {
+  return stagePhases.find((phaseId) => phaseIndexById.has(phaseId)) ?? dag.phases[0]?.id ?? "unphased";
+}
+
+export function pointsToPath(points: readonly DagPoint[]): string {
+  if (points.length === 0) return "";
+  const [first, ...rest] = points;
+  return [
+    `M ${first.x} ${first.y}`,
+    ...rest.map((point) => `L ${point.x} ${point.y}`),
+  ].join(" ");
+}

--- a/apps/mapgen-studio/src/ui/components/AppHeader.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppHeader.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { ChevronDown, GitBranch, Globe, Map, SlidersHorizontal } from 'lucide-react';
-import { AppBrand } from './AppBrand';
 import { ViewControls } from './ViewControls';
 import { Select } from './ui';
 import {
@@ -37,6 +36,7 @@ export interface AppHeaderProps {
   };
   onSetupConfigChange: (config: Civ7StudioSetupConfig) => void;
   onSavedConfigChange: (configId: string) => void;
+  statsAccessory?: React.ReactNode;
   onHeaderHeightChange?: (height: number) => void;
 }
 export const AppHeader: React.FC<AppHeaderProps> = ({
@@ -53,12 +53,13 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   setupOptions,
   onSetupConfigChange,
   onSavedConfigChange,
+  statsAccessory,
   onHeaderHeightChange
 }) => {
   const headerRef = React.useRef<HTMLElement | null>(null);
   const [setupOpen, setSetupOpen] = React.useState(false);
-  const panelBg = isLightMode ? 'bg-white/95' : 'bg-[#141418]/95';
-  const panelBorder = isLightMode ? 'border-gray-200' : 'border-[#2a2a32]';
+  const panelBg = isLightMode ? 'bg-white/70' : 'bg-[#141418]/62';
+  const panelBorder = isLightMode ? 'border-white/80' : 'border-white/10';
   const textSecondary = isLightMode ? 'text-[#6b7280]' : 'text-[#8a8a96]';
   const textMuted = isLightMode ? 'text-[#9ca3af]' : 'text-[#5a5a66]';
   const dividerColor = isLightMode ? 'bg-gray-200' : 'bg-[#2a2a32]';
@@ -117,20 +118,15 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   return (
     <header
       ref={headerRef}
-      className="absolute top-4 left-4 right-4 z-20 grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3"
+      className="pointer-events-none absolute left-3 right-3 top-2 z-20 h-10"
       style={{
         minHeight: HEADER_HEIGHT
       }}>
 
-      {/* Left: App Brand */}
-      <div className="shrink-0">
-        <AppBrand isLightMode={isLightMode} />
-      </div>
-
       {/* Center: World Settings */}
-      <div className="min-w-0 flex flex-col items-center gap-2 overflow-visible">
+      <div className="pointer-events-auto absolute left-1/2 top-0 flex w-[min(760px,calc(100vw-300px))] min-w-0 -translate-x-1/2 flex-col items-center gap-2 overflow-visible">
         <div
-          className={`flex min-h-10 max-w-full flex-wrap items-center justify-center gap-x-3 gap-y-2 px-3 py-1.5 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}>
+          className={`flex min-h-10 w-full max-w-full flex-nowrap items-center justify-center gap-x-3 px-3 py-1.5 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}>
 
           <div className="flex items-center gap-1.5">
             <Globe className={`w-4 h-4 ${textMuted}`} />
@@ -206,6 +202,8 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
             <ChevronDown className={`w-3.5 h-3.5 transition-transform ${setupOpen ? 'rotate-180' : ''}`} />
           </button>
         </div>
+
+        {statsAccessory ? statsAccessory : null}
 
         {setupOpen ? (
           <div
@@ -291,7 +289,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
       </div>
 
       {/* Right: View Controls */}
-      <div className="flex shrink-0 items-start gap-2">
+      <div className="pointer-events-auto absolute right-0 top-0 flex shrink-0 flex-col items-end gap-1.5">
         <div
           className={`h-10 inline-flex items-center gap-1 px-1.5 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}
           role="tablist"

--- a/apps/mapgen-studio/src/ui/components/ViewControls.tsx
+++ b/apps/mapgen-studio/src/ui/components/ViewControls.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 // ============================================================================
 // Toolbar for theme toggle and grid visibility.
 // ============================================================================
-import { Sun, Moon, Monitor } from 'lucide-react';
+import { Grid3X3, Sun, Moon, Monitor } from 'lucide-react';
 import { cn } from '../utils';
 import type { ThemePreference } from '../types';
 // ============================================================================
@@ -58,8 +58,8 @@ export const ViewControls: React.FC<ViewControlsProps> = ({
   // ==========================================================================
   // Styles
   // ==========================================================================
-  const panelBg = isLightMode ? 'bg-white/95' : 'bg-[#141418]/95';
-  const panelBorder = isLightMode ? 'border-gray-200' : 'border-[#2a2a32]';
+  const panelBg = isLightMode ? 'bg-white/70' : 'bg-[#141418]/62';
+  const panelBorder = isLightMode ? 'border-white/80' : 'border-white/10';
   const dividerColor = isLightMode ? 'bg-gray-200' : 'bg-[#2a2a32]';
   // Icon button styles based on theme
   const iconBtn = cn(
@@ -103,7 +103,7 @@ export const ViewControls: React.FC<ViewControlsProps> = ({
         aria-pressed={showGrid}
         className={showGrid ? iconBtnActive : iconBtn}>
 
-        <div className="w-4 h-4" />
+        <Grid3X3 className="w-4 h-4" />
       </button>
     </div>);
 

--- a/apps/mapgen-studio/src/ui/constants/layout.ts
+++ b/apps/mapgen-studio/src/ui/constants/layout.ts
@@ -5,8 +5,8 @@
 // ============================================================================
 
 export const LAYOUT = {
-  /** Header reserve in pixels; allows the top controls to wrap without covering panels. */
-  HEADER_HEIGHT: 104,
+  /** Floating top toolbar reserve in pixels. */
+  HEADER_HEIGHT: 40,
   /** Footer bar height in pixels */
   FOOTER_HEIGHT: 56,
   /** Default panel width in pixels */

--- a/apps/mapgen-studio/test/recipeDag/RecipeDagView.test.tsx
+++ b/apps/mapgen-studio/test/recipeDag/RecipeDagView.test.tsx
@@ -21,14 +21,13 @@ describe("RecipeDagView", () => {
       />
     );
 
-    expect(html).toContain("Recipe DAG");
     expect(html).toContain("Swooper Maps / Standard");
     expect(html).toContain("shape");
     expect(html).toContain("climate");
-    expect(html).toContain("Artifact edges");
+    expect(html).toContain("Sources");
     expect(html).toContain("seed-grid");
-    expect(html).toContain("1. seed");
-    expect(html).toContain("Provides");
+    expect(html).toContain("Step 1: seed");
+    expect(html).toContain("Creates");
   });
 });
 

--- a/apps/mapgen-studio/test/recipeDag/layout.test.ts
+++ b/apps/mapgen-studio/test/recipeDag/layout.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRecipeDagLayout, groupStageEdges, pointsToPath } from "../../src/features/recipeDag/layout";
+import type { RecipeDagResult } from "../../src/features/recipeDag/client";
+
+describe("recipe DAG layout", () => {
+  it("places stages by dependency rank while preserving phase grouping", () => {
+    const layout = buildRecipeDagLayout(recipeDag());
+
+    expect(layout.positions.get("source")?.rank).toBe(0);
+    expect(layout.positions.get("branch-a")?.rank).toBe(1);
+    expect(layout.positions.get("branch-b")?.rank).toBe(1);
+    expect(layout.positions.get("sink")?.rank).toBe(2);
+    expect(layout.positions.get("sink")?.phaseId).toBe("finish");
+    expect(layout.rankColumns.map((column) => column.label)).toEqual(["Sources", "D1", "D2"]);
+  });
+
+  it("groups stage edges and produces routed orthogonal paths", () => {
+    const dag = recipeDag();
+    const groups = groupStageEdges(dag);
+    const layout = buildRecipeDagLayout(dag);
+    const routed = layout.edgeGroups.find((edge) => edge.fromStageId === "source" && edge.toStageId === "branch-a");
+
+    expect(groups).toHaveLength(4);
+    expect(routed?.artifacts).toEqual(["seed-grid"]);
+    expect(pointsToPath(routed?.points ?? [])).toContain("L");
+  });
+});
+
+function recipeDag(): RecipeDagResult {
+  return {
+    recipeId: "standard",
+    recipeKey: "mod-swooper-maps/standard",
+    namespace: "mod-swooper-maps",
+    title: "Swooper Maps / Standard",
+    phases: [
+      { id: "shape", order: 0, stageIds: ["source", "branch-a", "branch-b"], stepCount: 3 },
+      { id: "finish", order: 1, stageIds: ["sink"], stepCount: 1 },
+    ],
+    stages: [
+      stage("source", 0, "shape", [], ["seed-grid"]),
+      stage("branch-a", 1, "shape", ["seed-grid"], ["coast-grid"]),
+      stage("branch-b", 2, "shape", ["seed-grid"], ["height-grid"]),
+      stage("sink", 3, "finish", ["coast-grid", "height-grid"], []),
+    ],
+    edges: [
+      edge("source", "seed", "branch-a", "coast", "seed-grid"),
+      edge("source", "seed", "branch-b", "height", "seed-grid"),
+      edge("branch-a", "coast", "sink", "finalize", "coast-grid"),
+      edge("branch-b", "height", "sink", "finalize", "height-grid"),
+    ],
+    diagnostics: [],
+  };
+}
+
+function stage(
+  stageId: string,
+  order: number,
+  phase: string,
+  requires: readonly string[],
+  provides: readonly string[]
+): RecipeDagResult["stages"][number] {
+  return {
+    id: stageId,
+    stageId,
+    order,
+    phases: [phase],
+    steps: [
+      {
+        id: `mod-swooper-maps.standard.${stageId}.step`,
+        stageId,
+        stepId: "step",
+        fullStepId: `mod-swooper-maps.standard.${stageId}.step`,
+        order,
+        orderInStage: 0,
+        phase,
+        artifactRequires: requires.map((id) => ({ id, name: id })),
+        artifactProvides: provides.map((id) => ({ id, name: id })),
+        tagRequires: [],
+        tagProvides: [],
+      },
+    ],
+    artifactRequires: requires.map((id) => ({ id, name: id })),
+    artifactProvides: provides.map((id) => ({ id, name: id })),
+    inboundArtifactEdgeCount: requires.length,
+    outboundArtifactEdgeCount: provides.length,
+    internalArtifactEdgeCount: 0,
+    diagnosticCount: 0,
+  };
+}
+
+function edge(
+  fromStageId: string,
+  fromStepId: string,
+  toStageId: string,
+  toStepId: string,
+  artifactId: string
+): RecipeDagResult["edges"][number] {
+  return {
+    id: `${fromStageId}->${toStageId}:${artifactId}`,
+    artifact: { id: artifactId, name: artifactId },
+    from: {
+      stageId: fromStageId,
+      stepId: fromStepId,
+      fullStepId: `mod-swooper-maps.standard.${fromStageId}.${fromStepId}`,
+    },
+    to: {
+      stageId: toStageId,
+      stepId: toStepId,
+      fullStepId: `mod-swooper-maps.standard.${toStageId}.${toStepId}`,
+    },
+    internal: false,
+  };
+}

--- a/openspec/changes/mapgen-recipe-dag-visualization/design.md
+++ b/openspec/changes/mapgen-recipe-dag-visualization/design.md
@@ -168,6 +168,12 @@ Visualization choice:
   renderer.
 - Layout should be deterministic from recipe order and phase grouping so tests
   can assert node/edge identity without pixel-fragile force simulation.
+- Dense real recipes should use a deterministic dependency-ranked layout:
+  stages remain the graph nodes, cross-stage artifact groups assign dependency
+  ranks, phase ids remain visual lanes, and edges route through stable
+  orthogonal ports. This preserves the native scroll surface that makes
+  trackpad navigation fluid while reducing long arbitrary splines and avoiding a
+  premature editable-canvas dependency.
 
 ## Review Lanes
 

--- a/openspec/changes/mapgen-recipe-dag-visualization/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/mapgen-recipe-dag-visualization/specs/mapgen-normalization-workstreams/spec.md
@@ -56,3 +56,12 @@ DAG as a peer to the existing map/config exploration experience.
 - **AND** loading, empty, diagnostic, and error states are accessible
 - **AND** selecting a different recipe reloads the DAG for that recipe id
 
+#### Scenario: Dense recipe dependency graph is scanned
+
+- **WHEN** the selected recipe contains many stages and cross-stage artifact
+  dependencies
+- **THEN** Studio lays out stages by dependency rank with phase lanes as visual
+  grouping
+- **AND** dependency edges use stable routed paths and labels that make producer
+  and consumer relationships easier to follow
+- **AND** the graph remains a smooth native scroll surface for trackpad panning

--- a/openspec/changes/mapgen-recipe-dag-visualization/tasks.md
+++ b/openspec/changes/mapgen-recipe-dag-visualization/tasks.md
@@ -33,6 +33,12 @@
 - [x] 4.4 Add accessible loading, diagnostic, and error states.
 - [x] 4.5 Add focused component and browser verification for recipe loading and
   stage expansion.
+- [x] 4.6 Add compact transparent Studio chrome for the DAG view: toolbar-height
+  top shell, right-side view/toolbox stack, and centered DAG stats under the
+  world controls.
+- [x] 4.7 Replace literal recipe-order spline rendering with a pure
+  dependency-ranked layout module, phase lanes, stable ports, and routed edge
+  paths while preserving native trackpad scrolling.
 
 ## 5. Verification And Realignment
 
@@ -44,3 +50,6 @@
   Studio DAG contracts beyond this OpenSpec design.
 - [x] 5.6 Complete review disposition, downstream realignment, closure checklist,
   and Graphite commit.
+- [x] 5.7 Verify the follow-on DAG layout/chrome slice with focused tests,
+  Studio check/build, OpenSpec validation, browser inspection, diff check, and
+  clean Graphite commit.

--- a/openspec/changes/mapgen-recipe-dag-visualization/workstream/phase-record.md
+++ b/openspec/changes/mapgen-recipe-dag-visualization/workstream/phase-record.md
@@ -5,26 +5,32 @@
 - Project: MapGen Studio recipe DAG visualization
 - Phase: `mapgen-recipe-dag-visualization`
 - Owner: main Codex agent
-- Branch/Graphite stack: detached `main` worktree, first Graphite slice pending
+- Branch/Graphite stack: `codex/mapgen-dag-ui-layout` stacked on
+  `codex/mapgen-recipe-dag-visualization`
 - Started: 2026-06-10
-- Status: implementation in progress
+- Status: follow-on layout/chrome implementation verified; Graphite commit
+  pending
 
 ## Objective
 
 - Target movement: add a read-only selected-recipe artifact dependency DAG
-  served by oRPC + Effect and rendered as a full-screen Studio tab.
+  served by oRPC + Effect and rendered as a full-screen Studio tab, then refine
+  the Studio chrome and dependency layout for dense recipe readability.
 - Non-goals: editable graph mutation, runtime trace overlays, generated-output
   hand edits, Civ7 runtime/control changes.
-- Done condition: graph DTO, service, view, tests, validation, review
-  disposition, downstream realignment, and clean Graphite closure.
+- Done condition: graph DTO, service, view, compact chrome, dependency-ranked
+  layout, tests, validation, review disposition, downstream realignment, and
+  clean Graphite closure.
 
 ## Authority
 
 - Root/subtree `AGENTS.md`: root, `packages/mapgen-core/AGENTS.md`,
   `packages/mapgen-core/src/AGENTS.md`, `mods/mod-swooper-maps/AGENTS.md`,
   `mods/mod-swooper-maps/src/AGENTS.md`, `packages/civ7-control-orpc/AGENTS.md`.
-- Product refs: direct user request for selected recipe DAG and full-screen
-  Studio tab.
+- Product refs: direct user request for selected recipe DAG, full-screen Studio
+  tab, minimized transparent chrome, centered stats, clearer step language,
+  better lane contrast, and easier dependency scanning without losing smooth
+  trackpad panning.
 - Architecture refs:
   `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`,
   `docs/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md`,
@@ -38,15 +44,17 @@
 
 ## Current State
 
-- Repo/Graphite state: new detached worktree at `main` `4feff5c63`; Graphite
-  stack visible; slice branch pending first commit.
-- Dirty files and owner: OpenSpec files in this change are owned by this phase.
+- Repo/Graphite state: isolated worktree on
+  `codex/mapgen-dag-ui-layout`; Graphite sees it as a follow-on slice above the
+  base DAG branch.
+- Dirty files and owner: follow-on UI/layout/source test/OpenSpec files are
+  owned by this phase until committed.
 - Current code evidence: MapGen authoring contracts expose stage/step artifact
   declarations; Studio has recipe catalog and Vite server middleware; control
   oRPC package demonstrates `effect-orpc` patterns.
 - Generated outputs affected: none yet.
-- Tests/guards affected: MapGen core authoring tests, Swooper recipe artifact
-  guards, Studio tests/build, OpenSpec validation.
+- Tests/guards affected: Studio recipe DAG tests/check/build, OpenSpec
+  validation, browser inspection, diff check.
 
 ## Scope
 
@@ -56,7 +64,9 @@
 - Owners: MapGen authoring core, Swooper recipe source, Studio server, Studio
   presentation.
 - Forbidden owners: generated outputs, direct-control runtime, adapter.
-- Consumer impact: read-only author insight into selected recipe pipeline.
+- Consumer impact: read-only author insight into selected recipe pipeline with
+  clearer dependency routes, separated stats, compact chrome, and preserved
+  native scroll/pan feel.
 - Downstream assumptions: future editable graph work can reuse identity model
   but is not implemented here.
 
@@ -64,8 +74,8 @@
 
 - Spec/proposal: `openspec/changes/mapgen-recipe-dag-visualization/proposal.md`
 - Tasks: `openspec/changes/mapgen-recipe-dag-visualization/tasks.md`
-- Validation status: pending; local worktree dependency setup currently lacks
-  `openspec` executable.
+- Validation status: focused layout tests passed; full Studio/OpenSpec
+  validation pending after docs and browser inspection.
 
 ## Review
 
@@ -76,8 +86,8 @@
 
 ## Agent Fleet State
 
-- Active agents: Turing, Dewey, Raman.
-- Completed agents: Turing, Dewey, Raman.
+- Active agents: none.
+- Completed agents: Turing, Dewey, Raman, Pasteur, Curie, Dirac.
 - Assigned write sets: read-only evidence gathering.
 - Latest evidence by agent:
   - Turing: derive DAG from authored `stages` arrays and explicit artifact
@@ -87,48 +97,63 @@
   - Raman: full-screen tab belongs in `apps/mapgen-studio`; no app-local graph
     library is installed, so deterministic SVG/HTML is the lowest-boundary
     implementation.
+  - Pasteur: choose a custom dependency-ranked layout now; React Flow remains a
+    future editable-canvas candidate but does not solve layout by itself.
+  - Curie: compact transparent header, right toolbox, centered stats, clearer
+    step copy, and lane color adjustments are the focused UI write set.
+  - Dirac: update the existing OpenSpec change and verify with focused Studio,
+    OpenSpec, browser, diff, and Graphite gates.
 - Open findings by agent: none blocking.
 - Running/stale status: no active evidence agents.
 - Integration owner: main Codex agent.
 
 ## Implementation
 
-- Completed tasks: 1.1 OpenSpec proposal/design/workstream records.
-- Remaining tasks: all source implementation and verification tasks.
-- Stop conditions triggered: worktree dependency setup gap recorded, not yet a
-  source-design blocker.
+- Completed tasks: base DAG implementation is committed on the downstack slice;
+  follow-on layout module, chrome refactor, centered stats, focused tests,
+  Studio check/build, OpenSpec validation, browser inspection, global OpenSpec
+  validation, and diff check are complete.
+- Remaining tasks: Graphite commit and clean closure.
+- Stop conditions triggered: none for this follow-on slice.
 
 ## Verification
 
 - Commands run:
-  - `git status --short --branch`
-  - `git worktree list`
-  - `gt log --no-interactive`
-  - `git rev-parse main`
-  - `git rev-parse origin/main`
-  - `bun run openspec -- list` in the new worktree, failed because executable
-    was unavailable.
-- Results: worktree is isolated at trunk; original checkout dirty state is
-  protected; OpenSpec executable setup must be restored before validation.
-- Skipped gates and rationale: no code gates yet because implementation has not
-  started.
-- Evidence boundary: current evidence is code/doc inspection and does not prove
-  runtime behavior.
+  - `bun test apps/mapgen-studio/test/recipeDag/layout.test.ts apps/mapgen-studio/test/recipeDag/RecipeDagView.test.tsx`
+  - `bun test apps/mapgen-studio/test/recipeDag/layout.test.ts apps/mapgen-studio/test/recipeDag/RecipeDagView.test.tsx apps/mapgen-studio/test/recipeDag/orpc.test.ts`
+  - `bun run --cwd apps/mapgen-studio check`
+  - `bun run --cwd apps/mapgen-studio build`
+  - `bun run openspec -- validate mapgen-recipe-dag-visualization --strict`
+  - `bun run openspec -- validate --changes --strict`
+  - `git diff --check`
+  - Chrome/Playwright browser inspection against `http://127.0.0.1:5173/`
+- Results: focused DAG tests passed; Studio typecheck passed; Studio production
+  build passed with the existing Vite chunk-size warning; worker bundle check
+  passed; the OpenSpec change and all active OpenSpec changes validate; diff
+  check passed; browser inspection confirmed a 40px header reserve, visible
+  right toolbox, centered stats, dependency-rank labels, phase lanes, clearer
+  step text, and native horizontal/vertical scroll offsets.
+- Skipped gates and rationale: full product runtime proof is not required for a
+  read-only Studio layout slice.
+- Evidence boundary: browser proof covers local dev render/scroll behavior, not
+  a pushed PR or in-game runtime.
 
 ## Realignment
 
-- Downstream docs/specs/issues updated: pending after implementation facts.
-- Tests/guards updated: pending.
+- Downstream docs/specs/issues updated: OpenSpec design/spec/task/workstream
+  records updated for the layout/readability slice.
+- Tests/guards updated: focused `RecipeDagView` assertions updated and
+  `recipeDag/layout.test.ts` added for the dependency-ranked layout module.
 - Deferrals/triage updated: none.
 - Downstream realignment ledger: to be added before closure if assumptions
   changed.
 
 ## Next Action
 
-- Exact next step: implement MapGen authoring DAG DTO/extractor.
-- First files to inspect:
-  - `packages/mapgen-core/src/authoring/index.ts`
-  - `packages/mapgen-core/src/authoring/types.ts`
-  - `mods/mod-swooper-maps/src/recipes/standard/recipe.ts`
-- Stop condition: extractor cannot access explicit artifact contracts without
-  violating package/import boundaries.
+- Exact next step: commit `codex/mapgen-dag-ui-layout`.
+- First files to inspect if a gate fails:
+  - `apps/mapgen-studio/src/features/recipeDag/layout.ts`
+  - `apps/mapgen-studio/src/features/recipeDag/RecipeDagView.tsx`
+  - `apps/mapgen-studio/src/ui/components/AppHeader.tsx`
+- Stop condition: final validation exposes a contract change beyond visual
+  layout/readability.

--- a/openspec/changes/mapgen-recipe-dag-visualization/workstream/workstream-record.md
+++ b/openspec/changes/mapgen-recipe-dag-visualization/workstream/workstream-record.md
@@ -7,7 +7,8 @@
   as a full-screen secondary Studio tab.
 - Future state: A recipe author can select a recipe, open the DAG tab, see
   phase clusters, stage nodes, artifact dependency edges, and expandable
-  sequential steps without reading source files.
+  sequential steps without reading source files; dense recipes use a
+  dependency-ranked layout that remains smooth to pan with a trackpad.
 - Non-goals: Editable graph mutation APIs; runtime trace overlays; generated
   artifact edits; Civ7 runtime/direct-control changes; phase-as-order semantics.
 - Hard core: Artifact edges come from authored `contract.artifacts` producer and
@@ -25,8 +26,8 @@
 ## Status
 
 - Last updated: 2026-06-10
-- Current gate: 11 - Review and closure after implementation verification.
-- Next gate: Graphite slice amendment and handoff.
+- Current gate: 8 - Follow-on DAG layout/chrome slice implementation.
+- Next gate: focused verification, browser inspection, and Graphite commit.
 - Blocked by: none.
 - Stop condition: Retarget if the unmerged MapGen Studio redesign stack is
   required for correctness.
@@ -34,10 +35,10 @@
 ## Repo State
 
 - Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-mapgen-recipe-dag`
-- Branch: `codex/mapgen-recipe-dag-visualization`
-- Parent branch: `main`
-- Stack position: Graphite-tracked slice on `main` for
-  `mapgen-recipe-dag-visualization`.
+- Branch: `codex/mapgen-dag-ui-layout`
+- Parent branch: `codex/mapgen-recipe-dag-visualization`
+- Stack position: Graphite-tracked follow-on slice above
+  `codex/mapgen-recipe-dag-visualization`.
 - Dirty files and owner: this workstream owns
   `openspec/changes/mapgen-recipe-dag-visualization/**` and later write-set
   files listed in `proposal.md`.
@@ -66,8 +67,9 @@
   recipe artifacts are touched.
 - Runtime proof: not required for read-only recipe source visualization.
 - Product proof: browser/component verification that selected recipe load,
-  full-screen DAG render, artifact edges, diagnostics, and stage expansion are
-  visible and accessible.
+  full-screen DAG render, compact chrome, centered stats, dependency-ranked
+  lanes, artifact edges, diagnostics, and stage expansion are visible,
+  accessible, and smooth under native scrolling.
 - Closure boundary: source tests, Studio build, OpenSpec validation, diff check,
   clean Graphite state.
 
@@ -78,6 +80,11 @@
   - Turing: recipe/stage/step/artifact corpus exploration.
   - Dewey: oRPC + Effect code pattern exploration.
   - Raman: Studio frontend/visualization exploration.
+  - Pasteur: DAG layout/library investigation for the follow-on UI slice.
+  - Curie: compact chrome and DAG presentation review for the follow-on UI
+    slice.
+  - Dirac: OpenSpec, verification, and Graphite hygiene review for the follow-on
+    UI slice.
 - Review agents: to be spawned after implementation for bounded review lanes.
 - Open findings:
   - Turing confirmed no separate persisted DAG exists; source recipe `stages`
@@ -88,3 +95,9 @@
   - Raman confirmed no React graph library exists; a deterministic SVG/HTML DAG
     view under `apps/mapgen-studio/src/features/recipeDag/` fits better than
     deck.gl or `packages/mapgen-viz`.
+  - Pasteur recommended a custom deterministic dependency-ranked layout now and
+    deferring React Flow/ELK/Dagre until editable graph semantics require them.
+  - Curie identified the compact transparent header, centered stats strip, step
+    copy, and lane color improvements as the UI write set.
+  - Dirac confirmed the existing OpenSpec change should receive a follow-on
+    layout/readability update rather than a new semantic change.


### PR DESCRIPTION
Replaces the recipe-order spline layout in the DAG view with a proper dependency-ranked layout module (`layout.ts`) that assigns stages to rank columns based on artifact dependencies, groups them into phase lane bands, and routes edges through stable orthogonal ports with artifact labels. Stages and edges that are unrelated to the currently selected stage are dimmed to make producer/consumer relationships easier to follow.

Moves the DAG stats panel (phases, stages, edges, diagnostics counts) out of the graph canvas and into a new `RecipeDagStatsBar` component that renders as a centered accessory below the world controls in the app header. The header is refactored to a compact 40px floating toolbar with a translucent backdrop, removing the `AppBrand` slot and repositioning the view controls to a right-side absolute stack. Phase bands now cycle through distinct tinted fill colors with accent bars rather than a single neutral fill. Step and artifact copy is updated to use clearer language ("Step N:", "Creates", "Needs"). The grid toggle button in `ViewControls` now renders the `Grid3X3` icon instead of an empty div. Layout tests are added for the dependency-rank assignment, phase lane grouping, edge routing, and `pointsToPath` output.