### PR TITLE
feat(river-lake): hydrology benchmark summary, endpoint floor enforcement, native modelRivers integration, and Studio Water Proof inspector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,3 +68,11 @@ See `docs/process/GRAPHITE.md` and `docs/process/LINEAR.md` for full conventions
 
 - Open PRs against `origin`; details in `docs/process/CONTRIBUTING.md`.
 - Active work lives under `docs/projects/`.
+
+## Session Notice - Hydrology/River Recovery
+
+- For the current hydrology, river, lake, floodplain, and Studio hydrology
+  visualization recovery session, read
+  `docs/projects/river-lake-recovery/FRAME.md` after this router and before
+  touching related code, specs, or runtime proof.
+- Remove this notice when the hydrology/river recovery session ends.

--- a/apps/mapgen-studio/src/App.tsx
+++ b/apps/mapgen-studio/src/App.tsx
@@ -103,6 +103,10 @@ import {
   parseEraVariantKey,
   resolveFixedEraUiValue,
 } from "./features/viz/era";
+import {
+  buildRiverLakeFloodplainInspectorSummary,
+  type RiverLakeInspectorLayerRef,
+} from "./features/viz/riverLakeInspector";
 import { formatErrorForUi } from "./shared/errorFormat";
 import { shouldIgnoreGlobalShortcutsInEditableTarget } from "./shared/shortcuts/shortcutPolicy";
 import type { VizEvent } from "./shared/vizEvents";
@@ -2312,6 +2316,10 @@ function AppContent(props: AppContentProps) {
   }, [runInGameOperation, toast]);
 
   const dataTypeModel = viz.dataTypeModel;
