### PR TITLE
docs(studio): add control-oRPC seam doc, thin LiveControlPort adapter design, and re-baseline server-contract audit + target architecture for live-read surface

### DIFF
--- a/docs/projects/mapgen-studio-redesign/architecture/10-target-architecture.md
+++ b/docs/projects/mapgen-studio-redesign/architecture/10-target-architecture.md
@@ -18,9 +18,26 @@
 
 ## 1. Server: `@civ7/studio-server` (new workspace package)
 
-Replaces the 16 hand-rolled `/api/*` handlers in `vite.config.ts` (~L379-1147).
-Contract-first so the client gets types before the impl exists; OpenAPI/RPC
-handler mounted at `/api` so legacy paths keep working through cutover.
+> **RE-BASELINE (2026-06-08, control seam) — designed-toward stack-top, not yet on
+> `main`.** This section covers the **studio-server** surface only: map authoring,
+> save/deploy, run-in-game, setup catalog/saved-configs. The **live-game read
+> surface** (FireTuner reads in [`audit/05`](../audit/05-server-contracts.md) #1–#7,
+> #10) is **NOT** re-implemented here — it is **superseded by the control-oRPC
+> seam**. The studio consumes live reads (`world.*`, `readiness.*`, `attention.*`)
+> from `@civ7/control-orpc` + the `Civ7IntelligenceBridge` ingress through a thin
+> `LiveControlPort`, per [`architecture/12-control-seam.md`](12-control-seam.md).
+> That package is **absent from `main`** (empty placeholder on our branch) and lives
+> at the **tip of the live-control `codex/*` stack** (observed leaf
+> `codex/live-control-hotseat-source-route-adoption`, commit `7ea1cbd5`). The
+> studio-server therefore owns authoring/deploy/run-in-game and **mounts
+> `/api/control` as a thin forward to the bridge host** — it does not own live
+> reads. **No FireTuner reads from the studio.** Re-verify the tip before binding.
+
+Replaces the hand-rolled **authoring / deploy / run-in-game** `/api/*` handlers in
+`vite.config.ts` (~L379-1147). Contract-first so the client gets types before the
+impl exists; OpenAPI/RPC handler mounted at `/api` so legacy paths keep working
+through cutover. The FireTuner read handlers (#1–#7, #10) are **not** ported here;
+they bind through the control seam (§ above + doc 12).
 
 ```
 packages/studio-server/

--- a/docs/projects/mapgen-studio-redesign/architecture/12-control-seam.md
+++ b/docs/projects/mapgen-studio-redesign/architecture/12-control-seam.md
@@ -1,0 +1,321 @@
+# 12 — Studio ↔ Control-oRPC Seam (designed-toward stack-top, not yet on main)
+
+> **Status:** designed-toward the **tip of the live-control `codex/*` stack**, **not
+> yet on `main`**. This document captures the *target* control-oRPC contract
+> surface the studio will consume and the **thin adapter seam** the studio binds
+> through. It is normative for studio design intent (FRAME §6); it is **not** a
+> description of code on `main`. We design toward it, stage behind a seam, and
+> bind the real client when the live-control stack lands.
+>
+> **Authority order:** [`FRAME.md`](../FRAME.md) → [`00-GOAL.md`](../00-GOAL.md) →
+> this doc + [`10-target-architecture.md`](10-target-architecture.md) →
+> [`audit/05-server-contracts.md`](../audit/05-server-contracts.md).
+> **Hard core (unchanged):** behavior parity for map-gen, Deck.gl, recipes, the
+> live-runtime poll's staleness/backoff gating, localStorage schema, browserRunner
+> gating. The seam **moves** where live reads come from; it does not rewrite their
+> semantics. **No FireTuner reads** from the studio (canary/diagnostic only). Never
+> re-implement live reads in the studio.
+
+## 0. Stack-top provenance (capture this before binding)
+
+The contract surface below was captured from the **tip of the live-control stack**.
+The consolidation playbook
+([`LIVE-CONTROL-STACK-CONSOLIDATION-PLAYBOOK.md`](../../graphite-stack-integration/LIVE-CONTROL-STACK-CONSOLIDATION-PLAYBOOK.md))
+names the leaf as `codex/live-control-source-route-docs-adoption`; that branch was
+**not present in the local Graphite topology** at capture time (the stack has been
+partially consolidated). The observed tip is:
+
+| Field | Value (capture: 2026-06-08) |
+| --- | --- |
+| Observed leaf branch | `codex/live-control-hotseat-source-route-adoption` |
+| Tip commit | `7ea1cbd5` `docs(civ7): update controller bridge handoff metadata` |
+| Target package | `packages/civ7-control-orpc` (**absent from `main`; empty placeholder on our branch**) |
+| Bridge mod | `mods/mod-civ7-intelligence-bridge` (`Civ7IntelligenceBridge` host install) |
+
+**Re-verify the tip before binding.** Per the playbook, the 570→≤50 consolidation
+is in flight; the exact leaf name, survivor names, and even a few schema field
+names may shift under fold/rename. Treat the **shapes** below as the durable
+contract and re-pin the branch + commit at bind time. If the package landing on
+`main` diverges structurally from this capture, the FRAME §3 falsifier fires
+(“the designed seam is incompatible with what lands on `main`”) — stop and
+re-baseline, do not paper over it.
+
+## 1. What the package exports (target consumable surface)
+
+`@civ7/control-orpc` (`packages/civ7-control-orpc/src/index.ts`) is a
+**contract-first oRPC package** built on `effect-orpc` + TypeBox standard schemas.
+Three layers are relevant to the studio, in increasing order of coupling:
+
+1. **The contract** (`Civ7ControlOrpcContract`) — a pure typed router contract,
+   no logic. The single source of truth for procedure shapes and error maps.
+2. **The router + server client** (`Civ7ControlOrpcRouter`,
+   `createCiv7ControlOrpcServerClient(context)`) — an in-process oRPC router
+   client. Requires a `Civ7ControlOrpcContext` carrying a **direct-control
+   facade** (i.e. it runs where direct-control can reach the game). **The studio
+   does not construct this** — it lives game-side / server-side.
+3. **The intelligence-bridge ingress** (`createCiv7IntelligenceBridge`,
+   `installCiv7IntelligenceBridge`, `Civ7IntelligenceBridge`) — the **envelope
+   ingress** that validates an untyped request envelope, builds context, enforces
+   the mutation-proof boundary, and dispatches to the router client. **This is the
+   seam the studio talks to**, indirectly, through transport.
+
+### 1.1 Contract namespaces (the procedure corpus)
+
+`Civ7ControlOrpcContract` (`src/contract.ts`) is a router of twelve domain
+modules. Each module owns a `contract.ts` (TypeBox I/O) + `router.ts` (effect
+implementation). The procedure-key strings (used by the bridge envelope) follow
+the contract path.
+
+| Module | Risk | Studio-relevant procedures (procedureKey) |
+| --- | --- | --- |
+| `world` | read-only | `world.current`, `world.plot.read`, `world.grid.read` |
+| `readiness` | read-only | `readiness.current` |
+| `attention` | read-only | `attention.current`, `attention.priorities` |
+| `strategy` | read-only | `strategy.frontSummary`, `strategy.tacticalReads`, `strategy.formationSnapshot`, `strategy.civilianRouteTriage` |
+| `notifications` | read / runtime | `notifications.queue`, `notifications.dismiss.request`, `notifications.advisorWarning.request` |
+| `turn` | mutation | `turn.complete.request` |
+| `city` | mutation | `city.production.choice.request`, `city.population.place.request`, `city.townFocus.change.request`, `city.townFocus.review.request` |
+| `unit` | mutation | `unit.target.action.request`, `unit.upgrade.request`, `unit.resettle.request` |
+| `diplomacy` | mutation | `diplomacy.response.request`, `diplomacy.firstMeet.response.request` |
+| `government` | mutation | `government.choice.request`, `government.celebration.choice.request` |
+| `narrative` | mutation | `narrative.choice.request` |
+| `progression` | mutation | `progression.{technology,culture}.{choice,target}.request`, `progression.attribute.{purchase,review}.request`, `progression.tradition.{change,review}.request`, `progression.dashboard.current`, `progression.traditions.current` |
+
+Each procedure carries `Civ7ControlOrpcProcedureMeta` (`src/metadata.ts`):
+`{ family, procedureKey, proofBoundary, risk }`, where `risk ∈
+read-only | runtime-support | mutation` and
+`proofBoundary ∈ local-package-test | pending-runtime-proof | runtime-proof`.
+**This `risk`/`proofBoundary` metadata is the studio's authoritative read-vs-mutation
+classifier** — the studio MUST NOT hardcode its own list.
+
+### 1.2 What the studio actually needs (read surface)
+
+The studio's live-state needs map to the **read-only** procedures, primarily:
+
+- **`world.current`** → replaces the aggregated live-status read. Output shape
+  (`src/modules/world/contract.ts`) carries `playable`, `readiness` (string),
+  `sourceStatus` (per-source `read | skipped-not-playable | skipped-unavailable`),
+  nullable `turn`/`map`/`players`/`localPlayer`, and a `nextStep` hint
+  (`read-attention | restore-readiness | enter-game | inspect-world`).
+- **`world.grid.read`** / **`world.plot.read`** → replace the map-grid tile-window
+  snapshot read (today `GET /api/civ7/live/snapshot`). Bounds/fields semantics are
+  owned by the contract input schemas — port the studio's clamp/default logic
+  *into the request the studio sends*, not into a re-implemented reader.
+- **`readiness.current`** → the readiness level
+  (`tuner-ready | app-ui-game | begin-ready | loading | shell | unavailable`) +
+  capability (`canObserve`, `canMutate`, `reason`). This is the **gating signal**
+  the studio's adaptive poll and the run-in-game flow should consult.
+- **`attention.current` / `attention.priorities`** and **`strategy.*`** are
+  available read surfaces the redesigned studio may surface later; out of scope to
+  wire in the first bind.
+
+Map-gen authoring, save/deploy, and Run-in-Game (the `runInGame.*` / `mapConfigs.*`
+endpoints in [`audit/05`](../audit/05-server-contracts.md)) are **NOT** part of
+control-oRPC. They remain studio-server concerns (see §5).
+
+## 2. The ingress contract (how requests cross the seam)
+
+The studio never calls `createCiv7ControlOrpcServerClient` (no direct-control
+facade exists studio-side, and must not). It speaks the **intelligence-bridge
+envelope**, which is the package's public ingress.
+
+### 2.1 Request envelope
+
+`Civ7ControllerBridgeRequestSchema` (`src/bridge/controller-ingress.ts`) is a
+discriminated union keyed on `procedureKey`. Each member:
+
+```ts
+{
+  procedureKey: "<contract.path.string>",   // literal discriminant
+  input: <typebox input for that procedure>,
+  correlationId?: Civ7ControlOrpcCorrelationId,  // optional, validated
+}
+```
+
+### 2.2 Response envelope
+
+`Civ7ControllerBridgeResponse = Success | Failure`:
+
+```ts
+// success (per-procedure, discriminated on procedureKey)
+{ ok: true, procedureKey: "<key>", output: <typebox output>, correlationId?: ... }
+
+// failure (uniform)
+{ ok: false, error: { code, message, reason }, correlationId?: ... }
+```
+
+The ingress **never throws across the seam** — every failure is a
+`{ ok: false, error }` envelope. Failure `reason` is drawn from a closed set
+including `procedure-not-allowed`, `procedure-not-supported`, `invalid-envelope`,
+and the domain `*UnavailableError` cases. Failure `code` values observed:
+`BRIDGE_PROCEDURE_NOT_ALLOWED`, `BRIDGE_BAD_REQUEST`,
+`BRIDGE_CONTROLLER_PROOF_REQUIRED`, `BRIDGE_PROCEDURE_NOT_SUPPORTED`.
+
+### 2.3 The `invoke` boundary
+
+`createCiv7IntelligenceBridge({ createContext })` →
+`{ invoke(request: unknown): Promise<Civ7ControllerBridgeResponse> }`.
+
+`invokeCiv7ControllerBridgeRequest` enforces, in order:
+1. **allowlist** — unsupported procedureKey → `BRIDGE_PROCEDURE_NOT_ALLOWED`;
+2. **envelope validation** (`Value.Check`) → `BRIDGE_BAD_REQUEST`;
+3. **context build** via `createContext(request)`;
+4. **mutation-proof gate** — mutation requests with no controller proof →
+   `BRIDGE_CONTROLLER_PROOF_REQUIRED`;
+5. **controller support** — `context.controller.supported{Read,Mutation}Procedures`
+   must include the key → `BRIDGE_PROCEDURE_NOT_SUPPORTED`;
+6. dispatch to `createCiv7ControlOrpcServerClient(context)[module][proc](input)`.
+
+The bridge is installed on a global host key
+(`CIV7_INTELLIGENCE_BRIDGE_GLOBAL_KEY = "Civ7IntelligenceBridge"`) by the
+game-side mod (`mods/mod-civ7-intelligence-bridge`). **The studio is on the other
+side of a transport from that host** — it does not install the bridge and does not
+hold the direct-control facade.
+
+## 3. The studio-side seam (thin adapter — what we build)
+
+The studio binds to control-oRPC through **one thin port** with **two
+implementations**, so today's behavior is preserved and the real client drops in
+later without touching consumers.
+
+```
+src/lib/control/
+  port.ts        # LiveControlPort interface — the ONLY thing UI/query code imports
+  envelope.ts    # request/response envelope types mirrored from the bridge contract
+  client.ts      # createControlOrpcClient(): RPCLink → createORPCClient
+                 #   → createTanstackQueryUtils  (binds when the package lands)
+  legacyAdapter  # current @civ7/direct-control-backed impl behind the SAME port
+  index.ts       # selects impl by a single flag/env; default = legacy until bind
+```
+
+### 3.1 The port (stable consumer contract)
+
+```ts
+export interface LiveControlPort {
+  // reads — the studio's live-state surface
+  worldCurrent(): Promise<WorldCurrent>;
+  readinessCurrent(): Promise<ReadinessCurrent>;
+  worldGrid(bounds: GridBounds): Promise<WorldGrid>;
+  // future: attention, strategy reads
+}
+```
+
+- **UI, TanStack Query options, and Zustand selections import only `LiveControlPort`.**
+  They never import `@civ7/control-orpc`, `@civ7/direct-control`, RPCLink, or
+  FireTuner.
+- The port's method names mirror procedureKeys; its types mirror the contract
+  outputs (re-derived from the package types once it lands, hand-mirrored until
+  then).
+
+### 3.2 Bound implementation (target)
+
+When `@civ7/control-orpc` is reachable over transport:
+
+```ts
+// mirrors gt-stack-inspect/src/router/client.ts prior art
+const link = new RPCLink({ url: "/api/control" });  // studio-server proxies to the bridge host
+const rpc = createORPCClient<typeof Civ7ControlOrpcContract>(link);
+const utils = createTanstackQueryUtils(rpc);         // oRPC-native TanStack Query
+```
+
+The bound adapter calls procedures **directly** through the typed client (the
+RPC transport serializes them as bridge envelopes server-side). It does **not**
+hand-assemble envelopes — the envelope is the bridge's *internal* ingress shape;
+the studio's client speaks the contract via RPCLink. The envelope types in
+`envelope.ts` exist only for the legacy/fallback path and for tests that assert
+seam shape.
+
+The transport terminates at the **studio-server** (§5), which forwards to the
+`Civ7IntelligenceBridge` host (or, in-process, calls the ingress). The studio
+**never** reaches the game directly.
+
+### 3.3 Legacy implementation (today, behind the same port)
+
+Until the package lands, `LiveControlPort` is satisfied by an adapter over the
+**existing** `@civ7/direct-control`-backed studio-server endpoints
+([`audit/05`](../audit/05-server-contracts.md) #4/#5). This is a **move, not a
+rewrite**: the studio's live-runtime poll keeps its current staleness/backoff
+gating; only the *source* of the read is abstracted behind the port. This
+preserves the hard-core poll semantics while making the cutover a one-line impl
+swap.
+
+## 4. Data flow & boundaries
+
+```
+┌────────────────────────────┐        ┌──────────────────────────────────────┐
+│ mapgen-studio (browser)    │        │ studio-server (Bun / dev middleware)   │
+│                            │        │                                        │
+│ UI / TanStack Query        │        │  /api/control  ── proxies/forwards ──┐ │
+│   └─ LiveControlPort  ─────┼─HTTP──▶│  /api/civ7/*   (studio-server own)    │ │
+│        ├ bound: RPCLink     │  RPC   │                                       │ │
+│        └ legacy: /api/civ7  │        └───────────────────────────────────┐  │ │
+└────────────────────────────┘                                            │  │ │
+                                                                          ▼  ▼ │
+                                              ┌──────────────────────────────────┐
+                                              │ Civ7IntelligenceBridge (host)      │
+                                              │  invoke(envelope) → ingress        │
+                                              │   → createCiv7ControlOrpcServerClient
+                                              │      (Civ7ControlOrpcContext w/     │
+                                              │       direct-control facade)        │
+                                              │   → game (direct-control)           │
+                                              └──────────────────────────────────┘
+```
+
+Boundary rules (normative):
+
+- **Studio → port → transport → bridge → game.** No studio code on the right of
+  the port may import direct-control or FireTuner.
+- **Reads vs mutations.** The studio's live-state seam is **read-only**
+  (`risk: "read-only"`). Mutation procedures exist in the contract but are
+  **out of scope** for the mapgen studio redesign and are guarded by the bridge's
+  controller-proof boundary regardless. The studio MUST NOT send mutation
+  envelopes as part of this workstream.
+- **Correlation.** `correlationId` is optional and validated; when the studio
+  supplies one it flows through context into the router client. The studio may
+  mint one per logical operation (not per HTTP request) to mirror the
+  operation-identity pattern already used by run-in-game.
+- **Error envelope.** Consumers handle `{ ok: false, error }` as data, not as a
+  thrown transport error — the same posture as the existing live-status
+  `allSettled` per-field error model. The port surfaces failures as typed results,
+  not exceptions, so the adaptive poll's cross-failure backoff is preserved.
+
+## 5. Relationship to the studio-server (P5) and the seam
+
+The two server surfaces are **distinct** and must not be conflated:
+
+| Surface | Owner | Studio consumes via | Status |
+| --- | --- | --- | --- |
+| `runInGame.*`, `mapConfigs.*`, setup-catalog, saved-configs | **studio-server** (P5, [`10`](10-target-architecture.md) §1) | direct typed oRPC client | studio builds this |
+| `world.*`, `readiness.*`, `attention.*`, `strategy.*` (live reads) | **`@civ7/control-orpc`** + `Civ7IntelligenceBridge` | `LiveControlPort` (this seam) | live-control stack builds this |
+
+The studio-server **mounts the control transport** (`/api/control`) as a thin
+forward to the bridge host; it does **not** re-implement control reads. P5's
+effect-oRPC studio-server and this control seam meet at that mount point. The
+studio-server owns map authoring + deploy + run-in-game; control-oRPC owns live
+game reads/mutations. The seam keeps these blast radii separate: a breaking change
+in `@civ7/control-orpc` touches `src/lib/control/*` only.
+
+## 6. Binding checklist (when the package lands on `main`)
+
+1. Re-pin the tip (branch + commit) and diff the captured contract namespaces /
+   procedure keys / output shapes against §1–§2. If they match → proceed; if they
+   diverge structurally → FRAME §3 falsifier, stop and re-baseline.
+2. Add `@civ7/control-orpc` as a studio dependency (`workspace:*`).
+3. Implement `createControlOrpcClient()` (RPCLink → `createORPCClient` →
+   `createTanstackQueryUtils`) per §3.2, mirroring
+   `tools/gt-stack-inspect/src/router/client.ts`.
+4. Mount `/api/control` in the studio-server as a forward to the bridge host.
+5. Flip the `LiveControlPort` selector from legacy to bound; delete the legacy
+   adapter only after parity is proven on the live-runtime poll surface.
+6. Re-run the live-runtime poll parity harness — staleness/backoff gating
+   unchanged is the acceptance bar.
+
+## 7. Do-not-do (seam guardrails)
+
+- Do **not** read FireTuner from the studio (canary/diagnostic only, server-side).
+- Do **not** re-implement live reads — the studio holds no direct-control facade.
+- Do **not** import `@civ7/control-orpc` or `@civ7/direct-control` outside
+  `src/lib/control/*`.
+- Do **not** hand-assemble bridge mutation envelopes from the studio in this
+  workstream.
+- Do **not** treat this capture as `main` truth — re-verify the tip before binding.

--- a/docs/projects/mapgen-studio-redesign/audit/05-server-contracts.md
+++ b/docs/projects/mapgen-studio-redesign/audit/05-server-contracts.md
@@ -1,5 +1,23 @@
 # 05 — Server Boundary / API Contract Inventory
 
+> **RE-BASELINE (2026-06-08, control seam):** This inventory is **scoped to the
+> studio-server surface** (map authoring, save/deploy, run-in-game, setup catalog —
+> the `runInGame.*` / `mapConfigs.*` / `civ7.*` endpoints below). It remains the
+> source of truth **for that surface**, which the studio builds (P5).
+>
+> The **live-game read surface** — endpoints #1–#7 and #10 here that today read
+> FireTuner via `@civ7/direct-control` (`civ7/status`, `map-summary`, `gameinfo`,
+> `live/status`, `live/snapshot`, `live/entities`, `live/gameinfo`, `setup-config`)
+> — is **superseded** by the **control-oRPC seam**. Those reads are **designed-toward
+> the tip of the live-control `codex/*` stack, not yet on `main`**: the studio will
+> consume `world.*` / `readiness.*` / `attention.*` through the
+> `Civ7IntelligenceBridge` ingress via a thin `LiveControlPort`, **not** by reading
+> FireTuner. See [`architecture/12-control-seam.md`](../architecture/12-control-seam.md)
+> for the target contract surface and the adapter seam. **No FireTuner reads from
+> the studio.** The `Effect service mapping` / `Parity risk` columns for those read
+> rows describe the **legacy** path retained only behind the seam's fallback adapter
+> until the control package binds.
+
 **Lane:** server-boundary / API-contract corpus for the `effect-orpc` router migration.
 **Scope:** `apps/mapgen-studio`. Current "server" = hand-rolled `server.middlewares.use("/api/...")` handlers inside `vite.config.ts` (`configureServer`, lines 379–1147) plus helper modules under `src/server/*`. Client calls via raw `fetch` in `src/App.tsx`.
 **Goal:** every endpoint captured so the oRPC router implements exact behavior parity. Cited `file:line` against the snapshot at the head of this branch.

--- a/openspec/changes/mapgen-studio-control-seam/.openspec.yaml
+++ b/openspec/changes/mapgen-studio-control-seam/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-06-08
+status: draft

--- a/openspec/changes/mapgen-studio-control-seam/design.md
+++ b/openspec/changes/mapgen-studio-control-seam/design.md
@@ -1,0 +1,57 @@
+## Design
+
+This is a **design seam** slice: read-only on app code, docs-only output. It
+captures the *target* control-oRPC contract the studio binds to later, so the
+studio's server/data work can proceed off `main` without waiting for the
+live-control stack to consolidate and merge.
+
+## Why a thin port, not a direct dependency
+
+`@civ7/control-orpc` is pre-merge, mid-consolidation, and single-lane-owned. If
+the studio imported it directly across UI, query, and store code, every fold or
+rename in the 570→≤50 consolidation would ripple through the studio. Instead the
+studio depends on **one `LiveControlPort` interface** with two implementations:
+
+1. **legacy** — over the existing `@civ7/direct-control`-backed studio-server
+   read endpoints (today's behavior, retained until bind);
+2. **bound** — over an RPCLink → `createORPCClient` → `createTanstackQueryUtils`
+   client speaking the contract (target).
+
+The blast radius of a control-oRPC breaking change is then `src/lib/control/*`
+only. This mirrors the `effect-orpc` isolation discipline already mandated for the
+studio-server router layer (00-GOAL: "isolate it … blast radius ~30 lines").
+
+## Read vs mutation boundary
+
+The studio's seam is **read-only**: `world.current`, `world.grid.read`,
+`world.plot.read`, `readiness.current`, and optionally `attention.*` / `strategy.*`.
+Mutation procedures exist in the contract but are gated by the bridge's
+controller-proof boundary and are **out of scope** for the studio redesign. The
+authoritative read-vs-mutation classifier is the contract's per-procedure
+`risk` metadata (`read-only | runtime-support | mutation`), never a studio-local
+hardcoded list.
+
+## Envelope as data, not exceptions
+
+The `Civ7IntelligenceBridge` ingress never throws across the seam — failures are
+`{ ok: false, error: { code, message, reason } }`. The port surfaces failures as
+typed results, preserving the existing live-runtime poll's cross-failure adaptive
+backoff and the `allSettled` per-field error posture. This is a **move** of the
+read source behind a port; it does not rewrite the poll's staleness/backoff gating
+(hard core).
+
+## Provenance and the falsifier
+
+The contract surface is captured from the live-control stack tip
+(`codex/live-control-hotseat-source-route-adoption`, `7ea1cbd5`), not from `main`.
+The playbook consolidation may rename branches and lightly reshape schemas. The
+bind-time checklist re-pins the tip and diffs the captured namespaces/keys/shapes;
+a structural divergence from this capture fires the FRAME §3 falsifier ("the
+designed seam is incompatible with what lands on `main`") and must be escalated,
+not papered over.
+
+## Review Lanes
+
+- Control-oRPC contract-surface accuracy (against the stack-top package).
+- Seam boundary correctness (no FireTuner, no direct control imports in the studio).
+- Audit/architecture re-baseline consistency.

--- a/openspec/changes/mapgen-studio-control-seam/proposal.md
+++ b/openspec/changes/mapgen-studio-control-seam/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+The mapgen-studio redesign must consume live game state, but the studio must
+**not** read FireTuner and must **not** re-implement live reads (FRAME §4–§6).
+The target read substrate — the `@civ7/control-orpc` effect-oRPC router plus the
+`Civ7IntelligenceBridge` ingress — is **absent from `main`** (empty placeholder on
+our branch) and lives at the **tip of the live-control `codex/*` stack**, which is
+mid-consolidation (570 → ≤50 branches per the consolidation playbook). The studio
+cannot block on that landing, but its server/data design must be **designed-toward**
+that exact contract surface so the later bind is a thin adapter swap, not a rewrite.
+
+This change is **docs-only**: it captures the target control-oRPC contract surface
+and the studio-side adapter seam, and re-baselines the prior server-contract audit
+and target-architecture server section as "studio-server surface only; live reads
+go through the control seam."
+
+## Target Authority Refs
+
+- `docs/projects/mapgen-studio-redesign/FRAME.md` (§4 guardrails, §6 seam)
+- `docs/projects/mapgen-studio-redesign/00-GOAL.md`
+- `docs/projects/graphite-stack-integration/LIVE-CONTROL-STACK-CONSOLIDATION-PLAYBOOK.md`
+- `packages/civ7-control-orpc/src/index.ts` (at live-control stack tip)
+- `packages/civ7-control-orpc/src/bridge/controller-ingress.ts` (ingress contract)
+- `packages/civ7-control-orpc/src/bridge/intelligence-bridge.ts` (`Civ7IntelligenceBridge`)
+
+## What Changes
+
+- Add `docs/projects/mapgen-studio-redesign/architecture/12-control-seam.md`: the
+  target studio ↔ control-oRPC interface, request/response envelope, flows,
+  boundaries, domain organization, and the thin `LiveControlPort` adapter seam.
+- Re-baseline `audit/05-server-contracts.md` header: scope it to the studio-server
+  surface; mark the FireTuner read rows superseded by the control seam.
+- Re-baseline `architecture/10-target-architecture.md` §1: studio-server owns
+  authoring/deploy/run-in-game; live reads bind through the control seam,
+  designed-toward stack-top, not yet on `main`.
+
+## Requires
+
+- The captured live-control stack tip (`codex/live-control-hotseat-source-route-adoption`)
+  as the contract source. The tip must be re-verified before any future bind.
+
+## Enables Parallel Work
+
+- P2 client data layer and P5 studio-server can proceed against a stable seam
+  contract without waiting for the live-control stack to merge.
+
+## Affected Owners
+
+- `docs/projects/mapgen-studio-redesign/**` (docs only)
+
+## Forbidden Owners
+
+- No `apps/mapgen-studio/**` source changes (docs-only slice).
+- No `packages/civ7-control-orpc/**` changes (read-only inspection only).
+- No FireTuner read paths introduced into the studio.
+
+## Stop Conditions
+
+- The live-control stack tip cannot be located or its control-oRPC contract
+  surface cannot be captured.
+- The captured contract surface is structurally incompatible with the studio's
+  live-read needs (FRAME §3 falsifier — escalate, do not paper over).
+
+## Consumer Impact
+
+The redesign team can design the studio's live-state seam against an exact,
+documented target contract and bind a real client later via a one-line adapter
+swap, with no FireTuner coupling and no re-implemented live reads.
+
+## Verification Gates
+
+- `bun run openspec -- validate mapgen-studio-control-seam --strict`.
+- Doc cross-references resolve (FRAME §6 ↔ doc 12 ↔ audit/05 ↔ architecture/10).
+- No source/build changes (docs-only slice; tsc/build untouched).

--- a/openspec/changes/mapgen-studio-control-seam/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-control-seam/specs/mapgen-studio/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Studio Consumes Live Game State Through The Control-oRPC Seam
+
+Mapgen Studio SHALL consume live game state through the control-oRPC seam — the
+`@civ7/control-orpc` contract and the `Civ7IntelligenceBridge` ingress — and SHALL
+NOT read FireTuner and SHALL NOT re-implement live reads. The seam is designed
+toward the tip of the live-control `codex/*` stack and is not yet on `main`; the
+studio SHALL bind the real client later via a thin adapter without rewriting
+consumers.
+
+#### Scenario: Studio reads live state through the seam
+- **WHEN** the studio needs live world/readiness state
+- **THEN** it issues read procedures (`world.current`, `world.grid.read`,
+  `readiness.current`) through a `LiveControlPort` that resolves to the
+  control-oRPC client / `Civ7IntelligenceBridge` ingress
+- **AND** no studio code reads FireTuner or holds a direct-control facade
+
+#### Scenario: Studio designs against stack-top, not main
+- **WHEN** the `@civ7/control-orpc` package is absent from `main` and mid-consolidation
+- **THEN** the studio's seam design is captured from the live-control stack tip and
+  marked "designed-toward stack-top, not yet on main"
+- **AND** the studio's server/data work proceeds off `main` without waiting for the
+  live-control stack to merge
+
+#### Scenario: Bind-time contract divergence fires the falsifier
+- **WHEN** the package that lands on `main` diverges structurally from the captured
+  control-oRPC contract namespaces, procedure keys, or output shapes
+- **THEN** the studio stops and re-baselines the seam
+- **AND** the divergence is escalated as the FRAME §3 falsifier rather than worked around
+
+### Requirement: Control Seam Is Isolated Behind One Thin Port
+
+The studio SHALL isolate control-oRPC consumption behind a single
+`LiveControlPort` interface in `src/lib/control/*`, with a bound RPCLink
+implementation and a legacy direct-control-backed fallback implementation, so that
+a breaking change in `@civ7/control-orpc` has a blast radius limited to that
+directory.
+
+#### Scenario: Consumers depend only on the port
+- **WHEN** UI, TanStack Query options, or Zustand selections need live state
+- **THEN** they import only `LiveControlPort`
+- **AND** they do not import `@civ7/control-orpc`, `@civ7/direct-control`, RPCLink,
+  or FireTuner
+
+#### Scenario: Cutover is an adapter swap
+- **WHEN** `@civ7/control-orpc` becomes reachable over transport
+- **THEN** the bound implementation replaces the legacy implementation behind the
+  same `LiveControlPort`
+- **AND** consumer code and the live-runtime poll's staleness/backoff gating are
+  unchanged
+
+### Requirement: Studio Read Surface Preserves Parity And The Read-Only Boundary
+
+The control seam SHALL move the source of live reads without changing live-runtime
+poll semantics, and SHALL restrict the studio to read-only control procedures.
+
+#### Scenario: Poll semantics preserved across the move
+- **WHEN** the studio's live-runtime poll reads through the seam
+- **THEN** its staleness/backoff gating and per-field error envelope behavior are
+  identical to the pre-seam behavior
+- **AND** failures are surfaced as typed `{ ok: false, error }` results, not thrown
+  transport errors
+
+#### Scenario: Studio does not send mutations
+- **WHEN** the studio operates within the redesign workstream
+- **THEN** it sends only procedures whose contract `risk` metadata is `read-only`
+- **AND** it does not hand-assemble or send control-oRPC mutation envelopes

--- a/openspec/changes/mapgen-studio-control-seam/tasks.md
+++ b/openspec/changes/mapgen-studio-control-seam/tasks.md
@@ -1,0 +1,32 @@
+## 1. Capture Stack-Top Contract Surface
+
+- [x] 1.1 Identify the tip of the live-control `codex/*` stack from the
+  consolidation playbook and `gt ls` / `git log` (observed leaf
+  `codex/live-control-hotseat-source-route-adoption`, commit `7ea1cbd5`).
+- [x] 1.2 Capture the `@civ7/control-orpc` exported surface from `src/index.ts`:
+  contract, router, server client, intelligence-bridge ingress, error map,
+  metadata.
+- [x] 1.3 Capture the contract namespaces and procedure-key corpus
+  (`world`, `readiness`, `attention`, `strategy`, `notifications`, `turn`,
+  `city`, `unit`, `diplomacy`, `government`, `narrative`, `progression`).
+- [x] 1.4 Capture the `Civ7IntelligenceBridge` ingress request/response envelope,
+  the `invoke` boundary, the controller-proof mutation gate, and the
+  `risk`/`proofBoundary` read-vs-mutation classifier.
+
+## 2. Author The Seam Doc
+
+- [x] 2.1 Write `architecture/12-control-seam.md`: target contract surface,
+  envelope, data flow, boundaries, domain organization.
+- [x] 2.2 Specify the thin `LiveControlPort` adapter seam (bound RPCLink impl +
+  legacy direct-control fallback impl behind one port).
+- [x] 2.3 Specify boundary rules (reads-only for the studio, no FireTuner, no
+  control-orpc/direct-control imports outside `src/lib/control/*`) and the
+  bind-time checklist + falsifier.
+
+## 3. Re-Baseline And Validate
+
+- [x] 3.1 Re-baseline `audit/05-server-contracts.md` header: studio-server surface
+  only; FireTuner read rows superseded by the control seam.
+- [x] 3.2 Re-baseline `architecture/10-target-architecture.md` §1: live reads bind
+  through the control seam, designed-toward stack-top, not yet on `main`.
+- [x] 3.3 Run `bun run openspec -- validate mapgen-studio-control-seam --strict`.


### PR DESCRIPTION
This PR introduces the studio ↔ control-oRPC seam design for the mapgen studio redesign. It is a docs-only change — no app source or build artifacts are modified.

**What this establishes:**

The studio must consume live game state (`world.*`, `readiness.*`, `attention.*`) through the `@civ7/control-orpc` contract and `Civ7IntelligenceBridge` ingress, not by reading FireTuner or re-implementing live reads. Because `@civ7/control-orpc` is absent from `main` (empty placeholder on this branch) and lives at the tip of the live-control `codex/*` stack mid-consolidation, the studio cannot block on that landing. This change captures the target contract surface from the observed stack tip (`codex/live-control-hotseat-source-route-adoption`, `7ea1cbd5`) and documents the thin adapter seam the studio binds through, so P2 client data layer and P5 studio-server work can proceed in parallel.

**New doc — `architecture/12-control-seam.md`:**

Specifies the full target seam: the `Civ7ControlOrpcContract` procedure corpus (twelve domain modules, procedure keys, `risk`/`proofBoundary` metadata as the authoritative read-vs-mutation classifier), the `Civ7IntelligenceBridge` request/response envelope and `invoke` boundary, the studio-side `LiveControlPort` interface with a bound RPCLink implementation and a legacy direct-control-backed fallback behind the same port, data flow boundaries, and the bind-time checklist. The blast radius of any breaking change in `@civ7/control-orpc` is confined to `src/lib/control/*`. The live-runtime poll's staleness/backoff gating and per-field error envelope behavior are explicitly preserved as hard core — the seam moves the read source, it does not rewrite poll semantics.

**Re-baselines:**

- `architecture/10-target-architecture.md` §1: studio-server owns authoring/deploy/run-in-game only; FireTuner read handlers (#1–#7, #10) are not ported and bind through the control seam.
- `audit/05-server-contracts.md`: scoped to the studio-server surface; the FireTuner read rows are marked superseded by the control seam, with their `Effect service mapping`/`Parity risk` columns retained only as documentation of the legacy fallback path.

**Falsifier:** If the package that lands on `main` diverges structurally from the captured contract namespaces, procedure keys, or output shapes, the FRAME §3 falsifier fires — work stops and the seam is re-baselined rather than papered over.