### PR TITLE
docs(graphite): add execution mandate and operator permissions to DAG Studio redesign handoff

### DIFF
--- a/docs/projects/graphite-stack-integration/DAG-STUDIO-REDESIGN-HANDOFF.md
+++ b/docs/projects/graphite-stack-integration/DAG-STUDIO-REDESIGN-HANDOFF.md
@@ -55,3 +55,19 @@ These are the invariants the redesigned tab must keep. Everything else is negoti
 - No changes to the projection contract or oRPC schema for the re-skin.
 - No runtime/execution overlay (the DAG is static authoring structure; a "live run" overlay is a separate future feature).
 - The integration lane (this doc's author) will not touch your stack; sequencing questions go to the operator.
+
+## 6. Execution mandate (operator-granted)
+
+This section states your authority and expected mode of work explicitly, so nothing here has to be inferred.
+
+**What is non-negotiable.** The invariants in §2 and every item this doc marks "preserve" in §1 are hard constraints: the projection contract, the server boundary and transport path, the layout/domain/label semantics, the interaction semantics, and the behavioral pins in the test suites. The §5 non-goals are equally binding. Do not weaken, fork, or re-derive any of these.
+
+**Within those bounds, you own the design.** Step fully into design mode and systemic-analysis mode. You are not being asked to transplant the merged code's shape into your shell — you are being asked to decide, as the owner of the Studio design system, what the most **idiomatic, native** expression of this feature is inside the redesigned Studio, and to build that. Where the merged code's structure and your design system disagree about anything outside the §2 invariants, your design system wins.
+
+**Explicit permissions.** You have operator permission to:
+
+- Integrate the feature properly into the design system you manage — its navigation primitives, state layer, theming, component vocabulary — including making reasonable choices and trade-offs to match what you already have.
+- **Modularize** the merged code as you see fit: split, re-home, rename, or re-layer `features/recipeDag/*` modules (keeping their exported semantics intact), introduce whatever internal structure your decomposed shell calls for.
+- **Take the time to plan and specify before building.** Up-front analysis, a written design/spec, and staged execution are encouraged, not tolerated.
+
+**Expected workflow.** Execute this systematically, the way the repo's other major effort runs: structure the work as a **workstream**, and use the **OpenSpec workstream** machinery (proposal → design → tasks → workstream/phase records under `openspec/changes/`) to plan, record, and verify it. The merged feature's own workstream at `openspec/changes/mapgen-recipe-dag-visualization/` is both prior art for the format and the record of what the feature committed to; your workstream should reference it. Land the work through your lane's normal stacked-branch discipline with gates green at each step (§4 lists the gate expectations).


### PR DESCRIPTION
Adds an "Execution mandate" section to the DAG Studio redesign handoff document that explicitly grants the Studio design system owner authority and operating instructions for integrating the DAG visualization feature.

The section clarifies which constraints are hard (the §2 invariants, projection contract, server boundary, layout/domain/label semantics, interaction semantics, behavioral test pins, and §5 non-goals) and which decisions belong to the implementer. It explicitly permits modularizing `features/recipeDag/*` modules, integrating into the existing design system's navigation, state layer, theming, and component vocabulary, and taking time to plan before building.

It also establishes the expected workflow: structure the integration as a workstream using the OpenSpec machinery (`proposal → design → tasks → workstream/phase records`), reference the existing `mapgen-recipe-dag-visualization` workstream as prior art, and land work through stacked-branch discipline with gates green at each step.