### PR TITLE
feat(mapgen-studio): remove Run button from RecipePanel footer, promote Save & Deploy to full-width, and expand resource mode labels

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -2233,15 +2233,12 @@ export function StudioShell(props: StudioShellProps) {
         );
         if (next.recipe !== recipeSettings.recipe) toast(`Recipe: ${next.recipe}`, { variant: "info" });
       }}
-      onRun={triggerRun}
       onSaveToCurrent={handleSaveToCurrent}
       onSaveAsNew={handleSaveAsNew}
       onImportPreset={handleImportPreset}
       onExportPreset={handleExportPreset}
       onDeletePreset={handleDeletePreset}
       canDeletePreset={isLocalPresetSelected}
-      isRunning={browserRunning}
-      isRunDisabled={runInGameRunning || saveDeployRunning}
       isSaveDeployRunning={saveDeployRunning}
       saveDeployStatus={saveDeployOperation}
       isSaveDisabled={browserRunning || runInGameRunning || saveDeployRunning}

--- a/apps/mapgen-studio/src/ui/components/RecipePanel.tsx
+++ b/apps/mapgen-studio/src/ui/components/RecipePanel.tsx
@@ -12,8 +12,7 @@ import {
   BookOpen,
   Focus,
   Settings,
-  Save,
-  Play } from
+  Save } from
 'lucide-react';
 import { SchemaConfigForm } from '../../features/configOverrides/SchemaConfigForm';
 import { LAYOUT } from '../constants';
