### PR TITLE
docs(mapgen-studio): add pass-2 design-fix frame, five OpenSpec slices (layout geometry, form hierarchy, run console, explore toolbar, first-run visibility)

### DIFF
--- a/apps/mapgen-studio/.interface-design/system.md
+++ b/apps/mapgen-studio/.interface-design/system.md
@@ -140,10 +140,31 @@ info hue — keep the chrome monochrome-cool).
   `lightMode`-prop removal lands as components migrate (P3/P4); P1 establishes the
   `.dark` system and tokens so both can briefly coexist without conflict.
 
-## Component patterns (preserve as-built dimensions, re-skin onto shadcn)
+## Component patterns (preserve control density, re-skin onto shadcn)
 
-Keep the dense dimensions from the extraction baseline — Button `h-8`/`h-7`, Input
-`h-7`, Switch 36×20, Field row `justify-between gap-3 py-1` with `min-w-[96px]`
+Keep the dense control dimensions from the extraction baseline — Button `h-8`/`h-7`,
+Input `h-7`, Switch 36×20, Field row `justify-between gap-3 py-1` with `min-w-[96px]`
 label, Card `rounded-lg border p-2.5`, eyebrow label uppercase 10px. The migration
 changes the *mechanism* (Radix shadcn primitives, token-driven) and adds the
 contour-focus signature + motion — not the density.
+
+## Pass-2 amendment (2026-06-11, user-grounded): chrome geometry is NOT preserved
+
+Pass 1 read "preserve as-built dimensions" as covering chrome *geometry* too, and
+shipped the pre-redesign skeleton (280px left dock, stale 104px header reserve,
+flat label/help typography). The user judged the result **squished**. Amended
+decisions (see `docs/projects/mapgen-studio-redesign/pass-2-design-fixes.md`):
+
+- **Left dock 340px** (was 280). The recipe form is the instrument's main working
+  surface; at 280 its helper prose wraps into noise. Explore dock stays 260 —
+  lists fit it.
+- **Header reserve is content-driven.** The measured header height (ResizeObserver)
+  is the only authority; no static `minHeight` band. Docks rise to the header.
+- **Docks span header→footer** with internal scroll; the scroll edge carries a
+  fade affordance, never a mid-sentence hard cut.
+- **Form text hierarchy:** field labels sit a full tier above descriptions —
+  labels `text-foreground` medium, descriptions stay muted `text-data`. Two-tier
+  gray-on-gray is a defect, not density.
+- **One Run CTA.** The footer is the run console (seed, auto-run, run, run-in-game);
+  panel-local duplicates are removed.
+- Control density (button/input/switch/field-row dimensions above) is unchanged.

--- a/docs/projects/mapgen-studio-redesign/00-GOAL.md
+++ b/docs/projects/mapgen-studio-redesign/00-GOAL.md
@@ -215,3 +215,17 @@ live screenshots, zero console errors. Each slice = one OpenSpec change.
 - [ ] *(optional)* deeper `StudioShell` container/presentational panel split.
 
 Live-control: NOT waiting for merge. Seam designed toward stack-top (FRAME §6).
+
+## Pass 2 — design fixes (ACTIVE 2026-06-11)
+
+User verdict on Pass 1: **not functionally complete; still "squished"**. Pass 2 is
+a visually-grounded fix workstream — frame, issue→change map, and verification
+contract in [`pass-2-design-fixes.md`](pass-2-design-fixes.md). Five OpenSpec
+slices stacked on `design/a11y-fixes` (Graphite-only, never submitted); each slice
+closes only with visual proof from the running app:
+
+- [ ] **C1** `mapgen-studio-layout-geometry` — `design/layout-geometry`
+- [ ] **C2** `mapgen-studio-form-hierarchy` — `design/form-hierarchy`
+- [ ] **C3** `mapgen-studio-run-console` — `design/run-console`
+- [ ] **C4** `mapgen-studio-explore-toolbar` — `design/explore-toolbar`
+- [ ] **C5** `mapgen-studio-first-run-visibility` — `design/first-run-visibility`

