### PR TITLE
fix(mapgen-studio): wrap AppFooter test in TooltipProvider and add `@` alias to vitest config

### DIFF
--- a/apps/mapgen-studio/test/runInGame/AppFooter.test.tsx
+++ b/apps/mapgen-studio/test/runInGame/AppFooter.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import { AppFooter } from "../../src/ui/components/AppFooter";
+import { TooltipProvider } from "../../src/components/ui/tooltip";
 import type { RecipeSettings, WorldSettings } from "../../src/ui/types";
 import type { RunInGameOperationStatus } from "../../src/features/runInGame/status";
 
@@ -19,8 +20,9 @@ const worldSettings: WorldSettings = {
 
 function renderFooter(status: RunInGameOperationStatus, relation: "current" | "stale" | "unknown" = "unknown") {
   return renderToStaticMarkup(
-    <AppFooter
-      status="ready"
+    <TooltipProvider>
+      <AppFooter
+        status="ready"
       lastRunSettings={recipeSettings}
       lastGlobalSettings={worldSettings}
       currentSettings={recipeSettings}
@@ -39,7 +41,8 @@ function renderFooter(status: RunInGameOperationStatus, relation: "current" | "s
       liveRuntime={{ status: "ok", readiness: "shell" }}
       autoRunEnabled={false}
       onAutoRunEnabledChange={vi.fn()}
-    />
+      />
+    </TooltipProvider>
   );
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -48,6 +48,9 @@ export default defineConfig({
       {
         extends: true,
         root: r('apps/mapgen-studio'),
+        // Mirror the app's `@/*` -> src alias (tsconfig + vite) so vitest resolves
+        // the shadcn `components/ui` -> `@/lib/utils` import chain.
+        resolve: { alias: { '@': r('apps/mapgen-studio/src') } },
         test: { name: 'mapgen-studio' }
       },
       {


### PR DESCRIPTION
Wraps `AppFooter` in `TooltipProvider` within the test render helper, which is required now that the component uses shadcn tooltip primitives internally. Also adds a `@/*` path alias to the `mapgen-studio` vitest project config to mirror the app's TypeScript and Vite alias, allowing vitest to correctly resolve the `components/ui` → `@/lib/utils` import chain used by shadcn components.