### PR TITLE
feat(mapgen-studio): migrate client transport to oRPC, add TanStack Query client, and introduce Zustand viewStore

### DIFF
--- a/apps/mapgen-studio/package.json
+++ b/apps/mapgen-studio/package.json
@@ -56,7 +56,8 @@
     "react-dom": "^19.2.4",
     "sonner": "2.0.7",
     "tailwind-merge": "latest",
-    "typebox": "^1.0.80"
+    "typebox": "^1.0.80",
+    "zustand": "5.0.14"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.13",

--- a/apps/mapgen-studio/src/App.tsx
+++ b/apps/mapgen-studio/src/App.tsx
@@ -70,7 +70,6 @@ import {
 } from "./features/mapConfigSave/status";
 import {
   buildLiveRuntimeErrorState,
-  buildLiveRuntimeSnapshotQuery,
   buildLiveRuntimeSnapshotRequest,
   buildLiveRuntimeSnapshotState,
   buildLiveRuntimeStatusState,
@@ -116,6 +115,9 @@ import {
   type BuiltInPreset,
 } from "./recipes/catalog";
 import { getOverlaySuggestions } from "./recipes/overlaySuggestions";
+
+import { orpcClient } from "./lib/orpc";
+import { useViewStore } from "./stores/viewStore";
 import { isAbortLikeError } from "./shared/async";
 import { clampNumber } from "./shared/number";
 import {
@@ -202,18 +204,35 @@ function AppContent(props: AppContentProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [viewportSize, setViewportSize] = useState({ width: 800, height: 600 });
 
-  const [showGrid, setShowGrid] = useState(true);
-  const [showEdges, setShowEdges] = useState(true);
-  const [overlaySelectionId, setOverlaySelectionId] = useState("");
-  const [overlayOpacity, setOverlayOpacity] = useState(0.45);
-  const [overlayVariantKeyPreference, setOverlayVariantKeyPreference] = useState<string | null>(null);
-  const [eraMode, setEraMode] = useState<"auto" | "fixed">("auto");
-  const [manualEra, setManualEra] = useState(1);
-  const [recipeSectionCollapsed, setRecipeSectionCollapsed] = useState(false);
-  const [configSectionCollapsed, setConfigSectionCollapsed] = useState(false);
-  const [exploreStageExpanded, setExploreStageExpanded] = useState(true);
-  const [exploreStepExpanded, setExploreStepExpanded] = useState(true);
-  const [exploreLayersExpanded, setExploreLayersExpanded] = useState(true);
+  // View-only state is owned by `viewStore` (Zustand, architecture/10 §3). These
+  // are presentation toggles/selections with no server coupling and no persistence
+  // contract; the store is the single owner so this component no longer holds a
+  // `useState` mirror. Field + setter names match the store API, so downstream
+  // usage in this file is unchanged.
+  const showGrid = useViewStore((s) => s.showGrid);
+  const setShowGrid = useViewStore((s) => s.setShowGrid);
+  const showEdges = useViewStore((s) => s.showEdges);
+  const setShowEdges = useViewStore((s) => s.setShowEdges);
+  const overlaySelectionId = useViewStore((s) => s.overlaySelectionId);
+  const setOverlaySelectionId = useViewStore((s) => s.setOverlaySelectionId);
+  const overlayOpacity = useViewStore((s) => s.overlayOpacity);
+  const setOverlayOpacity = useViewStore((s) => s.setOverlayOpacity);
+  const overlayVariantKeyPreference = useViewStore((s) => s.overlayVariantKeyPreference);
+  const setOverlayVariantKeyPreference = useViewStore((s) => s.setOverlayVariantKeyPreference);
+  const eraMode = useViewStore((s) => s.eraMode);
+  const setEraMode = useViewStore((s) => s.setEraMode);
+  const manualEra = useViewStore((s) => s.manualEra);
+  const setManualEra = useViewStore((s) => s.setManualEra);
+  const recipeSectionCollapsed = useViewStore((s) => s.recipeSectionCollapsed);
+  const setRecipeSectionCollapsed = useViewStore((s) => s.setRecipeSectionCollapsed);
+  const configSectionCollapsed = useViewStore((s) => s.configSectionCollapsed);
+  const setConfigSectionCollapsed = useViewStore((s) => s.setConfigSectionCollapsed);
+  const exploreStageExpanded = useViewStore((s) => s.exploreStageExpanded);
+  const setExploreStageExpanded = useViewStore((s) => s.setExploreStageExpanded);
+  const exploreStepExpanded = useViewStore((s) => s.exploreStepExpanded);
+  const setExploreStepExpanded = useViewStore((s) => s.setExploreStepExpanded);
+  const exploreLayersExpanded = useViewStore((s) => s.exploreLayersExpanded);
+  const setExploreLayersExpanded = useViewStore((s) => s.setExploreLayersExpanded);
   const [autoRunEnabled, setAutoRunEnabled] = useState(false);
   const autoRunTimerRef = useRef<number | null>(null);
   const autoRunPendingRef = useRef(false);
@@ -496,10 +515,34 @@ function AppContent(props: AppContentProps) {
       activeLiveSnapshotRequestKeyRef.current = request.key;
 
       try {
-        const res = await fetch(`/api/civ7/live/snapshot?${buildLiveRuntimeSnapshotQuery(request)}`, {
-          signal: snapshotAbortController.signal,
-        });
-        const body = (await res.json().catch(() => null)) as unknown;
+        // EVERYTHING talks oRPC: the snapshot read now goes through the typed
+        // client instead of a manual `fetch`. Parity is preserved exactly — the
+        // live/snapshot procedure returns the 200 body on success and throws an
+        // `ORPCError` (status 400) on a bad request, which maps to the SAME
+        // `{ ok:false, error }` shape the legacy `res.ok ? body : {...}` branch
+        // produced. The request-key staleness gate (`shouldCommitLiveRuntimeSnapshot`)
+        // and the abort plumbing below are untouched.
+        let body: unknown;
+        try {
+          body = await orpcClient.civ7.live.snapshot(
+            {
+              x: request.bounds.x,
+              y: request.bounds.y,
+              width: request.bounds.width,
+              height: request.bounds.height,
+              fields: request.fields.join(","),
+              maxPlots: request.maxPlots,
+              ...(request.playerId === undefined ? {} : { playerId: request.playerId }),
+            },
+            { signal: snapshotAbortController.signal },
+          );
+        } catch (snapshotErr) {
+          if (cancelled || isAbortLikeError(snapshotErr)) throw snapshotErr;
+          body = {
+            ok: false,
+            error: snapshotErr instanceof Error ? snapshotErr.message : "Live snapshot unavailable",
+          };
+        }
         if (cancelled) return;
         if (!shouldCommitLiveRuntimeSnapshot({
           activeRequestKey: activeLiveSnapshotRequestKeyRef.current,
@@ -510,7 +553,10 @@ function AppContent(props: AppContentProps) {
         }
         const snapshotState = buildLiveRuntimeSnapshotState({
           request,
-          body: res.ok ? body : { ok: false, error: isPlainObject(body) ? body.error : `HTTP ${res.status}` },
+          // `body` is already the procedure output (success) or the `{ ok:false,
+          // error }` envelope built from the thrown `ORPCError` above — the legacy
+          // `res.ok ? … : …` discrimination now lives in the try/catch.
+          body,
           observedAtFallback: new Date().toISOString(),
         });
         liveSnapshotFailureCountRef.current = snapshotState.status === "ok" ? 0 : liveSnapshotFailureCountRef.current + 1;
@@ -552,22 +598,35 @@ function AppContent(props: AppContentProps) {
       statusAbortController?.abort();
       statusAbortController = new AbortController();
       try {
-        const [res, readinessResult] = await Promise.all([
-          fetch("/api/civ7/live/status", { signal: statusAbortController.signal }),
-          civ7ControlOrpcClient.readiness.current({}),
-        ]);
-        const body = (await res.json().catch(() => null)) as unknown;
+        // EVERYTHING talks oRPC: the live-status read now goes through the typed
+        // client. Parity preserved exactly — live/status returns 200 (with per-field
+        // embedded `{ error }` via allSettled) on partial failure and only throws an
+        // `ORPCError` (status 500) on an outer defect. That throw maps to the SAME
+        // outer-catch path the legacy `!res.ok` branch hit (rethrown as an `Error`
+        // carrying the message), so the adaptive-backoff failure accounting below is
+        // unchanged.
+        let body: unknown;
+        try {
+          const [liveStatus, readinessResult] = await Promise.all([
+            orpcClient.civ7.live.status({}, { signal: statusAbortController.signal }),
+            civ7ControlOrpcClient.readiness.current({}),
+          ]);
+          body = isPlainObject(liveStatus)
+            ? {
+                ...liveStatus,
+                status: {
+                  ...(isPlainObject(liveStatus.status) ? liveStatus.status : {}),
+                  readiness: readinessResult.readiness,
+                },
+              }
+            : liveStatus;
+        } catch (statusErr) {
+          if (cancelled || isAbortLikeError(statusErr)) throw statusErr;
+          throw new Error(statusErr instanceof Error ? statusErr.message : "Live status unavailable");
+        }
         if (cancelled) return;
-        if (!res.ok || !body) throw new Error(isPlainObject(body) && typeof body.error === "string" ? body.error : `HTTP ${res.status}`);
-        const bodyWithOrpcReadiness = isPlainObject(body)
-          ? {
-              ...body,
-              status: {
-                ...(isPlainObject(body.status) ? body.status : {}),
-                readiness: readinessResult.readiness,
-              },
-            }
-          : body;
+        if (!body) throw new Error("Live status unavailable");
+        const bodyWithOrpcReadiness = body;
 
         const statusState = buildLiveRuntimeStatusState({
           body: bodyWithOrpcReadiness,
@@ -719,8 +778,12 @@ function AppContent(props: AppContentProps) {
     return () => ro.disconnect();
   }, []);
 
-  const [selectedStageId, setSelectedStageId] = useState("");
-  const [selectedStepId, setSelectedStepId] = useState("");
+  // Selected stage/step are part of the view surface — owned by `viewStore`
+  // (single owner; no App-local mirror), per architecture/10 §3.
+  const selectedStageId = useViewStore((s) => s.selectedStageId);
+  const setSelectedStageId = useViewStore((s) => s.setSelectedStageId);
+  const selectedStepId = useViewStore((s) => s.selectedStepId);
+  const setSelectedStepId = useViewStore((s) => s.setSelectedStepId);
 
   const recipeOptions = useMemo(
     () => STUDIO_RECIPE_OPTIONS.map((opt) => ({ value: opt.id, label: opt.label })),

--- a/apps/mapgen-studio/src/features/civ7Setup/api.ts
+++ b/apps/mapgen-studio/src/features/civ7Setup/api.ts
@@ -1,9 +1,18 @@
-// Civ7 setup HTTP surface: live setup-config snapshot, saved configurations,
+// Civ7 setup data surface: live setup-config snapshot, saved configurations,
 // the setup option catalog, and autoplay control.
 //
-// Thin `fetch` wrappers over `/api/civ7/*`. Extracted verbatim from `App.tsx`
-// during the app-decomposition slice — request shapes, the optional abort
-// signal, and the per-endpoint error/status-code handling are unchanged.
+// EVERYTHING talks oRPC (FRAME §4.7): these callers speak the studio's own
+// `@civ7/studio-server` contract through the typed oRPC client (`src/lib/orpc.ts`)
+// — there is NO manual `fetch` of `/api/*` here anymore. The request shapes, the
+// optional abort signal, and the per-endpoint error/status-code RESULT shapes are
+// preserved verbatim from the previous hand-rolled fetch wrappers: the transport
+// moved from `fetch` to the oRPC client, the returned `{ ok, error, statusCode,
+// observedAt }` envelopes did not. The non-uniform per-procedure status codes
+// (setup-config → 503, saved-configs/setup-catalog → 500) survive because the
+// router maps them onto `ORPCError.status`, which we read back below.
+import { ORPCError } from "@orpc/client";
+
+import { orpcClient } from "../../lib/orpc";
 import type { Civ7SavedSetupConfigFile, Civ7SetupSnapshotLike } from "./setupConfig";
 
 export type Civ7SetupCatalogOption = Readonly<{
@@ -21,33 +30,46 @@ export type Civ7SetupCatalog = Readonly<{
   gameSpeeds: ReadonlyArray<Civ7SetupCatalogOption>;
 }>;
 
+/**
+ * Translate a thrown oRPC client error into the legacy failure envelope fields.
+ *
+ * The studio-server router re-throws per-procedure `ORPCError`s whose `status`
+ * pins the legacy HTTP code and whose `data` carries the extra body fields
+ * (`observedAt`, …). A non-`ORPCError` throw (e.g. the link could not reach the
+ * dev server) maps to the same `err instanceof Error ? err.message : fallback`
+ * shape the old `catch` blocks used, with no `statusCode`.
+ */
+function orpcFailure(
+  err: unknown,
+  fallback: string,
+): { error: string; statusCode?: number; observedAt?: string } {
+  if (err instanceof ORPCError) {
+    const data = (err.data ?? undefined) as { observedAt?: string } | undefined;
+    return {
+      error: err.message || `HTTP ${err.status}`,
+      statusCode: err.status,
+      ...(typeof data?.observedAt === "string" ? { observedAt: data.observedAt } : {}),
+    };
+  }
+  return { error: err instanceof Error ? err.message : fallback };
+}
+
 export async function fetchCiv7SetupConfig(options: { signal?: AbortSignal } = {}): Promise<
   | { ok: true; observedAt: string; setup: Civ7SetupSnapshotLike }
   | { ok: false; error: string; observedAt?: string; statusCode?: number }
 > {
   try {
-    const res = await fetch("/api/civ7/setup-config", options.signal ? { signal: options.signal } : undefined);
-    const body = (await res.json().catch(() => null)) as {
-      ok?: boolean;
-      observedAt?: string;
-      setup?: Civ7SetupSnapshotLike;
-      error?: string;
-    } | null;
-    if (!res.ok || !body?.ok || !body.setup) {
-      return {
-        ok: false,
-        error: body?.error ?? `HTTP ${res.status}`,
-        observedAt: body?.observedAt,
-        statusCode: res.status,
-      };
-    }
+    const body = await orpcClient.civ7.setupConfig(
+      {},
+      options.signal ? { signal: options.signal } : undefined,
+    );
     return {
       ok: true,
       observedAt: body.observedAt ?? new Date().toISOString(),
-      setup: body.setup,
+      setup: body.setup as Civ7SetupSnapshotLike,
     };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "Civ7 setup config unavailable" };
+    return { ok: false, ...orpcFailure(err, "Civ7 setup config unavailable") };
   }
 }
 
@@ -56,30 +78,15 @@ export async function fetchCiv7SavedSetupConfigs(): Promise<
   | { ok: false; error: string; observedAt?: string; statusCode?: number }
 > {
   try {
-    const res = await fetch("/api/civ7/saved-configs");
-    const body = (await res.json().catch(() => null)) as {
-      ok?: boolean;
-      observedAt?: string;
-      directory?: string;
-      configurations?: ReadonlyArray<Civ7SavedSetupConfigFile>;
-      error?: string;
-    } | null;
-    if (!res.ok || !body?.ok || !Array.isArray(body.configurations)) {
-      return {
-        ok: false,
-        error: body?.error ?? `HTTP ${res.status}`,
-        observedAt: body?.observedAt,
-        statusCode: res.status,
-      };
-    }
+    const body = await orpcClient.civ7.savedConfigs({});
     return {
       ok: true,
       observedAt: body.observedAt ?? new Date().toISOString(),
       directory: body.directory ?? "",
-      configurations: body.configurations,
+      configurations: body.configurations as unknown as ReadonlyArray<Civ7SavedSetupConfigFile>,
     };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "Civ7 saved configurations unavailable" };
+    return { ok: false, ...orpcFailure(err, "Civ7 saved configurations unavailable") };
   }
 }
 
@@ -88,24 +95,10 @@ export async function fetchCiv7SetupCatalog(): Promise<
   | { ok: false; error: string; observedAt?: string; statusCode?: number }
 > {
   try {
-    const res = await fetch("/api/civ7/setup-catalog");
-    const body = (await res.json().catch(() => null)) as {
-      ok?: boolean;
-      catalog?: Civ7SetupCatalog;
-      error?: string;
-      observedAt?: string;
-    } | null;
-    if (!res.ok || !body?.ok || !body.catalog) {
-      return {
-        ok: false,
-        error: body?.error ?? `HTTP ${res.status}`,
-        observedAt: body?.observedAt,
-        statusCode: res.status,
-      };
-    }
-    return { ok: true, catalog: body.catalog };
+    const body = await orpcClient.civ7.setupCatalog({});
+    return { ok: true, catalog: body.catalog as unknown as Civ7SetupCatalog };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "Civ7 setup catalog unavailable" };
+    return { ok: false, ...orpcFailure(err, "Civ7 setup catalog unavailable") };
   }
 }
 
@@ -117,23 +110,24 @@ export async function requestCiv7Autoplay(action: "start" | "stop"): Promise<{
   error?: string;
 }> {
   try {
-    const res = await fetch("/api/civ7/autoplay", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action }),
-    });
-    const body = (await res.json().catch(() => null)) as {
-      ok?: boolean;
-      action?: "start" | "stop";
-      autoplay?: { isActive?: boolean; isPaused?: boolean; isPausedOrPending?: boolean };
-      game?: { turn?: { ok?: boolean; value?: number } };
-      error?: string;
-    } | null;
-    if (!res.ok || !body?.ok) {
-      return { ok: false, error: body?.error ?? `HTTP ${res.status}` };
+    const body = await orpcClient.civ7.autoplay({ action });
+    // Parity: the autoplay procedure returns 200 with `ok = result.verified`, so a
+    // succeeded-transport-but-unverified action still surfaces as `{ ok:false }`
+    // (the legacy handler returned `{ ok:false, error }` when `body.ok` was falsy).
+    if (!body.ok) {
+      return { ok: false, error: "Civ7 autoplay request failed" };
     }
-    return { ok: true, action: body.action, autoplay: body.autoplay, game: body.game };
+    return {
+      ok: true,
+      action: body.action,
+      autoplay: body.autoplay as {
+        isActive?: boolean;
+        isPaused?: boolean;
+        isPausedOrPending?: boolean;
+      },
+      game: body.game as { turn?: { ok?: boolean; value?: number } },
+    };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "Civ7 autoplay request failed" };
+    return { ok: false, error: orpcFailure(err, "Civ7 autoplay request failed").error };
   }
 }

--- a/apps/mapgen-studio/src/features/mapConfigSave/api.ts
+++ b/apps/mapgen-studio/src/features/mapConfigSave/api.ts
@@ -1,10 +1,16 @@
-// Map-config save/deploy HTTP surface and its persistence key.
+// Map-config save/deploy data surface and its persistence key.
 //
-// Thin `fetch` wrappers over the `/api/map-configs*` endpoints plus the
-// localStorage key used to correlate the last save/deploy request across
-// dev-server reloads. Extracted verbatim from `App.tsx` during the
-// app-decomposition slice — request shapes, error handling, and the key string
-// are unchanged (localStorage contract preserved).
+// EVERYTHING talks oRPC (FRAME §4.7): these callers speak the studio's own
+// `@civ7/studio-server` contract through the typed oRPC client (`src/lib/orpc.ts`)
+// — there is NO manual `fetch` of `/api/map-configs*` here anymore. The request
+// shapes, the running-status poll loop, the error handling, and the localStorage
+// key string are preserved verbatim (localStorage contract is hard-core parity):
+// only the transport moved from `fetch` to the oRPC client. The non-uniform error
+// codes (saveDeploy validation → 400, status miss → 404) survive on
+// `ORPCError.status`.
+import { ORPCError } from "@orpc/client";
+
+import { orpcClient } from "../../lib/orpc";
 import { delay } from "../../shared/async";
 import type { MapConfigSaveDeployStatus } from "./status";
 
@@ -19,18 +25,22 @@ export function toConfigId(label: string): string {
   return id || `map-config-${Date.now()}`;
 }
 
+/** Map a thrown oRPC client error to `{ error, statusCode }` (legacy code via `ORPCError.status`). */
+function saveDeployFailure(err: unknown, fallback: string): { error: string; statusCode?: number } {
+  if (err instanceof ORPCError) {
+    return { error: err.message || `HTTP ${err.status}`, statusCode: err.status };
+  }
+  return { error: err instanceof Error ? err.message : fallback };
+}
+
 export async function fetchMapConfigSaveDeployStatus(
   requestId: string,
 ): Promise<MapConfigSaveDeployStatus | { ok: false; error: string; statusCode?: number }> {
   try {
-    const res = await fetch(`/api/map-configs/status?requestId=${encodeURIComponent(requestId)}`);
-    const body = (await res.json().catch(() => null)) as (Partial<MapConfigSaveDeployStatus> & { error?: string }) | null;
-    if (!res.ok || !body?.requestId) {
-      return { ok: false, error: body?.error ?? `HTTP ${res.status}`, statusCode: res.status };
-    }
+    const body = await orpcClient.mapConfigs.status({ requestId });
     return body as MapConfigSaveDeployStatus;
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "Save/Deploy status unavailable" };
+    return { ok: false, ...saveDeployFailure(err, "Save/Deploy status unavailable") };
   }
 }
 
@@ -62,16 +72,20 @@ export async function saveRepoBackedConfig(args: {
     config: args.config,
   };
   try {
-    const res = await fetch("/api/map-configs", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ requestId: args.requestId, id: args.id, sourcePath: args.sourcePath, envelope }),
-    });
-    const body = (await res.json().catch(() => null)) as (Partial<MapConfigSaveDeployStatus> & { error?: string }) | null;
-    if (!res.ok || !body?.requestId) {
-      return { ok: false, error: body?.error ?? `HTTP ${res.status}`, path: body?.path };
+    let status: MapConfigSaveDeployStatus;
+    try {
+      status = (await orpcClient.mapConfigs.saveDeploy({
+        requestId: args.requestId,
+        id: args.id,
+        sourcePath: args.sourcePath,
+        envelope,
+      })) as MapConfigSaveDeployStatus;
+    } catch (err) {
+      // Parity: a saveDeploy throw carried `path` in the legacy body when present;
+      // the oRPC error data does not, so we surface the failure without a path
+      // (the engine only attaches `path` to the in-progress status, polled below).
+      return { ok: false, ...saveDeployFailure(err, "Repo config save failed") };
     }
-    let status = body as MapConfigSaveDeployStatus;
     args.onStatus?.(status);
     while (status.status === "running") {
       await delay(500);

--- a/apps/mapgen-studio/src/features/runInGame/api.ts
+++ b/apps/mapgen-studio/src/features/runInGame/api.ts
@@ -1,11 +1,42 @@
-// Run-in-game HTTP surface: start a run and poll its status.
+// Run-in-game data surface: start a run and poll its status.
 //
-// Thin `fetch` wrappers over `/api/civ7/run-in-game*`. Extracted verbatim from
-// `App.tsx` during the app-decomposition slice — the request body shape
-// (including the `assertNoRawControlFields`-protected payload assembled here),
-// non-uniform error handling, and status-code propagation are unchanged.
+// EVERYTHING talks oRPC (FRAME §4.7): these callers speak the studio's own
+// `@civ7/studio-server` contract through the typed oRPC client (`src/lib/orpc.ts`)
+// — there is NO manual `fetch` of `/api/*` here anymore. The request body shape
+// (including the `assertNoRawControlFields`-protected payload assembled here), the
+// non-uniform error handling, and the status-code propagation are preserved
+// verbatim: the transport moved from `fetch` to the oRPC client; the request
+// envelope, the result shapes, and the 404 `statusCode` the caller uses for
+// server-restart detection did not. The router pins the legacy HTTP code on
+// `ORPCError.status` and carries `details` (and the 404 server-id echo) in
+// `ORPCError.data`, which we read back below.
+import { ORPCError } from "@orpc/client";
+
+import { orpcClient } from "../../lib/orpc";
 import { normalizeStudioSetupConfig, type Civ7StudioSetupConfig } from "../civ7Setup/setupConfig";
 import type { RunInGameFailureDetails, RunInGameOperationStatus } from "./status";
+
+/**
+ * Translate a thrown oRPC client error into the legacy run-in-game failure
+ * envelope. `ORPCError.status` is the pinned legacy HTTP code (used for the 404
+ * restart-detection branch in `App.tsx`); `ORPCError.data.details` carries the
+ * `RunInGameFailureDetails` the engine attached. A non-`ORPCError` throw maps to
+ * the bare `err.message` shape the old `catch` block produced (no `statusCode`).
+ */
+function runInGameFailure(
+  err: unknown,
+  fallback: string,
+): { error: string; details?: RunInGameFailureDetails; statusCode?: number } {
+  if (err instanceof ORPCError) {
+    const data = (err.data ?? undefined) as { details?: RunInGameFailureDetails } | undefined;
+    return {
+      error: err.message || `HTTP ${err.status}`,
+      statusCode: err.status,
+      ...(data?.details !== undefined ? { details: data.details } : {}),
+    };
+  }
+  return { error: err instanceof Error ? err.message : fallback };
+}
 
 export async function runCurrentConfigInGame(args: {
   recipeId: string;
@@ -34,37 +65,28 @@ export async function runCurrentConfigInGame(args: {
   | { ok: false; error: string; details?: RunInGameFailureDetails; statusCode?: number }
 > {
   try {
-    const res = await fetch("/api/civ7/run-in-game", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        recipeId: args.recipeId,
-        seed: args.seed,
-        mapSize: args.mapSize,
-        playerCount: args.playerCount,
-        resources: args.resources,
-        setupConfig: normalizeStudioSetupConfig(args.setupConfig),
-        materialization: { mode: args.materializationMode },
-        ...(args.restartCivProcess ? { recovery: { restartCivProcess: true } } : {}),
-        selectedConfig: args.selectedConfig,
-        config: args.config,
-        sourceSnapshot: args.sourceSnapshot,
-      }),
-    });
-    const body = (await res.json().catch(() => null)) as
-      | (Partial<RunInGameOperationStatus> & { error?: string; details?: RunInGameFailureDetails })
-      | null;
-    if (!res.ok || !body?.requestId) {
-      return {
-        ok: false,
-        error: body?.error ?? `HTTP ${res.status}`,
-        details: body?.details,
-        statusCode: res.status,
-      };
-    }
+    // The request envelope is assembled exactly as before (the server runs
+    // `assertNoRawControlFields` over it); only the transport is the oRPC client.
+    // The legacy handler posted `selectedConfig` verbatim (its `id` may be absent
+    // for disposable runs) and `parseRunInGameSetupRequest` tolerates that, so we
+    // pass it through the permissive (`.catchall`) start input unchanged.
+    const request = {
+      recipeId: args.recipeId,
+      seed: args.seed,
+      mapSize: args.mapSize,
+      playerCount: args.playerCount,
+      resources: args.resources,
+      setupConfig: normalizeStudioSetupConfig(args.setupConfig),
+      materialization: { mode: args.materializationMode },
+      ...(args.restartCivProcess ? { recovery: { restartCivProcess: true } } : {}),
+      selectedConfig: args.selectedConfig,
+      config: args.config,
+      sourceSnapshot: args.sourceSnapshot,
+    } as unknown as Parameters<typeof orpcClient.runInGame.start>[0];
+    const body = await orpcClient.runInGame.start(request);
     return body as RunInGameOperationStatus;
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "Run in Game failed" };
+    return { ok: false, ...runInGameFailure(err, "Run in Game failed") };
   }
 }
 
@@ -72,13 +94,14 @@ export async function fetchRunInGameStatus(
   requestId: string,
 ): Promise<RunInGameOperationStatus | { ok: false; error: string; statusCode?: number }> {
   try {
-    const res = await fetch(`/api/civ7/run-in-game/status?requestId=${encodeURIComponent(requestId)}`);
-    const body = (await res.json().catch(() => null)) as (Partial<RunInGameOperationStatus> & { error?: string }) | null;
-    if (!res.ok || !body?.requestId) {
-      return { ok: false, error: body?.error ?? `HTTP ${res.status}`, statusCode: res.status };
-    }
+    const body = await orpcClient.runInGame.status({ requestId });
     return body as RunInGameOperationStatus;
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "Run in Game status unavailable" };
+    const failure = runInGameFailure(err, "Run in Game status unavailable");
+    return {
+      ok: false,
+      error: failure.error,
+      ...(failure.statusCode !== undefined ? { statusCode: failure.statusCode } : {}),
+    };
   }
 }

--- a/apps/mapgen-studio/src/lib/query.ts
+++ b/apps/mapgen-studio/src/lib/query.ts
@@ -1,0 +1,34 @@
+import { QueryClient } from "@tanstack/react-query";
+
+/**
+ * The studio's single TanStack Query client.
+ *
+ * Server state flows through oRPC-native query utils (`src/lib/orpc.ts`) into
+ * standard `useQuery`/`useMutation`; this client provides their shared cache and
+ * defaults. Per architecture/10 §2 we own ONLY the `QueryClient` — no hand-written
+ * query-key factory or wrapper-hook lib.
+ *
+ * Defaults are tuned for a live-authoring tool that polls a local dev server:
+ * - `staleTime` is short (a few seconds) — setup catalog / saved configs change
+ *   when the game or filesystem does, so we want refetch-on-focus to feel live
+ *   without hammering the socket on every render.
+ * - `retry: 1` — the studio surfaces transport errors inline (the legacy `/api`
+ *   callers returned `{ ok:false, error }`); a single retry smooths a transient
+ *   socket blip without masking a real outage behind exponential backoff.
+ * - `refetchOnWindowFocus` stays on (the legacy saved-configs effect re-loaded on
+ *   `window.focus`) so reconnecting the game refreshes the catalog.
+ */
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 5_000,
+        retry: 1,
+        refetchOnWindowFocus: true,
+      },
+      mutations: {
+        retry: 0,
+      },
+    },
+  });
+}

--- a/apps/mapgen-studio/src/main.tsx
+++ b/apps/mapgen-studio/src/main.tsx
@@ -9,17 +9,25 @@ import "./index.css";
 
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { App } from "./App";
+import { createQueryClient } from "./lib/query";
+
+// One QueryClient for the app lifetime. Created at the module root (not inside a
+// component) so the cache survives re-renders and the dev-only StrictMode skip
+// below cannot duplicate it. Server state reaches components through oRPC-native
+// query utils (`src/lib/orpc.ts`) bound to this client.
+const queryClient = createQueryClient();
+
+const app = (
+  <QueryClientProvider client={queryClient}>
+    <App />
+  </QueryClientProvider>
+);
 
 // deck.gl/luma currently has a known issue under React StrictMode in dev
 // (double-mount can break device/canvas initialization and crash on resize).
 // Keep StrictMode enabled for prod builds, but disable it during local dev for stability.
-const app = import.meta.env.DEV ? (
-  <App />
-) : (
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
+const tree = import.meta.env.DEV ? app : <StrictMode>{app}</StrictMode>;
 
-createRoot(document.getElementById("root")!).render(app);
+createRoot(document.getElementById("root")!).render(tree);

--- a/apps/mapgen-studio/src/stores/viewStore.ts
+++ b/apps/mapgen-studio/src/stores/viewStore.ts
@@ -1,0 +1,100 @@
+import { create } from "zustand";
+
+/**
+ * `viewStore` — the single owner of browser-only VIEW state (architecture/10 §3).
+ *
+ * This is presentation state with NO server coupling and NO persistence contract:
+ * canvas toggles, overlay selection, era mode, panel collapse, and the selected
+ * stage/step. Per the "crisp rule" (§3) it lives in Zustand, never in TanStack
+ * Query; server data is never mirrored in here. It is intentionally NOT persisted —
+ * these are ephemeral view preferences, unlike the authoring/run state whose
+ * localStorage schema is a parity contract (kept in `features/*` for now).
+ *
+ * Each field exposes a `setX` action whose signature mirrors React's `useState`
+ * setter (value OR updater function), so the migration off scattered `useState`
+ * is a drop-in: call sites that did `setManualEra((prev) => …)` keep working.
+ */
+
+type Updater<T> = T | ((prev: T) => T);
+
+function resolve<T>(updater: Updater<T>, prev: T): T {
+  return typeof updater === "function" ? (updater as (p: T) => T)(prev) : updater;
+}
+
+export type EraMode = "auto" | "fixed";
+
+export type ViewState = {
+  // Canvas layer toggles
+  showGrid: boolean;
+  showEdges: boolean;
+  // Overlay selection
+  overlaySelectionId: string;
+  overlayOpacity: number;
+  overlayVariantKeyPreference: string | null;
+  // Era controls
+  eraMode: EraMode;
+  manualEra: number;
+  // Panel collapse / expand
+  recipeSectionCollapsed: boolean;
+  configSectionCollapsed: boolean;
+  exploreStageExpanded: boolean;
+  exploreStepExpanded: boolean;
+  exploreLayersExpanded: boolean;
+  // Explore selection (single owner; App no longer mirrors these)
+  selectedStageId: string;
+  selectedStepId: string;
+
+  setShowGrid: (next: Updater<boolean>) => void;
+  setShowEdges: (next: Updater<boolean>) => void;
+  setOverlaySelectionId: (next: Updater<string>) => void;
+  setOverlayOpacity: (next: Updater<number>) => void;
+  setOverlayVariantKeyPreference: (next: Updater<string | null>) => void;
+  setEraMode: (next: Updater<EraMode>) => void;
+  setManualEra: (next: Updater<number>) => void;
+  setRecipeSectionCollapsed: (next: Updater<boolean>) => void;
+  setConfigSectionCollapsed: (next: Updater<boolean>) => void;
+  setExploreStageExpanded: (next: Updater<boolean>) => void;
+  setExploreStepExpanded: (next: Updater<boolean>) => void;
+  setExploreLayersExpanded: (next: Updater<boolean>) => void;
+  setSelectedStageId: (next: Updater<string>) => void;
+  setSelectedStepId: (next: Updater<string>) => void;
+};
+
+export const useViewStore = create<ViewState>((set) => ({
+  showGrid: true,
+  showEdges: true,
+  overlaySelectionId: "",
+  overlayOpacity: 0.45,
+  overlayVariantKeyPreference: null,
+  eraMode: "auto",
+  manualEra: 1,
+  recipeSectionCollapsed: false,
+  configSectionCollapsed: false,
+  exploreStageExpanded: true,
+  exploreStepExpanded: true,
+  exploreLayersExpanded: true,
+  selectedStageId: "",
+  selectedStepId: "",
+
+  setShowGrid: (next) => set((s) => ({ showGrid: resolve(next, s.showGrid) })),
+  setShowEdges: (next) => set((s) => ({ showEdges: resolve(next, s.showEdges) })),
+  setOverlaySelectionId: (next) =>
+    set((s) => ({ overlaySelectionId: resolve(next, s.overlaySelectionId) })),
+  setOverlayOpacity: (next) => set((s) => ({ overlayOpacity: resolve(next, s.overlayOpacity) })),
+  setOverlayVariantKeyPreference: (next) =>
+    set((s) => ({ overlayVariantKeyPreference: resolve(next, s.overlayVariantKeyPreference) })),
+  setEraMode: (next) => set((s) => ({ eraMode: resolve(next, s.eraMode) })),
+  setManualEra: (next) => set((s) => ({ manualEra: resolve(next, s.manualEra) })),
+  setRecipeSectionCollapsed: (next) =>
+    set((s) => ({ recipeSectionCollapsed: resolve(next, s.recipeSectionCollapsed) })),
+  setConfigSectionCollapsed: (next) =>
+    set((s) => ({ configSectionCollapsed: resolve(next, s.configSectionCollapsed) })),
+  setExploreStageExpanded: (next) =>
+    set((s) => ({ exploreStageExpanded: resolve(next, s.exploreStageExpanded) })),
+  setExploreStepExpanded: (next) =>
+    set((s) => ({ exploreStepExpanded: resolve(next, s.exploreStepExpanded) })),
+  setExploreLayersExpanded: (next) =>
+    set((s) => ({ exploreLayersExpanded: resolve(next, s.exploreLayersExpanded) })),
+  setSelectedStageId: (next) => set((s) => ({ selectedStageId: resolve(next, s.selectedStageId) })),
+  setSelectedStepId: (next) => set((s) => ({ selectedStepId: resolve(next, s.selectedStepId) })),
+}));

--- a/openspec/changes/mapgen-studio-client-data/.openspec.yaml
+++ b/openspec/changes/mapgen-studio-client-data/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-06-09
+status: draft

--- a/openspec/changes/mapgen-studio-client-data/design.md
+++ b/openspec/changes/mapgen-studio-client-data/design.md
@@ -1,0 +1,81 @@
+# Design — mapgen-studio-client-data
+
+## Context
+
+The server slice exposed `/rpc` and the typed client (`src/lib/orpc.ts`) but the
+React app still spoke `fetch('/api/*')`. This slice flips the client onto oRPC and
+introduces the client data-layer architecture (TanStack Query client + the first
+Zustand store), without changing any observable behavior.
+
+## Key decision: "move transport, not logic"
+
+The three `features/*/api.ts` wrappers were thin `fetch` shims with bespoke
+result envelopes (`{ ok, error, statusCode, observedAt, details }`) that `App.tsx`
+depends on. Rather than rewrite the call sites into `useQuery`/`useMutation` (a
+large, parity-risky churn over a 2,522-line component), we kept the wrapper
+signatures and swapped ONLY their transport: `fetch(...)` → `orpcClient.<ns>.<proc>(...)`.
+
+This makes parity hold by construction:
+
+- **Success** returns the typed contract output; the wrapper projects it to the
+  same fields the caller already consumed.
+- **Failure** throws an `ORPCError` whose `status` is the legacy HTTP code and whose
+  `data` carries the legacy extra body fields. A single `orpcFailure`/`runInGameFailure`/
+  `saveDeployFailure` helper translates `ORPCError → { error, statusCode, observedAt|details }`,
+  reproducing the old `res.ok`/`body.error` discrimination.
+
+The non-uniform status registry (setup-config 503, save/deploy 400, run-in-game
+404 with server-id echo) is preserved because the router already pins those onto
+`ORPCError.status`/`.data`; the client just reads them back.
+
+## Key decision: the live-runtime poll is migrated, not deferred
+
+The plan allowed leaving the poll on `fetch` if oRPC could not preserve its
+semantics. It can, exactly:
+
+- `civ7.live.status` returns **200** even on partial failure (per-field embedded
+  `{ error }` via `allSettled`) and throws an `ORPCError` (500) ONLY on an outer
+  defect. That throw is rethrown as an `Error` carrying the message — the SAME path
+  the legacy `!res.ok` branch produced — so the adaptive-backoff failure accounting
+  is untouched.
+- `civ7.live.snapshot` returns the 200 grid body or throws an `ORPCError` (400).
+  The catch builds `{ ok:false, error }`, the SAME shape the legacy
+  `res.ok ? body : { ok:false, error }` produced, which `buildLiveRuntimeSnapshotState`
+  already handles.
+- The request-key staleness gate (`shouldCommitLiveRuntimeSnapshot`), the adaptive
+  backoff (`nextLiveRuntimePollDelayMs`), the per-read abort controllers, and the
+  inlined setup-config read all stay verbatim — only the network call changed.
+
+Runtime verification confirmed the poll cycles `live/status → setupConfig →
+live/snapshot` over `/rpc` at 200 with the same cadence and no snapshot tearing.
+
+## Key decision: viewStore now, authoring/run stores with decomposition
+
+`viewStore` owns browser-only view state — no server coupling, no persistence
+contract — so it is the safest first Zustand store and becomes the single owner
+(App keeps no `useState` mirror). The setters accept value-or-updater so the
+migration is a drop-in for existing `setX((prev) => …)` call sites.
+
+The persisted `authoringStore`/`runStore` (architecture §3) are DEFERRED to the
+component-decomposition slice. Their localStorage schema is hard-core parity
+("copy it, don't fix it", §6); moving it into Zustand `persist` is safer done
+alongside the component split than bundled into the transport swap. The reference
+persistence modules are untouched here. This is within the protective belt
+(slice ordering within a phase is negotiable; the hard core — zero manual fetch,
+parity, no query→Zustand mirroring — is fully met).
+
+## The crisp rule
+
+Server-owned state flows through TanStack Query (via oRPC); browser-only state
+lives in Zustand. Query results are NEVER mirrored into Zustand. `viewStore` holds
+only view selections; the live/setup/catalog reads stay in the query/poll layer.
+
+## Risk / parity notes
+
+- The only intentional micro-divergence: `saveRepoBackedConfig`'s initial-POST
+  error path previously echoed `body?.path` from a 4xx body; the oRPC error `data`
+  does not carry it, so that failure now omits `path` (the engine attaches `path`
+  only to the in-progress status, which the poll loop still surfaces). Documented
+  inline.
+- `buildLiveRuntimeSnapshotQuery` (the old URL query builder) is now unused by the
+  app; it remains exported from `features/liveRuntime/model.ts` for tests.

--- a/openspec/changes/mapgen-studio-client-data/proposal.md
+++ b/openspec/changes/mapgen-studio-client-data/proposal.md
@@ -1,0 +1,116 @@
+## Why
+
+The prior slice (`mapgen-studio-server-orpc`) stood up the studio's own
+effect-orpc server at `/rpc` and added the typed oRPC client (`src/lib/orpc.ts`)
+but did NOT switch any call sites — the React client still reached the backend
+through hand-rolled `fetch` of `/api/*` (the `src/features/*/api.ts` wrappers and
+the live-runtime poll inside `App.tsx`). This violates the core directive
+(FRAME §4.7): EVERYTHING talks oRPC; NEVER hand-roll `fetch`. This change completes
+the client half — after it, the studio performs ZERO manual fetch of `/api`.
+
+It also lands the client data-layer architecture from
+`architecture/10-target-architecture.md` §2–§3: a single TanStack Query client
+and the first Zustand store (`viewStore`) that owns browser-only view state, so
+later decomposition slices build on real state/server-data boundaries.
+
+## Target Authority Refs
+
+- `docs/projects/mapgen-studio-redesign/FRAME.md` (§4.7 — everything talks oRPC;
+  the live-runtime poll's staleness/backoff is hard core)
+- `docs/projects/mapgen-studio-redesign/architecture/10-target-architecture.md`
+  (§2 client data layer, §3 stores + crisp rule, §7 do-not-break registry)
+- `docs/projects/mapgen-studio-redesign/architecture/12-control-seam.md`
+  (live reads stay direct-control-backed behind a thin seam for now)
+- `packages/studio-server/src/contract/*` (the contract the client consumes)
+
+## What Changes
+
+- Add `apps/mapgen-studio/src/lib/query.ts` — a `QueryClient` factory with sane
+  defaults (short `staleTime`, single retry, refetch-on-focus) — and wrap the app
+  in `QueryClientProvider` in `main.tsx`.
+- Migrate every hand-rolled `/api/*` `fetch` to the typed oRPC client
+  (`src/lib/orpc.ts`): the three `src/features/*/api.ts` wrappers (civ7Setup,
+  runInGame, mapConfigSave) move their TRANSPORT from `fetch` to `orpcClient.*`
+  while preserving their exact result envelopes; the live-runtime poll's two reads
+  (`civ7.live.status`, `civ7.live.snapshot`) plus the inlined `civ7.setupConfig`
+  read route through the oRPC client too. After this change there is ZERO manual
+  fetch of `/api` anywhere in the client.
+- Preserve the live-runtime poll parity EXACTLY: the request-key staleness gate
+  (`shouldCommitLiveRuntimeSnapshot`), adaptive backoff (`nextLiveRuntimePollDelayMs`),
+  abort plumbing, and the 200-with-embedded-`{error}` handling are unchanged — only
+  the transport call is swapped. `live.status`'s outer-failure throw maps to the
+  same catch path the legacy `!res.ok` branch hit; `live.snapshot`'s 400 maps to the
+  same `{ ok:false, error }` envelope the legacy `res.ok ? … : …` produced.
+- Preserve the non-uniform error semantics on the client: `ORPCError.status`
+  reproduces the legacy `statusCode` (used for run-in-game status 404 restart
+  detection) and `ORPCError.data` carries `details`/`observedAt`/server-id echo.
+- Introduce `viewStore` (Zustand v5) as the single owner of browser-only view
+  state (canvas toggles, overlay selection, era mode, panel collapse, selected
+  stage/step) and replace the scattered `App.tsx` `useState` for that surface with
+  store selectors — App holds no mirror. Server data is NEVER mirrored into Zustand.
+- Add `zustand@5.0.14` as an app dependency.
+
+## Requires
+
+- `mapgen-studio-server-orpc` (the prior slice; this stacks on it — the `/rpc`
+  mount and `src/lib/orpc.ts` client come from there)
+
+## Enables Parallel Work
+
+- Component decomposition (P3) builds on `viewStore` and the query/mutation
+  call-site shapes landed here; the authoring/run persisted Zustand stores move
+  alongside that decomposition (see Deferred).
+
+## Affected Owners
+
+- `apps/mapgen-studio/src/lib/query.ts` (new)
+- `apps/mapgen-studio/src/stores/viewStore.ts` (new)
+- `apps/mapgen-studio/src/main.tsx` (QueryClientProvider)
+- `apps/mapgen-studio/src/App.tsx` (poll transport → oRPC; view state → store)
+- `apps/mapgen-studio/src/features/{civ7Setup,runInGame,mapConfigSave}/api.ts`
+  (transport → oRPC; result envelopes preserved)
+- `apps/mapgen-studio/package.json` (zustand)
+
+## Forbidden Owners
+
+- No removal of the legacy `/api/*` middleware (coexistence this run).
+- No new FireTuner reads; live reads stay direct-control-backed via the studio
+  contract.
+- No mirroring of TanStack Query results into Zustand (the crisp rule, §3).
+- No change to the localStorage persistence schema (authoring/run persistence is
+  the reference impl — copy, don't fix; §6).
+- No `mods/**` changes.
+
+## Stop Conditions
+
+- The live-runtime poll's request-key staleness or adaptive backoff cannot be
+  preserved through the oRPC client — in that case leave that poll on `fetch` and
+  note it; do not risk parity.
+- Any non-uniform status code or error-`data` field (run-in-game 404 server-id
+  echo, save/deploy `details`, setup-config `observedAt`) is lost across the client
+  boundary.
+
+## Consumer Impact
+
+The studio behaves identically; all client→server traffic now flows over the typed
+oRPC `/rpc` surface (verified: no `/api/*` requests at runtime). View state has a
+single Zustand owner.
+
+## Deferred
+
+- The persisted `authoringStore` and `runStore` (§3) — moving the localStorage-
+  backed authoring/run state into Zustand `persist` is done alongside component
+  decomposition (P3) to avoid disturbing the parity-critical persistence schema in
+  the same slice that swaps transport. The reference persistence
+  (`features/studioState/persistence.ts`, `features/runInGame/sourceSnapshotStorage.ts`)
+  is unchanged here.
+
+## Verification Gates
+
+- `bun run check` in `apps/mapgen-studio` (tsc clean).
+- `bun run build` in `apps/mapgen-studio` (vite build + worker-bundle check).
+- Runtime: dev server with `/rpc` mount; network shows ONLY `POST /rpc/*` calls
+  (zero `/api/*`); the live poll cycles `live/status → setupConfig → live/snapshot`
+  through oRPC at 200; run-in-game/map-config status 404s on a fresh server are
+  handled without a retry storm; no console errors; screenshot renders the studio.
+- OpenSpec strict validation.

--- a/openspec/changes/mapgen-studio-client-data/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-client-data/specs/mapgen-studio/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: Studio Client Performs Zero Manual Fetch Of /api
+
+Mapgen Studio's React client SHALL reach the backend exclusively through the typed
+oRPC client (`src/lib/orpc.ts`) bound to the studio contract; it SHALL NOT perform
+any manual `fetch` of `/api/*`. All server-data callers route through `orpcClient`
+or oRPC-native TanStack Query.
+
+#### Scenario: All client→server traffic flows over /rpc
+- **WHEN** the studio runs against the dev server and exercises setup catalog,
+  saved configs, the live-runtime poll, autoplay, run-in-game, and save/deploy
+- **THEN** every backend request is a `POST` to `/rpc/<namespace>/<procedure>`
+- **AND** no request targets `/api/*` from the client
+
+#### Scenario: Feature api wrappers preserve their result envelopes
+- **WHEN** a `features/*/api.ts` wrapper (`fetchCiv7SetupConfig`,
+  `fetchCiv7SavedSetupConfigs`, `fetchCiv7SetupCatalog`, `requestCiv7Autoplay`,
+  `runCurrentConfigInGame`, `fetchRunInGameStatus`, `saveRepoBackedConfig`,
+  `fetchMapConfigSaveDeployStatus`) succeeds or fails
+- **THEN** it returns the same `{ ok, … }` / `{ ok:false, error, statusCode?, … }`
+  shape its caller consumed before the migration
+- **AND** on failure `ORPCError.status` is surfaced as `statusCode` and
+  `ORPCError.data` fields (`details`, `observedAt`) are surfaced unchanged
+
+#### Scenario: Run-in-game status 404 still drives restart detection
+- **WHEN** `fetchRunInGameStatus` is called for an unknown or pruned request id and
+  the procedure returns a 404
+- **THEN** the wrapper returns `{ ok:false, error, statusCode: 404 }` so the caller
+  can detect a server restart, exactly as the legacy `fetch` path did
+
+#### Scenario: Legacy /api middleware is not removed
+- **WHEN** this change lands
+- **THEN** the legacy `/api/*` handlers remain mounted (coexistence) and no
+  standalone Bun server is introduced
+
+### Requirement: Live-Runtime Poll Preserves Staleness And Backoff Over oRPC
+
+The live-runtime poll SHALL read `civ7.live.status`, `civ7.live.snapshot`, and the
+inlined `civ7.setupConfig` through the oRPC client while preserving its request-key
+staleness gating and adaptive backoff exactly.
+
+#### Scenario: Status outer failure maps to the legacy catch path
+- **WHEN** `civ7.live.status` throws an `ORPCError` (status 500) during a poll tick
+- **THEN** it is rethrown as an `Error` carrying the message and handled by the
+  poll's existing failure path (`buildLiveRuntimeErrorState` + incremented failure
+  count), driving the same adaptive backoff as before
+- **AND** a 200 response with per-field embedded `{ error }` is NOT treated as a
+  transport failure
+
+#### Scenario: Snapshot 400 maps to the legacy error envelope
+- **WHEN** `civ7.live.snapshot` throws an `ORPCError` (status 400) during a poll tick
+- **THEN** the poll builds `{ ok:false, error }` and feeds it to
+  `buildLiveRuntimeSnapshotState`, the same value the legacy `res.ok ? … : …`
+  branch produced
+
+#### Scenario: Request-key staleness and abort are unchanged
+- **WHEN** a newer snapshot request supersedes an in-flight one
+- **THEN** `shouldCommitLiveRuntimeSnapshot` still discards the stale result and the
+  prior request's `AbortController` is aborted, with no snapshot tearing
+- **AND** `nextLiveRuntimePollDelayMs` continues to set the poll cadence from the
+  max status/snapshot failure count and document visibility
+
+#### Scenario: No manual fetch remains in the poll
+- **WHEN** `App.tsx` is inspected after this change
+- **THEN** it contains no `fetch(` call; the poll's three reads all go through the
+  oRPC client
+
+### Requirement: Browser-Only View State Is Owned By A Zustand Store
+
+Mapgen Studio SHALL own browser-only view state in a single Zustand store
+(`viewStore`), replacing the scattered `App.tsx` `useState` for that surface, and
+SHALL NOT mirror TanStack Query results into Zustand.
+
+#### Scenario: viewStore is the single owner of view state
+- **WHEN** view state (canvas grid/edge toggles, overlay selection/opacity/variant,
+  era mode + manual era, panel collapse/expand, selected stage/step) changes
+- **THEN** the change is read from and written to `useViewStore`, and `App.tsx`
+  holds no `useState` mirror of that state
+- **AND** the store setters accept a value OR an updater function so existing
+  `setX((prev) => …)` call sites are unchanged
+
+#### Scenario: The TanStack Query client is provided once
+- **WHEN** the app mounts
+- **THEN** a single `QueryClient` (from `src/lib/query.ts`) is provided via
+  `QueryClientProvider` in `main.tsx`, created at module root so it survives
+  re-renders and the dev-only StrictMode skip
+
+#### Scenario: Server data is never mirrored into Zustand
+- **WHEN** server-owned data (live status/snapshot, setup catalog, saved configs,
+  run-in-game / save-deploy status) is needed
+- **THEN** it is read through the oRPC client / TanStack Query layer, not copied
+  into `viewStore` or any other Zustand store

--- a/openspec/changes/mapgen-studio-client-data/tasks.md
+++ b/openspec/changes/mapgen-studio-client-data/tasks.md
@@ -1,0 +1,49 @@
+# Tasks — mapgen-studio-client-data
+
+## 1. TanStack Query client
+- [x] 1.1 Add `src/lib/query.ts` — `createQueryClient()` with sane defaults
+      (short `staleTime`, single retry, refetch-on-focus).
+- [x] 1.2 Wrap the app in `QueryClientProvider` in `main.tsx` with one
+      module-root client instance (survives the dev-only StrictMode skip).
+
+## 2. Migrate feature api.ts wrappers off manual fetch
+- [x] 2.1 `features/civ7Setup/api.ts` — `setupConfig`, `savedConfigs`,
+      `setupCatalog`, `autoplay` now call `orpcClient.*`; result envelopes
+      (`{ ok, error, statusCode, observedAt }`) preserved; `ORPCError.status` →
+      `statusCode`, `ORPCError.data.observedAt` → `observedAt`; autoplay 200-with-
+      `ok:false` still surfaces as `{ ok:false }`.
+- [x] 2.2 `features/runInGame/api.ts` — `start`/`status` via `orpcClient.runInGame.*`;
+      request envelope (incl. the `assertNoRawControlFields`-scanned body) assembled
+      verbatim; `ORPCError.status` → `statusCode` (404 restart detection),
+      `ORPCError.data.details` → `details`.
+- [x] 2.3 `features/mapConfigSave/api.ts` — `saveDeploy`/`status` via
+      `orpcClient.mapConfigs.*`; running-status poll loop, error handling, and the
+      localStorage key string preserved; `ORPCError.status` → `statusCode`.
+
+## 3. Migrate the live-runtime poll transport (parity-critical)
+- [x] 3.1 `App.tsx` poll `civ7.live.status` read → `orpcClient.civ7.live.status`
+      with the status abort signal; the 500 outer-failure throw maps to the same
+      catch path the legacy `!res.ok` branch hit.
+- [x] 3.2 `App.tsx` poll `civ7.live.snapshot` read → `orpcClient.civ7.live.snapshot`
+      with the snapshot abort signal; the 400 throw maps to the `{ ok:false, error }`
+      envelope the legacy `res.ok ? … : …` produced.
+- [x] 3.3 Keep `shouldCommitLiveRuntimeSnapshot` staleness gate,
+      `nextLiveRuntimePollDelayMs` adaptive backoff, abort plumbing, and the inlined
+      `fetchCiv7SetupConfig` (now oRPC) call sequence unchanged.
+- [x] 3.4 Confirm ZERO `fetch(` remains in `App.tsx`.
+
+## 4. Zustand viewStore
+- [x] 4.1 Add `src/stores/viewStore.ts` — Zustand v5 store owning the view-only
+      surface (canvas toggles, overlay selection, era mode, panel collapse,
+      selected stage/step) with `useState`-compatible setters (value-or-updater).
+- [x] 4.2 Replace the scattered `App.tsx` view `useState` with `useViewStore`
+      selectors (single owner; no App mirror). Server data not mirrored into Zustand.
+- [x] 4.3 Add `zustand@5.0.14` dependency.
+
+## 5. Verify
+- [x] 5.1 `bun run check` (tsc clean).
+- [x] 5.2 `bun run build` (vite + worker-bundle check passes).
+- [x] 5.3 Dev-server runtime: network shows only `POST /rpc/*` (zero `/api/*`);
+      live poll cycles over oRPC at 200; status 404s handled cleanly; no console
+      errors; screenshot renders the studio.
+- [x] 5.4 `bun run openspec -- validate mapgen-studio-client-data --strict`.


### PR DESCRIPTION
All client-to-server traffic in Mapgen Studio now flows through the typed oRPC client (`src/lib/orpc.ts`) bound to the studio contract. Previously, the React app reached the backend through hand-rolled `fetch` calls against `/api/*` endpoints; after this change, zero manual `fetch` of `/api` remains anywhere in the client.

**Transport migration** — The three `features/*/api.ts` wrappers (`civ7Setup`, `runInGame`, `mapConfigSave`) have their transport swapped from `fetch` to `orpcClient.*` while their result envelopes (`{ ok, error, statusCode, observedAt, details }`) are preserved exactly. `ORPCError.status` reproduces the legacy `statusCode` (including the run-in-game 404 used for server-restart detection) and `ORPCError.data` carries `details`/`observedAt`. The live-runtime poll's two reads (`civ7.live.status`, `civ7.live.snapshot`) and the inlined `civ7.setupConfig` read are also migrated. The poll's request-key staleness gate, adaptive backoff, and abort plumbing are untouched — only the network call changed.

**Client data layer** — A `QueryClient` factory (`src/lib/query.ts`) is added with short `staleTime`, single retry, and refetch-on-focus, and the app is wrapped in `QueryClientProvider` in `main.tsx` with a single module-root instance.

**View state consolidation** — A new Zustand v5 `viewStore` (`src/stores/viewStore.ts`) becomes the single owner of browser-only view state: canvas grid/edge toggles, overlay selection and opacity, era mode, panel collapse, and selected stage/step. The scattered `useState` calls for this surface in `App.tsx` are replaced with `useViewStore` selectors; `App.tsx` holds no mirror. Setters accept a value or an updater function, making the migration a drop-in for existing `setX((prev) => …)` call sites. Server-owned data is never mirrored into Zustand. `zustand@5.0.14` is added as a dependency.