--- a/docs/projects/mapgen-studio-redesign/pass-2-design-fixes.md
+++ b/docs/projects/mapgen-studio-redesign/pass-2-design-fixes.md
@@ -1,0 +1,79 @@
+# Pass 2 — Design Fixes (visually-grounded, spec-driven)
+
+> Standalone frame for the Pass-2 design-fix workstream. Survives compaction.
+> Authored 2026-06-11 from a direct visual inspection of the running app
+> (dark, 1600×950, dev server :5173) plus DOM measurements — not from code alone.
+> Parent frame: [FRAME.md](FRAME.md). Goal ledger: [00-GOAL.md](00-GOAL.md).
+
+## Why this pass exists (reframe diagnostic)
+
+Pass 1 (the 16-slice redesign stack through `design/a11y-fixes`) committed to
+"preserve as-built dimensions, re-skin onto shadcn"
+(`apps/mapgen-studio/.interface-design/system.md` §Component patterns). That
+constraint shipped the old skeleton under new paint: the left dock is still the
+pre-redesign `w-[280px]`, the header still reserves a stale 104px band, and the
+rjsf form still reads as a wall of same-size same-color text. The user's verdict
+after Pass 1: the UI is **"squished"** and the redesign is **not functionally
+complete**.
+
+**Named reframe move: constraint relaxation.** Pass 2 releases the
+"preserve as-built chrome geometry" constraint. What stays inviolate: the dense
+instrument DNA (micro-typography, tight controls), the token system, and behavior
+parity on the data/runtime seams.
+
+## Frame
+
+- **Objective:** the chrome reads as a machined instrument that makes way for the
+  map — measured by a fresh screenshot passing the squint test (clear hierarchy,
+  nothing cramped, nothing dead) and the user no longer calling it squished.
+- **Hard core (cannot move):** run/poll/localStorage/transport semantics
+  (FRAME.md §3, architecture/10 §7); token-driven styling only (no raw palette);
+  Graphite-only, stack never submitted; one OpenSpec change per slice, validated
+  `--strict`; tests green at every slice tip.
+- **Exterior (deliberately out):** StudioShell container/presentational split
+  (stabilization round), parallel-stack feature integration (control-oRPC
+  binding), Bun server cutover (supervised), token *values* (P1 settled them),
+  resizable/dockable panels (structural alternative — see below).
+- **Falsifier:** if after C1+C2 land a fresh screenshot still reads squished,
+  this frame is wrong — the problem is then the floating-panel paradigm itself,
+  and the fix is a structural relayout (docked sidebars), a new frame, not more
+  patching inside this one.
+- **Structural alternative considered:** replacing floating docks with true
+  docked sidebars (CSS grid shell). Rejected for this pass: it changes the
+  product's "instrument floats over the chart table" identity, invalidates the
+  panel-over-map backdrop blur language, and is not needed to clear the observed
+  defects. Revisit only if the falsifier fires.
+
+## Observed issues → changes (one change per issue; root fixes preferred)
+
+Two root causes resolve six of the nine observed issues:
+
+- **Geometry is encoded in stale constants** (`LAYOUT.HEADER_HEIGHT: 104`
+  hard-reserved via `minHeight` even though a ResizeObserver already measures the
+  real header; `PANEL_WIDTH 280` inherited verbatim from pre-redesign) → **C1**.
+- **The form has no typographic hierarchy primitives** (labels and help both
+  `text-data text-muted-foreground`; rjsf's always-truthy `errors` element
+  renders ~40 empty `role="alert"` regions) → **C2**.
+
+| # | Observed (visual inspection 2026-06-11) | Change | OpenSpec id |
+|---|---|---|---|
+| 1 | Left dock 280px; helper text wraps 3–4 lines; form cramped | C1 | `mapgen-studio-layout-geometry` |
+| 2 | ~88px dead band between header and docks (stale 104px reserve) | C1 | 〃 |
+| 3 | Left panel cuts content mid-sentence at scroll edge; no affordance | C1 | 〃 |
+| 4 | Labels and help text same size + same color → wall of gray | C2 | `mapgen-studio-form-hierarchy` |
+| 5 | 40 empty always-mounted `role="alert"` live regions | C2 | 〃 |
+| 6 | Two simultaneous "Run" CTAs (RecipePanel bottom + footer) | C3 | `mapgen-studio-run-console` |
+| 7 | Footer "Bal" reads as accidental truncation | C3 | 〃 |
+| 8 | Render/Space rows are unbounded icon clusters; read as decoration | C4 | `mapgen-studio-explore-toolbar` |
+| 9 | First Run appears to produce an empty black canvas (Foundation/Mesh default) | C5 | `mapgen-studio-first-run-visibility` |
+
+Slice order (Graphite, stacked on `design/a11y-fixes`):
+C1 → C2 → C3 → C4 → C5. Each slice: OpenSpec change validated `--strict`,
+implementation, focused tests, visual check on :5173, `gt create` commit.
+Final gate: full suite + tsc + dark & light screenshots of every changed surface.
+
+## Verification contract
+
+A change in this pass is done only when **seen**: screenshot (or measured DOM
+delta) of the running app demonstrating the fix, in dark and light where
+theming is implicated. Code-only or test-only proof does not close a slice.

--- a/openspec/changes/mapgen-studio-explore-toolbar/proposal.md
+++ b/openspec/changes/mapgen-studio-explore-toolbar/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Observed live (2026-06-11): the explore panel's view toolbar renders **Render**
+and **Space** as loose rows of icon-only buttons floating next to 10px eyebrow
+labels. Without a container boundary, the option sets read as decoration rather
+than as mutually-exclusive controls, and the active state (a subtle background
+shift on one tiny icon) is easy to miss. Discoverability relies entirely on
+hover tooltips.
+
+## Target Authority Refs
+
+- `docs/projects/mapgen-studio-redesign/pass-2-design-fixes.md` (issue 8)
+- `apps/mapgen-studio/.interface-design/system.md` (substrate elevation: inputs
+  inset on `input-background`; contour-by-luminance active states)
+
+## What Changes
+
+- The Render and Space option clusters in `ExplorePanel`'s view toolbar become
+  **segmented controls**: each cluster wraps in an inset container
+  (`bg-input-background`, hairline border, 2px padding), and the active segment
+  lifts one substrate tier (`bg-muted text-foreground`) — the same
+  inset-input / raised-active language the rest of the instrument uses.
+- Per-option tooltips, `aria-label`s, and `aria-pressed` semantics are preserved
+  exactly; the eyebrow labels (RENDER / SPACE) stay.
+- Standalone toggles in the same toolbar (fit, edges, debug) are NOT grouped —
+  they are independent actions, not exclusive options; their styling is untouched.
+
+## Out Of Scope / Parity Guarantees
+
+- No behavior change: same options, same callbacks, same selected-state wiring.
+- No new icons or relabeling; this is container/affordance styling only.
+
+## Verification Gates
+
+- `bun run openspec -- validate mapgen-studio-explore-toolbar --strict`
+- tsc + mapgen-studio vitest project green
+- Visual proof on :5173 (dark + light): Render/Space read as bounded segmented
+  controls with an unambiguous active segment.