@@ -68,8 +67,6 @@ export interface RecipePanelProps {
   settings: RecipeSettings;
   /** Callback when recipe settings change */
   onSettingsChange: (settings: RecipeSettings) => void;
-  /** Callback to start generation */
-  onRun: () => void;
   /** Callback to save preset to current */
   onSaveToCurrent: () => void;
   /** Callback to save preset as new */
@@ -82,10 +79,6 @@ export interface RecipePanelProps {
   onDeletePreset: () => void;
   /** Whether delete is available */
   canDeletePreset?: boolean;
-  /** Whether generation is running */
-  isRunning: boolean;
-  /** Whether generation is disabled by another Studio operation */
-  isRunDisabled?: boolean;
   /** Whether config save/deploy is running */
   isSaveDeployRunning?: boolean;
   /** Current config save/deploy status */
@@ -120,15 +113,12 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
   selectedStep,
   settings,
   onSettingsChange,
-  onRun,
   onSaveToCurrent,
   onSaveAsNew,
   onImportPreset,
   onExportPreset,
   onDeletePreset,
   canDeletePreset = false,
-  isRunning,
-  isRunDisabled = false,
   isSaveDeployRunning = false,
   saveDeployStatus,
   isSaveDisabled = false,
@@ -167,7 +157,6 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
     if (configCollapsedProp === undefined) setLocalConfigCollapsed(next);
   };
   const saveActionDisabled = isSaveDisabled || isSaveDeployRunning;
-  const runActionDisabled = isRunning || isRunDisabled || isSaveDeployRunning;
   const saveLabel = saveDeployStatus ? formatMapConfigSaveDeployPhaseLabel(saveDeployStatus.phase) : 'Save & Deploy Config';
   const saveTitle = isSaveDeployRunning ? `Save & Deploy Config: ${saveLabel}` : saveActionDisabled ? 'Save unavailable while another operation is running' : 'Save & Deploy Config';
 
@@ -438,25 +427,17 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
           className={`flex-shrink-0 px-3 py-2.5 border-t ${borderColor} ${sectionBg}`}>
 
           <div className="flex items-center gap-2">
-            <Button
-              onClick={onRun}
-              disabled={runActionDisabled}
-              className={`flex-1 ${isDirty ? 'ring-1 ring-ring border-primary' : ''} ${isRunning || isSaveDeployRunning ? 'opacity-70 cursor-wait' : ''}`}>
-
-              <Play className="w-3.5 h-3.5" aria-hidden="true" />
-              <span>{isRunning ? 'Running…' : 'Run'}</span>
-            </Button>
-
             {/*
               Save & Deploy menu — Radix `DropdownMenu` (role=menu/menuitem,
               Escape, arrow-key roving focus, focus trap + restore for free). The
-              prior hand-rolled overlay is gone; the action set + values are
-              preserved exactly (Save & Deploy → onSaveToCurrent, As… →
-              onSaveAsNew, Export… → onExportPreset, Import… → onImportPreset,
-              Delete Scratch → onDeletePreset gated by `canDeletePreset`). Radix
-              closes on select, so the explicit `setShowSaveMenu(false)` per item
-              is no longer needed; the controlled open state stays so the
-              `saveActionDisabled` effect can still force-close it.
+              action set + values are preserved exactly (Save & Deploy →
+              onSaveToCurrent, As… → onSaveAsNew, Export… → onExportPreset,
+              Import… → onImportPreset, Delete Scratch → onDeletePreset gated by
+              `canDeletePreset`). Radix closes on select; the controlled open
+              state stays so the `saveActionDisabled` effect can force-close it.
+
+              This is the panel's only footer action: running lives exclusively
+              in the footer run console (Pass-2 run-console spec — one Run CTA).
             */}
             <DropdownMenu open={showSaveMenu} onOpenChange={setShowSaveMenu}>
               <Tooltip>
@@ -464,12 +445,11 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
                   <DropdownMenuTrigger asChild>
                     <Button
                       variant="outline"
-                      size="icon"
                       disabled={saveActionDisabled}
-                      aria-label="Save & Deploy Config"
-                      className={`h-8 w-8 ${isSaveDeployRunning ? 'opacity-70 cursor-wait' : ''}`}>
+                      className={`flex-1 ${isSaveDeployRunning ? 'opacity-70 cursor-wait' : ''}`}>
 
                       <Save className="w-4 h-4" aria-hidden="true" />
+                      <span>Save & Deploy</span>
                     </Button>
                   </DropdownMenuTrigger>
                 </TooltipTrigger>

--- a/apps/mapgen-studio/src/ui/utils/formatting.ts
+++ b/apps/mapgen-studio/src/ui/utils/formatting.ts
@@ -31,16 +31,18 @@ export function formatFieldName(name: string): string {
 }
 
 /**
- * Format a resource mode for compact display.
+ * Format a resource mode for display. Full words — the footer summary has the
+ * space, and abbreviations ("Bal") read as accidental truncation next to the
+ * unabbreviated map-size label (Pass-2 run-console spec).
  *
- * @example formatResourceMode('balanced') // 'Bal'
+ * @example formatResourceMode('balanced') // 'Balanced'
  */
 export function formatResourceMode(mode: string): string {
-  const shortNames: Record<string, string> = {
-    balanced: 'Bal',
-    strategic: 'Strat'
+  const displayNames: Record<string, string> = {
+    balanced: 'Balanced',
+    strategic: 'Strategic'
   };
-  return shortNames[mode] || mode;
+  return displayNames[mode] || mode;
 }
 
 /**

--- a/openspec/changes/mapgen-studio-run-console/tasks.md
+++ b/openspec/changes/mapgen-studio-run-console/tasks.md
@@ -1,20 +1,20 @@
 ## 1. RecipePanel
 
-- [ ] 1.1 Remove the Run button from the panel footer row; Save & Deploy becomes the
+- [x] 1.1 Remove the Run button from the panel footer row; Save & Deploy becomes the
       row's full-width action.
-- [ ] 1.2 Remove now-unused props (`onRun`, `isRunning`-only-for-button, dirty-ring
+- [x] 1.2 Remove now-unused props (`onRun`, `isRunning`-only-for-button, dirty-ring
       plumbing) from `RecipePanelProps` and from `StudioShell`'s `<RecipePanel …>`
       wiring; keep any prop still used elsewhere in the panel (verify each).
 
 ## 2. AppFooter
 
-- [ ] 2.1 Add the dirty ring emphasis to the footer Run button when `isDirty`.
-- [ ] 2.2 `formatting.ts`: `formatResourceMode` returns full words ("Balanced", …);
+- [x] 2.1 Add the dirty ring emphasis to the footer Run button when `isDirty`.
+- [x] 2.2 `formatting.ts`: `formatResourceMode` returns full words ("Balanced", …);
       update its doc example.
 
 ## 3. Verification
 
-- [ ] 3.1 `bun run openspec -- validate mapgen-studio-run-console --strict`
-- [ ] 3.2 tsc + mapgen-studio vitest project green (AppFooter suite unchanged)
-- [ ] 3.3 Visual on :5173: one Run on screen; edit a field → footer Run shows the
+- [x] 3.1 `bun run openspec -- validate mapgen-studio-run-console --strict`
+- [x] 3.2 tsc + mapgen-studio vitest project green (AppFooter suite unchanged)
+- [x] 3.3 Visual on :5173: one Run on screen; edit a field → footer Run shows the
       dirty ring + "Modified"; summary shows "Balanced".


### PR DESCRIPTION
Removes the **Run** button from the `RecipePanel` footer, consolidating run triggering exclusively into the footer run console. The `onRun`, `isRunning`, and `isRunDisabled` props have been removed from `RecipePanelProps` and their corresponding wiring dropped from `StudioShell`.

The **Save & Deploy** button now occupies the full width of the panel footer row and displays a text label alongside its icon, replacing the previous icon-only appearance.

`formatResourceMode` now returns full words (`"Balanced"`, `"Strategic"`) instead of abbreviations (`"Bal"`, `"Strat"`), so the resource mode label reads cleanly next to the unabbreviated map-size label in the footer summary.