### PR TITLE
docs(mapgen-studio-no-hardcoded-defaults): mark all tasks as executed

### DIFF
--- a/openspec/changes/mapgen-studio-no-hardcoded-defaults/tasks.md
+++ b/openspec/changes/mapgen-studio-no-hardcoded-defaults/tasks.md
@@ -1,14 +1,14 @@
 ## 1. Implementation
 
-- [ ] 1.1 Delete `apps/mapgen-studio/src/ui/data/defaultConfig.ts`; confirm no
+- [x] 1.1 Delete `apps/mapgen-studio/src/ui/data/defaultConfig.ts`; confirm no
       remaining importers (app or tests) besides the retargeted shape tests.
-- [ ] 1.2 Rewrite the two legacy-shape blocks in
+- [x] 1.2 Rewrite the two legacy-shape blocks in
       `test/config/defaultConfigSchema.test.ts` to assert against
       `STANDARD_RECIPE_CONFIG`, preserving the semantic-surface guards
       (expected key sets, no raw op envelopes, no legacy stage keys).
 
 ## 2. Verification
 
-- [ ] 2.1 `bun run openspec -- validate mapgen-studio-no-hardcoded-defaults --strict`
-- [ ] 2.2 tsc + mapgen-studio vitest green
-- [ ] 2.3 `rg` sweep: no app-side literal pipeline-default duplicates remain.
+- [x] 2.1 `bun run openspec -- validate mapgen-studio-no-hardcoded-defaults --strict`
+- [x] 2.2 tsc + mapgen-studio vitest green
+- [x] 2.3 `rg` sweep: no app-side literal pipeline-default duplicates remain.


### PR DESCRIPTION
All implementation and verification tasks for the `mapgen-studio-no-hardcoded-defaults` change have been completed:

- Deleted `defaultConfig.ts` and confirmed no remaining importers outside the retargeted shape tests
- Rewrote the legacy-shape test blocks in `defaultConfigSchema.test.ts` to assert against `STANDARD_RECIPE_CONFIG`, preserving semantic-surface guards
- Passed strict OpenSpec validation, tsc, and mapgen-studio vitest
- Confirmed via `rg` sweep that no app-side literal pipeline-default duplicates remain