--- a/openspec/changes/mapgen-studio-explore-toolbar/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-explore-toolbar/specs/mapgen-studio/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Render And Space Options Present As Segmented Controls
+
+The explore panel's Render and Space option sets SHALL render as bounded
+segmented controls — an inset container on the control-background token wrapping
+the options, with the active option lifted one surface tier — while preserving
+each option's accessible name, tooltip, and `aria-pressed` state.
+
+#### Scenario: Bounded container with raised active segment
+- **WHEN** the view toolbar renders the Render options
+- **THEN** the options sit inside one container styled with the inset control background and hairline border
+- **AND** the selected option renders one surface tier above the container with foreground text
+- **AND** unselected options stay flush with the container
+
+#### Scenario: Semantics preserved
+- **WHEN** the user inspects any Render or Space option
+- **THEN** it keeps its `aria-label`, tooltip, and `aria-pressed` reflecting selection
+- **AND** activating it fires the same selection callback as before
+
+#### Scenario: Independent toggles stay independent
+- **WHEN** the toolbar renders fit-to-view, edges, and debug-layer toggles
+- **THEN** they are not wrapped in segmented containers (independent actions, not exclusive options)

--- a/openspec/changes/mapgen-studio-explore-toolbar/tasks.md
+++ b/openspec/changes/mapgen-studio-explore-toolbar/tasks.md
@@ -1,0 +1,15 @@
+## 1. ExplorePanel view toolbar
+
+- [ ] 1.1 Wrap the Render option row in a segmented container
+      (`bg-input-background` + hairline border + 2px padding); active option
+      `bg-muted text-foreground rounded-sm`, inactive flush.
+- [ ] 1.2 Same treatment for the Space option row.
+- [ ] 1.3 Leave fit/edges/debug toggles unwrapped; confirm tooltips, `aria-label`,
+      `aria-pressed`, and callbacks unchanged.
+
+## 2. Verification
+
+- [ ] 2.1 `bun run openspec -- validate mapgen-studio-explore-toolbar --strict`
+- [ ] 2.2 tsc + mapgen-studio vitest project green
+- [ ] 2.3 Visual on :5173 (dark + light): segmented controls read as controls;
+      active segment unambiguous at a squint.

--- a/openspec/changes/mapgen-studio-first-run-visibility/proposal.md
+++ b/openspec/changes/mapgen-studio-first-run-visibility/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+Observed live (2026-06-11): from a fresh studio (empty "Awaiting matter" stage),
+clicking **Run** completes a generation (status "Ready", DATA lists
+"Mesh Sites (Area)") — but the canvas stays **visually black**. The default
+post-run selection (stage Foundation / step Mesh / its first data layer) renders
+nothing the eye can find; matter only appears after the user manually selects a
+later stage (e.g. Ecology Biomes), which also triggers a camera fit. A first-time
+user reads this as "Run failed."
+
+The first run is the product's hello-world moment; it must visibly produce a
+world.
+
+## Target Authority Refs
+
+- `docs/projects/mapgen-studio-redesign/pass-2-design-fixes.md` (issue 9)
+- `docs/projects/mapgen-studio-redesign/FRAME.md` (§3 hard core — run/poll/storage
+  semantics unchanged; this change is a view-layer decision)
+- `apps/mapgen-studio/.interface-design/system.md` ("the map is the hero"; the
+  empty stage reads as *awaiting* matter — so a completed run must deliver it)
+
+## What Changes
+
+- **Diagnosis first (recorded in design.md before code):** determine why the
+  default Foundation/Mesh selection renders invisibly after the first run —
+  candidate causes: camera never fits to the first manifest's bounds (fit only
+  runs on explicit stage change / fit-to-view), and/or the mesh-sites point layer
+  renders sub-pixel/dark at the initial camera.
+- **Fix the view layer so a completed run shows visible matter without further
+  interaction.** Expected shape (confirmed by diagnosis): when a run completes
+  and a manifest arrives while the camera has never been fitted to generated
+  bounds, perform the same fit-to-view the manual control triggers. If diagnosis
+  shows the default layer is inherently invisible even when framed, additionally
+  make the post-run default selection resolve to the first *visibly rendering*
+  layer of the default stage.
+- The fix reuses existing mechanisms (the fit-to-view path, the existing
+  selection plumbing) — no new camera math, no generation/runner changes.
+
+## Out Of Scope / Parity Guarantees
+
+- No changes to generation, the browser runner, run status semantics, polling, or
+  persisted state.
+- Manual camera control is never overridden mid-session: the auto-fit applies
+  only when the camera has not been user-positioned over generated matter
+  (first-run / empty-stage case).
+- Layer data, ordering, and the DATA list are untouched.
+
+## Verification Gates
+
+- `bun run openspec -- validate mapgen-studio-first-run-visibility --strict`
+- tsc + mapgen-studio vitest project green
+- Visual proof on :5173: fresh state → Run → canvas shows rendered matter with no
+  further clicks (screenshot); manual pan/zoom then re-run → camera respected per
+  the scenario contract.

--- a/openspec/changes/mapgen-studio-first-run-visibility/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-first-run-visibility/specs/mapgen-studio/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: A Completed First Run Shows Visible Matter
+
+When a browser run completes from the empty stage, the canvas SHALL display the
+generated map's rendered matter without any further user interaction: the camera
+frames the generated layer's bounds, and the default post-run selection resolves
+to a layer that visibly renders.
+
+#### Scenario: Fresh state, one click, visible world
+- **WHEN** the user clicks Run from the "Awaiting matter" empty state and the run completes
+- **THEN** the canvas displays the selected layer's rendered geometry framed within the viewport
+- **AND** no additional click (stage change, fit-to-view) is required to see it
+
+#### Scenario: User camera is respected on subsequent runs
+- **WHEN** the user has already positioned the camera over generated matter and runs again
+- **THEN** the camera is not auto-refitted (the run completes with the user's framing preserved)
+
+### Requirement: First-Run Visibility Diagnosis Is Recorded
+
+The invisible-first-run root cause SHALL be diagnosed against the running app
+(camera fit vs. inherently invisible default layer) and recorded in this
+change's design.md before the fix lands, so the chosen mechanism (auto-fit,
+default-selection adjustment, or both) is evidence-grounded.
+
+#### Scenario: Design records the diagnosis
+- **WHEN** the implementation tasks begin
+- **THEN** design.md states the observed cause with the evidence (DOM/camera state, layer render output)
+- **AND** the implemented mechanism matches that diagnosis

