### PR TITLE
feat(direct-control): add native MapRivers object readback with plot membership, content-marker proof, and closure gates

### DIFF
--- a/apps/mapgen-studio/src/features/runInGame/status.ts
+++ b/apps/mapgen-studio/src/features/runInGame/status.ts
@@ -28,6 +28,8 @@ export type RunInGameMaterializationStatus = Readonly<{
   generatedSourceScript?: RunInGameFileIdentity;
   localModScript?: RunInGameFileIdentity;
   deployedModScript?: RunInGameFileIdentity;
+  localModScriptContent?: RunInGameFileContentProof;
+  deployedModScriptContent?: RunInGameFileContentProof;
 }>;
 
 export type RunInGameFileIdentity = Readonly<{
@@ -36,6 +38,17 @@ export type RunInGameFileIdentity = Readonly<{
   sizeBytes: number;
   mtimeMs: number;
   mtimeIso: string;
+}>;
+
+export type RunInGameFileContentProof = Readonly<{
+  path: string;
+  markers: ReadonlyArray<RunInGameContentMarkerProof>;
+}>;
+
+export type RunInGameContentMarkerProof = Readonly<{
+  id: string;
+  marker: string;
+  present: boolean;
 }>;
 
 export type RunInGameSourceSnapshotProof = Readonly<{
@@ -192,6 +205,8 @@ export type RunInGameExactAuthorshipProof = Readonly<{
     generatedSourceScript?: RunInGameFileIdentity;
     localModScript?: RunInGameFileIdentity;
     deployedModScript?: RunInGameFileIdentity;
+    localModScriptContent?: RunInGameFileContentProof;
+    deployedModScriptContent?: RunInGameFileContentProof;
   }>;
   civSetup: Readonly<{
     mapScript?: string;

--- a/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
+++ b/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
@@ -3,12 +3,30 @@ import { readFile, stat } from "node:fs/promises";
 import { isAbsolute, relative, resolve } from "node:path";
 
 import type {
+  RunInGameContentMarkerProof,
   RunInGameExactAuthorshipProof,
+  RunInGameFileContentProof,
   RunInGameFileIdentity,
   RunInGameMaterializationStatus,
   RunInGameRequestStatus,
   RunInGameSourceSnapshotProof,
 } from "../../features/runInGame/status";
+
+export type RunInGameRequiredContentMarker = Readonly<{
+  id: string;
+  marker: string;
+}>;
+
+const NATIVE_RIVER_MODELING_CONTENT_MARKERS: readonly RunInGameRequiredContentMarker[] = [
+  {
+    id: "native-river-modeling-trace",
+    marker: "map.rivers.officialCivRiverModeling",
+  },
+  {
+    id: "native-river-modeling-checkpoint",
+    marker: "POST-MODEL-RIVERS",
+  },
+] as const;
 
 export async function fileIdentity(args: {
   repoRoot: string;
@@ -27,6 +45,46 @@ export async function fileIdentity(args: {
     mtimeMs: metadata.mtimeMs,
     mtimeIso: metadata.mtime.toISOString(),
   };
+}
+
+export async function fileContentMarkerProof(args: {
+  repoRoot: string;
+  path: string;
+  markers: ReadonlyArray<RunInGameRequiredContentMarker>;
+  exposeAs?: "relative-to-repo" | "absolute";
+}): Promise<RunInGameFileContentProof> {
+  const absolutePath = isAbsolute(args.path) ? args.path : resolve(args.repoRoot, args.path);
+  const text = await readFile(absolutePath, "utf8");
+  return {
+    path: args.exposeAs === "absolute" ? absolutePath : relative(args.repoRoot, absolutePath),
+    markers: args.markers.map((marker) => ({
+      id: marker.id,
+      marker: marker.marker,
+      present: text.includes(marker.marker),
+    })),
+  };
+}
+
+export function runInGameRequiredMaterializationMarkers(args: {
+  requestId: string;
+  configHash: string;
+  envelopeHash: string;
+}): ReadonlyArray<RunInGameRequiredContentMarker> {
+  return [
+    {
+      id: "run-request-id",
+      marker: args.requestId,
+    },
+    {
+      id: "run-config-hash",
+      marker: args.configHash,
+    },
+    {
+      id: "run-envelope-hash",
+      marker: args.envelopeHash,
+    },
+    ...NATIVE_RIVER_MODELING_CONTENT_MARKERS,
+  ];
 }
 
 export function buildRunInGameSourceSnapshotProof(args: {
@@ -86,6 +144,19 @@ export function buildRunInGameExactAuthorshipProof(args: {
   const localModScript = args.localModScript ?? args.materialization.localModScript;
   const deployedModScript = args.deployedModScript ?? args.materialization.deployedModScript;
   const unresolvedLinks: string[] = [];
+  const requiredMaterializationMarkers = args.materialization.configHash && args.materialization.envelopeHash
+    ? runInGameRequiredMaterializationMarkers({
+        requestId: args.requestId,
+        configHash: args.materialization.configHash,
+        envelopeHash: args.materialization.envelopeHash,
+      })
+    : undefined;
+  const materializationScriptLinks = runInGameMaterializationScriptUnresolvedLinks({
+    materialization: args.materialization,
+    localModScript,
+    deployedModScript,
+    requiredMarkers: requiredMaterializationMarkers,
+  });
 
   addMissing(unresolvedLinks, Boolean(args.sourceSnapshot?.identityHash), "source-snapshot.identity-hash");
   addMissing(unresolvedLinks, args.sourceSnapshot?.recipeSettings !== undefined, "source-snapshot.recipe-settings");
@@ -135,7 +206,7 @@ export function buildRunInGameExactAuthorshipProof(args: {
   addStringMismatch(unresolvedLinks, args.logProof?.envelopeHash, args.materialization.envelopeHash, "swooper-log.envelope-hash-mismatch");
   addNumberMismatch(unresolvedLinks, args.logProof?.dimensions.width, runtimeSummary.width, "runtime.log-width-mismatch");
   addNumberMismatch(unresolvedLinks, args.logProof?.dimensions.height, runtimeSummary.height, "runtime.log-height-mismatch");
-  addStringMismatch(unresolvedLinks, localModScript?.sha256, deployedModScript?.sha256, "materialization.deployed-mod-script-hash-mismatch");
+  unresolvedLinks.push(...materializationScriptLinks);
 
   return {
     status: unresolvedLinks.length === 0 ? "complete" : "unresolved",
@@ -162,6 +233,8 @@ export function buildRunInGameExactAuthorshipProof(args: {
       ...(generatedSourceScript ? { generatedSourceScript } : {}),
       ...(localModScript ? { localModScript } : {}),
       ...(deployedModScript ? { deployedModScript } : {}),
+      ...(args.materialization.localModScriptContent ? { localModScriptContent: args.materialization.localModScriptContent } : {}),
+      ...(args.materialization.deployedModScriptContent ? { deployedModScriptContent: args.materialization.deployedModScriptContent } : {}),
     },
     civSetup: {
       ...(setupReadback.mapScript === undefined ? {} : { mapScript: setupReadback.mapScript }),
@@ -184,6 +257,62 @@ export function buildRunInGameExactAuthorshipProof(args: {
     ...(args.logProof ? { log: args.logProof } : {}),
     unresolvedLinks,
   };
+}
+
+export function runInGameMaterializationScriptUnresolvedLinks(args: {
+  materialization: RunInGameMaterializationStatus;
+  localModScript?: RunInGameFileIdentity;
+  deployedModScript?: RunInGameFileIdentity;
+  requiredMarkers?: ReadonlyArray<RunInGameRequiredContentMarker>;
+}): string[] {
+  const localModScript = args.localModScript ?? args.materialization.localModScript;
+  const deployedModScript = args.deployedModScript ?? args.materialization.deployedModScript;
+  const links: string[] = [];
+  addStringMismatch(links, localModScript?.sha256, deployedModScript?.sha256, "materialization.deployed-mod-script-hash-mismatch");
+  addMissing(links, Boolean(args.materialization.localModScriptContent), "materialization.local-mod-script-content-proof");
+  addMissing(links, Boolean(args.materialization.deployedModScriptContent), "materialization.deployed-mod-script-content-proof");
+  addStringMismatch(
+    links,
+    args.materialization.localModScriptContent?.path,
+    localModScript?.path,
+    "materialization.local-mod-script-content-path-mismatch",
+  );
+  addStringMismatch(
+    links,
+    args.materialization.deployedModScriptContent?.path,
+    deployedModScript?.path,
+    "materialization.deployed-mod-script-content-path-mismatch",
+  );
+  pushMissingContentMarkers(
+    links,
+    args.materialization.localModScriptContent?.markers,
+    "materialization.local-mod-script-marker",
+    args.requiredMarkers,
+  );
+  pushMissingContentMarkers(
+    links,
+    args.materialization.deployedModScriptContent?.markers,
+    "materialization.deployed-mod-script-marker",
+    args.requiredMarkers,
+  );
+  return links;
+}
+
+function pushMissingContentMarkers(
+  links: string[],
+  markers: ReadonlyArray<RunInGameContentMarkerProof> | undefined,
+  prefix: string,
+  requiredMarkers: ReadonlyArray<RunInGameRequiredContentMarker> | undefined,
+): void {
+  if (markers === undefined) return;
+  for (const required of requiredMarkers ?? []) {
+    if (!markers.some((marker) => marker.id === required.id)) {
+      links.push(`${prefix}.${required.id}`);
+    }
+  }
+  for (const marker of markers) {
+    if (!marker.present) links.push(`${prefix}.${marker.id}`);
+  }
 }
 
 function addMissing(links: string[], condition: boolean, link: string): void {

--- a/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
+++ b/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import type {
+  RunInGameFileContentProof,
   RunInGameExactAuthorshipProof,
   RunInGameFileIdentity,
   RunInGameMaterializationStatus,
@@ -14,8 +15,11 @@ import type {
 import {
   buildRunInGameExactAuthorshipProof,
   buildRunInGameSourceSnapshotProof,
+  fileContentMarkerProof,
   fileIdentity,
   parseSwooperMapgenLogProof,
+  runInGameMaterializationScriptUnresolvedLinks,
+  runInGameRequiredMaterializationMarkers,
 } from "../../src/server/runInGame/proofIdentity";
 
 const requestId = "studio-run-in-game-test";
@@ -35,6 +39,41 @@ describe("Run in Game exact authorship proof identity", () => {
       expect(identity.path).toBe("studio-current.js");
       expect(identity.sha256).toHaveLength(64);
       expect(identity.sizeBytes).toBeGreaterThan(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("proves required materialization markers from generated script content", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "studio-proof-markers-"));
+    try {
+      const path = join(dir, "studio-current.js");
+      await writeFile(
+        path,
+        [
+          requestId,
+          configHash,
+          envelopeHash,
+          "map.rivers.officialCivRiverModeling",
+          "POST-MODEL-RIVERS",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const proof = await fileContentMarkerProof({
+        repoRoot: dir,
+        path,
+        markers: runInGameRequiredMaterializationMarkers({ requestId, configHash, envelopeHash }),
+      });
+
+      expect(proof.path).toBe("studio-current.js");
+      expect(proof.markers.map((marker) => [marker.id, marker.present])).toEqual([
+        ["run-request-id", true],
+        ["run-config-hash", true],
+        ["run-envelope-hash", true],
+        ["native-river-modeling-trace", true],
+        ["native-river-modeling-checkpoint", true],
+      ]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -507,6 +546,45 @@ describe("Run in Game exact authorship proof identity", () => {
     ]));
   });
 
+  it("keeps exact authorship unresolved when the deployed script lacks current river materialization markers", () => {
+    const args = completeProofArgs();
+    const proof = buildRunInGameExactAuthorshipProof({
+      ...args,
+      materialization: {
+        ...args.materialization,
+        deployedModScriptContent: contentProof(
+          "/Users/test/Civ Mods/Swooper Maps/maps/studio-current.js",
+          { "native-river-modeling-checkpoint": false },
+        ),
+      },
+    });
+
+    expect(proof.status).toBe("unresolved");
+    expect(proof.unresolvedLinks).toContain("materialization.deployed-mod-script-marker.native-river-modeling-checkpoint");
+  });
+
+  it("reports materialization script proof gaps before starting Civ", () => {
+    const args = completeProofArgs();
+    const links = runInGameMaterializationScriptUnresolvedLinks({
+      materialization: {
+        ...args.materialization,
+        localModScriptContent: contentProof("different.js"),
+        deployedModScriptContent: contentProof(
+          "/Users/test/Civ Mods/Swooper Maps/maps/studio-current.js",
+          { "run-request-id": false },
+        ),
+      },
+      localModScript: args.localModScript,
+      deployedModScript: args.deployedModScript,
+      requiredMarkers: runInGameRequiredMaterializationMarkers({ requestId, configHash, envelopeHash }),
+    });
+
+    expect(links).toEqual(expect.arrayContaining([
+      "materialization.local-mod-script-content-path-mismatch",
+      "materialization.deployed-mod-script-marker.run-request-id",
+    ]));
+  });
+
   it("uses setup config player count as exact-authorship readback", () => {
     const proof = buildRunInGameExactAuthorshipProof({
       ...completeProofArgs(),
@@ -569,15 +647,22 @@ function completeProofArgs(): Parameters<typeof buildRunInGameExactAuthorshipPro
     envelopeHash,
   };
   const localModScript = fileProof("mod/maps/studio-current.js", "same-deployed-js-hash");
+  const deployedModScript = fileProof("/Users/test/Civ Mods/Swooper Maps/maps/studio-current.js", localModScript.sha256);
   return {
     requestId,
     request,
     sourceSnapshot,
-    materialization,
+    materialization: {
+      ...materialization,
+      localModScript,
+      deployedModScript,
+      localModScriptContent: contentProof(localModScript.path),
+      deployedModScriptContent: contentProof(deployedModScript.path),
+    },
     sourceConfig: fileProof("configs/studio-current.config.json", "source-config-hash"),
     generatedSourceScript: fileProof("generated/studio-current.ts", "generated-source-hash"),
     localModScript,
-    deployedModScript: fileProof("/Users/test/Civ Mods/Swooper Maps/maps/studio-current.js", localModScript.sha256),
+    deployedModScript,
     rowProof: { rows: [{ file: mapScript }] },
     setupSnapshot: setupSnapshot(),
     startMapSummary: mapSummary(),
@@ -589,6 +674,21 @@ function completeProofArgs(): Parameters<typeof buildRunInGameExactAuthorshipPro
       gameHash: 123456,
     },
     createdAt: "2026-06-06T00:00:00.000Z",
+  };
+}
+
+function contentProof(
+  path: string,
+  overrides: Partial<Record<string, boolean>> = {},
+): RunInGameFileContentProof {
+  return {
+    path,
+    markers: runInGameRequiredMaterializationMarkers({ requestId, configHash, envelopeHash })
+      .map((marker) => ({
+        id: marker.id,
+        marker: marker.marker,
+        present: overrides[marker.id] ?? true,
+      })),
   };
 }
 

--- a/apps/mapgen-studio/vite.config.ts
+++ b/apps/mapgen-studio/vite.config.ts
@@ -41,8 +41,11 @@ import { waitForCiv7MapgenLogFailure } from "./src/server/runInGame/logFailure";
 import {
   buildRunInGameExactAuthorshipProof,
   buildRunInGameSourceSnapshotProof,
+  fileContentMarkerProof,
   fileIdentity,
   parseSwooperMapgenLogProof,
+  runInGameMaterializationScriptUnresolvedLinks,
+  runInGameRequiredMaterializationMarkers,
 } from "./src/server/runInGame/proofIdentity";
 import { parseRunInGameSetupRequest } from "./src/server/runInGame/requestValidation";
 import {
@@ -271,6 +274,10 @@ async function optionalFileIdentity(args: {
   exposeAs?: "relative-to-repo" | "absolute";
 }) {
   return await fileIdentity(args).catch(() => undefined);
+}
+
+async function optionalFileContentMarkerProof(args: Parameters<typeof fileContentMarkerProof>[0]) {
+  return await fileContentMarkerProof(args).catch(() => undefined);
 }
 
 function generatedSourceScriptPath(repoRoot: string, id: string): string {
@@ -694,13 +701,50 @@ async function runRunInGameStartEngine(body: {
             exposeAs: "absolute",
           })
         : undefined;
+      const requiredMaterializationMarkers = runInGameRequiredMaterializationMarkers({
+        requestId,
+        configHash,
+        envelopeHash,
+      });
+      const localModScriptContent = await optionalFileContentMarkerProof({
+        repoRoot,
+        path: localModScriptPath(repoRoot, id),
+        markers: requiredMaterializationMarkers,
+      });
+      const deployedModScriptContent = deploy.targetDir
+        ? await optionalFileContentMarkerProof({
+            repoRoot,
+            path: deployedModScriptPath(deploy.targetDir, id),
+            exposeAs: "absolute",
+            markers: requiredMaterializationMarkers,
+          })
+        : undefined;
       materialization = {
         ...materialization,
         ...(generatedSourceScript ? { generatedSourceScript } : {}),
         ...(localModScript ? { localModScript } : {}),
         ...(deployedModScript ? { deployedModScript } : {}),
+        ...(localModScriptContent ? { localModScriptContent } : {}),
+        ...(deployedModScriptContent ? { deployedModScriptContent } : {}),
       };
       runInGameOperations.update(requestId, { phase, materialization });
+      const materializationScriptUnresolvedLinks = runInGameMaterializationScriptUnresolvedLinks({
+        materialization,
+        localModScript,
+        deployedModScript,
+        requiredMarkers: requiredMaterializationMarkers,
+      });
+      if (materializationScriptUnresolvedLinks.length > 0) {
+        throw new RunInGameHttpError(
+          500,
+          "Generated Swooper map script is missing current materialization proof markers",
+          {
+            code: "map-script-materialization-proof-missing",
+            unresolvedLinks: materializationScriptUnresolvedLinks,
+            materialization,
+          },
+        );
+      }
 
       let processRestart;
       if (restartCivProcess) {

--- a/docs/projects/river-lake-recovery/FRAME.md
+++ b/docs/projects/river-lake-recovery/FRAME.md
@@ -153,6 +153,19 @@ Sources:
 | Studio hydrology visualization and status ladder | Studio / DX layer | Hydrology truth, projection logic |
 | Product acceptance | OpenSpec/product proof records plus reviewer disposition | unit tests or code slices self-closing |
 
+## Studio DAG Step Display
+
+For stage/step DAG navigation, stages own the high-level topology and steps
+must be disclosed as compact one-line rows inside their parent stage. A stage
+row should behave like a long rectangular shutter: collapsed by default when
+appropriate, smoothly expandable/collapsible, and preserving the user's place
+while exposing per-step proof, artifact, and visualization details on demand.
+
+The one-line step row is the stable scan surface. Expanded content may show
+hydrology/rivers/lakes/floodplains proof detail, but it must not turn the DAG
+into a dense wall of always-visible nested cards. This is a Studio DX
+requirement, not a Hydrology truth or projection policy.
+
 ## System Dynamics
 
 Dominant reinforcing loop:

--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -51,6 +51,7 @@ export type FinalSurfaceSnapshot = Readonly<{
   envelopeHash?: string;
   surfaces: Readonly<Record<FinalSurfaceKey, SurfaceGrid>>;
   riverMetadata?: RiverMetadataSnapshot;
+  nativeRiverObjects?: NativeRiverObjectSnapshot;
   evidence?: Readonly<Record<string, unknown>>;
 }>;
 
@@ -88,6 +89,27 @@ export type RiverMetadataSnapshot = Readonly<{
   minorRiverUnsupportedReason?: string;
 }>;
 
+export type NativeRiverObjectSampleSnapshot = Readonly<{
+  index: number;
+  riverType: number | null;
+  plotCount: number | null;
+  connectedToOcean: boolean | null;
+}>;
+
+export type NativeRiverObjectSnapshot = Readonly<{
+  exists: boolean;
+  numRivers: number | null;
+  sampleCount: number;
+  samples?: ReadonlyArray<NativeRiverObjectSampleSnapshot>;
+  blockedBy?: ReadonlyArray<string>;
+}>;
+
+export type NativeRiverObjectReadbackStatus =
+  | "present"
+  | "zero-rivers"
+  | "unavailable"
+  | "not-provided";
+
 export type RiverMetadataParityExample = Readonly<{
   x: number;
   y: number;
@@ -113,6 +135,9 @@ export type RiverMetadataParityReport = Readonly<{
   liveRiverTileCount: number;
   liveNavigableRiverTileCount: number;
   liveMinorRiverTileCount: number;
+  nativeRiverObjectReadbackStatus: NativeRiverObjectReadbackStatus;
+  nativeRiverObjectCount: number | null;
+  nativeRiverObjectSampleCount: number;
   projectedVsLiveTerrainMismatchCount: number;
   projectedVsLiveMetadataMismatchCount: number;
   liveTerrainVsMetadataMismatchCount: number;
@@ -834,6 +859,7 @@ export function liveGridToFinalSurfaceSnapshot(args: {
   seed?: number;
   configHash?: string;
   envelopeHash?: string;
+  nativeRiverObjects?: NativeRiverObjectSnapshot;
   evidence?: Readonly<Record<string, unknown>>;
 }): FinalSurfaceSnapshot {
   const { width, height } = args;
@@ -880,6 +906,7 @@ export function liveGridToFinalSurfaceSnapshot(args: {
     ...(args.envelopeHash === undefined ? {} : { envelopeHash: args.envelopeHash }),
     surfaces,
     riverMetadata,
+    ...(args.nativeRiverObjects === undefined ? {} : { nativeRiverObjects: args.nativeRiverObjects }),
     ...(args.evidence === undefined ? {} : { evidence: args.evidence }),
   };
 }
@@ -1079,6 +1106,16 @@ export function buildFinalSurfaceParityProof(args: {
     unresolvedLinks.push("river-metadata.dimensions");
   } else if (riverMetadataParity?.status === "mismatch") {
     unresolvedLinks.push("river-metadata.mismatch");
+  }
+  if (riverMetadataParity && riverMetadataParityExpectsNativeObjects(riverMetadataParity)) {
+    if (riverMetadataParity.nativeRiverObjectReadbackStatus === "zero-rivers") {
+      unresolvedLinks.push("river-metadata.native-river-objects");
+    } else if (
+      riverMetadataParity.nativeRiverObjectReadbackStatus === "unavailable" ||
+      riverMetadataParity.nativeRiverObjectReadbackStatus === "not-provided"
+    ) {
+      unresolvedLinks.push("river-metadata.native-river-readback");
+    }
   }
   if (
     riverMetadataParity?.minorRiverStampingSupported === false &&
@@ -1334,6 +1371,45 @@ function metadataReadbackClaim(
       ["river-metadata.readback"]
     );
   }
+  if (parity.status === "readback-missing") {
+    return proofClaim(
+      "metadata-readback",
+      "unresolved",
+      "Civ river metadata readback is missing or incomplete.",
+      ["river-metadata.readback"]
+    );
+  }
+  if (parity.status === "dimension-mismatch" || parity.status === "mismatch") {
+    return proofClaim(
+      "metadata-readback",
+      "fail",
+      "Civ river metadata comparison failed.",
+      [`river-metadata.${parity.status}`]
+    );
+  }
+  if (
+    riverMetadataParityExpectsNativeObjects(parity) &&
+    (parity.nativeRiverObjectReadbackStatus === "not-provided" ||
+      parity.nativeRiverObjectReadbackStatus === "unavailable")
+  ) {
+    return proofClaim(
+      "metadata-readback",
+      "unresolved",
+      "Civ native MapRivers object readback is missing or unavailable for a run with river surfaces.",
+      ["river-metadata.native-river-readback"]
+    );
+  }
+  if (
+    riverMetadataParityExpectsNativeObjects(parity) &&
+    parity.nativeRiverObjectReadbackStatus === "zero-rivers"
+  ) {
+    return proofClaim(
+      "metadata-readback",
+      "fail",
+      "Projected or live river terrain exists, but Civ MapRivers reports zero native river objects.",
+      ["river-metadata.native-river-objects"]
+    );
+  }
   if (parity.status === "match") {
     return proofClaim(
       "metadata-readback",
@@ -1348,14 +1424,6 @@ function metadataReadbackClaim(
       "fail",
       "Live terrain contains navigable-river terrain while Civ river metadata remains divergent.",
       ["river-metadata.terrain-match-metadata-divergent"]
-    );
-  }
-  if (parity.status === "readback-missing") {
-    return proofClaim(
-      "metadata-readback",
-      "unresolved",
-      "Civ river metadata readback is missing or incomplete.",
-      ["river-metadata.readback"]
     );
   }
   return proofClaim(
@@ -1554,6 +1622,20 @@ function buildRiverMetadataParityReport(
   const liveMinor = live.riverMetadata?.minorRiver;
   const liveRiverType = live.riverMetadata?.riverType;
   const minorRiverBoundary = minorRiverBoundaryFields(local.riverMetadata);
+  const plannedMinorRiverTileCount = countOnes(localPlannedMinor?.values);
+  const plannedMajorRiverTileCount = countOnes(localPlannedMajor?.values);
+  const projectedNavigableTerrainTileCount = countOnes(localProjected?.values);
+  const liveTerrainNavigableRiverTileCount = countOnes(liveTerrain?.values);
+  const liveRiverTileCount = countOnes(liveRiver?.values);
+  const liveNavigableRiverTileCount = countOnes(liveNavigable?.values);
+  const liveMinorRiverTileCount = countOnes(liveMinor?.values);
+  const nativeRiverObjects = nativeRiverObjectParityFields({
+    snapshot: live.nativeRiverObjects,
+    projectedNavigableTerrainTileCount,
+    liveTerrainNavigableRiverTileCount,
+    liveRiverTileCount,
+    liveNavigableRiverTileCount,
+  });
   if (
     localProjected === undefined &&
     liveTerrain === undefined &&
@@ -1575,13 +1657,14 @@ function buildRiverMetadataParityReport(
       status: "readback-missing",
       compared: 0,
       missingLiveReadback: 0,
-      plannedMinorRiverTileCount: countOnes(localPlannedMinor?.values),
-      plannedMajorRiverTileCount: countOnes(localPlannedMajor?.values),
-      projectedNavigableTerrainTileCount: countOnes(localProjected?.values),
-      liveTerrainNavigableRiverTileCount: countOnes(liveTerrain?.values),
-      liveRiverTileCount: countOnes(liveRiver?.values),
-      liveNavigableRiverTileCount: countOnes(liveNavigable?.values),
-      liveMinorRiverTileCount: countOnes(liveMinor?.values),
+      plannedMinorRiverTileCount,
+      plannedMajorRiverTileCount,
+      projectedNavigableTerrainTileCount,
+      liveTerrainNavigableRiverTileCount,
+      liveRiverTileCount,
+      liveNavigableRiverTileCount,
+      liveMinorRiverTileCount,
+      ...nativeRiverObjects,
       projectedVsLiveTerrainMismatchCount: 0,
       projectedVsLiveMetadataMismatchCount: 0,
       liveTerrainVsMetadataMismatchCount: 0,
@@ -1602,13 +1685,14 @@ function buildRiverMetadataParityReport(
       status: "dimension-mismatch",
       compared: 0,
       missingLiveReadback: 0,
-      plannedMinorRiverTileCount: countOnes(localPlannedMinor?.values),
-      plannedMajorRiverTileCount: countOnes(localPlannedMajor?.values),
-      projectedNavigableTerrainTileCount: countOnes(localProjected.values),
-      liveTerrainNavigableRiverTileCount: countOnes(liveTerrain.values),
-      liveRiverTileCount: countOnes(liveRiver?.values),
-      liveNavigableRiverTileCount: countOnes(liveNavigable.values),
-      liveMinorRiverTileCount: countOnes(liveMinor?.values),
+      plannedMinorRiverTileCount,
+      plannedMajorRiverTileCount,
+      projectedNavigableTerrainTileCount,
+      liveTerrainNavigableRiverTileCount,
+      liveRiverTileCount,
+      liveNavigableRiverTileCount,
+      liveMinorRiverTileCount,
+      ...nativeRiverObjects,
       projectedVsLiveTerrainMismatchCount: 0,
       projectedVsLiveMetadataMismatchCount: 0,
       liveTerrainVsMetadataMismatchCount: 0,
@@ -1669,19 +1753,70 @@ function buildRiverMetadataParityReport(
     status,
     compared,
     missingLiveReadback,
-    plannedMinorRiverTileCount: countOnes(localPlannedMinor?.values),
-    plannedMajorRiverTileCount: countOnes(localPlannedMajor?.values),
-    projectedNavigableTerrainTileCount: countOnes(localProjected.values),
-    liveTerrainNavigableRiverTileCount: countOnes(liveTerrain.values),
-    liveRiverTileCount: countOnes(liveRiver?.values),
-    liveNavigableRiverTileCount: countOnes(liveNavigable.values),
-    liveMinorRiverTileCount: countOnes(liveMinor?.values),
+    plannedMinorRiverTileCount,
+    plannedMajorRiverTileCount,
+    projectedNavigableTerrainTileCount,
+    liveTerrainNavigableRiverTileCount,
+    liveRiverTileCount,
+    liveNavigableRiverTileCount,
+    liveMinorRiverTileCount,
+    ...nativeRiverObjects,
     projectedVsLiveTerrainMismatchCount,
     projectedVsLiveMetadataMismatchCount,
     liveTerrainVsMetadataMismatchCount,
     ...minorRiverBoundary,
     examples,
   };
+}
+
+function nativeRiverObjectParityFields(args: {
+  snapshot: NativeRiverObjectSnapshot | undefined;
+  projectedNavigableTerrainTileCount: number;
+  liveTerrainNavigableRiverTileCount: number;
+  liveRiverTileCount: number;
+  liveNavigableRiverTileCount: number;
+}): Pick<
+  RiverMetadataParityReport,
+  "nativeRiverObjectReadbackStatus" | "nativeRiverObjectCount" | "nativeRiverObjectSampleCount"
+> {
+  const { snapshot } = args;
+  if (snapshot === undefined) {
+    return {
+      nativeRiverObjectReadbackStatus: "not-provided",
+      nativeRiverObjectCount: null,
+      nativeRiverObjectSampleCount: 0,
+    };
+  }
+  const sampleCount = snapshot.sampleCount ?? snapshot.samples?.length ?? 0;
+  const blocked = snapshot.blockedBy?.length ? true : false;
+  if (!snapshot.exists || snapshot.numRivers === null || blocked) {
+    return {
+      nativeRiverObjectReadbackStatus: "unavailable",
+      nativeRiverObjectCount: snapshot.numRivers,
+      nativeRiverObjectSampleCount: sampleCount,
+    };
+  }
+  const expectedRiverSurfaceCount = Math.max(
+    args.projectedNavigableTerrainTileCount,
+    args.liveTerrainNavigableRiverTileCount,
+    args.liveRiverTileCount,
+    args.liveNavigableRiverTileCount
+  );
+  return {
+    nativeRiverObjectReadbackStatus:
+      snapshot.numRivers === 0 && expectedRiverSurfaceCount > 0 ? "zero-rivers" : "present",
+    nativeRiverObjectCount: snapshot.numRivers,
+    nativeRiverObjectSampleCount: sampleCount,
+  };
+}
+
+function riverMetadataParityExpectsNativeObjects(parity: RiverMetadataParityReport): boolean {
+  return Math.max(
+    parity.projectedNavigableTerrainTileCount,
+    parity.liveTerrainNavigableRiverTileCount,
+    parity.liveRiverTileCount,
+    parity.liveNavigableRiverTileCount
+  ) > 0;
 }
 
 function minorRiverBoundaryFields(

--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -93,7 +93,16 @@ export type NativeRiverObjectSampleSnapshot = Readonly<{
   index: number;
   riverType: number | null;
   plotCount: number | null;
+  plotSampleCount?: number;
+  plotTruncated?: boolean;
+  plots?: ReadonlyArray<NativeRiverObjectPlotSnapshot>;
   connectedToOcean: boolean | null;
+}>;
+
+export type NativeRiverObjectPlotSnapshot = Readonly<{
+  raw: unknown;
+  index: number | null;
+  location: Readonly<{ x: number; y: number }> | null;
 }>;
 
 export type NativeRiverObjectSnapshot = Readonly<{

--- a/mods/mod-swooper-maps/test/build/map-bundle-runtime-imports.test.ts
+++ b/mods/mod-swooper-maps/test/build/map-bundle-runtime-imports.test.ts
@@ -7,6 +7,11 @@ const mapOutputDir = join(repoRoot, "mod", "maps");
 const modInfoPath = join(repoRoot, "mod", "swooper-maps.modinfo");
 const bareWorkspaceImportPattern =
   /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](@(?:swooper|civ7|mateicanavra)\/[^"']+)["']/g;
+const nativeRiverMaterializationMarkers = [
+  "context.adapter.modelRivers",
+  "map.rivers.officialCivRiverModeling",
+  "POST-MODEL-RIVERS",
+] as const;
 
 function listedModMapFiles(): string[] {
   const modInfo = readFileSync(modInfoPath, "utf8");
@@ -62,6 +67,22 @@ describe("built map runtime imports", () => {
           bootstrapIndex,
           `${mapFile} creates TextEncoder before installing the Civ7 bootstrap`
         ).toBeLessThan(firstUseIndex);
+      }
+    }
+  });
+
+  test("bundles native Civ river materialization into each map script", () => {
+    const mapFiles = listedModMapFiles();
+
+    expect(mapFiles.length).toBeGreaterThan(0);
+
+    for (const mapFile of mapFiles) {
+      const source = readFileSync(join(mapOutputDir, mapFile), "utf8");
+      for (const marker of nativeRiverMaterializationMarkers) {
+        expect(
+          source.includes(marker),
+          `${mapFile} is missing native river materialization marker ${marker}`
+        ).toBe(true);
       }
     }
   });

--- a/mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
@@ -98,6 +98,7 @@ function snapshot(args: {
   omitted?: number;
   localTerrain?: ReadonlyArray<number | null>;
   riverMetadata?: FinalSurfaceSnapshot["riverMetadata"];
+  nativeRiverObjects?: FinalSurfaceSnapshot["nativeRiverObjects"];
   lakeReadback?: {
     acceptedLakeTileCount: number;
     finalLakeWaterDriftCount: number;
@@ -236,6 +237,7 @@ function snapshot(args: {
       resource: { width, height, values: [7, 8] },
     },
     ...(args.riverMetadata === undefined ? {} : { riverMetadata: args.riverMetadata }),
+    ...(args.nativeRiverObjects === undefined ? {} : { nativeRiverObjects: args.nativeRiverObjects }),
     evidence: args.source === "live-civ7"
       ? {
           runtime: { turn: 1, gameHash: args.gameHash ?? 99, width, height, seed: 1234, plotCount: 2 },
@@ -285,6 +287,26 @@ function riverMetadata(args: {
   };
 }
 
+function nativeRiverObjects(numRivers: number): FinalSurfaceSnapshot["nativeRiverObjects"] {
+  return {
+    exists: true,
+    numRivers,
+    sampleCount: numRivers > 0 ? 1 : 0,
+    ...(numRivers > 0
+      ? {
+          samples: [
+            {
+              index: 0,
+              riverType: RIVER_TYPE_NAVIGABLE,
+              plotCount: 3,
+              connectedToOcean: true,
+            },
+          ],
+        }
+      : {}),
+  };
+}
+
 describe("final-surface parity proof", () => {
   test("reports river metadata parity with planned minor and major masks separated", () => {
     const localRiverMetadata: FinalSurfaceSnapshot["riverMetadata"] = {
@@ -317,7 +339,11 @@ describe("final-surface parity proof", () => {
         resourceCoordinateProof: true,
         riverMetadata: localRiverMetadata,
       }),
-      live: snapshot({ source: "live-civ7", riverMetadata: liveRiverMetadata }),
+      live: snapshot({
+        source: "live-civ7",
+        riverMetadata: liveRiverMetadata,
+        nativeRiverObjects: nativeRiverObjects(1),
+      }),
       now: () => new Date("2026-06-06T00:00:00.000Z"),
     });
 
@@ -494,6 +520,7 @@ describe("final-surface parity proof", () => {
           navigable: [0, 0],
           minor: [0, 0],
         }),
+        nativeRiverObjects: nativeRiverObjects(1),
       }),
     });
 
@@ -529,6 +556,45 @@ describe("final-surface parity proof", () => {
     expect(proof.residuals.find((residual) => residual.key === "rivers")).toMatchObject({
       status: "covered-by-terrain-grid",
     });
+  });
+
+  test("blocks river metadata closure when native MapRivers objects are absent", () => {
+    const proof = buildFinalSurfaceParityProof({
+      exactAuthorship: exactProof(),
+      local: snapshot({
+        source: "local-mapgen",
+        resourceCoordinateProof: true,
+        riverMetadata: riverMetadata({
+          projected: [1, 0],
+          minorRiverStampingSupported: false,
+          minorRiverUnsupportedReason: "minor metadata readback-only",
+        }),
+      }),
+      live: snapshot({
+        source: "live-civ7",
+        riverMetadata: riverMetadata({
+          terrain: [1, 0],
+          riverType: [RIVER_TYPE_NAVIGABLE, NO_RIVER_TYPE],
+          river: [1, 0],
+          navigable: [1, 0],
+          minor: [0, 0],
+        }),
+        nativeRiverObjects: nativeRiverObjects(0),
+      }),
+    });
+
+    expect(proof.status).toBe("unresolved");
+    expect(proof.riverMetadataParity).toMatchObject({
+      status: "match",
+      nativeRiverObjectReadbackStatus: "zero-rivers",
+      nativeRiverObjectCount: 0,
+      nativeRiverObjectSampleCount: 0,
+    });
+    expect(proof.proofClaims.claims["metadata-readback"]).toMatchObject({
+      status: "fail",
+      evidenceLinks: ["river-metadata.native-river-objects"],
+    });
+    expect(proof.unresolvedLinks).toContain("river-metadata.native-river-objects");
   });
 
   test("blocks river metadata parity when local and live grids have different dimensions", () => {

--- a/openspec/changes/river-catalog-adapter-contract-hardening/design.md
+++ b/openspec/changes/river-catalog-adapter-contract-hardening/design.md
@@ -6,8 +6,10 @@ Hardening targets:
   `NO_RIVER` metadata so consumers see the live divergence.
 - Generated catalog headers should distinguish official resource evidence from
   repo-owned policy contracts.
-- `modelRivers()` remains available only for compatibility/official generator
-  evidence and is not used by standard authored river projection.
+- `modelRivers()` remains a Civ-native materialization surface invoked from
+  `map-rivers` only after Hydrology truth and projection have selected river
+  terrain. It is not an upstream Hydrology generator, public selector contract,
+  or replacement for same-run terrain/metadata/native-object readback.
 - `riverClass` is either closed to `0/1/2` or documented as
   `0 none`, `1 minor`, `>=2 major/projectable`, with validation.
 

--- a/openspec/changes/river-catalog-adapter-contract-hardening/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/river-catalog-adapter-contract-hardening/specs/mapgen-normalization-workstreams/spec.md
@@ -17,6 +17,9 @@ and Hydrology river-class truth.
 - **AND** repo-owned constants remain owned by the map-policy source
 
 #### Scenario: Standard MapGen stages author rivers
-- **WHEN** standard stages materialize MapGen-owned rivers
-- **THEN** they do not call `adapter.modelRivers()`
-- **AND** `modelRivers()` remains an engine-generator compatibility surface
+- **WHEN** `map-rivers` materializes Hydrology-owned river truth into Civ
+  terrain/runtime state
+- **THEN** it may call `adapter.modelRivers()` only as the bounded Civ-native
+  materialization pass described by `@civ7/map-policy`
+- **AND** `modelRivers()` must not become an upstream Hydrology generator,
+  public length-selector model, or proof substitute for same-run readback

--- a/openspec/changes/river-catalog-adapter-contract-hardening/tasks.md
+++ b/openspec/changes/river-catalog-adapter-contract-hardening/tasks.md
@@ -3,7 +3,8 @@
 - [x] 1.1 Add or update river-class validation and docs.
 - [x] 1.2 Update mock adapter behavior to simulate terrain-without-metadata.
 - [x] 1.3 Update generated catalog wording to source evidence where relevant.
-- [x] 1.4 Mark `modelRivers()` compatibility-only and keep standard-stage guard.
+- [x] 1.4 Mark `modelRivers()` as a bounded Civ-native materialization surface
+  for `map-rivers`, not an upstream Hydrology generator or public selector.
 
 ## 2. Tests
 

--- a/openspec/changes/river-lake-adversarial-workstream-design/workstream/agent-notes/2026-06-10-studio-materialization-proof-audit.md
+++ b/openspec/changes/river-lake-adversarial-workstream-design/workstream/agent-notes/2026-06-10-studio-materialization-proof-audit.md
@@ -1,0 +1,75 @@
+# Studio Materialization Proof Audit
+
+Date: 2026-06-10
+Branch: `codex/river-native-object-proof`
+Scope: fresh read-only peer-agent audit of Studio Run in Game / generated map
+materialization after native `modelRivers` restoration.
+
+## Framed Goal
+
+Prove or falsify the hypothesis that Studio/Civ can still run stale generated
+map JavaScript even when current source contains the native river materializer,
+and identify closure-grade proof gaps that could let rivers be declared working
+without same-run product evidence.
+
+## Inquiry Design
+
+- Compare current source, local generated map JS, installed Civ mod JS, and
+  latest log markers.
+- Trace Run in Game and Save/Deploy build/deploy sequence.
+- Review proof surfaces for false-completion paths after native `MapRivers`
+  readback was added.
+- Keep findings scoped to owner boundaries: Studio proof owns artifact identity;
+  map-rivers owns Civ materialization; Hydrology truth remains upstream.
+
+## Findings
+
+- The stale deployed-mod hypothesis was confirmed: local `mod/maps/*.js`
+  contained `context.adapter.modelRivers`,
+  `map.rivers.officialCivRiverModeling`, and `POST-MODEL-RIVERS`, while the
+  installed Civ `Mods/mod-swooper-maps/maps/*.js` files had zero of those
+  markers. Installed manifest/config hashes can match while map JS is stale.
+- Run in Game does rebuild before launch through Turbo and injects
+  `SWOOPER_STUDIO_RUN_ID`, but there was no independent post-build/deploy
+  content proof before Civ start.
+- Save/Deploy is weaker than Run in Game because it reports saved/deployed
+  status without source/generated/local/deployed artifact identities.
+- Native `MapRivers` proof is currently aggregate; it does not yet bind sampled
+  visible tiles to native river object plots/chains.
+- Rendered proof still needs real on-target camera/screenshot capture and
+  same-run identity binding. Packet-shape proof and fake image bytes are not
+  product evidence.
+- Final-surface parity top-level `complete` can still coexist with unresolved
+  rendered/product proof rows. Consumers must read proof-class labels, not the
+  top-level status alone.
+- `river-catalog-adapter-contract-hardening` contained stale text forbidding
+  standard stages from calling `adapter.modelRivers()`, conflicting with the
+  accepted native materialization path.
+
+## Disposition
+
+- Accepted now: add Run in Game local/deployed content-marker proof for the
+  request id, config hash, envelope hash, and native river materialization
+  markers; fail before game start if those links are missing.
+- Accepted now: add generated bundle guard requiring native river materializer
+  markers in every manifest-listed map script.
+- Accepted now: reconcile stale `modelRivers()` OpenSpec language so it is a
+  bounded `map-rivers` Civ materialization surface, not an upstream generator or
+  public selector model.
+- Accepted as downstream: extend native `MapRivers` readback to preserve plot
+  membership and bind camera samples to native river objects.
+- Accepted as downstream: replace screenshot packet-shape proof with actual
+  same-run rendered capture evidence tied to branch/commit/request/config/seed.
+- Accepted as downstream: strengthen Save/Deploy artifact identity if it is
+  used as product proof rather than a deployment convenience.
+
+## Stop Conditions For River Closure
+
+- Stop if the installed map script lacks the same request/config/envelope and
+  native river materialization markers as the local built script.
+- Stop if a sampled visible river tile cannot be tied to a native `MapRivers`
+  object/chain in the same run.
+- Stop if rendered evidence is manual-file, off-target, or only Studio-layer
+  evidence.
+- Stop if any product row reads top-level parity `complete` instead of the
+  required proof-class labels.

--- a/openspec/changes/river-runtime-visible-proof/design.md
+++ b/openspec/changes/river-runtime-visible-proof/design.md
@@ -7,7 +7,8 @@ The visible proof runner emits one packet with:
 - setup row/readback, live map identity, seed, dimensions, game hash when
   available;
 - final terrain parity and metadata status;
-- sampled live river tile coordinates and connected-chain ids;
+- sampled live river tile coordinates and native `MapRivers` object/plot
+  membership for each closure camera target;
 - camera target, zoom, visibility/layer/graphics state;
 - screenshot paths and hashes;
 - visual verdict (`visible`, `not-visible`, `obscured`, `inconclusive`) with
@@ -32,6 +33,8 @@ cannot claim minor-river success from terrain-only evidence.
 Closure-capable `civ-rendered` proof also requires:
 
 - `exact-authorship=pass` for the same run before visible proof can pass;
+- each camera target to be both live `TERRAIN_NAVIGABLE_RIVER` terrain and a
+  plot returned by native `MapRivers.getRiverPlots(...)` in the same run;
 - direct-control camera targeting/state capture, even when screenshot capture
   falls back to OS capture;
 - manual-file screenshots to remain debug-only evidence rather than

--- a/openspec/changes/river-runtime-visible-proof/proposal.md
+++ b/openspec/changes/river-runtime-visible-proof/proposal.md
@@ -18,15 +18,16 @@ sampled live river tiles.
   centering the camera, recording camera/zoom/visibility state, and capturing
   screenshots.
 - Add a river visible-proof runner that composes exact-authored run, final
-  surface parity, live river tile sampling, camera targeting, screenshots, and
-  explicit visual verdict.
+  surface parity, live river tile sampling, native `MapRivers` plot membership,
+  camera targeting, screenshots, and explicit visual verdict.
 - Add positive and negative controls so stale/off-target screenshots cannot
   pass.
 
 ## Requires
 
 - Exact-authorship proof.
-- Live terrain readback and sampled river coordinates.
+- Live terrain readback, sampled river coordinates, and native `MapRivers`
+  object plot readback for the same run.
 - A currently running Civ session for visual proof.
 
 ## Enables Parallel Work
@@ -52,8 +53,8 @@ sampled live river tiles.
 ## Stop Conditions
 
 - Camera cannot be centered on sampled river tiles.
-- Screenshot cannot be tied to request id, seed, dimensions, camera state, and
-  sampled coordinates.
+- Screenshot cannot be tied to request id, seed, dimensions, camera state,
+  sampled coordinates, and native river object membership.
 - Visual verdict is missing or based only on terrain readback.
 
 ## Verification Gates

--- a/openspec/changes/river-runtime-visible-proof/tasks.md
+++ b/openspec/changes/river-runtime-visible-proof/tasks.md
@@ -6,19 +6,24 @@
 - [ ] 1.3 Add screenshot capture with explicit fallback labeling.
 - [ ] 1.4 Add metadata/materialization disposition fields for terrain-only,
   native-writer parity pass/fail, not-run, and unsupported-writer states.
+- [x] 1.5 Extend native `MapRivers` readback to preserve bounded plot
+  membership for sampled river objects.
 
 ## 2. Visible Proof Runner
 
 - [x] 2.1 Select sampled live river tiles/chains from final-surface readback.
-- [ ] 2.2 Center camera on samples, capture screenshots, hash artifacts, and
+- [x] 2.2 Require sampled camera targets to be both live river terrain and a
+  native `MapRivers` object plot in the same final-surface proof.
+- [ ] 2.3 Center camera on samples, capture screenshots, hash artifacts, and
   emit visual verdict fields.
-- [ ] 2.3 Add negative controls for wrong map/seed, off-target camera, and
+- [ ] 2.4 Add negative controls for wrong map/seed, off-target camera, and
   no-river configs.
-- [ ] 2.4 Require minor-river claims to cite metadata/native-writer evidence,
+- [ ] 2.5 Require minor-river claims to cite metadata/native-writer evidence,
   not terrain-only readback.
 
 ## 3. Validation
 
-- [ ] 3.1 Run focused direct-control and proof packet tests.
+- [x] 3.1 Run focused direct-control and proof packet tests for native-object
+  plot binding.
 - [ ] 3.2 Run at least one live visual proof and attach artifact paths.
 - [ ] 3.3 Validate this OpenSpec change and `bun run openspec:validate`.

--- a/openspec/changes/studio-river-lake-inspector-dx/design.md
+++ b/openspec/changes/studio-river-lake-inspector-dx/design.md
@@ -35,6 +35,13 @@ for known binary masks. Those counts are display evidence, not a replacement for
 Hydrology benchmark summaries, live readback counters, rendered screenshots, or
 product acceptance proof.
 
+For the pipeline DAG, stage rows remain the primary topology surface. Steps
+within a stage must render as compact one-line rows in an expandable list: a
+long rectangular shutter interaction that can slide open for per-step layer,
+artifact, and proof detail, then collapse back to the scan row without losing
+stage context. River/lake/floodplain proof details belong in the expanded step
+content, not as always-visible nested cards that make the DAG unreadable.
+
 Statuses include:
 
 - `no-physical-rivers`

--- a/openspec/changes/studio-runtime-step-navigation/proposal.md
+++ b/openspec/changes/studio-runtime-step-navigation/proposal.md
@@ -29,6 +29,9 @@ steps.
   when there is an exact public property match, or at the stage root otherwise.
 - Make Studio recipe preflight refresh stale generated artifacts instead of
   accepting any existing artifact set as current.
+- Render steps within each stage as one-line expandable DAG rows so the stage
+  topology remains scannable while per-step artifact/proof details live behind a
+  smooth rectangular shutter interaction.
 - Add tests proving Morphology runtime steps remain visible in Studio artifacts
   while the public authoring schema remains semantic.
 
@@ -44,11 +47,15 @@ steps.
 - Do not couple runtime step visibility to public schema property names.
 - Do not make Studio infer SDK authoring-layer boundaries locally.
 - Do not add one-off mutable config value assertions as proof.
+- Do not render every step's full detail body by default or turn the stage DAG
+  into nested always-open cards.
 
 ## Verification Gates
 
 - `bun test apps/mapgen-studio/test/config/defaultConfigSchema.test.ts`
 - `bun run --cwd mods/mod-swooper-maps build:studio-recipes`
 - `bun run --cwd apps/mapgen-studio build`
+- Browser/Playwright check that stage step rows collapse to one-line scan rows
+  and expand/collapse without losing the selected stage/step context.
 - `bun run openspec -- validate studio-runtime-step-navigation --strict`
 - `git diff --check`

--- a/openspec/changes/studio-runtime-step-navigation/tasks.md
+++ b/openspec/changes/studio-runtime-step-navigation/tasks.md
@@ -9,6 +9,8 @@
   keys to default public config.
 - [x] 2.3 Refresh stale Studio recipe artifacts during Studio preflight.
 - [x] 2.4 Regenerate Studio recipe artifacts.
+- [ ] 2.5 Render stage steps in the DAG as compact one-line expandable rows
+  with smooth rectangular shutter expand/collapse behavior for step detail.
 
 ## 3. Verification
 
@@ -17,3 +19,5 @@
 - [x] 3.2 Run the focused Studio artifact test.
 - [x] 3.3 Run Studio recipe generation and app build gates.
 - [x] 3.4 Run OpenSpec validation and `git diff --check`.
+- [ ] 3.5 Browser/Playwright check that stage step rows are scannable when
+  collapsed, expand/collapse smoothly, and preserve selected stage/step context.

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -216,6 +216,7 @@ import type {
 import {
   getCiv7MapGrid,
   getCiv7MapSummary,
+  getCiv7NativeRiverObjects,
   getCiv7PlotSnapshot,
 } from "./play/map/reads.js";
 import {
@@ -568,6 +569,9 @@ export {
   Civ7MapGridResultSchema,
   Civ7MapSummaryInputSchema,
   Civ7MapSummaryResultSchema,
+  Civ7NativeRiverObjectSampleSchema,
+  Civ7NativeRiverObjectsInputSchema,
+  Civ7NativeRiverObjectsResultSchema,
   Civ7PlotSnapshotFieldSchema,
   Civ7PlotSnapshotInputSchema,
   Civ7PlotSnapshotResultSchema,
@@ -831,6 +835,9 @@ export type {
   Civ7MapLocation,
   Civ7MapSummaryOptions,
   Civ7MapSummaryResult,
+  Civ7NativeRiverObjectSample,
+  Civ7NativeRiverObjectsInput,
+  Civ7NativeRiverObjectsResult,
   Civ7PlotSnapshot,
   Civ7PlotSnapshotField,
   Civ7PlotSnapshotInput,
@@ -839,6 +846,7 @@ export type {
 export {
   getCiv7MapGrid,
   getCiv7MapSummary,
+  getCiv7NativeRiverObjects,
   getCiv7PlotSnapshot,
 };
 export {

--- a/packages/civ7-direct-control/src/play/map/reads.ts
+++ b/packages/civ7-direct-control/src/play/map/reads.ts
@@ -22,6 +22,8 @@ import type {
   Civ7MapSummaryInput,
   Civ7MapSummaryOptions,
   Civ7MapSummaryResult,
+  Civ7NativeRiverObjectsInput,
+  Civ7NativeRiverObjectsResult,
   Civ7PlotSnapshotField,
   Civ7PlotSnapshotInput,
   Civ7PlotSnapshotResult,
@@ -39,6 +41,7 @@ type MapReadDependencies = Readonly<{
   jsLiteral: (value: unknown) => string;
   parseMapGrid: (result: Civ7CommandResult, label: string) => Civ7MapGridResult;
   parseMapSummary: (result: Civ7CommandResult, label: string) => Civ7MapSummaryResult;
+  parseNativeRiverObjects: (result: Civ7CommandResult, label: string) => Civ7NativeRiverObjectsResult;
   parsePlotSnapshot: (result: Civ7CommandResult, label: string) => Civ7PlotSnapshotResult;
   probeHelperSource: () => string;
   validateMapBounds: (bounds: Civ7MapBounds) => void;
@@ -66,6 +69,11 @@ export type MapGridReadDependencies = Pick<
   | "probeHelperSource"
   | "validateMapBounds"
   | "validateMapLocation"
+>;
+
+export type NativeRiverObjectsReadDependencies = Pick<
+  MapReadDependencies,
+  "boundedInteger" | "executeTunerCommand" | "jsLiteral" | "parseNativeRiverObjects" | "probeHelperSource"
 >;
 
 export async function getCiv7MapSummary(
@@ -124,6 +132,19 @@ export async function getCiv7MapGrid(
     ),
   });
   return dependencies.parseMapGrid(result, "Civ7 map grid");
+}
+
+export async function getCiv7NativeRiverObjects(
+  input: Civ7NativeRiverObjectsInput = {},
+  options: Civ7DirectControlOptions = {},
+  dependencies: NativeRiverObjectsReadDependencies = defaultMapReadDependencies,
+): Promise<Civ7NativeRiverObjectsResult> {
+  const maxSamples = dependencies.boundedInteger(input.maxSamples ?? 16, 0, 256, "maxSamples");
+  const result = await dependencies.executeTunerCommand({
+    ...options,
+    command: buildNativeRiverObjectsCommand({ maxSamples }, dependencies),
+  });
+  return dependencies.parseNativeRiverObjects(result, "Civ7 native river objects");
 }
 
 function buildMapSummaryCommand(
@@ -209,6 +230,52 @@ function buildMapGridCommand(input: Civ7MapGridInput & {
       hiddenInfoPolicy: input.playerId === undefined ? "not-player-scoped" : input.includeHidden ? "include-hidden" : "visibility-filtered",
       map: { width, height },
       plots: locations.map((location) => readPlotSnapshot({ ...input, ...location })),
+    });
+  })()`;
+}
+
+function buildNativeRiverObjectsCommand(
+  input: Required<Civ7NativeRiverObjectsInput>,
+  dependencies: NativeRiverObjectsReadDependencies,
+): string {
+  return `(() => {
+    ${dependencies.probeHelperSource()}
+    const input = ${dependencies.jsLiteral(input)};
+    const exists = typeof MapRivers !== "undefined" && MapRivers !== null;
+    const numRivers = exists
+      ? probe(() => {
+          const raw = typeof MapRivers.numRivers === "function"
+            ? MapRivers.numRivers()
+            : MapRivers.numRivers;
+          if (!Number.isInteger(raw)) throw new Error("MapRivers.numRivers did not return an integer");
+          return raw;
+        })
+      : { ok: false, error: "MapRivers unavailable" };
+    const riverCount = numRivers.ok ? Math.max(0, numRivers.value) : 0;
+    const sampleCount = Math.min(riverCount, input.maxSamples);
+    const samples = [];
+    for (let index = 0; index < sampleCount; index += 1) {
+      const plots = probe(() => typeof MapRivers.getRiverPlots === "function"
+        ? MapRivers.getRiverPlots(index)
+        : null);
+      samples.push({
+        index,
+        riverType: probe(() => typeof MapRivers.getRiverTypeByIndex === "function"
+          ? MapRivers.getRiverTypeByIndex(index)
+          : null),
+        plotCount: plots.ok
+          ? { ok: true, value: plots.value && typeof plots.value.length === "number" ? plots.value.length : null }
+          : plots,
+        connectedToOcean: probe(() => typeof MapRivers.isRiverConnectedToOcean === "function"
+          ? MapRivers.isRiverConnectedToOcean(index)
+          : null),
+      });
+    }
+    return JSON.stringify({
+      exists,
+      numRivers,
+      samples,
+      truncated: riverCount > sampleCount,
     });
   })()`;
 }
@@ -358,6 +425,8 @@ const defaultMapReadDependencies: MapReadDependencies = {
     jsonPayloadFromCommandResult<Civ7MapGridResult>(result, label),
   parseMapSummary: (result, label) =>
     jsonPayloadFromCommandResult<Civ7MapSummaryResult>(result, label),
+  parseNativeRiverObjects: (result, label) =>
+    jsonPayloadFromCommandResult<Civ7NativeRiverObjectsResult>(result, label),
   parsePlotSnapshot: (result, label) =>
     jsonPayloadFromCommandResult<Civ7PlotSnapshotResult>(result, label),
   probeHelperSource,

--- a/packages/civ7-direct-control/src/play/map/reads.ts
+++ b/packages/civ7-direct-control/src/play/map/reads.ts
@@ -140,9 +140,10 @@ export async function getCiv7NativeRiverObjects(
   dependencies: NativeRiverObjectsReadDependencies = defaultMapReadDependencies,
 ): Promise<Civ7NativeRiverObjectsResult> {
   const maxSamples = dependencies.boundedInteger(input.maxSamples ?? 16, 0, 256, "maxSamples");
+  const maxPlotsPerRiver = dependencies.boundedInteger(input.maxPlotsPerRiver ?? 256, 0, 2048, "maxPlotsPerRiver");
   const result = await dependencies.executeTunerCommand({
     ...options,
-    command: buildNativeRiverObjectsCommand({ maxSamples }, dependencies),
+    command: buildNativeRiverObjectsCommand({ maxSamples, maxPlotsPerRiver }, dependencies),
   });
   return dependencies.parseNativeRiverObjects(result, "Civ7 native river objects");
 }
@@ -253,19 +254,80 @@ function buildNativeRiverObjectsCommand(
       : { ok: false, error: "MapRivers unavailable" };
     const riverCount = numRivers.ok ? Math.max(0, numRivers.value) : 0;
     const sampleCount = Math.min(riverCount, input.maxSamples);
+    const safeRawPlot = (plot) => {
+      if (plot === null || typeof plot === "number" || typeof plot === "string" || typeof plot === "boolean") return plot;
+      if (plot && typeof plot === "object") {
+        const out = {};
+        for (const key of ["index", "Index", "$index", "plotIndex", "x", "y"]) {
+          if (typeof plot[key] === "number" || typeof plot[key] === "string" || typeof plot[key] === "boolean" || plot[key] === null) {
+            out[key] = plot[key];
+          }
+        }
+        return out;
+      }
+      return String(plot);
+    };
+    const numericPlotIndex = (plot) => {
+      if (Number.isInteger(plot)) return plot;
+      if (typeof plot === "string" && plot.trim() !== "" && Number.isInteger(Number(plot))) return Number(plot);
+      if (plot && typeof plot === "object") {
+        for (const key of ["index", "Index", "$index", "plotIndex"]) {
+          if (Number.isInteger(plot[key])) return plot[key];
+          if (typeof plot[key] === "string" && plot[key].trim() !== "" && Number.isInteger(Number(plot[key]))) return Number(plot[key]);
+        }
+        if (Number.isInteger(plot.x) && Number.isInteger(plot.y)) {
+          const indexResult = probe(() => GameplayMap.getIndexFromXY(plot.x, plot.y));
+          if (indexResult.ok && Number.isInteger(indexResult.value)) return indexResult.value;
+        }
+      }
+      return null;
+    };
+    const locationFromIndex = (index) => {
+      if (!Number.isInteger(index) || index < 0) return null;
+      const location = probe(() => GameplayMap.getLocationFromIndex(index));
+      if (!location.ok || !location.value || !Number.isInteger(location.value.x) || !Number.isInteger(location.value.y)) return null;
+      return { x: location.value.x, y: location.value.y };
+    };
+    const locationFromPlot = (plot, index) => {
+      if (plot && typeof plot === "object" && Number.isInteger(plot.x) && Number.isInteger(plot.y)) {
+        return { x: plot.x, y: plot.y };
+      }
+      return locationFromIndex(index);
+    };
+    const normalizeRiverPlots = (plots) => {
+      if (!plots.ok) return plots;
+      if (!Array.isArray(plots.value)) return { ok: true, value: [] };
+      const selected = plots.value.slice(0, input.maxPlotsPerRiver);
+      return {
+        ok: true,
+        value: selected.map((plot) => {
+          const index = numericPlotIndex(plot);
+          return {
+            raw: safeRawPlot(plot),
+            index,
+            location: locationFromPlot(plot, index),
+          };
+        }),
+      };
+    };
     const samples = [];
     for (let index = 0; index < sampleCount; index += 1) {
       const plots = probe(() => typeof MapRivers.getRiverPlots === "function"
         ? MapRivers.getRiverPlots(index)
         : null);
+      const normalizedPlots = normalizeRiverPlots(plots);
+      const plotCount = plots.ok && plots.value && typeof plots.value.length === "number"
+        ? plots.value.length
+        : null;
       samples.push({
         index,
         riverType: probe(() => typeof MapRivers.getRiverTypeByIndex === "function"
           ? MapRivers.getRiverTypeByIndex(index)
           : null),
-        plotCount: plots.ok
-          ? { ok: true, value: plots.value && typeof plots.value.length === "number" ? plots.value.length : null }
-          : plots,
+        plotCount: plots.ok ? { ok: true, value: plotCount } : plots,
+        plotSampleCount: normalizedPlots.ok ? normalizedPlots.value.length : 0,
+        plotTruncated: typeof plotCount === "number" && plotCount > input.maxPlotsPerRiver,
+        plots: normalizedPlots,
         connectedToOcean: probe(() => typeof MapRivers.isRiverConnectedToOcean === "function"
           ? MapRivers.isRiverConnectedToOcean(index)
           : null),

--- a/packages/civ7-direct-control/src/play/map/types.ts
+++ b/packages/civ7-direct-control/src/play/map/types.ts
@@ -256,3 +256,38 @@ export type Civ7FullMapGridResult = Readonly<{
   chunks: ReadonlyArray<Civ7MapGridReadChunk>;
   plots: ReadonlyArray<Civ7PlotSnapshot>;
 }>;
+
+export const Civ7NativeRiverObjectsInputSchema = Type.Object({
+  maxSamples: Type.Optional(Type.Integer({ minimum: 0, maximum: 256 })),
+}, { additionalProperties: false });
+
+export type Civ7NativeRiverObjectsInput = Readonly<Static<typeof Civ7NativeRiverObjectsInputSchema>>;
+
+export const Civ7NativeRiverObjectSampleSchema = Type.Object({
+  index: Type.Integer({ minimum: 0, maximum: 1_000_000 }),
+  riverType: Civ7RuntimeProbeSchema(Type.Union([Type.Number(), Type.Null()])),
+  plotCount: Civ7RuntimeProbeSchema(Type.Union([Type.Number(), Type.Null()])),
+  connectedToOcean: Civ7RuntimeProbeSchema(Type.Union([Type.Boolean(), Type.Null()])),
+}, { additionalProperties: false });
+
+export type Civ7NativeRiverObjectSample = Readonly<Static<typeof Civ7NativeRiverObjectSampleSchema>>;
+
+export const Civ7NativeRiverObjectsResultSchema = Type.Object({
+  host: Type.String(),
+  port: Type.Number(),
+  state: civ7TunerStateSchema,
+  exists: Type.Boolean(),
+  numRivers: Civ7RuntimeProbeSchema(Type.Number()),
+  samples: Type.Array(Civ7NativeRiverObjectSampleSchema),
+  truncated: Type.Boolean(),
+}, { additionalProperties: false });
+
+export type Civ7NativeRiverObjectsResult = Readonly<{
+  host: string;
+  port: number;
+  state: Civ7TunerState;
+  exists: boolean;
+  numRivers: Civ7RuntimeProbe<number>;
+  samples: ReadonlyArray<Civ7NativeRiverObjectSample>;
+  truncated: boolean;
+}>;

--- a/packages/civ7-direct-control/src/play/map/types.ts
+++ b/packages/civ7-direct-control/src/play/map/types.ts
@@ -259,14 +259,26 @@ export type Civ7FullMapGridResult = Readonly<{
 
 export const Civ7NativeRiverObjectsInputSchema = Type.Object({
   maxSamples: Type.Optional(Type.Integer({ minimum: 0, maximum: 256 })),
+  maxPlotsPerRiver: Type.Optional(Type.Integer({ minimum: 0, maximum: 2048 })),
 }, { additionalProperties: false });
 
 export type Civ7NativeRiverObjectsInput = Readonly<Static<typeof Civ7NativeRiverObjectsInputSchema>>;
+
+export const Civ7NativeRiverObjectPlotSchema = Type.Object({
+  raw: Type.Unknown(),
+  index: Type.Union([Type.Integer({ minimum: 0, maximum: 1_000_000 }), Type.Null()]),
+  location: Type.Union([Civ7MapLocationSchema, Type.Null()]),
+}, { additionalProperties: false });
+
+export type Civ7NativeRiverObjectPlot = Readonly<Static<typeof Civ7NativeRiverObjectPlotSchema>>;
 
 export const Civ7NativeRiverObjectSampleSchema = Type.Object({
   index: Type.Integer({ minimum: 0, maximum: 1_000_000 }),
   riverType: Civ7RuntimeProbeSchema(Type.Union([Type.Number(), Type.Null()])),
   plotCount: Civ7RuntimeProbeSchema(Type.Union([Type.Number(), Type.Null()])),
+  plotSampleCount: Type.Number(),
+  plotTruncated: Type.Boolean(),
+  plots: Civ7RuntimeProbeSchema(Type.Array(Civ7NativeRiverObjectPlotSchema)),
   connectedToOcean: Civ7RuntimeProbeSchema(Type.Union([Type.Boolean(), Type.Null()])),
 }, { additionalProperties: false });
 

--- a/packages/civ7-direct-control/test/map-and-visibility.test.ts
+++ b/packages/civ7-direct-control/test/map-and-visibility.test.ts
@@ -9,6 +9,8 @@ import {
   Civ7MapGridResultSchema,
   Civ7MapSummaryInputSchema,
   Civ7MapSummaryResultSchema,
+  Civ7NativeRiverObjectsInputSchema,
+  Civ7NativeRiverObjectsResultSchema,
   Civ7PlotSnapshotInputSchema,
   Civ7PlotSnapshotResultSchema,
   Civ7VisibilitySummaryInputSchema,
@@ -16,6 +18,7 @@ import {
   getCiv7GameInfoRows,
   getCiv7MapGrid,
   getCiv7MapSummary,
+  getCiv7NativeRiverObjects,
   getCiv7PlotSnapshot,
   getCiv7VisibilitySummary,
   revealCiv7MapForPlayer,
@@ -133,6 +136,20 @@ describe("map and visibility reads", () => {
     })).toBe(false);
   });
 
+  test("validates native river object schema boundaries beside the read atom", () => {
+    expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { maxSamples: 16 })).toBe(true);
+    expect(Value.Check(Civ7NativeRiverObjectsInputSchema, {})).toBe(true);
+    expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { maxSamples: -1 })).toBe(false);
+    expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { maxSamples: 257 })).toBe(false);
+    expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { maxSamples: 1.5 })).toBe(false);
+    expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { command: "MapRivers.numRivers()" })).toBe(false);
+    expect(Value.Check(Civ7NativeRiverObjectsResultSchema, nativeRiverObjectsResult())).toBe(true);
+    expect(Value.Check(Civ7NativeRiverObjectsResultSchema, {
+      ...nativeRiverObjectsResult(),
+      rawCommand: "MapRivers.numRivers()",
+    })).toBe(false);
+  });
+
   test("validates visibility summary schema boundaries beside the read atom", () => {
     expect(Value.Check(Civ7VisibilitySummaryInputSchema, {
       playerId: 0,
@@ -219,6 +236,40 @@ describe("map and visibility reads", () => {
       expect(grid.plotCount).toBe(100_000_000);
       expect(grid.omitted).toBe(99_999_999);
       expect(server.received.some((message) => message.includes("break outer"))).toBe(true);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("wraps bounded native MapRivers object reads", async () => {
+    const server = await startMapTunerServer();
+    try {
+      const { port } = server.address();
+      const nativeRivers = await getCiv7NativeRiverObjects(
+        { maxSamples: 2 },
+        { host: "127.0.0.1", port, timeoutMs: 1_000 }
+      );
+
+      expect(nativeRivers).toMatchObject({
+        exists: true,
+        numRivers: { ok: true, value: 2 },
+        samples: [
+          {
+            index: 0,
+            riverType: { ok: true, value: 1 },
+            plotCount: { ok: true, value: 4 },
+            connectedToOcean: { ok: true, value: true },
+          },
+          {
+            index: 1,
+            riverType: { ok: true, value: 0 },
+            plotCount: { ok: true, value: 2 },
+            connectedToOcean: { ok: true, value: false },
+          },
+        ],
+        truncated: false,
+      });
+      expect(server.received.some((message) => message.includes("MapRivers.numRivers"))).toBe(true);
     } finally {
       await server.close();
     }
@@ -374,6 +425,8 @@ async function startMapTunerServer(): Promise<FakeTunerServer> {
           socket.write(encodeResponse(frame.listenerId, [JSON.stringify(mapSummaryPayload())]));
         } else if (frame.message.includes("locationsFromBounds")) {
           socket.write(encodeResponse(frame.listenerId, [JSON.stringify(mapGridPayload())]));
+        } else if (frame.message.includes("MapRivers") && frame.message.includes("numRivers")) {
+          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(nativeRiverObjectsPayload())]));
         } else if (frame.message.includes("readPlotSnapshot")) {
           socket.write(encodeResponse(frame.listenerId, [JSON.stringify(plotSnapshotPayload())]));
         } else if (frame.message === "CMD:1:Visibility.revealAllPlots(0)") {
@@ -429,6 +482,15 @@ function mapGridResult() {
     port: 4318,
     state: { id: "1", name: "Tuner" },
     ...mapGridPayload(),
+  };
+}
+
+function nativeRiverObjectsResult() {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "1", name: "Tuner" },
+    ...nativeRiverObjectsPayload(),
   };
 }
 
@@ -500,6 +562,28 @@ function plotSnapshotPayload() {
       revealedState: { ok: true, value: 1 },
       visible: { ok: true, value: true },
     },
+  };
+}
+
+function nativeRiverObjectsPayload() {
+  return {
+    exists: true,
+    numRivers: { ok: true, value: 2 },
+    samples: [
+      {
+        index: 0,
+        riverType: { ok: true, value: 1 },
+        plotCount: { ok: true, value: 4 },
+        connectedToOcean: { ok: true, value: true },
+      },
+      {
+        index: 1,
+        riverType: { ok: true, value: 0 },
+        plotCount: { ok: true, value: 2 },
+        connectedToOcean: { ok: true, value: false },
+      },
+    ],
+    truncated: false,
   };
 }
 

--- a/packages/civ7-direct-control/test/map-and-visibility.test.ts
+++ b/packages/civ7-direct-control/test/map-and-visibility.test.ts
@@ -138,10 +138,12 @@ describe("map and visibility reads", () => {
 
   test("validates native river object schema boundaries beside the read atom", () => {
     expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { maxSamples: 16 })).toBe(true);
+    expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { maxSamples: 16, maxPlotsPerRiver: 128 })).toBe(true);
     expect(Value.Check(Civ7NativeRiverObjectsInputSchema, {})).toBe(true);
     expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { maxSamples: -1 })).toBe(false);
     expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { maxSamples: 257 })).toBe(false);
     expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { maxSamples: 1.5 })).toBe(false);
+    expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { maxPlotsPerRiver: 2049 })).toBe(false);
     expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { command: "MapRivers.numRivers()" })).toBe(false);
     expect(Value.Check(Civ7NativeRiverObjectsResultSchema, nativeRiverObjectsResult())).toBe(true);
     expect(Value.Check(Civ7NativeRiverObjectsResultSchema, {
@@ -258,12 +260,32 @@ describe("map and visibility reads", () => {
             index: 0,
             riverType: { ok: true, value: 1 },
             plotCount: { ok: true, value: 4 },
+            plotSampleCount: 4,
+            plotTruncated: false,
+            plots: {
+              ok: true,
+              value: [
+                { raw: 1, index: 1, location: { x: 1, y: 0 } },
+                { raw: 3, index: 3, location: { x: 3, y: 0 } },
+                { raw: 5, index: 5, location: { x: 5, y: 0 } },
+                { raw: 7, index: 7, location: { x: 7, y: 0 } },
+              ],
+            },
             connectedToOcean: { ok: true, value: true },
           },
           {
             index: 1,
             riverType: { ok: true, value: 0 },
             plotCount: { ok: true, value: 2 },
+            plotSampleCount: 2,
+            plotTruncated: false,
+            plots: {
+              ok: true,
+              value: [
+                { raw: 2, index: 2, location: { x: 2, y: 0 } },
+                { raw: 4, index: 4, location: { x: 4, y: 0 } },
+              ],
+            },
             connectedToOcean: { ok: true, value: false },
           },
         ],
@@ -574,12 +596,32 @@ function nativeRiverObjectsPayload() {
         index: 0,
         riverType: { ok: true, value: 1 },
         plotCount: { ok: true, value: 4 },
+        plotSampleCount: 4,
+        plotTruncated: false,
+        plots: {
+          ok: true,
+          value: [
+            { raw: 1, index: 1, location: { x: 1, y: 0 } },
+            { raw: 3, index: 3, location: { x: 3, y: 0 } },
+            { raw: 5, index: 5, location: { x: 5, y: 0 } },
+            { raw: 7, index: 7, location: { x: 7, y: 0 } },
+          ],
+        },
         connectedToOcean: { ok: true, value: true },
       },
       {
         index: 1,
         riverType: { ok: true, value: 0 },
         plotCount: { ok: true, value: 2 },
+        plotSampleCount: 2,
+        plotTruncated: false,
+        plots: {
+          ok: true,
+          value: [
+            { raw: 2, index: 2, location: { x: 2, y: 0 } },
+            { raw: 4, index: 4, location: { x: 4, y: 0 } },
+          ],
+        },
         connectedToOcean: { ok: true, value: false },
       },
     ],

--- a/packages/civ7-direct-control/test/public-api.test.ts
+++ b/packages/civ7-direct-control/test/public-api.test.ts
@@ -23,6 +23,8 @@ import {
   Civ7MapLocationSchema,
   Civ7MapSummaryInputSchema,
   Civ7MapSummaryResultSchema,
+  Civ7NativeRiverObjectsInputSchema,
+  Civ7NativeRiverObjectsResultSchema,
   Civ7PlotSnapshotInputSchema,
   Civ7PlotSnapshotResultSchema,
   Civ7BattlefieldScanInputSchema,
@@ -288,6 +290,25 @@ describe("Civ7 direct control public API", () => {
         "omitted",
         "hiddenInfoPolicy",
         "plots",
+      ]),
+    });
+  });
+
+  test("exports native river object read schemas from the public facade", () => {
+    expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { maxSamples: 16 })).toBe(true);
+    expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { maxSamples: 257 })).toBe(false);
+    expect(Value.Check(Civ7NativeRiverObjectsInputSchema, { rawCommand: "MapRivers.numRivers()" })).toBe(false);
+    expect(Civ7NativeRiverObjectsResultSchema).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+      required: expect.arrayContaining([
+        "host",
+        "port",
+        "state",
+        "exists",
+        "numRivers",
+        "samples",
+        "truncated",
       ]),
     });
   });

--- a/packages/studio-server/src/contract/runInGame.ts
+++ b/packages/studio-server/src/contract/runInGame.ts
@@ -48,6 +48,17 @@ const fileIdentity = z.object({
   mtimeIso: z.string(),
 });
 
+const contentMarkerProof = z.object({
+  id: z.string(),
+  marker: z.string(),
+  present: z.boolean(),
+});
+
+const fileContentProof = z.object({
+  path: z.string(),
+  markers: z.array(contentMarkerProof),
+});
+
 // RunInGameSourceSnapshotProof
 const sourceSnapshotProof = z.object({
   identityHash: z.string(),
@@ -73,6 +84,8 @@ const materializationStatus = z.object({
   generatedSourceScript: fileIdentity.optional(),
   localModScript: fileIdentity.optional(),
   deployedModScript: fileIdentity.optional(),
+  localModScriptContent: fileContentProof.optional(),
+  deployedModScriptContent: fileContentProof.optional(),
 });
 
 // RunInGameRequestStatus

--- a/scripts/civ7-direct-control/probe-river-modeling.ts
+++ b/scripts/civ7-direct-control/probe-river-modeling.ts
@@ -6,8 +6,11 @@ import { dirname, resolve } from "node:path";
 import {
   executeCiv7TunerCommand,
   getCiv7FullMapGrid,
+  getCiv7NativeRiverObjects,
   type Civ7CommandResult,
   type Civ7DirectControlOptions,
+  type Civ7NativeRiverObjectsResult,
+  type Civ7RuntimeProbe,
 } from "../../packages/civ7-direct-control/src/index.ts";
 import { CIV7_DEFAULT_RIVER_MODELING_ARGS } from "../../packages/civ7-map-policy/src/index.ts";
 
@@ -387,11 +390,39 @@ async function readRuntimeInventory(options: Civ7DirectControlOptions): Promise<
 }
 
 async function readNativeRiverObjects(options: Civ7DirectControlOptions): Promise<NativeRiverObjectSummary> {
-  const result = await executeCiv7TunerCommand({
-    ...options,
-    command: buildNativeRiverObjectsCommand(),
-  });
-  return jsonPayloadFromCommandResult<NativeRiverObjectSummary>(result, "native river object summary");
+  return summarizeNativeRiverObjects(await getCiv7NativeRiverObjects({ maxSamples: 16 }, options));
+}
+
+function summarizeNativeRiverObjects(result: Civ7NativeRiverObjectsResult): NativeRiverObjectSummary {
+  return {
+    exists: result.exists,
+    numRivers: probeNumberValue(result.numRivers),
+    samples: result.samples.map((sample) => ({
+      index: sample.index,
+      riverType: probeNullableNumberValue(sample.riverType),
+      plotCount: probeNullableNumberValue(sample.plotCount),
+      connectedToOcean: probeNullableBooleanValue(sample.connectedToOcean),
+    })),
+    blockedBy: [
+      ...(result.exists ? [] : ["native-river-objects.MapRivers.missing"]),
+      ...(result.numRivers.ok ? [] : ["native-river-objects.numRivers.unavailable"]),
+    ],
+  };
+}
+
+function probeNumberValue(probe: Civ7RuntimeProbe<number> | undefined): number | null {
+  if (!probe || probe.ok !== true || typeof probe.value !== "number" || !Number.isFinite(probe.value)) return null;
+  return probe.value;
+}
+
+function probeNullableNumberValue(probe: Civ7RuntimeProbe<number | null> | undefined): number | null {
+  if (!probe || probe.ok !== true || typeof probe.value !== "number" || !Number.isFinite(probe.value)) return null;
+  return probe.value;
+}
+
+function probeNullableBooleanValue(probe: Civ7RuntimeProbe<boolean | null> | undefined): boolean | null {
+  if (!probe || probe.ok !== true || typeof probe.value !== "boolean") return null;
+  return probe.value;
 }
 
 async function callModelRiversSequence(
@@ -447,57 +478,6 @@ function buildRuntimeInventoryCommand(): string {
         maxLength: ${OFFICIAL_DEFAULT_MAX_LENGTH},
       },
     });
-  })()`;
-}
-
-function buildNativeRiverObjectsCommand(): string {
-  return `(() => {
-    const out = {
-      exists: typeof MapRivers !== "undefined" && MapRivers !== null,
-      numRivers: null,
-      samples: [],
-      blockedBy: [],
-    };
-    try {
-      if (!out.exists) {
-        out.blockedBy.push("native-river-objects.MapRivers.missing");
-        return JSON.stringify(out);
-      }
-      const rawCount = typeof MapRivers.numRivers === "function" ? MapRivers.numRivers() : MapRivers.numRivers;
-      if (!Number.isInteger(rawCount)) {
-        out.blockedBy.push("native-river-objects.numRivers.unavailable");
-        return JSON.stringify(out);
-      }
-      out.numRivers = rawCount;
-      const sampleCount = Math.min(rawCount, 16);
-      for (let index = 0; index < sampleCount; index += 1) {
-        let riverType = null;
-        let plotCount = null;
-        let connectedToOcean = null;
-        try {
-          if (typeof MapRivers.getRiverTypeByIndex === "function") {
-            const value = MapRivers.getRiverTypeByIndex(index);
-            riverType = Number.isInteger(value) ? value : null;
-          }
-        } catch (_error) {}
-        try {
-          if (typeof MapRivers.getRiverPlots === "function") {
-            const plots = MapRivers.getRiverPlots(index);
-            plotCount = plots && typeof plots.length === "number" ? plots.length : null;
-          }
-        } catch (_error) {}
-        try {
-          if (typeof MapRivers.isRiverConnectedToOcean === "function") {
-            const value = MapRivers.isRiverConnectedToOcean(index);
-            connectedToOcean = typeof value === "boolean" ? value : null;
-          }
-        } catch (_error) {}
-        out.samples.push({ index, riverType, plotCount, connectedToOcean });
-      }
-    } catch (error) {
-      out.blockedBy.push(error instanceof Error ? error.message : String(error));
-    }
-    return JSON.stringify(out);
   })()`;
 }
 

--- a/scripts/civ7-direct-control/verify-final-surface-parity.ts
+++ b/scripts/civ7-direct-control/verify-final-surface-parity.ts
@@ -5,6 +5,8 @@ import { dirname, resolve } from "node:path";
 
 import {
   getCiv7FullMapGrid,
+  getCiv7NativeRiverObjects,
+  type Civ7NativeRiverObjectsResult,
   type Civ7RuntimeProbe,
 } from "../../packages/civ7-direct-control/src/index.ts";
 import {
@@ -16,6 +18,7 @@ import {
   runLocalFinalSurfaceSnapshot,
   validateExactAuthorshipProofPacket,
   type ExactAuthorshipProofLike,
+  type NativeRiverObjectSnapshot,
 } from "../../mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts";
 
 type Args = Readonly<{
@@ -154,6 +157,34 @@ function probeNumber(value: Civ7RuntimeProbe<number> | undefined): number | unde
   return value.value;
 }
 
+function probeNullableNumber(value: Civ7RuntimeProbe<number | null> | undefined): number | null {
+  if (!value || value.ok !== true || typeof value.value !== "number" || !Number.isFinite(value.value)) return null;
+  return value.value;
+}
+
+function probeNullableBoolean(value: Civ7RuntimeProbe<boolean | null> | undefined): boolean | null {
+  if (!value || value.ok !== true || typeof value.value !== "boolean") return null;
+  return value.value;
+}
+
+function nativeRiverObjectsSnapshot(result: Civ7NativeRiverObjectsResult): NativeRiverObjectSnapshot {
+  return {
+    exists: result.exists,
+    numRivers: probeNumber(result.numRivers) ?? null,
+    sampleCount: result.samples.length,
+    samples: result.samples.map((sample) => ({
+      index: sample.index,
+      riverType: probeNullableNumber(sample.riverType),
+      plotCount: probeNullableNumber(sample.plotCount),
+      connectedToOcean: probeNullableBoolean(sample.connectedToOcean),
+    })),
+    blockedBy: [
+      ...(result.exists ? [] : ["native-river-objects.MapRivers.missing"]),
+      ...(result.numRivers.ok ? [] : ["native-river-objects.numRivers.unavailable"]),
+    ],
+  };
+}
+
 export function buildBlockedFinalSurfaceParityOutput(args: {
   exact: ExactAuthorshipProofLike;
   blockedBy: ReadonlyArray<string>;
@@ -219,6 +250,14 @@ async function main(): Promise<number> {
     port: args.port,
     timeoutMs: args.timeoutMs,
   });
+  const nativeRiverObjects = await getCiv7NativeRiverObjects(
+    { maxSamples: 16 },
+    {
+      host: args.host,
+      port: args.port,
+      timeoutMs: args.timeoutMs,
+    }
+  );
 
   const liveSeed = probeNumber(grid.summary.map.randomSeed);
   const liveTurn = probeNumber(grid.summary.game.turn);
@@ -230,7 +269,9 @@ async function main(): Promise<number> {
     ...(liveSeed === undefined ? {} : { seed: liveSeed }),
     configHash: exact.sourceSnapshot?.configHash,
     envelopeHash: exact.sourceSnapshot?.envelopeHash,
+    nativeRiverObjects: nativeRiverObjectsSnapshot(nativeRiverObjects),
     evidence: {
+      nativeRiverObjects,
       fullGrid: {
         bounds: grid.bounds,
         plotCount: grid.plotCount,

--- a/scripts/civ7-direct-control/verify-final-surface-parity.ts
+++ b/scripts/civ7-direct-control/verify-final-surface-parity.ts
@@ -167,17 +167,36 @@ function probeNullableBoolean(value: Civ7RuntimeProbe<boolean | null> | undefine
   return value.value;
 }
 
+function probeNativeRiverPlots(
+  value: Civ7NativeRiverObjectsResult["samples"][number]["plots"] | undefined,
+): NonNullable<NativeRiverObjectSnapshot["samples"]>[number]["plots"] {
+  if (!value || value.ok !== true || !Array.isArray(value.value)) return undefined;
+  return value.value.map((plot) => ({
+    raw: plot.raw,
+    index: typeof plot.index === "number" && Number.isFinite(plot.index) ? plot.index : null,
+    location: plot.location && typeof plot.location.x === "number" && typeof plot.location.y === "number"
+      ? { x: plot.location.x, y: plot.location.y }
+      : null,
+  }));
+}
+
 function nativeRiverObjectsSnapshot(result: Civ7NativeRiverObjectsResult): NativeRiverObjectSnapshot {
   return {
     exists: result.exists,
     numRivers: probeNumber(result.numRivers) ?? null,
     sampleCount: result.samples.length,
-    samples: result.samples.map((sample) => ({
-      index: sample.index,
-      riverType: probeNullableNumber(sample.riverType),
-      plotCount: probeNullableNumber(sample.plotCount),
-      connectedToOcean: probeNullableBoolean(sample.connectedToOcean),
-    })),
+    samples: result.samples.map((sample) => {
+      const plots = probeNativeRiverPlots(sample.plots);
+      return {
+        index: sample.index,
+        riverType: probeNullableNumber(sample.riverType),
+        plotCount: probeNullableNumber(sample.plotCount),
+        plotSampleCount: sample.plotSampleCount,
+        plotTruncated: sample.plotTruncated,
+        ...(plots === undefined ? {} : { plots }),
+        connectedToOcean: probeNullableBoolean(sample.connectedToOcean),
+      };
+    }),
     blockedBy: [
       ...(result.exists ? [] : ["native-river-objects.MapRivers.missing"]),
       ...(result.numRivers.ok ? [] : ["native-river-objects.numRivers.unavailable"]),

--- a/scripts/civ7-direct-control/verify-river-visible-proof.test.ts
+++ b/scripts/civ7-direct-control/verify-river-visible-proof.test.ts
@@ -45,6 +45,10 @@ describe("river visible proof verifier", () => {
         totalProjectedNavigableTerrainTiles: 2,
         sampleCount: 2,
       });
+      expect(output.proof.nativeRiverObjects).toMatchObject({
+        status: "present",
+        numRivers: 1,
+      });
       expect(output.proof.camera).toMatchObject({
         status: "bound-to-sample",
         source: "direct-control",
@@ -118,6 +122,31 @@ describe("river visible proof verifier", () => {
     expect(output.status).toBe("blocked");
     expect(output.proof.liveRiverSamples.status).toBe("missing");
     expect(output.proof.blockedBy).toContain("river-visible.live-terrain-river-samples");
+  });
+
+  test("blocks when native MapRivers has no river objects for sampled river terrain", () => {
+    const output = buildRiverVisibleProofOutput({
+      parity: parityProof({
+        terrainReadbackStatus: "pass",
+        exactAuthorshipStatus: "pass",
+        projected: [0, 1, 0, 0],
+        liveTerrain: [0, 1, 0, 0],
+        nativeRiverCount: 0,
+      }),
+      cameraTarget: { x: 1, y: 0 },
+      cameraSource: "direct-control",
+      verdict: "visible",
+      verdictSource: "manual-review",
+      captureMode: "direct-control",
+    });
+
+    expect(output.ok).toBe(false);
+    expect(output.status).toBe("blocked");
+    expect(output.proof.nativeRiverObjects).toMatchObject({
+      status: "zero-rivers",
+      numRivers: 0,
+    });
+    expect(output.proof.blockedBy).toContain("river-visible.native-river-objects-present");
   });
 
   test("blocks when final-surface terrain readback did not pass", () => {
@@ -236,9 +265,12 @@ function parityProof(args: {
   projected: ReadonlyArray<number | null>;
   liveTerrain: ReadonlyArray<number | null>;
   liveNavigable?: ReadonlyArray<number | null>;
+  nativeRiverCount?: number | null;
+  nativeRiverBlockedBy?: ReadonlyArray<string>;
 }): FinalSurfaceParityProof {
   const width = 2;
   const height = 2;
+  const nativeRiverCount = args.nativeRiverCount ?? (args.liveTerrain.includes(1) ? 1 : 0);
   return {
     status: "complete",
     createdAt: "2026-06-09T20:00:00.000Z",
@@ -280,6 +312,24 @@ function parityProof(args: {
         terrainNavigableRiver: { width, height, values: args.liveTerrain },
         navigableRiver: { width, height, values: args.liveNavigable ?? args.liveTerrain },
         riverType: { width, height, values: [0, 1, 0, 1] },
+      },
+      nativeRiverObjects: {
+        exists: args.nativeRiverBlockedBy === undefined,
+        numRivers: args.nativeRiverBlockedBy === undefined ? nativeRiverCount : null,
+        sampleCount: nativeRiverCount && nativeRiverCount > 0 ? 1 : 0,
+        ...(nativeRiverCount && nativeRiverCount > 0
+          ? {
+              samples: [
+                {
+                  index: 0,
+                  riverType: 1,
+                  plotCount: 2,
+                  connectedToOcean: true,
+                },
+              ],
+            }
+          : {}),
+        ...(args.nativeRiverBlockedBy === undefined ? {} : { blockedBy: args.nativeRiverBlockedBy }),
       },
     },
     diffs: [],

--- a/scripts/civ7-direct-control/verify-river-visible-proof.test.ts
+++ b/scripts/civ7-direct-control/verify-river-visible-proof.test.ts
@@ -48,7 +48,17 @@ describe("river visible proof verifier", () => {
       expect(output.proof.nativeRiverObjects).toMatchObject({
         status: "present",
         numRivers: 1,
+        sampledPlotCount: 2,
+        samplesWithPlots: 1,
       });
+      expect(output.proof.liveRiverSamples.samples[0]?.nativeRiverObjects).toEqual([
+        {
+          riverIndex: 0,
+          riverType: 1,
+          connectedToOcean: true,
+          plotIndex: 1,
+        },
+      ]);
       expect(output.proof.camera).toMatchObject({
         status: "bound-to-sample",
         source: "direct-control",
@@ -147,6 +157,38 @@ describe("river visible proof verifier", () => {
       numRivers: 0,
     });
     expect(output.proof.blockedBy).toContain("river-visible.native-river-objects-present");
+  });
+
+  test("blocks when camera target is live river terrain but not a native river object plot", () => {
+    const temp = mkdtempSync(join(tmpdir(), "river-visible-proof-"));
+    try {
+      const screenshot = join(temp, "unbound-native.png");
+      writeFileSync(screenshot, "unbound native");
+
+      const output = buildRiverVisibleProofOutput({
+        parity: parityProof({
+          terrainReadbackStatus: "pass",
+          exactAuthorshipStatus: "pass",
+          projected: [0, 1, 0, 1],
+          liveTerrain: [0, 1, 0, 1],
+          nativeRiverPlots: [3],
+        }),
+        screenshots: [screenshot],
+        cameraTarget: { x: 1, y: 0 },
+        cameraSource: "direct-control",
+        verdict: "visible",
+        verdictSource: "manual-review",
+        captureMode: "direct-control",
+      });
+
+      expect(output.ok).toBe(false);
+      expect(output.status).toBe("blocked");
+      expect(output.proof.camera.status).toBe("bound-to-sample");
+      expect(output.proof.liveRiverSamples.samples[0]?.nativeRiverObjects).toEqual([]);
+      expect(output.proof.blockedBy).toContain("river-visible.camera-target-native-river-object");
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
   });
 
   test("blocks when final-surface terrain readback did not pass", () => {
@@ -267,10 +309,12 @@ function parityProof(args: {
   liveNavigable?: ReadonlyArray<number | null>;
   nativeRiverCount?: number | null;
   nativeRiverBlockedBy?: ReadonlyArray<string>;
+  nativeRiverPlots?: ReadonlyArray<number>;
 }): FinalSurfaceParityProof {
   const width = 2;
   const height = 2;
   const nativeRiverCount = args.nativeRiverCount ?? (args.liveTerrain.includes(1) ? 1 : 0);
+  const nativeRiverPlots = args.nativeRiverPlots ?? [1, 3];
   return {
     status: "complete",
     createdAt: "2026-06-09T20:00:00.000Z",
@@ -323,7 +367,14 @@ function parityProof(args: {
                 {
                   index: 0,
                   riverType: 1,
-                  plotCount: 2,
+                  plotCount: nativeRiverPlots.length,
+                  plotSampleCount: nativeRiverPlots.length,
+                  plotTruncated: false,
+                  plots: nativeRiverPlots.map((plotIndex) => ({
+                    raw: plotIndex,
+                    index: plotIndex,
+                    location: { x: plotIndex % width, y: Math.floor(plotIndex / width) },
+                  })),
                   connectedToOcean: true,
                 },
               ],

--- a/scripts/civ7-direct-control/verify-river-visible-proof.ts
+++ b/scripts/civ7-direct-control/verify-river-visible-proof.ts
@@ -41,6 +41,14 @@ type RiverSample = Readonly<{
   liveTerrainNavigableRiver: number | null;
   liveNavigableRiver: number | null;
   liveRiverType: number | null;
+  nativeRiverObjects: ReadonlyArray<NativeRiverSampleBinding>;
+}>;
+
+type NativeRiverSampleBinding = Readonly<{
+  riverIndex: number;
+  riverType: number | null;
+  connectedToOcean: boolean | null;
+  plotIndex: number;
 }>;
 
 type ScreenshotProof = Readonly<{
@@ -55,6 +63,8 @@ type NativeRiverObjectsProof = Readonly<{
   status: "present" | "zero-rivers" | "missing" | "unavailable";
   numRivers: number | null;
   sampleCount: number;
+  sampledPlotCount: number;
+  samplesWithPlots: number;
   blockedBy: ReadonlyArray<string>;
 }>;
 
@@ -245,10 +255,18 @@ export function buildRiverVisibleProofOutput(args: {
   const maxSamples = Math.max(1, Math.trunc(args.maxSamples ?? 8));
   const parityProofHash = hashValue(args.parity);
   const allLiveSamples = collectLiveRiverSamples(args.parity.live.riverMetadata, args.parity.local.riverMetadata);
-  const selectedSamples = sampleEvenly(allLiveSamples, maxSamples);
+  const nativeRiverPlotMembership = nativeRiverPlotMembershipByIndex(args.parity.live.nativeRiverObjects);
+  const selectedSamples = sampleEvenly(allLiveSamples, maxSamples).map((sample) => ({
+    ...sample,
+    nativeRiverObjects: nativeRiverPlotMembership.get(sample.index) ?? [],
+  }));
   const nativeRiverObjects = nativeRiverObjectsProof(args.parity.live.nativeRiverObjects);
   const target = args.cameraTarget;
-  const targetIsSampled = target !== undefined && selectedSamples.some((sample) => sameLocation(sample, target));
+  const targetSample = target === undefined
+    ? undefined
+    : selectedSamples.find((sample) => sameLocation(sample, target));
+  const targetIsSampled = targetSample !== undefined;
+  const targetIsNativeRiverObject = Boolean(targetSample && targetSample.nativeRiverObjects.length > 0);
   const screenshots = args.screenshots ?? [];
   const missingPaths = screenshots.filter((path) => !existsSync(path));
   const screenshotItems = missingPaths.length === 0 && target !== undefined && targetIsSampled
@@ -269,9 +287,15 @@ export function buildRiverVisibleProofOutput(args: {
   } else if (nativeRiverObjects.status === "zero-rivers") {
     blockedBy.add("river-visible.native-river-objects-present");
   }
+  if (nativeRiverObjects.status === "present" && nativeRiverObjects.samplesWithPlots === 0) {
+    blockedBy.add("river-visible.native-river-object-plots");
+  }
   if (allLiveSamples.length === 0) blockedBy.add("river-visible.live-terrain-river-samples");
   if (target === undefined) blockedBy.add("river-visible.camera-target");
   if (target !== undefined && !targetIsSampled) blockedBy.add("river-visible.camera-target-sampled-live-river");
+  if (target !== undefined && targetIsSampled && !targetIsNativeRiverObject) {
+    blockedBy.add("river-visible.camera-target-native-river-object");
+  }
   if (args.cameraSource === undefined || args.cameraSource === "unknown") {
     blockedBy.add("river-visible.camera-source");
   }
@@ -348,15 +372,21 @@ function nativeRiverObjectsProof(snapshot: NativeRiverObjectSnapshot | undefined
       status: "missing",
       numRivers: null,
       sampleCount: 0,
+      sampledPlotCount: 0,
+      samplesWithPlots: 0,
       blockedBy: ["native-river-objects.not-provided"],
     };
   }
   const blockedBy = snapshot.blockedBy ?? [];
+  const sampledPlotCount = nativeRiverSampledPlotCount(snapshot);
+  const samplesWithPlots = snapshot.samples?.filter((sample) => (sample.plots?.length ?? 0) > 0).length ?? 0;
   if (!snapshot.exists || snapshot.numRivers === null || blockedBy.length > 0) {
     return {
       status: "unavailable",
       numRivers: snapshot.numRivers,
       sampleCount: snapshot.sampleCount,
+      sampledPlotCount,
+      samplesWithPlots,
       blockedBy,
     };
   }
@@ -364,8 +394,36 @@ function nativeRiverObjectsProof(snapshot: NativeRiverObjectSnapshot | undefined
     status: snapshot.numRivers === 0 ? "zero-rivers" : "present",
     numRivers: snapshot.numRivers,
     sampleCount: snapshot.sampleCount,
+    sampledPlotCount,
+    samplesWithPlots,
     blockedBy: [],
   };
+}
+
+function nativeRiverPlotMembershipByIndex(
+  snapshot: NativeRiverObjectSnapshot | undefined,
+): ReadonlyMap<number, ReadonlyArray<NativeRiverSampleBinding>> {
+  const membership = new Map<number, NativeRiverSampleBinding[]>();
+  for (const sample of snapshot?.samples ?? []) {
+    for (const plot of sample.plots ?? []) {
+      if (plot.index === null) continue;
+      const existing = membership.get(plot.index) ?? [];
+      existing.push({
+        riverIndex: sample.index,
+        riverType: sample.riverType,
+        connectedToOcean: sample.connectedToOcean,
+        plotIndex: plot.index,
+      });
+      membership.set(plot.index, existing);
+    }
+  }
+  return membership;
+}
+
+function nativeRiverSampledPlotCount(snapshot: NativeRiverObjectSnapshot | undefined): number {
+  let count = 0;
+  for (const sample of snapshot?.samples ?? []) count += sample.plots?.length ?? 0;
+  return count;
 }
 
 function collectLiveRiverSamples(
@@ -389,6 +447,7 @@ function collectLiveRiverSamples(
       liveTerrainNavigableRiver: gridValue(terrain, index),
       liveNavigableRiver: gridValue(navigable, index),
       liveRiverType: gridValue(riverType, index),
+      nativeRiverObjects: [],
     });
   }
   return samples;

--- a/scripts/civ7-direct-control/verify-river-visible-proof.ts
+++ b/scripts/civ7-direct-control/verify-river-visible-proof.ts
@@ -6,6 +6,7 @@ import { dirname, resolve } from "node:path";
 
 import type {
   FinalSurfaceParityProof,
+  NativeRiverObjectSnapshot,
   RiverMetadataSnapshot,
   SurfaceGrid,
 } from "../../mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts";
@@ -50,6 +51,13 @@ type ScreenshotProof = Readonly<{
   target: MapLocation;
 }>;
 
+type NativeRiverObjectsProof = Readonly<{
+  status: "present" | "zero-rivers" | "missing" | "unavailable";
+  numRivers: number | null;
+  sampleCount: number;
+  blockedBy: ReadonlyArray<string>;
+}>;
+
 type RiverVisibleProofStatus =
   | "visible"
   | "not-visible"
@@ -70,6 +78,7 @@ export type RiverVisibleProof = Readonly<{
     sampleCount: number;
     samples: ReadonlyArray<RiverSample>;
   }>;
+  nativeRiverObjects: NativeRiverObjectsProof;
   camera: Readonly<{
     status: "bound-to-sample" | "missing" | "target-not-sampled";
     source: CameraSource;
@@ -237,6 +246,7 @@ export function buildRiverVisibleProofOutput(args: {
   const parityProofHash = hashValue(args.parity);
   const allLiveSamples = collectLiveRiverSamples(args.parity.live.riverMetadata, args.parity.local.riverMetadata);
   const selectedSamples = sampleEvenly(allLiveSamples, maxSamples);
+  const nativeRiverObjects = nativeRiverObjectsProof(args.parity.live.nativeRiverObjects);
   const target = args.cameraTarget;
   const targetIsSampled = target !== undefined && selectedSamples.some((sample) => sameLocation(sample, target));
   const screenshots = args.screenshots ?? [];
@@ -251,6 +261,13 @@ export function buildRiverVisibleProofOutput(args: {
   }
   if (args.parity.proofClaims.claims["exact-authorship"]?.status !== "pass") {
     blockedBy.add("final-surface-parity.exact-authorship-pass");
+  }
+  if (nativeRiverObjects.status === "missing") {
+    blockedBy.add("river-visible.native-river-objects");
+  } else if (nativeRiverObjects.status === "unavailable") {
+    blockedBy.add("river-visible.native-river-objects-readable");
+  } else if (nativeRiverObjects.status === "zero-rivers") {
+    blockedBy.add("river-visible.native-river-objects-present");
   }
   if (allLiveSamples.length === 0) blockedBy.add("river-visible.live-terrain-river-samples");
   if (target === undefined) blockedBy.add("river-visible.camera-target");
@@ -297,6 +314,7 @@ export function buildRiverVisibleProofOutput(args: {
       sampleCount: selectedSamples.length,
       samples: selectedSamples,
     },
+    nativeRiverObjects,
     camera: {
       status: cameraStatus,
       source: args.cameraSource ?? "unknown",
@@ -321,6 +339,32 @@ export function buildRiverVisibleProofOutput(args: {
     status,
     proofHash: hashValue(proof),
     proof,
+  };
+}
+
+function nativeRiverObjectsProof(snapshot: NativeRiverObjectSnapshot | undefined): NativeRiverObjectsProof {
+  if (snapshot === undefined) {
+    return {
+      status: "missing",
+      numRivers: null,
+      sampleCount: 0,
+      blockedBy: ["native-river-objects.not-provided"],
+    };
+  }
+  const blockedBy = snapshot.blockedBy ?? [];
+  if (!snapshot.exists || snapshot.numRivers === null || blockedBy.length > 0) {
+    return {
+      status: "unavailable",
+      numRivers: snapshot.numRivers,
+      sampleCount: snapshot.sampleCount,
+      blockedBy,
+    };
+  }
+  return {
+    status: snapshot.numRivers === 0 ? "zero-rivers" : "present",
+    numRivers: snapshot.numRivers,
+    sampleCount: snapshot.sampleCount,
+    blockedBy: [],
   };
 }
 


### PR DESCRIPTION
Adds native `MapRivers` object readback as a required proof surface for river closure, blocking game start and visible proof when the installed map script or runtime state cannot demonstrate current river materialization.

**Run in Game materialization proof**

Before starting Civ, the Studio server now reads the local and deployed mod script files and checks that each contains the current request ID, config hash, envelope hash, and native river materialization markers (`map.rivers.officialCivRiverModeling`, `POST-MODEL-RIVERS`). If any marker is absent or the content proof paths do not match the deployed file identities, the start-engine handler throws a 500 error with the specific unresolved links rather than launching a stale script. The `RunInGameMaterializationStatus` and `RunInGameExactAuthorshipProof` types carry the new `localModScriptContent` and `deployedModScriptContent` fields, and the exact-authorship proof replaces the previous single hash-mismatch check with the full set of content-marker link checks.

A build-time test asserts that every manifest-listed map script in `mod/maps/` contains all three native river materialization markers.

**Native `MapRivers` object read atom**

`getCiv7NativeRiverObjects` is added to `civ7-direct-control` as a first-class read alongside `getCiv7MapGrid` and `getCiv7MapSummary`. It queries `MapRivers.numRivers`, `getRiverTypeByIndex`, `getRiverPlots`, and `isRiverConnectedToOcean` for up to `maxSamples` river objects, normalizing each plot to a `{ raw, index, location }` shape with bounded integer extraction and `GameplayMap` coordinate resolution. Input and result schemas are exported from the public facade with `additionalProperties: false` guards.

**Final-surface parity and visible proof**

`FinalSurfaceSnapshot` gains a `nativeRiverObjects` field. `buildRiverMetadataParityReport` computes `nativeRiverObjectReadbackStatus` (`present`, `zero-rivers`, `unavailable`, `not-provided`), `nativeRiverObjectCount`, and `nativeRiverObjectSampleCount` for every parity report path. When projected or live navigable river terrain exists, a `zero-rivers` status fails the `metadata-readback` proof claim and adds `river-metadata.native-river-objects` to unresolved links; `unavailable` or `not-provided` statuses add `river-metadata.native-river-readback`.

`buildRiverVisibleProofOutput` now builds a `nativeRiverObjects` proof summary and a per-plot membership index from the snapshot. Each selected river sample carries the native river objects whose plot list contains that plot index. The camera target must be both live `TERRAIN_NAVIGABLE_RIVER` terrain and a member of at least one native river object plot list; if not, `river-visible.camera-target-native-river-object` is added to `blockedBy`. Zero native rivers or an unavailable `MapRivers` object also block the proof.

The `verify-final-surface-parity` and `probe-river-modeling` scripts are updated to call `getCiv7NativeRiverObjects` and pass the resulting snapshot into the parity proof rather than running their own inline `MapRivers` command strings.