### PR TITLE
feat(mapgen-studio): domain-aware artifact icons, phase lane labels, and spread edge label layout

### DIFF
--- a/apps/mapgen-studio/src/features/recipeDag/RecipeDagView.tsx
+++ b/apps/mapgen-studio/src/features/recipeDag/RecipeDagView.tsx
@@ -1,8 +1,23 @@
 import React, { useMemo } from "react";
-import { AlertTriangle, Boxes, ChevronDown, GitBranch, Loader2, Package } from "lucide-react";
+import {
+  AlertTriangle,
+  Boxes,
+  ChevronDown,
+  CloudSun,
+  Flag,
+  GitBranch,
+  Layers3,
+  Loader2,
+  Mountain,
+  Package,
+  Route,
+  Sprout,
+  Waves,
+  type LucideIcon,
+} from "lucide-react";
 
 import type { RecipeDagResult } from "./client";
-import { formatArtifactLabel } from "./artifactPresentation";
+import { formatArtifactLabel, resolveArtifactGroupDomainId } from "./artifactPresentation";
 import { buildRecipeDagLayout, pointsToPath } from "./layout";
 
 type RecipeDagLoadStatus = "idle" | "loading" | "ready" | "error";
@@ -140,15 +155,6 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                       fill={palette.phaseAccents[index % palette.phaseAccents.length]}
                       opacity="0.9"
                     />
-                    <text
-                      x={52}
-                      y={phase.y + 26}
-                      fill={palette.phaseText}
-                      fontSize="12"
-                      fontWeight="700"
-                    >
-                      {phase.id}
-                    </text>
                   </g>
                 ))}
                 {layout.edgeGroups.map((edge) => {
@@ -177,6 +183,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                   <ArtifactEdgeLabel
                     key={`${edge.id}:label`}
                     label={edge.label}
+                    domainId={resolveArtifactGroupDomainId(edge.artifacts)}
                     title={`${edge.fromStageId} provides ${edge.artifacts.join(", ")} to ${edge.toStageId}`}
                     x={edge.labelX}
                     y={edge.labelY - 14}
@@ -185,6 +192,17 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                   />
                 );
               })}