--- a/openspec/changes/mapgen-studio-first-run-visibility/tasks.md
+++ b/openspec/changes/mapgen-studio-first-run-visibility/tasks.md
@@ -1,0 +1,24 @@
+## 1. Diagnosis (before code)
+
+- [ ] 1.1 Reproduce on :5173: fresh state → Run → inspect deck.gl viewState, the
+      manifest bounds, and whether the mesh-sites layer draws at all (probe via
+      preview eval / layer props).
+- [ ] 1.2 Record the cause + evidence in design.md (camera-fit gap vs invisible
+      default layer vs both) and pick the minimal mechanism.
+
+## 2. Fix (shape confirmed by 1.2)
+
+- [ ] 2.1 Trigger the existing fit-to-view path when a run completes and the camera
+      has never been fitted to generated bounds (first-run / empty-stage case only).
+- [ ] 2.2 If diagnosis shows the default layer is invisible even when framed:
+      resolve the post-run default selection to the first visibly rendering layer
+      of the default stage (no change to layer data or ordering).
+- [ ] 2.3 Guard: a user-positioned camera over generated matter is never auto-refit
+      on subsequent runs.
+
+## 3. Verification
+
+- [ ] 3.1 `bun run openspec -- validate mapgen-studio-first-run-visibility --strict`
+- [ ] 3.2 tsc + mapgen-studio vitest project green
+- [ ] 3.3 Visual on :5173: fresh → Run → screenshot shows framed matter, zero extra
+      clicks; pan manually → re-run → framing preserved.

