### PR TITLE
fix(mapgen-studio): replace global reset with body-only flash guard and align theme bootstrap with useTheme system-preference resolution

### DIFF
--- a/apps/mapgen-studio/index.html
+++ b/apps/mapgen-studio/index.html
@@ -4,27 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MapGen Studio</title>
-    <script>
-      // Apply theme before first paint (no flash). Default dark; `.dark` drives
-      // the design tokens in index.css. localStorage key written by the app.
-      (function () {
-        try {
-          var stored = localStorage.getItem("mapgen-studio:theme");
-          if (stored ? stored === "dark" : true) {
-            document.documentElement.classList.add("dark");
-          }
-        } catch (e) {
-          document.documentElement.classList.add("dark");
-        }
-      })();
-    </script>
     <style>
-      * {
-        margin: 0;
-        padding: 0;
-        box-sizing: border-box;
-      }
-      /* Pre-React flash color matches the dark page token (index.css --background). */
+      /* Pre-paint flash guard ONLY. This block must stay unlayered-minimal:
+         unlayered author CSS outranks every Tailwind @layer, so a global reset
+         here would zero all padding/margin utilities app-wide (Pass-3 root
+         cause). Element resets come from Tailwind preflight in index.css.
+         Colors match the dark page tokens (index.css --background/--foreground);
+         the theme script below out-cascades them for light users. */
       body {
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
         background: #0d0d11;
@@ -32,6 +18,34 @@
         min-height: 100vh;
       }
     </style>
+    <script>
+      // Apply theme before first paint (no flash). `.dark` drives the design
+      // tokens in index.css. Must stay AFTER the flash-guard <style> so the
+      // light override it appends wins by source order.
+      (function () {
+        try {
+          // Same key + resolution as `useTheme.ts`: explicit light/dark wins;
+          // "system" (or anything else) follows the OS preference.
+          var stored = localStorage.getItem("theme-preference");
+          var dark =
+            stored === "dark" ||
+            (stored !== "light" &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches);
+          if (dark) {
+            document.documentElement.classList.add("dark");
+          } else {
+            // The static flash guard above is dark; out-cascade it (same
+            // specificity, later source order) so light users don't get a
+            // dark pre-React flash (index.css :root --background/--foreground).
+            var s = document.createElement("style");
+            s.textContent = "body { background: #f2f2f7; color: #1f2937; }";
+            document.head.appendChild(s);
+          }
+        } catch (e) {
+          document.documentElement.classList.add("dark");
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/openspec/changes/mapgen-studio-spacing-substrate/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-spacing-substrate/specs/mapgen-studio/spec.md
@@ -14,15 +14,17 @@ and element resets come only from Tailwind preflight.
 - **WHEN** the page loads before React hydrates
 - **THEN** the body still paints the dark flash-guard background and font stack from `index.html`
 
-### Requirement: The Theme Bootstrap Reads The Persisted Preference Key
+### Requirement: The Theme Bootstrap Mirrors The App's Preference Resolution
 
 The pre-paint theme script SHALL read the same localStorage key the app writes
-(`theme-preference`), defaulting to dark when the key is absent or unreadable.
+(`theme-preference`) and resolve it the same way `useTheme` does — explicit
+light/dark wins; absent or `system` follows the OS preference; storage errors
+fall back to dark.
 
 #### Scenario: Light preference applies before first paint
 - **WHEN** `localStorage["theme-preference"]` is `"light"` and the page loads
 - **THEN** the bootstrap does not add the `dark` class, so no dark pre-paint flash occurs
 
-#### Scenario: Absent key keeps the dark default
+#### Scenario: Absent key follows the OS preference
 - **WHEN** no theme preference is persisted
-- **THEN** the bootstrap adds the `dark` class before first paint
+- **THEN** the bootstrap adds the `dark` class exactly when the OS prefers dark, matching what the app will resolve after hydration

--- a/openspec/changes/mapgen-studio-spacing-substrate/tasks.md
+++ b/openspec/changes/mapgen-studio-spacing-substrate/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Implementation
 
-- [ ] 1.1 Remove the unlayered `* { margin; padding; box-sizing }` rule from
+- [x] 1.1 Remove the unlayered `* { margin; padding; box-sizing }` rule from
       `apps/mapgen-studio/index.html`; keep the `body` flash guard.
-- [ ] 1.2 Point the pre-paint theme script at `theme-preference` (the key
+- [x] 1.2 Point the pre-paint theme script at `theme-preference` (the key
       `useTheme.ts` writes); keep dark-by-default and the try/catch fallback.
 
 ## 2. Verification
 
-- [ ] 2.1 `bun run openspec -- validate mapgen-studio-spacing-substrate --strict`
-- [ ] 2.2 tsc + mapgen-studio vitest project green
-- [ ] 2.3 Live DOM proof on :5173: `px-3` row computes 12px inline padding;
+- [x] 2.1 `bun run openspec -- validate mapgen-studio-spacing-substrate --strict`
+- [x] 2.2 tsc + mapgen-studio vitest project green
+- [x] 2.3 Live DOM proof on :5173: `px-3` row computes 12px inline padding;
       stage card computes 10px padding; screenshot the restored texture.
-- [ ] 2.4 Theme: with `theme-preference=light` persisted, reload shows no dark
+- [x] 2.4 Theme: with `theme-preference=light` persisted, reload shows no dark
       flash and the app mounts light; cleared key mounts dark.
-- [ ] 2.5 Full-app visual sweep (header, docks, footer, dialogs) for surfaces
+- [x] 2.5 Full-app visual sweep (header, docks, footer, dialogs) for surfaces
       that over-inflate with restored spacing; log re-tunes to owning slices.


### PR DESCRIPTION
Fixes two bugs in the `index.html` pre-paint bootstrap that were introduced alongside the Tailwind spacing substrate work:

**Unlayered global reset removed**

The `* { margin: 0; padding: 0; box-sizing: border-box }` rule was written as unlayered author CSS, which outranks every Tailwind `@layer` rule. This caused all `padding`/`margin` utilities (e.g. `px-3`, `p-2.5`) to be zeroed out app-wide. The rule has been removed; element resets are now handled exclusively by Tailwind preflight in `index.css`.

**Theme bootstrap aligned with `useTheme` resolution logic**

The script was reading the wrong localStorage key (`mapgen-studio:theme` instead of `theme-preference`) and always defaulted to dark when no value was stored. It now mirrors `useTheme.ts` exactly: an explicit `"light"` or `"dark"` value wins outright; anything else (absent key, `"system"`) defers to `prefers-color-scheme`. For light users, a late `<style>` tag is injected after the dark flash-guard to override the body background and foreground before React hydrates, preventing a dark flash on light-mode page loads.