### PR TITLE
feat(mapgen-studio): domain-aware DAG edge labels with semantic phase colors and clickable artifact selection

### DIFF
--- a/apps/mapgen-studio/src/features/recipeDag/RecipeDagView.tsx
+++ b/apps/mapgen-studio/src/features/recipeDag/RecipeDagView.tsx
@@ -1,24 +1,20 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import {
   AlertTriangle,
-  Boxes,
   ChevronDown,
-  CloudSun,
-  Flag,
   GitBranch,
-  Layers3,
   Loader2,
-  Mountain,
-  Package,
-  Route,
-  Sprout,
-  Waves,
-  type LucideIcon,
 } from "lucide-react";
 
 import type { RecipeDagResult } from "./client";
 import { formatArtifactLabel, resolveArtifactGroupDomainId } from "./artifactPresentation";
-import { buildRecipeDagLayout, pointsToPath } from "./layout";
+import { chooseRecipeDagDomainId, getRecipeDagDomainPresentation, getRecipeDagPhaseLaneColors } from "./domainPresentation";
+import {
+  buildArtifactEdgeLabels,
+  buildRecipeDagLayout,
+  pointsToPath,
+  type RoutedStageEdgeGroup,
+} from "./layout";
 
 type RecipeDagLoadStatus = "idle" | "loading" | "ready" | "error";
 
@@ -48,17 +44,59 @@ export function RecipeDagView(props: RecipeDagViewProps) {
     onSelectStage,
     topInset,
   } = props;
+  const [selectedLabelId, setSelectedLabelId] = useState<string | null>(null);
   const palette = useMemo(() => createPalette(lightMode), [lightMode]);
   const layout = useMemo(() => (dag ? buildRecipeDagLayout(dag) : null), [dag]);