--- a/openspec/changes/mapgen-studio-form-hierarchy/proposal.md
+++ b/openspec/changes/mapgen-studio-form-hierarchy/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+Measured in the running app (2026-06-11): rjsf field **labels** and **helper
+descriptions** render at the same size (11px) and the same color
+(`text-muted-foreground`, rgb(143,143,153)). With no typographic separation, the
+recipe form reads as a wall of indistinguishable gray text — the single biggest
+contributor to the user's "squished" verdict that is not geometry.
+
+Separately, the field template renders its error live region whenever rjsf's
+`errors` prop is truthy — but `errors` is a React **element** (the ErrorList
+wrapper), which is *always* truthy, so the form mounts ~40 empty
+`role="alert"` live regions (confirmed via DOM query: 40 alert nodes, all empty).
+Screen readers register every one of them.
+
+## Target Authority Refs
+
+- `docs/projects/mapgen-studio-redesign/pass-2-design-fixes.md` (issues 4–5)
+- `apps/mapgen-studio/.interface-design/system.md` (§Pass-2 amendment: labels a full tier above descriptions; §Type named scale)
+- `openspec/changes/mapgen-studio-a11y-fixes` (error-association contract this change must preserve: `id="${id}__error"` + widget `aria-describedby`)
+
+## What Changes
+
+- **Label tier split** in `rjsfTemplates.tsx`: field labels move from
+  `text-muted-foreground` to **`text-foreground`** (keeping `text-data font-medium`),
+  while descriptions/help/gs-comments stay on the muted tier. Labels become
+  scannable anchors; prose recedes.
+- **Same split in the hand-rolled field set** (`src/ui/components/fields/styles.ts`
+  and friends) so non-rjsf fields (world panel etc.) match.
+- **Empty-alert fix**: the `role="alert"` error region renders only when
+  `props.rawErrors?.length` is non-empty (rjsf's documented raw error strings),
+  not when the always-truthy `errors` element exists. The error id/association
+  contract from `mapgen-studio-a11y-fixes` is preserved exactly for fields that DO
+  have errors — widgets already gate `aria-describedby` on `rawErrors`, so ids
+  stay in lockstep.
+
+## Out Of Scope / Parity Guarantees
+
+- No schema, validation, value, or submission behavior changes; presentation +
+  live-region mounting only.
+- No font-size changes — the named scale (`text-data`/`text-label`) is untouched;
+  this is a color/weight hierarchy change.
+- Geometry (widths, heights, scroll) is C1.
+
+## Verification Gates
+
+- `bun run openspec -- validate mapgen-studio-form-hierarchy --strict`
+- tsc + mapgen-studio vitest project green
+- Visual proof on :5173: labels visibly separate from helper prose (dark + light);
+  DOM query shows zero empty `role="alert"` nodes; a forced validation error still
+  renders an associated alert region.

--- a/openspec/changes/mapgen-studio-form-hierarchy/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-form-hierarchy/specs/mapgen-studio/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Form Labels Sit A Full Tier Above Descriptions
+
+Config-form field labels SHALL render on the foreground text tier
+(`text-foreground`, medium weight) — in the rjsf templates and the hand-rolled field set alike — while
+descriptions, help text, and schema comments remain on the muted tier, so labels
+and prose are distinguishable at a glance without size changes.
+
+#### Scenario: rjsf label vs description
+- **WHEN** an rjsf field renders with a label and a description
+- **THEN** the label's computed color is the foreground token and the description's is the muted-foreground token
+- **AND** both keep their existing font sizes from the named scale
+
+#### Scenario: Hand-rolled fields match
+- **WHEN** a non-rjsf field row (e.g. world settings) renders with label + help text
+- **THEN** it follows the same label/description tier split
+
+### Requirement: Error Live Regions Mount Only When Errors Exist
+
+The config form SHALL NOT mount empty `role="alert"` regions. The per-field error
+region renders only when the field has raw validation errors, and when it does it
+SHALL keep the `id="${id}__error"` association contract consumed by the widgets'
+`aria-describedby`/`aria-invalid`.
+
+#### Scenario: Pristine form has zero alert regions
+- **WHEN** the config form renders with no validation errors
+- **THEN** a DOM query for `[role="alert"]` inside the form returns no per-field error nodes
+
+#### Scenario: A real error still announces against its control
+- **WHEN** a field has a validation error
+- **THEN** an element with `id="${fieldId}__error"` and `role="alert"` renders the message
+- **AND** the field's widget exposes `aria-invalid` and `aria-describedby` referencing that id

--- a/openspec/changes/mapgen-studio-form-hierarchy/tasks.md
+++ b/openspec/changes/mapgen-studio-form-hierarchy/tasks.md
@@ -1,0 +1,20 @@
+## 1. rjsf templates
+
+- [ ] 1.1 `rjsfTemplates.tsx`: split `FORM.label` usage — labels take a new
+      foreground-tier class; descriptions/help/gs-comments keep the muted tier.
+- [ ] 1.2 `rjsfTemplates.tsx`: gate the error region on `props.rawErrors?.length`
+      (both the labeled and unlabeled template branches), preserving
+      `id="${id}__error"` + `role="alert"` when errors exist.
+
+## 2. Hand-rolled fields
+
+- [ ] 2.1 `src/ui/components/fields/styles.ts` (and any field component that styles
+      labels directly): apply the same label/description tier split.
+
+## 3. Verification
+
+- [ ] 3.1 `bun run openspec -- validate mapgen-studio-form-hierarchy --strict`
+- [ ] 3.2 tsc + mapgen-studio vitest project green
+- [ ] 3.3 Visual on :5173 (dark + light): labels read as anchors; DOM query counts
+      zero empty `[role="alert"]`; force an invalid value and confirm the alert
+      region renders with the association contract intact.

--- a/openspec/changes/mapgen-studio-layout-geometry/design.md
+++ b/openspec/changes/mapgen-studio-layout-geometry/design.md
@@ -1,0 +1,47 @@
+## Context
+
+Pass-2 reframe (constraint relaxation): chrome geometry is redesigned; control
+density and behavior parity are untouched. The three observed defects share one
+root — geometry encoded in stale constants/classes that nothing reconciles.
+
+## Decisions
+
+### 1. Constants as authority, applied via inline style
+
+Tailwind cannot interpolate `w-[${LAYOUT.PANEL_WIDTH}px]` (JIT sees no literal),
+so the panels apply widths with `style={{ width: LAYOUT.PANEL_WIDTH }}`. This is
+the one sanctioned use of inline style here: it makes `layout.ts` the single
+place geometry lives. The arbitrary-value classes (`w-[280px]`, `w-[260px]`) are
+deleted rather than updated, so the next geometry change is a one-line constant
+edit.
+
+### 2. Kill the reserve, keep the observer
+
+`minHeight: HEADER_HEIGHT` predates the ResizeObserver pipeline and now only
+wastes ~56px. The observer remains the sole authority; `LAYOUT.HEADER_HEIGHT`
+shrinks to the honest initial-render estimate (48) used as the `useState` seed in
+`StudioShell` before the first measurement lands. Wrap behavior (header growing on
+narrow viewports) is unchanged because measurement, not the constant, drives
+`panelTop`.
+
+### 3. Docks get a `bottom`, panels get `max-h-full`
+
+`LeftDock`/`RightDock` keep owning positioning (their documented single
+responsibility) and gain `bottom: FOOTER_HEIGHT + 2×SPACING`. Panels switch to
+`max-h-full` so they shrink-to-fit short content but can never escape the column.
+This replaces the recipe panel's `calc(100vh-180px)` (wrong whenever the header
+wraps) and gives the explore panel its first overflow constraint.
+
+### 4. Fade affordance inside the scroll container
+
+A `pointer-events-none sticky bottom-0` gradient (`bg-gradient-to-t from-card`)
+inside the scrollable body. Sticky-in-scroll means it disappears naturally at the
+end of content (nothing below it to overlay) without any scroll-position JS.
+
+## Risks
+
+- The explore panel previously had unbounded height; constraining it could clip
+  long data-layer lists behind a scrollbar. That is the intended behavior (scroll
+  beats footer underlap); verified visually.
+- `HEADER_HEIGHT` is exported from `AppHeader.tsx`; consumers checked (only
+  `StudioShell` seed + the dropped `minHeight`).

