### PR TITLE
feat(mapgen-studio): wrap Render and Space toolbar options in segmented controls

### DIFF
--- a/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
+++ b/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
@@ -243,6 +243,13 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
   const stepItemInactive = 'border-transparent text-muted-foreground hover:bg-accent hover:text-foreground';
   const iconBtn = 'h-7 w-7 flex items-center justify-center rounded transition-colors shrink-0 text-muted-foreground hover:text-foreground hover:bg-accent';
   const iconBtnActive = 'h-7 w-7 flex items-center justify-center rounded transition-colors shrink-0 text-foreground bg-muted';
+  // Segmented controls for mutually-exclusive option sets (Render / Space):
+  // an inset container on the control-background token bounds the options so
+  // they read as one control; the active segment lifts one surface tier
+  // (Pass-2 explore-toolbar spec). Independent toggles keep `iconBtn`.
+  const segGroup = 'inline-flex items-center rounded border border-border-subtle bg-input-background p-0.5';
+  const segBtn = 'h-6 w-6 flex items-center justify-center rounded-sm transition-colors shrink-0 text-muted-foreground hover:text-foreground';
+  const segBtnActive = 'h-6 w-6 flex items-center justify-center rounded-sm transition-colors shrink-0 text-foreground bg-muted';
   const stageBadge = (isActive: boolean) => `
     w-5 h-5 flex items-center justify-center rounded-full text-label font-semibold shrink-0
     ${isActive ? 'bg-muted text-foreground' : 'bg-muted/50 text-muted-foreground'}
@@ -533,7 +540,7 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
           {/* Right: Render */}
           <div className="flex flex-col items-end gap-1">
             <span className={`text-label uppercase tracking-wider ${textMuted}`}>Render</span>
-            <div className="flex items-center gap-1">
+            <div className={segGroup}>
               {renderModeOptions.map((option) => (
                 <Tooltip key={option.value}>
                   <TooltipTrigger asChild>
@@ -541,7 +548,7 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
                       onClick={() => onSelectedRenderModeChange(option.value)}
                       aria-label={option.label}
                       aria-pressed={selectedRenderMode === option.value}
-                      className={selectedRenderMode === option.value ? iconBtnActive : iconBtn}
+                      className={selectedRenderMode === option.value ? segBtnActive : segBtn}
                     >
                       {getRenderModeIcon(option.value)}
                     </button>
@@ -557,7 +564,7 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
           {/* Left: Space */}
           <div className="flex flex-col gap-1">
             <span className={`text-label uppercase tracking-wider ${textMuted}`}>Space</span>
-            <div className="flex items-center gap-1">
+            <div className={segGroup}>
               {spaceOptions.map((option) => (
                 <Tooltip key={option.value}>
                   <TooltipTrigger asChild>
@@ -565,7 +572,7 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
                       onClick={() => onSelectedSpaceChange(option.value)}
                       aria-label={option.label}
                       aria-pressed={selectedSpace === option.value}
-                      className={selectedSpace === option.value ? iconBtnActive : iconBtn}
+                      className={selectedSpace === option.value ? segBtnActive : segBtn}
                     >
                       {getSpaceIcon(option.value)}
                     </button>

--- a/openspec/changes/mapgen-studio-explore-toolbar/tasks.md
+++ b/openspec/changes/mapgen-studio-explore-toolbar/tasks.md
@@ -1,15 +1,15 @@
 ## 1. ExplorePanel view toolbar
 
-- [ ] 1.1 Wrap the Render option row in a segmented container
+- [x] 1.1 Wrap the Render option row in a segmented container
       (`bg-input-background` + hairline border + 2px padding); active option
       `bg-muted text-foreground rounded-sm`, inactive flush.
-- [ ] 1.2 Same treatment for the Space option row.
-- [ ] 1.3 Leave fit/edges/debug toggles unwrapped; confirm tooltips, `aria-label`,
+- [x] 1.2 Same treatment for the Space option row.
+- [x] 1.3 Leave fit/edges/debug toggles unwrapped; confirm tooltips, `aria-label`,
       `aria-pressed`, and callbacks unchanged.
 
 ## 2. Verification
 
-- [ ] 2.1 `bun run openspec -- validate mapgen-studio-explore-toolbar --strict`
-- [ ] 2.2 tsc + mapgen-studio vitest project green
-- [ ] 2.3 Visual on :5173 (dark + light): segmented controls read as controls;
+- [x] 2.1 `bun run openspec -- validate mapgen-studio-explore-toolbar --strict`
+- [x] 2.2 tsc + mapgen-studio vitest project green
+- [x] 2.3 Visual on :5173 (dark + light): segmented controls read as controls;
       active segment unambiguous at a squint.


### PR DESCRIPTION
The Render and Space option rows in the ExplorePanel toolbar are now styled as segmented controls rather than loose icon button groups. Each row is wrapped in an inset container using `bg-input-background` with a hairline border and 2px padding, making the options read as a single cohesive control. The active segment uses `bg-muted text-foreground rounded-sm` to lift visually within the container, while inactive segments sit flush. Independent toggles (fit, edges, debug) remain unwrapped and retain their existing `iconBtn` styles, tooltips, `aria-label`, `aria-pressed`, and callbacks.