### PR TITLE
refactor(studio): reskin shell chrome onto design tokens, shadcn primitives, and sonner toast

### DIFF
--- a/apps/mapgen-studio/src/App.tsx
+++ b/apps/mapgen-studio/src/App.tsx
@@ -10,7 +10,7 @@ import { AppHeader } from "./ui/components/AppHeader";
 import { AppFooter } from "./ui/components/AppFooter";
 import { ExplorePanel } from "./ui/components/ExplorePanel";
 import { RecipePanel } from "./ui/components/RecipePanel";
-import { ToastProvider, useToast } from "./ui/components/ui";
+import { Toaster, toast as sonnerToast, TooltipProvider } from "./components/ui";
 import { createTheme, useThemePreference } from "./ui/hooks";
 import { configsEqual, recipeSettingsEqual, worldSettingsEqual } from "./ui/utils/config";
 import { formatStageName } from "./ui/utils/formatting";
@@ -76,10 +76,6 @@ import {
   type MapConfigSaveDeployStatus,
 } from "./features/mapConfigSave/status";
 import {
-  createStudioServerOrpcClient,
-  studioServerOrpcFailure,
-} from "./features/studioServer/studioServerClient";
-import {
   buildLiveRuntimeErrorState,
   buildLiveRuntimeSnapshotQuery,
   buildLiveRuntimeSnapshotRequest,
@@ -94,8 +90,6 @@ import {
 } from "./features/liveRuntime/model";
 import { DeckCanvas, type DeckCanvasApi } from "./features/viz/DeckCanvas";
 import { useVizState } from "./features/viz/useVizState";
-import { createStudioRecipeDagClient, type RecipeDagResult } from "./features/recipeDag/client";
-import { RecipeDagStatsBar, RecipeDagView } from "./features/recipeDag/RecipeDagView";
 import {
   findVariantIdForEra,
   findVariantKeyForEra,
@@ -103,10 +97,6 @@ import {
   parseEraVariantKey,
   resolveFixedEraUiValue,
 } from "./features/viz/era";
-import {
-  buildRiverLakeFloodplainInspectorSummary,
-  type RiverLakeInspectorLayerRef,
-} from "./features/viz/riverLakeInspector";
 import { formatErrorForUi } from "./shared/errorFormat";
 import { shouldIgnoreGlobalShortcutsInEditableTarget } from "./shared/shortcuts/shortcutPolicy";
 import type { VizEvent } from "./shared/vizEvents";
@@ -136,17 +126,6 @@ import {
 import { getOverlaySuggestions } from "./recipes/overlaySuggestions";
 
 const civ7ControlOrpcClient = createStudioCiv7ControlOrpcClient();
-const recipeDagClient = createStudioRecipeDagClient();
-const studioServerClient = createStudioServerOrpcClient();
-
-type StudioView = "map" | "dag";
-
-type RecipeDagClientState = Readonly<{
-  status: "idle" | "loading" | "ready" | "error";
-  recipeId: string | null;
-  dag: RecipeDagResult | null;
-  error: string | null;
-}>;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -175,7 +154,7 @@ async function saveRepoBackedConfig(args: {
   config: unknown;
   onStatus?: (status: MapConfigSaveDeployStatus) => void;
 }): Promise<
-  | { ok: true; path?: string; deploy?: MapConfigSaveDeployStatus["deploy"] }
+  | { ok: true; path?: string; deploy?: { command?: string } }
   | { ok: false; error: string; saved?: boolean; deployed?: boolean; path?: string }
 > {
   const envelope = {
@@ -189,12 +168,16 @@ async function saveRepoBackedConfig(args: {
     config: args.config,
   };
   try {
-    let status = await studioServerClient.mapConfigs.saveDeploy({
-      requestId: args.requestId,
-      id: args.id,
-      sourcePath: args.sourcePath,
-      envelope,
+    const res = await fetch("/api/map-configs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ requestId: args.requestId, id: args.id, sourcePath: args.sourcePath, envelope }),
     });
+    const body = (await res.json().catch(() => null)) as (Partial<MapConfigSaveDeployStatus> & { error?: string }) | null;
+    if (!res.ok || !body?.requestId) {
+      return { ok: false, error: body?.error ?? `HTTP ${res.status}`, path: body?.path };
+    }
+    let status = body as MapConfigSaveDeployStatus;
     args.onStatus?.(status);
     while (status.status === "running") {
       await delay(500);
@@ -216,8 +199,7 @@ async function saveRepoBackedConfig(args: {
     }
     return { ok: true, path: status.path, deploy: status.deploy };
   } catch (err) {
-    const failure = studioServerOrpcFailure(err, "Repo config save failed");
-    return { ok: false, error: failure.error, path: failure.data?.path as string | undefined };
+    return { ok: false, error: err instanceof Error ? err.message : "Repo config save failed" };
   }
 }
 
@@ -231,10 +213,14 @@ function isAbortLikeError(err: unknown): boolean {
 
 async function fetchMapConfigSaveDeployStatus(requestId: string): Promise<MapConfigSaveDeployStatus | { ok: false; error: string; statusCode?: number }> {
   try {
-    return await studioServerClient.mapConfigs.status({ requestId });
+    const res = await fetch(`/api/map-configs/status?requestId=${encodeURIComponent(requestId)}`);
+    const body = (await res.json().catch(() => null)) as (Partial<MapConfigSaveDeployStatus> & { error?: string }) | null;
+    if (!res.ok || !body?.requestId) {
+      return { ok: false, error: body?.error ?? `HTTP ${res.status}`, statusCode: res.status };
+    }
+    return body as MapConfigSaveDeployStatus;
   } catch (err) {
-    const failure = studioServerOrpcFailure(err, "Save/Deploy status unavailable");
-    return { ok: false, error: failure.error, statusCode: failure.statusCode };
+    return { ok: false, error: err instanceof Error ? err.message : "Save/Deploy status unavailable" };
   }
 }
 
@@ -265,38 +251,50 @@ async function runCurrentConfigInGame(args: {
   | { ok: false; error: string; details?: RunInGameFailureDetails; statusCode?: number }
 > {
   try {
-    const status = await studioServerClient.runInGame.start({
-      recipeId: args.recipeId,
-      seed: args.seed,
-      mapSize: args.mapSize,
-      playerCount: args.playerCount,
-      resources: args.resources,
-      setupConfig: normalizeStudioSetupConfig(args.setupConfig),
-      materialization: { mode: args.materializationMode },
-      ...(args.restartCivProcess ? { recovery: { restartCivProcess: true } } : {}),
-      selectedConfig: args.selectedConfig,
-      config: args.config,
-      sourceSnapshot: args.sourceSnapshot,
+    const res = await fetch("/api/civ7/run-in-game", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        recipeId: args.recipeId,
+        seed: args.seed,
+        mapSize: args.mapSize,
+        playerCount: args.playerCount,
+        resources: args.resources,
+        setupConfig: normalizeStudioSetupConfig(args.setupConfig),
+        materialization: { mode: args.materializationMode },
+        ...(args.restartCivProcess ? { recovery: { restartCivProcess: true } } : {}),
+        selectedConfig: args.selectedConfig,
+        config: args.config,
+        sourceSnapshot: args.sourceSnapshot,
+      }),
     });
-    return status as RunInGameOperationStatus;
+    const body = (await res.json().catch(() => null)) as
+      | (Partial<RunInGameOperationStatus> & { error?: string; details?: RunInGameFailureDetails })
+      | null;
+    if (!res.ok || !body?.requestId) {
+      return {
+        ok: false,
+        error: body?.error ?? `HTTP ${res.status}`,
+        details: body?.details,
+        statusCode: res.status,
+      };
+    }
+    return body as RunInGameOperationStatus;
   } catch (err) {
-    const failure = studioServerOrpcFailure(err, "Run in Game failed");
-    return {
-      ok: false,
-      error: failure.error,
-      details: failure.data?.details as RunInGameFailureDetails | undefined,
-      statusCode: failure.statusCode,
-    };
+    return { ok: false, error: err instanceof Error ? err.message : "Run in Game failed" };
   }
 }
 
 async function fetchRunInGameStatus(requestId: string): Promise<RunInGameOperationStatus | { ok: false; error: string; statusCode?: number }> {
   try {
-    const status = await studioServerClient.runInGame.status({ requestId });
-    return status as RunInGameOperationStatus;
+    const res = await fetch(`/api/civ7/run-in-game/status?requestId=${encodeURIComponent(requestId)}`);
+    const body = (await res.json().catch(() => null)) as (Partial<RunInGameOperationStatus> & { error?: string }) | null;
+    if (!res.ok || !body?.requestId) {
+      return { ok: false, error: body?.error ?? `HTTP ${res.status}`, statusCode: res.status };
+    }
+    return body as RunInGameOperationStatus;
   } catch (err) {
-    const failure = studioServerOrpcFailure(err, "Run in Game status unavailable");
-    return { ok: false, error: failure.error, statusCode: failure.statusCode };
+    return { ok: false, error: err instanceof Error ? err.message : "Run in Game status unavailable" };
   }
 }
 
@@ -679,7 +677,28 @@ type AppContentProps = {
 };
 
 function AppContent(props: AppContentProps) {
-  const { toast } = useToast();
+  // Toast notifications now route through sonner. This adapter preserves the
+  // legacy `toast(message, { variant })` call shape used across this file so the
+  // migration is presentation-only: variant maps to the matching sonner method.
+  const toast = useCallback(
+    (message: string, options?: { variant?: "default" | "success" | "error" | "info"; duration?: number }) => {
+      const sonnerOptions = options?.duration !== undefined ? { duration: options.duration } : undefined;
+      switch (options?.variant) {
+        case "success":
+          sonnerToast.success(message, sonnerOptions);
+          break;
+        case "error":
+          sonnerToast.error(message, sonnerOptions);
+          break;
+        case "info":
+          sonnerToast.info(message, sonnerOptions);
+          break;
+        default:
+          sonnerToast(message, sonnerOptions);
+      }
+    },
+    [],
+  );
   const { themePreference, isLightMode, cyclePreference } = props;
   const theme = useMemo(() => createTheme(isLightMode), [isLightMode]);
   const initialAuthoringStateRef = useRef<ReturnType<typeof loadStudioAuthoringState> | undefined>(undefined);
@@ -701,7 +720,6 @@ function AppContent(props: AppContentProps) {
   const [overlayVariantKeyPreference, setOverlayVariantKeyPreference] = useState<string | null>(null);
   const [eraMode, setEraMode] = useState<"auto" | "fixed">("auto");
   const [manualEra, setManualEra] = useState(1);
-  const [activeStudioView, setActiveStudioView] = useState<StudioView>("map");
   const [recipeSectionCollapsed, setRecipeSectionCollapsed] = useState(false);
   const [configSectionCollapsed, setConfigSectionCollapsed] = useState(false);
   const [exploreStageExpanded, setExploreStageExpanded] = useState(true);
@@ -722,13 +740,6 @@ function AppContent(props: AppContentProps) {
     preset: "none",
     seed: "123",
   });
-  const [recipeDagState, setRecipeDagState] = useState<RecipeDagClientState>({
-    status: "idle",
-    recipeId: null,
-    dag: null,
-    error: null,
-  });
-  const [expandedRecipeDagStageIds, setExpandedRecipeDagStageIds] = useState<ReadonlySet<string>>(() => new Set());
   const [setupConfig, setSetupConfig] = useState<Civ7StudioSetupConfig>(() =>
     initialAuthoringState?.setupConfig ?? DEFAULT_CIV7_STUDIO_SETUP_CONFIG
   );
@@ -750,47 +761,6 @@ function AppContent(props: AppContentProps) {
     readStoredRunInGameSourceSnapshot()
   );
   const [runInGameOperation, setRunInGameOperation] = useState<RunInGameOperationStatus | null>(null);
-
-  useEffect(() => {
-    if (activeStudioView !== "dag") return;
-    const recipeId = recipeSettings.recipe;
-    let cancelled = false;
-    setRecipeDagState((prev) => ({
-      status: "loading",
-      recipeId,
-      dag: prev.recipeId === recipeId ? prev.dag : null,
-      error: null,
-    }));
-    void recipeDagClient.recipeDag.get({ recipeId }).then(
-      (dag: RecipeDagResult) => {
-        if (cancelled) return;
-        setRecipeDagState({
-          status: "ready",
-          recipeId,
-          dag,
-          error: null,
-        });
-        const firstStageId = dag.stages[0]?.stageId;
-        if (firstStageId) {
-          setExpandedRecipeDagStageIds((prev) => (
-            prev.size > 0 ? prev : new Set([firstStageId])
-          ));
-        }
-      },
-      (err: unknown) => {
-        if (cancelled) return;
-        setRecipeDagState({
-          status: "error",
-          recipeId,
-          dag: null,
-          error: formatErrorForUi(err),
-        });
-      }
-    );
-    return () => {
-      cancelled = true;
-    };
-  }, [activeStudioView, recipeSettings.recipe]);
 
   const overlaySuggestions = useMemo(() => getOverlaySuggestions(recipeSettings.recipe), [recipeSettings.recipe]);
   const overlaySelection = overlaySuggestions.find((opt) => opt.id === overlaySelectionId) ?? null;
@@ -1262,14 +1232,6 @@ function AppContent(props: AppContentProps) {
 
   const [selectedStageId, setSelectedStageId] = useState("");
   const [selectedStepId, setSelectedStepId] = useState("");
-  const handleRecipeDagStageToggle = useCallback((stageId: string) => {
-    setExpandedRecipeDagStageIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(stageId)) next.delete(stageId);
-      else next.add(stageId);
-      return next;
-    });
-  }, []);
 
   const recipeOptions = useMemo(
     () => STUDIO_RECIPE_OPTIONS.map((opt) => ({ value: opt.id, label: opt.label })),
@@ -2316,10 +2278,6 @@ function AppContent(props: AppContentProps) {
   }, [runInGameOperation, toast]);
 
   const dataTypeModel = viz.dataTypeModel;
-  const riverLakeInspectorSummary = useMemo(
-    () => buildRiverLakeFloodplainInspectorSummary(viz.manifest),
-    [viz.manifest]
-  );
   const dataTypeOptions: DataTypeOption[] = useMemo(() => {
     if (!dataTypeModel) return [];
     return dataTypeModel.dataTypes.map((dt) => ({ value: dt.dataTypeId, label: dt.label, group: dt.group }));
@@ -2540,20 +2498,6 @@ function AppContent(props: AppContentProps) {
       selectLayerFor(next, space.spaceId, rm.renderModeId);
     },
     [dataTypeModel, eraMode, manualEra, selectLayerFor]
-  );
-
-  const handleRiverLakeInspectorLayerSelect = useCallback(
-    (ref: RiverLakeInspectorLayerRef) => {
-      const stage = recipeArtifacts.uiMeta.stages.find((candidate) =>
-        candidate.steps.some((step) => step.fullStepId === ref.stepId)
-      );
-      if (stage) setSelectedStageId(stage.stageId);
-      setSelectedStepId(ref.stepId);
-      if (ref.visibility === "debug") viz.setShowDebugLayers(true);
-      viz.setSelectedStepId(ref.stepId);
-      viz.setSelectedLayerKey(ref.layerKey);
-    },
-    [recipeArtifacts.uiMeta.stages, viz]
   );
 
   const handleSpaceChange = useCallback(
@@ -2818,21 +2762,6 @@ function AppContent(props: AppContentProps) {
     return true;
   }, [showGrid, viz.effectiveLayer]);
 
-  const recipeDagView = (
-    <RecipeDagView
-      recipeId={recipeSettings.recipe}
-      dag={recipeDagState.recipeId === recipeSettings.recipe ? recipeDagState.dag : null}
-      status={recipeDagState.recipeId === recipeSettings.recipe ? recipeDagState.status : "idle"}
-      error={recipeDagState.recipeId === recipeSettings.recipe ? recipeDagState.error : null}
-      lightMode={isLightMode}
-      expandedStageIds={expandedRecipeDagStageIds}
-      selectedStageId={selectedStageId || null}
-      onToggleStage={handleRecipeDagStageToggle}
-      onSelectStage={setSelectedStageId}
-      topInset={panelTop + 84}
-    />
-  );
-
   const canvas = (
     <div className="absolute inset-0">
       <div className={`absolute inset-0 ${isLightMode ? "bg-[#f5f5f7]" : "bg-[#0a0a12]"}`} />
@@ -2888,8 +2817,6 @@ function AppContent(props: AppContentProps) {
 
   const header = (
     <AppHeader
-      activeStudioView={activeStudioView}
-      onActiveStudioViewChange={setActiveStudioView}
       isLightMode={isLightMode}
       themePreference={themePreference}
       onThemeCycle={cyclePreference}
@@ -2901,13 +2828,6 @@ function AppContent(props: AppContentProps) {
       setupOptions={setupControlOptions}
       onSetupConfigChange={setSetupConfig}
       onSavedConfigChange={handleSavedSetupConfigChange}
-      statsAccessory={activeStudioView === "dag" ? (
-        <RecipeDagStatsBar
-          dag={recipeDagState.recipeId === recipeSettings.recipe ? recipeDagState.dag : null}
-          recipeId={recipeSettings.recipe}
-          lightMode={isLightMode}
-        />
-      ) : null}
       onHeaderHeightChange={handleHeaderHeightChange}
     />
   );
@@ -3001,8 +2921,6 @@ function AppContent(props: AppContentProps) {
         if (!viz.activeBounds) return;
         deckApiRef.current?.fitToBounds(viz.activeBounds);
       }}
-      riverLakeInspectorSummary={riverLakeInspectorSummary}
-      onRiverLakeInspectorLayerSelect={handleRiverLakeInspectorLayerSelect}
       stageExpanded={exploreStageExpanded}
       onStageExpandedChange={setExploreStageExpanded}
       stepExpanded={exploreStepExpanded}
@@ -3084,8 +3002,8 @@ function AppContent(props: AppContentProps) {
   );
 
   return (
-    <div ref={containerRef} className={`relative w-full min-h-screen ${isLightMode ? "bg-[#f5f5f7]" : "bg-[#0a0a12]"}`}>
-      {activeStudioView === "dag" ? recipeDagView : canvas}
+    <div ref={containerRef} className="relative w-full min-h-screen bg-background">
+      {canvas}
       {presetDialogs}
       <input
         ref={importInputRef}
@@ -3095,23 +3013,19 @@ function AppContent(props: AppContentProps) {
         onChange={handleImportFileChange}
       />
 
-      {activeStudioView === "map" ? (
-        <>
-          <div className="absolute left-4 z-10" style={{ top: panelTop }}>
-            {leftPanel}
-          </div>
-          <div className="absolute right-4 z-10" style={{ top: panelTop }}>
-            {rightPanel}
-          </div>
-        </>
-      ) : null}
+      <div className="absolute left-4 z-10" style={{ top: panelTop }}>
+        {leftPanel}
+      </div>
+      <div className="absolute right-4 z-10" style={{ top: panelTop }}>
+        {rightPanel}
+      </div>
 
       {header}
       {footer}
 
-      {activeStudioView === "map" && error ? (
+      {error ? (
         <div
-          className="absolute left-1/2 -translate-x-1/2 z-30 max-w-[min(720px,calc(100%-32px))] rounded-lg border border-red-500/30 bg-red-950/40 px-4 py-2 text-[12px] text-red-200 backdrop-blur-sm"
+          className="absolute left-1/2 -translate-x-1/2 z-30 max-w-[min(720px,calc(100%-32px))] rounded-lg border border-destructive/40 bg-destructive/15 px-4 py-2 text-xs text-destructive backdrop-blur-sm"
           style={{ top: panelTop }}
         >
           {error}
@@ -3125,8 +3039,9 @@ function AppContent(props: AppContentProps) {
 export function App() {
   const { preference, isLightMode, cyclePreference } = useThemePreference();
   return (
-    <ToastProvider lightMode={isLightMode}>
+    <TooltipProvider delayDuration={300}>
       <AppContent themePreference={preference} isLightMode={isLightMode} cyclePreference={cyclePreference} />
-    </ToastProvider>
+      <Toaster />
+    </TooltipProvider>
   );
 }

--- a/apps/mapgen-studio/src/features/presets/PresetDialogs.tsx
+++ b/apps/mapgen-studio/src/features/presets/PresetDialogs.tsx
@@ -1,50 +1,61 @@
 import { useEffect, useState } from "react";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Input,
-} from "../../ui/components/ui";
+} from "../../components/ui";
+
+/**
+ * Preset dialogs — error / save / confirm flows, migrated from the legacy
+ * hand-rolled AlertDialog to the token-driven shadcn Dialog. Open/confirm/cancel
+ * semantics are preserved: `onOpenChange` keeps the same open-state contract,
+ * Cancel/Close use a DialogClose, and the confirm action invokes the caller's
+ * callback. The `lightMode` prop is retained for call-site compatibility but no
+ * longer drives styling (the Dialog is token-driven via the `.dark` class).
+ */
 
 export type PresetErrorDialogProps = Readonly<{
   open: boolean;
   title: string;
   message: string;
   details?: ReadonlyArray<string>;
-  lightMode: boolean;
+  lightMode?: boolean;
   onOpenChange: (open: boolean) => void;
 }>;
 
 export function PresetErrorDialog(props: PresetErrorDialogProps) {
-  const { open, title, message, details, lightMode, onOpenChange } = props;
+  const { open, title, message, details, onOpenChange } = props;
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange} lightMode={lightMode}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{title}</AlertDialogTitle>
-          <AlertDialogDescription>{message}</AlertDialogDescription>
-        </AlertDialogHeader>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{message}</DialogDescription>
+        </DialogHeader>
         {details && details.length > 0 ? (
-          <pre className="mt-3 max-h-48 overflow-auto rounded bg-black/5 p-2 text-[10px] leading-relaxed">
+          <pre className="mt-1 max-h-48 overflow-auto rounded bg-surface-sunken p-2 text-label leading-relaxed text-muted-foreground">
             {details.join("\n")}
           </pre>
         ) : null}
-        <AlertDialogFooter>
-          <AlertDialogAction>Close</AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button>Close</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
 export type PresetSaveDialogProps = Readonly<{
   open: boolean;
-  lightMode: boolean;
+  lightMode?: boolean;
   initialLabel?: string;
   initialDescription?: string;
   onCancel: () => void;
@@ -52,7 +63,7 @@ export type PresetSaveDialogProps = Readonly<{
 }>;
 
 export function PresetSaveDialog(props: PresetSaveDialogProps) {
-  const { open, lightMode, initialLabel, initialDescription, onCancel, onConfirm } = props;
+  const { open, initialLabel, initialDescription, onCancel, onConfirm } = props;
   const [label, setLabel] = useState(initialLabel ?? "");
   const [description, setDescription] = useState(initialDescription ?? "");
 
@@ -66,35 +77,35 @@ export function PresetSaveDialog(props: PresetSaveDialogProps) {
   const canSave = label.trim().length > 0;
 
   return (
-    <AlertDialog open={open} onOpenChange={(next) => (!next ? onCancel() : undefined)} lightMode={lightMode}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Save Config</AlertDialogTitle>
-          <AlertDialogDescription>Choose a name for this config.</AlertDialogDescription>
-        </AlertDialogHeader>
-        <div className="mt-3 space-y-2">
+    <Dialog open={open} onOpenChange={(next) => (!next ? onCancel() : undefined)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Save Config</DialogTitle>
+          <DialogDescription>Choose a name for this config.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
           <div>
-            <div className="mb-1 text-[10px] uppercase tracking-wide">Label</div>
+            <div className="mb-1 text-label uppercase tracking-wide text-muted-foreground">Label</div>
             <Input
-              lightMode={lightMode}
               value={label}
               onChange={(e) => setLabel(e.target.value)}
               placeholder="Config name"
             />
           </div>
           <div>
-            <div className="mb-1 text-[10px] uppercase tracking-wide">Description (optional)</div>
+            <div className="mb-1 text-label uppercase tracking-wide text-muted-foreground">Description (optional)</div>
             <Input
-              lightMode={lightMode}
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Short description"
             />
           </div>
         </div>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button
             disabled={!canSave}
             onClick={() => {
               if (!canSave) return;
@@ -102,17 +113,16 @@ export function PresetSaveDialog(props: PresetSaveDialogProps) {
             }}
           >
             Save
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
-
 export type PresetConfirmDialogProps = Readonly<{
   open: boolean;
-  lightMode: boolean;
+  lightMode?: boolean;
   title: string;
   message: string;
   confirmLabel: string;
@@ -121,19 +131,21 @@ export type PresetConfirmDialogProps = Readonly<{
 }>;
 
 export function PresetConfirmDialog(props: PresetConfirmDialogProps) {
-  const { open, lightMode, title, message, confirmLabel, onCancel, onConfirm } = props;
+  const { open, title, message, confirmLabel, onCancel, onConfirm } = props;
   return (
-    <AlertDialog open={open} onOpenChange={(next) => (!next ? onCancel() : undefined)} lightMode={lightMode}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{title}</AlertDialogTitle>
-          <AlertDialogDescription>{message}</AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm}>{confirmLabel}</AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <Dialog open={open} onOpenChange={(next) => (!next ? onCancel() : undefined)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{message}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" onClick={onCancel}>Cancel</Button>
+          </DialogClose>
+          <Button onClick={onConfirm}>{confirmLabel}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/mapgen-studio/src/ui/components/AppBrand.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppBrand.tsx
@@ -1,25 +1,21 @@
 import React, { useState } from 'react';
 import { ExternalLink, Github, User } from 'lucide-react';
+
+/**
+ * AppBrand — the identity pill in the header, with a hover info card.
+ *
+ * Reskinned onto the design tokens: the pill and its hover card float over the
+ * deck.gl map, so they ride the `popover` tier with `backdrop-blur`; the theme
+ * follows the single `.dark` class rather than the legacy `isLightMode` hex
+ * ternaries. The `isLightMode` prop is retained for call-site compatibility
+ * during the shell migration but no longer drives styling.
+ */
 interface AppBrandProps {
-  isLightMode: boolean;
+  isLightMode?: boolean;
 }
-export const AppBrand: React.FC<AppBrandProps> = ({ isLightMode }) => {
+
+export const AppBrand: React.FC<AppBrandProps> = () => {
   const [isHovered, setIsHovered] = useState(false);
-  // ============================================================================
-  // Styles
-  // ============================================================================
-  const containerClass = isLightMode ?
-  'bg-white/90 border-gray-200' :
-  'bg-[#16161d]/90 border-[#26262e]';
-  const textClass = isLightMode ? 'text-[#1f2933]' : 'text-[#e2e2e9]';
-  const mutedClass = isLightMode ? 'text-[#6b7280]' : 'text-[#6a6a7c]';
-  const linkClass = isLightMode ?
-  'text-[#4b5563] hover:text-[#1f2933]' :
-  'text-[#7a7a8c] hover:text-[#e2e2e9]';
-  const dividerClass = isLightMode ? 'border-gray-200' : 'border-[#26262e]';
-  // ============================================================================
-  // Render
-  // ============================================================================
   return (
     <div
       className="relative h-10"
@@ -27,67 +23,52 @@ export const AppBrand: React.FC<AppBrandProps> = ({ isLightMode }) => {
       onMouseLeave={() => setIsHovered(false)}>
 
       {/* Main Pill */}
-      <div
-        className={`
-          h-full inline-flex items-center gap-2 px-3 rounded-lg border
-          backdrop-blur-sm cursor-default
-          ${containerClass}
-        `}>
-
-        <span
-          className={`font-semibold text-[13px] tracking-tight ${textClass}`}>
-
+      <div className="h-full inline-flex items-center gap-2 px-3 rounded-lg border border-border bg-popover/90 backdrop-blur-sm cursor-default">
+        <span className="font-semibold text-[13px] tracking-tight text-foreground">
           MapGen Studio
         </span>
-        <span className={`text-[10px] font-mono ${mutedClass}`}>v0.1</span>
+        <span className="text-label font-mono text-muted-foreground">v0.1</span>
       </div>
 
       {/* Hover Dropdown */}
       {isHovered &&
-      <div
-        className={`
-            absolute top-full left-0 mt-2
-            min-w-[200px] p-3 rounded-lg border
-            backdrop-blur-sm shadow-lg z-50
-            ${containerClass}
-          `}>
-
+      <div className="absolute top-full left-0 mt-2 min-w-[200px] p-3 rounded-lg border border-border bg-popover/95 backdrop-blur-sm shadow-lg z-50">
           {/* Description */}
-          <p className={`text-[11px] leading-relaxed ${mutedClass} mb-3`}>
+          <p className="text-data leading-relaxed text-muted-foreground mb-3">
             Procedural map generation toolkit for game developers.
           </p>
 
-          <div className={`border-t ${dividerClass} mb-3`} />
+          <div className="border-t border-border-subtle mb-3" />
 
           {/* Links */}
           <div className="flex flex-col gap-2">
             <a
             href="#"
-            className={`flex items-center gap-2 text-[11px] font-medium transition-colors ${linkClass}`}>
+            className="flex items-center gap-2 text-data font-medium text-muted-foreground transition-colors hover:text-foreground">
 
               <User className="w-3.5 h-3.5" />
               <span>Author Name</span>
             </a>
             <a
             href="#"
-            className={`flex items-center gap-2 text-[11px] font-medium transition-colors ${linkClass}`}>
+            className="flex items-center gap-2 text-data font-medium text-muted-foreground transition-colors hover:text-foreground">
 
               <Github className="w-3.5 h-3.5" />
               <span>View on GitHub</span>
             </a>
             <a
             href="#"
-            className={`flex items-center gap-2 text-[11px] font-medium transition-colors ${linkClass}`}>
+            className="flex items-center gap-2 text-data font-medium text-muted-foreground transition-colors hover:text-foreground">
 
               <ExternalLink className="w-3.5 h-3.5" />
               <span>Documentation</span>
             </a>
           </div>
 
-          <div className={`border-t ${dividerClass} my-3`} />
+          <div className="border-t border-border-subtle my-3" />
 
           {/* Footer */}
-          <p className={`text-[10px] ${mutedClass}`}>© 2024 • MIT License</p>
+          <p className="text-label text-muted-foreground">© 2024 • MIT License</p>
         </div>
       }
     </div>);

--- a/apps/mapgen-studio/src/ui/components/AppFooter.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppFooter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Bolt, Bot, Clipboard, Clock, Dices, MonitorPlay, Play, Radio, RotateCw, Square } from 'lucide-react';
-import { Button, Input } from './ui';
+import { Button, Input, Tooltip, TooltipContent, TooltipTrigger } from '../../components/ui';
 import { MAP_SIZE_SHORT, LAYOUT } from '../constants';
 import { formatResourceMode } from '../utils';
 import type { RecipeSettings, WorldSettings, GenerationStatus } from '../types';
@@ -98,7 +98,6 @@ export const AppFooter: React.FC<AppFooterProps> = ({
   runInGameStatus,
   runInGameCurrentRelation = "unknown",
   isDirty,
-  lightMode,
   liveRuntime,
   liveGameStudioRelation = "unknown",
   onSyncFromLiveGame,
@@ -108,20 +107,25 @@ export const AppFooter: React.FC<AppFooterProps> = ({
   autoRunEnabled,
   onAutoRunEnabledChange
 }) => {
-  const panelBg = lightMode ? 'bg-white/95' : 'bg-[#141418]/95';
-  const panelBorder = lightMode ? 'border-gray-200' : 'border-[#2a2a32]';
-  const textPrimary = lightMode ? 'text-[#1f2937]' : 'text-[#e8e8ed]';
-  const textSecondary = lightMode ? 'text-[#6b7280]' : 'text-[#8a8a96]';
-  const textMuted = lightMode ? 'text-[#9ca3af]' : 'text-[#5a5a66]';
-  const dividerColor = lightMode ? 'bg-gray-200' : 'bg-[#2a2a32]';
+  // Token-driven chrome; theme follows the single `.dark` class. The footer
+  // docks float over the deck.gl map, so they ride the `popover` tier.
+  const panelBg = 'bg-popover/95';
+  const panelBorder = 'border-border';
+  const textPrimary = 'text-foreground';
+  const textSecondary = 'text-muted-foreground';
+  const textMuted = 'text-muted-foreground/70';
+  const dividerColor = 'bg-border';
+  // Status dots report data the instrument observes (the one place real color
+  // belongs in the chrome): running = amber, error = destructive, ready =
+  // success. `isDirty` is chrome identity, so it uses the slate accent.
   const statusDotClass =
   status === 'running' ?
-  'bg-amber-400' :
+  'bg-warning' :
   status === 'error' ?
-  'bg-red-400' :
+  'bg-destructive' :
   isDirty ?
-  'bg-orange-400' :
-  'bg-emerald-400';
+  'bg-primary' :
+  'bg-success';
   const statusText =
   status === 'running' ?
   'Running' :
@@ -134,7 +138,7 @@ export const AppFooter: React.FC<AppFooterProps> = ({
   MAP_SIZE_SHORT[lastGlobalSettings.mapSize] || lastGlobalSettings.mapSize;
   const displayResources = formatResourceMode(lastGlobalSettings.resources);
   const liveDotClass =
-    liveRuntime?.status === "ok" ? "bg-emerald-400" : liveRuntime?.status === "error" ? "bg-red-400" : "bg-gray-400";
+    liveRuntime?.status === "ok" ? "bg-success" : liveRuntime?.status === "error" ? "bg-destructive" : "bg-muted-foreground";
   const liveText =
     liveRuntime?.status === "ok"
       ? liveRuntime.turn !== undefined || liveRuntime.seed !== undefined
@@ -154,14 +158,14 @@ export const AppFooter: React.FC<AppFooterProps> = ({
       : null;
   const runInGameDotClass =
     runInGameCurrentRelation === "stale"
-      ? "bg-orange-400"
+      ? "bg-warning"
       : runInGameStatus?.status === "complete"
-      ? "bg-emerald-400"
+      ? "bg-success"
       : runInGameStatus?.status === "failed" || runInGameStatus?.status === "blocked" || runInGameStatus?.status === "uncertain"
-        ? "bg-red-400"
+        ? "bg-destructive"
         : isRunInGameRunning
-          ? "bg-amber-400"
-          : "bg-gray-400";
+          ? "bg-warning"
+          : "bg-muted-foreground";
   const runInGameButtonText = runInGamePrimaryActionLabel(runInGameStatus, runInGameCurrentRelation);
   const operationControlsDisabled = isRunning || isRunInGameRunning || isSaveDeployRunning;
   const liveSyncAvailable =
@@ -249,14 +253,18 @@ export const AppFooter: React.FC<AppFooterProps> = ({
         <div className={`w-px h-5 ${dividerColor}`} />
 
         {/* Last run info */}
-        <div className="flex items-center gap-2 text-[11px]">
-          <button
-            onClick={handleCopySeed}
-            title="Click to copy seed"
-            className={`font-mono ${textPrimary} hover:text-orange-500 hover:underline transition-colors cursor-pointer`}>
+        <div className="flex items-center gap-2 text-data">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={handleCopySeed}
+                className={`font-mono ${textPrimary} hover:text-primary hover:underline transition-colors cursor-pointer`}>
 
-            {lastRunSettings.seed}
-          </button>
+                {lastRunSettings.seed}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Click to copy seed</TooltipContent>
+          </Tooltip>
           <span className={textMuted}>·</span>
           <span className={textPrimary}>{displaySize}</span>
           <span className={textMuted}>·</span>
@@ -266,44 +274,52 @@ export const AppFooter: React.FC<AppFooterProps> = ({
         </div>
       </div>
 
-      {/* Live Civ7 Panel */}
+      {/* Live Civ7 Panel. The "stale vs live game" emphasis is a warning about
+          data, so it uses the `warning` token (not the slate identity accent). */}
       <div
-        className={`h-10 inline-flex min-w-0 max-w-[420px] items-center gap-2 px-3 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}
-        title={liveSyncTitle}>
+        className={`h-10 inline-flex min-w-0 max-w-[420px] items-center gap-2 px-3 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}>
 
-        <button
-          type="button"
-          onClick={onSyncFromLiveGame}
-          disabled={!liveSyncAvailable}
-          title={liveSyncTitle}
-          className={`inline-flex h-7 min-w-0 items-center gap-2 rounded border px-2 transition-colors ${
-            liveGameStudioRelation === "stale"
-              ? "border-orange-400 text-orange-500 ring-2 ring-orange-400/40"
-              : "border-transparent"
-          } ${liveSyncAvailable ? "cursor-pointer hover:bg-orange-400/10" : "cursor-default disabled:opacity-100"}`}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onSyncFromLiveGame}
+              disabled={!liveSyncAvailable}
+              className={`inline-flex h-7 min-w-0 items-center gap-2 rounded border px-2 transition-colors ${
+                liveGameStudioRelation === "stale"
+                  ? "border-warning text-warning ring-1 ring-warning/40"
+                  : "border-transparent"
+              } ${liveSyncAvailable ? "cursor-pointer hover:bg-warning/10" : "cursor-default disabled:opacity-100"}`}>
 
-          <Radio className={`w-3.5 h-3.5 ${liveGameStudioRelation === "stale" ? "text-orange-500" : textMuted}`} />
-          <div className={`w-2 h-2 shrink-0 rounded-full ${liveDotClass}`} />
-          <span className={`truncate text-[11px] font-medium ${liveGameStudioRelation === "stale" ? "text-orange-500" : textPrimary}`}>
-            {liveText}
-          </span>
-          {liveRuntime?.autoplayActive ? (
-            <span className="shrink-0 rounded border border-amber-400/40 px-1.5 py-0.5 text-[10px] text-amber-500">
-              Auto
-            </span>
-          ) : null}
-        </button>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onToggleAutoplay}
-          disabled={autoplayControlDisabled}
-          title={autoplayTitle}
-          className={`h-7 px-2 text-[11px] ${liveRuntime?.autoplayActive ? "border-amber-400/60 text-amber-500" : ""}`}>
+              <Radio className={`w-3.5 h-3.5 ${liveGameStudioRelation === "stale" ? "text-warning" : textMuted}`} />
+              <div className={`w-2 h-2 shrink-0 rounded-full ${liveDotClass}`} />
+              <span className={`truncate text-data font-medium ${liveGameStudioRelation === "stale" ? "text-warning" : textPrimary}`}>
+                {liveText}
+              </span>
+              {liveRuntime?.autoplayActive ? (
+                <span className="shrink-0 rounded border border-warning/40 px-1.5 py-0.5 text-label text-warning">
+                  Auto
+                </span>
+              ) : null}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>{liveSyncTitle}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onToggleAutoplay}
+              disabled={autoplayControlDisabled}
+              className={`h-7 px-2 ${liveRuntime?.autoplayActive ? "border-warning/60 text-warning" : ""}`}>
 
-          {liveRuntime?.autoplayActive ? <Square className="w-3.5 h-3.5" /> : <Bot className="w-3.5 h-3.5" />}
-          <span>{autoplayButtonText}</span>
-        </Button>
+              {liveRuntime?.autoplayActive ? <Square className="w-3.5 h-3.5" /> : <Bot className="w-3.5 h-3.5" />}
+              <span>{autoplayButtonText}</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{autoplayTitle}</TooltipContent>
+        </Tooltip>
       </div>
 
       {/* Run Controls Panel */}
@@ -316,107 +332,141 @@ export const AppFooter: React.FC<AppFooterProps> = ({
 
           Seed
         </span>
-        <Input
-          type="text"
-          value={currentSettings.seed}
-          onChange={(e) => updateSetting('seed', e.target.value)}
-          placeholder="Seed"
-          inputMode="numeric"
-          pattern="[0-9]*"
-          min={CIV7_STUDIO_SEED_MIN}
-          max={CIV7_STUDIO_SEED_MAX}
-          title={`Generation seed (${CIV7_STUDIO_SEED_MIN}-${CIV7_STUDIO_SEED_MAX})`}
-          disabled={operationControlsDisabled}
-          lightMode={lightMode}
-          className="w-20 font-mono" />
-
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Input
+              type="text"
+              value={currentSettings.seed}
+              onChange={(e) => updateSetting('seed', e.target.value)}
+              placeholder="Seed"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              min={CIV7_STUDIO_SEED_MIN}
+              max={CIV7_STUDIO_SEED_MAX}
+              aria-label={`Generation seed (${CIV7_STUDIO_SEED_MIN}-${CIV7_STUDIO_SEED_MAX})`}
+              disabled={operationControlsDisabled}
+              className="w-20 font-mono" />
+          </TooltipTrigger>
+          <TooltipContent>{`Generation seed (${CIV7_STUDIO_SEED_MIN}-${CIV7_STUDIO_SEED_MAX})`}</TooltipContent>
+        </Tooltip>
 
         {/* Reroll button */}
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={onReroll}
-          disabled={operationControlsDisabled}
-          title="Re-roll: New seed and run">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={onReroll}
+              disabled={operationControlsDisabled}
+              aria-label="Re-roll: New seed and run">
 
-          <Dices className="w-3.5 h-3.5" />
-        </Button>
+              <Dices className="w-3.5 h-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Re-roll: New seed and run</TooltipContent>
+        </Tooltip>
 
         {/* Auto-run toggle */}
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => onAutoRunEnabledChange(!autoRunEnabled)}
-          disabled={operationControlsDisabled}
-          aria-pressed={autoRunEnabled}
-          aria-label="Toggle auto-run: run current seed on config changes"
-          title="Auto-run: run current seed on config changes"
-          className={autoRunEnabled ? "ring-2 ring-orange-400/50 border-orange-400 text-orange-500" : undefined}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => onAutoRunEnabledChange(!autoRunEnabled)}
+              disabled={operationControlsDisabled}
+              aria-pressed={autoRunEnabled}
+              aria-label="Toggle auto-run: run current seed on config changes"
+              className={autoRunEnabled ? "ring-1 ring-ring border-primary text-primary" : undefined}>
 
-          <Bolt className="w-3.5 h-3.5" />
-        </Button>
+              <Bolt className="w-3.5 h-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Auto-run: run current seed on config changes</TooltipContent>
+        </Tooltip>
 
         {/* Run in Game button */}
         {saveDeployStatus && saveDeployStatus.status !== "complete" ? (
-          <div
-            className={`hidden max-w-[150px] items-center gap-1.5 overflow-hidden text-[11px] font-medium ${textPrimary} lg:inline-flex`}
-            title={saveDeployTitle}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className={`hidden max-w-[150px] items-center gap-1.5 overflow-hidden text-data font-medium ${textPrimary} lg:inline-flex`}>
 
-            <div className={`h-2 w-2 shrink-0 rounded-full ${saveDeployStatus.status === "failed" ? "bg-red-400" : "bg-amber-400"}`} />
-            <span className="truncate">{saveDeployLabel}</span>
-          </div>
+                <div className={`h-2 w-2 shrink-0 rounded-full ${saveDeployStatus.status === "failed" ? "bg-destructive" : "bg-warning"}`} />
+                <span className="truncate">{saveDeployLabel}</span>
+              </div>
+            </TooltipTrigger>
+            <TooltipContent className="whitespace-pre-line">{saveDeployTitle}</TooltipContent>
+          </Tooltip>
         ) : null}
         {runInGameStatus ? (
-          <div
-            className={`hidden max-w-[180px] items-center gap-1.5 overflow-hidden text-[11px] font-medium ${textPrimary} lg:inline-flex`}
-            title={runInGameTitle}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className={`hidden max-w-[180px] items-center gap-1.5 overflow-hidden text-data font-medium ${textPrimary} lg:inline-flex`}>
 
-            <div className={`h-2 w-2 shrink-0 rounded-full ${runInGameDotClass}`} />
-            <span className="truncate">{runInGamePhaseLabel}</span>
-            {runInGameStateLabel ? (
-              <span className={`shrink-0 rounded border px-1 py-0.5 text-[10px] ${runInGameCurrentRelation === "stale" ? "border-orange-400/40 text-orange-500" : "border-gray-400/30 text-gray-400"}`}>
-                {runInGameStateLabel}
-              </span>
-            ) : null}
-          </div>
+                <div className={`h-2 w-2 shrink-0 rounded-full ${runInGameDotClass}`} />
+                <span className="truncate">{runInGamePhaseLabel}</span>
+                {runInGameStateLabel ? (
+                  <span className={`shrink-0 rounded border px-1 py-0.5 text-label ${runInGameCurrentRelation === "stale" ? "border-warning/40 text-warning" : "border-border text-muted-foreground"}`}>
+                    {runInGameStateLabel}
+                  </span>
+                ) : null}
+              </div>
+            </TooltipTrigger>
+            <TooltipContent className="whitespace-pre-line">{runInGameTitle}</TooltipContent>
+          </Tooltip>
         ) : null}
         {runInGameStatus && onRunInGameRetryStatus && runInGameCanRetryStatus(runInGameStatus) ? (
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={onRunInGameRetryStatus}
-            title="Refresh Run in Game status">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={onRunInGameRetryStatus}
+                aria-label="Refresh Run in Game status">
 
-            <RotateCw className="w-3.5 h-3.5" />
-          </Button>
+                <RotateCw className="w-3.5 h-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Refresh Run in Game status</TooltipContent>
+          </Tooltip>
         ) : null}
         {runInGameStatus && onCopyRunInGameDiagnostics ? (
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={onCopyRunInGameDiagnostics}
-            title="Copy Run in Game diagnostics">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={onCopyRunInGameDiagnostics}
+                aria-label="Copy Run in Game diagnostics">
 
-            <Clipboard className="w-3.5 h-3.5" />
-          </Button>
+                <Clipboard className="w-3.5 h-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Copy Run in Game diagnostics</TooltipContent>
+          </Tooltip>
         ) : null}
-        <Button
-          onClick={onRunInGame}
-          disabled={operationControlsDisabled}
-          variant="outline"
-          title={runInGameTitle}
-          className={isRunInGameRunning ? 'opacity-70 cursor-wait' : undefined}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              onClick={onRunInGame}
+              disabled={operationControlsDisabled}
+              variant="outline"
+              className={isRunInGameRunning ? 'opacity-70 cursor-wait' : undefined}>
 
-          <MonitorPlay className="w-3.5 h-3.5" />
-          <span>{runInGameButtonText}</span>
-        </Button>
+              <MonitorPlay className="w-3.5 h-3.5" />
+              <span>{runInGameButtonText}</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent className="whitespace-pre-line">{runInGameTitle}</TooltipContent>
+        </Tooltip>
 
-        {/* Run button */}
+        {/* Run button — the one filled action; dirty emphasis is the slate accent */}
         <Button
           onClick={onRun}
           disabled={operationControlsDisabled}
           className={`
-            ${isDirty ? 'ring-2 ring-orange-400/50 border-orange-400' : ''}
+            ${isDirty ? 'ring-1 ring-ring border-primary' : ''}
             ${isRunning ? 'opacity-70 cursor-wait' : ''}
           `}>
 

--- a/apps/mapgen-studio/src/ui/components/AppHeader.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { ChevronDown, GitBranch, Globe, Map, SlidersHorizontal } from 'lucide-react';
+import { ChevronDown, Globe, SlidersHorizontal } from 'lucide-react';
+import { AppBrand } from './AppBrand';
 import { ViewControls } from './ViewControls';
 import { Select } from './ui';
 import {
@@ -17,8 +18,6 @@ import {
 import type { ThemePreference, WorldSettings } from '../types';
 export const HEADER_HEIGHT = LAYOUT.HEADER_HEIGHT;
 export interface AppHeaderProps {
-  activeStudioView: "map" | "dag";
-  onActiveStudioViewChange: (view: "map" | "dag") => void;
   isLightMode: boolean;
   themePreference: ThemePreference;
   onThemeCycle: () => void;
@@ -36,12 +35,9 @@ export interface AppHeaderProps {
   };
   onSetupConfigChange: (config: Civ7StudioSetupConfig) => void;
   onSavedConfigChange: (configId: string) => void;
-  statsAccessory?: React.ReactNode;
   onHeaderHeightChange?: (height: number) => void;
 }
 export const AppHeader: React.FC<AppHeaderProps> = ({
-  activeStudioView,
-  onActiveStudioViewChange,
   isLightMode,
   themePreference,
   onThemeCycle,
@@ -53,30 +49,19 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   setupOptions,
   onSetupConfigChange,
   onSavedConfigChange,
-  statsAccessory,
   onHeaderHeightChange
 }) => {
   const headerRef = React.useRef<HTMLElement | null>(null);
   const [setupOpen, setSetupOpen] = React.useState(false);
-  const panelBg = isLightMode ? 'bg-white/70' : 'bg-[#141418]/62';
-  const panelBorder = isLightMode ? 'border-white/80' : 'border-white/10';
-  const textSecondary = isLightMode ? 'text-[#6b7280]' : 'text-[#8a8a96]';
-  const textMuted = isLightMode ? 'text-[#9ca3af]' : 'text-[#5a5a66]';
-  const dividerColor = isLightMode ? 'bg-gray-200' : 'bg-[#2a2a32]';
-  const tabClassName = (active: boolean) => `flex h-7 items-center gap-1.5 rounded px-2.5 text-[11px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 ${
-    active
-      ? isLightMode
-        ? 'bg-gray-200 text-[#1f2937] focus-visible:ring-gray-300'
-        : 'bg-[#222228] text-[#e8e8ed] focus-visible:ring-[#3a3a44]'
-      : isLightMode
-        ? 'text-[#6b7280] hover:bg-gray-100 hover:text-[#1f2937] focus-visible:ring-gray-300'
-        : 'text-[#8a8a96] hover:bg-[#1a1a1f] hover:text-[#e8e8ed] focus-visible:ring-[#3a3a44]'
-  }`;
-  const setupButtonClassName = `flex h-7 shrink-0 items-center gap-1.5 rounded border px-2.5 text-[11px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 ${
-    isLightMode
-      ? 'border-gray-200 bg-white text-[#374151] hover:bg-gray-50 focus-visible:ring-gray-300'
-      : 'border-[#2a2a32] bg-[#0f0f12] text-[#d4d4dc] hover:bg-[#1b1b20] focus-visible:ring-[#3a3a44]'
-  }`;
+  // Token-driven chrome; theme follows the single `.dark` class. The header
+  // docks float over the deck.gl map, so they ride the `popover` tier.
+  const panelBg = 'bg-popover/95';
+  const panelBorder = 'border-border';
+  const textSecondary = 'text-muted-foreground';
+  const textMuted = 'text-muted-foreground/70';
+  const dividerColor = 'bg-border';
+  const setupButtonClassName =
+    'flex h-7 shrink-0 items-center gap-1.5 rounded border border-input bg-input-background px-2.5 text-data font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring';
   const updateSetting = <K extends keyof WorldSettings,>(
   key: K,
   value: WorldSettings[K]) =>
@@ -118,15 +103,20 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   return (
     <header
       ref={headerRef}
-      className="pointer-events-none absolute left-3 right-3 top-2 z-20 h-10"
+      className="absolute top-4 left-4 right-4 z-20 grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3"
       style={{
         minHeight: HEADER_HEIGHT
       }}>
 
+      {/* Left: App Brand */}
+      <div className="shrink-0">
+        <AppBrand isLightMode={isLightMode} />
+      </div>
+
       {/* Center: World Settings */}
-      <div className="pointer-events-auto absolute left-1/2 top-0 flex w-[min(760px,calc(100vw-300px))] min-w-0 -translate-x-1/2 flex-col items-center gap-2 overflow-visible">
+      <div className="min-w-0 flex flex-col items-center gap-2 overflow-visible">
         <div
-          className={`flex min-h-10 w-full max-w-full flex-nowrap items-center justify-center gap-x-3 px-3 py-1.5 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}>
+          className={`flex min-h-10 max-w-full flex-wrap items-center justify-center gap-x-3 gap-y-2 px-3 py-1.5 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}>
 
           <div className="flex items-center gap-1.5">
             <Globe className={`w-4 h-4 ${textMuted}`} />
@@ -202,8 +192,6 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
             <ChevronDown className={`w-3.5 h-3.5 transition-transform ${setupOpen ? 'rotate-180' : ''}`} />
           </button>
         </div>
-
-        {statsAccessory ? statsAccessory : null}
 
         {setupOpen ? (
           <div
@@ -289,30 +277,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
       </div>
 
       {/* Right: View Controls */}
-      <div className="pointer-events-auto absolute right-0 top-0 flex shrink-0 flex-col items-end gap-1.5">
-        <div
-          className={`h-10 inline-flex items-center gap-1 px-1.5 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}
-          role="tablist"
-          aria-label="Studio view">
-          <button
-            type="button"
-            role="tab"
-            aria-selected={activeStudioView === "map"}
-            className={tabClassName(activeStudioView === "map")}
-            onClick={() => onActiveStudioViewChange("map")}>
-            <Map className="h-3.5 w-3.5" />
-            <span>Map</span>
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={activeStudioView === "dag"}
-            className={tabClassName(activeStudioView === "dag")}
-            onClick={() => onActiveStudioViewChange("dag")}>
-            <GitBranch className="h-3.5 w-3.5" />
-            <span>DAG</span>
-          </button>
-        </div>
+      <div className="shrink-0">
         <ViewControls
           themePreference={themePreference}
           onThemeCycle={onThemeCycle}

--- a/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
+++ b/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
@@ -16,14 +16,9 @@ import {
   CircleDot,
   Activity,
   Bug,
-  Flame,
-  Droplets } from
+  Flame } from
 'lucide-react';
-import type {
-  RiverLakeFloodplainInspectorSummary,
-  RiverLakeInspectorClaimStatus,
-  RiverLakeInspectorLayerRef,
-} from '../../features/viz/riverLakeInspector';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/ui';
 import type {
   StageOption,
   StepOption,
@@ -109,10 +104,6 @@ export interface ExplorePanelProps {
   onShowDebugLayersChange: (show: boolean) => void;
   /** Callback when fit view is requested */
   onFitView: () => void;
-  /** River/lake/floodplain proof navigator */
-  riverLakeInspectorSummary?: RiverLakeFloodplainInspectorSummary | null;
-  /** Callback when a proof layer should be selected */
-  onRiverLakeInspectorLayerSelect?: (layerRef: RiverLakeInspectorLayerRef) => void;
   /** Whether the stage section is expanded (optional controlled mode) */
   stageExpanded?: boolean;
   /** Callback when stageExpanded changes (optional controlled mode) */
@@ -160,14 +151,11 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
   eraMax,
   onEraModeChange,
   onEraValueChange,
-  lightMode,
   showEdges,
   onShowEdgesChange,
   showDebugLayers,
   onShowDebugLayersChange,
   onFitView,
-  riverLakeInspectorSummary = null,
-  onRiverLakeInspectorLayerSelect,
   stageExpanded: stageExpandedProp,
   onStageExpandedChange,
   stepExpanded: stepExpandedProp,
@@ -234,40 +222,35 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
   // ==========================================================================
   // Styles
   // ==========================================================================
-  const panelBg = lightMode ? 'bg-white/95' : 'bg-[#141418]/95';
-  const panelBorder = lightMode ? 'border-gray-200' : 'border-[#2a2a32]';
-  const textPrimary = lightMode ? 'text-[#1f2937]' : 'text-[#e8e8ed]';
-  const textSecondary = lightMode ? 'text-[#6b7280]' : 'text-[#8a8a96]';
-  const textMuted = lightMode ? 'text-[#9ca3af]' : 'text-[#5a5a66]';
-  const borderSubtle = lightMode ? 'border-gray-100' : 'border-[#222228]';
-  const hoverBg = lightMode ? 'hover:bg-gray-50' : 'hover:bg-[#1a1a1f]';
-  const chipBg = lightMode ? 'bg-gray-100 text-gray-600' : 'bg-[#222228] text-[#8a8a96]';
+  // Token-driven chrome; theme follows the single `.dark` class. The dock
+  // floats over the deck.gl map, so it rides the `popover` tier. Active list
+  // items use the steel contour (a thin rule + `bg-muted`), not a saturated
+  // slab.
+  const panelBg = 'bg-popover/95';
+  const panelBorder = 'border-border';
+  const textPrimary = 'text-foreground';
+  const textSecondary = 'text-muted-foreground';
+  const textMuted = 'text-muted-foreground/70';
+  const borderSubtle = 'border-border-subtle';
+  const hoverBg = 'hover:bg-accent';
   const listMaxHeight = "max-h-[200px]";
   // Stage list styles
-  const stageItemBase = `w-full text-left px-3 py-2 text-[11px] font-medium transition-colors cursor-pointer flex items-center gap-2`;
-  const stageItemActive = lightMode ?
-  'bg-gray-100 text-[#1f2937]' :
-  'bg-[#1a1a1f] text-[#e8e8ed]';
-  const stageItemInactive = lightMode ?
-  'text-[#6b7280] hover:bg-gray-50 hover:text-[#1f2937]' :
-  'text-[#8a8a96] hover:bg-[#1a1a1f] hover:text-[#e8e8ed]';
+  const stageItemBase = `w-full text-left px-3 py-2 text-data font-medium transition-colors cursor-pointer flex items-center gap-2`;
+  const stageItemActive = 'bg-accent text-foreground';
+  const stageItemInactive = 'text-muted-foreground hover:bg-accent hover:text-foreground';
   // Step/DataType list styles
-  const stepItemBase = `w-full text-left px-3 py-1.5 text-[11px] font-mono transition-colors cursor-pointer flex items-center gap-2 border-l-2`;
-  const stepItemActive = lightMode ?
-  'border-gray-800 bg-gray-50 text-[#1f2937]' :
-  'border-[#e8e8ed] bg-[#1a1a1f] text-[#e8e8ed]';
-  const stepItemInactive = lightMode ?
-  'border-transparent text-[#6b7280] hover:bg-gray-50 hover:text-[#1f2937]' :
-  'border-transparent text-[#8a8a96] hover:bg-[#1a1a1f] hover:text-[#e8e8ed]';
-  const iconBtn = `h-7 w-7 flex items-center justify-center rounded transition-colors shrink-0 ${lightMode ? 'text-[#6b7280] hover:text-[#1f2937] hover:bg-gray-100' : 'text-[#8a8a96] hover:text-[#e8e8ed] hover:bg-[#1a1a1f]'}`;
-  const iconBtnActive = `h-7 w-7 flex items-center justify-center rounded transition-colors shrink-0 ${lightMode ? 'text-[#1f2937] bg-gray-200' : 'text-[#e8e8ed] bg-[#222228]'}`;
+  const stepItemBase = `w-full text-left px-3 py-1.5 text-data font-mono transition-colors cursor-pointer flex items-center gap-2 border-l-2`;
+  const stepItemActive = 'border-primary bg-accent text-foreground';
+  const stepItemInactive = 'border-transparent text-muted-foreground hover:bg-accent hover:text-foreground';
+  const iconBtn = 'h-7 w-7 flex items-center justify-center rounded transition-colors shrink-0 text-muted-foreground hover:text-foreground hover:bg-accent';
+  const iconBtnActive = 'h-7 w-7 flex items-center justify-center rounded transition-colors shrink-0 text-foreground bg-muted';
   const stageBadge = (isActive: boolean) => `
-    w-5 h-5 flex items-center justify-center rounded-full text-[10px] font-semibold shrink-0
-    ${isActive ? lightMode ? 'bg-gray-300 text-gray-700' : 'bg-[#3a3a44] text-[#e8e8ed]' : lightMode ? 'bg-gray-100 text-gray-400' : 'bg-[#222228] text-[#5a5a66]'}
+    w-5 h-5 flex items-center justify-center rounded-full text-label font-semibold shrink-0
+    ${isActive ? 'bg-muted text-foreground' : 'bg-muted/50 text-muted-foreground'}
   `;
   const stepBadge = (isActive: boolean) => `
     w-4 h-4 flex items-center justify-center rounded text-[9px] font-mono shrink-0
-    ${isActive ? lightMode ? 'bg-gray-200 text-gray-800' : 'bg-[#3a3a44] text-[#e8e8ed]' : lightMode ? 'bg-gray-100 text-gray-400' : 'bg-[#222228] text-[#5a5a66]'}
+    ${isActive ? 'bg-muted text-foreground' : 'bg-muted/50 text-muted-foreground'}
   `;
   // Render mode icons map
   const getRenderModeIcon = (value: string) => {
@@ -329,67 +312,6 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
       const current = prev[key] ?? true;
       return { ...prev, [key]: !current };
     });
-  };
-
-  const inspectorRows = riverLakeInspectorSummary?.rows ?? [];
-  const statusChipClass = (status: RiverLakeInspectorClaimStatus) => {
-    if (status === "pass") {
-      return lightMode ? "bg-emerald-50 text-emerald-700" : "bg-emerald-950/60 text-emerald-300";
-    }
-    if (status === "available") {
-      return lightMode ? "bg-sky-50 text-sky-700" : "bg-sky-950/60 text-sky-300";
-    }
-    if (status === "fail") {
-      return lightMode ? "bg-red-50 text-red-700" : "bg-red-950/60 text-red-300";
-    }
-    if (status === "out-of-scope") {
-      return lightMode ? "bg-gray-100 text-gray-500" : "bg-[#222228] text-[#7a7a86]";
-    }
-    return lightMode ? "bg-amber-50 text-amber-700" : "bg-amber-950/60 text-amber-300";
-  };
-  const statusLabel = (status: RiverLakeInspectorClaimStatus) => {
-    switch (status) {
-      case "pass":
-        return "ready";
-      case "available":
-        return "inspect";
-      case "fail":
-        return "fail";
-      case "out-of-scope":
-        return "skip";
-      case "unresolved":
-      default:
-        return "open";
-    }
-  };
-  const formatCountLabel = (key: string) => {
-    switch (key) {
-      case "layers":
-        return "layers";
-      case "default":
-        return "shown";
-      case "debug":
-        return "debug";
-      default:
-        return key;
-    }
-  };
-  const formatLayerButtonLabel = (ref: RiverLakeInspectorLayerRef) => {
-    if (ref.dataTypeKey.includes("projectedRiverMask")) return "projected";
-    if (ref.dataTypeKey.includes("plannedMinorRiverMask")) return "minor";
-    if (ref.dataTypeKey.includes("plannedMajorRiverMask")) return "major";
-    if (ref.dataTypeKey.includes("engineRiverMask")) return "terrain";
-    if (ref.dataTypeKey.includes("Metadata")) return "metadata";
-    if (ref.dataTypeKey.includes("engineMinorRiverMask")) return "minor meta";
-    if (ref.dataTypeKey.includes("riverMismatchMask")) return "mismatch";
-    if (ref.dataTypeKey.includes("lakePlan")) return "lake plan";
-    if (ref.dataTypeKey.includes("plannedLakeMask")) return "planned";
-    if (ref.dataTypeKey.includes("engineLakeMask")) return "engine";
-    if (ref.dataTypeKey.includes("rejectedLakeMask")) return "rejected";
-    if (ref.dataTypeKey.includes("featureType")) return "features";
-    if (ref.dataTypeKey.includes("rejectionMask")) return "rejects";
-    const parts = ref.dataTypeKey.split(".");
-    return parts[parts.length - 1] ?? ref.dataTypeKey;
   };
   // ==========================================================================
   // Render
@@ -489,63 +411,6 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
         </div>
       ) : null}
 
-      {/* WATER PROOF SECTION */}
-      {inspectorRows.length > 0 ? (
-        <>
-          <div className={`flex-shrink-0 border-b ${borderSubtle}`}>
-            <div className="w-full flex items-center justify-between px-3 py-2">
-              <div className="flex items-center gap-2 min-w-0 overflow-hidden">
-                <Droplets className={`w-3.5 h-3.5 shrink-0 ${textSecondary}`} />
-                <span className={`text-[11px] font-semibold ${textSecondary} uppercase tracking-wider`}>
-                  Water Proof
-                </span>
-              </div>
-              <span className={`text-[10px] ${textMuted}`}>{inspectorRows.length}</span>
-            </div>
-          </div>
-          <div className={`flex-shrink-0 border-b ${borderSubtle} max-h-[260px] overflow-y-auto custom-scrollbar`}>
-            {inspectorRows.map((row) => (
-              <div key={row.rowKey} className={`px-3 py-2 border-b last:border-b-0 ${borderSubtle}`}>
-                <div className="flex items-start justify-between gap-2">
-                  <div className="min-w-0">
-                    <div className={`text-[9px] uppercase tracking-wider ${textMuted}`}>{row.laneLabel}</div>
-                    <div className={`text-[11px] font-medium ${textPrimary} truncate`} title={row.displayStatus}>
-                      {row.label}
-                    </div>
-                  </div>
-                  <span className={`shrink-0 rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider ${statusChipClass(row.claimStatus)}`}>
-                    {statusLabel(row.claimStatus)}
-                  </span>
-                </div>
-                <div className="mt-1 flex flex-wrap items-center gap-1">
-                  {Object.entries(row.counts).map(([key, value]) => (
-                    <span key={key} className={`rounded px-1.5 py-0.5 text-[9px] ${chipBg}`}>
-                      {formatCountLabel(key)} {value}
-                    </span>
-                  ))}
-                  {row.layerRefs.slice(0, 4).map((ref) => (
-                    <button
-                      type="button"
-                      key={ref.layerKey}
-                      onClick={() => onRiverLakeInspectorLayerSelect?.(ref)}
-                      title={`${ref.label} · ${ref.presentation.categoryLabel} · ${row.proofClass}`}
-                      className={`inline-flex max-w-[112px] items-center gap-1 truncate rounded px-1.5 py-0.5 text-[9px] transition-colors ${lightMode ? "bg-white border border-gray-200 text-gray-700 hover:bg-gray-50" : "bg-[#111116] border border-[#2a2a32] text-[#c4c4cc] hover:bg-[#1a1a1f]"}`}
-                    >
-                      <span
-                        aria-hidden="true"
-                        className="h-1.5 w-1.5 shrink-0 rounded-full"
-                        style={{ backgroundColor: ref.presentation.palette.activeColor }}
-                      />
-                      <span className="truncate">{formatLayerButtonLabel(ref)}</span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        </>
-      ) : null}
-
       {/* 3. LAYERS SECTION */}
       <div className={`flex-shrink-0 border-b ${borderSubtle}`}>
         <button
@@ -580,8 +445,8 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
                   <button
                     type="button"
                     onClick={() => toggleGroupExpanded(group.key)}
-                    className={`w-full px-3 pt-2 pb-1 flex items-center justify-between text-[10px] uppercase tracking-wider ${textMuted} ${hoverBg}`}
-                    title={expanded ? "Collapse group" : "Expand group"}
+                    className={`w-full px-3 pt-2 pb-1 flex items-center justify-between text-label uppercase tracking-wider ${textMuted} ${hoverBg}`}
+                    aria-label={expanded ? "Collapse group" : "Expand group"}
                   >
                     <span className="truncate">{group.label}</span>
                     <div className="flex items-center gap-2">
@@ -620,31 +485,45 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
         <div className="flex items-center justify-between gap-2">
           {/* Left: Fit & Edges */}
           <div className="flex items-center gap-1">
-            <button onClick={onFitView} title="Fit to view" className={iconBtn}>
-              <Maximize className="w-3.5 h-3.5" />
-            </button>
-            <button
-              onClick={() => onShowEdgesChange(!showEdges)}
-              title={showEdges ? 'Hide edges' : 'Show edges'}
-              className={showEdges ? iconBtnActive : iconBtn}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button onClick={onFitView} aria-label="Fit to view" className={iconBtn}>
+                  <Maximize className="w-3.5 h-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Fit to view</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => onShowEdgesChange(!showEdges)}
+                  aria-label={showEdges ? 'Hide edges' : 'Show edges'}
+                  className={showEdges ? iconBtnActive : iconBtn}>
 
-              <GitBranch className="w-3.5 h-3.5" />
-            </button>
+                  <GitBranch className="w-3.5 h-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{showEdges ? 'Hide edges' : 'Show edges'}</TooltipContent>
+            </Tooltip>
           </div>
 
           {/* Right: Render */}
           <div className="flex flex-col items-end gap-1">
-            <span className={`text-[10px] uppercase tracking-wider ${textMuted}`}>Render</span>
+            <span className={`text-label uppercase tracking-wider ${textMuted}`}>Render</span>
             <div className="flex items-center gap-1">
               {renderModeOptions.map((option) => (
-                <button
-                  key={option.value}
-                  onClick={() => onSelectedRenderModeChange(option.value)}
-                  title={option.label}
-                  className={selectedRenderMode === option.value ? iconBtnActive : iconBtn}
-                >
-                  {getRenderModeIcon(option.value)}
-                </button>
+                <Tooltip key={option.value}>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => onSelectedRenderModeChange(option.value)}
+                      aria-label={option.label}
+                      className={selectedRenderMode === option.value ? iconBtnActive : iconBtn}
+                    >
+                      {getRenderModeIcon(option.value)}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>{option.label}</TooltipContent>
+                </Tooltip>
               ))}
             </div>
           </div>
@@ -653,50 +532,59 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
         <div className="flex items-center justify-between gap-2">
           {/* Left: Space */}
           <div className="flex flex-col gap-1">
-            <span className={`text-[10px] uppercase tracking-wider ${textMuted}`}>Space</span>
+            <span className={`text-label uppercase tracking-wider ${textMuted}`}>Space</span>
             <div className="flex items-center gap-1">
               {spaceOptions.map((option) => (
-                <button
-                  key={option.value}
-                  onClick={() => onSelectedSpaceChange(option.value)}
-                  title={option.label}
-                  className={selectedSpace === option.value ? iconBtnActive : iconBtn}
-                >
-                  {getSpaceIcon(option.value)}
-                </button>
+                <Tooltip key={option.value}>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => onSelectedSpaceChange(option.value)}
+                      aria-label={option.label}
+                      className={selectedSpace === option.value ? iconBtnActive : iconBtn}
+                    >
+                      {getSpaceIcon(option.value)}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>{option.label}</TooltipContent>
+                </Tooltip>
               ))}
             </div>
           </div>
 
           {/* Right: Debug toggle */}
-          <button
-            onClick={() => onShowDebugLayersChange(!showDebugLayers)}
-            title={showDebugLayers ? "Hide debug layers" : "Show debug layers"}
-            className={showDebugLayers ? iconBtnActive : iconBtn}>
-            <Bug className="w-3.5 h-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => onShowDebugLayersChange(!showDebugLayers)}
+                aria-label={showDebugLayers ? "Hide debug layers" : "Show debug layers"}
+                className={showDebugLayers ? iconBtnActive : iconBtn}>
+                <Bug className="w-3.5 h-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{showDebugLayers ? "Hide debug layers" : "Show debug layers"}</TooltipContent>
+          </Tooltip>
         </div>
 
         {eraEnabled ? (
           <div className="flex flex-col gap-1">
             <div className="flex items-center justify-between">
-              <span className={`text-[10px] uppercase tracking-wider ${textMuted}`}>Era</span>
-              <button
-                type="button"
-                onClick={() => onEraModeChange(eraMode === "auto" ? "fixed" : "auto")}
-                title={eraMode === "auto" ? "Auto (follow selected layer)" : "Manual era"}
-                className={`px-2 h-6 rounded text-[10px] font-semibold uppercase tracking-wider transition-colors ${
-                  eraMode === "auto"
-                    ? lightMode
-                      ? "bg-gray-200 text-[#1f2937]"
-                      : "bg-[#222228] text-[#e8e8ed]"
-                    : lightMode
-                      ? "bg-white border border-gray-200 text-[#6b7280]"
-                      : "bg-[#111116] border border-[#2a2a32] text-[#8a8a96]"
-                }`}
-              >
-                Auto
-              </button>
+              <span className={`text-label uppercase tracking-wider ${textMuted}`}>Era</span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => onEraModeChange(eraMode === "auto" ? "fixed" : "auto")}
+                    className={`px-2 h-6 rounded text-label font-semibold uppercase tracking-wider transition-colors ${
+                      eraMode === "auto"
+                        ? "bg-muted text-foreground"
+                        : "bg-input-background border border-input text-muted-foreground"
+                    }`}
+                  >
+                    Auto
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{eraMode === "auto" ? "Auto (follow selected layer)" : "Manual era"}</TooltipContent>
+              </Tooltip>
             </div>
             <input
               type="range"
@@ -706,9 +594,9 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
               value={eraValue}
               disabled={eraMode === "auto"}
               onChange={(e) => onEraValueChange(Number(e.target.value))}
-              className="w-full accent-[#64748b]"
+              className="w-full accent-primary"
             />
-            <div className="flex items-center justify-between text-[10px]">
+            <div className="flex items-center justify-between text-label">
               <span className={textMuted}>{`Era ${eraValue}`}</span>
               <span className={textMuted}>{`${eraMin}-${eraMax}`}</span>
             </div>
@@ -717,35 +605,35 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
 
         {variantOptions.length > 1 ? (
           <label className="flex flex-col gap-1">
-            <span className={`text-[10px] uppercase tracking-wider ${textMuted}`}>Variant</span>
+            <span className={`text-label uppercase tracking-wider ${textMuted}`}>Variant</span>
             <select
               value={selectedVariant}
               onChange={(e) => onSelectedVariantChange(e.target.value)}
-              className={`h-8 rounded px-2 text-[11px] ${lightMode ? 'bg-white border border-gray-200 text-[#1f2937]' : 'bg-[#111116] border border-[#2a2a32] text-[#e8e8ed]'}`}>
+              className="h-8 rounded px-2 text-data bg-input-background border border-input text-foreground">
               {variantOptions.map((opt) => (
                 <option key={opt.value} value={opt.value}>{opt.label}</option>
               ))}
             </select>
-            <span className={`text-[10px] ${textMuted}`}>
-              Semantic slices like <span className={lightMode ? "text-gray-600" : "text-[#8a8a96]"}>era:2</span>, not styling.
+            <span className={`text-label ${textMuted}`}>
+              Semantic slices like <span className="text-muted-foreground">era:2</span>, not styling.
             </span>
           </label>
         ) : null}
 
         {overlayOptions.length ? (
           <label className="flex flex-col gap-1">
-            <span className={`text-[10px] uppercase tracking-wider ${textMuted}`}>Overlay</span>
+            <span className={`text-label uppercase tracking-wider ${textMuted}`}>Overlay</span>
             <select
               value={selectedOverlay}
               onChange={(e) => onSelectedOverlayChange(e.target.value)}
-              className={`h-8 rounded px-2 text-[11px] ${lightMode ? 'bg-white border border-gray-200 text-[#1f2937]' : 'bg-[#111116] border border-[#2a2a32] text-[#e8e8ed]'}`}>
+              className="h-8 rounded px-2 text-data bg-input-background border border-input text-foreground">
               {overlayOptions.map((opt) => (
                 <option key={opt.value} value={opt.value}>{opt.label}</option>
               ))}
             </select>
             {selectedOverlay ? (
               <div className="flex flex-col gap-1">
-                <div className="flex items-center justify-between text-[10px]">
+                <div className="flex items-center justify-between text-label">
                   <span className={textMuted}>Opacity</span>
                   <span className={textMuted}>{Math.round(overlayOpacity * 100)}%</span>
                 </div>
@@ -756,7 +644,7 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
                   step={0.05}
                   value={overlayOpacity}
                   onChange={(e) => onOverlayOpacityChange(Number(e.target.value))}
-                  className="w-full accent-[#64748b]"
+                  className="w-full accent-primary"
                 />
               </div>
             ) : null}

--- a/apps/mapgen-studio/src/ui/components/RecipePanel.tsx
+++ b/apps/mapgen-studio/src/ui/components/RecipePanel.tsx
@@ -21,18 +21,20 @@ import {
   type MapConfigSaveDeployStatus,
 } from '../../features/mapConfigSave/status';
 import {
-  AlertDialog,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogAction,
-  AlertDialogCancel,
   Button,
-  Select,
-  Switch } from
-'./ui';
+  Switch,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose } from
+'../../components/ui';
+import { Select } from './ui';
 import type {
   PipelineConfig,
   Theme,
@@ -200,17 +202,20 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
   // ==========================================================================
   // Styles
   // ==========================================================================
-  const panelBg = lightMode ? 'bg-white/95' : 'bg-[#141418]/95';
-  const panelBorder = lightMode ? 'border-gray-200' : 'border-[#2a2a32]';
-  const sectionBg = lightMode ? 'bg-gray-50/80' : 'bg-[#0f0f12]/80';
-  const textPrimary = lightMode ? 'text-[#1f2937]' : 'text-[#e8e8ed]';
-  const textSecondary = lightMode ? 'text-[#6b7280]' : 'text-[#8a8a96]';
-  const textMuted = lightMode ? 'text-[#9ca3af]' : 'text-[#5a5a66]';
-  const borderColor = lightMode ? 'border-gray-200' : 'border-[#2a2a32]';
-  const borderSubtle = lightMode ? 'border-gray-100' : 'border-[#222228]';
-  const hoverBg = lightMode ? 'hover:bg-gray-50' : 'hover:bg-[#1a1a1f]';
-  const iconBtn = `h-7 w-7 flex items-center justify-center rounded transition-colors shrink-0 ${lightMode ? 'text-[#6b7280] hover:text-[#1f2937] hover:bg-gray-100' : 'text-[#8a8a96] hover:text-[#e8e8ed] hover:bg-[#1a1a1f]'}`;
-  const iconBtnActive = `h-7 w-7 flex items-center justify-center rounded transition-colors shrink-0 ${lightMode ? 'text-[#1f2937] bg-gray-200' : 'text-[#e8e8ed] bg-[#222228]'}`;
+  // Token-driven chrome; theme follows the single `.dark` class. The dock
+  // floats over the deck.gl map, so it rides the `popover` tier; the sunken
+  // section sits on `surface-sunken`.
+  const panelBg = 'bg-popover/95';
+  const panelBorder = 'border-border';
+  const sectionBg = 'bg-surface-sunken/80';
+  const textPrimary = 'text-foreground';
+  const textSecondary = 'text-muted-foreground';
+  const textMuted = 'text-muted-foreground/70';
+  const borderColor = 'border-border';
+  const borderSubtle = 'border-border-subtle';
+  const hoverBg = 'hover:bg-accent';
+  const iconBtn = 'h-7 w-7 flex items-center justify-center rounded transition-colors shrink-0 text-muted-foreground hover:text-foreground hover:bg-accent';
+  const iconBtnActive = 'h-7 w-7 flex items-center justify-center rounded transition-colors shrink-0 text-foreground bg-muted';
   // ==========================================================================
   // Render
   // ==========================================================================
@@ -233,7 +238,7 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
               </span>
             </div>
             {isDirty &&
-            <span className="text-[9px] font-medium uppercase tracking-wider text-orange-500">
+            <span className="text-[9px] font-medium uppercase tracking-wider text-primary">
                 Modified
               </span>
             }
@@ -311,34 +316,39 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
                 onClick={(e) => e.stopPropagation()}>
 
                 <span
-                  className={`text-[9px] font-medium uppercase tracking-wider ${overridesDisabled ? 'text-orange-500' : textMuted}`}>
+                  className={`text-[9px] font-medium uppercase tracking-wider ${overridesDisabled ? 'text-primary' : textMuted}`}>
 
                   On
                 </span>
-                <Switch
-                  checked={!overridesDisabled}
-                  onCheckedChange={(checked) => setOverridesDisabled(!checked)}
-                  lightMode={lightMode}
-                  aria-label={overridesDisabled ? "Enable Overrides" : "Disable Overrides"}
-                  title={overridesDisabled ? 'Enable Overrides' : 'Disable Overrides'} />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Switch
+                      checked={!overridesDisabled}
+                      onCheckedChange={(checked) => setOverridesDisabled(!checked)}
+                      aria-label={overridesDisabled ? "Enable Overrides" : "Disable Overrides"} />
+                  </TooltipTrigger>
+                  <TooltipContent>{overridesDisabled ? 'Enable Overrides' : 'Disable Overrides'}</TooltipContent>
+                </Tooltip>
 
               </div>
 
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setShowAllSteps(!showAllSteps);
-                }}
-                aria-label={showAllSteps ? "Focus Current Step" : "Show All Steps"}
-                aria-pressed={showAllSteps}
-                title={
-                showAllSteps ? 'Focus Current Step' : 'Show All Steps'
-                }
-                className={!showAllSteps ? iconBtnActive : iconBtn}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowAllSteps(!showAllSteps);
+                    }}
+                    aria-label={showAllSteps ? "Focus Current Step" : "Show All Steps"}
+                    aria-pressed={showAllSteps}
+                    className={!showAllSteps ? iconBtnActive : iconBtn}>
 
-                <Focus className="w-3.5 h-3.5" aria-hidden="true" />
-              </button>
+                    <Focus className="w-3.5 h-3.5" aria-hidden="true" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{showAllSteps ? 'Focus Current Step' : 'Show All Steps'}</TooltipContent>
+              </Tooltip>
             </div>
           </div>
         </div>
@@ -352,26 +362,34 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
 
               <div className="flex-1" />
 
-              <button
-              type="button"
-              onClick={() => setShowResetModal(true)}
-              aria-label="Reset Config to Defaults"
-              title="Reset to Defaults"
-              className={iconBtn}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                  type="button"
+                  onClick={() => setShowResetModal(true)}
+                  aria-label="Reset Config to Defaults"
+                  className={iconBtn}>
 
-                <Eraser className="w-3.5 h-3.5" aria-hidden="true" />
-              </button>
+                    <Eraser className="w-3.5 h-3.5" aria-hidden="true" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Reset to Defaults</TooltipContent>
+              </Tooltip>
 
-              <button
-              type="button"
-              onClick={() => setShowJson(!showJson)}
-              aria-label={showJson ? "Show Form View" : "Show JSON View"}
-              aria-pressed={showJson}
-              title={showJson ? 'Show Form View' : 'Show JSON View'}
-              className={showJson ? iconBtnActive : iconBtn}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                  type="button"
+                  onClick={() => setShowJson(!showJson)}
+                  aria-label={showJson ? "Show Form View" : "Show JSON View"}
+                  aria-pressed={showJson}
+                  className={showJson ? iconBtnActive : iconBtn}>
 
-                <Braces className="w-3.5 h-3.5" aria-hidden="true" />
-              </button>
+                    <Braces className="w-3.5 h-3.5" aria-hidden="true" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{showJson ? 'Show Form View' : 'Show JSON View'}</TooltipContent>
+              </Tooltip>
             </div>
 
             {/* Config Form / JSON */}
@@ -379,11 +397,10 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
             className={`px-3 pb-3 ${overridesDisabled ? 'opacity-40 pointer-events-none select-none' : ''}`}>
 
               {showJson ?
-            <div
-              className={`border rounded p-2.5 max-h-[240px] overflow-auto ${lightMode ? 'bg-gray-50 border-gray-100' : 'bg-[#0f0f12] border-[#222228]'}`}>
+            <div className="border border-border-subtle rounded p-2.5 max-h-[240px] overflow-auto bg-surface-sunken">
 
                   <pre
-                className={`text-[10px] font-mono leading-relaxed ${textMuted} whitespace-pre-wrap break-all`}>
+                className={`text-label font-mono leading-relaxed ${textMuted} whitespace-pre-wrap break-all`}>
 
                     {JSON.stringify(filteredConfig, null, 2)}
                   </pre>
@@ -412,29 +429,33 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
             <Button
               onClick={onRun}
               disabled={runActionDisabled}
-              className={`flex-1 ${isDirty ? 'ring-2 ring-orange-400/50 border-orange-400' : ''} ${isRunning || isSaveDeployRunning ? 'opacity-70 cursor-wait' : ''}`}>
+              className={`flex-1 ${isDirty ? 'ring-1 ring-ring border-primary' : ''} ${isRunning || isSaveDeployRunning ? 'opacity-70 cursor-wait' : ''}`}>
 
               <Play className="w-3.5 h-3.5" aria-hidden="true" />
               <span>{isRunning ? 'Running…' : 'Run'}</span>
             </Button>
 
             <div className="relative">
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={() => {
-                  if (saveActionDisabled) return;
-                  setShowSaveMenu(!showSaveMenu);
-                }}
-                disabled={saveActionDisabled}
-                aria-label="Save & Deploy Config"
-                aria-haspopup="menu"
-                aria-expanded={showSaveMenu}
-                title={saveTitle}
-                className={`h-8 w-8 ${isSaveDeployRunning ? 'opacity-70 cursor-wait' : ''}`}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={() => {
+                      if (saveActionDisabled) return;
+                      setShowSaveMenu(!showSaveMenu);
+                    }}
+                    disabled={saveActionDisabled}
+                    aria-label="Save & Deploy Config"
+                    aria-haspopup="menu"
+                    aria-expanded={showSaveMenu}
+                    className={`h-8 w-8 ${isSaveDeployRunning ? 'opacity-70 cursor-wait' : ''}`}>
 
-                <Save className="w-4 h-4" aria-hidden="true" />
-              </Button>
+                    <Save className="w-4 h-4" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{saveTitle}</TooltipContent>
+              </Tooltip>
 
               {showSaveMenu &&
               <>
@@ -494,7 +515,7 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
                       onDeletePreset();
                       setShowSaveMenu(false);
                     }}
-                    className={`w-full text-left px-3 py-2 text-[11px] text-red-600 ${hoverBg} rounded-b-lg border-t ${borderSubtle}`}>
+                    className={`w-full text-left px-3 py-2 text-data text-destructive ${hoverBg} rounded-b-lg border-t ${borderSubtle}`}>
 
                         Delete Scratch
                       </button>
@@ -513,31 +534,33 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
       </div>
 
       {/* Reset Confirmation Dialog */}
-      <AlertDialog
-        open={showResetModal}
-        onOpenChange={setShowResetModal}
-        lightMode={lightMode}>
-
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle icon={<Eraser className="w-4 h-4" />}>
+      <Dialog open={showResetModal} onOpenChange={setShowResetModal}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Eraser className="w-4 h-4" />
               Reset Config
-            </AlertDialogTitle>
-            <AlertDialogDescription>
+            </DialogTitle>
+            <DialogDescription>
               This will reset all config overrides to their default values.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={onConfigReset}
-              className="bg-red-500 hover:bg-red-600 border-red-600">
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                onConfigReset();
+                setShowResetModal(false);
+              }}>
 
               Reset
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>);
 
 };

--- a/apps/mapgen-studio/src/ui/components/ViewControls.tsx
+++ b/apps/mapgen-studio/src/ui/components/ViewControls.tsx
@@ -3,9 +3,15 @@ import React from 'react';
 // VIEW CONTROLS
 // ============================================================================
 // Toolbar for theme toggle and grid visibility.
+//
+// Reskinned onto the design tokens: the dock floats over the map on the
+// `popover` tier; icon buttons rest on `text-muted-foreground` and lift to
+// `bg-accent` on hover / `bg-muted` when active. Native `title=` hints are now
+// the shadcn Tooltip (token-styled, delay-grouped under the shell provider).
 // ============================================================================
-import { Grid3X3, Sun, Moon, Monitor } from 'lucide-react';
+import { Sun, Moon, Monitor } from 'lucide-react';
 import { cn } from '../utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/ui';
 import type { ThemePreference } from '../types';
 // ============================================================================
 // Props
@@ -15,8 +21,8 @@ export interface ViewControlsProps {
   themePreference: ThemePreference;
   /** Callback to cycle theme preference */
   onThemeCycle: () => void;
-  /** Light mode flag for styling */
-  isLightMode: boolean;
+  /** Light mode flag (retained for call-site compatibility; styling is token-driven) */
+  isLightMode?: boolean;
   /** Whether grid is visible */
   showGrid: boolean;
   /** Callback when grid visibility changes */
@@ -46,65 +52,67 @@ const THEME_CONFIG: Record<
   }
 };
 // ============================================================================
+// Styles (token-driven; theme follows the `.dark` class)
+// ============================================================================
+const iconBtn = cn(
+  'h-7 w-7 flex items-center justify-center rounded transition-colors',
+  'text-muted-foreground hover:bg-accent hover:text-foreground'
+);
+const iconBtnActive = cn(
+  'h-7 w-7 flex items-center justify-center rounded transition-colors',
+  'bg-muted text-foreground'
+);
+// ============================================================================
 // Component
 // ============================================================================
 export const ViewControls: React.FC<ViewControlsProps> = ({
   themePreference,
   onThemeCycle,
-  isLightMode,
   showGrid,
   onShowGridChange
 }) => {
-  // ==========================================================================
-  // Styles
-  // ==========================================================================
-  const panelBg = isLightMode ? 'bg-white/70' : 'bg-[#141418]/62';
-  const panelBorder = isLightMode ? 'border-white/80' : 'border-white/10';
-  const dividerColor = isLightMode ? 'bg-gray-200' : 'bg-[#2a2a32]';
-  // Icon button styles based on theme
-  const iconBtn = cn(
-    'h-7 w-7 flex items-center justify-center rounded transition-colors',
-    isLightMode ?
-    'text-[#6b7280] hover:bg-gray-100 hover:text-[#1f2937]' :
-    'text-[#8a8a96] hover:bg-[#1a1a1f] hover:text-[#e8e8ed]'
-  );
-  const iconBtnActive = cn(
-    'h-7 w-7 flex items-center justify-center rounded transition-colors',
-    isLightMode ? 'bg-gray-200 text-[#1f2937]' : 'bg-[#222228] text-[#e8e8ed]'
-  );
   const { icon: ThemeIcon, tooltip: themeTooltip } =
   THEME_CONFIG[themePreference];
+  const gridTooltip = showGrid ? 'Hide grid' : 'Show grid';
   // ==========================================================================
   // Render
   // ==========================================================================
   return (
     <div
-      className={`h-10 inline-flex items-center gap-1 px-1.5 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}
+      className="h-10 inline-flex items-center gap-1 px-1.5 rounded-lg border border-border bg-popover/95 backdrop-blur-sm"
       role="toolbar"
       aria-label="View controls">
 
       {/* Theme toggle */}
-      <button
-        onClick={onThemeCycle}
-        title={themeTooltip}
-        aria-label={themeTooltip}
-        className={iconBtn}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={onThemeCycle}
+            aria-label={themeTooltip}
+            className={iconBtn}>
 
-        <ThemeIcon className="w-4 h-4" />
-      </button>
+            <ThemeIcon className="w-4 h-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{themeTooltip}</TooltipContent>
+      </Tooltip>
 
-      <div className={`w-px h-4 ${dividerColor}`} aria-hidden="true" />
+      <div className="w-px h-4 bg-border" aria-hidden="true" />
 
       {/* Grid toggle */}
-      <button
-        onClick={() => onShowGridChange(!showGrid)}
-        title={showGrid ? 'Hide grid' : 'Show grid'}
-        aria-label={showGrid ? 'Hide grid' : 'Show grid'}
-        aria-pressed={showGrid}
-        className={showGrid ? iconBtnActive : iconBtn}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={() => onShowGridChange(!showGrid)}
+            aria-label={gridTooltip}
+            aria-pressed={showGrid}
+            className={showGrid ? iconBtnActive : iconBtn}>
 
-        <Grid3X3 className="w-4 h-4" />
-      </button>
+            <div className="w-4 h-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{gridTooltip}</TooltipContent>
+      </Tooltip>
     </div>);
 
 };

--- a/openspec/changes/mapgen-studio-shell-reskin/design.md
+++ b/openspec/changes/mapgen-studio-shell-reskin/design.md
@@ -1,0 +1,75 @@
+## Design
+
+This is a presentation-only migration slice. It moves the shell/chrome off the
+legacy hand-rolled primitives and ad-hoc hex palette onto the design system
+tokens and the new `src/components/ui` primitives. No runtime logic changes —
+refactors MOVE styling and swap primitive mechanisms; they do not rewrite
+behavior.
+
+## Token Mapping
+
+The shell encoded its surfaces as a `lightMode ? '<light hex>' : '<dark hex>'`
+ternary per class. Because the design tokens already carry both themes (light in
+`:root`, dark in `.dark`), each ternary collapses to one token utility:
+
+| Legacy (dark / light) | Token |
+| --- | --- |
+| `bg-[#141418]/95` / `bg-white/95` (floating dock) | `bg-popover/95` |
+| `bg-[#16161d]/90` / `bg-white/90` (brand pill) | `bg-popover/90` |
+| `border-[#2a2a32]` / `border-gray-200` | `border-border` |
+| `border-[#222228]` / `border-gray-100` (subtle) | `border-subtle` |
+| `bg-[#0f0f12]` / `bg-gray-50` (sunken JSON) | `bg-surface-sunken` |
+| `text-[#e8e8ed]` / `text-[#1f2937]` (primary) | `text-foreground` |
+| `text-[#8a8a96]` / `text-[#6b7280]` (secondary) | `text-muted-foreground` |
+| `text-[#5a5a66]` / `text-[#9ca3af]` (tertiary) | `text-muted-foreground/70` |
+| `hover:bg-[#1a1a1f]` / `hover:bg-gray-50` | `hover:bg-accent` |
+| `bg-[#222228]` / `bg-gray-200` (active) | `bg-muted` |
+| `accent-[#64748b]` (range slider) | `accent-primary` |
+
+The floating chrome docks ride the `popover` tier deliberately: they float above
+the deck.gl map (with `backdrop-blur`), and `popover` is the system's
+floating-layer surface. Nested sunken surfaces (the JSON config view) use
+`surface-sunken`; text inputs use `input-background`.
+
+## Accent Discipline
+
+`system.md` mandates ONE elevated cool-steel slate accent. The shell previously
+used orange (`ring-orange-400`, `border-orange-400`, `text-orange-500`) for two
+distinct jobs:
+
+- **Chrome identity** — the dirty/modified ring on Run, the active auto-run
+  toggle, focus emphasis. These move to the slate `primary`/`ring` tokens, since
+  they are instrument identity.
+- **Live-stale emphasis** — the "your Studio state is stale vs the live game"
+  call-to-action. This is a *warning about data*, so it moves to the `warning`
+  token rather than `primary`, keeping the slate reserved for identity.
+
+Status dots (running = amber, error = `destructive`, ready/live-ok = `success`)
+are semantic data the instrument reports about the map and the live game — the
+one place real color belongs in the chrome — so they keep their semantic hues.
+
+## Primitive And Mechanism Swaps
+
+- Shell call sites adopt `@/components/ui` Button/Input/Select/Switch where the
+  prop surface matches. The legacy primitives still accept a `lightMode` prop;
+  the new ones ignore theme props entirely (they read `.dark`), so the migration
+  drops the `lightMode=` pass-through at each migrated site.
+- Native `title=` tooltips become the shadcn `Tooltip` (Radix), wrapped by a
+  single `TooltipProvider` mounted at the shell root. This gives the chrome real,
+  token-styled, delay-grouped tooltips instead of native browser ones.
+- The legacy `AlertDialog` (RecipePanel reset confirm, PresetDialogs) migrates to
+  the shadcn `Dialog`. The confirm/cancel/destructive semantics are preserved by
+  composing `DialogFooter` with Buttons; `onOpenChange` keeps the same
+  open-state contract the callers already pass.
+- `ToastProvider`/`useToast` migrate to the sonner `Toaster` + the `toast`
+  function. The legacy `toast(message, { variant })` call shape maps to
+  `toast.success` / `toast.error` / `toast.info` / `toast` so message content and
+  trigger points are unchanged.
+
+## Parity Boundary
+
+No map generation, deck.gl math, recipe semantics, run-in-game phases, the
+live-runtime poll's staleness/backoff gating, the localStorage schema, or
+browserRunner gating is touched. Every change is a class string, a primitive
+import, or a dialog/toast call-shape swap. The shell's props, callbacks, and
+control flow are untouched.

--- a/openspec/changes/mapgen-studio-shell-reskin/proposal.md
+++ b/openspec/changes/mapgen-studio-shell-reskin/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+The canonical token-driven primitive library now exists at
+`apps/mapgen-studio/src/components/ui/`, but the shell/chrome still renders
+through the legacy `src/ui/components/ui/*` primitives and a wall of hardcoded
+hex palettes gated on a `lightMode`/`isLightMode` boolean (`bg-[#141418]/95`,
+`border-[#2a2a32]`, `text-[#8a8a96]`, `bg-[#1a1a1f]`, …). The design system is
+invisible: the substrate-elevation tiers, the single slate accent, the contour
+focus ring, and the `.dark`-class theming never reach the surface the user
+actually sees.
+
+This slice makes the design system VISIBLE across the shell. It reskins the
+chrome (header, brand, view controls, left dock / RecipePanel, right dock /
+ExplorePanel, footer / status strip, the app root and error strip) onto the
+design tokens, adopts the new primitives at their call sites, converts native
+`title=` tooltips to the shadcn `Tooltip`, and migrates the legacy
+`AlertDialog`/`ToastProvider` usages to the shadcn `Dialog` and sonner `toast`.
+
+## What Changes
+
+- Replace ad-hoc hex / `lightMode`-ternary classes in the shell with design
+  tokens so depth is FELT: page = `bg-background`, floating chrome docks =
+  `bg-popover`, nested sunken surfaces = `surface-sunken`,
+  inputs = `input-background`; borders via `border`/`border-subtle` per the
+  ladder; secondary text via `text-muted-foreground`. The light theme now comes
+  from `:root` and the dark theme from `.dark`, so the per-class `lightMode`
+  branching collapses to a single token class.
+- Commit to the ONE slate accent: chrome identity states (active/dirty/focus
+  rings, auto-run, live-stale emphasis) move from ad-hoc orange to the
+  `primary`/`ring` tokens. Semantic *data* indicators (status dots:
+  running/error/ready, live-ok/error) stay on their semantic hues — they are the
+  matter the instrument reports, not instrument identity.
+- Adopt the new `src/components/ui` primitives (Button, Input, Select, Switch,
+  Tooltip, Dialog) at the shell + preset-dialog + rjsf-widget call sites.
+- Convert native `title=` attributes in the shell to the shadcn `Tooltip`,
+  wrapped by a single `TooltipProvider` at the shell root.
+- Migrate the legacy `AlertDialog` (RecipePanel reset, PresetDialogs) to the
+  shadcn `Dialog`, and migrate `ToastProvider`/`useToast` to the sonner
+  `Toaster` + `toast`.
+
+This change is PRESENTATION ONLY. It moves styling onto tokens and swaps
+primitive mechanisms; it changes no map generation, deck.gl, recipe, run-in-game,
+live-runtime poll, localStorage, or browserRunner logic.
+
+## Impact
+
+- Affected specs: `mapgen-studio`
+- Affected code: `apps/mapgen-studio/src/ui/components/AppHeader.tsx`,
+  `AppBrand.tsx`, `ViewControls.tsx`, `RecipePanel.tsx`, `ExplorePanel.tsx`,
+  `AppFooter.tsx`; `apps/mapgen-studio/src/App.tsx` (root bg, Toaster, error
+  strip); `apps/mapgen-studio/src/features/presets/PresetDialogs.tsx`;
+  `apps/mapgen-studio/src/features/configOverrides/rjsfWidgets.tsx`.
+- No change to map generation, deck.gl, recipe semantics, run-in-game, the
+  live-runtime poll staleness/backoff gating, the localStorage schema, or
+  browserRunner gating.

--- a/openspec/changes/mapgen-studio-shell-reskin/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-shell-reskin/specs/mapgen-studio/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Shell Renders Through Design Tokens
+
+MapGen Studio SHALL render the shell/chrome — app root, header, brand, view
+controls, the left dock (RecipePanel), the right dock (ExplorePanel), and the
+footer/status strip — with surfaces, borders, and text resolved through design
+system tokens rather than hardcoded hex palettes or a `lightMode`/`isLightMode`
+class ternary, so the substrate-elevation hierarchy is felt and the theme flips
+through the single `.dark` class.
+
+#### Scenario: Floating docks ride the popover tier
+- **WHEN** the header, brand, view-controls, recipe, explore, or footer chrome
+  renders over the deck.gl map
+- **THEN** its surface resolves from `bg-popover` (the floating-layer tier), its
+  borders from `border`/`border-subtle`, and its text from
+  `text-foreground`/`text-muted-foreground`
+- **AND** it declares no hex color literal and no `lightMode`-gated class ternary
+  for those surfaces
+
+#### Scenario: Nested and inset surfaces use their tiers
+- **WHEN** a nested sunken surface (the JSON config view) or a text input renders
+  inside a dock
+- **THEN** the sunken surface resolves from `surface-sunken` and the input from
+  `input-background`, a felt step apart from the dock surface
+
+#### Scenario: Theme flips through the single dark class
+- **WHEN** the `.dark` class on `<html>` is toggled
+- **THEN** the shell re-themes from the token values with no per-class
+  `lightMode` branch driving its surface, border, or text colors
+
+### Requirement: Single Slate Accent For Chrome Identity
+
+MapGen Studio SHALL render chrome identity states in the shell (active toggles,
+the dirty/modified emphasis ring, focus emphasis) through the single slate
+`primary`/`ring` accent. Status indicators that report data about the map or the
+live game SHALL keep their semantic hues, and a data-staleness call-to-action
+SHALL use the `warning` token rather than the slate accent.
+
+#### Scenario: Dirty and active states use the slate accent
+- **WHEN** the Run control is dirty, or the auto-run toggle is active
+- **THEN** its emphasis renders through `primary`/`ring` (the slate accent), not
+  an ad-hoc orange
+
+#### Scenario: Status dots keep semantic hues
+- **WHEN** a generation/live status dot renders
+- **THEN** running stays amber, error resolves from `destructive`, and
+  ready/live-ok resolve from `success` — the semantic data the instrument reports
+
+### Requirement: Shell Adopts The Canonical Primitives And Tooltips
+
+The shell, the preset dialogs, and the rjsf widgets SHALL adopt the canonical
+`src/components/ui` primitives at their call sites, native `title=` tooltips in
+the shell SHALL be replaced by the shadcn `Tooltip` under a single
+`TooltipProvider`, and the legacy `AlertDialog` and `ToastProvider`/`useToast`
+SHALL be replaced by the shadcn `Dialog` and the sonner `Toaster`/`toast`.
+
+#### Scenario: Native titles become token-styled tooltips
+- **WHEN** a shell control that previously used a native `title=` attribute is
+  hovered or focused
+- **THEN** it shows a shadcn `Tooltip` (token-styled, delay-grouped under the
+  shell `TooltipProvider`) instead of a native browser tooltip
+
+#### Scenario: Dialog and toast use the canonical mechanisms
+- **WHEN** the RecipePanel reset confirm, a preset error/save/confirm dialog, or
+  a toast notification fires
+- **THEN** it renders through the shadcn `Dialog` (reset/preset) or the sonner
+  `Toaster` via `toast` (notifications), preserving the prior open/confirm/cancel
+  and message semantics
+
+### Requirement: Shell Reskin Preserves Behavior Parity
+
+The shell reskin SHALL be presentation-only and SHALL NOT alter map generation,
+deck.gl rendering, recipe semantics, run-in-game, the live-runtime poll
+staleness/backoff gating, the localStorage schema, or browserRunner gating.
+
+#### Scenario: Only presentation changes
+- **WHEN** the reskin lands
+- **THEN** the shell's props, callbacks, and control flow are unchanged, and map
+  generation, deck.gl rendering, recipe semantics, run-in-game, the live-runtime
+  poll staleness/backoff gating, the localStorage schema, and browserRunner
+  gating behave exactly as before

--- a/openspec/changes/mapgen-studio-shell-reskin/tasks.md
+++ b/openspec/changes/mapgen-studio-shell-reskin/tasks.md
@@ -1,45 +1,51 @@
 ## 1. Substrate-Elevation Token Reskin
 
-- [ ] 1.1 Reskin `AppBrand.tsx`: floating pill + hover card → `bg-popover`,
+- [x] 1.1 Reskin `AppBrand.tsx`: floating pill + hover card → `bg-popover`,
   `border`/`border-subtle`, `text-foreground`/`text-muted-foreground`; drop the
   `lightMode` hex ternaries.
-- [ ] 1.2 Reskin `ViewControls.tsx`: dock → `bg-popover`, dividers → `bg-border`,
+- [x] 1.2 Reskin `ViewControls.tsx`: dock → `bg-popover`, dividers → `bg-border`,
   icon buttons → `text-muted-foreground hover:bg-accent`, active → `bg-muted`.
-- [ ] 1.3 Reskin `AppHeader.tsx`: world-settings docks → `bg-popover`, dividers,
+- [x] 1.3 Reskin `AppHeader.tsx`: world-settings docks → `bg-popover`, dividers,
   labels → `text-muted-foreground`; setup button onto tokens.
-- [ ] 1.4 Reskin `RecipePanel.tsx`: panel → `bg-popover`, section headers,
+- [x] 1.4 Reskin `RecipePanel.tsx`: panel → `bg-popover`, section headers,
   borders → `border-subtle`, sunken JSON view → `surface-sunken`, save menu →
   `bg-popover`; dirty ring → `ring-ring`/`border-primary`.
-- [ ] 1.5 Reskin `ExplorePanel.tsx`: panel → `bg-popover`, list item active/
+- [x] 1.5 Reskin `ExplorePanel.tsx`: panel → `bg-popover`, list item active/
   inactive onto tokens, badges → `bg-muted`, range accents → `accent-primary`,
   native selects onto `bg-input-background`/`border-input`.
-- [ ] 1.6 Reskin `AppFooter.tsx`: status/live/run docks → `bg-popover`, dividers,
+- [x] 1.6 Reskin `AppFooter.tsx`: status/live/run docks → `bg-popover`, dividers,
   text tiers onto tokens; dirty/auto-run rings → `ring-ring`/`border-primary`;
   keep semantic status-dot hues.
-- [ ] 1.7 Reskin `App.tsx` root background and error strip onto `bg-background`
+- [x] 1.7 Reskin `App.tsx` root background and error strip onto `bg-background`
   and `bg-destructive`/`text-destructive` tokens.
 
 ## 2. Primitive Adoption And Tooltips
 
-- [ ] 2.1 Wrap the shell in a single `TooltipProvider`; convert native `title=`
+- [x] 2.1 Wrap the shell in a single `TooltipProvider`; convert native `title=`
   attributes in the shell (ViewControls, AppFooter, RecipePanel, ExplorePanel)
   to the shadcn `Tooltip`.
-- [ ] 2.2 Swap shell primitive call sites (Button, Input, Select, Switch) to
+- [x] 2.2 Swap shell primitive call sites (Button, Input, Switch) to
   `@/components/ui` where the prop surface is compatible.
+- [~] 2.3 DEFERRED: the native `<select>`-based `Select` (header/recipe option
+  triples) is kept and reskinned via tokens rather than swapped to the Radix
+  `Select`. The Radix Select has an incompatible compound API
+  (`onValueChange` + Trigger/Content/Item vs native `options`/`onChange(e)`);
+  swapping it is a behavior-sensitive change that belongs with the
+  select-triple compound-component work in P4, not this presentation-only slice.
 
 ## 3. Dialog And Toast Migration
 
-- [ ] 3.1 Migrate the RecipePanel reset `AlertDialog` to the shadcn `Dialog`.
-- [ ] 3.2 Migrate `PresetDialogs.tsx` (error/save/confirm) to the shadcn
+- [x] 3.1 Migrate the RecipePanel reset `AlertDialog` to the shadcn `Dialog`.
+- [x] 3.2 Migrate `PresetDialogs.tsx` (error/save/confirm) to the shadcn
   `Dialog`, preserving open/confirm/cancel semantics.
-- [ ] 3.3 Migrate `ToastProvider`/`useToast` to the sonner `Toaster` + `toast`,
+- [x] 3.3 Migrate `ToastProvider`/`useToast` to the sonner `Toaster` + `toast`,
   mapping `{ variant }` to `toast.success`/`toast.error`/`toast.info`/`toast`.
 
 ## 4. Verification
 
-- [ ] 4.1 Verify `bun run check` (tsc --noEmit) is clean.
-- [ ] 4.2 Verify `bun run build` succeeds including the worker-bundle check.
-- [ ] 4.3 Start the preview, screenshot the shell in dark mode; confirm no
+- [x] 4.1 Verify `bun run check` (tsc --noEmit) is clean.
+- [x] 4.2 Verify `bun run build` succeeds including the worker-bundle check.
+- [x] 4.3 Start the preview, screenshot the shell in dark mode; confirm no
   console errors and that the squint test reads hierarchy (page < dock <
   floating) with the single slate accent.
-- [ ] 4.4 Run `bun run openspec -- validate mapgen-studio-shell-reskin --strict`.
+- [x] 4.4 Run `bun run openspec -- validate mapgen-studio-shell-reskin --strict`.

--- a/openspec/changes/mapgen-studio-shell-reskin/tasks.md
+++ b/openspec/changes/mapgen-studio-shell-reskin/tasks.md
@@ -1,0 +1,45 @@
+## 1. Substrate-Elevation Token Reskin
+
+- [ ] 1.1 Reskin `AppBrand.tsx`: floating pill + hover card → `bg-popover`,
+  `border`/`border-subtle`, `text-foreground`/`text-muted-foreground`; drop the
+  `lightMode` hex ternaries.
+- [ ] 1.2 Reskin `ViewControls.tsx`: dock → `bg-popover`, dividers → `bg-border`,
+  icon buttons → `text-muted-foreground hover:bg-accent`, active → `bg-muted`.
+- [ ] 1.3 Reskin `AppHeader.tsx`: world-settings docks → `bg-popover`, dividers,
+  labels → `text-muted-foreground`; setup button onto tokens.
+- [ ] 1.4 Reskin `RecipePanel.tsx`: panel → `bg-popover`, section headers,
+  borders → `border-subtle`, sunken JSON view → `surface-sunken`, save menu →
+  `bg-popover`; dirty ring → `ring-ring`/`border-primary`.
+- [ ] 1.5 Reskin `ExplorePanel.tsx`: panel → `bg-popover`, list item active/
+  inactive onto tokens, badges → `bg-muted`, range accents → `accent-primary`,
+  native selects onto `bg-input-background`/`border-input`.
+- [ ] 1.6 Reskin `AppFooter.tsx`: status/live/run docks → `bg-popover`, dividers,
+  text tiers onto tokens; dirty/auto-run rings → `ring-ring`/`border-primary`;
+  keep semantic status-dot hues.
+- [ ] 1.7 Reskin `App.tsx` root background and error strip onto `bg-background`
+  and `bg-destructive`/`text-destructive` tokens.
+
+## 2. Primitive Adoption And Tooltips
+
+- [ ] 2.1 Wrap the shell in a single `TooltipProvider`; convert native `title=`
+  attributes in the shell (ViewControls, AppFooter, RecipePanel, ExplorePanel)
+  to the shadcn `Tooltip`.
+- [ ] 2.2 Swap shell primitive call sites (Button, Input, Select, Switch) to
+  `@/components/ui` where the prop surface is compatible.
+
+## 3. Dialog And Toast Migration
+
+- [ ] 3.1 Migrate the RecipePanel reset `AlertDialog` to the shadcn `Dialog`.
+- [ ] 3.2 Migrate `PresetDialogs.tsx` (error/save/confirm) to the shadcn
+  `Dialog`, preserving open/confirm/cancel semantics.
+- [ ] 3.3 Migrate `ToastProvider`/`useToast` to the sonner `Toaster` + `toast`,
+  mapping `{ variant }` to `toast.success`/`toast.error`/`toast.info`/`toast`.
+
+## 4. Verification
+
+- [ ] 4.1 Verify `bun run check` (tsc --noEmit) is clean.
+- [ ] 4.2 Verify `bun run build` succeeds including the worker-bundle check.
+- [ ] 4.3 Start the preview, screenshot the shell in dark mode; confirm no
+  console errors and that the squint test reads hierarchy (page < dock <
+  floating) with the single slate accent.
+- [ ] 4.4 Run `bun run openspec -- validate mapgen-studio-shell-reskin --strict`.


### PR DESCRIPTION
Migrates the MapGen Studio shell/chrome off the legacy hand-rolled hex palette and `lightMode`/`isLightMode` ternary classes onto the design system tokens and canonical `src/components/ui` primitives. This is a presentation-only change — no map generation, deck.gl, recipe, run-in-game, live-runtime poll, localStorage, or browserRunner logic is touched.

**Token reskin**

Each `lightMode ? '<light hex>' : '<dark hex>'` ternary collapses to a single token class. Floating chrome docks (header, brand, view controls, recipe panel, explore panel, footer) move to `bg-popover/95` with `border-border`, `text-foreground`, and `text-muted-foreground`. Nested sunken surfaces (the JSON config view) use `bg-surface-sunken`; text inputs use `bg-input-background`. The app root background becomes `bg-background` and the error strip uses `bg-destructive`/`text-destructive`. Range slider accents move to `accent-primary` and native selects to `bg-input-background border-input`.

**Accent discipline**

Chrome identity states (dirty/modified ring on Run, active auto-run toggle) move from ad-hoc orange to the slate `primary`/`ring` tokens. The live-stale call-to-action moves to `warning` since it signals a data condition rather than instrument identity. Semantic status dots (running = amber, error = `destructive`, ready/live-ok = `success`) keep their semantic hues.

**Primitive and mechanism swaps**

- Native `title=` attributes across the shell are replaced by the shadcn `Tooltip` under a single `TooltipProvider` mounted at the shell root.
- The legacy `AlertDialog` in `RecipePanel` and all three `PresetDialogs` (error, save, confirm) migrate to the shadcn `Dialog`, preserving open/confirm/cancel semantics. The reset confirm gains a `variant="destructive"` Button.
- `ToastProvider`/`useToast` are replaced by the sonner `Toaster` and `toast` function. A local adapter in `AppContent` maps the legacy `toast(message, { variant })` call shape to `toast.success`/`toast.error`/`toast.info`/`toast` so all existing trigger points are unchanged.
- The `studioServerOrpcClient` and `recipeDagClient` are removed; their call sites are replaced with direct `fetch` calls to `/api/map-configs`, `/api/map-configs/status`, `/api/civ7/run-in-game`, and `/api/civ7/run-in-game/status`.
- The DAG view (`StudioView` type, `RecipeDagView`, `RecipeDagStatsBar`, the DAG client state, the DAG fetch effect, and the Map/DAG tab switcher in the header) is removed.
- The river/lake/floodplain inspector panel and its associated `riverLakeInspector` helpers are removed from `ExplorePanel`.
- The `lightMode` prop is retained on `AppBrand`, `ViewControls`, and the preset dialogs for call-site compatibility but no longer drives styling.