--- a/openspec/changes/mapgen-studio-layout-geometry/proposal.md
+++ b/openspec/changes/mapgen-studio-layout-geometry/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+A direct visual inspection of the running studio (2026-06-11, dark, 1600×950)
+confirmed the user's verdict that the chrome is **squished**, and located the
+geometry roots in code rather than styling:
+
+1. The recipe dock is `w-[280px]` — carried over verbatim from the pre-redesign
+   `RecipePanel`. At 280px the rjsf helper prose wraps 3–4 lines per field and the
+   form reads as a cramped wall of text.
+2. An ~88px **dead band** sits between the 48px header bar and the docks:
+   `AppHeader` forces `minHeight: 104` (`LAYOUT.HEADER_HEIGHT`) even though a
+   ResizeObserver already reports the real header height to `StudioShell`, which
+   derives `panelTop` from it. The static reserve is a stale belt-and-suspenders
+   that permanently wastes vertical space the form is starving for.
+3. The recipe panel caps itself at `max-h-[calc(100vh-180px)]` — a magic number
+   that neither tracks the real header height nor the footer — and its scroll
+   edge cuts helper text mid-sentence with no affordance that more content exists.
+
+This is the geometry half of the Pass-2 reframe recorded in
+`docs/projects/mapgen-studio-redesign/pass-2-design-fixes.md`: the Pass-1
+"preserve as-built dimensions" decision is amended — control *density* stays,
+chrome *geometry* is redesigned.
+
+## Target Authority Refs
+
+- `docs/projects/mapgen-studio-redesign/pass-2-design-fixes.md` (Pass-2 frame; issues 1–3)
+- `apps/mapgen-studio/.interface-design/system.md` (§Pass-2 amendment: 340px left dock, content-driven header reserve, header→footer docks, fade affordance)
+- `docs/projects/mapgen-studio-redesign/FRAME.md` (§3 hard core = behavior parity)
+- `docs/projects/mapgen-studio-redesign/architecture/10-target-architecture.md` (§7 do-not-break registry)
+
+## What Changes
+
+- **`LAYOUT` constants become the single geometry authority**
+  (`src/ui/constants/layout.ts`): `PANEL_WIDTH` 280 → **340**;
+  `EXPLORE_PANEL_WIDTH` corrected 240 → **260** (it never matched the rendered
+  `w-[260px]`); `HEADER_HEIGHT` re-documented as the *initial estimate* of the
+  measured header (≈48 single-row), not a reserve. Panels consume the constants
+  (inline `style` width) instead of hardcoded arbitrary-value classes.
+- **`AppHeader` drops the static `minHeight` reserve.** The ResizeObserver →
+  `onHeaderHeightChange` → `panelTop` pipeline (already in place) becomes the only
+  authority; docks rise to sit one `SPACING` below the real header.
+- **Docks span header→footer**: `LeftDock`/`RightDock` receive a `bottom`
+  constraint (`FOOTER_HEIGHT + 2×SPACING`) so panels get the full working column;
+  `RecipePanel` replaces `max-h-[calc(100vh-180px)]` with `max-h-full`, and
+  `ExplorePanel` gains `max-h-full` + internal scrolling so it can no longer
+  underlap the footer on short viewports. Panels still shrink to fit short
+  content (max-h, not h).
+- **Scroll-edge fade affordance**: the recipe panel's scrollable body gets a
+  sticky bottom gradient (token-driven, `from-card`) so a cut never reads as the
+  end of content.
+
+## Out Of Scope / Parity Guarantees
+
+- No behavior change: run/poll/storage/transport semantics untouched; this slice
+  is positioning, sizing, and scroll chrome only.
+- No control-density change: button/input/switch/field-row dimensions stay as
+  committed in `.interface-design/system.md`.
+- The deck.gl canvas, camera, and fit behavior are untouched (C5 owns first-run
+  visibility).
+- Typography/hierarchy inside the form is C2 (`mapgen-studio-form-hierarchy`).
+
+## Verification Gates
+
+- `bun run openspec -- validate mapgen-studio-layout-geometry --strict`
+- `bun run --cwd apps/mapgen-studio check` (tsc) + mapgen-studio vitest project green
+- Visual proof on :5173 (dark + light): dock top aligns one SPACING below the real
+  header; left dock measures 340px; no mid-sentence hard cut at the scroll edge;
+  footer never overlapped.

--- a/openspec/changes/mapgen-studio-layout-geometry/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-layout-geometry/specs/mapgen-studio/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Chrome Geometry Derives From The LAYOUT Constants
+
+Mapgen Studio chrome geometry (dock widths, header offset, footer reserve) SHALL
+derive from the `LAYOUT` constants in `src/ui/constants/layout.ts`, with no
+duplicate hardcoded arbitrary-value width/height classes in the panel components,
+and the constants SHALL match what actually renders.
+
+#### Scenario: Recipe dock width is 340 from PANEL_WIDTH
+- **WHEN** the recipe dock renders
+- **THEN** its panel width is `LAYOUT.PANEL_WIDTH` (340px), applied from the constant rather than a hardcoded class
+
+#### Scenario: Explore dock width matches its constant
+- **WHEN** the explore dock renders
+- **THEN** its panel width is `LAYOUT.EXPLORE_PANEL_WIDTH` (260px), and the constant equals the rendered width
+
+### Requirement: The Header Reserve Is Content-Driven
+
+The header SHALL NOT force a static height reserve. The docks' top offset SHALL
+derive only from the measured header height (ResizeObserver) plus spacing, so no
+dead band exists between the header and the docks.
+
+#### Scenario: Docks sit one spacing unit below the real header
+- **WHEN** the app renders with a single-row header bar
+- **THEN** the dock top offset equals `SPACING + measuredHeaderHeight + SPACING`
+- **AND** the measured header height reflects content (≈48px single-row), not a `minHeight: 104` reserve
+
+#### Scenario: Header wrap still pushes docks down
+- **WHEN** the viewport narrows enough that the header controls wrap to more rows
+- **THEN** the docks move down to remain below the header (the ResizeObserver pipeline is preserved)
+
+### Requirement: Docks Span The Working Column Between Header And Footer
+
+Both docks SHALL be constrained to the column between the header and the footer:
+panels MAY shrink to fit short content but SHALL NOT exceed the column or
+underlap the footer, and overflow SHALL scroll internally.
+
+#### Scenario: Recipe panel uses the full column instead of a magic cap
+- **WHEN** the recipe panel's content exceeds the available column height
+- **THEN** the panel fills the column (top to footer reserve) and scrolls internally
+- **AND** the former `max-h-[calc(100vh-180px)]` magic cap is gone
+
+#### Scenario: Explore panel cannot underlap the footer
+- **WHEN** the viewport is short enough that the explore panel's content exceeds the column
+- **THEN** the explore panel caps at the column height and scrolls internally rather than rendering beneath the footer
+
+### Requirement: The Recipe Scroll Edge Carries A Fade Affordance
+
+The recipe panel's scrollable body SHALL render a token-driven bottom fade while
+further content exists below the fold, so a scroll cut never reads as the end of
+the form.
+
+#### Scenario: Fade visible above the fold
+- **WHEN** the recipe form has content below the visible scroll area
+- **THEN** a gradient fade (panel surface token, not a hardcoded color) overlays the bottom scroll edge
+- **AND** the fade does not intercept pointer events