+
+              {layout.phaseBands.map((phase, index) => (
+                <PhaseLaneLabel
+                  key={`${phase.id}:label`}
+                  phaseId={phase.id}
+                  x={52}
+                  y={phase.y + 16}
+                  accent={palette.phaseAccents[index % palette.phaseAccents.length]}
+                  lightMode={lightMode}
+                />
+              ))}
 
               {dag.stages.map((stage) => {
                 const position = layout.positions.get(stage.stageId);
@@ -196,34 +214,51 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                 const headingClass = dimmed ? palette.headingDimmed : palette.heading;
                 const bodyClass = dimmed ? palette.bodyDimmed : palette.body;
                 const iconClass = dimmed ? palette.iconDimmed : palette.icon;
+                const zIndex = expanded ? 70 : selected ? 50 : dimmed ? 20 : 30;
+                const expandedPanelId = `recipe-dag-stage-${stage.stageId}-steps`;
                 return (
                   <article
                     key={stage.stageId}
-                    className={`absolute z-20 overflow-hidden rounded-lg border shadow-sm transition-[background-color,border-color,box-shadow,color] ${stageClass}`}
+                    className={`absolute rounded-lg border shadow-sm transition-[background-color,border-color,box-shadow,color,transform] duration-200 ${expanded ? "shadow-2xl" : ""} ${stageClass}`}
                     style={{
                       left: position.x,
                       top: position.y,
                       width: position.width,
+                      zIndex,
                     }}
+                    data-stage-id={stage.stageId}
+                    data-stage-selected={selected ? "true" : "false"}
+                    data-stage-expanded={expanded ? "true" : "false"}
                   >
-                    <button
-                      type="button"
-                      className="flex w-full items-start gap-2 px-3 py-2 text-left"
-                      aria-expanded={expanded}
-                      onClick={() => {
-                        onSelectStage(stage.stageId);
-                        onToggleStage(stage.stageId);
-                      }}
-                    >
-                      <Boxes className={`mt-0.5 h-4 w-4 shrink-0 ${iconClass}`} />
-                      <span className="min-w-0 flex-1">
-                        <span className={`block truncate text-[13px] font-semibold ${headingClass}`}>{stage.stageId}</span>
-                        <span className={`mt-0.5 block truncate text-[11px] ${bodyClass}`}>
-                          Runs {stage.steps.length} {stage.steps.length === 1 ? "step" : "steps"}; creates {stage.artifactProvides.length}; needs {stage.artifactRequires.length}
+                    <div className="flex items-start gap-1.5 px-3 py-2">
+                      <button
+                        type="button"
+                        className="flex min-w-0 flex-1 items-start gap-2 text-left"
+                        aria-pressed={selected}
+                        onClick={() => onSelectStage(stage.stageId)}
+                      >
+                        <Boxes className={`mt-0.5 h-4 w-4 shrink-0 ${iconClass}`} />
+                        <span className="min-w-0 flex-1">
+                          <span className={`block truncate text-[13px] font-semibold ${headingClass}`}>{stage.stageId}</span>
+                          <span className={`mt-0.5 block truncate text-[11px] ${bodyClass}`}>
+                            Runs {stage.steps.length} {stage.steps.length === 1 ? "step" : "steps"}; creates {stage.artifactProvides.length}; needs {stage.artifactRequires.length}
+                          </span>
                         </span>
-                      </span>
-                      <ChevronDown className={`mt-0.5 h-4 w-4 shrink-0 transition-transform ${expanded ? "rotate-180" : ""} ${iconClass}`} />
-                    </button>
+                      </button>
+                      <button
+                        type="button"
+                        className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md border transition ${palette.expandButton}`}
+                        aria-expanded={expanded}
+                        aria-controls={expandedPanelId}
+                        aria-label={`${expanded ? "Collapse" : "Expand"} ${stage.stageId} steps`}
+                        onClick={() => {
+                          onSelectStage(stage.stageId);
+                          onToggleStage(stage.stageId);
+                        }}
+                      >
+                        <ChevronDown className={`h-4 w-4 transition-transform duration-200 ${expanded ? "rotate-180" : ""} ${iconClass}`} />
+                      </button>
+                    </div>
 
                     <div className={`grid grid-cols-3 border-t text-center text-[10px] ${palette.rule}`}>
                       <StageCounter label="In" value={stage.inboundArtifactEdgeCount} />
@@ -231,8 +266,14 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                       <StageCounter label="Internal" value={stage.internalArtifactEdgeCount} />
                     </div>
 
-                    {expanded ? (
-                      <div className={`max-h-[320px] overflow-auto border-t px-3 py-2 ${palette.rule}`}>
+                    <div
+                      id={expandedPanelId}
+                      aria-hidden={!expanded}
+                      className={`origin-top overflow-hidden border-t transition-[max-height,opacity,transform] duration-200 ${palette.rule} ${
+                        expanded ? "max-h-[340px] opacity-100 translate-y-0" : "max-h-0 opacity-0 -translate-y-1"
+                      }`}
+                    >
+                      <div className="max-h-[320px] overflow-auto px-3 py-2">
                         <ol className="space-y-2">
                           {stage.steps.map((step) => (
                             <li key={step.fullStepId} className={`rounded border px-2 py-1.5 ${palette.step}`}>
@@ -246,7 +287,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                           ))}
                         </ol>
                       </div>
-                    ) : null}
+                    </div>
                   </article>
                 );
               })}
@@ -261,7 +302,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                     {dag.diagnostics.slice(0, 6).map((diagnostic, index) => (
                       <li key={`${diagnostic.kind}-${diagnostic.artifact.id}-${index}`} className="flex min-w-0 items-center gap-1 truncate">
                         <span className="truncate">{diagnostic.kind}</span>
-                        <ArtifactInlineIcon />
+                        <ArtifactInlineIcon domainId={resolveArtifactGroupDomainId([diagnostic.artifact.id])} />
                         <span className="truncate" title={diagnostic.artifact.id}>{formatArtifactLabel(diagnostic.artifact.id)}</span>
                       </li>
                     ))}
@@ -320,6 +361,7 @@ function StageCounter(props: { label: string; value: number }) {
 
 function ArtifactEdgeLabel(props: {
   label: string;
+  domainId: string | null;
   title: string;
   x: number;
   y: number;
@@ -338,7 +380,7 @@ function ArtifactEdgeLabel(props: {
       }}
       title={props.title}
     >
-      <ArtifactInlineIcon />
+      <ArtifactInlineIcon domainId={props.domainId} />
       <span className="truncate">{props.label}</span>
     </div>
   );
@@ -359,7 +401,7 @@ function ArtifactList(props: { label: string; values: readonly string[]; lightMo
             className={`flex max-w-full items-center gap-1 truncate rounded border px-1 py-0.5 text-[9px] ${chip}`}
             title={value}
           >
-            <ArtifactInlineIcon />
+            <ArtifactInlineIcon domainId={resolveArtifactGroupDomainId([value])} />
             <span className="truncate">{formatArtifactLabel(value)}</span>
           </span>
         ))}
@@ -371,8 +413,44 @@ function ArtifactList(props: { label: string; values: readonly string[]; lightMo
   );
 }
 
-function ArtifactInlineIcon() {
-  return <Package className="h-2.5 w-2.5 shrink-0 text-current" aria-hidden="true" />;
+function ArtifactInlineIcon(props: { domainId: string | null }) {
+  const Icon = iconForDomainId(props.domainId);
+  return <Icon className="h-2.5 w-2.5 shrink-0 text-current" aria-hidden="true" />;
+}
+
+function PhaseLaneLabel(props: {
+  phaseId: string;
+  x: number;
+  y: number;
+  accent: string;
+  lightMode: boolean;
+}) {
+  const Icon = iconForDomainId(props.phaseId);
+  const className = props.lightMode
+    ? "border-white/80 bg-white/88 text-slate-700"
+    : "border-white/10 bg-[#0d0d11]/88 text-[#d4d4dc]";
+  return (
+    <div
+      className={`absolute z-10 flex items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] font-semibold uppercase tracking-normal shadow-sm backdrop-blur-sm ${className}`}
+      style={{ left: props.x, top: props.y }}
+      title={`Phase ${props.phaseId}`}
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" style={{ color: props.accent }} aria-hidden="true" />
+      <span>{props.phaseId}</span>
+    </div>
+  );
+}
+
+function iconForDomainId(domainId: string | null): LucideIcon {
+  const normalized = domainId?.toLowerCase() ?? "";
+  if (normalized.includes("hydro") || normalized.includes("river") || normalized.includes("lake")) return Waves;
+  if (normalized.includes("climate") || normalized.includes("temperature") || normalized.includes("rain")) return CloudSun;
+  if (normalized.includes("terrain") || normalized.includes("height") || normalized.includes("elevation")) return Mountain;
+  if (normalized.includes("biome") || normalized.includes("vegetation") || normalized.includes("resource")) return Sprout;
+  if (normalized.includes("route") || normalized.includes("path") || normalized.includes("river")) return Route;
+  if (normalized.includes("finish") || normalized.includes("final")) return Flag;
+  if (normalized.includes("shape") || normalized.includes("land")) return Layers3;
+  return Package;
 }
 
 function CenteredState(props: {
@@ -416,6 +494,7 @@ function createPalette(lightMode: boolean) {
       kicker: "text-cyan-700",
       icon: "text-cyan-700",
       iconDimmed: "text-gray-400",
+      expandButton: "border-gray-200 bg-white text-gray-500 hover:border-cyan-300 hover:text-cyan-700",
       edge: "#0891b2",
       edgeLabelPill: "border-cyan-200 bg-white text-cyan-800",
       edgeLabelPillDimmed: "border-slate-200 bg-slate-50 text-slate-500",
@@ -448,6 +527,7 @@ function createPalette(lightMode: boolean) {
     kicker: "text-cyan-300",
     icon: "text-cyan-300",
     iconDimmed: "text-[#5f6570]",
+    expandButton: "border-[#30303a] bg-[#15151a] text-[#8a8a96] hover:border-cyan-400/50 hover:text-cyan-200",
     edge: "#22d3ee",
     edgeLabelPill: "border-cyan-400/35 bg-[#101014] text-cyan-200",
     edgeLabelPillDimmed: "border-[#24242c] bg-[#101014] text-[#6f7480]",

--- a/apps/mapgen-studio/src/features/recipeDag/artifactPresentation.ts
+++ b/apps/mapgen-studio/src/features/recipeDag/artifactPresentation.ts
@@ -1,12 +1,48 @@
 const ARTIFACT_TAG_PREFIX = /^artifact:/i;
 
+export type ArtifactPresentation = Readonly<{
+  id: string;
+  domainId: string | null;
+  label: string;
+}>;
+
+export function parseArtifactPresentation(id: string): ArtifactPresentation {
+  const withoutTag = id.replace(ARTIFACT_TAG_PREFIX, "");
+  const segments = withoutTag.split(".").filter((segment) => segment.length > 0);
+  if (segments.length < 2) {
+    return {
+      id,
+      domainId: null,
+      label: withoutTag.length > 0 ? withoutTag : id,
+    };
+  }
+
+  const [, ...localSegments] = segments;
+  const visibleSegments = localSegments.filter((segment) => !segment.startsWith("_"));
+  const label = visibleSegments.at(-1) ?? localSegments.at(-1) ?? withoutTag;
+
+  return {
+    id,
+    domainId: segments[0] ?? null,
+    label,
+  };
+}
+
 export function formatArtifactLabel(id: string): string {
-  const label = id.replace(ARTIFACT_TAG_PREFIX, "");
-  return label.length > 0 ? label : id;
+  return parseArtifactPresentation(id).label;
 }
 
 export function formatArtifactGroupLabel(artifacts: readonly string[]): string {
   if (artifacts.length === 0) return "dependency";
   const first = formatArtifactLabel(artifacts[0] ?? "artifact");
   return artifacts.length === 1 ? first : `${first} +${artifacts.length - 1}`;
+}
+
+export function resolveArtifactGroupDomainId(artifacts: readonly string[]): string | null {
+  const domains = artifacts
+    .map((artifact) => parseArtifactPresentation(artifact).domainId)
+    .filter((domainId): domainId is string => Boolean(domainId));
+  if (domains.length === 0) return null;
+  const [first] = domains;
+  return domains.every((domainId) => domainId === first) ? first : null;
 }

--- a/apps/mapgen-studio/src/features/recipeDag/layout.ts
+++ b/apps/mapgen-studio/src/features/recipeDag/layout.ts
@@ -53,14 +53,15 @@ export type RecipeDagLayout = Readonly<{
 
 const STAGE_WIDTH = 248;
 const STAGE_HEIGHT = 122;
-const RANK_GAP_X = 122;
+const RANK_GAP_X = 150;
 const GRAPH_PAD_X = 80;
 const GRAPH_PAD_TOP = 96;
 const GRAPH_PAD_BOTTOM = 110;
 const PHASE_TITLE_HEIGHT = 42;
 const PHASE_MIN_HEIGHT = 188;
-const STAGE_GAP_Y = 28;
+const STAGE_GAP_Y = 36;
 const EDGE_STEM = 34;
+const EDGE_LABEL_MIN_GAP = 26;
 
 export function buildRecipeDagLayout(dag: RecipeDagResult): RecipeDagLayout {
   const edgeGroups = groupStageEdges(dag);
@@ -90,7 +91,7 @@ export function buildRecipeDagLayout(dag: RecipeDagResult): RecipeDagLayout {
       };
     }),
     rankColumns,
-    edgeGroups: routeEdges(edgeGroups, positions),
+    edgeGroups: spreadEdgeLabels(routeEdges(edgeGroups, positions)),
   };
 }
 
@@ -294,6 +295,32 @@ function anchorOffset(edges: readonly StageEdgeGroup[], edgeId: string, height: 
 
 function formatEdgeLabel(artifacts: readonly string[]): string {
   return formatArtifactGroupLabel(artifacts);
+}
+
+function spreadEdgeLabels(edgeGroups: readonly RoutedStageEdgeGroup[]): RoutedStageEdgeGroup[] {
+  const routed = edgeGroups
+    .filter((edge) => edge.points.length > 0)
+    .sort((a, b) => a.labelX - b.labelX || a.labelY - b.labelY);
+  const buckets = new Map<number, RoutedStageEdgeGroup[]>();
+  for (const edge of routed) {
+    const bucket = Math.round(edge.labelX / 96);
+    buckets.set(bucket, [...(buckets.get(bucket) ?? []), edge]);
+  }
+
+  const labelYByEdgeId = new Map<string, number>();
+  for (const edges of buckets.values()) {
+    let previousY = Number.NEGATIVE_INFINITY;
+    for (const edge of [...edges].sort((a, b) => a.labelY - b.labelY)) {
+      const nextY = Math.max(edge.labelY, previousY + EDGE_LABEL_MIN_GAP);
+      labelYByEdgeId.set(edge.id, nextY);
+      previousY = nextY;
+    }
+  }
+
+  return edgeGroups.map((edge) => ({
+    ...edge,
+    labelY: labelYByEdgeId.get(edge.id) ?? edge.labelY,
+  }));
 }
 
 function resolveStagePhaseId(

--- a/apps/mapgen-studio/test/recipeDag/RecipeDagView.test.tsx
+++ b/apps/mapgen-studio/test/recipeDag/RecipeDagView.test.tsx
@@ -25,7 +25,12 @@ describe("RecipeDagView", () => {
     expect(html).toContain("shape");
     expect(html).toContain("climate");
     expect(html).toContain("Sources");
-    expect(html).toContain(">hydrology.hydrography<");
+    expect(html).toContain(">hydrography<");
+    expect(html).toContain("aria-pressed=\"true\"");
+    expect(html).toContain("aria-expanded=\"true\"");
+    expect(html).toContain("aria-controls=\"recipe-dag-stage-shape-steps\"");
+    expect(html).toContain("data-stage-expanded=\"true\"");
+    expect(html).toContain("z-index:70");
     expect(html).toContain("Step 1: seed");
     expect(html).toContain("Creates");
     expect(html).not.toContain("opacity-45");

--- a/apps/mapgen-studio/test/recipeDag/artifactPresentation.test.ts
+++ b/apps/mapgen-studio/test/recipeDag/artifactPresentation.test.ts
@@ -1,11 +1,33 @@
 import { describe, expect, it } from "vitest";
 
-import { formatArtifactGroupLabel, formatArtifactLabel } from "../../src/features/recipeDag/artifactPresentation";
+import {
+  formatArtifactGroupLabel,
+  formatArtifactLabel,
+  parseArtifactPresentation,
+  resolveArtifactGroupDomainId,
+} from "../../src/features/recipeDag/artifactPresentation";
 
 describe("recipe DAG artifact presentation", () => {
-  it("removes the artifact tag prefix from visible labels without changing grouping counts", () => {
-    expect(formatArtifactLabel("artifact:hydrology.hydrography")).toBe("hydrology.hydrography");
+  it("uses artifact domains as icon metadata and keeps visible labels local", () => {
+    expect(parseArtifactPresentation("artifact:hydrology.hydrography")).toEqual({
+      id: "artifact:hydrology.hydrography",
+      domainId: "hydrology",
+      label: "hydrography",
+    });
+    expect(parseArtifactPresentation("artifact:map.hydrology.engineProjectionLakes")).toEqual({
+      id: "artifact:map.hydrology.engineProjectionLakes",
+      domainId: "map",
+      label: "engineProjectionLakes",
+    });
+    expect(parseArtifactPresentation("artifact:hydrology._internal.windField")).toEqual({
+      id: "artifact:hydrology._internal.windField",
+      domainId: "hydrology",
+      label: "windField",
+    });
+    expect(formatArtifactLabel("artifact:hydrology.hydrography")).toBe("hydrography");
     expect(formatArtifactLabel("seed-grid")).toBe("seed-grid");
-    expect(formatArtifactGroupLabel(["artifact:hydrology.hydrography", "artifact:hydrology.lakePlan"])).toBe("hydrology.hydrography +1");
+    expect(formatArtifactGroupLabel(["artifact:hydrology.hydrography", "artifact:hydrology.lakePlan"])).toBe("hydrography +1");
+    expect(resolveArtifactGroupDomainId(["artifact:hydrology.hydrography", "artifact:hydrology.lakePlan"])).toBe("hydrology");
+    expect(resolveArtifactGroupDomainId(["artifact:hydrology.hydrography", "artifact:ecology.biomes"])).toBeNull();
   });
 });

--- a/apps/mapgen-studio/test/recipeDag/layout.test.ts
+++ b/apps/mapgen-studio/test/recipeDag/layout.test.ts
@@ -25,6 +25,19 @@ describe("recipe DAG layout", () => {
     expect(routed?.artifacts).toEqual(["seed-grid"]);
     expect(pointsToPath(routed?.points ?? [])).toContain("L");
   });
+
+  it("spreads crowded edge labels in the same horizontal bucket", () => {
+    const layout = buildRecipeDagLayout(crowdedRecipeDag());
+    const labels = layout.edgeGroups
+      .filter((edge) => edge.fromStageId === "source")
+      .map((edge) => edge.labelY)
+      .sort((a, b) => a - b);
+
+    expect(labels.length).toBe(4);
+    for (let index = 1; index < labels.length; index += 1) {
+      expect(labels[index]! - labels[index - 1]!).toBeGreaterThanOrEqual(26);
+    }
+  });
 });
 
 function recipeDag(): RecipeDagResult {
@@ -48,6 +61,32 @@ function recipeDag(): RecipeDagResult {
       edge("source", "seed", "branch-b", "height", "seed-grid"),
       edge("branch-a", "coast", "sink", "finalize", "coast-grid"),
       edge("branch-b", "height", "sink", "finalize", "height-grid"),
+    ],
+    diagnostics: [],
+  };
+}
+
+function crowdedRecipeDag(): RecipeDagResult {
+  return {
+    recipeId: "crowded",
+    recipeKey: "mod-swooper-maps/crowded",
+    namespace: "mod-swooper-maps",
+    title: "Crowded DAG",
+    phases: [
+      { id: "shape", order: 0, stageIds: ["source", "branch-a", "branch-b", "branch-c", "branch-d"], stepCount: 5 },
+    ],
+    stages: [
+      stage("source", 0, "shape", [], ["seed-a", "seed-b", "seed-c", "seed-d"]),
+      stage("branch-a", 1, "shape", ["seed-a"], []),
+      stage("branch-b", 2, "shape", ["seed-b"], []),
+      stage("branch-c", 3, "shape", ["seed-c"], []),
+      stage("branch-d", 4, "shape", ["seed-d"], []),
+    ],
+    edges: [
+      edge("source", "seed", "branch-a", "step", "seed-a"),
+      edge("source", "seed", "branch-b", "step", "seed-b"),
+      edge("source", "seed", "branch-c", "step", "seed-c"),
+      edge("source", "seed", "branch-d", "step", "seed-d"),
     ],
     diagnostics: [],
   };


### PR DESCRIPTION
Artifact labels in the DAG view now show only the local segment of a dotted artifact ID (e.g. `hydrography` instead of `hydrology.hydrography`), with the leading domain segment extracted separately as metadata used to drive icon selection.

A new `iconForDomainId` function maps domain keywords such as `hydro`, `terrain`, `biome`, `climate`, and `route` to matching Lucide icons. These icons appear on edge labels, artifact chips, diagnostic entries, and phase lane labels throughout the graph.

Phase lane labels are now rendered as a separate `PhaseLaneLabel` component positioned above the SVG layer, replacing the plain SVG `<text>` element that was previously embedded inside the phase band rectangle. Each label shows the phase icon tinted with the phase accent colour and is styled as a pill with backdrop blur.

The stage card expand/collapse control is split into two separate buttons: one to select the stage and one to expand its step list. The expand button is a small dedicated icon button with its own `aria-expanded`, `aria-controls`, and `aria-label` attributes. The step panel now animates open and closed using CSS `max-height`, `opacity`, and `translate` transitions instead of a conditional render. Selected and expanded stages receive higher `z-index` values via inline styles, and data attributes are added to stage cards for `stageId`, selection state, and expanded state.

Edge label positions are post-processed by a `spreadEdgeLabels` pass that groups labels into horizontal buckets and nudges vertically overlapping labels apart by at least 26 px. Horizontal spacing between rank columns and vertical spacing between stages are also increased slightly.