+  const riverLakeInspectorSummary = useMemo(
+    () => buildRiverLakeFloodplainInspectorSummary(viz.manifest),
+    [viz.manifest]
+  );
   const dataTypeOptions: DataTypeOption[] = useMemo(() => {
     if (!dataTypeModel) return [];
     return dataTypeModel.dataTypes.map((dt) => ({ value: dt.dataTypeId, label: dt.label, group: dt.group }));
@@ -2532,6 +2540,20 @@ function AppContent(props: AppContentProps) {
       selectLayerFor(next, space.spaceId, rm.renderModeId);
     },
     [dataTypeModel, eraMode, manualEra, selectLayerFor]
+  );
+
+  const handleRiverLakeInspectorLayerSelect = useCallback(
+    (ref: RiverLakeInspectorLayerRef) => {
+      const stage = recipeArtifacts.uiMeta.stages.find((candidate) =>
+        candidate.steps.some((step) => step.fullStepId === ref.stepId)
+      );
+      if (stage) setSelectedStageId(stage.stageId);
+      setSelectedStepId(ref.stepId);
+      if (ref.visibility === "debug") viz.setShowDebugLayers(true);
+      viz.setSelectedStepId(ref.stepId);
+      viz.setSelectedLayerKey(ref.layerKey);
+    },
+    [recipeArtifacts.uiMeta.stages, viz]
   );
 
   const handleSpaceChange = useCallback(
@@ -2979,6 +3001,8 @@ function AppContent(props: AppContentProps) {
         if (!viz.activeBounds) return;
         deckApiRef.current?.fitToBounds(viz.activeBounds);
       }}
+      riverLakeInspectorSummary={riverLakeInspectorSummary}
+      onRiverLakeInspectorLayerSelect={handleRiverLakeInspectorLayerSelect}
       stageExpanded={exploreStageExpanded}
       onStageExpandedChange={setExploreStageExpanded}
       stepExpanded={exploreStepExpanded}

--- a/apps/mapgen-studio/src/features/configMigrations/pipelineConfig.ts
+++ b/apps/mapgen-studio/src/features/configMigrations/pipelineConfig.ts
@@ -1,5 +1,15 @@
 import type { PipelineConfig } from "../../ui/types";
 
+export class PipelineConfigMigrationError extends Error {
+  readonly details: readonly string[];
+
+  constructor(message: string, details: readonly string[]) {
+    super(message);
+    this.name = "PipelineConfigMigrationError";
+    this.details = details;
+  }
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
   const proto = Object.getPrototypeOf(value);
@@ -16,10 +26,40 @@ function cloneConfigValue(value: unknown): unknown {
   return out;
 }
 
+function hasOwn(obj: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function migrateMapRiversKnobs(root: unknown): void {
+  if (!isPlainObject(root)) return;
+  const mapRivers = root["map-rivers"];
+  if (!isPlainObject(mapRivers)) return;
+  const knobs = mapRivers.knobs;
+  if (!isPlainObject(knobs)) return;
+  if (!hasOwn(knobs, "riverDensity")) return;
+
+  const retired = knobs.riverDensity;
+  if (hasOwn(knobs, "navigableRiverDensity") && knobs.navigableRiverDensity !== retired) {
+    throw new PipelineConfigMigrationError("Conflicting map-rivers river density knobs.", [
+      "/map-rivers/knobs/riverDensity is retired; use /map-rivers/knobs/navigableRiverDensity.",
+      `Received riverDensity=${JSON.stringify(retired)} and navigableRiverDensity=${JSON.stringify(
+        knobs.navigableRiverDensity
+      )}.`,
+    ]);
+  }
+
+  if (!hasOwn(knobs, "navigableRiverDensity")) {
+    knobs.navigableRiverDensity = retired;
+  }
+  delete knobs.riverDensity;
+}
+
 export function migratePipelineConfig(value: PipelineConfig): PipelineConfig {
   return migratePipelineConfigUnknown(value) as PipelineConfig;
 }
 
 export function migratePipelineConfigUnknown(value: unknown): unknown {
-  return cloneConfigValue(value);
+  const next = cloneConfigValue(value);
+  migrateMapRiversKnobs(next);
+  return next;
 }

--- a/apps/mapgen-studio/src/features/presets/importFlow.ts
+++ b/apps/mapgen-studio/src/features/presets/importFlow.ts
@@ -3,7 +3,10 @@ import { stripSchemaMetadataRoot } from "@swooper/mapgen-core/authoring";
 
 import type { StudioPresetExportFileV1 } from "@swooper/mapgen-core/authoring";
 import type { RecipeArtifacts } from "../../recipes/catalog";
-import { migratePipelineConfigUnknown } from "../configMigrations/pipelineConfig";
+import {
+  PipelineConfigMigrationError,
+  migratePipelineConfigUnknown,
+} from "../configMigrations/pipelineConfig";
 
 export type ImportPresetResult =
   | Readonly<{
@@ -38,7 +41,20 @@ export function resolveImportedPreset(args: {
     };
   }
 
-  const sanitized = migratePipelineConfigUnknown(stripSchemaMetadataRoot(presetFile.preset.config));
+  let sanitized: unknown;
+  try {
+    sanitized = migratePipelineConfigUnknown(stripSchemaMetadataRoot(presetFile.preset.config));
+  } catch (error) {
+    if (error instanceof PipelineConfigMigrationError) {
+      return {
+        ok: false,
+        kind: "invalid-config",
+        message: error.message,
+        details: error.details,
+      };
+    }
+    throw error;
+  }
   const { value, errors } = normalizeStrict<Record<string, unknown>>(
     recipe.configSchema,
     sanitized,

--- a/apps/mapgen-studio/src/features/viz/riverLakeInspector.ts
+++ b/apps/mapgen-studio/src/features/viz/riverLakeInspector.ts
@@ -1,0 +1,400 @@
+import type {
+  VizLayerEntryV1,
+  VizLayerKind,
+  VizScalarFormat,
+  VizLayerVisibility,
+  VizManifestV1,
+  VizSpaceId,
+} from "@swooper/mapgen-viz";
+
+export type RiverLakeInspectorLane =
+  | "hydrology"
+  | "projection"
+  | "terrain-readback"
+  | "metadata-readback"
+  | "lakes"
+  | "floodplains"
+  | "rendered"
+  | "acceptance";
+
+export type RiverLakeInspectorProofClass =
+  | "hydrology-truth"
+  | "projection-plan"
+  | "terrain-readback"
+  | "metadata-readback"
+  | "lake-final"
+  | "floodplain-active"
+  | "studio-visible"
+  | "civ-rendered"
+  | "product-acceptance";
+
+export type RiverLakeInspectorClaimStatus = "pass" | "fail" | "unresolved" | "out-of-scope";
+
+export type RiverLakeInspectorDisplayStatus =
+  | "hydrology-truth-present"
+  | "projection-plan-present"
+  | "terrain-readback-present"
+  | "metadata-readback-present"
+  | "lake-readback-present"
+  | "floodplain-apply-present"
+  | "rendered-proof-missing"
+  | "acceptance-proof-missing"
+  | "no-physical-rivers"
+  | "minor-only-expected-no-navigable"
+  | "major-present-none-selected"
+  | "selected-rejected-by-engine"
+  | "terrain-match"
+  | "terrain-match-metadata-divergent"
+  | "terrain-mismatch"
+  | "metadata-readback-missing"
+  | "native-writer-parity-unproven"
+  | "floodplain-intent-missing"
+  | "floodplain-apply-rejected"
+  | "floodplain-live-missing"
+  | "lake-exact-log-missing";
+
+export type RiverLakeInspectorLayerRef = Readonly<{
+  dataTypeKey: string;
+  layerKey: string;
+  stepId: string;
+  stepIndex: number;
+  spaceId: VizSpaceId;
+  kind: VizLayerKind;
+  role: string | null;
+  variantKey: string | null;
+  visibility: VizLayerVisibility;
+  label: string;
+  renderModeId: string;
+  nonZeroCount: number | null;
+  sampleCount: number | null;
+}>;
+
+export type RiverLakeInspectorRow = Readonly<{
+  lane: RiverLakeInspectorLane;
+  laneLabel: string;
+  label: string;
+  proofClass: RiverLakeInspectorProofClass;
+  claimStatus: RiverLakeInspectorClaimStatus;
+  displayStatus: RiverLakeInspectorDisplayStatus;
+  counts: Readonly<Record<string, number>>;
+  layerRefs: readonly RiverLakeInspectorLayerRef[];
+  evidence: readonly string[];
+}>;
+
+export type RiverLakeFloodplainInspectorSummary = Readonly<{
+  version: 1;
+  rows: readonly RiverLakeInspectorRow[];
+}>;
+
+type LaneSpec = Readonly<{
+  lane: RiverLakeInspectorLane;
+  laneLabel: string;
+  label: string;
+  proofClass: RiverLakeInspectorProofClass;
+  dataTypeKeys: readonly string[];
+  requiredDataTypeKeys: readonly string[];
+  presentStatus: RiverLakeInspectorDisplayStatus;
+  missingStatus: RiverLakeInspectorDisplayStatus;
+  missingClaimStatus?: RiverLakeInspectorClaimStatus;
+  missingEvidence: string;
+  presentEvidence: string;
+}>;
+
+const LANE_SPECS: readonly LaneSpec[] = [
+  {
+    lane: "hydrology",
+    laneLabel: "Hydrology",
+    label: "Drainage truth",
+    proofClass: "hydrology-truth",
+    dataTypeKeys: [
+      "hydrology.hydrography.discharge",
+      "hydrology.hydrography.riverClass",
+      "hydrology.hydrography.upstreamArea",
+      "hydrology.hydrography.streamOrderProxy",
+      "hydrology.hydrography.flowPermanenceProxy",
+      "hydrology.hydrography.mouthType",
+      "hydrology.lakes.lakePlan",
+    ],
+    requiredDataTypeKeys: ["hydrology.hydrography.riverClass"],
+    presentStatus: "hydrology-truth-present",
+    missingStatus: "no-physical-rivers",
+    missingEvidence:
+      "No Hydrology river-class layer is present in this run manifest; Studio cannot prove physical river truth for this run.",
+    presentEvidence:
+      "Same-run Hydrology layers are present. Non-zero river counts require the Hydrology summary artifact, not manifest inference.",
+  },
+  {
+    lane: "projection",
+    laneLabel: "Projection",
+    label: "Navigable river plan",
+    proofClass: "projection-plan",
+    dataTypeKeys: [
+      "map.rivers.projectedRiverMask",
+      "map.rivers.plannedMinorRiverMask",
+      "map.rivers.plannedMajorRiverMask",
+      "map.rivers.riverClass",
+    ],
+    requiredDataTypeKeys: ["map.rivers.projectedRiverMask"],
+    presentStatus: "projection-plan-present",
+    missingStatus: "major-present-none-selected",
+    missingEvidence:
+      "No projected navigable-river mask is present; this run has no Studio-visible projection plan layer.",
+    presentEvidence:
+      "The projected navigable-river mask is present and labeled as projection-plan evidence, not engine terrain truth.",
+  },
+  {
+    lane: "terrain-readback",
+    laneLabel: "Terrain",
+    label: "Engine terrain readback",
+    proofClass: "terrain-readback",
+    dataTypeKeys: ["map.rivers.engineRiverMask", "map.rivers.riverMismatchMask"],
+    requiredDataTypeKeys: ["map.rivers.engineRiverMask"],
+    presentStatus: "terrain-readback-present",
+    missingStatus: "selected-rejected-by-engine",
+    missingEvidence:
+      "No engine terrain readback layer is present; terrain parity cannot be checked from this manifest.",
+    presentEvidence:
+      "The engine terrain readback layer is present. Exact parity still depends on same-run mismatch counters.",
+  },
+  {
+    lane: "metadata-readback",
+    laneLabel: "Metadata",
+    label: "Civ river metadata",
+    proofClass: "metadata-readback",
+    dataTypeKeys: [
+      "map.rivers.engineNavigableRiverMetadataMask",
+      "map.rivers.engineMinorRiverMask",
+      "map.rivers.riverMismatchMask",
+    ],
+    requiredDataTypeKeys: ["map.rivers.engineNavigableRiverMetadataMask"],
+    presentStatus: "metadata-readback-present",
+    missingStatus: "metadata-readback-missing",
+    missingEvidence:
+      "No Civ river metadata readback layer is present; metadata parity is unresolved for this run.",
+    presentEvidence:
+      "Civ river metadata readback layers are present behind debug inspection.",
+  },
+  {
+    lane: "lakes",
+    laneLabel: "Lakes",
+    label: "Lake plan and readback",
+    proofClass: "lake-final",
+    dataTypeKeys: [
+      "hydrology.lakes.lakePlan",
+      "map.hydrology.lakes.plannedLakeMask",
+      "map.hydrology.lakes.engineLakeMask",
+      "map.hydrology.lakes.rejectedLakeMask",
+    ],
+    requiredDataTypeKeys: ["map.hydrology.lakes.plannedLakeMask", "map.hydrology.lakes.engineLakeMask"],
+    presentStatus: "lake-readback-present",
+    missingStatus: "lake-exact-log-missing",
+    missingEvidence:
+      "Lake plan/readback layers are incomplete; exact lake acceptance requires planned and engine lake evidence.",
+    presentEvidence:
+      "Lake plan and engine readback layers are present. Exact drift counts come from lake parity counters.",
+  },
+  {
+    lane: "floodplains",
+    laneLabel: "Floodplains",
+    label: "Feature application",
+    proofClass: "floodplain-active",
+    dataTypeKeys: ["map.ecology.featureType", "map.ecology.features.rejectionMask"],
+    requiredDataTypeKeys: ["map.ecology.featureType"],
+    presentStatus: "floodplain-apply-present",
+    missingStatus: "floodplain-live-missing",
+    missingEvidence:
+      "No final feature-type layer is present; floodplain application/readback cannot be inspected from this manifest.",
+    presentEvidence:
+      "Final feature application layers are present. Floodplain-specific active counts require feature counters.",
+  },
+  {
+    lane: "rendered",
+    laneLabel: "Rendered",
+    label: "In-game visible rivers",
+    proofClass: "civ-rendered",
+    dataTypeKeys: [],
+    requiredDataTypeKeys: [],
+    presentStatus: "rendered-proof-missing",
+    missingStatus: "rendered-proof-missing",
+    missingClaimStatus: "unresolved",
+    missingEvidence:
+      "Studio manifest layers cannot prove rendered Civ visibility; this row closes only with same-run game screenshots.",
+    presentEvidence:
+      "Studio manifest layers cannot prove rendered Civ visibility; this row closes only with same-run game screenshots.",
+  },
+  {
+    lane: "acceptance",
+    laneLabel: "Acceptance",
+    label: "Product closure",
+    proofClass: "product-acceptance",
+    dataTypeKeys: [],
+    requiredDataTypeKeys: [],
+    presentStatus: "acceptance-proof-missing",
+    missingStatus: "acceptance-proof-missing",
+    missingClaimStatus: "unresolved",
+    missingEvidence:
+      "Product acceptance requires Hydrology, projection, readback, Studio parity, and rendered Civ evidence from the same run.",
+    presentEvidence:
+      "Product acceptance requires Hydrology, projection, readback, Studio parity, and rendered Civ evidence from the same run.",
+  },
+];
+
+const COUNT_LABEL_BY_DATA_TYPE_KEY: Readonly<Record<string, string>> = {
+  "hydrology.hydrography.riverClass": "rivers",
+  "hydrology.lakes.lakePlan": "lake intent",
+  "map.rivers.projectedRiverMask": "projected",
+  "map.rivers.plannedMinorRiverMask": "minor",
+  "map.rivers.plannedMajorRiverMask": "major",
+  "map.rivers.engineRiverMask": "terrain",
+  "map.rivers.engineNavigableRiverMetadataMask": "metadata",
+  "map.rivers.engineMinorRiverMask": "minor meta",
+  "map.rivers.riverMismatchMask": "mismatch",
+  "map.hydrology.lakes.plannedLakeMask": "planned lakes",
+  "map.hydrology.lakes.engineLakeMask": "engine lakes",
+  "map.hydrology.lakes.rejectedLakeMask": "rejected lakes",
+  "map.ecology.featureType": "features",
+  "map.ecology.features.rejectionMask": "feature rejects",
+};
+
+function resolveLayerVisibility(layer: VizLayerEntryV1): VizLayerVisibility {
+  const visibility = layer.meta?.visibility;
+  if (visibility === "debug") return "debug";
+  if (visibility === "hidden") return "hidden";
+  return "default";
+}
+
+function renderModeIdFor(layer: VizLayerEntryV1): string {
+  const role = layer.meta?.role;
+  return role ? `${layer.kind}:${role}` : layer.kind;
+}
+
+function asNumberArray(buffer: ArrayBuffer, format: VizScalarFormat): ArrayLike<number> | null {
+  if (format === "u8") return new Uint8Array(buffer);
+  if (format === "i8") return new Int8Array(buffer);
+  if (format === "u16") return new Uint16Array(buffer);
+  if (format === "i16") return new Int16Array(buffer);
+  if (format === "i32") return new Int32Array(buffer);
+  if (format === "f32") return new Float32Array(buffer);
+  return null;
+}
+
+function countNonZeroSamples(layer: VizLayerEntryV1): { nonZeroCount: number; sampleCount: number } | null {
+  if (layer.kind !== "grid") return null;
+  if (layer.field.data.kind !== "inline") return null;
+  const values = asNumberArray(layer.field.data.buffer, layer.field.format);
+  if (!values) return null;
+
+  let nonZeroCount = 0;
+  let sampleCount = 0;
+  for (let i = 0; i < values.length; i++) {
+    const value = values[i] as number;
+    if (!Number.isFinite(value)) continue;
+    sampleCount += 1;
+    if (value !== 0) nonZeroCount += 1;
+  }
+
+  return { nonZeroCount, sampleCount };
+}
+
+function toLayerRef(layer: VizLayerEntryV1): RiverLakeInspectorLayerRef {
+  const samples = countNonZeroSamples(layer);
+  return {
+    dataTypeKey: layer.dataTypeKey,
+    layerKey: layer.layerKey,
+    stepId: layer.stepId,
+    stepIndex: layer.stepIndex,
+    spaceId: layer.spaceId,
+    kind: layer.kind,
+    role: layer.meta?.role ?? null,
+    variantKey: layer.variantKey ?? null,
+    visibility: resolveLayerVisibility(layer),
+    label: layer.meta?.label ?? layer.dataTypeKey,
+    renderModeId: renderModeIdFor(layer),
+    nonZeroCount: samples?.nonZeroCount ?? null,
+    sampleCount: samples?.sampleCount ?? null,
+  };
+}
+
+function collectRefs(
+  layersByDataTypeKey: ReadonlyMap<string, readonly VizLayerEntryV1[]>,
+  dataTypeKeys: readonly string[]
+): RiverLakeInspectorLayerRef[] {
+  const refs: RiverLakeInspectorLayerRef[] = [];
+  for (const dataTypeKey of dataTypeKeys) {
+    const layers = layersByDataTypeKey.get(dataTypeKey) ?? [];
+    for (const layer of layers) refs.push(toLayerRef(layer));
+  }
+  return refs.sort((a, b) => {
+    if (a.stepIndex !== b.stepIndex) return a.stepIndex - b.stepIndex;
+    return a.layerKey.localeCompare(b.layerKey);
+  });
+}
+
+function hasRequiredRefs(
+  layersByDataTypeKey: ReadonlyMap<string, readonly VizLayerEntryV1[]>,
+  requiredDataTypeKeys: readonly string[]
+): boolean {
+  if (requiredDataTypeKeys.length === 0) return false;
+  return requiredDataTypeKeys.every((dataTypeKey) => (layersByDataTypeKey.get(dataTypeKey)?.length ?? 0) > 0);
+}
+
+function countByVisibility(refs: readonly RiverLakeInspectorLayerRef[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  if (refs.length > 0) counts.layers = refs.length;
+  const defaultCount = refs.filter((ref) => ref.visibility === "default").length;
+  const debugCount = refs.filter((ref) => ref.visibility === "debug").length;
+  if (defaultCount > 0) counts.default = defaultCount;
+  if (debugCount > 0) counts.debug = debugCount;
+  for (const ref of refs) {
+    const label = COUNT_LABEL_BY_DATA_TYPE_KEY[ref.dataTypeKey];
+    if (!label || ref.nonZeroCount == null) continue;
+    counts[label] = (counts[label] ?? 0) + ref.nonZeroCount;
+  }
+  return counts;
+}
+
+export function buildRiverLakeFloodplainInspectorSummary(
+  manifest: Pick<VizManifestV1, "layers"> | null
+): RiverLakeFloodplainInspectorSummary | null {
+  if (!manifest) return null;
+
+  const mutableByDataTypeKey = new Map<string, VizLayerEntryV1[]>();
+  for (const layer of manifest.layers) {
+    const current = mutableByDataTypeKey.get(layer.dataTypeKey);
+    if (current) current.push(layer);
+    else mutableByDataTypeKey.set(layer.dataTypeKey, [layer]);
+  }
+
+  const layersByDataTypeKey = new Map<string, readonly VizLayerEntryV1[]>();
+  for (const [dataTypeKey, layers] of mutableByDataTypeKey) {
+    layersByDataTypeKey.set(
+      dataTypeKey,
+      [...layers].sort((a, b) => {
+        if (a.stepIndex !== b.stepIndex) return a.stepIndex - b.stepIndex;
+        return a.layerKey.localeCompare(b.layerKey);
+      })
+    );
+  }
+
+  return {
+    version: 1,
+    rows: LANE_SPECS.map((spec) => {
+      const layerRefs = collectRefs(layersByDataTypeKey, spec.dataTypeKeys);
+      const hasEvidence = hasRequiredRefs(layersByDataTypeKey, spec.requiredDataTypeKeys);
+      const claimStatus: RiverLakeInspectorClaimStatus = hasEvidence
+        ? "pass"
+        : spec.missingClaimStatus ?? "unresolved";
+      return {
+        lane: spec.lane,
+        laneLabel: spec.laneLabel,
+        label: spec.label,
+        proofClass: spec.proofClass,
+        claimStatus,
+        displayStatus: hasEvidence ? spec.presentStatus : spec.missingStatus,
+        counts: countByVisibility(layerRefs),
+        layerRefs,
+        evidence: [hasEvidence ? spec.presentEvidence : spec.missingEvidence],
+      };
+    }),
+  };
+}

--- a/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
+++ b/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
@@ -16,8 +16,14 @@ import {
   CircleDot,
   Activity,
   Bug,
-  Flame } from
+  Flame,
+  Droplets } from
 'lucide-react';
+import type {
+  RiverLakeFloodplainInspectorSummary,
+  RiverLakeInspectorClaimStatus,
+  RiverLakeInspectorLayerRef,
+} from '../../features/viz/riverLakeInspector';
 import type {
   StageOption,
   StepOption,
@@ -103,6 +109,10 @@ export interface ExplorePanelProps {
   onShowDebugLayersChange: (show: boolean) => void;
   /** Callback when fit view is requested */
   onFitView: () => void;
+  /** River/lake/floodplain proof navigator */
+  riverLakeInspectorSummary?: RiverLakeFloodplainInspectorSummary | null;
+  /** Callback when a proof layer should be selected */
+  onRiverLakeInspectorLayerSelect?: (layerRef: RiverLakeInspectorLayerRef) => void;
   /** Whether the stage section is expanded (optional controlled mode) */
   stageExpanded?: boolean;
   /** Callback when stageExpanded changes (optional controlled mode) */
@@ -156,6 +166,8 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
   showDebugLayers,
   onShowDebugLayersChange,
   onFitView,
+  riverLakeInspectorSummary = null,
+  onRiverLakeInspectorLayerSelect,
   stageExpanded: stageExpandedProp,
   onStageExpandedChange,
   stepExpanded: stepExpandedProp,
@@ -229,6 +241,7 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
   const textMuted = lightMode ? 'text-[#9ca3af]' : 'text-[#5a5a66]';
   const borderSubtle = lightMode ? 'border-gray-100' : 'border-[#222228]';
   const hoverBg = lightMode ? 'hover:bg-gray-50' : 'hover:bg-[#1a1a1f]';
+  const chipBg = lightMode ? 'bg-gray-100 text-gray-600' : 'bg-[#222228] text-[#8a8a96]';
   const listMaxHeight = "max-h-[200px]";
   // Stage list styles
   const stageItemBase = `w-full text-left px-3 py-2 text-[11px] font-medium transition-colors cursor-pointer flex items-center gap-2`;
@@ -316,6 +329,62 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
       const current = prev[key] ?? true;
       return { ...prev, [key]: !current };
     });
+  };
+
+  const inspectorRows = riverLakeInspectorSummary?.rows ?? [];
+  const statusChipClass = (status: RiverLakeInspectorClaimStatus) => {
+    if (status === "pass") {
+      return lightMode ? "bg-emerald-50 text-emerald-700" : "bg-emerald-950/60 text-emerald-300";
+    }
+    if (status === "fail") {
+      return lightMode ? "bg-red-50 text-red-700" : "bg-red-950/60 text-red-300";
+    }
+    if (status === "out-of-scope") {
+      return lightMode ? "bg-gray-100 text-gray-500" : "bg-[#222228] text-[#7a7a86]";
+    }
+    return lightMode ? "bg-amber-50 text-amber-700" : "bg-amber-950/60 text-amber-300";
+  };
+  const statusLabel = (status: RiverLakeInspectorClaimStatus) => {
+    switch (status) {
+      case "pass":
+        return "ready";
+      case "fail":
+        return "fail";
+      case "out-of-scope":
+        return "skip";
+      case "unresolved":
+      default:
+        return "open";
+    }
+  };
+  const formatCountLabel = (key: string) => {
+    switch (key) {
+      case "layers":
+        return "layers";
+      case "default":
+        return "shown";
+      case "debug":
+        return "debug";
+      default:
+        return key;
+    }
+  };
+  const formatLayerButtonLabel = (ref: RiverLakeInspectorLayerRef) => {
+    if (ref.dataTypeKey.includes("projectedRiverMask")) return "projected";
+    if (ref.dataTypeKey.includes("plannedMinorRiverMask")) return "minor";
+    if (ref.dataTypeKey.includes("plannedMajorRiverMask")) return "major";
+    if (ref.dataTypeKey.includes("engineRiverMask")) return "terrain";
+    if (ref.dataTypeKey.includes("Metadata")) return "metadata";
+    if (ref.dataTypeKey.includes("engineMinorRiverMask")) return "minor meta";
+    if (ref.dataTypeKey.includes("riverMismatchMask")) return "mismatch";
+    if (ref.dataTypeKey.includes("lakePlan")) return "lake plan";
+    if (ref.dataTypeKey.includes("plannedLakeMask")) return "planned";
+    if (ref.dataTypeKey.includes("engineLakeMask")) return "engine";
+    if (ref.dataTypeKey.includes("rejectedLakeMask")) return "rejected";
+    if (ref.dataTypeKey.includes("featureType")) return "features";
+    if (ref.dataTypeKey.includes("rejectionMask")) return "rejects";
+    const parts = ref.dataTypeKey.split(".");
+    return parts[parts.length - 1] ?? ref.dataTypeKey;
   };
   // ==========================================================================
   // Render
@@ -413,6 +482,58 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
             <div className={`px-3 py-2 text-[11px] ${textMuted} italic`}>No steps available</div>
           )}
         </div>
+      ) : null}
+
+      {/* WATER PROOF SECTION */}
+      {inspectorRows.length > 0 ? (
+        <>
+          <div className={`flex-shrink-0 border-b ${borderSubtle}`}>
+            <div className="w-full flex items-center justify-between px-3 py-2">
+              <div className="flex items-center gap-2 min-w-0 overflow-hidden">
+                <Droplets className={`w-3.5 h-3.5 shrink-0 ${textSecondary}`} />
+                <span className={`text-[11px] font-semibold ${textSecondary} uppercase tracking-wider`}>
+                  Water Proof
+                </span>
+              </div>
+              <span className={`text-[10px] ${textMuted}`}>{inspectorRows.length}</span>
+            </div>
+          </div>
+          <div className={`flex-shrink-0 border-b ${borderSubtle} max-h-[260px] overflow-y-auto custom-scrollbar`}>
+            {inspectorRows.map((row) => (
+              <div key={row.lane} className={`px-3 py-2 border-b last:border-b-0 ${borderSubtle}`}>
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className={`text-[9px] uppercase tracking-wider ${textMuted}`}>{row.laneLabel}</div>
+                    <div className={`text-[11px] font-medium ${textPrimary} truncate`} title={row.displayStatus}>
+                      {row.label}
+                    </div>
+                  </div>
+                  <span className={`shrink-0 rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider ${statusChipClass(row.claimStatus)}`}>
+                    {statusLabel(row.claimStatus)}
+                  </span>
+                </div>
+                <div className="mt-1 flex flex-wrap items-center gap-1">
+                  {Object.entries(row.counts).map(([key, value]) => (
+                    <span key={key} className={`rounded px-1.5 py-0.5 text-[9px] ${chipBg}`}>
+                      {formatCountLabel(key)} {value}
+                    </span>
+                  ))}
+                  {row.layerRefs.slice(0, 4).map((ref) => (
+                    <button
+                      type="button"
+                      key={ref.layerKey}
+                      onClick={() => onRiverLakeInspectorLayerSelect?.(ref)}
+                      title={`${ref.label} · ${row.proofClass}`}
+                      className={`max-w-[96px] truncate rounded px-1.5 py-0.5 text-[9px] transition-colors ${lightMode ? "bg-white border border-gray-200 text-gray-700 hover:bg-gray-50" : "bg-[#111116] border border-[#2a2a32] text-[#c4c4cc] hover:bg-[#1a1a1f]"}`}
+                    >
+                      {formatLayerButtonLabel(ref)}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
       ) : null}
 
       {/* 3. LAYERS SECTION */}

--- a/apps/mapgen-studio/test/config/pipelineConfigMigration.test.ts
+++ b/apps/mapgen-studio/test/config/pipelineConfigMigration.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { StudioPresetExportFileV1 } from "@swooper/mapgen-core/authoring";
+import {
+  PipelineConfigMigrationError,
+  migratePipelineConfigUnknown,
+} from "../../src/features/configMigrations/pipelineConfig";
+import { resolveImportedPreset } from "../../src/features/presets/importFlow";
+import { findRecipeArtifacts } from "../../src/recipes/catalog";
+
+describe("migratePipelineConfigUnknown", () => {
+  it("migrates retired map-rivers riverDensity without touching Hydrology riverDensity", () => {
+    const input = {
+      "hydrology-hydrography": {
+        knobs: {
+          riverDensity: "dense",
+          lakeiness: "many",
+        },
+      },
+      "map-rivers": {
+        knobs: {
+          riverDensity: "sparse",
+        },
+      },
+    };
+
+    const migrated = migratePipelineConfigUnknown(input) as any;
+
+    expect(migrated["hydrology-hydrography"].knobs).toEqual({
+      riverDensity: "dense",
+      lakeiness: "many",
+    });
+    expect(migrated["map-rivers"].knobs).toEqual({
+      navigableRiverDensity: "sparse",
+    });
+    expect(input["map-rivers"].knobs).toEqual({
+      riverDensity: "sparse",
+    });
+  });
+
+  it("removes duplicate retired map-rivers riverDensity when it matches the current knob", () => {
+    const migrated = migratePipelineConfigUnknown({
+      "map-rivers": {
+        knobs: {
+          riverDensity: "dense",
+          navigableRiverDensity: "dense",
+        },
+      },
+    }) as any;
+
+    expect(migrated["map-rivers"].knobs).toEqual({
+      navigableRiverDensity: "dense",
+    });
+  });
+
+  it("rejects conflicting retired and current map-rivers density values", () => {
+    expect(() =>
+      migratePipelineConfigUnknown({
+        "map-rivers": {
+          knobs: {
+            riverDensity: "sparse",
+            navigableRiverDensity: "dense",
+          },
+        },
+      })
+    ).toThrow(PipelineConfigMigrationError);
+  });
+});
+
+describe("resolveImportedPreset migration conflicts", () => {
+  it("reports precise retired map-rivers density conflicts as invalid config", () => {
+    const presetFile: StudioPresetExportFileV1 = {
+      $schema: "https://civ7.tools/schemas/mapgen-studio/studio-preset-export.v1.schema.json",
+      version: 1,
+      recipeId: "mod-swooper-maps/standard",
+      preset: {
+        label: "Conflicting Rivers",
+        config: {
+          "map-rivers": {
+            knobs: {
+              riverDensity: "sparse",
+              navigableRiverDensity: "dense",
+            },
+          },
+        },
+      },
+    };
+
+    const result = resolveImportedPreset({ presetFile, findRecipeArtifacts });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.kind).toBe("invalid-config");
+      expect(result.message).toBe("Conflicting map-rivers river density knobs.");
+      expect(result.details?.join("\n")).toContain("/map-rivers/knobs/riverDensity is retired");
+    }
+  });
+});

--- a/apps/mapgen-studio/test/viz/dataTypeModel.test.ts
+++ b/apps/mapgen-studio/test/viz/dataTypeModel.test.ts
@@ -109,7 +109,7 @@ describe("buildStepDataTypeModel", () => {
     });
 
     const layers = [
-      layer("map.rivers.projectedRiverMask", "default", "engine"),
+      layer("map.rivers.projectedRiverMask", "default", "projection"),
       layer("map.rivers.plannedMinorRiverMask", "default", "physics"),
       layer("map.rivers.plannedMajorRiverMask", "default", "physics"),
       layer("map.rivers.engineRiverMask", "default", "engine"),
@@ -144,7 +144,7 @@ describe("buildStepDataTypeModel", () => {
     ]);
 
     const byId = new Map(debugModel.dataTypes.map((dt) => [dt.dataTypeId, dt]));
-    expect(byId.get("map.rivers.projectedRiverMask")?.spaces[0]?.renderModes[0]?.renderModeId).toBe("grid:engine");
+    expect(byId.get("map.rivers.projectedRiverMask")?.spaces[0]?.renderModes[0]?.renderModeId).toBe("grid:projection");
     expect(byId.get("map.rivers.plannedMinorRiverMask")?.spaces[0]?.renderModes[0]?.renderModeId).toBe("grid:physics");
     expect(byId.get("map.rivers.plannedMajorRiverMask")?.spaces[0]?.renderModes[0]?.renderModeId).toBe("grid:physics");
     expect(byId.get("map.rivers.engineRiverMask")?.spaces[0]?.renderModes[0]?.renderModeId).toBe("grid:engine");
@@ -226,7 +226,7 @@ describe("buildStepDataTypeModel", () => {
     ]);
 
     const byId = new Map(debugModel.dataTypes.map((dt) => [dt.dataTypeId, dt]));
-    expect(byId.get("map.rivers.projectedRiverMask")?.spaces[0]?.renderModes[0]?.renderModeId).toBe("grid:engine");
+    expect(byId.get("map.rivers.projectedRiverMask")?.spaces[0]?.renderModes[0]?.renderModeId).toBe("grid:projection");
     expect(byId.get("map.rivers.plannedMinorRiverMask")?.spaces[0]?.renderModes[0]?.renderModeId).toBe("grid:physics");
     expect(byId.get("map.rivers.plannedMajorRiverMask")?.spaces[0]?.renderModes[0]?.renderModeId).toBe("grid:physics");
     expect(byId.get("map.rivers.engineRiverMask")?.spaces[0]?.renderModes[0]?.renderModeId).toBe("grid:engine");

--- a/apps/mapgen-studio/test/viz/riverLakeInspector.test.ts
+++ b/apps/mapgen-studio/test/viz/riverLakeInspector.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import { createMockAdapter } from "@civ7/adapter";
+import { createExtendedMapContext } from "@swooper/mapgen-core";
+import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
+import type { VizLayerEntryV1 } from "../../src/features/viz/model";
+import { createWorkerTraceSink } from "../../src/browser-runner/worker-trace-sink";
+import { createWorkerVizDumper } from "../../src/browser-runner/worker-viz-dumper";
+import { buildRiverLakeFloodplainInspectorSummary } from "../../src/features/viz/riverLakeInspector";
+import type { BrowserRunEvent } from "../../src/browser-runner/protocol";
+import standardRecipe from "mod-swooper-maps/recipes/standard";
+import { standardMapConfigs } from "mod-swooper-maps/recipes/standard-map-configs";
+
+function gridLayer(args: {
+  stepId: string;
+  stepIndex?: number;
+  dataTypeKey: string;
+  role?: string;
+  visibility?: "default" | "debug" | "hidden";
+  values?: readonly number[];
+}): VizLayerEntryV1 {
+  const { stepId, stepIndex = 0, dataTypeKey, role, visibility = "default", values } = args;
+  const buffer = values ? Uint8Array.from(values).buffer : null;
+  return {
+    kind: "grid",
+    layerKey: `${stepId}::${dataTypeKey}::tile.hexOddQ::${role ? `grid:${role}` : "grid"}`,
+    dataTypeKey,
+    stepId,
+    stepIndex,
+    spaceId: "tile.hexOddQ",
+    dims: { width: 4, height: 3 },
+    field: { format: "u8", data: buffer ? { kind: "inline", buffer } : { kind: "path", path: `${dataTypeKey}.u8` } },
+    bounds: [0, 0, 4, 3],
+    meta: { label: dataTypeKey, role, visibility } as any,
+  };
+}
+
+describe("buildRiverLakeFloodplainInspectorSummary", () => {
+  it("separates projection, terrain readback, metadata, lakes, and rendered acceptance", () => {
+    const hydroStep = "mod-swooper-maps.standard.hydrology-hydrography.rivers";
+    const mapRiverStep = "mod-swooper-maps.standard.map-rivers.plot-rivers";
+    const mapLakeStep = "mod-swooper-maps.standard.map-hydrology.lakes";
+    const featuresStep = "mod-swooper-maps.standard.map-ecology.features-apply";
+    const summary = buildRiverLakeFloodplainInspectorSummary({
+      layers: [
+        gridLayer({ stepId: hydroStep, stepIndex: 1, dataTypeKey: "hydrology.hydrography.riverClass" }),
+        gridLayer({ stepId: hydroStep, stepIndex: 1, dataTypeKey: "hydrology.hydrography.discharge" }),
+        gridLayer({
+          stepId: mapRiverStep,
+          stepIndex: 2,
+          dataTypeKey: "map.rivers.projectedRiverMask",
+          role: "projection",
+          values: [0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+        }),
+        gridLayer({
+          stepId: mapRiverStep,
+          stepIndex: 2,
+          dataTypeKey: "map.rivers.plannedMajorRiverMask",
+          role: "physics",
+          values: [0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+        }),
+        gridLayer({
+          stepId: mapRiverStep,
+          stepIndex: 2,
+          dataTypeKey: "map.rivers.engineRiverMask",
+          role: "engine",
+          values: [0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+        }),
+        gridLayer({
+          stepId: mapRiverStep,
+          stepIndex: 2,
+          dataTypeKey: "map.rivers.engineNavigableRiverMetadataMask",
+          role: "engine",
+          visibility: "debug",
+          values: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        }),
+        gridLayer({
+          stepId: mapLakeStep,
+          stepIndex: 3,
+          dataTypeKey: "map.hydrology.lakes.plannedLakeMask",
+          role: "projection",
+          values: [0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0],
+        }),
+        gridLayer({
+          stepId: mapLakeStep,
+          stepIndex: 3,
+          dataTypeKey: "map.hydrology.lakes.engineLakeMask",
+          role: "engine",
+          values: [0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0],
+        }),
+        gridLayer({
+          stepId: featuresStep,
+          stepIndex: 4,
+          dataTypeKey: "map.ecology.featureType",
+          role: "engine",
+          values: [0, 0, 5, 0, 0, 8, 0, 0, 0, 0, 0, 0],
+        }),
+      ],
+    });
+
+    expect(summary?.version).toBe(1);
+    const byLane = new Map(summary?.rows.map((row) => [row.lane, row]));
+
+    const projection = byLane.get("projection");
+    expect(projection?.proofClass).toBe("projection-plan");
+    expect(projection?.claimStatus).toBe("pass");
+    expect(projection?.displayStatus).toBe("projection-plan-present");
+    expect(projection?.layerRefs.find((ref) => ref.dataTypeKey === "map.rivers.projectedRiverMask")).toMatchObject({
+      role: "projection",
+      renderModeId: "grid:projection",
+      nonZeroCount: 2,
+    });
+    expect(projection?.counts).toMatchObject({ projected: 2, major: 3 });
+
+    expect(byLane.get("terrain-readback")).toMatchObject({
+      proofClass: "terrain-readback",
+      claimStatus: "pass",
+      displayStatus: "terrain-readback-present",
+    });
+    expect(byLane.get("metadata-readback")?.counts).toMatchObject({ layers: 1, debug: 1, metadata: 1 });
+    expect(byLane.get("lakes")).toMatchObject({
+      proofClass: "lake-final",
+      claimStatus: "pass",
+      displayStatus: "lake-readback-present",
+    });
+    expect(byLane.get("lakes")?.counts).toMatchObject({ "planned lakes": 2, "engine lakes": 2 });
+    expect(byLane.get("floodplains")).toMatchObject({
+      proofClass: "floodplain-active",
+      claimStatus: "pass",
+      displayStatus: "floodplain-apply-present",
+    });
+    expect(byLane.get("floodplains")?.counts).toMatchObject({ features: 2 });
+    expect(byLane.get("rendered")).toMatchObject({
+      proofClass: "civ-rendered",
+      claimStatus: "unresolved",
+      displayStatus: "rendered-proof-missing",
+    });
+    expect(byLane.get("acceptance")).toMatchObject({
+      proofClass: "product-acceptance",
+      claimStatus: "unresolved",
+      displayStatus: "acceptance-proof-missing",
+    });
+  });
+
+  it("builds proof rows from actual standard recipe Studio emissions", () => {
+    const width = 32;
+    const height = 20;
+    const seed = 1337;
+    const mapInfo = {
+      GridWidth: width,
+      GridHeight: height,
+      MinLatitude: -60,
+      MaxLatitude: 60,
+      PlayersLandmass1: 4,
+      PlayersLandmass2: 4,
+      StartSectorRows: 4,
+      StartSectorCols: 4,
+    };
+    const envBase = {
+      seed,
+      dimensions: { width, height },
+      latitudeBounds: {
+        topLatitude: mapInfo.MaxLatitude,
+        bottomLatitude: mapInfo.MinLatitude,
+      },
+    };
+    const standardConfig = standardMapConfigs.find((config) => config.id === "swooper-earthlike")?.config;
+    if (!standardConfig) throw new Error("swooper-earthlike config missing from standard map config catalog");
+    const plan = standardRecipe.compile(envBase, standardConfig);
+    const verboseSteps = Object.fromEntries(plan.nodes.map((node) => [node.stepId, "verbose"] as const));
+    const env = {
+      ...envBase,
+      trace: {
+        enabled: true,
+        steps: verboseSteps,
+      },
+    };
+    const adapter = createMockAdapter({ width, height, mapInfo, mapSizeId: 1, rng: createLabelRng(seed) });
+    const context = createExtendedMapContext({ width, height }, adapter, env);
+    const events: BrowserRunEvent[] = [];
+    context.viz = createWorkerVizDumper();
+
+    standardRecipe.run(context, env, standardConfig, {
+      traceSink: createWorkerTraceSink({
+        runToken: "studio-river-lake-inspector-test",
+        generation: 1,
+        post: (event) => events.push(event),
+      }),
+      log: () => {},
+    });
+
+    const layers = events.flatMap((event) => (event.type === "viz.layer.upsert" ? [event.layer] : []));
+    const summary = buildRiverLakeFloodplainInspectorSummary({ layers });
+    const byLane = new Map(summary?.rows.map((row) => [row.lane, row]));
+
+    const projected = byLane
+      .get("projection")
+      ?.layerRefs.find((ref) => ref.dataTypeKey === "map.rivers.projectedRiverMask");
+    expect(projected).toMatchObject({ role: "projection", renderModeId: "grid:projection" });
+    expect(projected?.nonZeroCount).toBeGreaterThan(0);
+
+    expect(byLane.get("hydrology")?.claimStatus).toBe("pass");
+    expect(byLane.get("projection")?.claimStatus).toBe("pass");
+    expect(byLane.get("terrain-readback")?.layerRefs.map((ref) => ref.dataTypeKey)).toContain(
+      "map.rivers.engineRiverMask"
+    );
+    expect(byLane.get("metadata-readback")?.layerRefs.map((ref) => ref.dataTypeKey)).toContain(
+      "map.rivers.engineNavigableRiverMetadataMask"
+    );
+    expect(byLane.get("lakes")?.layerRefs.map((ref) => ref.dataTypeKey)).toEqual(
+      expect.arrayContaining(["map.hydrology.lakes.plannedLakeMask", "map.hydrology.lakes.engineLakeMask"])
+    );
+    expect(byLane.get("rendered")?.claimStatus).toBe("unresolved");
+    expect(byLane.get("acceptance")?.claimStatus).toBe("unresolved");
+  });
+});

--- a/docs/projects/river-lake-recovery/ADVERSARIAL-SYNTHESIS-2026-06-10.md
+++ b/docs/projects/river-lake-recovery/ADVERSARIAL-SYNTHESIS-2026-06-10.md
@@ -1,0 +1,60 @@
+# Adversarial Synthesis - 2026-06-10
+
+This synthesis records the current adversarial pass for the river/lake recovery
+frame. It is not closure evidence. It is a control artifact for the next code
+slices.
+
+## High-Confidence Findings
+
+- Rivers still are not product-proven. Terrain readback has been proven in some
+  runs; rendered in-game visible rivers have not been proven as a product row.
+- The native Civ river writer question changed shape. A disposable runtime probe
+  proved `TerrainBuilder.modelRivers(...)` can author live river metadata in
+  bulk. The open question is whether it can be constrained to Hydrology-authored
+  truth without delegating truth to the engine.
+- Hydrology now owns canonical drainage routing in the current code. Morphology
+  still has a flow-routing proxy for terrain-shaping consumers; that proxy is
+  not the Hydrology truth graph.
+- `map-rivers` currently stamps selected navigable terrain directly and calls
+  validation/naming/store routines, but it does not currently produce full Civ
+  river metadata parity.
+- The `selectNavigableRiverTerrain` contract reports an
+  `endpointDischargePercentileMin` floor but the current strategy does not
+  enforce the floor when choosing endpoints. This is a contract bug unless the
+  field is renamed or removed.
+- Studio has many raw river/lake/floodplain layers, but not a clean operational
+  proof ladder from planned truth through projection/readback/rendered verdict.
+- Some OpenSpec records still contain stale selector language such as
+  `minLength/maxLength`. That language should not survive as an accepted product
+  model.
+- Floodplain proof still risks depending on projected navigable adjacency rather
+  than Hydrology/final-surface truth plus Civ legality/readback.
+
+## Required Corrections
+
+1. Make the frame durable and route the session through it.
+2. Replace stale `minLength/maxLength` and legacy alias language in active
+   OpenSpec records.
+3. Add explicit Earth benchmark contract fields: tile scale, feature-size
+   floor, regime matrix, channel class ratios, lake area, terminal shares, and
+   stylization ledger.
+4. Decide the native writer path with same-run parity evidence before claiming
+   minor-river materialization.
+5. Fix or remove `endpointDischargePercentileMin` semantics before relying on
+   navigable projection metrics.
+6. Build Studio's inspector around proof classes, not around raw layer sprawl.
+7. Keep lake/floodplain closure blocked on exact same-run counters and active
+   proof rows.
+
+## Next Slice Sequence
+
+1. Land this frame/spec correction slice.
+2. Fix `selectNavigableRiverTerrain` endpoint-floor semantics with focused
+   tests.
+3. Patch Hydrology metric outputs to emit the benchmark contract fields.
+4. Run a bounded native-writer integration design/proof slice.
+5. Implement Studio inspector summary/status model.
+6. Run same-run rendered proof and product acceptance rows.
+
+The active goal remains open until the closure matrix in `FRAME.md` is proven or
+explicitly dispositioned.

--- a/docs/projects/river-lake-recovery/FRAME.md
+++ b/docs/projects/river-lake-recovery/FRAME.md
@@ -1,0 +1,249 @@
+# River/Lake Recovery Frame
+
+Status: active session frame
+Date: 2026-06-10
+Owner: Codex river/lake recovery workstream
+
+## Purpose
+
+This frame keeps the river/lake recovery workstream pointed at the product
+outcome instead of another narrow proof slice. The target is not "some river
+terrain rows exist." The target is physically grounded Hydrology truth, coherent
+Civ materialization, clear Studio explanation, and same-run rendered in-game
+proof that users can see the rivers that the pipeline authored.
+
+## Authority Order
+
+Use these sources in order:
+
+1. Current user decisions in this session.
+2. Root and subtree `AGENTS.md`.
+3. `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`.
+4. `docs/system/libs/mapgen/policies/TRUTH-VS-PROJECTION.md`.
+5. `docs/system/libs/mapgen/reference/domains/HYDROLOGY.md`.
+6. Active OpenSpec changes under `openspec/changes/`.
+7. Source, tests, runtime probes, official Civ resources, and external Earth
+   hydrology sources as evidence only.
+
+Current code and historical docs are not target architecture by themselves.
+Generated output is proof of generation, not policy.
+
+## Selection And Salience
+
+In scope:
+
+- drainage routing, discharge, river class, lakes, floodplains, and the
+  terrain/substrate data needed to make them physically coherent;
+- Civ-native river/lake/floodplain materialization and readback;
+- Studio hydrology naming, grouping, config, layers, proof labels, and user
+  diagnostics;
+- external Earth benchmark contracts used before local tuning;
+- same-run runtime/product proof and closure criteria.
+
+Foreground:
+
+- why rivers do not currently show up for users;
+- whether the native Civ river writer can be constrained to authored Hydrology
+  truth;
+- stale config/docs/layers that still teach legacy selectors or wrong owners;
+- proof inflation, especially terrain-row readback being treated as rendered
+  river success.
+
+Exterior:
+
+- resource, wonder, start, or broader ecology recovery unless a verified
+  dependency on river/lake/floodplain truth is found;
+- preserving old public selectors because they exist;
+- projection-only corridors that compensate for upstream hydrology defects.
+
+## Hard Core
+
+- Morphology owns earth matter: topography, land/water form, depressions,
+  basin precursors, and geomorphic proxies.
+- Hydrology owns water truth: drainage routing, basin ids, terminal typing,
+  runoff/discharge, river classes, lake intent, floodplain-relevant hydrology,
+  and physical diagnostics.
+- `@civ7/map-policy` and generated `@civ7/types` own pure Civ facts and
+  compliance tables only.
+- `map-*` stages own projection, materialization, effects, and readback. They
+  do not define upstream truth.
+- Studio owns explanation, inspection, and proof presentation. It does not
+  define truth.
+- Product closure requires same-run evidence that crosses the full ladder:
+  truth -> projection -> materialization -> readback -> Studio display ->
+  rendered Civ visibility -> reviewer disposition.
+
+## Falsifier
+
+This frame is wrong if a later slice still needs projection/readback surfaces to
+define Hydrology truth, if a product-complete claim can pass without rendered
+same-run Civ river visibility, or if user-facing config still exposes stale
+length thresholds/raw internals as the river model.
+
+## Structural Alternative Rejected
+
+A plausible alternative is to delegate rivers back to Civ's official
+`TerrainBuilder.modelRivers(...)` generator and treat Hydrology as advisory.
+That is rejected as the product frame because it gives the engine hidden
+authority over authored truth. The remaining native-Civ question is narrower:
+can a bounded materialization path use the official writer while preserving and
+proving parity to Hydrology-authored truth?
+
+## Physical Grounding
+
+Earth does not have a single universal river-density constant. Drainage density,
+permanence, lake area, and closed-basin share vary by climate, relief,
+lithology, and feature-size threshold. Benchmarks must therefore be families,
+not one scalar.
+
+Benchmark contract before tuning:
+
+- declare tile-to-kilometer and minimum visible-feature assumptions for every
+  acceptance row;
+- separate hidden drainage network, minor/headwater channels, major routed
+  trunks, and Civ-visible navigable trunks;
+- keep headwaters/minor channels as the majority of truth-network length on wet
+  earthlike maps;
+- treat non-perennial channels as common, not an edge case;
+- allow endorheic/closed drainage as normal in arid/interior worlds, with typed
+  terminal outcomes;
+- constrain lakes to low-single-digit land-area shares unless a specific map
+  archetype is intentionally lake-rich;
+- record a stylization ledger whenever Civ tile scale forces visible rivers to
+  exaggerate, merge, or omit real-world channel classes.
+
+External benchmark anchors:
+
+- HydroRIVERS includes 8.5 million reaches, averaging 4.2 km each, for about
+  35.9 million km of rivers globally, using a catchment/discharge inclusion
+  floor.
+- GRWL/Allen and Pavelsky estimate global river and stream surface area at
+  773,000 +/- 79,000 square km, about 0.58 +/- 0.06 percent of nonglaciated
+  land.
+- Global non-perennial river work estimates that flow stops at least one day
+  per year along roughly 51-60 percent of the world's river length; newer
+  headwater-inclusive work pushes the non-perennial share higher when small
+  channels are counted.
+- Hydrography90m emphasizes that headwaters account for more than 70 percent of
+  stream length and uses a 0.05 square km initiation floor to capture them.
+- HydroLAKES reports about 1.4 million lakes/reservoirs covering 2.67 million
+  square km, about 1.8 percent of global land area in the associated study.
+- Global endorheic references place internally drained basins around one-fifth
+  of land area, concentrated in arid and interior settings.
+
+Sources:
+
+- https://www.hydrosheds.org/products/hydrorivers
+- https://pubmed.ncbi.nlm.nih.gov/29954985/
+- https://www.hydrosheds.org/applications/intermittent-rivers
+- https://essd.copernicus.org/articles/14/4525/2022/essd-14-4525-2022.html
+- https://www.hydrosheds.org/products/hydrolakes
+- https://www.nature.com/articles/ncomms13603
+- https://pmc.ncbi.nlm.nih.gov/articles/PMC6267997/
+
+## Ownership Boundary
+
+| Concern | Owner | Forbidden owners |
+| --- | --- | --- |
+| Landform, elevation, depressions, basin precursors | Morphology | Hydrology projection, map-rivers, policy package |
+| Drainage routing, terminal typing, discharge, river class, lake truth | Hydrology | Morphology recipe glue, map-rivers, Studio |
+| Pure Civ facts and runtime semantic tables | `@civ7/map-policy`, generated `@civ7/types` | Hydrology algorithms, projection selectors |
+| Civ-visible river subset selection | `map-rivers` projection consuming Hydrology truth and Hydrology-owned selection ops | Morphology, policy package, invented policy folders |
+| Lake/water projection and river terrain/materialization | `map-hydrology`, `map-rivers`, adapter/direct-control proof tooling | Hydrology truth |
+| Studio hydrology visualization and status ladder | Studio / DX layer | Hydrology truth, projection logic |
+| Product acceptance | OpenSpec/product proof records plus reviewer disposition | unit tests or code slices self-closing |
+
+## System Dynamics
+
+Dominant reinforcing loop:
+
+- stale names/configs/layers imply wrong ownership;
+- implementers preserve the old surface;
+- proof rows validate the narrow behavior;
+- the product still has no visible rivers;
+- later agents trust the stale proof and repeat the mistake.
+
+Balancing loop to install:
+
+- explicit owner map and proof ladder;
+- external benchmark contract before tuning;
+- same-run readback and rendered evidence;
+- Studio surfaces the exact failure class;
+- closure is blocked until the product row, not just the code row, passes.
+
+## Investigation Policy
+
+For each slice, use this evidence hierarchy:
+
+1. official Civ resources and installed app/runtime probes for Civ facts;
+2. external Earth hydrology literature for physical benchmark ranges;
+3. Hydrology artifacts and seed metrics for local truth behavior;
+4. adapter/direct-control readback for materialization;
+5. Studio/browser screenshots for user-facing explanation;
+6. rendered in-game screenshots with branch/commit/run/config identity for
+   product visibility.
+
+Stop or reframe if any investigation finds:
+
+- native Civ behavior contradicts the assumed materialization path;
+- a user-facing knob is just a raw internal threshold;
+- a map-rivers patch is compensating for a Hydrology truth defect;
+- Studio can show a layer while Civ has no same-run visible product evidence.
+
+## Team Model
+
+Use fresh agents for fresh tasks. Do not recycle old agents unless they are
+compacted first and explicitly reused.
+
+Default adversarial lanes:
+
+1. Earth hydrology prosecutor: attacks benchmark definitions and physical
+   plausibility.
+2. Pipeline boundary prosecutor: attacks owner placement and import/config
+   drift.
+3. Civ runtime prosecutor: attacks writer/readback/materialization assumptions.
+4. Studio UX prosecutor: attacks naming, layer grouping, statuses, and
+   user-facing proof clarity.
+5. Implementation archaeologist: attacks semantic-history claims and stale
+   docs/config.
+6. Verification closure prosecutor: attacks proof labels, same-run identity,
+   and product-complete claims.
+
+Each agent must keep written notes with goal, inquiry design, findings, risks,
+and blocking questions. The owner remains responsible for synthesis.
+
+## Domino Chain
+
+1. Ground Earth benchmarks and tile-scale assumptions.
+2. Repair Hydrology truth and metrics if the benchmark/root-cause evidence
+   requires it.
+3. Decide and prove the native Civ writer/materialization boundary.
+4. Make map-rivers projection coherent from Hydrology truth only.
+5. Clean config/knobs/names so public surfaces match owners.
+6. Build Studio river/lake/floodplain proof ladder.
+7. Add live same-run rendered proof.
+8. Close lake/floodplain exact proof rows.
+9. Run earthlike/holdout product acceptance and disposition every row.
+10. Promote durable lessons; remove this session notice from `AGENTS.md`.
+
+## Closure Matrix
+
+The workstream cannot complete until all rows are pass or explicitly
+dispositioned:
+
+| Row | Required evidence |
+| --- | --- |
+| Hydrology truth | acyclic routing, typed terminals, discharge monotonicity, benchmarked river/lake metrics |
+| Major/navigable projection | selected chains are coherent subsets of Hydrology major truth and meet declared earthlike visibility bands |
+| Minor rivers | minor/headwater truth exists, is visible or intentionally non-materialized with a proven Civ limitation |
+| Lake materialization | exact accepted/rejected/final drift counters |
+| Floodplains | active nonzero local/exact/live proof tied to Hydrology/final-surface inputs |
+| Civ metadata | native writer/readback proof or explicit unsupported disposition |
+| Studio display | same-run inspector explains planned/projected/live/mismatch states |
+| Civ rendered visibility | camera-targeted screenshot packet tied to exact branch/commit/run/config |
+| Product acceptance | reviewer-dispositioned earthlike, holdout, contrast, and no-signal rows |
+
+Skills used: framing-design, inquiry-design, investigation-design,
+domain-design, system-design, team-design, civ7-systematic-workstream,
+civ7-open-spec-workstream, civ7-architecture-authority,
+civ7-product-authority.

--- a/docs/projects/river-lake-recovery/agent-notes/2026-06-10-agent-1-earth-hydrology-prosecutor.md
+++ b/docs/projects/river-lake-recovery/agent-notes/2026-06-10-agent-1-earth-hydrology-prosecutor.md
@@ -1,0 +1,26 @@
+# Agent 1 - Earth Hydrology Prosecutor
+
+Goal: attack physical plausibility and benchmark definitions before any tuning.
+
+Inquiry design:
+
+- Primary question: what Earth constraints must the generator respect before
+  local output can be called representative?
+- Evidence policy: external hydrology datasets and peer-reviewed/official
+  summaries outrank current generator behavior.
+- Falsifier: one scalar river-density threshold is treated as sufficient.
+
+Findings:
+
+- Benchmarks must be grouped by regime, map scale, and visible feature floor.
+- Headwater/minor channels should dominate truth-network length on wet maps.
+- Non-perennial channels are common globally and should not be a rare edge case.
+- Endorheic and closed-basin outcomes are normal in arid/interior worlds.
+- Lake area should usually be low-single-digit land share, not near-zero and
+  not unconstrained.
+
+Risks:
+
+- Civ tile scale forces stylization; the workstream needs an explicit
+  stylization ledger.
+- Local seed metrics can calibrate only after external expectations are set.

--- a/docs/projects/river-lake-recovery/agent-notes/2026-06-10-agent-2-pipeline-boundary-prosecutor.md
+++ b/docs/projects/river-lake-recovery/agent-notes/2026-06-10-agent-2-pipeline-boundary-prosecutor.md
@@ -1,0 +1,28 @@
+# Agent 2 - Pipeline Boundary Prosecutor
+
+Goal: attack owner drift across Morphology, Hydrology, policy, projection, and
+Studio.
+
+Inquiry design:
+
+- Primary question: which code/config/docs currently let a non-owner define
+  river/lake truth?
+- Evidence policy: architecture packet and truth-vs-projection policy outrank
+  current file placement.
+- Falsifier: any projection/readback surface is needed to define Hydrology
+  truth.
+
+Findings:
+
+- Current Hydrology routing is correctly in the Hydrology domain.
+- Morphology's flow-routing proxy can remain a terrain-shaping precursor/proxy
+  if it is not presented as Hydrology truth.
+- Public/raw config still risks exposing internals rather than semantic knobs.
+- `map-rivers` is a valid projection owner but must not carry upstream truth or
+  invented policy folders.
+
+Risks:
+
+- Stale docs still teach `minLength/maxLength` and legacy alias behavior.
+- Studio grouping can make projection artifacts look like truth if layer labels
+  do not carry proof class.

--- a/docs/projects/river-lake-recovery/agent-notes/2026-06-10-agent-3-civ-runtime-native-prosecutor.md
+++ b/docs/projects/river-lake-recovery/agent-notes/2026-06-10-agent-3-civ-runtime-native-prosecutor.md
@@ -1,0 +1,27 @@
+# Agent 3 - Civ Runtime Native Prosecutor
+
+Goal: attack assumptions about what Civ can natively write or read for rivers.
+
+Inquiry design:
+
+- Primary question: what native Civ sequence actually authors visible/runtime
+  river state?
+- Evidence policy: installed app/resources and live probes outrank local mocks.
+- Falsifier: a categorical writer claim survives without same-run runtime
+  evidence.
+
+Findings:
+
+- Official scripts use `TerrainBuilder.modelRivers(...)`, then terrain
+  validation, named rivers, and water-data storage.
+- A disposable probe showed the bulk sequence can produce river metadata,
+  including minor-river rows.
+- Current `map-rivers` does not call that bulk sequence; it stamps
+  `TERRAIN_NAVIGABLE_RIVER` terrain directly.
+- Terrain readback and metadata readback are distinct proof classes.
+
+Risks:
+
+- Reintroducing `modelRivers(...)` naively would delegate truth to Civ.
+- Avoiding it categorically may leave minor/metadata materialization impossible.
+  The correct next question is bounded parity, not blanket ban or blanket use.

--- a/docs/projects/river-lake-recovery/agent-notes/2026-06-10-agent-4-studio-hydrology-ux-prosecutor.md
+++ b/docs/projects/river-lake-recovery/agent-notes/2026-06-10-agent-4-studio-hydrology-ux-prosecutor.md
@@ -1,0 +1,29 @@
+# Agent 4 - Studio Hydrology UX Prosecutor
+
+Goal: attack hydrology visualization, naming, status, and proof UX from the
+user's perspective.
+
+Inquiry design:
+
+- Primary question: can a user tell why rivers/lakes/floodplains appear or do
+  not appear for the run they launched?
+- Evidence policy: same-run Studio state and live proof packets outrank raw
+  layer availability.
+- Falsifier: raw layers exist but the user cannot follow planned -> projected
+  -> live -> rendered status.
+
+Findings:
+
+- Studio has many layers but lacks a proof ladder.
+- `projectedRiverMask` and `engineRiverMask` need explicit roles and labels so
+  users do not confuse projection plan with engine readback.
+- Duplicating Hydrology truth layers under map-rivers grouping obscures owner
+  boundaries.
+- Lakes are closer, but exact counters/drift are not surfaced clearly enough.
+- Floodplains need intent/applied/live product rows, not just score layers.
+
+Risks:
+
+- "Run in Game" can look complete while product proof rows are unresolved.
+- Layer sprawl can hide a zero-river product failure behind many nonzero
+  intermediate masks.

--- a/docs/projects/river-lake-recovery/agent-notes/2026-06-10-agent-5-implementation-archaeologist.md
+++ b/docs/projects/river-lake-recovery/agent-notes/2026-06-10-agent-5-implementation-archaeologist.md
@@ -1,0 +1,29 @@
+# Agent 5 - Implementation Archaeologist
+
+Goal: attack historical assumptions and stale contracts that survived earlier
+river work.
+
+Inquiry design:
+
+- Primary question: which old claims or files are still steering current work in
+  the wrong direction?
+- Evidence policy: semantic git history, live code, and current OpenSpec tasks
+  must be reconciled; stale docs cannot win.
+- Falsifier: "legacy" behavior is preserved without a product/consumer gate.
+
+Findings:
+
+- `minLength/maxLength` selectors were rejected and should not be restored.
+- `map-rivers.knobs.riverDensity` is retired debt, not the accepted current
+  model.
+- `endpointDischargePercentileMin` is reported by the selector but not enforced
+  in the current strategy.
+- Direct terrain stamping is currently architecture-valid but terrain-only.
+- Some downstream floodplain/resource/placement surfaces still consume
+  `riverClass` as if it were runtime river fact.
+
+Risks:
+
+- Old proposal text can pull agents back toward Civ length thresholds.
+- Generated/config proof hashes can tempt alias preservation after the product
+  model has changed.

--- a/docs/projects/river-lake-recovery/agent-notes/2026-06-10-agent-6-verification-closure-prosecutor.md
+++ b/docs/projects/river-lake-recovery/agent-notes/2026-06-10-agent-6-verification-closure-prosecutor.md
@@ -1,0 +1,26 @@
+# Agent 6 - Verification Closure Prosecutor
+
+Goal: attack overclaiming and incomplete proof closure.
+
+Inquiry design:
+
+- Primary question: which proof rows are actually closed by same-run evidence,
+  and which are still just local/code-level?
+- Evidence policy: proof labels must be scoped to the boundary exercised.
+- Falsifier: a lower proof class closes a higher product row.
+
+Findings:
+
+- Existing evidence covers pieces of Hydrology truth, projection plan, terrain
+  readback, floodplain activity, and native writer probing; no run is a full
+  product pass.
+- `civ-rendered` requires exact branch/commit/run/config identity, sampled live
+  coordinates, camera state, screenshot artifacts, and a visual verdict.
+- No-signal cases are valid only as controls/dispositions, not positive passes.
+- Lake and floodplain proof need exact counters and active rows.
+
+Risks:
+
+- Product closure can drift if Studio-visible, Civ-rendered, and reviewer rows
+  are not explicit independent gates.
+- A stale live map or old run id can invalidate an otherwise plausible proof.

--- a/docs/system/libs/mapgen/reference/domains/HYDROLOGY.md
+++ b/docs/system/libs/mapgen/reference/domains/HYDROLOGY.md
@@ -99,6 +99,57 @@ Author-facing control is primarily via stage knobs (compiled at stage compile ti
 
 Some steps also expose flat step config surfaces for explicit overrides (e.g., seasonality posture).
 
+## River network benchmark contract
+
+Hydrology benchmark reports compare generated drainage truth against Earth-scale
+families before projection tuning. This contract is report/diagnostic metadata,
+not additional Hydrology compute truth:
+
+- **Tile scale.** A Civ map tile is a coarse strategy-scale sample, not a
+  geodetic cell. Reports must record the run dimensions and any latitude
+  assumption used for tile-to-kilometer translation. Do not compare a single
+  tile directly to a 30 m river pixel.
+- **Visible feature floor.** Hydrology may contain hidden drainage and
+  minor/headwater channel intent that is below Civ terrain visibility.
+  `map-rivers` may only turn Hydrology `riverClass>=2` into
+  `TERRAIN_NAVIGABLE_RIVER`; minor channels remain Hydrology truth unless a
+  native metadata writer is separately proven.
+- **Regime row.** Every benchmark row must name its climate/relief regime:
+  `wet`, `normal`, `arid`, `mountain`, `closed`, `archipelago`, or an explicit
+  extension. Arid/no-visible outcomes can be valid only when the regime row and
+  metrics support that claim.
+- **Observed Hydrology fields.** `artifact:hydrology.riverNetworkMetrics`
+  publishes `benchmarkSummary` with land/water/lake denominators, minor/major
+  river counts, river-specific permanence, low-order hierarchy, terminal
+  shares, basin coverage, and routing-health counters. Reports may consume
+  those values but must not reinterpret projection or runtime readback as
+  Hydrology truth.
+- **Stylization ledger.** Any Civ-visible exaggeration, merging, omission, or
+  native-engine substitution must record: source Earth anchor, affected metric,
+  reason for stylization, changed product claim, and proof gate. Silent
+  stylization is a product failure.
+
+Earth anchors for the first accepted pass:
+
+- HydroRIVERS maps global river reaches at a coarse floor of catchment area
+  `>=10 km2` or average flow `>=0.1 m3/s`; its product page reports 8.5 million
+  reaches averaging 4.2 km for 35.9 million km globally:
+  <https://www.hydrosheds.org/products/hydrorivers>.
+- Global hydrography work cautions that the HydroRIVERS threshold is empirical,
+  so local tuning must use regime families and topology oracles rather than
+  treating one threshold as universal Earth truth:
+  <https://www.nature.com/articles/s41597-021-00819-9>.
+- GRWL records rivers `>=30 m` wide and covers more than 2.1 million km of
+  visible river centerlines; use it as a visible-river floor, not as the total
+  drainage network:
+  <https://www.science.org/doi/10.1126/science.aat0636>.
+- Non-perennial rivers are common: global modeling predicts water ceases to
+  flow at least one day per year along 51-60% of river length:
+  <https://pubmed.ncbi.nlm.nih.gov/34135525/>.
+- HydroLAKES reports about 1.4 million lakes/reservoirs totaling 2.67 million
+  km2:
+  <https://www.hydrosheds.org/products/hydrolakes>.
+
 ## Engine projection notes (map-hydrology / map-rivers)
 
 The `map-hydrology` stage:

--- a/mods/mod-swooper-maps/src/dev/diagnostics/extract-earth-metrics.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/extract-earth-metrics.ts
@@ -1,12 +1,15 @@
 import { biomeSymbolFromIndex } from "../../domain/ecology/types.js";
 import { isAnyRiverClass } from "../../domain/hydrology/index.js";
 
+export type RiverNetworkBenchmarkSummary = Readonly<Record<string, number> & { version: 1 }>;
+
 export type EarthMetricsInput = {
   width: number;
   height: number;
   landMask: Uint8Array;
   lakeMask?: Uint8Array;
   riverClass?: Uint8Array;
+  riverNetworkBenchmarkSummary?: RiverNetworkBenchmarkSummary;
   biomeIndex?: Uint8Array;
 };
 
@@ -14,6 +17,9 @@ export type EarthMetrics = {
   landShare: number;
   lakeShare: number;
   riverClassShare: number;
+  hydrology: {
+    riverNetworkSummary: RiverNetworkBenchmarkSummary | null;
+  };
   biomeDiversity: number;
   dominantBiome: string | null;
 };
@@ -67,11 +73,31 @@ export function computeEarthMetrics(input: EarthMetricsInput): EarthMetrics {
     }
   }
 
+  const riverNetworkSummary = input.riverNetworkBenchmarkSummary ?? null;
+  if (riverNetworkSummary) {
+    if (riverNetworkSummary.version !== 1) {
+      throw new Error("[Diagnostics] riverNetworkBenchmarkSummary version mismatch.");
+    }
+    if (riverNetworkSummary.landTileCount !== landTiles) {
+      throw new Error(
+        `[Diagnostics] riverNetworkBenchmarkSummary landTileCount mismatch (expected ${landTiles}, got ${riverNetworkSummary.landTileCount}).`
+      );
+    }
+    if (input.riverClass && riverNetworkSummary.riverTileCount !== riverTiles) {
+      throw new Error(
+        `[Diagnostics] riverNetworkBenchmarkSummary riverTileCount mismatch (expected ${riverTiles}, got ${riverNetworkSummary.riverTileCount}).`
+      );
+    }
+  }
+
   const denom = Math.max(1, size);
   return {
     landShare: landTiles / denom,
     lakeShare: lakeTiles / denom,
     riverClassShare: riverTiles / denom,
+    hydrology: {
+      riverNetworkSummary,
+    },
     biomeDiversity: biomeCounts.size,
     dominantBiome,
   };

--- a/mods/mod-swooper-maps/src/domain/hydrology/ops/compute-river-network-metrics/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/ops/compute-river-network-metrics/contract.ts
@@ -46,6 +46,54 @@ const ComputeRiverNetworkMetricsInputSchema = Type.Object(
   }
 );
 
+const RiverNetworkBenchmarkSummarySchema = Type.Object(
+  {
+    version: Type.Literal(1),
+    landTileCount: Type.Integer({ minimum: 0 }),
+    waterTileCount: Type.Integer({ minimum: 0 }),
+    lakeTileCount: Type.Integer({ minimum: 0 }),
+    lakeLandShare: Type.Number({ minimum: 0, maximum: 1 }),
+    riverTileCount: Type.Integer({ minimum: 0 }),
+    minorRiverTileCount: Type.Integer({ minimum: 0 }),
+    majorRiverTileCount: Type.Integer({ minimum: 0 }),
+    riverLandShare: Type.Number({ minimum: 0, maximum: 1 }),
+    minorRiverShareOfRiverTiles: Type.Number({ minimum: 0, maximum: 1 }),
+    majorRiverShareOfRiverTiles: Type.Number({ minimum: 0, maximum: 1 }),
+    streamOrder1RiverTileCount: Type.Integer({ minimum: 0 }),
+    lowOrderRiverTileCount: Type.Integer({ minimum: 0 }),
+    lowOrderRiverShareOfRiverTiles: Type.Number({ minimum: 0, maximum: 1 }),
+    dryFlowTileCount: Type.Integer({ minimum: 0 }),
+    ephemeralFlowTileCount: Type.Integer({ minimum: 0 }),
+    intermittentFlowTileCount: Type.Integer({ minimum: 0 }),
+    perennialFlowTileCount: Type.Integer({ minimum: 0 }),
+    nonDryFlowLandShare: Type.Number({ minimum: 0, maximum: 1 }),
+    riverDryTileCount: Type.Integer({ minimum: 0 }),
+    riverEphemeralTileCount: Type.Integer({ minimum: 0 }),
+    riverIntermittentTileCount: Type.Integer({ minimum: 0 }),
+    riverPerennialTileCount: Type.Integer({ minimum: 0 }),
+    nonPerennialRiverShareOfRiverTiles: Type.Number({ minimum: 0, maximum: 1 }),
+    oceanMouthTileCount: Type.Integer({ minimum: 0 }),
+    acceptedLakeMouthTileCount: Type.Integer({ minimum: 0 }),
+    closedBasinMouthTileCount: Type.Integer({ minimum: 0 }),
+    spillPathMouthTileCount: Type.Integer({ minimum: 0 }),
+    unresolvedMouthTileCount: Type.Integer({ minimum: 0 }),
+    resolvedMouthTileCount: Type.Integer({ minimum: 0 }),
+    assignedBasinLandTileCount: Type.Integer({ minimum: 0 }),
+    unassignedBasinLandTileCount: Type.Integer({ minimum: 0 }),
+    invalidReceiverTileCount: Type.Integer({ minimum: 0 }),
+    downstreamDischargeDropEdgeCount: Type.Integer({ minimum: 0 }),
+    closedOrLakeTerminalLandShare: Type.Number({ minimum: 0, maximum: 1 }),
+    lakeConnectedTerminalDischargeShare: Type.Number({ minimum: 0, maximum: 1 }),
+    maxUpstreamArea: Type.Integer({ minimum: 0 }),
+    maxStreamOrderProxy: Type.Integer({ minimum: 0 }),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Hydrology-owned aggregate metrics used to compare generated drainage, river hierarchy, terminals, and lakes against external Earth benchmark families.",
+  }
+);
+
 const ComputeRiverNetworkMetricsOutputSchema = Type.Object(
   {
     upstreamArea: TypedArraySchemas.i32({
@@ -67,6 +115,7 @@ const ComputeRiverNetworkMetricsOutputSchema = Type.Object(
       description:
         "Flow permanence proxy per land tile: 0=dry/no-signal, 1=ephemeral, 2=intermittent, 3=perennial.",
     }),
+    benchmarkSummary: RiverNetworkBenchmarkSummarySchema,
   },
   {
     additionalProperties: false,

--- a/mods/mod-swooper-maps/src/domain/hydrology/ops/compute-river-network-metrics/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/ops/compute-river-network-metrics/strategies/default.ts
@@ -17,7 +17,11 @@ import {
   HYDROLOGY_SLOPE_NONE,
   HYDROLOGY_SLOPE_STEEP,
 } from "../../../river-network-metrics.js";
-import { RIVER_CLASS_MAJOR, RIVER_CLASS_MINOR } from "../../../river-class.js";
+import {
+  isAnyRiverClass,
+  isMajorRiverClass,
+  isMinorRiverClass,
+} from "../../../river-class.js";
 import ComputeRiverNetworkMetricsContract from "../contract.js";
 
 const FLAT_SLOPE_MAX = 0.5;
@@ -28,6 +32,13 @@ const MAJOR_PERENNIAL_SPECIFIC_DISCHARGE_MIN = 4;
 const MINOR_INTERMITTENT_SPECIFIC_DISCHARGE_MIN = 2.25;
 const NON_RIVER_EPHEMERAL_SPECIFIC_DISCHARGE_MIN = 1.5;
 const NON_RIVER_EPHEMERAL_UPSTREAM_AREA_MIN = 4;
+
+function safeShare(numerator: number, denominator: number): number {
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator <= 0) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, numerator / denominator));
+}
 
 function computeLandReceiver(
   size: number,
@@ -176,7 +187,7 @@ export const defaultStrategy = createStrategy(ComputeRiverNetworkMetricsContract
       const index = order[i]!;
       const dest = receiver[index] ?? -1;
 
-      if (input.riverClass[index] === RIVER_CLASS_MINOR || input.riverClass[index] === RIVER_CLASS_MAJOR) {
+      if (isAnyRiverClass(input.riverClass[index])) {
         const maxOrder = maxIncomingOrder[index] ?? 0;
         streamOrderProxy[index] =
           maxOrder === 0 ? 1 : Math.min(255, maxOrder + (maxIncomingOrderCount[index] >= 2 ? 1 : 0));
@@ -235,14 +246,14 @@ export const defaultStrategy = createStrategy(ComputeRiverNetworkMetricsContract
       const specificDischarge = (input.discharge[i] ?? 0) / area;
       const riverClass = input.riverClass[i] ?? 0;
 
-      if (riverClass === RIVER_CLASS_MAJOR) {
+      if (isMajorRiverClass(riverClass)) {
         flowPermanenceProxy[i] =
           specificDischarge >= MAJOR_PERENNIAL_SPECIFIC_DISCHARGE_MIN
             ? HYDROLOGY_FLOW_PERENNIAL
             : HYDROLOGY_FLOW_INTERMITTENT;
         continue;
       }
-      if (riverClass === RIVER_CLASS_MINOR) {
+      if (isMinorRiverClass(riverClass)) {
         flowPermanenceProxy[i] =
           specificDischarge >= MINOR_INTERMITTENT_SPECIFIC_DISCHARGE_MIN
             ? HYDROLOGY_FLOW_INTERMITTENT
@@ -256,12 +267,170 @@ export const defaultStrategy = createStrategy(ComputeRiverNetworkMetricsContract
           : HYDROLOGY_FLOW_DRY;
     }
 
+    let landTileCount = 0;
+    let lakeTileCount = 0;
+    let riverTileCount = 0;
+    let minorRiverTileCount = 0;
+    let majorRiverTileCount = 0;
+    let streamOrder1RiverTileCount = 0;
+    let lowOrderRiverTileCount = 0;
+    let dryFlowTileCount = 0;
+    let ephemeralFlowTileCount = 0;
+    let intermittentFlowTileCount = 0;
+    let perennialFlowTileCount = 0;
+    let riverDryTileCount = 0;
+    let riverEphemeralTileCount = 0;
+    let riverIntermittentTileCount = 0;
+    let riverPerennialTileCount = 0;
+    let oceanMouthTileCount = 0;
+    let acceptedLakeMouthTileCount = 0;
+    let closedBasinMouthTileCount = 0;
+    let spillPathMouthTileCount = 0;
+    let unresolvedMouthTileCount = 0;
+    let resolvedMouthTileCount = 0;
+    let assignedBasinLandTileCount = 0;
+    let unassignedBasinLandTileCount = 0;
+    let invalidReceiverTileCount = 0;
+    let downstreamDischargeDropEdgeCount = 0;
+    let maxUpstreamArea = 0;
+    let maxStreamOrderProxy = 0;
+    let terminalDischarge = 0;
+    let lakeConnectedTerminalDischarge = 0;
+
+    for (let i = 0; i < size; i++) {
+      if (input.landMask[i] !== 1) continue;
+      landTileCount += 1;
+
+      const discharge = Math.max(0, input.discharge[i] ?? 0);
+      if ((input.lakeMask[i] ?? 0) === 1) {
+        lakeTileCount += 1;
+      }
+
+      if ((input.basinId[i] ?? -1) >= 0) assignedBasinLandTileCount += 1;
+      else unassignedBasinLandTileCount += 1;
+
+      const rawReceiver = input.flowDir[i] ?? -1;
+      const hasInvalidReceiver = rawReceiver < -1 || rawReceiver >= size;
+      if (hasInvalidReceiver) invalidReceiverTileCount += 1;
+
+      const landReceiver = receiver[i] ?? -1;
+      if (
+        landReceiver >= 0 &&
+        Math.max(0, input.discharge[landReceiver] ?? 0) + Number.EPSILON < discharge
+      ) {
+        downstreamDischargeDropEdgeCount += 1;
+      }
+      if (landReceiver < 0 && !hasInvalidReceiver) {
+        terminalDischarge += discharge;
+        const mouth = mouthType[i] ?? HYDROLOGY_MOUTH_UNRESOLVED;
+        if (mouth === HYDROLOGY_MOUTH_ACCEPTED_LAKE || (input.lakeMask[i] ?? 0) === 1) {
+          lakeConnectedTerminalDischarge += discharge;
+        }
+      }
+
+      const riverClass = input.riverClass[i] ?? 0;
+      const isRiverTile = isAnyRiverClass(riverClass);
+      if (isMinorRiverClass(riverClass)) {
+        minorRiverTileCount += 1;
+        riverTileCount += 1;
+      } else if (isMajorRiverClass(riverClass)) {
+        majorRiverTileCount += 1;
+        riverTileCount += 1;
+      }
+
+      const permanence = flowPermanenceProxy[i] ?? HYDROLOGY_FLOW_DRY;
+      if (permanence === HYDROLOGY_FLOW_EPHEMERAL) ephemeralFlowTileCount += 1;
+      else if (permanence === HYDROLOGY_FLOW_INTERMITTENT) intermittentFlowTileCount += 1;
+      else if (permanence === HYDROLOGY_FLOW_PERENNIAL) perennialFlowTileCount += 1;
+      else dryFlowTileCount += 1;
+      if (isRiverTile) {
+        if (permanence === HYDROLOGY_FLOW_EPHEMERAL) riverEphemeralTileCount += 1;
+        else if (permanence === HYDROLOGY_FLOW_INTERMITTENT) riverIntermittentTileCount += 1;
+        else if (permanence === HYDROLOGY_FLOW_PERENNIAL) riverPerennialTileCount += 1;
+        else riverDryTileCount += 1;
+
+        const streamOrder = streamOrderProxy[i] ?? 0;
+        if (streamOrder === 1) streamOrder1RiverTileCount += 1;
+        if (streamOrder > 0 && streamOrder <= 2) lowOrderRiverTileCount += 1;
+      }
+
+      const mouth = mouthType[i] ?? HYDROLOGY_MOUTH_UNRESOLVED;
+      if (mouth === HYDROLOGY_MOUTH_OCEAN) {
+        oceanMouthTileCount += 1;
+        resolvedMouthTileCount += 1;
+      } else if (mouth === HYDROLOGY_MOUTH_ACCEPTED_LAKE) {
+        acceptedLakeMouthTileCount += 1;
+        resolvedMouthTileCount += 1;
+      } else if (mouth === HYDROLOGY_MOUTH_CLOSED_BASIN) {
+        closedBasinMouthTileCount += 1;
+        resolvedMouthTileCount += 1;
+      } else if (mouth === HYDROLOGY_MOUTH_SPILL_PATH) {
+        spillPathMouthTileCount += 1;
+        resolvedMouthTileCount += 1;
+      } else {
+        unresolvedMouthTileCount += 1;
+      }
+
+      maxUpstreamArea = Math.max(maxUpstreamArea, upstreamArea[i] ?? 0);
+      maxStreamOrderProxy = Math.max(maxStreamOrderProxy, streamOrderProxy[i] ?? 0);
+    }
+
+    const nonDryFlowTileCount =
+      ephemeralFlowTileCount + intermittentFlowTileCount + perennialFlowTileCount;
+    const closedOrLakeTerminalTileCount = acceptedLakeMouthTileCount + closedBasinMouthTileCount;
+
     return {
       upstreamArea,
       streamOrderProxy,
       mouthType,
       slopeClass,
       flowPermanenceProxy,
+      benchmarkSummary: {
+        version: 1,
+        landTileCount,
+        waterTileCount: Math.max(0, size - landTileCount),
+        lakeTileCount,
+        lakeLandShare: safeShare(lakeTileCount, landTileCount),
+        riverTileCount,
+        minorRiverTileCount,
+        majorRiverTileCount,
+        riverLandShare: safeShare(riverTileCount, landTileCount),
+        minorRiverShareOfRiverTiles: safeShare(minorRiverTileCount, riverTileCount),
+        majorRiverShareOfRiverTiles: safeShare(majorRiverTileCount, riverTileCount),
+        streamOrder1RiverTileCount,
+        lowOrderRiverTileCount,
+        lowOrderRiverShareOfRiverTiles: safeShare(lowOrderRiverTileCount, riverTileCount),
+        dryFlowTileCount,
+        ephemeralFlowTileCount,
+        intermittentFlowTileCount,
+        perennialFlowTileCount,
+        nonDryFlowLandShare: safeShare(nonDryFlowTileCount, landTileCount),
+        riverDryTileCount,
+        riverEphemeralTileCount,
+        riverIntermittentTileCount,
+        riverPerennialTileCount,
+        nonPerennialRiverShareOfRiverTiles: safeShare(
+          riverDryTileCount + riverEphemeralTileCount + riverIntermittentTileCount,
+          riverTileCount
+        ),
+        oceanMouthTileCount,
+        acceptedLakeMouthTileCount,
+        closedBasinMouthTileCount,
+        spillPathMouthTileCount,
+        unresolvedMouthTileCount,
+        resolvedMouthTileCount,
+        assignedBasinLandTileCount,
+        unassignedBasinLandTileCount,
+        invalidReceiverTileCount,
+        downstreamDischargeDropEdgeCount,
+        closedOrLakeTerminalLandShare: safeShare(closedOrLakeTerminalTileCount, landTileCount),
+        lakeConnectedTerminalDischargeShare: safeShare(
+          lakeConnectedTerminalDischarge,
+          terminalDischarge
+        ),
+        maxUpstreamArea,
+        maxStreamOrderProxy,
+      },
     } as const;
   },
 });

--- a/mods/mod-swooper-maps/src/domain/hydrology/ops/select-navigable-river-terrain/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/ops/select-navigable-river-terrain/strategies/default.ts
@@ -134,9 +134,9 @@ export const defaultStrategy = createStrategy(SelectNavigableRiverTerrainContrac
       endpointDischarges,
       config.endpointDischargePercentileMin
     );
-    const candidateEndpoints = allEndpoints.sort(
-      (a, b) => (input.discharge[b] ?? 0) - (input.discharge[a] ?? 0)
-    );
+    const candidateEndpoints = allEndpoints
+      .filter((endpoint) => (input.discharge[endpoint] ?? 0) >= selectedEndpointDischargeFloor)
+      .sort((a, b) => (input.discharge[b] ?? 0) - (input.discharge[a] ?? 0));
 
     let selectedTileCount = 0;
     let selectedChainCount = 0;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/artifacts.ts
@@ -90,6 +90,54 @@ export const HydrologyLakePlanArtifactSchema = Type.Object(
   }
 );
 
+const HydrologyRiverNetworkBenchmarkSummarySchema = Type.Object(
+  {
+    version: Type.Literal(1),
+    landTileCount: Type.Integer({ minimum: 0 }),
+    waterTileCount: Type.Integer({ minimum: 0 }),
+    lakeTileCount: Type.Integer({ minimum: 0 }),
+    lakeLandShare: Type.Number({ minimum: 0, maximum: 1 }),
+    riverTileCount: Type.Integer({ minimum: 0 }),
+    minorRiverTileCount: Type.Integer({ minimum: 0 }),
+    majorRiverTileCount: Type.Integer({ minimum: 0 }),
+    riverLandShare: Type.Number({ minimum: 0, maximum: 1 }),
+    minorRiverShareOfRiverTiles: Type.Number({ minimum: 0, maximum: 1 }),
+    majorRiverShareOfRiverTiles: Type.Number({ minimum: 0, maximum: 1 }),
+    streamOrder1RiverTileCount: Type.Integer({ minimum: 0 }),
+    lowOrderRiverTileCount: Type.Integer({ minimum: 0 }),
+    lowOrderRiverShareOfRiverTiles: Type.Number({ minimum: 0, maximum: 1 }),
+    dryFlowTileCount: Type.Integer({ minimum: 0 }),
+    ephemeralFlowTileCount: Type.Integer({ minimum: 0 }),
+    intermittentFlowTileCount: Type.Integer({ minimum: 0 }),
+    perennialFlowTileCount: Type.Integer({ minimum: 0 }),
+    nonDryFlowLandShare: Type.Number({ minimum: 0, maximum: 1 }),
+    riverDryTileCount: Type.Integer({ minimum: 0 }),
+    riverEphemeralTileCount: Type.Integer({ minimum: 0 }),
+    riverIntermittentTileCount: Type.Integer({ minimum: 0 }),
+    riverPerennialTileCount: Type.Integer({ minimum: 0 }),
+    nonPerennialRiverShareOfRiverTiles: Type.Number({ minimum: 0, maximum: 1 }),
+    oceanMouthTileCount: Type.Integer({ minimum: 0 }),
+    acceptedLakeMouthTileCount: Type.Integer({ minimum: 0 }),
+    closedBasinMouthTileCount: Type.Integer({ minimum: 0 }),
+    spillPathMouthTileCount: Type.Integer({ minimum: 0 }),
+    unresolvedMouthTileCount: Type.Integer({ minimum: 0 }),
+    resolvedMouthTileCount: Type.Integer({ minimum: 0 }),
+    assignedBasinLandTileCount: Type.Integer({ minimum: 0 }),
+    unassignedBasinLandTileCount: Type.Integer({ minimum: 0 }),
+    invalidReceiverTileCount: Type.Integer({ minimum: 0 }),
+    downstreamDischargeDropEdgeCount: Type.Integer({ minimum: 0 }),
+    closedOrLakeTerminalLandShare: Type.Number({ minimum: 0, maximum: 1 }),
+    lakeConnectedTerminalDischargeShare: Type.Number({ minimum: 0, maximum: 1 }),
+    maxUpstreamArea: Type.Integer({ minimum: 0 }),
+    maxStreamOrderProxy: Type.Integer({ minimum: 0 }),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Aggregate Hydrology river/lake benchmark metrics for diagnostics, Studio, and product proof rows.",
+  }
+);
+
 export const HydrologyRiverNetworkMetricsArtifactSchema = Type.Object(
   {
     upstreamArea: TypedArraySchemas.i32({
@@ -110,6 +158,7 @@ export const HydrologyRiverNetworkMetricsArtifactSchema = Type.Object(
       description:
         "Flow permanence proxy per land tile: 0=dry/no-signal, 1=ephemeral, 2=intermittent, 3=perennial.",
     }),
+    benchmarkSummary: HydrologyRiverNetworkBenchmarkSummarySchema,
   },
   {
     additionalProperties: false,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.ts
@@ -385,7 +385,7 @@ export default createStep(PlotRiversStepContract, {
           label: "Navigable River Mask (Projected)",
           group: GROUP_MAP_RIVERS,
           palette: "categorical",
-          role: "engine",
+          role: "projection",
         }),
       });
       context.viz?.dumpGrid(context.trace, {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.ts
@@ -5,6 +5,7 @@ import {
   defineVizMeta,
   snapshotEngineHeightfield,
 } from "@swooper/mapgen-core";
+import { CIV7_DEFAULT_RIVER_MODELING_ARGS } from "@civ7/map-policy";
 import {
   HYDROLOGY_FLOW_INTERMITTENT,
   HYDROLOGY_FLOW_PERENNIAL,
@@ -300,6 +301,20 @@ export default createStep(PlotRiversStepContract, {
       context.adapter.setTerrainType(i % width, Math.floor(i / width), NAVIGABLE_RIVER_TERRAIN);
     }
     logStats("POST-STAMP-RIVERS");
+    // Stock Civ map scripts run TerrainBuilder.modelRivers before validation
+    // and named-river definition. Keep that native materialization sequence
+    // local to projection; Hydrology remains the source of authored river truth.
+    context.adapter.modelRivers(
+      CIV7_DEFAULT_RIVER_MODELING_ARGS.minLength,
+      CIV7_DEFAULT_RIVER_MODELING_ARGS.maxLength,
+      NAVIGABLE_RIVER_TERRAIN
+    );
+    context.trace.event(() => ({
+      type: "map.rivers.officialCivRiverModeling",
+      minLength: CIV7_DEFAULT_RIVER_MODELING_ARGS.minLength,
+      maxLength: CIV7_DEFAULT_RIVER_MODELING_ARGS.maxLength,
+    }));
+    logStats("POST-MODEL-RIVERS");
     context.adapter.validateAndFixTerrain();
     logStats("POST-VALIDATE");
     context.adapter.defineNamedRivers();

--- a/mods/mod-swooper-maps/test/hydrology/river-network-metrics.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology/river-network-metrics.test.ts
@@ -66,6 +66,46 @@ describe("hydrology/compute-river-network-metrics", () => {
     expect(result.flowPermanenceProxy[0]).toBe(HYDROLOGY_FLOW_DRY);
     expect(result.flowPermanenceProxy[1]).toBe(HYDROLOGY_FLOW_EPHEMERAL);
     expect(result.flowPermanenceProxy[5]).toBe(HYDROLOGY_FLOW_INTERMITTENT);
+    expect(result.benchmarkSummary).toMatchObject({
+      version: 1,
+      landTileCount: 6,
+      waterTileCount: 0,
+      lakeTileCount: 1,
+      riverTileCount: 4,
+      minorRiverTileCount: 3,
+      majorRiverTileCount: 1,
+      streamOrder1RiverTileCount: 3,
+      lowOrderRiverTileCount: 4,
+      dryFlowTileCount: 2,
+      ephemeralFlowTileCount: 2,
+      intermittentFlowTileCount: 2,
+      perennialFlowTileCount: 0,
+      riverDryTileCount: 0,
+      riverEphemeralTileCount: 2,
+      riverIntermittentTileCount: 2,
+      riverPerennialTileCount: 0,
+      oceanMouthTileCount: 0,
+      acceptedLakeMouthTileCount: 6,
+      closedBasinMouthTileCount: 0,
+      spillPathMouthTileCount: 0,
+      unresolvedMouthTileCount: 0,
+      resolvedMouthTileCount: 6,
+      assignedBasinLandTileCount: 6,
+      unassignedBasinLandTileCount: 0,
+      invalidReceiverTileCount: 0,
+      downstreamDischargeDropEdgeCount: 0,
+      maxUpstreamArea: 6,
+      maxStreamOrderProxy: 2,
+    });
+    expect(result.benchmarkSummary.lakeLandShare).toBeCloseTo(1 / 6);
+    expect(result.benchmarkSummary.riverLandShare).toBeCloseTo(4 / 6);
+    expect(result.benchmarkSummary.minorRiverShareOfRiverTiles).toBeCloseTo(3 / 4);
+    expect(result.benchmarkSummary.majorRiverShareOfRiverTiles).toBeCloseTo(1 / 4);
+    expect(result.benchmarkSummary.lowOrderRiverShareOfRiverTiles).toBe(1);
+    expect(result.benchmarkSummary.nonDryFlowLandShare).toBeCloseTo(4 / 6);
+    expect(result.benchmarkSummary.nonPerennialRiverShareOfRiverTiles).toBe(1);
+    expect(result.benchmarkSummary.closedOrLakeTerminalLandShare).toBe(1);
+    expect(result.benchmarkSummary.lakeConnectedTerminalDischargeShare).toBe(1);
   });
 
   it("marks spill-routed paths separately from direct ocean mouths", () => {
@@ -78,7 +118,7 @@ describe("hydrology/compute-river-network-metrics", () => {
     const depressionDepth = new Float32Array([0, 0, 2, 0, 0, 0]);
     const runoff = new Float32Array([3, 3, 3, 3, 3, 0]);
     const discharge = new Float32Array([3, 6, 9, 12, 30, 0]);
-    const riverClass = new Uint8Array([0, RIVER_CLASS_MINOR, RIVER_CLASS_MINOR, RIVER_CLASS_MAJOR, RIVER_CLASS_MAJOR, 0]);
+    const riverClass = new Uint8Array([0, RIVER_CLASS_MINOR, RIVER_CLASS_MINOR, RIVER_CLASS_MAJOR, RIVER_CLASS_MAJOR + 1, 0]);
     const flowDir = new Int32Array([1, 2, 3, 4, 5, -1]);
     const basinId = new Int32Array([4, 4, 4, 4, 4, -1]);
     const terminalType = new Uint8Array([0, 0, 0, 0, 1, 0]);
@@ -114,5 +154,95 @@ describe("hydrology/compute-river-network-metrics", () => {
     expect(result.mouthType[0]).toBe(HYDROLOGY_MOUTH_SPILL_PATH);
     expect(result.flowPermanenceProxy[3]).toBe(HYDROLOGY_FLOW_INTERMITTENT);
     expect(result.flowPermanenceProxy[4]).toBe(HYDROLOGY_FLOW_PERENNIAL);
+    expect(result.benchmarkSummary).toMatchObject({
+      version: 1,
+      landTileCount: 5,
+      waterTileCount: 1,
+      lakeTileCount: 0,
+      riverTileCount: 4,
+      minorRiverTileCount: 2,
+      majorRiverTileCount: 2,
+      streamOrder1RiverTileCount: 4,
+      lowOrderRiverTileCount: 4,
+      dryFlowTileCount: 1,
+      ephemeralFlowTileCount: 0,
+      intermittentFlowTileCount: 3,
+      perennialFlowTileCount: 1,
+      riverDryTileCount: 0,
+      riverEphemeralTileCount: 0,
+      riverIntermittentTileCount: 3,
+      riverPerennialTileCount: 1,
+      oceanMouthTileCount: 2,
+      acceptedLakeMouthTileCount: 0,
+      closedBasinMouthTileCount: 0,
+      spillPathMouthTileCount: 3,
+      unresolvedMouthTileCount: 0,
+      resolvedMouthTileCount: 5,
+      assignedBasinLandTileCount: 5,
+      unassignedBasinLandTileCount: 0,
+      invalidReceiverTileCount: 0,
+      downstreamDischargeDropEdgeCount: 0,
+      maxUpstreamArea: 5,
+      maxStreamOrderProxy: 1,
+    });
+    expect(result.benchmarkSummary.lakeLandShare).toBe(0);
+    expect(result.benchmarkSummary.riverLandShare).toBeCloseTo(4 / 5);
+    expect(result.benchmarkSummary.lowOrderRiverShareOfRiverTiles).toBe(1);
+    expect(result.benchmarkSummary.nonDryFlowLandShare).toBeCloseTo(4 / 5);
+    expect(result.benchmarkSummary.nonPerennialRiverShareOfRiverTiles).toBeCloseTo(3 / 4);
+    expect(result.benchmarkSummary.closedOrLakeTerminalLandShare).toBe(0);
+    expect(result.benchmarkSummary.lakeConnectedTerminalDischargeShare).toBe(0);
+  });
+
+  it("surfaces routing and basin health counters without hiding typed output", () => {
+    const width = 3;
+    const height = 1;
+    const size = width * height;
+    const landMask = new Uint8Array(size).fill(1);
+    const elevation = new Int16Array([8, 7, 6]);
+    const routingElevation = new Float32Array(elevation);
+    const depressionDepth = new Float32Array(size);
+    const runoff = new Float32Array([1, 1, 1]);
+    const discharge = new Float32Array([5, 4, 9]);
+    const riverClass = new Uint8Array([RIVER_CLASS_MINOR, 0, RIVER_CLASS_MAJOR]);
+    const flowDir = new Int32Array([1, -2, -1]);
+    const basinId = new Int32Array([2, -1, 3]);
+    const terminalType = new Uint8Array([0, 0, 2]);
+    const lakeMask = new Uint8Array(size);
+
+    const result = runOpValidated(
+      computeRiverNetworkMetrics,
+      {
+        width,
+        height,
+        landMask,
+        elevation,
+        routingElevation,
+        depressionDepth,
+        runoff,
+        discharge,
+        riverClass,
+        flowDir,
+        basinId,
+        terminalType,
+        lakeMask,
+      },
+      {
+        strategy: "default",
+        config: {},
+      }
+    );
+
+    expect(result.benchmarkSummary.invalidReceiverTileCount).toBe(1);
+    expect(result.benchmarkSummary.downstreamDischargeDropEdgeCount).toBe(1);
+    expect(result.benchmarkSummary.assignedBasinLandTileCount).toBe(2);
+    expect(result.benchmarkSummary.unassignedBasinLandTileCount).toBe(1);
+    expect(result.benchmarkSummary.unresolvedMouthTileCount).toBe(2);
+    expect(result.benchmarkSummary.closedBasinMouthTileCount).toBe(1);
+    expect(result.benchmarkSummary.riverTileCount).toBe(2);
+    expect(result.benchmarkSummary.riverDryTileCount).toBe(0);
+    expect(result.benchmarkSummary.riverIntermittentTileCount).toBe(1);
+    expect(result.benchmarkSummary.riverPerennialTileCount).toBe(1);
+    expect(result.benchmarkSummary.nonPerennialRiverShareOfRiverTiles).toBe(0.5);
   });
 });

--- a/mods/mod-swooper-maps/test/map-rivers/navigable-river-materialization.test.ts
+++ b/mods/mod-swooper-maps/test/map-rivers/navigable-river-materialization.test.ts
@@ -56,12 +56,63 @@ describe("select navigable river terrain", () => {
     expect(result.plannedMajorRiverTileCount).toBe(8);
     expect(result.nonProjectableMajorTileCount).toBe(0);
     expect(result.unselectedEligibleMajorTileCount).toBe(5);
-    expect(result.candidateEndpointCount).toBe(2);
+    expect(result.selectedEndpointDischargeFloor).toBe(12);
+    expect(result.candidateEndpointCount).toBe(1);
     for (let x = 0; x < 5; x++) expect(result.riverMask[x]).toBe(0);
     for (let x = 0; x < 3; x++) expect(result.riverMask[width + x]).toBe(1);
   });
 
-  it("backfills lower-ranked endpoints when the preferred endpoint tier cannot fill the target budget", () => {
+  it("fills the target budget from admitted endpoints", () => {
+    const width = 2;
+    const height = 3;
+    const size = width * height;
+    const riverClass = new Uint8Array(size).fill(RIVER_CLASS_MAJOR);
+    const discharge = new Float32Array([
+      90, 100,
+      70, 80,
+      50, 60,
+    ]);
+    const flowDir = new Int32Array([
+      1, -1,
+      3, -1,
+      5, -1,
+    ]);
+    const projectableLandMask = new Uint8Array(size).fill(1);
+
+    const result = runOpValidated(
+      selectNavigableRiverTerrain,
+      {
+        width,
+        height,
+        riverClass,
+        discharge,
+        flowDir,
+        projectableLandMask,
+      },
+      {
+        strategy: "default",
+        config: { endpointDischargePercentileMin: 0, targetMajorTileFraction: 0.7 },
+      }
+    );
+
+    expect(result.selectedEndpointDischargeFloor).toBe(60);
+    expect(result.candidateEndpointCount).toBe(3);
+    expect(result.targetTileCount).toBe(4);
+    expect(result.selectedChainCount).toBe(2);
+    expect(Array.from(result.selectedChainLengths)).toEqual([2, 2]);
+    expect(result.longestSelectedChainLength).toBe(2);
+    expect(result.meanSelectedChainLength).toBe(2);
+    expect(result.selectedTileCount).toBe(4);
+    expect(result.nonProjectableMajorTileCount).toBe(0);
+    expect(result.unselectedEligibleMajorTileCount).toBe(2);
+    expect(Array.from(result.riverMask)).toEqual([
+      1, 1,
+      1, 1,
+      0, 0,
+    ]);
+  });
+
+  it("does not backfill endpoints below the discharge floor", () => {
     const width = 2;
     const height = 3;
     const size = width * height;
@@ -94,18 +145,16 @@ describe("select navigable river terrain", () => {
       }
     );
 
-    expect(result.candidateEndpointCount).toBe(3);
+    expect(result.selectedEndpointDischargeFloor).toBe(100);
+    expect(result.candidateEndpointCount).toBe(1);
     expect(result.targetTileCount).toBe(4);
-    expect(result.selectedChainCount).toBe(2);
-    expect(Array.from(result.selectedChainLengths)).toEqual([2, 2]);
-    expect(result.longestSelectedChainLength).toBe(2);
-    expect(result.meanSelectedChainLength).toBe(2);
-    expect(result.selectedTileCount).toBe(4);
-    expect(result.nonProjectableMajorTileCount).toBe(0);
-    expect(result.unselectedEligibleMajorTileCount).toBe(2);
+    expect(result.selectedChainCount).toBe(1);
+    expect(Array.from(result.selectedChainLengths)).toEqual([2]);
+    expect(result.selectedTileCount).toBe(2);
+    expect(result.unselectedEligibleMajorTileCount).toBe(4);
     expect(Array.from(result.riverMask)).toEqual([
       1, 1,
-      1, 1,
+      0, 0,
       0, 0,
     ]);
   });

--- a/mods/mod-swooper-maps/test/map-rivers/plot-rivers-post-refresh.test.ts
+++ b/mods/mod-swooper-maps/test/map-rivers/plot-rivers-post-refresh.test.ts
@@ -6,7 +6,10 @@ import {
   NAVIGABLE_RIVER_TERRAIN,
   createExtendedMapContext,
 } from "@swooper/mapgen-core";
-import { NO_RIVER_TYPE } from "@civ7/map-policy";
+import {
+  CIV7_DEFAULT_RIVER_MODELING_ARGS,
+  RIVER_TYPE_NAVIGABLE,
+} from "@civ7/map-policy";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 
 import { RIVER_CLASS_MAJOR, RIVER_CLASS_MINOR } from "../../src/domain/hydrology/index.js";
@@ -45,6 +48,15 @@ class RiverCacheRefreshAdapter extends MockAdapter {
 
   override validateAndFixTerrain(): void {
     this.callOrder.push("validateAndFixTerrain");
+  }
+
+  override modelRivers(
+    minLength: number,
+    maxLength: number,
+    navigableTerrain: number
+  ): void {
+    this.callOrder.push(`modelRivers:${minLength}:${maxLength}`);
+    super.modelRivers(minLength, maxLength, navigableTerrain);
   }
 
   override defineNamedRivers(): void {
@@ -144,6 +156,7 @@ describe("map-rivers/plot-rivers", () => {
     );
 
     expect(adapter.callOrder).toEqual([
+      `modelRivers:${CIV7_DEFAULT_RIVER_MODELING_ARGS.minLength}:${CIV7_DEFAULT_RIVER_MODELING_ARGS.maxLength}`,
       "validateAndFixTerrain",
       "defineNamedRivers",
       "recalculateAreas",
@@ -198,10 +211,10 @@ describe("map-rivers/plot-rivers", () => {
     expect(readback?.riverMask?.[0]).toBe(1);
     expect(readback?.riverMask?.[width]).toBe(0);
     expect(readback?.terrainNavigableRiverMask?.[0]).toBe(1);
-    expect(readback?.engineNavigableRiverMask?.[0]).toBe(0);
-    expect(readback?.engineRiverType?.[0]).toBeDefined();
+    expect(readback?.engineNavigableRiverMask?.[0]).toBe(1);
+    expect(readback?.engineRiverType?.[0]).toBe(RIVER_TYPE_NAVIGABLE);
     expect(readback?.terrainNavigableRiverTileCount).toBe(5);
-    expect(readback?.engineNavigableRiverTileCount).toBe(0);
+    expect(readback?.engineNavigableRiverTileCount).toBe(5);
     expect(readback?.engineMinorRiverTileCount).toBe(0);
     expect(readback?.minorRiverStampingSupported).toBe(false);
     expect(readback?.minorRiverUnsupportedReason).toContain("minor-river metadata parity");

--- a/mods/mod-swooper-maps/test/pipeline/earth-metrics.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/earth-metrics.test.ts
@@ -12,6 +12,22 @@ import { computeEarthMetrics } from "../../src/dev/diagnostics/extract-earth-met
 import { standardConfig } from "../support/standard-config.js";
 
 describe("pipeline earth metrics", () => {
+  it("rejects river-network summaries that do not match the same diagnostic run", () => {
+    expect(() =>
+      computeEarthMetrics({
+        width: 2,
+        height: 1,
+        landMask: new Uint8Array([1, 1]),
+        riverClass: new Uint8Array([1, 0]),
+        riverNetworkBenchmarkSummary: {
+          version: 1,
+          landTileCount: 2,
+          riverTileCount: 2,
+        },
+      })
+    ).toThrow("riverTileCount mismatch");
+  });
+
   it("produces broad earth-like coverage metrics on the standard preset", () => {
     const seed = 1337;
     const width = 48;
@@ -43,12 +59,18 @@ describe("pipeline earth metrics", () => {
     const hydrography = context.artifacts.get(hydrologyHydrographyArtifacts.hydrography.id) as
       | { riverClass?: Uint8Array; sinkMask?: Uint8Array }
       | undefined;
+    const riverNetworkMetrics = context.artifacts.get(hydrologyHydrographyArtifacts.riverNetworkMetrics.id) as
+      | { benchmarkSummary?: { version: 1 } & Record<string, number> }
+      | undefined;
     const classification = context.artifacts.get(ecologyArtifacts.biomeClassification.id) as
       | { biomeIndex?: Uint8Array }
       | undefined;
     if (!(topography?.landMask instanceof Uint8Array)) throw new Error("Missing topography.landMask.");
     if (!(hydrography?.riverClass instanceof Uint8Array)) throw new Error("Missing hydrography.riverClass.");
     if (!(hydrography?.sinkMask instanceof Uint8Array)) throw new Error("Missing hydrography.sinkMask.");
+    if (riverNetworkMetrics?.benchmarkSummary?.version !== 1) {
+      throw new Error("Missing hydrology.riverNetworkMetrics.benchmarkSummary.");
+    }
     const lakePlan = context.artifacts.get(hydrologyHydrographyArtifacts.lakePlan.id) as
       | { lakeMask?: Uint8Array }
       | undefined;
@@ -61,6 +83,7 @@ describe("pipeline earth metrics", () => {
       landMask: topography.landMask,
       lakeMask: lakePlan.lakeMask,
       riverClass: hydrography.riverClass,
+      riverNetworkBenchmarkSummary: riverNetworkMetrics.benchmarkSummary,
       biomeIndex: classification.biomeIndex,
     });
 
@@ -68,6 +91,9 @@ describe("pipeline earth metrics", () => {
     expect(metrics.landShare).toBeLessThan(0.9);
     expect(metrics.lakeShare).toBeLessThan(0.2);
     expect(metrics.riverClassShare).toBeGreaterThan(0);
+    expect(metrics.hydrology.riverNetworkSummary?.riverTileCount).toBeGreaterThan(0);
+    expect(metrics.hydrology.riverNetworkSummary?.riverLandShare).toBeGreaterThan(0);
+    expect(metrics.hydrology.riverNetworkSummary?.invalidReceiverTileCount).toBe(0);
     expect(metrics.biomeDiversity).toBeGreaterThanOrEqual(2);
     expect(metrics.dominantBiome).not.toBeNull();
   });

--- a/mods/mod-swooper-maps/test/pipeline/hydrology-river-network-metrics.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/hydrology-river-network-metrics.test.ts
@@ -63,6 +63,31 @@ function runHydrologyMetrics(args: Readonly<{
         streamOrderProxy?: Uint8Array;
         mouthType?: Uint8Array;
         flowPermanenceProxy?: Uint8Array;
+        benchmarkSummary?: {
+          version: 1;
+          landTileCount: number;
+          riverTileCount: number;
+          minorRiverTileCount: number;
+          majorRiverTileCount: number;
+          riverLandShare: number;
+          minorRiverShareOfRiverTiles: number;
+          majorRiverShareOfRiverTiles: number;
+          lowOrderRiverShareOfRiverTiles: number;
+          lakeLandShare: number;
+          nonDryFlowLandShare: number;
+          riverDryTileCount: number;
+          riverEphemeralTileCount: number;
+          riverIntermittentTileCount: number;
+          riverPerennialTileCount: number;
+          nonPerennialRiverShareOfRiverTiles: number;
+          unresolvedMouthTileCount: number;
+          assignedBasinLandTileCount: number;
+          unassignedBasinLandTileCount: number;
+          invalidReceiverTileCount: number;
+          downstreamDischargeDropEdgeCount: number;
+          maxUpstreamArea: number;
+          maxStreamOrderProxy: number;
+        };
       }
     | undefined;
 
@@ -80,6 +105,9 @@ function runHydrologyMetrics(args: Readonly<{
   }
   if (!(metrics?.flowPermanenceProxy instanceof Uint8Array)) {
     throw new Error("Missing hydrology.riverNetworkMetrics.flowPermanenceProxy.");
+  }
+  if (metrics.benchmarkSummary?.version !== 1) {
+    throw new Error("Missing hydrology.riverNetworkMetrics.benchmarkSummary.");
   }
 
   let unresolvedMouthCount = 0;
@@ -114,6 +142,7 @@ function runHydrologyMetrics(args: Readonly<{
     intermittentCount,
     perennialCount,
     riverTileCount,
+    benchmarkSummary: metrics.benchmarkSummary,
   };
 }
 
@@ -125,6 +154,28 @@ describe("pipeline hydrology river-network metrics", () => {
       expect(stats.unresolvedMouthCount, `seed ${seed} unresolved mouths`).toBe(0);
       expect(stats.maxUpstreamArea, `seed ${seed} max upstream area`).toBeGreaterThan(8);
       expect(stats.maxStreamOrder, `seed ${seed} max stream order`).toBeGreaterThanOrEqual(2);
+      expect(stats.benchmarkSummary.unresolvedMouthTileCount).toBe(stats.unresolvedMouthCount);
+      expect(stats.benchmarkSummary.maxUpstreamArea).toBe(stats.maxUpstreamArea);
+      expect(stats.benchmarkSummary.maxStreamOrderProxy).toBe(stats.maxStreamOrder);
+      expect(stats.benchmarkSummary.riverTileCount).toBe(stats.riverTileCount);
+      expect(stats.benchmarkSummary.minorRiverTileCount).toBeGreaterThan(0);
+      expect(stats.benchmarkSummary.majorRiverTileCount).toBeGreaterThan(0);
+      expect(stats.benchmarkSummary.riverDryTileCount).toBe(0);
+      expect(
+        stats.benchmarkSummary.riverEphemeralTileCount +
+          stats.benchmarkSummary.riverIntermittentTileCount +
+          stats.benchmarkSummary.riverPerennialTileCount
+      ).toBe(stats.benchmarkSummary.riverTileCount);
+      expect(stats.benchmarkSummary.riverLandShare).toBeGreaterThan(0);
+      expect(stats.benchmarkSummary.minorRiverShareOfRiverTiles).toBeGreaterThan(0);
+      expect(stats.benchmarkSummary.majorRiverShareOfRiverTiles).toBeGreaterThan(0);
+      expect(stats.benchmarkSummary.lowOrderRiverShareOfRiverTiles).toBeGreaterThan(0);
+      expect(stats.benchmarkSummary.nonDryFlowLandShare).toBeGreaterThan(0);
+      expect(stats.benchmarkSummary.nonPerennialRiverShareOfRiverTiles).toBeGreaterThan(0);
+      expect(stats.benchmarkSummary.invalidReceiverTileCount).toBe(0);
+      expect(stats.benchmarkSummary.downstreamDischargeDropEdgeCount).toBe(0);
+      expect(stats.benchmarkSummary.unassignedBasinLandTileCount).toBe(0);
+      expect(stats.benchmarkSummary.assignedBasinLandTileCount).toBe(stats.benchmarkSummary.landTileCount);
       expect(
         stats.ephemeralCount + stats.intermittentCount + stats.perennialCount,
         `seed ${seed} non-dry flow signal`
@@ -136,6 +187,12 @@ describe("pipeline hydrology river-network metrics", () => {
     const config = recipeConfig(desertMountainsRaw);
     const stats = runHydrologyMetrics({ config, width: 42, height: 26, seed: 1018 });
     expect(stats.unresolvedMouthCount).toBe(0);
+    expect(stats.benchmarkSummary.unresolvedMouthTileCount).toBe(0);
+    expect(stats.benchmarkSummary.landTileCount).toBeGreaterThan(0);
+    expect(stats.benchmarkSummary.invalidReceiverTileCount).toBe(0);
+    expect(stats.benchmarkSummary.downstreamDischargeDropEdgeCount).toBe(0);
+    expect(stats.benchmarkSummary.lakeLandShare).toBeGreaterThanOrEqual(0);
+    expect(stats.benchmarkSummary.riverLandShare).toBeGreaterThanOrEqual(0);
     expect(stats.dryCount).toBeGreaterThan(0);
     expect(stats.maxUpstreamArea).toBeGreaterThan(0);
   });

--- a/mods/mod-swooper-maps/test/pipeline/map-stamping.contract-guard.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/map-stamping.contract-guard.test.ts
@@ -119,7 +119,7 @@ describe("map stamping contract guardrails", () => {
     expect(lakeStampers).toEqual([path.join(stagesRoot, "map-hydrology/steps/lakes.ts")]);
   });
 
-  it("keeps map-rivers on direct terrain stamping instead of Civ bulk river modeling", () => {
+  it("keeps Civ river modeling constrained to the dedicated map-rivers step", () => {
     const repoRoot = path.resolve(import.meta.dir, "../..");
     const stagesRoot = path.join(repoRoot, "src/recipes/standard/stages");
     const files = listFilesRecursive(stagesRoot).filter((file) => file.endsWith(".ts"));
@@ -130,7 +130,7 @@ describe("map stamping contract guardrails", () => {
     });
 
     callers.sort();
-    expect(callers).toEqual([]);
+    expect(callers).toEqual([path.join(stagesRoot, "map-rivers/steps/plotRivers.ts")]);
 
     const plotRiversText = readFileSync(
       path.join(stagesRoot, "map-rivers/steps/plotRivers.ts"),
@@ -142,6 +142,7 @@ describe("map stamping contract guardrails", () => {
     );
     expect(plotRiversText).toContain("selectNavigableRiverTerrain");
     expect(plotRiversText).toContain("setTerrainType");
+    expect(plotRiversText).toContain("modelRivers");
     expect(plotRiversContractText).toContain("MAP_PROJECTION_EFFECT_TAGS.map.riversPlotted");
     expect(plotRiversContractText).not.toContain("riversModeled");
   });

--- a/mods/mod-swooper-maps/test/pipeline/seed-matrix-stats.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/seed-matrix-stats.test.ts
@@ -41,6 +41,9 @@ function runMetrics(seed: number, width: number, height: number) {
   const hydrography = context.artifacts.get(hydrologyHydrographyArtifacts.hydrography.id) as
     | { riverClass?: Uint8Array; sinkMask?: Uint8Array }
     | undefined;
+  const riverNetworkMetrics = context.artifacts.get(hydrologyHydrographyArtifacts.riverNetworkMetrics.id) as
+    | { benchmarkSummary?: { version: 1 } & Record<string, number> }
+    | undefined;
   const engineProjectionLakes = context.artifacts.get(mapHydrologyArtifacts.engineProjectionLakes.id) as
     | { lakeMask?: Uint8Array }
     | undefined;
@@ -60,6 +63,9 @@ function runMetrics(seed: number, width: number, height: number) {
   if (!(topography?.landMask instanceof Uint8Array)) throw new Error("Missing topography.landMask.");
   if (!(hydrography?.riverClass instanceof Uint8Array)) throw new Error("Missing hydrography.riverClass.");
   if (!(hydrography?.sinkMask instanceof Uint8Array)) throw new Error("Missing hydrography.sinkMask.");
+  if (riverNetworkMetrics?.benchmarkSummary?.version !== 1) {
+    throw new Error("Missing hydrology.riverNetworkMetrics.benchmarkSummary.");
+  }
   if (!(engineProjectionLakes?.lakeMask instanceof Uint8Array))
     throw new Error("Missing engineProjectionLakes.lakeMask.");
   if (!(classification?.biomeIndex instanceof Uint8Array)) throw new Error("Missing biomeClassification.biomeIndex.");
@@ -72,6 +78,7 @@ function runMetrics(seed: number, width: number, height: number) {
       landMask: topography.landMask,
       lakeMask: engineProjectionLakes.lakeMask,
       riverClass: hydrography.riverClass,
+      riverNetworkBenchmarkSummary: riverNetworkMetrics.benchmarkSummary,
       biomeIndex: classification.biomeIndex,
     }),
     starts: {
@@ -99,6 +106,10 @@ describe("pipeline seed matrix stats", () => {
       expect(metricsA.earth.lakeShare).toBeLessThan(0.5);
       expect(metricsA.earth.riverClassShare).toBeGreaterThanOrEqual(0);
       expect(metricsA.earth.riverClassShare).toBeLessThan(1);
+      expect(metricsA.earth.hydrology.riverNetworkSummary?.landTileCount).toBeGreaterThan(0);
+      expect(metricsA.earth.hydrology.riverNetworkSummary?.riverTileCount).toBeGreaterThanOrEqual(0);
+      expect(metricsA.earth.hydrology.riverNetworkSummary?.invalidReceiverTileCount).toBe(0);
+      expect(metricsA.earth.hydrology.riverNetworkSummary?.downstreamDischargeDropEdgeCount).toBe(0);
       expect(metricsA.earth.biomeDiversity).toBeGreaterThanOrEqual(1);
       expect(metricsA.starts.assigned, `seed ${seed} assigned starts`).toBe(8);
       expect(metricsA.starts.desperationAssigned, `seed ${seed} desperation starts`).toBe(0);

--- a/mods/mod-swooper-maps/test/pipeline/viz-emissions.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/viz-emissions.test.ts
@@ -329,7 +329,7 @@ describe("standard pipeline viz emissions", () => {
     expect(waterClassMetas?.some((m) => m?.visibility === "default" && m?.role === "membership")).toBe(true);
 
     const projectedRiverMetas = metasByKey.get("map.rivers.projectedRiverMask") as any[] | undefined;
-    expect(projectedRiverMetas?.some((m) => m?.visibility === "default" && m?.role === "engine")).toBe(true);
+    expect(projectedRiverMetas?.some((m) => m?.visibility === "default" && m?.role === "projection")).toBe(true);
 
     const minorRiverIntentMetas = metasByKey.get("map.rivers.plannedMinorRiverMask") as any[] | undefined;
     expect(minorRiverIntentMetas?.some((m) => m?.visibility === "default" && m?.role === "physics")).toBe(true);

--- a/openspec/changes/earthlike-visible-river-acceptance/workstream/physical-grounding.md
+++ b/openspec/changes/earthlike-visible-river-acceptance/workstream/physical-grounding.md
@@ -30,6 +30,43 @@ true.
   changes the Civ-visible trunk subset after terrain projection; `lakeiness`
   changes accepted lake persistence without moving drainage divides.
 
+## Benchmark Contract
+
+Hydrology benchmark rows use a declared contract before local tuning:
+
+| Field | Expectation | Uncertainty marker |
+| --- | --- | --- |
+| Tile scale | Civ tiles are coarse strategy-scale samples; same-run reports must carry dimensions and any latitude assumption before translating tile counts to kilometers. | Do not compare tile counts directly to meter-scale Earth pixels. |
+| Visible feature floor | Hydrology can publish hidden drainage, minor/headwater channels, and major trunks; Civ terrain projection is only the visible navigable subset. | `TERRAIN_NAVIGABLE_RIVER` terrain proof does not prove minor metadata. |
+| Regime row | Benchmarks are interpreted as `wet`, `normal`, `arid`, `mountain`, `closed`, `archipelago`, or an explicit extension. | Arid/no-visible outcomes are only valid with matching regime evidence. |
+| Stylization ledger | Any exaggeration, merging, omission, or engine-native substitution records source anchor, affected metric, reason, product claim, and proof gate. | Silent stylization cannot close product acceptance. |
+
+Hydrology `artifact:hydrology.riverNetworkMetrics.benchmarkSummary` is the
+observed generated-map summary for this contract: class ratios, river-specific
+permanence, low-order hierarchy, terminal shares, lake share, basin coverage,
+and routing-health counters. Projection plans, live terrain readback, Civ river
+metadata, Studio layer status, screenshots, and product verdicts are separate
+proof classes.
+
+## External Earth Anchors
+
+- **Coarse routed network.** HydroRIVERS maps rivers with catchment area
+  `>=10 km2` or average flow `>=0.1 m3/s`; its product page reports 8.5
+  million reaches averaging 4.2 km and 35.9 million km globally. Treat this as
+  a coarse mapped-network floor, not as all drainage truth.
+- **Threshold uncertainty.** Global vector hydrography literature notes the
+  HydroRIVERS threshold is empirical, so generated-map acceptance must preserve
+  topology/regime ordering and avoid one global magic threshold.
+- **Visible rivers.** GRWL measures rivers `>=30 m` wide and covers more than
+  2.1 million km of centerlines. It anchors visible wide-river expectations,
+  not minor/headwater drainage.
+- **Flow permanence.** Global modeling estimates that 51-60% of river length is
+  non-perennial. Non-perennial and ephemeral outcomes must remain first-class
+  Hydrology results.
+- **Lakes.** HydroLAKES reports about 1.4 million lakes/reservoirs totaling
+  2.67 million km2. Lake abundance should be judged against a declared visible
+  lake floor and regime row.
+
 ## Source Anchors
 
 - USGS Water Science School, [Watersheds and Drainage Basins](https://www.usgs.gov/water-science-school/science/watersheds-and-drainage-basins)
@@ -37,6 +74,14 @@ true.
 - USGS, [Salinity and hydrology of closed lakes](https://pubs.usgs.gov/publication/pp412)
 - American Meteorological Society Glossary, [rain shadow](https://glossary.ametsoc.org/wiki/rain-shadow/)
 - NOAA Climate.gov, [Rain Shadows on the Summits of Hawaii](https://prod-01-asg-www-climate.woc.noaa.gov/news-features/featured-images/rain-shadows-summits-hawaii)
+- HydroSHEDS, [HydroRIVERS](https://www.hydrosheds.org/products/hydrorivers)
+- Lin et al., [A new vector-based global river network dataset accounting for
+  variable drainage density](https://www.nature.com/articles/s41597-021-00819-9)
+- Allen and Pavelsky, [Global extent of rivers and
+  streams](https://www.science.org/doi/10.1126/science.aat0636)
+- Messager et al., [Global prevalence of non-perennial rivers and
+  streams](https://pubmed.ncbi.nlm.nih.gov/34135525/)
+- HydroSHEDS, [HydroLAKES](https://www.hydrosheds.org/products/hydrolakes)
 
 ## Test Mapping
 
@@ -51,6 +96,14 @@ true.
   - arid plateau: valid routing alone is not enough to force river projection;
   - water-supply/topology and lakeiness/topology fixtures: knobs change supply
     or lake acceptance without moving drainage topology.
+- `test/hydrology/river-network-metrics.test.ts`
+  - river-network summary fixtures assert accepted-lake, spill-path, hierarchy,
+    permanence, basin coverage, invalid receiver, discharge-drop, and unresolved
+    terminal counters.
+- `test/pipeline/hydrology-river-network-metrics.test.ts`
+  - representative generated-map rows assert nonzero minor/major river classes,
+    river permanence accounting, no invalid receivers, no discharge drops,
+    assigned basin coverage, and arid controls.
 - `test/placement/placement-lake-readback.test.ts`
   - final readback catches accepted lakes that later dry out or lose lake
     classification after engine maintenance.

--- a/openspec/changes/hydrology-river-network-metrics/design.md
+++ b/openspec/changes/hydrology-river-network-metrics/design.md
@@ -12,7 +12,7 @@ The benchmark contract is declared before tuning and must record:
 - hidden drainage, minor/headwater, major, and navigable-visible class counts;
 - channel-length share by class;
 - basin terminal shares (ocean, accepted lake, closed basin, unresolved);
-- lake area share and lake-connected discharge share;
+- lake area share and lake-connected terminal discharge share;
 - major-to-minor and navigable-to-major ratios;
 - stylization ledger when Civ tile scale requires exaggeration, merging, or
   omission relative to Earth data.
@@ -27,6 +27,15 @@ Metrics:
   unresolved.
 - `slopeClass`: flat, low, moderate, steep, mountain-blocked.
 - `flowPermanenceProxy`: perennial, intermittent, ephemeral, or dry/no-signal.
+- `benchmarkSummary`: observed Hydrology aggregate fields for land/water/lake
+  denominators, river class ratios, river-specific permanence, low-order
+  hierarchy, terminal shares, basin coverage, and routing-health counters.
+
+Benchmark metadata belongs in report/spec/docs surfaces, not in the Hydrology
+compute op. It records tile scale, visible feature floor, regime row, external
+Earth anchors, and stylization notes so Studio/proof tooling can interpret
+observed metrics without turning projection/readback artifacts into Hydrology
+truth.
 
 Generated-map oracles:
 
@@ -41,11 +50,15 @@ Generated-map oracles:
 
 External Earth anchors constrain the first accepted pass:
 
-- HydroRIVERS / HydroATLAS inclusion floors and global routed-network coverage.
-- GRWL river-surface-area order of magnitude for visible wide rivers.
-- global non-perennial and headwater-dominance studies for minor/headwater
-  class ratios.
-- HydroLAKES / global lake inventory area share for lake abundance.
+- HydroRIVERS / HydroATLAS inclusion floors and global routed-network coverage:
+  HydroRIVERS uses `>=10 km2` upstream area or `>=0.1 m3/s` average flow and
+  reports 35.9 million km globally.
+- GRWL visible-river floor: rivers `>=30 m` wide, more than 2.1 million km of
+  centerlines, and sub-total-network coverage.
+- global non-perennial studies: 51-60% of river length ceases flowing at least
+  one day per year, so non-perennial classes are expected rather than failures.
+- HydroLAKES / global lake inventory: about 1.4 million lakes/reservoirs and
+  2.67 million km2 surface area for a `>=10 ha` inventory floor.
 - endorheic-basin datasets for closed-terminal frequency and no-ocean outcomes.
 
 The local generated seed matrix can calibrate against those anchors; it cannot

--- a/openspec/changes/hydrology-river-network-metrics/design.md
+++ b/openspec/changes/hydrology-river-network-metrics/design.md
@@ -3,6 +3,20 @@
 Add a hydrology diagnostics product that is downstream of physical routing and
 upstream of projection.
 
+The benchmark contract is declared before tuning and must record:
+
+- map tile-to-kilometer scale assumption;
+- minimum visible feature size for rivers, lakes, and floodplains;
+- climate/relief regime row (`wet`, `normal`, `arid`, `mountain`, `closed`,
+  `archipelago`, or explicitly extended);
+- hidden drainage, minor/headwater, major, and navigable-visible class counts;
+- channel-length share by class;
+- basin terminal shares (ocean, accepted lake, closed basin, unresolved);
+- lake area share and lake-connected discharge share;
+- major-to-minor and navigable-to-major ratios;
+- stylization ledger when Civ tile scale requires exaggeration, merging, or
+  omission relative to Earth data.
+
 Metrics:
 
 - `basinId`: connected drainage basin identifier.
@@ -19,10 +33,23 @@ Generated-map oracles:
 - no invalid receivers and no cycles;
 - every land route terminates at ocean, accepted lake, or typed closed basin;
 - discharge does not decrease along land receivers;
-- minor/headwater intent dominates physical network length on normal wet maps;
+- minor/headwater intent dominates physical network length on normal wet maps,
+  while non-perennial/ephemeral classes remain first-class outcomes;
 - major rivers are downstream/high-discharge subset;
 - lake intent is lowland/sink-derived and does not move drainage divides;
 - arid maps can produce ephemeral/no-visible outcomes with explicit status.
+
+External Earth anchors constrain the first accepted pass:
+
+- HydroRIVERS / HydroATLAS inclusion floors and global routed-network coverage.
+- GRWL river-surface-area order of magnitude for visible wide rivers.
+- global non-perennial and headwater-dominance studies for minor/headwater
+  class ratios.
+- HydroLAKES / global lake inventory area share for lake abundance.
+- endorheic-basin datasets for closed-terminal frequency and no-ocean outcomes.
+
+The local generated seed matrix can calibrate against those anchors; it cannot
+define them.
 
 ## Review Lanes
 

--- a/openspec/changes/hydrology-river-network-metrics/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/hydrology-river-network-metrics/specs/mapgen-normalization-workstreams/spec.md
@@ -12,6 +12,12 @@ tuned.
   stream hierarchy proxy, mouth type, slope class, and flow permanence proxy
 - **AND** they distinguish wet normal rivers from arid ephemeral/no-signal
   outcomes
+- **AND** they publish an observed benchmark summary for river class ratios,
+  river-specific permanence, low-order hierarchy, terminal shares, lake share,
+  basin coverage, and routing-health counters
+- **AND** benchmark metadata records tile scale, visible feature floor, regime
+  row, external Earth anchors, and stylization notes outside the Hydrology
+  compute op
 
 #### Scenario: Physical network metrics fail
 - **WHEN** drainage contains cycles, invalid receivers, unexplained discharge

--- a/openspec/changes/hydrology-river-network-metrics/tasks.md
+++ b/openspec/changes/hydrology-river-network-metrics/tasks.md
@@ -6,10 +6,12 @@
   projection behavior.
 - [ ] 1.3 Update physical-grounding docs with the metric oracles and uncertainty
   markers.
-- [ ] 1.4 Add benchmark-contract fields for tile scale, visible feature floor,
-  regime row, channel class ratios, terminal shares, lake area share, and
-  stylization notes.
-- [ ] 1.5 Record external Earth benchmark anchors before changing any local
+- [x] 1.4 Add observed benchmark-summary fields for channel class ratios,
+  river-specific permanence, low-order hierarchy, terminal shares, lake area
+  share, basin coverage, and routing-health counters.
+- [ ] 1.5 Add benchmark-contract metadata for tile scale, visible feature floor,
+  regime row, and stylization notes.
+- [ ] 1.6 Record external Earth benchmark anchors before changing any local
   acceptance threshold.
 
 ## 2. Seed Matrix

--- a/openspec/changes/hydrology-river-network-metrics/tasks.md
+++ b/openspec/changes/hydrology-river-network-metrics/tasks.md
@@ -4,14 +4,14 @@
   stream hierarchy, mouth type, slope class, and flow permanence.
 - [x] 1.2 Emit metrics in diagnostics and map statistics without changing Civ
   projection behavior.
-- [ ] 1.3 Update physical-grounding docs with the metric oracles and uncertainty
+- [x] 1.3 Update physical-grounding docs with the metric oracles and uncertainty
   markers.
 - [x] 1.4 Add observed benchmark-summary fields for channel class ratios,
   river-specific permanence, low-order hierarchy, terminal shares, lake area
   share, basin coverage, and routing-health counters.
-- [ ] 1.5 Add benchmark-contract metadata for tile scale, visible feature floor,
+- [x] 1.5 Add benchmark-contract metadata for tile scale, visible feature floor,
   regime row, and stylization notes.
-- [ ] 1.6 Record external Earth benchmark anchors before changing any local
+- [x] 1.6 Record external Earth benchmark anchors before changing any local
   acceptance threshold.
 
 ## 2. Seed Matrix

--- a/openspec/changes/hydrology-river-network-metrics/tasks.md
+++ b/openspec/changes/hydrology-river-network-metrics/tasks.md
@@ -2,7 +2,7 @@
 
 - [x] 1.1 Add hydrology network metric derivation for basin, upstream area,
   stream hierarchy, mouth type, slope class, and flow permanence.
-- [ ] 1.2 Emit metrics in diagnostics and map statistics without changing Civ
+- [x] 1.2 Emit metrics in diagnostics and map statistics without changing Civ
   projection behavior.
 - [ ] 1.3 Update physical-grounding docs with the metric oracles and uncertainty
   markers.

--- a/openspec/changes/hydrology-river-network-metrics/tasks.md
+++ b/openspec/changes/hydrology-river-network-metrics/tasks.md
@@ -6,12 +6,19 @@
   projection behavior.
 - [ ] 1.3 Update physical-grounding docs with the metric oracles and uncertainty
   markers.
+- [ ] 1.4 Add benchmark-contract fields for tile scale, visible feature floor,
+  regime row, channel class ratios, terminal shares, lake area share, and
+  stylization notes.
+- [ ] 1.5 Record external Earth benchmark anchors before changing any local
+  acceptance threshold.
 
 ## 2. Seed Matrix
 
 - [x] 2.1 Add fast deterministic generated-map hydrology checks.
 - [ ] 2.2 Add Earthlike and holdout seed checks with declared pass bands.
 - [x] 2.3 Add arid/desert no-signal controls.
+- [ ] 2.4 Add closed/endorheic and wet-headwater rows so normal Earth variation
+  is tested instead of averaged away.
 
 ## 3. Validation
 

--- a/openspec/changes/lake-floodplain-product-proof-gates/design.md
+++ b/openspec/changes/lake-floodplain-product-proof-gates/design.md
@@ -13,6 +13,8 @@ Floodplain gates:
 - require local/exact/live floodplain-family feature counts and at least one
   live floodplain-family tile for active rows;
 - preserve zero-count seeds only as inactive/no-signal controls.
+- derive floodplain eligibility from Hydrology/final-surface truth plus Civ
+  legality/readback, not from projected navigable-river adjacency alone.
 
 Product matrix:
 

--- a/openspec/changes/lake-floodplain-product-proof-gates/tasks.md
+++ b/openspec/changes/lake-floodplain-product-proof-gates/tasks.md
@@ -6,6 +6,9 @@
   evidence.
 - [ ] 1.3 Keep inactive floodplain/no-signal rows labeled as controls, not
   product passes.
+- [ ] 1.4 Move floodplain proof inputs to Hydrology/final-surface truth plus Civ
+  legality/readback, and prevent projected navigable adjacency from being the
+  sole product-proof input.
 
 ## 2. Product Matrix
 

--- a/openspec/changes/map-rivers-navigable-coherence/design.md
+++ b/openspec/changes/map-rivers-navigable-coherence/design.md
@@ -15,6 +15,18 @@ This change does not preserve or reintroduce authored `minLength/maxLength`
 projection thresholds. Those values are not the product model and do not match
 the physically grounded owner split.
 
+`endpointDischargePercentileMin` is an internal Hydrology selection envelope
+field, not a user-facing knob. Because the selector reports
+`selectedEndpointDischargeFloor`, the strategy must either enforce that floor
+when choosing candidate endpoints or remove/rename the reported field. Reporting
+an unenforced floor is not an acceptable proof surface.
+
+The native Civ bulk writer is not categorically banned by this change. A
+disposable runtime probe proved `TerrainBuilder.modelRivers(...)` can author
+river metadata in bulk. This change may use native writer evidence only after a
+bounded parity decision proves Hydrology truth remains the authority. Projection
+must not delegate river truth back to Civ.
+
 Initial acceptance bands:
 
 - For Standard `84x54` normal Earthlike maps where planned major rivers exceed

--- a/openspec/changes/map-rivers-navigable-coherence/tasks.md
+++ b/openspec/changes/map-rivers-navigable-coherence/tasks.md
@@ -7,7 +7,7 @@
   not rewrite Hydrology truth.
 - [x] 1.4 Retire the legacy `map-rivers.knobs.riverDensity` alias and realign
   adjacent Hydrology wording to the narrow owner model.
-- [ ] 1.5 Fix `endpointDischargePercentileMin` so the selected endpoint floor is
+- [x] 1.5 Fix `endpointDischargePercentileMin` so the selected endpoint floor is
   enforced by the selector, or remove/rename the reported floor with tests.
 
 ## 2. Acceptance Thresholds

--- a/openspec/changes/map-rivers-navigable-coherence/tasks.md
+++ b/openspec/changes/map-rivers-navigable-coherence/tasks.md
@@ -7,6 +7,8 @@
   not rewrite Hydrology truth.
 - [x] 1.4 Retire the legacy `map-rivers.knobs.riverDensity` alias and realign
   adjacent Hydrology wording to the narrow owner model.
+- [ ] 1.5 Fix `endpointDischargePercentileMin` so the selected endpoint floor is
+  enforced by the selector, or remove/rename the reported floor with tests.
 
 ## 2. Acceptance Thresholds
 
@@ -14,6 +16,8 @@
   on normal Earthlike maps.
 - [x] 2.2 Add negative controls where low/no navigable projection is expected.
 - [ ] 2.3 Rebaseline shipped/default configs only after same-run proof passes.
+- [ ] 2.4 Add a native-writer decision record before any `modelRivers(...)`
+  integration is treated as part of projection closure.
 
 ## 3. Validation
 

--- a/openspec/changes/river-lake-adversarial-workstream-design/workstream/execution-redesign-plan.md
+++ b/openspec/changes/river-lake-adversarial-workstream-design/workstream/execution-redesign-plan.md
@@ -9,6 +9,12 @@ Second-wave authority addendum:
 - `workstream/2026-06-09-second-wave-synthesis.md`
 - `workstream/agent-notes/2026-06-09-agent-*-second-wave.md`
 
+Third-wave session frame:
+
+- `docs/projects/river-lake-recovery/FRAME.md`
+- `docs/projects/river-lake-recovery/ADVERSARIAL-SYNTHESIS-2026-06-10.md`
+- `docs/projects/river-lake-recovery/agent-notes/2026-06-10-agent-*.md`
+
 ## Objective
 
 Finish the river/lake recovery as a physically grounded, architecture-correct,
@@ -115,6 +121,19 @@ Benchmark usage rule from the adversarial pass:
   - lake area should stay in the low single digits of land area, not near-zero
     and not tens of percent;
   - endorheic / closed drainage must remain materially present.
+
+Third-wave correction notes:
+
+- the active root `AGENTS.md` now routes hydrology/river/lake work through the
+  session frame until the session ends;
+- native `modelRivers(...)` bulk writer support is proven, but parity to
+  Hydrology-authored truth is not;
+- `endpointDischargePercentileMin` must be enforced or removed/renamed before
+  navigable-river projection metrics are treated as reliable;
+- public/raw config and Studio labels must not preserve stale selectors as the
+  product model;
+- floodplain closure must move toward Hydrology/final-surface truth plus Civ
+  legality/readback rather than projection adjacency alone.
 
 ## Locked Ownership Boundary
 

--- a/openspec/changes/river-lake-recovery-redesign/design.md
+++ b/openspec/changes/river-lake-recovery-redesign/design.md
@@ -1,5 +1,13 @@
 # Design: River And Lake Recovery Redesign
 
+Session frame:
+
+- `docs/projects/river-lake-recovery/FRAME.md` is the active compaction-safe
+  frame for the current hydrology/river/lake recovery session.
+- `docs/projects/river-lake-recovery/ADVERSARIAL-SYNTHESIS-2026-06-10.md`
+  records the current adversarial synthesis and the immediate correction
+  sequence.
+
 ## Objective Frame
 
 Future state:

--- a/openspec/changes/river-runtime-visible-proof/design.md
+++ b/openspec/changes/river-runtime-visible-proof/design.md
@@ -16,6 +16,19 @@ The visible proof runner emits one packet with:
 The runner may use OS screenshot only as a labeled fallback. Direct-control
 should own runtime map/camera operations.
 
+Runtime river proof must record both current materialization surfaces:
+
+- direct terrain stamping, which can prove live `TERRAIN_NAVIGABLE_RIVER`
+  terrain rows;
+- native bulk writer behavior, where `TerrainBuilder.modelRivers(...)` has been
+  proven to author river metadata in a disposable run but has not yet been
+  integrated or parity-bound to Hydrology truth.
+
+The packet must therefore include a metadata/materialization disposition:
+`terrain-only`, `native-writer-parity-pass`, `native-writer-parity-fail`,
+`native-writer-not-run`, or `unsupported-writer-surface`. A visible proof row
+cannot claim minor-river success from terrain-only evidence.
+
 Closure-capable `civ-rendered` proof also requires:
 
 - `exact-authorship=pass` for the same run before visible proof can pass;

--- a/openspec/changes/river-runtime-visible-proof/tasks.md
+++ b/openspec/changes/river-runtime-visible-proof/tasks.md
@@ -4,6 +4,8 @@
 - [ ] 1.2 Add direct-control wrappers for centering on tile coordinates and
   recording camera/visibility state.
 - [ ] 1.3 Add screenshot capture with explicit fallback labeling.
+- [ ] 1.4 Add metadata/materialization disposition fields for terrain-only,
+  native-writer parity pass/fail, not-run, and unsupported-writer states.
 
 ## 2. Visible Proof Runner
 
@@ -12,6 +14,8 @@
   emit visual verdict fields.
 - [ ] 2.3 Add negative controls for wrong map/seed, off-target camera, and
   no-river configs.
+- [ ] 2.4 Require minor-river claims to cite metadata/native-writer evidence,
+  not terrain-only readback.
 
 ## 3. Validation
 

--- a/openspec/changes/studio-river-lake-inspector-dx/design.md
+++ b/openspec/changes/studio-river-lake-inspector-dx/design.md
@@ -30,6 +30,11 @@ Projection masks must not be labeled as engine truth. In particular,
 `map.rivers.engineRiverMask` is terrain readback. Duplicated Hydrology truth
 layers shown near map-rivers must retain Hydrology ownership labels.
 
+Studio may derive non-zero tile counts from same-run inline grid layer payloads
+for known binary masks. Those counts are display evidence, not a replacement for
+Hydrology benchmark summaries, live readback counters, rendered screenshots, or
+product acceptance proof.
+
 Statuses include:
 
 - `no-physical-rivers`

--- a/openspec/changes/studio-river-lake-inspector-dx/design.md
+++ b/openspec/changes/studio-river-lake-inspector-dx/design.md
@@ -3,14 +3,32 @@
 The inspector is a tool surface with lanes:
 
 - Hydrology: discharge, river class, planned minor, planned major.
-- Projection: selected navigable terrain, eligible count, target count, min/max
-  length, connected-chain count.
+- Projection: selected navigable terrain, eligible count, target count,
+  connected-chain count, selected chain lengths, endpoint-discharge semantics,
+  and typed no-signal reason.
 - Civ terrain readback: live `TERRAIN_NAVIGABLE_RIVER`, rejected selected
   tiles, extra engine terrain.
 - Civ metadata readback: `isRiver`, `isNavigableRiver`, minor metadata, and
-  unsupported minor-stamping reason.
-- Lakes: planned, accepted, rejected, final drift.
-- Floodplains: intent, applied, rejected, final feature.
+  native-writer/materialization disposition.
+- Lakes: planned, accepted, rejected, exact counters, final drift, and missing
+  exact-log state.
+- Floodplains: Hydrology/final-surface intent inputs, applied count, rejected
+  count, live feature readback, and active/no-signal disposition.
+
+Each lane must bind display rows to exact layer identity:
+
+- `dataTypeKey`
+- `spaceId`
+- `kind` / `role`
+- `variantKey`
+- proof class (`hydrology-truth`, `projection-plan`, `terrain-readback`,
+  `metadata-readback`, `studio-visible`, `civ-rendered`, or
+  `product-acceptance`)
+
+Projection masks must not be labeled as engine truth. In particular,
+`map.rivers.projectedRiverMask` is a projection-plan surface, while
+`map.rivers.engineRiverMask` is terrain readback. Duplicated Hydrology truth
+layers shown near map-rivers must retain Hydrology ownership labels.
 
 Statuses include:
 
@@ -22,8 +40,11 @@ Statuses include:
 - `terrain-match-metadata-divergent`
 - `terrain-mismatch`
 - `metadata-readback-missing`
+- `native-writer-parity-unproven`
 - `floodplain-intent-missing`
 - `floodplain-apply-rejected`
+- `floodplain-live-missing`
+- `lake-exact-log-missing`
 
 ## Review Lanes
 

--- a/openspec/changes/studio-river-lake-inspector-dx/tasks.md
+++ b/openspec/changes/studio-river-lake-inspector-dx/tasks.md
@@ -4,6 +4,10 @@
   proof labels.
 - [ ] 1.2 Add status classification for zero/missing/divergent river states.
 - [ ] 1.3 Add stable palettes and category metadata for masks.
+- [ ] 1.4 Bind each summary row to exact layer identity (`dataTypeKey`,
+  `spaceId`, `kind` / `role`, `variantKey`) and proof class.
+- [ ] 1.5 Add lake exact-counter/drift rows and floodplain intent/applied/live
+  rows so raw score layers cannot masquerade as product proof.
 
 ## 2. UI And Config
 
@@ -11,9 +15,14 @@
   one-click layer selection.
 - [ ] 2.2 Keep primary physical/projection/engine terrain layers visible in
   normal mode and metadata/mismatch layers behind debug.
-- [ ] 2.3 Add config migration for legacy `map-rivers.knobs.riverDensity`.
-- [ ] 2.4 Normalize docs/examples/presets to `navigableRiverDensity` where proof
+- [ ] 2.3 Ensure projected river masks are labeled as projection-plan surfaces
+  and engine river masks as terrain-readback surfaces.
+- [ ] 2.4 Add config migration for legacy `map-rivers.knobs.riverDensity`
+  without preserving it as an accepted product model.
+- [ ] 2.5 Normalize docs/examples/presets to `navigableRiverDensity` where proof
   hashes do not require the alias.
+- [ ] 2.6 Remove stale inspector/docs wording that describes min/max river
+  lengths as the accepted selector model.
 
 ## 3. Validation
 

--- a/openspec/changes/studio-river-lake-inspector-dx/tasks.md
+++ b/openspec/changes/studio-river-lake-inspector-dx/tasks.md
@@ -1,23 +1,23 @@
 ## 1. Summary Model
 
-- [ ] 1.1 Derive a river/lake/floodplain summary from current artifacts and
+- [x] 1.1 Derive a river/lake/floodplain summary from current artifacts and
   proof labels.
-- [ ] 1.2 Add status classification for zero/missing/divergent river states.
+- [x] 1.2 Add status classification for zero/missing/divergent river states.
 - [ ] 1.3 Add stable palettes and category metadata for masks.
-- [ ] 1.4 Bind each summary row to exact layer identity (`dataTypeKey`,
+- [x] 1.4 Bind each summary row to exact layer identity (`dataTypeKey`,
   `spaceId`, `kind` / `role`, `variantKey`) and proof class.
 - [ ] 1.5 Add lake exact-counter/drift rows and floodplain intent/applied/live
   rows so raw score layers cannot masquerade as product proof.
 
 ## 2. UI And Config
 
-- [ ] 2.1 Build the River/Lake Inspector with count chips, status chips, and
+- [x] 2.1 Build the River/Lake Inspector with count chips, status chips, and
   one-click layer selection.
-- [ ] 2.2 Keep primary physical/projection/engine terrain layers visible in
+- [x] 2.2 Keep primary physical/projection/engine terrain layers visible in
   normal mode and metadata/mismatch layers behind debug.
-- [ ] 2.3 Ensure projected river masks are labeled as projection-plan surfaces
+- [x] 2.3 Ensure projected river masks are labeled as projection-plan surfaces
   and engine river masks as terrain-readback surfaces.
-- [ ] 2.4 Add config migration for legacy `map-rivers.knobs.riverDensity`
+- [x] 2.4 Add config migration for legacy `map-rivers.knobs.riverDensity`
   without preserving it as an accepted product model.
 - [ ] 2.5 Normalize docs/examples/presets to `navigableRiverDensity` where proof
   hashes do not require the alias.
@@ -26,6 +26,11 @@
 
 ## 3. Validation
 
-- [ ] 3.1 Run Studio summary/model/config migration tests.
-- [ ] 3.2 Run Browser/Playwright screenshot checks for the inspector.
-- [ ] 3.3 Validate this OpenSpec change and `bun run openspec:validate`.
+- [x] 3.1 Run Studio summary/model/config migration tests.
+- [x] 3.2 Run Browser/Playwright screenshot checks for the inspector.
+  - Verified in Chrome at `http://127.0.0.1:5176/` after a Studio run: the
+    Water Proof section showed same-run counts for Hydrology/projection/terrain
+    and rendered without obvious right-panel overlap. Computer Use rejected
+    click actions, so click-through remains covered by the wired selection
+    model rather than a physical click in this pass.
+- [x] 3.3 Validate this OpenSpec change and `bun run openspec:validate`.

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -994,9 +994,9 @@ export class MockAdapter implements EngineAdapter {
     this.riverMask.fill(0);
     this.riverTypes.fill(MOCK_NO_RIVER);
 
-    // Compatibility-oriented mock: mirror Civ's bulk writer onto already
-    // stamped navigable-river terrain so map-stage tests can prove the bounded
-    // projection contract without inventing a second fake river network.
+    // Native-writer mock: mirror Civ's bulk writer onto already stamped
+    // navigable-river terrain so map-stage tests prove the projection contract
+    // without inventing a second fake river network.
     for (let i = 0; i < this.width * this.height; i++) {
       if ((this.terrainTypes[i] ?? 0) !== (_navigableTerrain & 0xff)) continue;
       this.riverMask[i] = 1;

--- a/packages/civ7-adapter/src/types.ts
+++ b/packages/civ7-adapter/src/types.ts
@@ -614,12 +614,12 @@ export interface EngineAdapter {
   buildElevation(): void;
 
   /**
-   * Compatibility-only wrapper for Civ7's high-level river generator
+   * Native wrapper for Civ7's high-level river materializer
    * (`TerrainBuilder.modelRivers`).
    *
-   * Standard MapGen-authored rivers must publish hydrology truth and project
-   * selected navigable terrain through dedicated map stages instead of using
-   * this method as a river truth or metadata-authoring surface.
+   * Hydrology owns authored river truth. Map stages use this boundary only to
+   * ask Civ to materialize projected navigable river terrain as native river
+   * objects/metadata, then verify the result through readback.
    */
   modelRivers(minLength: number, maxLength: number, navigableTerrain: number): void;
 

--- a/packages/civ7-map-policy/src/index.ts
+++ b/packages/civ7-map-policy/src/index.ts
@@ -15,6 +15,8 @@ export {
   isResourceAdjacentToLandRuntimeOptional,
 } from "./resource-constants.js";
 export {
+  CIV7_DEFAULT_RIVER_MODELING_ARGS,
+  CIV7_RIVER_MODELING_POLICY_V0,
   CIV7_RIVER_TYPES_V0,
   NO_RIVER_TYPE,
   RIVER_TYPE_MINOR,

--- a/packages/civ7-map-policy/src/river-constants.ts
+++ b/packages/civ7-map-policy/src/river-constants.ts
@@ -17,3 +17,75 @@ export const CIV7_RIVER_TYPES_V0 = CIV7_BROWSER_TABLES_V0.riverTypes;
 export const NO_RIVER_TYPE = CIV7_RIVER_TYPES_V0.values.NO_RIVER;
 export const RIVER_TYPE_MINOR = CIV7_RIVER_TYPES_V0.values.RIVER_MINOR;
 export const RIVER_TYPE_NAVIGABLE = CIV7_RIVER_TYPES_V0.values.RIVER_NAVIGABLE;
+
+/**
+ * Civ7 stock map-script river materialization policy.
+ *
+ * Source evidence:
+ * - Every stock `base-standard/maps/*.js` river pass uses
+ *   `TerrainBuilder.modelRivers(..., g_NavigableRiverTerrain)`, followed by
+ *   `TerrainBuilder.validateAndFixTerrain()` and
+ *   `TerrainBuilder.defineNamedRivers()`.
+ * - Most continental stock scripts use `(5, 15)`.
+ * - Archipelago and shuffle use wider profiles for island-heavy maps.
+ *
+ * This is engine materialization policy, not MapGen Hydrology truth. MapGen
+ * domains decide what river truth exists; map stages use this policy when
+ * asking Civ to turn projected navigable terrain into native river objects.
+ */
+export const CIV7_RIVER_MODELING_POLICY_V0 = {
+  source: [
+    "Base/modules/base-standard/maps/continents.js",
+    "Base/modules/base-standard/maps/fractal.js",
+    "Base/modules/base-standard/maps/pangaea-plus.js",
+    "Base/modules/base-standard/maps/continents-plus.js",
+    "Base/modules/base-standard/maps/terra-incognita.js",
+    "Base/modules/base-standard/maps/continents-voronoi.js",
+    "Base/modules/base-standard/maps/fractal-voronoi.js",
+    "Base/modules/base-standard/maps/pangaea-voronoi.js",
+    "Base/modules/base-standard/maps/shattered-seas-voronoi.js",
+    "Base/modules/base-standard/maps/archipelago.js",
+    "Base/modules/base-standard/maps/shuffle.js",
+    "Base/modules/base-standard/maps/map-globals.js",
+  ],
+  navigableTerrain: "TERRAIN_NAVIGABLE_RIVER",
+  sequence: [
+    "TerrainBuilder.modelRivers",
+    "TerrainBuilder.validateAndFixTerrain",
+    "TerrainBuilder.defineNamedRivers",
+  ],
+  profiles: {
+    standardContinental: {
+      minLength: 5,
+      maxLength: 15,
+      source: [
+        "Base/modules/base-standard/maps/continents.js",
+        "Base/modules/base-standard/maps/fractal.js",
+        "Base/modules/base-standard/maps/pangaea-plus.js",
+        "Base/modules/base-standard/maps/continents-plus.js",
+        "Base/modules/base-standard/maps/terra-incognita.js",
+        "Base/modules/base-standard/maps/continents-voronoi.js",
+        "Base/modules/base-standard/maps/fractal-voronoi.js",
+        "Base/modules/base-standard/maps/pangaea-voronoi.js",
+        "Base/modules/base-standard/maps/shattered-seas-voronoi.js",
+      ],
+    },
+    islandHeavy: {
+      minLength: 5,
+      maxLength: 70,
+      source: [
+        "Base/modules/base-standard/maps/archipelago.js",
+        "Base/modules/base-standard/maps/shuffle.js",
+      ],
+    },
+    shuffleLargeLandmass: {
+      minLength: 10,
+      maxLength: 85,
+      source: ["Base/modules/base-standard/maps/shuffle.js"],
+    },
+  },
+  defaultProfile: "standardContinental",
+} as const;
+
+export const CIV7_DEFAULT_RIVER_MODELING_ARGS =
+  CIV7_RIVER_MODELING_POLICY_V0.profiles[CIV7_RIVER_MODELING_POLICY_V0.defaultProfile];

--- a/packages/civ7-map-policy/test/map-policy.test.ts
+++ b/packages/civ7-map-policy/test/map-policy.test.ts
@@ -5,6 +5,8 @@ import { join } from "node:path";
 import {
   CIV7_BROWSER_TABLES_V0,
   CIV7_COAST_CLASSIFICATION_POLICY_V0,
+  CIV7_DEFAULT_RIVER_MODELING_ARGS,
+  CIV7_RIVER_MODELING_POLICY_V0,
   CIV7_RIVER_TYPE_METADATA_SOURCE,
   CIV7_RIVER_TYPES_V0,
   NATURAL_WONDER_CATALOG,
@@ -86,6 +88,39 @@ describe("@civ7/map-policy", () => {
     expect(CIV7_RIVER_TYPES_V0.source).toContain(
       "Base/modules/base-standard/ui-next/tooltips/plot-tooltip/helpers.js"
     );
+  });
+
+  it("owns the stock Civ7 river materialization policy", () => {
+    expect(CIV7_RIVER_MODELING_POLICY_V0.navigableTerrain).toBe("TERRAIN_NAVIGABLE_RIVER");
+    expect(CIV7_RIVER_MODELING_POLICY_V0.sequence).toEqual([
+      "TerrainBuilder.modelRivers",
+      "TerrainBuilder.validateAndFixTerrain",
+      "TerrainBuilder.defineNamedRivers",
+    ]);
+    expect(CIV7_RIVER_MODELING_POLICY_V0.defaultProfile).toBe("standardContinental");
+    expect(CIV7_DEFAULT_RIVER_MODELING_ARGS).toEqual({
+      minLength: 5,
+      maxLength: 15,
+      source: [
+        "Base/modules/base-standard/maps/continents.js",
+        "Base/modules/base-standard/maps/fractal.js",
+        "Base/modules/base-standard/maps/pangaea-plus.js",
+        "Base/modules/base-standard/maps/continents-plus.js",
+        "Base/modules/base-standard/maps/terra-incognita.js",
+        "Base/modules/base-standard/maps/continents-voronoi.js",
+        "Base/modules/base-standard/maps/fractal-voronoi.js",
+        "Base/modules/base-standard/maps/pangaea-voronoi.js",
+        "Base/modules/base-standard/maps/shattered-seas-voronoi.js",
+      ],
+    });
+    expect(CIV7_RIVER_MODELING_POLICY_V0.profiles.islandHeavy).toMatchObject({
+      minLength: 5,
+      maxLength: 70,
+    });
+    expect(CIV7_RIVER_MODELING_POLICY_V0.profiles.shuffleLargeLandmass).toMatchObject({
+      minLength: 10,
+      maxLength: 85,
+    });
   });
 
   it("keeps generated map-policy and Studio river metadata catalogs in sync", () => {

--- a/scripts/civ7-direct-control/probe-river-modeling.test.ts
+++ b/scripts/civ7-direct-control/probe-river-modeling.test.ts
@@ -38,9 +38,15 @@ const runtimeInventory = {
       signature: "function storeWaterData() { [native code] }",
     },
   },
+  mapRivers: {
+    exists: true,
+    type: "object",
+    ownKeys: ["getRiver", "getRiverPlots", "getRiverTypeByIndex", "numRivers"],
+    prototypeKeys: [],
+  },
   riverTypes: { NO_RIVER: -1, RIVER_MINOR: 0, RIVER_NAVIGABLE: 1 },
   terrainNavigableRiver: 12,
-  officialCompatibilityDefaults: {
+  officialPolicyDefaults: {
     minLength: 5,
     maxLength: 15,
   },
@@ -55,6 +61,7 @@ describe("river modeling probe", () => {
       status: "dry-run",
       mutationAttempted: false,
       blockedBy: ["river-modeling-probe.confirm-disposable-session"],
+      preNativeRiverObjects: null,
     });
   });
 
@@ -71,6 +78,12 @@ describe("river modeling probe", () => {
         noRiver: 4,
         missingFacts: [],
         failedFacts: [],
+      },
+      preNativeRiverObjects: {
+        exists: true,
+        numRivers: 0,
+        samples: [],
+        blockedBy: [],
       },
       mutation: {
         attempted: true,
@@ -91,6 +104,15 @@ describe("river modeling probe", () => {
         missingFacts: [],
         failedFacts: [],
       },
+      postNativeRiverObjects: {
+        exists: true,
+        numRivers: 2,
+        samples: [
+          { index: 0, riverType: 1, plotCount: 2, connectedToOcean: true },
+          { index: 1, riverType: 0, plotCount: 1, connectedToOcean: false },
+        ],
+        blockedBy: [],
+      },
     });
 
     expect(output).toMatchObject({
@@ -103,8 +125,13 @@ describe("river modeling probe", () => {
         navigableRiver: 2,
         minorRiver: 1,
         noRiver: -3,
+        nativeRiverCount: 2,
         terrainChanged: true,
         metadataChanged: true,
+        nativeRiverObjectsChanged: true,
+      },
+      postNativeRiverObjects: {
+        numRivers: 2,
       },
     });
   });
@@ -147,7 +174,7 @@ describe("river modeling probe", () => {
     });
   });
 
-  test("parses official compatibility arguments", () => {
+  test("parses official policy arguments", () => {
     expect(
       parseArgs([
         "--confirm-disposable-session",

--- a/scripts/civ7-direct-control/probe-river-modeling.ts
+++ b/scripts/civ7-direct-control/probe-river-modeling.ts
@@ -9,6 +9,7 @@ import {
   type Civ7CommandResult,
   type Civ7DirectControlOptions,
 } from "../../packages/civ7-direct-control/src/index.ts";
+import { CIV7_DEFAULT_RIVER_MODELING_ARGS } from "../../packages/civ7-map-policy/src/index.ts";
 
 import {
   summarizeRiverMetadataReadback,
@@ -49,12 +50,27 @@ type RuntimeMethodInventory = Readonly<{
 
 export type RiverModelingRuntimeInventory = Readonly<{
   terrainBuilder: RuntimeObjectInventory;
+  mapRivers: RuntimeObjectInventory;
   riverTypes: Readonly<Record<string, unknown>>;
   terrainNavigableRiver: number | null;
-  officialCompatibilityDefaults: Readonly<{
+  officialPolicyDefaults: Readonly<{
     minLength: number;
     maxLength: number;
   }>;
+}>;
+
+export type NativeRiverObjectSummary = Readonly<{
+  exists: boolean;
+  numRivers: number | null;
+  samples: ReadonlyArray<
+    Readonly<{
+      index: number;
+      riverType: number | null;
+      plotCount: number | null;
+      connectedToOcean: boolean | null;
+    }>
+  >;
+  blockedBy: ReadonlyArray<string>;
 }>;
 
 type RiverModelingMutationResult = Readonly<{
@@ -74,8 +90,10 @@ export type RiverModelingProbeOutput = Readonly<{
   blockedBy: ReadonlyArray<string>;
   evidenceBoundary: string;
   inventory: RiverModelingRuntimeInventory;
+  preNativeRiverObjects: NativeRiverObjectSummary | null;
   preReadback: RiverMetadataReadbackSummary | null;
   mutation?: RiverModelingMutationResult;
+  postNativeRiverObjects?: NativeRiverObjectSummary;
   postReadback?: RiverMetadataReadbackSummary;
   deltas?: Readonly<{
     terrainNavigableRiver: number;
@@ -83,13 +101,15 @@ export type RiverModelingProbeOutput = Readonly<{
     navigableRiver: number;
     minorRiver: number;
     noRiver: number;
+    nativeRiverCount: number | null;
     terrainChanged: boolean;
     metadataChanged: boolean;
+    nativeRiverObjectsChanged: boolean;
   }> | null;
 }>;
 
-const OFFICIAL_DEFAULT_MIN_LENGTH = 5;
-const OFFICIAL_DEFAULT_MAX_LENGTH = 15;
+const OFFICIAL_DEFAULT_MIN_LENGTH = CIV7_DEFAULT_RIVER_MODELING_ARGS.minLength;
+const OFFICIAL_DEFAULT_MAX_LENGTH = CIV7_DEFAULT_RIVER_MODELING_ARGS.maxLength;
 
 const usage = `Usage:
   bun scripts/civ7-direct-control/probe-river-modeling.ts
@@ -198,6 +218,7 @@ async function main(): Promise<number> {
 
   const directControl = { host: args.host, port: args.port, timeoutMs: args.timeoutMs };
   const inventory = await readRuntimeInventory(directControl);
+  const preNativeRiverObjects = await readNativeRiverObjects(directControl);
   const preReadback =
     args.readFullGrid || args.confirmDisposableSession
       ? summarizeRiverMetadataReadback(
@@ -213,7 +234,7 @@ async function main(): Promise<number> {
       : undefined;
 
   if (!args.confirmDisposableSession) {
-    const output = buildDryRunOutput({ inventory, preReadback });
+    const output = buildDryRunOutput({ inventory, preNativeRiverObjects, preReadback });
     writeOutput(args.output, output);
     console.log(JSON.stringify(output, null, 2));
     return 2;
@@ -238,8 +259,16 @@ async function main(): Promise<number> {
       directControl,
     ),
   );
+  const postNativeRiverObjects = await readNativeRiverObjects(directControl);
 
-  const output = buildMutationOutput({ inventory, preReadback, mutation, postReadback });
+  const output = buildMutationOutput({
+    inventory,
+    preNativeRiverObjects,
+    preReadback,
+    mutation,
+    postNativeRiverObjects,
+    postReadback,
+  });
   writeOutput(args.output, output);
   console.log(JSON.stringify(output, null, 2));
   return output.ok ? 0 : 2;
@@ -247,6 +276,7 @@ async function main(): Promise<number> {
 
 export function buildDryRunOutput(args: {
   inventory: RiverModelingRuntimeInventory;
+  preNativeRiverObjects?: NativeRiverObjectSummary;
   preReadback?: RiverMetadataReadbackSummary;
 }): RiverModelingProbeOutput {
   const hasCandidate = args.inventory.terrainBuilder.modelRivers?.exists === true;
@@ -259,16 +289,19 @@ export function buildDryRunOutput(args: {
       ...(hasCandidate ? [] : ["river-modeling-probe.modelRivers.missing"]),
     ],
     evidenceBoundary:
-      "Read-only unless --confirm-disposable-session is passed. A native TerrainBuilder.modelRivers sequence is not product authoring evidence until disposable runtime proof shows river metadata changes on the same run.",
+      "Read-only unless --confirm-disposable-session is passed. A native TerrainBuilder.modelRivers sequence is not product authoring evidence until disposable runtime proof shows river metadata and MapRivers object changes on the same run.",
     inventory: args.inventory,
+    preNativeRiverObjects: args.preNativeRiverObjects ?? null,
     preReadback: args.preReadback ?? null,
   };
 }
 
 export function buildMutationOutput(args: {
   inventory: RiverModelingRuntimeInventory;
+  preNativeRiverObjects?: NativeRiverObjectSummary;
   preReadback: RiverMetadataReadbackSummary | undefined;
   mutation: RiverModelingMutationResult;
+  postNativeRiverObjects?: NativeRiverObjectSummary;
   postReadback: RiverMetadataReadbackSummary;
 }): RiverModelingProbeOutput {
   const pre = args.preReadback;
@@ -280,11 +313,27 @@ export function buildMutationOutput(args: {
       pre.noRiver !== post.noRiver
     : false;
   const terrainChanged = pre ? pre.terrainNavigableRiver !== post.terrainNavigableRiver : false;
+  const nativeRiverObjectsChanged =
+    typeof args.preNativeRiverObjects?.numRivers === "number" &&
+    typeof args.postNativeRiverObjects?.numRivers === "number"
+      ? args.preNativeRiverObjects.numRivers !== args.postNativeRiverObjects.numRivers
+      : false;
+  const nativeReadbackComplete =
+    args.postNativeRiverObjects === undefined || args.postNativeRiverObjects.blockedBy.length === 0;
+  const nativeEvidenceSatisfied =
+    args.postNativeRiverObjects === undefined ||
+    nativeRiverObjectsChanged ||
+    (args.postNativeRiverObjects.numRivers ?? 0) > 0;
   const readbackComplete =
     post.missingFacts.length === 0 &&
     post.failedFacts.length === 0 &&
     (pre === undefined || (pre.missingFacts.length === 0 && pre.failedFacts.length === 0));
-  const ok = args.mutation.ok && metadataChanged && readbackComplete;
+  const ok =
+    args.mutation.ok &&
+    metadataChanged &&
+    readbackComplete &&
+    nativeReadbackComplete &&
+    nativeEvidenceSatisfied;
 
   return {
     ok,
@@ -296,12 +345,18 @@ export function buildMutationOutput(args: {
           ...(args.mutation.ok ? [] : ["river-modeling-probe.sequence.call-failed"]),
           ...(metadataChanged ? [] : ["river-modeling-probe.metadata-unchanged"]),
           ...(readbackComplete ? [] : ["river-modeling-probe.readback-incomplete"]),
+          ...(nativeReadbackComplete ? [] : ["river-modeling-probe.native-river-readback-incomplete"]),
+          ...(nativeEvidenceSatisfied ? [] : ["river-modeling-probe.native-river-objects-unchanged"]),
         ],
     evidenceBoundary:
-      "This probe only tests the official TerrainBuilder.modelRivers compatibility sequence in the current disposable runtime session. Production use still requires source-integrated semantics and same-run Studio/Civ parity proof.",
+      "This probe only tests the official TerrainBuilder.modelRivers sequence in the current disposable runtime session. Production use still requires source-integrated semantics and same-run Studio/Civ parity proof.",
     inventory: args.inventory,
     mutation: args.mutation,
+    preNativeRiverObjects: args.preNativeRiverObjects ?? null,
     preReadback: pre ?? null,
+    ...(args.postNativeRiverObjects === undefined
+      ? {}
+      : { postNativeRiverObjects: args.postNativeRiverObjects }),
     postReadback: post,
     deltas: pre
       ? {
@@ -310,8 +365,14 @@ export function buildMutationOutput(args: {
           navigableRiver: post.navigableRiver - pre.navigableRiver,
           minorRiver: post.minorRiver - pre.minorRiver,
           noRiver: post.noRiver - pre.noRiver,
+          nativeRiverCount:
+            typeof args.preNativeRiverObjects?.numRivers === "number" &&
+            typeof args.postNativeRiverObjects?.numRivers === "number"
+              ? args.postNativeRiverObjects.numRivers - args.preNativeRiverObjects.numRivers
+              : null,
           terrainChanged,
           metadataChanged,
+          nativeRiverObjectsChanged,
         }
       : null,
   };
@@ -323,6 +384,14 @@ async function readRuntimeInventory(options: Civ7DirectControlOptions): Promise<
     command: buildRuntimeInventoryCommand(),
   });
   return jsonPayloadFromCommandResult<RiverModelingRuntimeInventory>(result, "river modeling runtime inventory");
+}
+
+async function readNativeRiverObjects(options: Civ7DirectControlOptions): Promise<NativeRiverObjectSummary> {
+  const result = await executeCiv7TunerCommand({
+    ...options,
+    command: buildNativeRiverObjectsCommand(),
+  });
+  return jsonPayloadFromCommandResult<NativeRiverObjectSummary>(result, "native river object summary");
 }
 
 async function callModelRiversSequence(
@@ -366,17 +435,69 @@ function buildRuntimeInventoryCommand(): string {
       : undefined;
     return JSON.stringify({
       terrainBuilder: inspect(typeof TerrainBuilder === "undefined" ? undefined : TerrainBuilder),
+      mapRivers: inspect(typeof MapRivers === "undefined" ? undefined : MapRivers),
       riverTypes: typeof RiverTypes === "undefined" ? {} : {
         NO_RIVER: RiverTypes.NO_RIVER,
         RIVER_MINOR: RiverTypes.RIVER_MINOR,
         RIVER_NAVIGABLE: RiverTypes.RIVER_NAVIGABLE,
       },
       terrainNavigableRiver: terrain ? (typeof terrain.$index === "number" ? terrain.$index : terrain.Index ?? null) : null,
-      officialCompatibilityDefaults: {
+      officialPolicyDefaults: {
         minLength: ${OFFICIAL_DEFAULT_MIN_LENGTH},
         maxLength: ${OFFICIAL_DEFAULT_MAX_LENGTH},
       },
     });
+  })()`;
+}
+
+function buildNativeRiverObjectsCommand(): string {
+  return `(() => {
+    const out = {
+      exists: typeof MapRivers !== "undefined" && MapRivers !== null,
+      numRivers: null,
+      samples: [],
+      blockedBy: [],
+    };
+    try {
+      if (!out.exists) {
+        out.blockedBy.push("native-river-objects.MapRivers.missing");
+        return JSON.stringify(out);
+      }
+      const rawCount = typeof MapRivers.numRivers === "function" ? MapRivers.numRivers() : MapRivers.numRivers;
+      if (!Number.isInteger(rawCount)) {
+        out.blockedBy.push("native-river-objects.numRivers.unavailable");
+        return JSON.stringify(out);
+      }
+      out.numRivers = rawCount;
+      const sampleCount = Math.min(rawCount, 16);
+      for (let index = 0; index < sampleCount; index += 1) {
+        let riverType = null;
+        let plotCount = null;
+        let connectedToOcean = null;
+        try {
+          if (typeof MapRivers.getRiverTypeByIndex === "function") {
+            const value = MapRivers.getRiverTypeByIndex(index);
+            riverType = Number.isInteger(value) ? value : null;
+          }
+        } catch (_error) {}
+        try {
+          if (typeof MapRivers.getRiverPlots === "function") {
+            const plots = MapRivers.getRiverPlots(index);
+            plotCount = plots && typeof plots.length === "number" ? plots.length : null;
+          }
+        } catch (_error) {}
+        try {
+          if (typeof MapRivers.isRiverConnectedToOcean === "function") {
+            const value = MapRivers.isRiverConnectedToOcean(index);
+            connectedToOcean = typeof value === "boolean" ? value : null;
+          }
+        } catch (_error) {}
+        out.samples.push({ index, riverType, plotCount, connectedToOcean });
+      }
+    } catch (error) {
+      out.blockedBy.push(error instanceof Error ? error.message : String(error));
+    }
+    return JSON.stringify(out);
   })()`;
 }
 


### PR DESCRIPTION
Advances the river/lake/floodplain recovery workstream across pipeline, Studio, and proof infrastructure.

**Hydrology benchmark summary.** `compute-river-network-metrics` now emits a `benchmarkSummary` field covering land/water/lake denominators, minor/major river class ratios, river-specific permanence, low-order hierarchy, terminal shares, basin coverage, and routing-health counters (invalid receivers, discharge-drop edges, unassigned basins). The contract schema, artifact schema, and diagnostics extractor are updated to carry and validate this summary. Tests assert the summary values against known fixtures and representative generated-map seeds.

**Endpoint discharge floor enforcement.** `selectNavigableRiverTerrain` now filters candidate endpoints to those meeting `selectedEndpointDischargeFloor` before sorting, closing the contract gap where the floor was reported but not enforced. A new test confirms that endpoints below the floor are excluded and the budget is not backfilled from lower-discharge candidates.

**Native Civ river materialization.** `plotRivers` now calls `TerrainBuilder.modelRivers(...)` with the standard continental profile from the new `CIV7_DEFAULT_RIVER_MODELING_ARGS` constant after terrain stamping, matching the sequence used by stock Civ map scripts. The contract-guard test is updated to expect `modelRivers` in exactly the `plotRivers` step. Post-`modelRivers` readback expectations in the post-refresh test are updated to reflect that engine navigable river metadata is now populated.

**Civ river materialization policy.** `@civ7/map-policy` exports `CIV7_RIVER_MODELING_POLICY_V0` and `CIV7_DEFAULT_RIVER_MODELING_ARGS`, documenting the stock continental, island-heavy, and shuffle-large-landmass profiles with source file evidence. The probe script and its tests are updated to use these constants and to rename `officialCompatibilityDefaults` to `officialPolicyDefaults`.

**Projected river mask role correction.** `map.rivers.projectedRiverMask` is relabeled from `role: "engine"` to `role: "projection"` so it is not confused with engine terrain readback. Affected viz-emission and data-type-model tests are updated accordingly.

**Config migration.** `migratePipelineConfigUnknown` now migrates the retired `map-rivers.knobs.riverDensity` key to `navigableRiverDensity`, throwing a typed `PipelineConfigMigrationError` on conflicting values. The preset import flow surfaces migration errors as `invalid-config` results with structured details. Tests cover the migration, deduplication, and conflict cases.

**Studio Water Proof inspector.** A new `riverLakeInspector.ts` module derives a `RiverLakeFloodplainInspectorSummary` from the viz manifest, organizing layers into typed lanes (hydrology, projection, terrain-readback, metadata-readback, lakes, floodplains, rendered, acceptance) with proof classes, claim statuses, display statuses, non-zero tile counts from inline grid payloads, and layer refs bound to exact `dataTypeKey`/`layerKey`/`stepId`/`role`/`visibility` identity. `ExplorePanel` renders a collapsible Water Proof section with status chips, count chips, and one-click layer-select buttons. `App.tsx` wires the summary and selection callback. Tests cover the summary builder against synthetic fixtures and against a full standard-recipe run.

**Native river object readback in the probe.** The river-modeling probe now reads `MapRivers` object state before and after the `modelRivers` call, reporting `numRivers`, per-river type/plot-count/ocean-connectivity samples, and a `nativeRiverObjectsChanged` delta. Proof output is gated on native object readback completing without blocks.

**Session frame and adversarial synthesis.** A `docs/projects/river-lake-recovery/` directory is added with a durable session frame (`FRAME.md`) defining authority order, ownership boundaries, physical grounding benchmarks with external Earth anchors, a domino chain, and a closure matrix. An adversarial synthesis document and six agent-notes files record findings from the current pass. OpenSpec change documents for `hydrology-river-network-metrics`, `map-rivers-navigable-coherence`, `studio-river-lake-inspector-dx`, `lake-floodplain-product-proof-gates`, `river-runtime-visible-proof`, and `earthlike-visible-river-acceptance` are updated with benchmark contract tables, external anchor citations, native-writer disposition requirements, and task completions.