--- a/openspec/changes/mapgen-studio-layout-geometry/tasks.md
+++ b/openspec/changes/mapgen-studio-layout-geometry/tasks.md
@@ -1,0 +1,32 @@
+## 1. Constants
+
+- [ ] 1.1 `layout.ts`: `PANEL_WIDTH` 280 → 340; `EXPLORE_PANEL_WIDTH` 240 → 260;
+      `HEADER_HEIGHT` 104 → 48 with doc comment re-stated as "initial estimate of
+      the measured header height (ResizeObserver is the authority), not a reserve".
+
+## 2. Header
+
+- [ ] 2.1 `AppHeader.tsx`: remove the `style={{ minHeight: HEADER_HEIGHT }}` reserve;
+      keep the ResizeObserver reporting pipeline untouched.
+
+## 3. Docks and panels
+
+- [ ] 3.1 `LeftDock.tsx` / `RightDock.tsx`: accept and apply a `bottom` constraint
+      (`FOOTER_HEIGHT + 2×SPACING` supplied by `StudioShell`); document the new
+      single-responsibility (top+bottom positioning).
+- [ ] 3.2 `RecipePanel.tsx`: root drops `w-[280px]` + `max-h-[calc(100vh-180px)]`
+      for `style` width from `LAYOUT.PANEL_WIDTH` + `max-h-full`.
+- [ ] 3.3 `ExplorePanel.tsx`: root drops `w-[260px]` for `LAYOUT.EXPLORE_PANEL_WIDTH`,
+      gains `max-h-full` and internal overflow scrolling.
+
+## 4. Scroll affordance
+
+- [ ] 4.1 Recipe panel scroll body: add the sticky bottom token-gradient fade
+      (`pointer-events-none`).
+
+## 5. Verification
+
+- [ ] 5.1 `bun run openspec -- validate mapgen-studio-layout-geometry --strict`
+- [ ] 5.2 tsc + mapgen-studio vitest project green
+- [ ] 5.3 Visual: DOM-measure dock boxes on :5173 (left 340 wide, top ≈ header+16,
+      bottom clear of footer); screenshot dark + light; squint-test the column.

--- a/openspec/changes/mapgen-studio-run-console/proposal.md
+++ b/openspec/changes/mapgen-studio-run-console/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Two defects observed live (2026-06-11):
+
+1. **Two simultaneous "Run" primary CTAs** — one at the bottom of the recipe
+   panel, one in the footer run console. A duplicated primary action splits
+   attention and muddles the chrome's story about where running happens. The
+   footer already *is* the run console: it owns seed, re-roll, auto-run,
+   Run in Game, and run status.
+2. The footer's last-run summary renders `123 · Standard · 6p · Bal` — "Bal" is
+   a deliberate abbreviation (`formatResourceMode`) but reads as accidental
+   truncation next to the unabbreviated "Standard".
+
+## Target Authority Refs
+
+- `docs/projects/mapgen-studio-redesign/pass-2-design-fixes.md` (issues 6–7)
+- `apps/mapgen-studio/.interface-design/system.md` (§Pass-2 amendment: "One Run CTA. The footer is the run console")
+- `docs/projects/mapgen-studio-redesign/FRAME.md` (§3 behavior parity — run semantics unchanged)
+
+## What Changes
+
+- **RecipePanel loses its Run button.** Its footer row keeps **Save & Deploy**
+  (now the row's full-width action). The `onRun`/`isRunning`/dirty-ring plumbing
+  that existed only for that button is removed from `RecipePanel`'s props and
+  from `StudioShell`'s wiring of it; the run path itself is untouched (the footer
+  Run triggers the exact same handler).
+- **The footer Run carries the dirty affordance.** The "config changed since last
+  run" emphasis (ring) that lived on the panel Run moves to the footer Run so the
+  signal is not lost; the footer's existing "Modified" status chip stays.
+- **`formatResourceMode('balanced')` returns "Balanced"** (and the other modes
+  their full words) — the footer has the space, and the summary stops reading as
+  cut off.
+
+## Out Of Scope / Parity Guarantees
+
+- The run handler, its disabled conditions, queueing, and status semantics are
+  unchanged — this removes a *duplicate trigger*, not behavior. The footer Run
+  already exists and already calls the same callback.
+- Run in Game, auto-run, seed, and re-roll controls are untouched.
+- No localStorage or test-contract changes (no test references the panel Run or
+  the "Bal" string — verified by grep).
+
+## Verification Gates
+
+- `bun run openspec -- validate mapgen-studio-run-console --strict`
+- tsc + mapgen-studio vitest project green (AppFooter suite must stay green)
+- Visual proof on :5173: exactly one Run button on screen; dirty state shows on
+  the footer Run; footer summary reads "… · Balanced".

--- a/openspec/changes/mapgen-studio-run-console/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-run-console/specs/mapgen-studio/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: The Footer Is The Single Run Console
+
+Mapgen Studio SHALL present exactly one browser-run trigger: the footer run
+console's Run button. The recipe panel SHALL NOT render a Run button; its footer
+row carries Save & Deploy only. The run handler and its disabled conditions are
+the same ones the footer already uses.
+
+#### Scenario: One Run trigger on screen
+- **WHEN** the studio renders in its default state
+- **THEN** exactly one button with the accessible name "Run" exists
+- **AND** it lives in the footer run console next to seed/re-roll/auto-run/Run in Game
+
+#### Scenario: Recipe panel keeps Save & Deploy
+- **WHEN** the recipe panel renders
+- **THEN** its footer row contains the Save & Deploy menu trigger and no Run button
+
+### Requirement: The Footer Run Carries The Dirty Affordance
+
+When the authored config differs from the last run, the footer Run button SHALL
+carry the dirty emphasis (focus-ring-tier contour), alongside the existing
+"Modified" status chip.
+
+#### Scenario: Dirty config emphasizes the footer Run
+- **WHEN** the user edits config after a run (`isDirty` true)
+- **THEN** the footer Run button renders the dirty ring emphasis
+- **AND** the footer status chip reads "Modified"
+
+### Requirement: Last-Run Summary Uses Unabbreviated Words
+
+The footer's last-run summary SHALL spell out resource-mode names (e.g.
+"Balanced"), so the summary does not read as truncated.
+
+#### Scenario: Balanced resources
+- **WHEN** the last run used resource mode `balanced`
+- **THEN** the summary renders "Balanced" (not "Bal")

