### PR TITLE
feat(recipe-dag): add artifact pill labels and dimmed-state palette to DAG edges and stages

### DIFF
--- a/apps/mapgen-studio/src/features/recipeDag/RecipeDagView.tsx
+++ b/apps/mapgen-studio/src/features/recipeDag/RecipeDagView.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from "react";
-import { AlertTriangle, Boxes, ChevronDown, GitBranch, Loader2 } from "lucide-react";
+import { AlertTriangle, Boxes, ChevronDown, GitBranch, Loader2, Package } from "lucide-react";
 
 import type { RecipeDagResult } from "./client";
+import { formatArtifactLabel } from "./artifactPresentation";
 import { buildRecipeDagLayout, pointsToPath } from "./layout";
 
 type RecipeDagLoadStatus = "idle" | "loading" | "ready" | "error";
@@ -163,22 +164,27 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                         markerEnd="url(#recipe-dag-arrow)"
                         opacity={related ? "0.82" : "0.22"}
                       />
-                      <text
-                        x={edge.labelX}
-                        y={edge.labelY - 5}
-                        fill={palette.edgeLabel}
-                        fontSize="9"
-                        fontWeight="700"
-                        textAnchor="middle"
-                        opacity={related ? "0.9" : "0.25"}
-                      >
-                        {edge.label}
-                      </text>
                       <title>{`${edge.fromStageId} provides ${edge.artifacts.join(", ")} to ${edge.toStageId}`}</title>
                     </g>
                   );
                 })}
               </svg>