+  const phaseIdByStageId = useMemo(() => {
+    const ids = new Map<string, string | null>();
+    if (!dag) return ids;
+    for (const stage of dag.stages) {
+      ids.set(stage.stageId, chooseRecipeDagDomainId(stage.phases));
+    }
+    return ids;
+  }, [dag]);
+  const edgeLayerGroups = useMemo(() => {
+    if (!layout) return [];
+    return [...layout.edgeGroups].sort((a, b) => a.id.localeCompare(b.id));
+  }, [layout]);
+  const baseArtifactLabels = useMemo(() => buildArtifactEdgeLabels(edgeLayerGroups), [edgeLayerGroups]);
+  const selectedLabel = useMemo(
+    () => baseArtifactLabels.find((label) => label.id === selectedLabelId) ?? null,
+    [baseArtifactLabels, selectedLabelId]
+  );
+  const artifactLabels = useMemo(
+    () => buildArtifactEdgeLabels(edgeLayerGroups, selectedLabel ? null : selectedStageId),
+    [edgeLayerGroups, selectedLabel, selectedStageId]
+  );
   const neighborStageIds = useMemo(() => {
+    if (selectedLabel) return new Set([selectedLabel.fromStageId, ...selectedLabel.toStageIds]);
     if (!selectedStageId || !layout) return null;
-    const ids = new Set([selectedStageId]);
+    const ids = new Set<string>([selectedStageId]);
     for (const edge of layout.edgeGroups) {
       if (edge.fromStageId === selectedStageId) ids.add(edge.toStageId);
       if (edge.toStageId === selectedStageId) ids.add(edge.fromStageId);
     }
     return ids;
-  }, [layout, selectedStageId]);
+  }, [layout, selectedLabel, selectedStageId]);
+  const sortedEdgeLayerGroups = useMemo(() => {
+    const score = (edge: RoutedStageEdgeGroup) => {
+      if (selectedLabel?.edgeIds.includes(edge.id)) return 3;
+      if (!selectedLabel && selectedStageId && (edge.fromStageId === selectedStageId || edge.toStageId === selectedStageId)) return 2;
+      return 1;
+    };
+    return [...edgeLayerGroups].sort((a, b) => score(a) - score(b) || a.id.localeCompare(b.id));
+  }, [edgeLayerGroups, selectedLabel, selectedStageId]);
+  const focusActive = Boolean(selectedLabel || selectedStageId);
+  const getStageAccent = (stageId: string) =>
+    getRecipeDagPhaseLaneColors(phaseIdByStageId.get(stageId) ?? null, lightMode).accent;
+  const handleSelectStage = (stageId: string, options?: { keepSelected?: boolean }) => {
+    setSelectedLabelId(null);
+    if (!options?.keepSelected && !selectedLabel && selectedStageId === stageId) {
+      onSelectStage("");
+      return;
+    }
+    onSelectStage(stageId);
+  };
 
   return (
     <section
@@ -110,7 +148,18 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                     orient="auto"
                     markerUnits="strokeWidth"
                   >
-                    <path d="M0,0 L0,6 L8,3 z" fill={palette.edge} />
+                    <path d="M0,0 L0,6 L8,3 z" fill="context-stroke" />
+                  </marker>
+                  <marker
+                    id="recipe-dag-arrow-active"
+                    markerWidth="10"
+                    markerHeight="10"
+                    refX="8"
+                    refY="3"
+                    orient="auto"
+                    markerUnits="strokeWidth"
+                  >
+                    <path d="M0,0 L0,6 L8,3 z" fill="context-stroke" />
                   </marker>
                 </defs>
                 {layout.rankColumns.map((column) => (
@@ -135,40 +184,48 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                     </text>
                   </g>
                 ))}
-                {layout.phaseBands.map((phase, index) => (
-                  <g key={phase.id}>
-                    <rect
-                      x={32}
-                      y={phase.y}
-                      width={layout.width - 64}
-                      height={phase.height}
-                      rx={8}
-                      fill={palette.phaseFills[index % palette.phaseFills.length]}
-                      stroke={palette.phaseStroke}
-                    />
-                    <rect
-                      x={32}
-                      y={phase.y}
-                      width={4}
-                      height={phase.height}
-                      rx={2}
-                      fill={palette.phaseAccents[index % palette.phaseAccents.length]}
-                      opacity="0.9"
-                    />
-                  </g>
-                ))}
-                {layout.edgeGroups.map((edge) => {
+                {layout.phaseBands.map((phase) => {
+                  const lane = getRecipeDagPhaseLaneColors(phase.id, lightMode);
+                  return (
+                    <g key={phase.id}>
+                      <rect
+                        x={32}
+                        y={phase.y}
+                        width={layout.width - 64}
+                        height={phase.height}
+                        rx={8}
+                        fill={lane.fill}
+                        stroke={palette.phaseStroke}
+                      />
+                      <rect
+                        x={32}
+                        y={phase.y}
+                        width={4}
+                        height={phase.height}
+                        rx={2}
+                        fill={lane.accent}
+                        opacity="0.9"
+                      />
+                    </g>
+                  );
+                })}
+                {sortedEdgeLayerGroups.map((edge) => {
                   if (!edge.points.length) return null;
-                  const related = !selectedStageId || edge.fromStageId === selectedStageId || edge.toStageId === selectedStageId;
+                  const selected = Boolean(selectedLabel?.edgeIds.includes(edge.id));
+                  const related = selectedLabel
+                    ? selected
+                    : !selectedStageId || edge.fromStageId === selectedStageId || edge.toStageId === selectedStageId;
+                  const edgeAccent = getStageAccent(edge.fromStageId);
+                  const stroke = focusActive && related ? edgeAccent : palette.edge;
                   return (
                     <g key={edge.id}>
                       <path
                         d={pointsToPath(edge.points)}
                         fill="none"
-                        stroke={palette.edge}
-                        strokeWidth={related ? "2.4" : "1.4"}
-                        markerEnd="url(#recipe-dag-arrow)"
-                        opacity={related ? "0.82" : "0.22"}
+                        stroke={stroke}
+                        strokeWidth={selected ? "3" : focusActive && related ? "2.4" : "1.35"}
+                        markerEnd={focusActive && related ? "url(#recipe-dag-arrow-active)" : "url(#recipe-dag-arrow)"}
+                        opacity={selected ? "0.96" : focusActive && related ? "0.82" : focusActive ? "0.22" : "0.42"}
                       />
                       <title>{`${edge.fromStageId} provides ${edge.artifacts.join(", ")} to ${edge.toStageId}`}</title>
                     </g>
@@ -176,30 +233,39 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                 })}
               </svg>
 
-              {layout.edgeGroups.map((edge) => {
-                if (!edge.points.length) return null;
-                const related = !selectedStageId || edge.fromStageId === selectedStageId || edge.toStageId === selectedStageId;
+              {artifactLabels.map((label) => {
+                const selected = selectedLabelId === label.id;
+                const related = selectedLabel
+                  ? selected
+                  : !selectedStageId || label.fromStageId === selectedStageId || label.toStageIds.includes(selectedStageId);
+                const visible = selectedLabel ? selected : !selectedStageId || related;
+                if (!visible) return null;
+                const edgeAccent = getStageAccent(label.fromStageId);
                 return (
                   <ArtifactEdgeLabel
-                    key={`${edge.id}:label`}
-                    label={edge.label}
-                    domainId={resolveArtifactGroupDomainId(edge.artifacts)}
-                    title={`${edge.fromStageId} provides ${edge.artifacts.join(", ")} to ${edge.toStageId}`}
-                    x={edge.labelX}
-                    y={edge.labelY - 14}
+                    key={label.id}
+                    label={label.label}
+                    domainId={resolveArtifactGroupDomainId(label.artifacts)}
+                    title={`${label.fromStageId} provides ${label.artifact} to ${label.toStageIds.join(", ")}`}
+                    x={label.labelX}
+                    y={label.labelY - 14}
                     related={related}
+                    selected={selected}
+                    focused={focusActive}
+                    accent={focusActive && (selected || related) ? edgeAccent : palette.edge}
                     lightMode={lightMode}
+                    onSelect={() => setSelectedLabelId(label.id)}
                   />
                 );
               })}
 
-              {layout.phaseBands.map((phase, index) => (
+              {layout.phaseBands.map((phase) => (
                 <PhaseLaneLabel
                   key={`${phase.id}:label`}
                   phaseId={phase.id}
                   x={52}
                   y={phase.y + 16}
-                  accent={palette.phaseAccents[index % palette.phaseAccents.length]}
+                  accent={getRecipeDagPhaseLaneColors(phase.id, lightMode).accent}
                   lightMode={lightMode}
                 />
               ))}
@@ -208,13 +274,17 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                 const position = layout.positions.get(stage.stageId);
                 if (!position) return null;
                 const expanded = expandedStageIds.has(stage.stageId);
-                const selected = selectedStageId === stage.stageId;
+                const selected = !selectedLabel && selectedStageId === stage.stageId;
+                const edgeActive = Boolean(selectedLabel && neighborStageIds?.has(stage.stageId));
                 const dimmed = Boolean(neighborStageIds && !neighborStageIds.has(stage.stageId));
-                const stageClass = selected ? palette.stageSelected : dimmed ? palette.stageDimmed : palette.stage;
+                const stageClass = selected || edgeActive ? palette.stageSelected : dimmed ? palette.stageDimmed : palette.stage;
                 const headingClass = dimmed ? palette.headingDimmed : palette.heading;
                 const bodyClass = dimmed ? palette.bodyDimmed : palette.body;
                 const iconClass = dimmed ? palette.iconDimmed : palette.icon;
-                const zIndex = expanded ? 70 : selected ? 50 : dimmed ? 20 : 30;
+                const stageDomainId = chooseRecipeDagDomainId(stage.phases);
+                const stageAccent = getRecipeDagPhaseLaneColors(stageDomainId, lightMode).accent;
+                const activeNodeAccent = selected || edgeActive ? stageAccent : null;
+                const zIndex = selected || edgeActive ? (expanded ? 95 : 85) : expanded ? 70 : dimmed ? 20 : 30;
                 const expandedPanelId = `recipe-dag-stage-${stage.stageId}-steps`;
                 return (
                   <article
@@ -225,9 +295,12 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                       top: position.y,
                       width: position.width,
                       zIndex,
+                      borderColor: activeNodeAccent ?? undefined,
+                      boxShadow: activeNodeAccent ? `0 0 0 2px ${activeNodeAccent}38, 0 16px 42px ${activeNodeAccent}18` : undefined,
                     }}
                     data-stage-id={stage.stageId}
-                    data-stage-selected={selected ? "true" : "false"}
+                    data-stage-selected={selected || edgeActive ? "true" : "false"}
+                    data-stage-edge-active={edgeActive ? "true" : "false"}
                     data-stage-expanded={expanded ? "true" : "false"}
                   >
                     <div className="flex items-start gap-1.5 px-3 py-2">
@@ -235,9 +308,13 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                         type="button"
                         className="flex min-w-0 flex-1 items-start gap-2 text-left"
                         aria-pressed={selected}
-                        onClick={() => onSelectStage(stage.stageId)}
+                        onClick={() => handleSelectStage(stage.stageId)}
                       >
-                        <Boxes className={`mt-0.5 h-4 w-4 shrink-0 ${iconClass}`} />
+                        <DomainInlineIcon
+                          domainId={stageDomainId}
+                          className={`mt-0.5 h-4 w-4 ${iconClass}`}
+                          style={activeNodeAccent ? { color: activeNodeAccent } : undefined}
+                        />
                         <span className="min-w-0 flex-1">
                           <span className={`block truncate text-[13px] font-semibold ${headingClass}`}>{stage.stageId}</span>
                           <span className={`mt-0.5 block truncate text-[11px] ${bodyClass}`}>
@@ -252,7 +329,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                         aria-controls={expandedPanelId}
                         aria-label={`${expanded ? "Collapse" : "Expand"} ${stage.stageId} steps`}
                         onClick={() => {
-                          onSelectStage(stage.stageId);
+                          handleSelectStage(stage.stageId, { keepSelected: true });
                           onToggleStage(stage.stageId);
                         }}
                       >
@@ -280,7 +357,10 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                               <div className={`truncate text-[11px] font-medium ${headingClass}`}>
                                 Step {step.orderInStage + 1}: {step.stepId}
                               </div>
-                              <div className={`mt-1 truncate text-[10px] ${bodyClass}`}>Phase: {step.phase}</div>
+                              <div className={`mt-1 flex items-center gap-1 truncate text-[10px] ${bodyClass}`}>
+                                <DomainInlineIcon domainId={step.phase} className="h-2.5 w-2.5" />
+                                <span className="truncate">Phase: {step.phase}</span>
+                              </div>
                               <ArtifactList label="Needs" values={step.artifactRequires.map((artifact) => artifact.id)} lightMode={lightMode} />
                               <ArtifactList label="Creates" values={step.artifactProvides.map((artifact) => artifact.id)} lightMode={lightMode} />
                             </li>
@@ -302,7 +382,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                     {dag.diagnostics.slice(0, 6).map((diagnostic, index) => (
                       <li key={`${diagnostic.kind}-${diagnostic.artifact.id}-${index}`} className="flex min-w-0 items-center gap-1 truncate">
                         <span className="truncate">{diagnostic.kind}</span>
-                        <ArtifactInlineIcon domainId={resolveArtifactGroupDomainId([diagnostic.artifact.id])} />
+                        <DomainInlineIcon domainId={resolveArtifactGroupDomainId([diagnostic.artifact.id])} className="h-2.5 w-2.5" />
                         <span className="truncate" title={diagnostic.artifact.id}>{formatArtifactLabel(diagnostic.artifact.id)}</span>
                       </li>
                     ))}
@@ -366,23 +446,40 @@ function ArtifactEdgeLabel(props: {
   x: number;
   y: number;
   related: boolean;
+  selected: boolean;
+  focused: boolean;
+  accent: string;
   lightMode: boolean;
+  onSelect: () => void;
 }) {
   const palette = createPalette(props.lightMode);
-  const className = props.related ? palette.edgeLabelPill : palette.edgeLabelPillDimmed;
+  const className = props.focused
+    ? props.related
+      ? palette.edgeLabelPill
+      : palette.edgeLabelPillDimmed
+    : palette.edgeLabelPillNeutral;
   return (
-    <div
-      className={`absolute z-10 flex max-w-[180px] cursor-default items-center gap-1 rounded-full border px-1.5 py-0.5 text-[9px] font-semibold shadow-sm ${className}`}
+    <button
+      type="button"
+      className={`absolute flex max-w-[190px] cursor-pointer items-center gap-1 rounded-full border px-[6.5px] py-0.5 text-[9.5px] font-semibold shadow-sm transition-[left,top,border-color,box-shadow,color,background-color] duration-200 ${className}`}
       style={{
         left: props.x,
         top: props.y,
+        zIndex: props.selected ? 98 : props.related ? 62 : 10,
         transform: "translate(-50%, -50%)",
+        borderColor: props.focused && props.related ? props.accent : undefined,
+        boxShadow: props.selected ? `0 0 0 2px ${props.accent}33` : undefined,
+        color: props.focused && props.related ? props.accent : undefined,
       }}
       title={props.title}
+      aria-pressed={props.selected}
+      aria-label={`Select dependency ${props.label}`}
+      data-edge-label-selected={props.selected ? "true" : "false"}
+      onClick={props.onSelect}
     >
-      <ArtifactInlineIcon domainId={props.domainId} />
+      <DomainInlineIcon domainId={props.domainId} className="h-[11px] w-[11px]" />
       <span className="truncate">{props.label}</span>
-    </div>
+    </button>
   );
 }
 
@@ -401,7 +498,7 @@ function ArtifactList(props: { label: string; values: readonly string[]; lightMo
             className={`flex max-w-full items-center gap-1 truncate rounded border px-1 py-0.5 text-[9px] ${chip}`}
             title={value}
           >
-            <ArtifactInlineIcon domainId={resolveArtifactGroupDomainId([value])} />
+            <DomainInlineIcon domainId={resolveArtifactGroupDomainId([value])} className="h-2.5 w-2.5" />
             <span className="truncate">{formatArtifactLabel(value)}</span>
           </span>
         ))}
@@ -413,9 +510,9 @@ function ArtifactList(props: { label: string; values: readonly string[]; lightMo
   );
 }
 
-function ArtifactInlineIcon(props: { domainId: string | null }) {
-  const Icon = iconForDomainId(props.domainId);
-  return <Icon className="h-2.5 w-2.5 shrink-0 text-current" aria-hidden="true" />;
+function DomainInlineIcon(props: { domainId: string | null; className: string; style?: React.CSSProperties }) {
+  const { Icon, strokeWidth } = getRecipeDagDomainPresentation(props.domainId);
+  return <Icon className={`shrink-0 text-current ${props.className}`} strokeWidth={strokeWidth} style={props.style} aria-hidden="true" />;
 }
 
 function PhaseLaneLabel(props: {
@@ -425,7 +522,7 @@ function PhaseLaneLabel(props: {
   accent: string;
   lightMode: boolean;
 }) {
-  const Icon = iconForDomainId(props.phaseId);
+  const { Icon, label, strokeWidth } = getRecipeDagDomainPresentation(props.phaseId);
   const className = props.lightMode
     ? "border-white/80 bg-white/88 text-slate-700"
     : "border-white/10 bg-[#0d0d11]/88 text-[#d4d4dc]";
@@ -433,24 +530,12 @@ function PhaseLaneLabel(props: {
     <div
       className={`absolute z-10 flex items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] font-semibold uppercase tracking-normal shadow-sm backdrop-blur-sm ${className}`}
       style={{ left: props.x, top: props.y }}
-      title={`Phase ${props.phaseId}`}
+      title={`Phase ${label}`}
     >
-      <Icon className="h-3.5 w-3.5 shrink-0" style={{ color: props.accent }} aria-hidden="true" />
+      <Icon className="h-3.5 w-3.5 shrink-0" strokeWidth={strokeWidth} style={{ color: props.accent }} aria-hidden="true" />
       <span>{props.phaseId}</span>
     </div>
   );
-}
-
-function iconForDomainId(domainId: string | null): LucideIcon {
-  const normalized = domainId?.toLowerCase() ?? "";
-  if (normalized.includes("hydro") || normalized.includes("river") || normalized.includes("lake")) return Waves;
-  if (normalized.includes("climate") || normalized.includes("temperature") || normalized.includes("rain")) return CloudSun;
-  if (normalized.includes("terrain") || normalized.includes("height") || normalized.includes("elevation")) return Mountain;
-  if (normalized.includes("biome") || normalized.includes("vegetation") || normalized.includes("resource")) return Sprout;
-  if (normalized.includes("route") || normalized.includes("path") || normalized.includes("river")) return Route;
-  if (normalized.includes("finish") || normalized.includes("final")) return Flag;
-  if (normalized.includes("shape") || normalized.includes("land")) return Layers3;
-  return Package;
 }
 
 function CenteredState(props: {
@@ -482,7 +567,7 @@ function createPalette(lightMode: boolean) {
       grid: "bg-[linear-gradient(rgba(0,0,0,0.045)_1px,transparent_1px),linear-gradient(90deg,rgba(0,0,0,0.045)_1px,transparent_1px)] bg-[length:48px_48px]",
       panel: "border-white/80 bg-white/78",
       stage: "border-gray-200 bg-white",
-      stageSelected: "border-cyan-500 bg-white ring-2 ring-cyan-500/30",
+      stageSelected: "border-gray-200 bg-white",
       stageDimmed: "border-gray-200 bg-[#f8fafc] shadow-none",
       step: "border-gray-200 bg-gray-50",
       rule: "border-gray-200 text-gray-500",
@@ -495,17 +580,11 @@ function createPalette(lightMode: boolean) {
       icon: "text-cyan-700",
       iconDimmed: "text-gray-400",
       expandButton: "border-gray-200 bg-white text-gray-500 hover:border-cyan-300 hover:text-cyan-700",
-      edge: "#0891b2",
+      edge: "#64748b",
       edgeLabelPill: "border-cyan-200 bg-white text-cyan-800",
+      edgeLabelPillNeutral: "border-slate-200 bg-white text-slate-600",
       edgeLabelPillDimmed: "border-slate-200 bg-slate-50 text-slate-500",
       rankLine: "rgba(71,85,105,0.22)",
-      phaseFills: [
-        "rgba(236,253,245,0.68)",
-        "rgba(239,246,255,0.68)",
-        "rgba(255,247,237,0.66)",
-        "rgba(245,243,255,0.64)",
-      ],
-      phaseAccents: ["#059669", "#2563eb", "#d97706", "#7c3aed"],
       phaseStroke: "rgba(100,116,139,0.42)",
       phaseText: "#334155",
     } as const;
@@ -515,7 +594,7 @@ function createPalette(lightMode: boolean) {
     grid: "bg-[linear-gradient(rgba(255,255,255,0.035)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.035)_1px,transparent_1px)] bg-[length:48px_48px]",
     panel: "border-white/10 bg-[#141418]/72",
     stage: "border-[#2a2a32] bg-[#101014]",
-    stageSelected: "border-cyan-400 bg-[#101014] ring-2 ring-cyan-400/30",
+    stageSelected: "border-[#2a2a32] bg-[#101014]",
     stageDimmed: "border-[#24242c] bg-[#0d0d11] shadow-none",
     step: "border-[#30303a] bg-[#15151a]",
     rule: "border-[#2a2a32] text-[#8a8a96]",
@@ -528,17 +607,11 @@ function createPalette(lightMode: boolean) {
     icon: "text-cyan-300",
     iconDimmed: "text-[#5f6570]",
     expandButton: "border-[#30303a] bg-[#15151a] text-[#8a8a96] hover:border-cyan-400/50 hover:text-cyan-200",
-    edge: "#22d3ee",
+    edge: "#5f6570",
     edgeLabelPill: "border-cyan-400/35 bg-[#101014] text-cyan-200",
+    edgeLabelPillNeutral: "border-[#2a2a32] bg-[#101014] text-[#a7a7b2]",
     edgeLabelPillDimmed: "border-[#24242c] bg-[#101014] text-[#6f7480]",
     rankLine: "rgba(148,163,184,0.16)",
-    phaseFills: [
-      "rgba(6,78,59,0.20)",
-      "rgba(30,64,175,0.18)",
-      "rgba(146,64,14,0.18)",
-      "rgba(91,33,182,0.17)",
-    ],
-    phaseAccents: ["#34d399", "#60a5fa", "#f59e0b", "#a78bfa"],
     phaseStroke: "rgba(100,116,139,0.42)",
     phaseText: "#d4d4dc",
   } as const;

--- a/apps/mapgen-studio/src/features/recipeDag/artifactPresentation.ts
+++ b/apps/mapgen-studio/src/features/recipeDag/artifactPresentation.ts
@@ -1,3 +1,5 @@
+import { chooseRecipeDagDomainId, normalizeRecipeDagDomainId } from "./domainPresentation";
+
 const ARTIFACT_TAG_PREFIX = /^artifact:/i;
 
 export type ArtifactPresentation = Readonly<{
@@ -9,21 +11,23 @@ export type ArtifactPresentation = Readonly<{
 export function parseArtifactPresentation(id: string): ArtifactPresentation {
   const withoutTag = id.replace(ARTIFACT_TAG_PREFIX, "");
   const segments = withoutTag.split(".").filter((segment) => segment.length > 0);
+  const domainId = resolveSemanticArtifactDomainId(withoutTag, segments);
   if (segments.length < 2) {
     return {
       id,
-      domainId: null,
-      label: withoutTag.length > 0 ? withoutTag : id,
+      domainId,
+      label: formatLocalArtifactLabel(withoutTag.length > 0 ? withoutTag : id, domainId),
     };
   }
 
   const [, ...localSegments] = segments;
   const visibleSegments = localSegments.filter((segment) => !segment.startsWith("_"));
-  const label = visibleSegments.at(-1) ?? localSegments.at(-1) ?? withoutTag;
+  const localLabel = visibleSegments.at(-1) ?? localSegments.at(-1) ?? withoutTag;
+  const label = formatLocalArtifactLabel(localLabel, domainId);
 
   return {
     id,
-    domainId: segments[0] ?? null,
+    domainId,
     label,
   };
 }
@@ -43,6 +47,28 @@ export function resolveArtifactGroupDomainId(artifacts: readonly string[]): stri
     .map((artifact) => parseArtifactPresentation(artifact).domainId)
     .filter((domainId): domainId is string => Boolean(domainId));
   if (domains.length === 0) return null;
-  const [first] = domains;
-  return domains.every((domainId) => domainId === first) ? first : null;
+  const [first] = domains.map((domainId) => normalizeRecipeDagDomainId(domainId));
+  return domains.every((domainId) => normalizeRecipeDagDomainId(domainId) === first) ? first ?? null : null;
+}
+
+function resolveSemanticArtifactDomainId(withoutTag: string, segments: readonly string[]): string | null {
+  const candidates = segments.length > 1 ? segments : [withoutTag];
+  const mapNamespaceCandidates = segments[0] === "map" ? segments.slice(1) : [];
+  const domainId = chooseRecipeDagDomainId([...mapNamespaceCandidates, ...candidates]);
+  return domainId;
+}
+
+function formatLocalArtifactLabel(label: string, domainId: string | null): string {
+  const normalizedDomain = normalizeRecipeDagDomainId(domainId);
+  const domainPrefixPatterns: Partial<Record<ReturnType<typeof normalizeRecipeDagDomainId>, RegExp>> = {
+    foundation: /^foundation(?=[A-Z0-9_-])/,
+    hydrology: /^hydrology(?=[A-Z0-9_-])/,
+    ecology: /^ecology(?=[A-Z0-9_-])/,
+    morphology: /^morphology(?=[A-Z0-9_-])/,
+    placement: /^placement(?=[A-Z0-9_-])/,
+    climate: /^climate(?=[A-Z0-9_-])/,
+  };
+  const pattern = domainPrefixPatterns[normalizedDomain];
+  const nextLabel = pattern ? label.replace(pattern, "") : label;
+  return nextLabel.length > 0 ? nextLabel : label;
 }

--- a/apps/mapgen-studio/src/features/recipeDag/domainPresentation.ts
+++ b/apps/mapgen-studio/src/features/recipeDag/domainPresentation.ts
@@ -1,0 +1,239 @@
+import {
+  Blocks,
+  createLucideIcon,
+  Droplet,
+  Flag,
+  Leaf,
+  MapPin,
+  Package,
+  Route,
+  Settings2,
+  SunSnow,
+  type LucideIcon,
+} from "lucide-react";
+
+export type RecipeDagDomainPresentation = Readonly<{
+  id: string;
+  label: string;
+  Icon: LucideIcon;
+  lane: RecipeDagDomainLaneColors;
+  strokeWidth?: number;
+}>;
+
+export type RecipeDagDomainLaneColors = Readonly<{
+  lightFill: string;
+  lightAccent: string;
+  darkFill: string;
+  darkAccent: string;
+}>;
+
+const Stone = createLucideIcon("Stone", [
+  [
+    "path",
+    {
+      d: "M11.264 2.205A4 4 0 0 0 6.42 4.211l-4 8a4 4 0 0 0 1.359 5.117l6 4a4 4 0 0 0 4.438 0l6-4a4 4 0 0 0 1.576-4.592l-2-6a4 4 0 0 0-2.53-2.53z",
+      key: "stone-shell",
+    },
+  ],
+  ["path", { d: "M11.99 22 14 12l7.822 3.184", key: "stone-crack-a" }],
+  ["path", { d: "M14 12 8.47 2.302", key: "stone-crack-b" }],
+]);
+
+const Bolt = createLucideIcon("Bolt", [
+  [
+    "path",
+    {
+      d: "M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z",
+      key: "bolt-shell",
+    },
+  ],
+  ["circle", { cx: "12", cy: "12", r: "4", key: "bolt-core" }],
+]);
+
+const LANE_COLORS: Record<string, RecipeDagDomainLaneColors> = {
+  setup: {
+    lightFill: "rgba(241,245,249,0.66)",
+    lightAccent: "#64748b",
+    darkFill: "rgba(51,65,85,0.18)",
+    darkAccent: "#94a3b8",
+  },
+  foundation: {
+    lightFill: "rgba(245,245,244,0.70)",
+    lightAccent: "#78716c",
+    darkFill: "rgba(87,83,78,0.20)",
+    darkAccent: "#a8a29e",
+  },
+  morphology: {
+    lightFill: "rgba(255,247,237,0.66)",
+    lightAccent: "#b45309",
+    darkFill: "rgba(146,64,14,0.18)",
+    darkAccent: "#f59e0b",
+  },
+  hydrology: {
+    lightFill: "rgba(239,246,255,0.70)",
+    lightAccent: "#0284c7",
+    darkFill: "rgba(14,116,144,0.19)",
+    darkAccent: "#38bdf8",
+  },
+  ecology: {
+    lightFill: "rgba(236,253,245,0.70)",
+    lightAccent: "#16a34a",
+    darkFill: "rgba(6,95,70,0.22)",
+    darkAccent: "#34d399",
+  },
+  gameplay: {
+    lightFill: "rgba(245,243,255,0.64)",
+    lightAccent: "#7c3aed",
+    darkFill: "rgba(91,33,182,0.17)",
+    darkAccent: "#a78bfa",
+  },
+  placement: {
+    lightFill: "rgba(255,241,242,0.62)",
+    lightAccent: "#e11d48",
+    darkFill: "rgba(159,18,57,0.16)",
+    darkAccent: "#fb7185",
+  },
+  finish: {
+    lightFill: "rgba(240,253,250,0.64)",
+    lightAccent: "#0f766e",
+    darkFill: "rgba(19,78,74,0.18)",
+    darkAccent: "#2dd4bf",
+  },
+  climate: {
+    lightFill: "rgba(240,249,255,0.66)",
+    lightAccent: "#2563eb",
+    darkFill: "rgba(30,64,175,0.18)",
+    darkAccent: "#60a5fa",
+  },
+  routing: {
+    lightFill: "rgba(250,245,255,0.62)",
+    lightAccent: "#9333ea",
+    darkFill: "rgba(107,33,168,0.16)",
+    darkAccent: "#c084fc",
+  },
+  artifact: {
+    lightFill: "rgba(248,250,252,0.62)",
+    lightAccent: "#64748b",
+    darkFill: "rgba(30,41,59,0.16)",
+    darkAccent: "#94a3b8",
+  },
+};
+
+const DOMAIN_PRESENTATIONS: Record<string, RecipeDagDomainPresentation> = {
+  setup: { id: "setup", label: "Setup", Icon: Settings2, lane: LANE_COLORS.setup },
+  foundation: { id: "foundation", label: "Foundation", Icon: Blocks, lane: LANE_COLORS.foundation },
+  morphology: { id: "morphology", label: "Morphology", Icon: Stone, lane: LANE_COLORS.morphology, strokeWidth: 1.9 },
+  hydrology: {
+    id: "hydrology",
+    label: "Hydrology",
+    Icon: Droplet,
+    lane: LANE_COLORS.hydrology,
+    strokeWidth: 1.9,
+  },
+  ecology: {
+    id: "ecology",
+    label: "Ecology",
+    Icon: Leaf,
+    lane: LANE_COLORS.ecology,
+    strokeWidth: 1.8,
+  },
+  gameplay: { id: "gameplay", label: "Gameplay", Icon: Bolt, lane: LANE_COLORS.gameplay },
+  placement: { id: "placement", label: "Placement", Icon: MapPin, lane: LANE_COLORS.placement },
+  finish: { id: "finish", label: "Finish", Icon: Flag, lane: LANE_COLORS.finish },
+  climate: { id: "climate", label: "Climate", Icon: SunSnow, lane: LANE_COLORS.climate, strokeWidth: 1.8 },
+  routing: { id: "routing", label: "Routing", Icon: Route, lane: LANE_COLORS.routing },
+  artifact: { id: "artifact", label: "Artifact", Icon: Package, lane: LANE_COLORS.artifact },
+};
+
+const ORDERED_DOMAIN_IDS = [
+  "setup",
+  "foundation",
+  "morphology",
+  "hydrology",
+  "ecology",
+  "gameplay",
+  "placement",
+  "finish",
+  "climate",
+  "routing",
+] as const;
+
+export function getRecipeDagDomainPresentation(domainId: string | null): RecipeDagDomainPresentation {
+  const normalized = normalizeRecipeDagDomainId(domainId);
+  return DOMAIN_PRESENTATIONS[normalized] ?? DOMAIN_PRESENTATIONS.artifact;
+}
+
+export function getRecipeDagPhaseLaneColors(phaseId: string | null, lightMode: boolean): Readonly<{
+  fill: string;
+  accent: string;
+}> {
+  const lane = getRecipeDagDomainPresentation(phaseId).lane;
+  return {
+    fill: lightMode ? lane.lightFill : lane.darkFill,
+    accent: lightMode ? lane.lightAccent : lane.darkAccent,
+  };
+}
+
+export function normalizeRecipeDagDomainId(domainId: string | null): keyof typeof DOMAIN_PRESENTATIONS {
+  const normalized = normalizeDomainText(domainId);
+  if (!normalized) return "artifact";
+  if (normalized.includes("shape")) return "morphology";
+  if (normalized.includes("foundation") || normalized.includes("tectonic") || normalized.includes("plate")) return "foundation";
+  if (
+    normalized.includes("hydrology") ||
+    normalized.includes("hydro") ||
+    normalized.includes("river") ||
+    normalized.includes("lake") ||
+    normalized.includes("water")
+  ) return "hydrology";
+  if (normalized.includes("placement") || normalized.includes("start") || normalized.includes("discovery")) return "placement";
+  if (normalized.includes("setup") || normalized.includes("config") || normalized.includes("input")) return "setup";
+  if (
+    normalized.includes("morphology") ||
+    normalized.includes("terrain") ||
+    normalized.includes("topography") ||
+    normalized.includes("elevation") ||
+    normalized.includes("coast") ||
+    normalized.includes("landmass") ||
+    normalized.includes("mountain") ||
+    normalized.includes("volcano")
+  ) return "morphology";
+  if (
+    normalized.includes("ecology") ||
+    normalized.includes("biome") ||
+    normalized.includes("soil") ||
+    normalized.includes("vegetation") ||
+    normalized.includes("wetland") ||
+    normalized.includes("reef") ||
+    normalized.includes("floodplain") ||
+    normalized.includes("resource")
+  ) return "ecology";
+  if (
+    normalized.includes("climate") ||
+    normalized.includes("temperature") ||
+    normalized.includes("rain") ||
+    normalized.includes("wind") ||
+    normalized.includes("cryosphere")
+  ) return "climate";
+  if (normalized.includes("route") || normalized.includes("routing") || normalized.includes("path")) return "routing";
+  if (normalized.includes("gameplay") || normalized.includes("projection") || normalized.includes("engine")) return "gameplay";
+  if (normalized.includes("finish") || normalized.includes("final")) return "finish";
+  return "artifact";
+}
+
+export function chooseRecipeDagDomainId(candidates: readonly (string | null | undefined)[]): string | null {
+  for (const candidate of candidates) {
+    const normalized = normalizeRecipeDagDomainId(candidate ?? null);
+    if (normalized !== "artifact") return normalized;
+  }
+  for (const fallback of ORDERED_DOMAIN_IDS) {
+    if (candidates.some((candidate) => normalizeRecipeDagDomainId(candidate ?? null) === fallback)) return fallback;
+  }
+  return null;
+}
+
+function normalizeDomainText(value: string | null | undefined): string {
+  return (value ?? "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase();
+}

--- a/apps/mapgen-studio/src/features/recipeDag/layout.ts
+++ b/apps/mapgen-studio/src/features/recipeDag/layout.ts
@@ -1,5 +1,5 @@
 import type { RecipeDagResult } from "./client";
-import { formatArtifactGroupLabel } from "./artifactPresentation";
+import { formatArtifactGroupLabel, formatArtifactLabel } from "./artifactPresentation";
 
 export type DagPoint = Readonly<{
   x: number;
@@ -12,6 +12,7 @@ export type StagePosition = Readonly<{
   width: number;
   height: number;
   rank: number;
+  phaseRow: number;
   phaseId: string;
 }>;
 
@@ -29,6 +30,18 @@ export type RoutedStageEdgeGroup = StageEdgeGroup &
     labelX: number;
     labelY: number;
   }>;
+
+export type RoutedArtifactEdgeLabel = Readonly<{
+  id: string;
+  fromStageId: string;
+  toStageIds: readonly string[];
+  edgeIds: readonly string[];
+  artifact: string;
+  artifacts: readonly string[];
+  label: string;
+  labelX: number;
+  labelY: number;
+}>;
 
 export type PhaseBand = Readonly<{
   id: string;
@@ -62,14 +75,20 @@ const PHASE_MIN_HEIGHT = 188;
 const STAGE_GAP_Y = 36;
 const EDGE_STEM = 34;
 const EDGE_LABEL_MIN_GAP = 26;
+const EDGE_LABEL_ENDPOINT_MIN_OFFSET = 118;
+const EDGE_LABEL_ENDPOINT_MAX_OFFSET = 168;
+const EDGE_LABEL_ENDPOINT_FRACTION = 0.28;
+const EDGE_LABEL_DESTINATION_X_OFFSET = 128;
+const EDGE_LABEL_COLLISION_GAP = 30;
 
 export function buildRecipeDagLayout(dag: RecipeDagResult): RecipeDagLayout {
   const edgeGroups = groupStageEdges(dag);
   const phaseIndexById = new Map(dag.phases.map((phase, index) => [phase.id, index]));
   const rankByStageId = assignDependencyRanks(dag, edgeGroups);
+  const phaseRowByStageId = assignPhaseRows(dag, phaseIndexById);
   const rankCount = Math.max(1, Math.max(...Array.from(rankByStageId.values()), 0) + 1);
-  const phaseMetrics = measurePhaseLanes(dag, phaseIndexById, rankByStageId);
-  const positions = positionStages(dag, phaseMetrics, phaseIndexById, rankByStageId);
+  const phaseMetrics = measurePhaseLanes(dag, phaseIndexById, phaseRowByStageId);
+  const positions = positionStages(dag, phaseMetrics, phaseIndexById, rankByStageId, phaseRowByStageId);
   const width = Math.max(1040, GRAPH_PAD_X * 2 + rankCount * STAGE_WIDTH + Math.max(0, rankCount - 1) * RANK_GAP_X);
   const height = Math.max(560, GRAPH_PAD_TOP + phaseMetrics.totalHeight + GRAPH_PAD_BOTTOM);
   const rankColumns = Array.from({ length: rankCount }, (_, rank) => ({
@@ -129,7 +148,7 @@ function assignDependencyRanks(
     incomingByStageId.set(edge.toStageId, incoming);
   }
 
-  for (const stage of [...dag.stages].sort((a, b) => a.order - b.order)) {
+  for (const stage of [...dag.stages].sort((a, b) => a.order - b.order || a.stageId.localeCompare(b.stageId))) {
     const incoming = incomingByStageId.get(stage.stageId) ?? [];
     let rank = rankByStageId.get(stage.stageId) ?? 0;
     for (const edge of incoming) {
@@ -146,28 +165,24 @@ function assignDependencyRanks(
 function measurePhaseLanes(
   dag: RecipeDagResult,
   phaseIndexById: ReadonlyMap<string, number>,
-  rankByStageId: ReadonlyMap<string, number>
+  phaseRowByStageId: ReadonlyMap<string, number>
 ): {
   totalHeight: number;
-  byPhaseId: ReadonlyMap<string, { y: number; height: number; maxSlotCount: number }>;
+  byPhaseId: ReadonlyMap<string, { y: number; height: number; rowCount: number }>;
 } {
-  const slotCountByPhaseRank = new Map<string, number>();
+  const rowCountByPhaseId = new Map<string, number>();
   for (const stage of dag.stages) {
     const phaseId = resolveStagePhaseId(dag, phaseIndexById, stage.phases);
-    const rank = rankByStageId.get(stage.stageId) ?? 0;
-    const key = `${phaseId}:${rank}`;
-    slotCountByPhaseRank.set(key, (slotCountByPhaseRank.get(key) ?? 0) + 1);
+    const phaseRow = phaseRowByStageId.get(stage.stageId) ?? 0;
+    rowCountByPhaseId.set(phaseId, Math.max(rowCountByPhaseId.get(phaseId) ?? 0, phaseRow + 1));
   }
 
-  const byPhaseId = new Map<string, { y: number; height: number; maxSlotCount: number }>();
+  const byPhaseId = new Map<string, { y: number; height: number; rowCount: number }>();
   let cursor = GRAPH_PAD_TOP;
   for (const phase of dag.phases) {
-    let maxSlotCount = 1;
-    for (const [key, count] of slotCountByPhaseRank) {
-      if (key.startsWith(`${phase.id}:`)) maxSlotCount = Math.max(maxSlotCount, count);
-    }
-    const height = Math.max(PHASE_MIN_HEIGHT, PHASE_TITLE_HEIGHT + maxSlotCount * STAGE_HEIGHT + Math.max(0, maxSlotCount - 1) * STAGE_GAP_Y + 26);
-    byPhaseId.set(phase.id, { y: cursor, height, maxSlotCount });
+    const rowCount = Math.max(1, rowCountByPhaseId.get(phase.id) ?? 1);
+    const height = Math.max(PHASE_MIN_HEIGHT, PHASE_TITLE_HEIGHT + rowCount * STAGE_HEIGHT + Math.max(0, rowCount - 1) * STAGE_GAP_Y + 26);
+    byPhaseId.set(phase.id, { y: cursor, height, rowCount });
     cursor += height + 28;
   }
 
@@ -181,35 +196,43 @@ function positionStages(
   dag: RecipeDagResult,
   phaseMetrics: ReturnType<typeof measurePhaseLanes>,
   phaseIndexById: ReadonlyMap<string, number>,
-  rankByStageId: ReadonlyMap<string, number>
+  rankByStageId: ReadonlyMap<string, number>,
+  phaseRowByStageId: ReadonlyMap<string, number>
 ): ReadonlyMap<string, StagePosition> {
   const positions = new Map<string, StagePosition>();
-  const stagesByPhaseRank = new Map<string, typeof dag.stages>();
+
   for (const stage of dag.stages) {
     const phaseId = resolveStagePhaseId(dag, phaseIndexById, stage.phases);
     const rank = rankByStageId.get(stage.stageId) ?? 0;
-    const key = `${phaseId}:${rank}`;
-    stagesByPhaseRank.set(key, [...(stagesByPhaseRank.get(key) ?? []), stage]);
-  }
-
-  for (const [key, stages] of stagesByPhaseRank) {
-    const [phaseId, rankText] = key.split(":");
-    const rank = Number(rankText);
+    const phaseRow = phaseRowByStageId.get(stage.stageId) ?? 0;
     const phase = phaseMetrics.byPhaseId.get(phaseId);
-    const sortedStages = [...stages].sort((a, b) => a.order - b.order);
-    sortedStages.forEach((stage, slot) => {
-      positions.set(stage.stageId, {
-        x: GRAPH_PAD_X + rank * (STAGE_WIDTH + RANK_GAP_X),
-        y: (phase?.y ?? GRAPH_PAD_TOP) + PHASE_TITLE_HEIGHT + slot * (STAGE_HEIGHT + STAGE_GAP_Y),
-        width: STAGE_WIDTH,
-        height: STAGE_HEIGHT,
-        rank,
-        phaseId,
-      });
+    positions.set(stage.stageId, {
+      x: GRAPH_PAD_X + rank * (STAGE_WIDTH + RANK_GAP_X),
+      y: (phase?.y ?? GRAPH_PAD_TOP) + PHASE_TITLE_HEIGHT + phaseRow * (STAGE_HEIGHT + STAGE_GAP_Y),
+      width: STAGE_WIDTH,
+      height: STAGE_HEIGHT,
+      rank,
+      phaseRow,
+      phaseId,
     });
   }
 
   return positions;
+}
+
+function assignPhaseRows(
+  dag: RecipeDagResult,
+  phaseIndexById: ReadonlyMap<string, number>
+): ReadonlyMap<string, number> {
+  const rowByStageId = new Map<string, number>();
+  const nextRowByPhaseId = new Map<string, number>();
+  for (const stage of [...dag.stages].sort((a, b) => a.order - b.order || a.stageId.localeCompare(b.stageId))) {
+    const phaseId = resolveStagePhaseId(dag, phaseIndexById, stage.phases);
+    const row = nextRowByPhaseId.get(phaseId) ?? 0;
+    rowByStageId.set(stage.stageId, row);
+    nextRowByPhaseId.set(phaseId, row + 1);
+  }
+  return rowByStageId;
 }
 
 function routeEdges(
@@ -232,18 +255,20 @@ function routeEdges(
       };
     }
 
-    const outOffset = anchorOffset(outboundIndex.get(edge.fromStageId) ?? [], edge.id, from.height);
+    const outboundEdges = outboundIndex.get(edge.fromStageId) ?? [];
+    const outOffset = outboundEdges.length > 1 ? from.height / 2 : anchorOffset(outboundEdges, edge.id, from.height);
     const inOffset = anchorOffset(inboundIndex.get(edge.toStageId) ?? [], edge.id, to.height);
     const start = { x: from.x + from.width, y: from.y + outOffset };
     const end = { x: to.x, y: to.y + inOffset };
     const forward = end.x > start.x;
-    const midX = forward ? start.x + Math.max(EDGE_STEM * 2, (end.x - start.x) / 2) : start.x + EDGE_STEM * 1.6;
+    const bundleX = forward
+      ? start.x + Math.min(Math.max(EDGE_STEM, (end.x - start.x) * 0.32), EDGE_STEM * 2.4)
+      : start.x + EDGE_STEM * 1.6;
     const points = forward
       ? [
           start,
-          { x: start.x + EDGE_STEM, y: start.y },
-          { x: midX, y: start.y },
-          { x: midX, y: end.y },
+          { x: bundleX, y: start.y },
+          { x: bundleX, y: end.y },
           { x: end.x - EDGE_STEM, y: end.y },
           end,
         ]
@@ -260,7 +285,7 @@ function routeEdges(
       ...edge,
       points,
       label: formatEdgeLabel(edge.artifacts),
-      labelX: forward ? midX : (start.x + end.x) / 2,
+      labelX: forward ? bundleX : (start.x + end.x) / 2,
       labelY: (start.y + end.y) / 2,
     };
   });
@@ -338,4 +363,220 @@ export function pointsToPath(points: readonly DagPoint[]): string {
     `M ${first.x} ${first.y}`,
     ...rest.map((point) => `L ${point.x} ${point.y}`),
   ].join(" ");
+}
+
+export function buildArtifactEdgeLabels(
+  edgeGroups: readonly RoutedStageEdgeGroup[],
+  selectedStageId: string | null = null
+): readonly RoutedArtifactEdgeLabel[] {
+  const labelsByKey = new Map<string, { fromStageId: string; artifact: string; edges: RoutedStageEdgeGroup[] }>();
+  for (const edge of edgeGroups) {
+    for (const artifact of edge.artifacts) {
+      const key = `${edge.fromStageId}:${artifact}`;
+      const label = labelsByKey.get(key) ?? { fromStageId: edge.fromStageId, artifact, edges: [] };
+      label.edges.push(edge);
+      labelsByKey.set(key, label);
+    }
+  }
+
+  const labels = Array.from(labelsByKey.values()).map((label) => {
+    const edges = [...label.edges].sort((a, b) => a.toStageId.localeCompare(b.toStageId) || a.id.localeCompare(b.id));
+    const position = resolveArtifactLabelPreferredPosition(edges, selectedStageId);
+    return {
+      id: `${label.fromStageId}:${label.artifact}`,
+      fromStageId: label.fromStageId,
+      toStageIds: Array.from(new Set(edges.map((edge) => edge.toStageId))).sort(),
+      edgeIds: edges.map((edge) => edge.id).sort(),
+      artifact: label.artifact,
+      artifacts: [label.artifact],
+      label: formatArtifactLabel(label.artifact),
+      labelX: position.x,
+      labelY: position.y,
+    };
+  });
+
+  return spreadArtifactLabels(labels, selectedStageId);
+}
+
+export function resolveEdgeLabelPosition(
+  edge: RoutedStageEdgeGroup,
+  selectedStageId: string | null
+): DagPoint {
+  if (!selectedStageId || edge.points.length === 0) return { x: edge.labelX, y: edge.labelY };
+  const selectedIsSource = edge.fromStageId === selectedStageId;
+  const selectedIsTarget = edge.toStageId === selectedStageId;
+  if (!selectedIsSource && !selectedIsTarget) return { x: edge.labelX, y: edge.labelY };
+
+  return resolveDestinationEdgeLabelPosition(edge);
+}
+
+export function resolveEdgeLabelPositions(
+  edgeGroups: readonly RoutedStageEdgeGroup[],
+  selectedStageId: string | null
+): ReadonlyMap<string, DagPoint> {
+  const positions = new Map(
+    edgeGroups.map((edge) => [
+      edge.id,
+      selectedStageId ? resolveEdgeLabelPosition(edge, selectedStageId) : resolveDestinationEdgeLabelPosition(edge),
+    ])
+  );
+
+  const clusters = new Map<string, RoutedStageEdgeGroup[]>();
+  for (const edge of edgeGroups) {
+    if (!edge.points.length) continue;
+    if (selectedStageId && edge.fromStageId !== selectedStageId && edge.toStageId !== selectedStageId) continue;
+    clusters.set(edge.toStageId, [...(clusters.get(edge.toStageId) ?? []), edge]);
+  }
+
+  for (const edges of clusters.values()) {
+    if (edges.length < 2) continue;
+    const sorted = [...edges].sort((a, b) => {
+      const aPosition = positions.get(a.id) ?? { x: a.labelX, y: a.labelY };
+      const bPosition = positions.get(b.id) ?? { x: b.labelX, y: b.labelY };
+      return aPosition.y - bPosition.y || a.id.localeCompare(b.id);
+    });
+    const resolvedY = resolveVerticalLabelCollisions(
+      sorted.map((edge) => positions.get(edge.id)?.y ?? edge.labelY),
+      EDGE_LABEL_COLLISION_GAP
+    );
+    sorted.forEach((edge, index) => {
+      const position = positions.get(edge.id) ?? { x: edge.labelX, y: edge.labelY };
+      positions.set(edge.id, { x: position.x, y: resolvedY[index] ?? position.y });
+    });
+  }
+
+  return positions;
+}
+
+function resolveArtifactLabelPreferredPosition(
+  edges: readonly RoutedStageEdgeGroup[],
+  selectedStageId: string | null
+): DagPoint {
+  const first = edges[0];
+  if (!first) return { x: 0, y: 0 };
+  const selectedDestinationEdge = selectedStageId
+    ? edges.find((edge) => edge.toStageId === selectedStageId)
+    : null;
+  if (selectedDestinationEdge) return resolveDestinationEdgeLabelPosition(selectedDestinationEdge);
+  if (edges.length === 1) return resolveDestinationEdgeLabelPosition(first);
+
+  const start = first.points[0];
+  const trunk = first.points[1];
+  if (!start || !trunk) return { x: first.labelX, y: first.labelY };
+  return {
+    x: start.x + (trunk.x - start.x) * 0.82,
+    y: start.y,
+  };
+}
+
+function spreadArtifactLabels(
+  labels: readonly RoutedArtifactEdgeLabel[],
+  selectedStageId: string | null
+): readonly RoutedArtifactEdgeLabel[] {
+  const clusters = new Map<string, RoutedArtifactEdgeLabel[]>();
+  for (const label of labels) {
+    const clusterKey = selectedStageId && label.toStageIds.includes(selectedStageId)
+      ? `destination:${selectedStageId}`
+      : label.toStageIds.length > 1
+      ? `source:${label.fromStageId}`
+      : `destination:${label.toStageIds[0] ?? label.fromStageId}`;
+    clusters.set(clusterKey, [...(clusters.get(clusterKey) ?? []), label]);
+  }
+
+  const labelYById = new Map<string, number>();
+  for (const cluster of clusters.values()) {
+    const sorted = [...cluster].sort((a, b) => a.labelY - b.labelY || a.id.localeCompare(b.id));
+    const resolvedY = resolveVerticalLabelCollisions(
+      sorted.map((label) => label.labelY),
+      EDGE_LABEL_COLLISION_GAP
+    );
+    sorted.forEach((label, index) => labelYById.set(label.id, resolvedY[index] ?? label.labelY));
+  }
+
+  return labels
+    .map((label) => ({
+      ...label,
+      labelY: labelYById.get(label.id) ?? label.labelY,
+    }))
+    .sort((a, b) => a.labelX - b.labelX || a.labelY - b.labelY || a.id.localeCompare(b.id));
+}
+
+function resolveDestinationEdgeLabelPosition(edge: RoutedStageEdgeGroup): DagPoint {
+  if (edge.points.length === 0) return { x: edge.labelX, y: edge.labelY };
+  const length = polylineLength(edge.points);
+  if (length === 0) return { x: edge.labelX, y: edge.labelY };
+
+  const endpointOffset = Math.min(
+    EDGE_LABEL_ENDPOINT_MAX_OFFSET,
+    Math.max(EDGE_LABEL_ENDPOINT_MIN_OFFSET, length * EDGE_LABEL_ENDPOINT_FRACTION)
+  );
+  const distanceFromStart = Math.max(0, length - endpointOffset);
+  return nudgeLabelOutsideDestination(edge, pointAlongPolyline(edge.points, distanceFromStart));
+}
+
+function nudgeLabelOutsideDestination(edge: RoutedStageEdgeGroup, point: DagPoint): DagPoint {
+  const destination = edge.points[edge.points.length - 1];
+  if (!destination) return point;
+  const branchStart = edge.points.length >= 3 ? edge.points[edge.points.length - 3] : null;
+  const destinationX = Math.max(
+    GRAPH_PAD_X * 0.75,
+    destination.x - EDGE_LABEL_DESTINATION_X_OFFSET,
+    branchStart ? branchStart.x + EDGE_STEM * 0.55 : Number.NEGATIVE_INFINITY
+  );
+  return {
+    x: destinationX,
+    y: destination.y,
+  };
+}
+
+function resolveVerticalLabelCollisions(preferredY: readonly number[], gap: number): number[] {
+  if (preferredY.length < 2) return [...preferredY];
+
+  const resolved = [...preferredY];
+  for (let index = 1; index < resolved.length; index += 1) {
+    resolved[index] = Math.max(resolved[index]!, resolved[index - 1]! + gap);
+  }
+
+  const preferredCenter = average(preferredY);
+  const resolvedCenter = average(resolved);
+  return resolved.map((y) => y + preferredCenter - resolvedCenter);
+}
+
+function average(values: readonly number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / Math.max(1, values.length);
+}
+
+function polylineLength(points: readonly DagPoint[]): number {
+  let length = 0;
+  for (let index = 1; index < points.length; index += 1) {
+    length += distance(points[index - 1]!, points[index]!);
+  }
+  return length;
+}
+
+function pointAlongPolyline(points: readonly DagPoint[], distanceFromStart: number): DagPoint {
+  if (points.length === 0) return { x: 0, y: 0 };
+  if (points.length === 1) return points[0]!;
+
+  let remaining = distanceFromStart;
+  for (let index = 1; index < points.length; index += 1) {
+    const start = points[index - 1]!;
+    const end = points[index]!;
+    const segmentLength = distance(start, end);
+    if (segmentLength === 0) continue;
+    if (remaining <= segmentLength) {
+      const progress = remaining / segmentLength;
+      return {
+        x: start.x + (end.x - start.x) * progress,
+        y: start.y + (end.y - start.y) * progress,
+      };
+    }
+    remaining -= segmentLength;
+  }
+
+  return points[points.length - 1]!;
+}
+
+function distance(a: DagPoint, b: DagPoint): number {
+  return Math.hypot(b.x - a.x, b.y - a.y);
 }

--- a/apps/mapgen-studio/test/recipeDag/RecipeDagView.test.tsx
+++ b/apps/mapgen-studio/test/recipeDag/RecipeDagView.test.tsx
@@ -30,10 +30,37 @@ describe("RecipeDagView", () => {
     expect(html).toContain("aria-expanded=\"true\"");
     expect(html).toContain("aria-controls=\"recipe-dag-stage-shape-steps\"");
     expect(html).toContain("data-stage-expanded=\"true\"");
-    expect(html).toContain("z-index:70");
+    expect(html).toContain("z-index:95");
+    expect(html).toContain("marker-end=\"url(#recipe-dag-arrow-active)\"");
+    expect(html).toContain("stroke=\"#f59e0b\"");
+    expect(html).toContain("aria-label=\"Select dependency hydrography\"");
+    expect(html).toContain("data-edge-label-selected=\"false\"");
+    expect(html).toContain("text-[9.5px]");
     expect(html).toContain("Step 1: seed");
     expect(html).toContain("Creates");
     expect(html).not.toContain("opacity-45");
+  });
+
+  it("keeps connector paths and labels neutral before selection", () => {
+    const html = renderToStaticMarkup(
+      <RecipeDagView
+        recipeId="mod-swooper-maps/standard"
+        dag={recipeDag()}
+        status="ready"
+        error={null}
+        lightMode={false}
+        expandedStageIds={new Set()}
+        selectedStageId={null}
+        onToggleStage={vi.fn()}
+        onSelectStage={vi.fn()}
+        topInset={96}
+      />
+    );
+
+    expect(html).toContain("stroke=\"#5f6570\"");
+    expect(html).toContain("border-[#2a2a32] bg-[#101014] text-[#a7a7b2]");
+    expect(html).toContain(" L ");
+    expect(html).not.toContain("border-color:#f59e0b");
   });
 });
 

--- a/apps/mapgen-studio/test/recipeDag/artifactPresentation.test.ts
+++ b/apps/mapgen-studio/test/recipeDag/artifactPresentation.test.ts
@@ -6,6 +6,7 @@ import {
   parseArtifactPresentation,
   resolveArtifactGroupDomainId,
 } from "../../src/features/recipeDag/artifactPresentation";
+import { createRecipeDagService } from "../../src/server/recipeDag/service";
 
 describe("recipe DAG artifact presentation", () => {
   it("uses artifact domains as icon metadata and keeps visible labels local", () => {
@@ -16,8 +17,33 @@ describe("recipe DAG artifact presentation", () => {
     });
     expect(parseArtifactPresentation("artifact:map.hydrology.engineProjectionLakes")).toEqual({
       id: "artifact:map.hydrology.engineProjectionLakes",
-      domainId: "map",
+      domainId: "hydrology",
       label: "engineProjectionLakes",
+    });
+    expect(parseArtifactPresentation("artifact:map.riversEngineTerrainSnapshot")).toEqual({
+      id: "artifact:map.riversEngineTerrainSnapshot",
+      domainId: "hydrology",
+      label: "riversEngineTerrainSnapshot",
+    });
+    expect(parseArtifactPresentation("artifact:map.placementEngineTerrainSnapshot")).toEqual({
+      id: "artifact:map.placementEngineTerrainSnapshot",
+      domainId: "placement",
+      label: "EngineTerrainSnapshot",
+    });
+    expect(parseArtifactPresentation("artifact:map.foundationPlates")).toEqual({
+      id: "artifact:map.foundationPlates",
+      domainId: "foundation",
+      label: "Plates",
+    });
+    expect(parseArtifactPresentation("artifact:placementInputs")).toEqual({
+      id: "artifact:placementInputs",
+      domainId: "placement",
+      label: "Inputs",
+    });
+    expect(parseArtifactPresentation("artifact:climateField")).toEqual({
+      id: "artifact:climateField",
+      domainId: "climate",
+      label: "Field",
     });
     expect(parseArtifactPresentation("artifact:hydrology._internal.windField")).toEqual({
       id: "artifact:hydrology._internal.windField",
@@ -28,6 +54,23 @@ describe("recipe DAG artifact presentation", () => {
     expect(formatArtifactLabel("seed-grid")).toBe("seed-grid");
     expect(formatArtifactGroupLabel(["artifact:hydrology.hydrography", "artifact:hydrology.lakePlan"])).toBe("hydrography +1");
     expect(resolveArtifactGroupDomainId(["artifact:hydrology.hydrography", "artifact:hydrology.lakePlan"])).toBe("hydrology");
+    expect(resolveArtifactGroupDomainId(["artifact:map.hydrology.engineProjectionLakes", "artifact:map.riversEngineTerrainSnapshot"])).toBe("hydrology");
     expect(resolveArtifactGroupDomainId(["artifact:hydrology.hydrography", "artifact:ecology.biomes"])).toBeNull();
+  });
+
+  it("classifies every bundled standard recipe artifact into a semantic icon domain", async () => {
+    const dag = await createRecipeDagService().getRecipeDag("mod-swooper-maps/standard");
+    const artifactIds = new Set<string>();
+    for (const stage of dag.stages) {
+      for (const artifact of stage.artifactRequires) artifactIds.add(artifact.id);
+      for (const artifact of stage.artifactProvides) artifactIds.add(artifact.id);
+    }
+
+    expect(artifactIds.size).toBeGreaterThan(60);
+    const generic = Array.from(artifactIds)
+      .map((id) => parseArtifactPresentation(id))
+      .filter((artifact) => !artifact.domainId || artifact.domainId === "artifact");
+
+    expect(generic).toEqual([]);
   });
 });

--- a/apps/mapgen-studio/test/recipeDag/domainPresentation.test.ts
+++ b/apps/mapgen-studio/test/recipeDag/domainPresentation.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from "node:fs";
+import { Blocks, Droplet, Leaf, SunSnow } from "lucide-react";
+import { describe, expect, it } from "vitest";
+
+import {
+  getRecipeDagDomainPresentation,
+  getRecipeDagPhaseLaneColors,
+  normalizeRecipeDagDomainId,
+} from "../../src/features/recipeDag/domainPresentation";
+
+describe("recipe DAG domain presentation", () => {
+  it("covers canonical phases and Studio aliases with stable domain ids", () => {
+    expect(normalizeRecipeDagDomainId("setup")).toBe("setup");
+    expect(normalizeRecipeDagDomainId("foundation")).toBe("foundation");
+    expect(normalizeRecipeDagDomainId("morphology")).toBe("morphology");
+    expect(normalizeRecipeDagDomainId("shape")).toBe("morphology");
+    expect(normalizeRecipeDagDomainId("hydrology")).toBe("hydrology");
+    expect(normalizeRecipeDagDomainId("ecology")).toBe("ecology");
+    expect(normalizeRecipeDagDomainId("gameplay")).toBe("gameplay");
+    expect(normalizeRecipeDagDomainId("placement")).toBe("placement");
+    expect(normalizeRecipeDagDomainId("finish")).toBe("finish");
+    expect(normalizeRecipeDagDomainId("finalize")).toBe("finish");
+    expect(normalizeRecipeDagDomainId("climate")).toBe("climate");
+    expect(normalizeRecipeDagDomainId("routing")).toBe("routing");
+    expect(normalizeRecipeDagDomainId("unknown-domain")).toBe("artifact");
+  });
+
+  it("returns non-generic presentations for every canonical DAG phase", () => {
+    const phases = ["setup", "foundation", "morphology", "hydrology", "ecology", "gameplay", "placement"] as const;
+
+    for (const phase of phases) {
+      const presentation = getRecipeDagDomainPresentation(phase);
+      expect(presentation.id).toBe(phase);
+      expect(presentation.label).not.toBe("Artifact");
+    }
+  });
+
+  it("uses one stable visual vocabulary for domain icons across every DAG surface", () => {
+    expect(getRecipeDagDomainPresentation("foundation")).toMatchObject({
+      id: "foundation",
+      Icon: Blocks,
+    });
+    expect(getRecipeDagDomainPresentation("morphology")).toMatchObject({
+      id: "morphology",
+      strokeWidth: 1.9,
+    });
+    expect(getRecipeDagDomainPresentation("morphology").Icon.displayName).toBe("Stone");
+    expect(getRecipeDagDomainPresentation("hydrology")).toMatchObject({
+      id: "hydrology",
+      Icon: Droplet,
+      strokeWidth: 1.9,
+    });
+    expect(getRecipeDagDomainPresentation("ecology")).toMatchObject({
+      id: "ecology",
+      Icon: Leaf,
+      strokeWidth: 1.8,
+    });
+    expect(getRecipeDagDomainPresentation("climate")).toMatchObject({
+      id: "climate",
+      Icon: SunSnow,
+      strokeWidth: 1.8,
+    });
+    expect(getRecipeDagDomainPresentation("gameplay")).toMatchObject({
+      id: "gameplay",
+    });
+    expect(getRecipeDagDomainPresentation("gameplay").Icon.displayName).toBe("Bolt");
+  });
+
+  it("maps phase lane colors to domain meaning instead of cycling by order", () => {
+    expect(getRecipeDagPhaseLaneColors("ecology", false)).toMatchObject({
+      fill: "rgba(6,95,70,0.22)",
+      accent: "#34d399",
+    });
+    expect(getRecipeDagPhaseLaneColors("ecology", true)).toMatchObject({
+      fill: "rgba(236,253,245,0.70)",
+      accent: "#16a34a",
+    });
+    expect(getRecipeDagPhaseLaneColors("hydrology", false).accent).toBe("#38bdf8");
+    expect(getRecipeDagPhaseLaneColors("morphology", false).accent).toBe("#f59e0b");
+    expect(getRecipeDagPhaseLaneColors("gameplay", false).accent).toBe("#a78bfa");
+  });
+
+  it("does not expose surface-specific artifact icon overrides", () => {
+    expect(getRecipeDagDomainPresentation("hydrology")).toBe(getRecipeDagDomainPresentation("artifact:hydrology.hydrography"));
+    expect(getRecipeDagDomainPresentation("ecology")).toBe(getRecipeDagDomainPresentation("artifact:ecology.biomes"));
+  });
+
+  it("keeps domain lucide imports centralized outside the view", () => {
+    const source = readFileSync(new URL("../../src/features/recipeDag/RecipeDagView.tsx", import.meta.url), "utf8");
+    const lucideImport = source.match(/import\s*{([\s\S]*?)}\s*from "lucide-react";/)?.[1] ?? "";
+    const importedNames = lucideImport
+      .split(",")
+      .map((name) => name.trim())
+      .filter(Boolean);
+
+    expect(importedNames).toEqual(["AlertTriangle", "ChevronDown", "GitBranch", "Loader2"]);
+  });
+});

--- a/apps/mapgen-studio/test/recipeDag/layout.test.ts
+++ b/apps/mapgen-studio/test/recipeDag/layout.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { buildRecipeDagLayout, groupStageEdges, pointsToPath } from "../../src/features/recipeDag/layout";
+import {
+  buildArtifactEdgeLabels,
+  buildRecipeDagLayout,
+  groupStageEdges,
+  pointsToPath,
+  resolveEdgeLabelPosition,
+  resolveEdgeLabelPositions,
+  type RoutedStageEdgeGroup,
+} from "../../src/features/recipeDag/layout";
 import type { RecipeDagResult } from "../../src/features/recipeDag/client";
 
 describe("recipe DAG layout", () => {
@@ -13,6 +21,25 @@ describe("recipe DAG layout", () => {
     expect(layout.positions.get("sink")?.rank).toBe(2);
     expect(layout.positions.get("sink")?.phaseId).toBe("finish");
     expect(layout.rankColumns.map((column) => column.label)).toEqual(["Sources", "D1", "D2"]);
+  });
+
+  it("assigns every stage in a phase to its own vertical row", () => {
+    const layout = buildRecipeDagLayout(recipeDag());
+    const source = layout.positions.get("source");
+    const branchA = layout.positions.get("branch-a");
+    const branchB = layout.positions.get("branch-b");
+    const sink = layout.positions.get("sink");
+    const shapeBand = layout.phaseBands.find((phase) => phase.id === "shape");
+
+    expect(source?.phaseRow).toBe(0);
+    expect(branchA?.phaseRow).toBe(1);
+    expect(branchB?.phaseRow).toBe(2);
+    expect(sink?.phaseRow).toBe(0);
+    expect(new Set([source?.y, branchA?.y, branchB?.y])).toHaveLength(3);
+    expect(branchA?.rank).toBe(branchB?.rank);
+    expect(branchA?.y).not.toBe(branchB?.y);
+    expect(shapeBand).toBeDefined();
+    expect(shapeBand!.y + shapeBand!.height).toBeGreaterThanOrEqual(branchB!.y + branchB!.height + 26);
   });
 
   it("groups stage edges and produces routed orthogonal paths", () => {
@@ -38,7 +65,115 @@ describe("recipe DAG layout", () => {
       expect(labels[index]! - labels[index - 1]!).toBeGreaterThanOrEqual(26);
     }
   });
+
+  it("pulls selected-stage edge labels toward the dependency destination", () => {
+    const layout = buildRecipeDagLayout(recipeDag());
+    const edge = layout.edgeGroups.find((candidate) => candidate.fromStageId === "source" && candidate.toStageId === "branch-a");
+
+    expect(edge).toBeDefined();
+    const routed = edge!;
+    const last = routed.points[routed.points.length - 1]!;
+    const defaultPosition = resolveEdgeLabelPosition(routed, null);
+    const sourcePosition = resolveEdgeLabelPosition(routed, "source");
+    const targetPosition = resolveEdgeLabelPosition(routed, "branch-a");
+    const unrelatedPosition = resolveEdgeLabelPosition(routed, "sink");
+
+    expect(defaultPosition).toEqual({ x: routed.labelX, y: routed.labelY });
+    expect(unrelatedPosition).toEqual(defaultPosition);
+    expect(Math.abs(sourcePosition.y - last.y)).toBeLessThan(Math.abs(defaultPosition.y - last.y));
+    expect(Math.abs(targetPosition.y - last.y)).toBeLessThan(Math.abs(defaultPosition.y - last.y));
+    expect(sourcePosition.x).toBeLessThan(last.x);
+  });
+
+  it("fans crowded selected-stage labels around the shared destination", () => {
+    const edges: RoutedStageEdgeGroup[] = [
+      routedEdge("a->sink", "a", "sink", 98),
+      routedEdge("b->sink", "b", "sink", 100),
+      routedEdge("c->sink", "c", "sink", 102),
+    ];
+    const resolved = resolveEdgeLabelPositions(edges, "sink");
+    const positions = edges
+      .map((edge) => resolved.get(edge.id)!)
+      .sort((a, b) => a.y - b.y);
+
+    expect(positions[1]!.y - positions[0]!.y).toBeGreaterThanOrEqual(30);
+    expect(positions[2]!.y - positions[1]!.y).toBeGreaterThanOrEqual(30);
+  });
+
+  it("applies destination crowding to the non-selected graph", () => {
+    const edges: RoutedStageEdgeGroup[] = [
+      routedEdge("a->sink", "a", "sink", 98),
+      routedEdge("b->sink", "b", "sink", 100),
+      routedEdge("c->sink", "c", "sink", 102),
+    ];
+    const resolved = resolveEdgeLabelPositions(edges, null);
+    const positions = edges
+      .map((edge) => resolved.get(edge.id)!)
+      .sort((a, b) => a.y - b.y);
+
+    expect(positions.every((position) => position.x < 320)).toBe(true);
+    expect(positions[1]!.y - positions[0]!.y).toBeGreaterThanOrEqual(30);
+    expect(positions[2]!.y - positions[1]!.y).toBeGreaterThanOrEqual(30);
+  });
+
+  it("bundles shared-source edges before separating toward destinations", () => {
+    const layout = buildRecipeDagLayout(recipeDag());
+    const outgoing = layout.edgeGroups.filter((edge) => edge.fromStageId === "source");
+
+    expect(outgoing).toHaveLength(2);
+    expect(new Set(outgoing.map((edge) => edge.points[0]?.y))).toHaveLength(1);
+    expect(new Set(outgoing.map((edge) => edge.points[1]?.x))).toHaveLength(1);
+    expect(new Set(outgoing.map((edge) => edge.points[2]?.y))).toHaveLength(2);
+  });
+
+  it("labels each provided artifact once across split destination connectors", () => {
+    const layout = buildRecipeDagLayout(recipeDag());
+    const labels = buildArtifactEdgeLabels(layout.edgeGroups);
+    const seedLabels = labels.filter((label) => label.artifact === "seed-grid");
+    const seedLabel = seedLabels[0];
+    const sourceEdge = layout.edgeGroups.find((edge) => edge.fromStageId === "source")!;
+
+    expect(seedLabels).toHaveLength(1);
+    expect(seedLabel?.edgeIds).toHaveLength(2);
+    expect(seedLabel?.toStageIds).toEqual(["branch-a", "branch-b"]);
+    expect(seedLabel?.label).toBe("seed-grid");
+    expect(seedLabel?.labelX).toBeGreaterThan(sourceEdge.points[0]!.x);
+    expect(seedLabel?.labelX).toBeLessThanOrEqual(sourceEdge.points[1]!.x);
+    expect(seedLabel?.labelX).toBeGreaterThan(sourceEdge.points[0]!.x + (sourceEdge.points[1]!.x - sourceEdge.points[0]!.x) * 0.7);
+  });
+
+  it("moves a split artifact label near the selected destination branch", () => {
+    const layout = buildRecipeDagLayout(recipeDag());
+    const labels = buildArtifactEdgeLabels(layout.edgeGroups, "branch-b");
+    const seedLabel = labels.find((label) => label.artifact === "seed-grid");
+    const branchBEdge = layout.edgeGroups.find((edge) => edge.fromStageId === "source" && edge.toStageId === "branch-b")!;
+    const branchBEndpoint = branchBEdge.points[branchBEdge.points.length - 1]!;
+
+    expect(seedLabel).toBeDefined();
+    expect(seedLabel?.edgeIds).toHaveLength(2);
+    expect(seedLabel?.toStageIds).toEqual(["branch-a", "branch-b"]);
+    expect(seedLabel?.labelX).toBeGreaterThan(branchBEdge.points[1]!.x);
+    expect(Math.abs(seedLabel!.labelY - branchBEndpoint.y)).toBeLessThan(8);
+  });
 });
+
+function routedEdge(id: string, fromStageId: string, toStageId: string, destinationY: number): RoutedStageEdgeGroup {
+  return {
+    id,
+    fromStageId,
+    toStageId,
+    artifacts: [`${fromStageId}-artifact`],
+    points: [
+      { x: 80, y: destinationY },
+      { x: 240, y: destinationY },
+      { x: 240, y: 100 },
+      { x: 320, y: 100 },
+    ],
+    label: id,
+    labelX: 220,
+    labelY: destinationY,
+  };
+}
 
 function recipeDag(): RecipeDagResult {
   return {


### PR DESCRIPTION
## Semantic domain presentation for recipe DAG edges and phase lanes

Replaces the ad-hoc icon lookup and hardcoded phase color cycling in the recipe DAG view with a centralized `domainPresentation` module that maps phase and artifact domain identifiers to stable visual identities (icon, lane fill, accent color).

### Domain presentation system

- Introduces `domainPresentation.ts` with `normalizeRecipeDagDomainId`, `chooseRecipeDagDomainId`, `getRecipeDagDomainPresentation`, and `getRecipeDagPhaseLaneColors`
- Defines ten semantic domains (`setup`, `foundation`, `morphology`, `hydrology`, `ecology`, `gameplay`, `placement`, `finish`, `climate`, `routing`) each with a dedicated icon, light/dark fill, and accent color
- Adds two custom Lucide-compatible icons: `Stone` (morphology) and `Bolt` (gameplay)
- Phase lane colors are now resolved by domain meaning rather than cycling by phase order index
- All Lucide icon imports are removed from `RecipeDagView` except the four UI-only icons (`AlertTriangle`, `ChevronDown`, `GitBranch`, `Loader2`); domain icons are accessed exclusively through `DomainInlineIcon`

### Artifact label consolidation

- Introduces `buildArtifactEdgeLabels` in `layout.ts`, which groups edges by `(fromStageId, artifact)` so a single artifact shared across multiple destination stages renders as one label rather than one per edge
- Labels are positioned near the destination endpoint of the relevant branch, with collision spreading to prevent overlap
- When a stage is selected, split-destination labels move toward the selected branch's endpoint
- `RoutedArtifactEdgeLabel` type added to expose `toStageIds` and `edgeIds` for multi-destination tracking

### Edge label interactivity

- Artifact edge labels are now `<button>` elements with `aria-pressed` and `onSelect` callbacks
- Selecting a label highlights the contributing edges and their endpoint stages using the source stage's domain accent color, independently of stage selection
- `selectedLabelId` state drives a separate focus mode: when a label is selected, stage selection is cleared and neighbor highlighting reflects the label's source and destination stages
- Edge stroke color and opacity respond to the combined `focusActive` state (either a stage or a label is selected), with selected edges rendered at full accent color and unrelated edges faded

### Layout improvements

- Stage vertical positioning within a phase lane is now assigned by a dedicated `assignPhaseRows` pass (ordered by `stage.order` then `stageId`) rather than being derived from rank-slot bucketing; each stage gets its own row
- Outbound edges from a stage with multiple destinations now share a single exit point (`from.height / 2`) and bundle to a common horizontal before branching, producing cleaner fan-out paths
- The horizontal bundle point uses a tighter fraction of the available span rather than always reaching the midpoint

### Artifact domain classification

- `parseArtifactPresentation` now resolves a semantic `domainId` using `chooseRecipeDagDomainId` against the artifact's namespace segments, including special handling for the `map.*` namespace
- Domain-prefixed label segments (e.g. `foundationPlates` → `Plates`, `placementInputs` → `Inputs`) are stripped from the visible label when the prefix matches the resolved domain
- `resolveArtifactGroupDomainId` normalizes domain ids before comparing, so `map.hydrology.*` and `hydrology.*` artifacts resolve to the same group domain