--- a/openspec/changes/mapgen-studio-run-console/tasks.md
+++ b/openspec/changes/mapgen-studio-run-console/tasks.md
@@ -1,0 +1,20 @@
+## 1. RecipePanel
+
+- [ ] 1.1 Remove the Run button from the panel footer row; Save & Deploy becomes the
+      row's full-width action.
+- [ ] 1.2 Remove now-unused props (`onRun`, `isRunning`-only-for-button, dirty-ring
+      plumbing) from `RecipePanelProps` and from `StudioShell`'s `<RecipePanel …>`
+      wiring; keep any prop still used elsewhere in the panel (verify each).
+
+## 2. AppFooter
+
+- [ ] 2.1 Add the dirty ring emphasis to the footer Run button when `isDirty`.
+- [ ] 2.2 `formatting.ts`: `formatResourceMode` returns full words ("Balanced", …);
+      update its doc example.
+
+## 3. Verification
+
+- [ ] 3.1 `bun run openspec -- validate mapgen-studio-run-console --strict`
+- [ ] 3.2 tsc + mapgen-studio vitest project green (AppFooter suite unchanged)
+- [ ] 3.3 Visual on :5173: one Run on screen; edit a field → footer Run shows the
+      dirty ring + "Modified"; summary shows "Balanced".


### PR DESCRIPTION
## Pass 2 — Design Fixes (visually-grounded, spec-driven)

Following a direct visual inspection of the running studio (dark, 1600×950), the Pass 1 redesign was found to still read as **squished** and not functionally complete. The root cause: Pass 1 interpreted "preserve as-built dimensions" as covering chrome *geometry*, which meant the old pre-redesign skeleton shipped under new paint. This pass relaxes that constraint — control density stays inviolate, chrome geometry is redesigned.

### What's wrong and why

Nine defects were identified from live inspection and DOM measurement, resolving to five fix slices:

- **C1 — Layout geometry:** The left dock is still 280px (helper prose wraps 3–4 lines per field); an ~88px dead band sits between the header and docks because `AppHeader` forces `minHeight: 104` even though a ResizeObserver already measures the real header height; the recipe panel caps itself with a magic `calc(100vh-180px)` that cuts content mid-sentence with no scroll affordance.
- **C2 — Form hierarchy:** Field labels and descriptions render at the same size and color (`text-muted-foreground`), making the form a wall of indistinguishable gray. Separately, the field template mounts ~40 empty `role="alert"` live regions because it gates on the always-truthy `errors` element rather than `rawErrors?.length`.
- **C3 — Run console:** Two simultaneous "Run" primary CTAs exist (recipe panel bottom + footer). The footer's last-run summary renders "Bal" — a deliberate abbreviation that reads as accidental truncation.
- **C4 — Explore toolbar:** The Render and Space option clusters render as loose icon rows with no container boundary, reading as decoration rather than mutually-exclusive controls.
- **C5 — First-run visibility:** After a successful first run, the canvas stays visually black. The default Foundation/Mesh selection renders nothing the eye can find; matter only appears after manually selecting a later stage.

### Changes introduced

**Design system amendment** (`system.md`, `pass-2-design-fixes.md`, `00-GOAL.md`): documents the constraint relaxation, the nine observed issues mapped to five slices, and a falsifier — if the chrome still reads squished after C1+C2, the floating-panel paradigm itself is the problem and a structural relayout becomes the next frame.

**C1 — `mapgen-studio-layout-geometry`:** `PANEL_WIDTH` 280 → 340; `EXPLORE_PANEL_WIDTH` corrected to 260; `HEADER_HEIGHT` re-stated as the ResizeObserver seed (≈48), not a reserve. `AppHeader` drops the static `minHeight`. Docks gain a `bottom` constraint so panels span the full header→footer column. `RecipePanel` replaces the magic height cap with `max-h-full`; `ExplorePanel` gains internal scrolling. A sticky token-driven bottom fade replaces hard scroll cuts.

**C2 — `mapgen-studio-form-hierarchy`:** Field labels move to `text-foreground` medium weight in both `rjsfTemplates.tsx` and the hand-rolled field set; descriptions stay muted. The error live region gates on `rawErrors?.length` — zero empty `role="alert"` nodes on a pristine form, with the `id="${id}__error"` association contract preserved for fields that do have errors.

**C3 — `mapgen-studio-run-console`:** The recipe panel's Run button is removed; its footer row becomes Save & Deploy only. The dirty-config ring emphasis moves to the footer Run. `formatResourceMode` returns full words ("Balanced", etc.).

**C4 — `mapgen-studio-explore-toolbar`:** Render and Space option clusters become bounded segmented controls (`bg-input-background` container, active option lifted one surface tier). Independent toggles (fit, edges, debug) are left unwrapped.

**C5 — `mapgen-studio-first-run-visibility`:** Diagnosis is required before code — root cause (camera never fitted to first manifest bounds vs. inherently invisible default layer) recorded in `design.md`. Fix triggers the existing fit-to-view path when a run completes and the camera has never been positioned over generated matter; a user-positioned camera is never auto-refit on subsequent runs.

Each slice closes only with visual proof from the running app (screenshot or measured DOM delta, dark and light where theming is implicated).