+
+              {layout.edgeGroups.map((edge) => {
+                if (!edge.points.length) return null;
+                const related = !selectedStageId || edge.fromStageId === selectedStageId || edge.toStageId === selectedStageId;
+                return (
+                  <ArtifactEdgeLabel
+                    key={`${edge.id}:label`}
+                    label={edge.label}
+                    title={`${edge.fromStageId} provides ${edge.artifacts.join(", ")} to ${edge.toStageId}`}
+                    x={edge.labelX}
+                    y={edge.labelY - 14}
+                    related={related}
+                    lightMode={lightMode}
+                  />
+                );
+              })}
 
               {dag.stages.map((stage) => {
                 const position = layout.positions.get(stage.stageId);
@@ -186,10 +192,14 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                 const expanded = expandedStageIds.has(stage.stageId);
                 const selected = selectedStageId === stage.stageId;
                 const dimmed = Boolean(neighborStageIds && !neighborStageIds.has(stage.stageId));
+                const stageClass = selected ? palette.stageSelected : dimmed ? palette.stageDimmed : palette.stage;
+                const headingClass = dimmed ? palette.headingDimmed : palette.heading;
+                const bodyClass = dimmed ? palette.bodyDimmed : palette.body;
+                const iconClass = dimmed ? palette.iconDimmed : palette.icon;
                 return (
                   <article
                     key={stage.stageId}
-                    className={`absolute overflow-hidden rounded-lg border shadow-sm transition-opacity ${selected ? palette.stageSelected : palette.stage} ${dimmed ? "opacity-45" : "opacity-100"}`}
+                    className={`absolute z-20 overflow-hidden rounded-lg border shadow-sm transition-[background-color,border-color,box-shadow,color] ${stageClass}`}
                     style={{
                       left: position.x,
                       top: position.y,
@@ -205,14 +215,14 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                         onToggleStage(stage.stageId);
                       }}
                     >
-                      <Boxes className={`mt-0.5 h-4 w-4 shrink-0 ${palette.icon}`} />
+                      <Boxes className={`mt-0.5 h-4 w-4 shrink-0 ${iconClass}`} />
                       <span className="min-w-0 flex-1">
-                        <span className={`block truncate text-[13px] font-semibold ${palette.heading}`}>{stage.stageId}</span>
-                        <span className={`mt-0.5 block truncate text-[11px] ${palette.body}`}>
+                        <span className={`block truncate text-[13px] font-semibold ${headingClass}`}>{stage.stageId}</span>
+                        <span className={`mt-0.5 block truncate text-[11px] ${bodyClass}`}>
                           Runs {stage.steps.length} {stage.steps.length === 1 ? "step" : "steps"}; creates {stage.artifactProvides.length}; needs {stage.artifactRequires.length}
                         </span>
                       </span>
-                      <ChevronDown className={`mt-0.5 h-4 w-4 shrink-0 transition-transform ${expanded ? "rotate-180" : ""} ${palette.icon}`} />
+                      <ChevronDown className={`mt-0.5 h-4 w-4 shrink-0 transition-transform ${expanded ? "rotate-180" : ""} ${iconClass}`} />
                     </button>
 
                     <div className={`grid grid-cols-3 border-t text-center text-[10px] ${palette.rule}`}>
@@ -226,10 +236,10 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                         <ol className="space-y-2">
                           {stage.steps.map((step) => (
                             <li key={step.fullStepId} className={`rounded border px-2 py-1.5 ${palette.step}`}>
-                              <div className={`truncate text-[11px] font-medium ${palette.heading}`}>
+                              <div className={`truncate text-[11px] font-medium ${headingClass}`}>
                                 Step {step.orderInStage + 1}: {step.stepId}
                               </div>
-                              <div className={`mt-1 truncate text-[10px] ${palette.body}`}>Phase: {step.phase}</div>
+                              <div className={`mt-1 truncate text-[10px] ${bodyClass}`}>Phase: {step.phase}</div>
                               <ArtifactList label="Needs" values={step.artifactRequires.map((artifact) => artifact.id)} lightMode={lightMode} />
                               <ArtifactList label="Creates" values={step.artifactProvides.map((artifact) => artifact.id)} lightMode={lightMode} />
                             </li>
@@ -249,8 +259,10 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                   </div>
                   <ul className="grid gap-1 sm:grid-cols-2">
                     {dag.diagnostics.slice(0, 6).map((diagnostic, index) => (
-                      <li key={`${diagnostic.kind}-${diagnostic.artifact.id}-${index}`} className="truncate">
-                        {diagnostic.kind}: {diagnostic.artifact.id}
+                      <li key={`${diagnostic.kind}-${diagnostic.artifact.id}-${index}`} className="flex min-w-0 items-center gap-1 truncate">
+                        <span className="truncate">{diagnostic.kind}</span>
+                        <ArtifactInlineIcon />
+                        <span className="truncate" title={diagnostic.artifact.id}>{formatArtifactLabel(diagnostic.artifact.id)}</span>
                       </li>
                     ))}
                   </ul>
@@ -306,6 +318,32 @@ function StageCounter(props: { label: string; value: number }) {
   );
 }
 
+function ArtifactEdgeLabel(props: {
+  label: string;
+  title: string;
+  x: number;
+  y: number;
+  related: boolean;
+  lightMode: boolean;
+}) {
+  const palette = createPalette(props.lightMode);
+  const className = props.related ? palette.edgeLabelPill : palette.edgeLabelPillDimmed;
+  return (
+    <div
+      className={`absolute z-10 flex max-w-[180px] cursor-default items-center gap-1 rounded-full border px-1.5 py-0.5 text-[9px] font-semibold shadow-sm ${className}`}
+      style={{
+        left: props.x,
+        top: props.y,
+        transform: "translate(-50%, -50%)",
+      }}
+      title={props.title}
+    >
+      <ArtifactInlineIcon />
+      <span className="truncate">{props.label}</span>
+    </div>
+  );
+}
+
 function ArtifactList(props: { label: string; values: readonly string[]; lightMode: boolean }) {
   if (props.values.length === 0) return null;
   const chip = props.lightMode
@@ -316,8 +354,13 @@ function ArtifactList(props: { label: string; values: readonly string[]; lightMo
       <div className="mb-1 text-[9px] font-semibold uppercase opacity-70">{props.label}</div>
       <div className="flex flex-wrap gap-1">
         {props.values.slice(0, 5).map((value) => (
-          <span key={value} className={`max-w-full truncate rounded border px-1 py-0.5 text-[9px] ${chip}`}>
-            {value}
+          <span
+            key={value}
+            className={`flex max-w-full items-center gap-1 truncate rounded border px-1 py-0.5 text-[9px] ${chip}`}
+            title={value}
+          >
+            <ArtifactInlineIcon />
+            <span className="truncate">{formatArtifactLabel(value)}</span>
           </span>
         ))}
         {props.values.length > 5 ? (
@@ -326,6 +369,10 @@ function ArtifactList(props: { label: string; values: readonly string[]; lightMo
       </div>
     </div>
   );
+}
+
+function ArtifactInlineIcon() {
+  return <Package className="h-2.5 w-2.5 shrink-0 text-current" aria-hidden="true" />;
 }
 
 function CenteredState(props: {
@@ -358,15 +405,20 @@ function createPalette(lightMode: boolean) {
       panel: "border-white/80 bg-white/78",
       stage: "border-gray-200 bg-white",
       stageSelected: "border-cyan-500 bg-white ring-2 ring-cyan-500/30",
+      stageDimmed: "border-gray-200 bg-[#f8fafc] shadow-none",
       step: "border-gray-200 bg-gray-50",
       rule: "border-gray-200 text-gray-500",
       diagnostic: "border-amber-300 bg-amber-50 text-amber-900",
       heading: "text-gray-900",
+      headingDimmed: "text-gray-500",
       body: "text-gray-600",
+      bodyDimmed: "text-gray-400",
       kicker: "text-cyan-700",
       icon: "text-cyan-700",
+      iconDimmed: "text-gray-400",
       edge: "#0891b2",
-      edgeLabel: "#0e7490",
+      edgeLabelPill: "border-cyan-200 bg-white text-cyan-800",
+      edgeLabelPillDimmed: "border-slate-200 bg-slate-50 text-slate-500",
       rankLine: "rgba(71,85,105,0.22)",
       phaseFills: [
         "rgba(236,253,245,0.68)",
@@ -385,15 +437,20 @@ function createPalette(lightMode: boolean) {
     panel: "border-white/10 bg-[#141418]/72",
     stage: "border-[#2a2a32] bg-[#101014]",
     stageSelected: "border-cyan-400 bg-[#101014] ring-2 ring-cyan-400/30",
+    stageDimmed: "border-[#24242c] bg-[#0d0d11] shadow-none",
     step: "border-[#30303a] bg-[#15151a]",
     rule: "border-[#2a2a32] text-[#8a8a96]",
     diagnostic: "border-amber-500/40 bg-amber-500/10 text-amber-200",
     heading: "text-[#f0f0f4]",
+    headingDimmed: "text-[#747482]",
     body: "text-[#a9a9b5]",
+    bodyDimmed: "text-[#696976]",
     kicker: "text-cyan-300",
     icon: "text-cyan-300",
+    iconDimmed: "text-[#5f6570]",
     edge: "#22d3ee",
-    edgeLabel: "#67e8f9",
+    edgeLabelPill: "border-cyan-400/35 bg-[#101014] text-cyan-200",
+    edgeLabelPillDimmed: "border-[#24242c] bg-[#101014] text-[#6f7480]",
     rankLine: "rgba(148,163,184,0.16)",
     phaseFills: [
       "rgba(6,78,59,0.20)",

--- a/apps/mapgen-studio/src/features/recipeDag/artifactPresentation.ts
+++ b/apps/mapgen-studio/src/features/recipeDag/artifactPresentation.ts
@@ -1,0 +1,12 @@
+const ARTIFACT_TAG_PREFIX = /^artifact:/i;
+
+export function formatArtifactLabel(id: string): string {
+  const label = id.replace(ARTIFACT_TAG_PREFIX, "");
+  return label.length > 0 ? label : id;
+}
+
+export function formatArtifactGroupLabel(artifacts: readonly string[]): string {
+  if (artifacts.length === 0) return "dependency";
+  const first = formatArtifactLabel(artifacts[0] ?? "artifact");
+  return artifacts.length === 1 ? first : `${first} +${artifacts.length - 1}`;
+}

--- a/apps/mapgen-studio/src/features/recipeDag/layout.ts
+++ b/apps/mapgen-studio/src/features/recipeDag/layout.ts
@@ -1,4 +1,5 @@
 import type { RecipeDagResult } from "./client";
+import { formatArtifactGroupLabel } from "./artifactPresentation";
 
 export type DagPoint = Readonly<{
   x: number;
@@ -292,9 +293,7 @@ function anchorOffset(edges: readonly StageEdgeGroup[], edgeId: string, height: 
 }
 
 function formatEdgeLabel(artifacts: readonly string[]): string {
-  if (artifacts.length === 0) return "artifact";
-  if (artifacts.length === 1) return artifacts[0] ?? "artifact";
-  return `${artifacts[0]} +${artifacts.length - 1}`;
+  return formatArtifactGroupLabel(artifacts);
 }
 
 function resolveStagePhaseId(

--- a/apps/mapgen-studio/test/recipeDag/RecipeDagView.test.tsx
+++ b/apps/mapgen-studio/test/recipeDag/RecipeDagView.test.tsx
@@ -25,9 +25,10 @@ describe("RecipeDagView", () => {
     expect(html).toContain("shape");
     expect(html).toContain("climate");
     expect(html).toContain("Sources");
-    expect(html).toContain("seed-grid");
+    expect(html).toContain(">hydrology.hydrography<");
     expect(html).toContain("Step 1: seed");
     expect(html).toContain("Creates");
+    expect(html).not.toContain("opacity-45");
   });
 });
 
@@ -41,8 +42,8 @@ function recipeDag(): RecipeDagResult {
       {
         id: "shape",
         order: 0,
-        stageIds: ["shape"],
-        stepCount: 1,
+        stageIds: ["shape", "isolated"],
+        stepCount: 2,
       },
       {
         id: "climate",
@@ -67,13 +68,13 @@ function recipeDag(): RecipeDagResult {
             orderInStage: 0,
             phase: "shape",
             artifactRequires: [],
-            artifactProvides: [{ id: "seed-grid", name: "Seed grid" }],
+            artifactProvides: [{ id: "artifact:hydrology.hydrography", name: "Hydrology hydrography" }],
             tagRequires: [],
             tagProvides: [],
           },
         ],
         artifactRequires: [],
-        artifactProvides: [{ id: "seed-grid", name: "Seed grid" }],
+        artifactProvides: [{ id: "artifact:hydrology.hydrography", name: "Hydrology hydrography" }],
         inboundArtifactEdgeCount: 0,
         outboundArtifactEdgeCount: 1,
         internalArtifactEdgeCount: 0,
@@ -93,15 +94,42 @@ function recipeDag(): RecipeDagResult {
             order: 1,
             orderInStage: 0,
             phase: "climate",
-            artifactRequires: [{ id: "seed-grid", name: "Seed grid" }],
+            artifactRequires: [{ id: "artifact:hydrology.hydrography", name: "Hydrology hydrography" }],
             artifactProvides: [],
             tagRequires: [],
             tagProvides: [],
           },
         ],
-        artifactRequires: [{ id: "seed-grid", name: "Seed grid" }],
+        artifactRequires: [{ id: "artifact:hydrology.hydrography", name: "Hydrology hydrography" }],
         artifactProvides: [],
         inboundArtifactEdgeCount: 1,
+        outboundArtifactEdgeCount: 0,
+        internalArtifactEdgeCount: 0,
+        diagnosticCount: 0,
+      },
+      {
+        id: "isolated",
+        stageId: "isolated",
+        order: 2,
+        phases: ["shape"],
+        steps: [
+          {
+            id: "mod-swooper-maps.standard.isolated.note",
+            stageId: "isolated",
+            stepId: "note",
+            fullStepId: "mod-swooper-maps.standard.isolated.note",
+            order: 2,
+            orderInStage: 0,
+            phase: "shape",
+            artifactRequires: [],
+            artifactProvides: [],
+            tagRequires: [],
+            tagProvides: [],
+          },
+        ],
+        artifactRequires: [],
+        artifactProvides: [],
+        inboundArtifactEdgeCount: 0,
         outboundArtifactEdgeCount: 0,
         internalArtifactEdgeCount: 0,
         diagnosticCount: 0,
@@ -109,8 +137,8 @@ function recipeDag(): RecipeDagResult {
     ],
     edges: [
       {
-        id: "mod-swooper-maps.standard.shape.seed->mod-swooper-maps.standard.climate.temperature:seed-grid",
-        artifact: { id: "seed-grid", name: "Seed grid" },
+        id: "mod-swooper-maps.standard.shape.seed->mod-swooper-maps.standard.climate.temperature:artifact:hydrology.hydrography",
+        artifact: { id: "artifact:hydrology.hydrography", name: "Hydrology hydrography" },
         from: {
           stageId: "shape",
           stepId: "seed",

--- a/apps/mapgen-studio/test/recipeDag/artifactPresentation.test.ts
+++ b/apps/mapgen-studio/test/recipeDag/artifactPresentation.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { formatArtifactGroupLabel, formatArtifactLabel } from "../../src/features/recipeDag/artifactPresentation";
+
+describe("recipe DAG artifact presentation", () => {
+  it("removes the artifact tag prefix from visible labels without changing grouping counts", () => {
+    expect(formatArtifactLabel("artifact:hydrology.hydrography")).toBe("hydrology.hydrography");
+    expect(formatArtifactLabel("seed-grid")).toBe("seed-grid");
+    expect(formatArtifactGroupLabel(["artifact:hydrology.hydrography", "artifact:hydrology.lakePlan"])).toBe("hydrology.hydrography +1");
+  });
+});


### PR DESCRIPTION
Artifact IDs with the `artifact:` prefix are now stripped of that prefix before being displayed in the DAG view, so labels like `artifact:hydrology.hydrography` render as `hydrology.hydrography`. A `formatArtifactLabel` / `formatArtifactGroupLabel` utility in a new `artifactPresentation` module handles this consistently across edge labels, artifact chips, and the diagnostics list.

Edge labels are no longer rendered as SVG `<text>` elements. They are now HTML `<div>` pill badges layered above the SVG, which allows them to use Tailwind classes, truncate long names, and carry a `Package` icon. The same icon appears inside every artifact chip in the `ArtifactList` and in the diagnostics panel.

Dimmed stages (those not connected to the currently selected stage) now use dedicated palette tokens (`stageDimmed`, `headingDimmed`, `bodyDimmed`, `iconDimmed`) instead of a blanket `opacity-45` class, giving finer control over how each element fades in both light and dark mode. Stage cards also transition on `background-color`, `border-color`, `box-shadow`, and `color` rather than `opacity`, and carry `z-20` so they sit above the edge layer.