### PR TITLE
feat(explore-toolbar): regroup into VIEW/LAYER clusters and relocate debug toggle to data list header

### DIFF
--- a/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
+++ b/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
@@ -247,6 +247,10 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
   // an inset container on the control-background token bounds the options so
   // they read as one control; the active segment lifts one surface tier
   // (Pass-2 explore-toolbar spec). Independent toggles keep `iconBtn`.
+  // Toolbar cluster anatomy (Pass-3): a cluster heading names the target
+  // (View = camera/map, Layer = selected data); row labels sit a tier below.
+  const clusterHeading = `text-label font-semibold uppercase tracking-wider ${textSecondary}`;
+  const rowLabel = `text-label uppercase tracking-wider ${textMuted}`;
   const segGroup = 'inline-flex items-center rounded border border-border-subtle bg-input-background p-0.5';
   const segBtn = 'h-6 w-6 flex items-center justify-center rounded-sm transition-colors shrink-0 text-muted-foreground hover:text-foreground';
   const segBtnActive = 'h-6 w-6 flex items-center justify-center rounded-sm transition-colors shrink-0 text-foreground bg-muted';
@@ -431,14 +435,17 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
         </div>
       ) : null}
 
-      {/* 3. LAYERS SECTION */}
-      <div className={`flex-shrink-0 border-b ${borderSubtle}`}>
+      {/* 3. LAYERS SECTION. The debug toggle lives on this header — it filters
+          which entries the data list shows (`includeDebug`), so it belongs to
+          the list, not to the view toolbar (Pass-3 explore-toolbar spec). It is
+          a sibling of the disclosure button, never nested inside it. */}
+      <div className={`flex-shrink-0 border-b ${borderSubtle} flex items-center`}>
         <button
           type="button"
           onClick={() => setIsLayersExpanded(!isLayersExpanded)}
           aria-expanded={isLayersExpanded}
           aria-controls="explore-layers-list"
-          className={`w-full flex items-center justify-between px-3 py-2 transition-colors ${hoverBg}`}>
+          className={`flex-1 min-w-0 flex items-center justify-between pl-3 pr-2 py-2 transition-colors ${hoverBg}`}>
 
           <div className="flex items-center gap-2 min-w-0 overflow-hidden">
             <SquareStack className={`w-3.5 h-3.5 shrink-0 ${textSecondary}`} />
@@ -456,6 +463,18 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
             <ChevronDown className={`w-3.5 h-3.5 ${textMuted} transition-transform ${isLayersExpanded ? "rotate-180" : ""}`} />
           </div>
         </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => onShowDebugLayersChange(!showDebugLayers)}
+              aria-label={showDebugLayers ? "Hide debug layers" : "Show debug layers"}
+              aria-pressed={showDebugLayers}
+              className={`mr-2 ${showDebugLayers ? iconBtnActive : iconBtn}`}>
+              <Bug className="w-3.5 h-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>{showDebugLayers ? "Hide debug layers" : "Show debug layers"}</TooltipContent>
+        </Tooltip>
       </div>
       {isLayersExpanded ? (
         <div id="explore-layers-list" className={`flex-shrink-0 pb-2 border-b ${borderSubtle} ${listMaxHeight} overflow-y-auto custom-scrollbar`}>
@@ -510,10 +529,13 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
         </div>
       ) : null}
 
-      {/* 4. VIEW TOOLBAR */}
+      {/* 4. VIEW + LAYER TOOLBAR — controls grouped by target (Pass-3):
+          VIEW acts on the camera/map display; LAYER acts on the selected data
+          layer's presentation. Rows are label-left / control-right. */}
       <div className="flex-shrink-0 p-2 flex flex-col gap-2">
+        {/* VIEW cluster: camera + map-display */}
         <div className="flex items-center justify-between gap-2">
-          {/* Left: Fit & Edges */}
+          <span className={clusterHeading}>View</span>
           <div className="flex items-center gap-1">
             <Tooltip>
               <TooltipTrigger asChild>
@@ -528,6 +550,7 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
                 <button
                   onClick={() => onShowEdgesChange(!showEdges)}
                   aria-label={showEdges ? 'Hide edges' : 'Show edges'}
+                  aria-pressed={showEdges}
                   className={showEdges ? iconBtnActive : iconBtn}>
 
                   <GitBranch className="w-3.5 h-3.5" />
@@ -536,10 +559,16 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
               <TooltipContent>{showEdges ? 'Hide edges' : 'Show edges'}</TooltipContent>
             </Tooltip>
           </div>
+        </div>
 
-          {/* Right: Render */}
-          <div className="flex flex-col items-end gap-1">
-            <span className={`text-label uppercase tracking-wider ${textMuted}`}>Render</span>
+        <div className={`border-t ${borderSubtle}`} />
+
+        {/* LAYER cluster: how the selected data layer renders. ("Layer", not
+            "Data" — the Data list section sits directly above this toolbar.) */}
+        <div className="flex flex-col gap-1.5">
+          <span className={clusterHeading}>Layer</span>
+          <div className="flex items-center justify-between gap-2">
+            <span className={rowLabel}>Render</span>
             <div className={segGroup}>
               {renderModeOptions.map((option) => (
                 <Tooltip key={option.value}>
@@ -558,12 +587,8 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
               ))}
             </div>
           </div>
-        </div>
-
-        <div className="flex items-center justify-between gap-2">
-          {/* Left: Space */}
-          <div className="flex flex-col gap-1">
-            <span className={`text-label uppercase tracking-wider ${textMuted}`}>Space</span>
+          <div className="flex items-center justify-between gap-2">
+            <span className={rowLabel}>Space</span>
             <div className={segGroup}>
               {spaceOptions.map((option) => (
                 <Tooltip key={option.value}>
@@ -582,19 +607,6 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
               ))}
             </div>
           </div>
-
-          {/* Right: Debug toggle */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={() => onShowDebugLayersChange(!showDebugLayers)}
-                aria-label={showDebugLayers ? "Hide debug layers" : "Show debug layers"}
-                className={showDebugLayers ? iconBtnActive : iconBtn}>
-                <Bug className="w-3.5 h-3.5" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>{showDebugLayers ? "Hide debug layers" : "Show debug layers"}</TooltipContent>
-          </Tooltip>
         </div>
 
         {eraEnabled ? (

--- a/docs/projects/mapgen-studio-redesign/00-GOAL.md
+++ b/docs/projects/mapgen-studio-redesign/00-GOAL.md
@@ -244,3 +244,41 @@ Gates green at tip: tsc, build + worker-bundle, 144 tests, six strict OpenSpec
 validations. Review wave: no P1/P2; two P3s repaired in-stack (scroll-fade padding;
 a foreign `codex/sieve-engine-reference` docs commit `gt move`d out of the stack
 base). Stack remains UNSUBMITTED per the standing rule.
+
+## Pass 3 — spacing substrate + config surface + console split (2026-06-11, evening)
+
+Next user wave: config-panel padding/margins "really bad" (wants a ground-up
+elevation/nesting pass), separate live-game vs studio-only bottom controls,
+inventory + regroup the explore bottom buttons, and a new standing law: **no
+hard-coded config overrides anywhere**. Frame, root-cause diagnosis, and
+designs in [`pass-3-design-fixes.md`](pass-3-design-fixes.md). Five OpenSpec
+slices stacked on `design/theme-class-sync`:
+
+- [x] **D0** `mapgen-studio-spacing-substrate` — `design/spacing-substrate`
+  (ROOT CAUSE: unlayered `* {margin:0;padding:0}` in index.html outranked
+  Tailwind v4's `@layer utilities`, zeroing every spacing utility app-wide;
+  removed. Theme bootstrap now reads `theme-preference` with useTheme's
+  resolution + light pre-paint flash guard)
+- [x] **D4** `mapgen-studio-no-hardcoded-defaults` — `design/no-hardcoded-defaults`
+  (deleted the 330-line hand-maintained default-config duplicate the app never
+  imported; shape tests retargeted at STANDARD_RECIPE_CONFIG, exposing real
+  drift in the ecology stages)
+- [x] **D1** `mapgen-studio-config-surface` — `design/config-surface` (nesting
+  by surface elevation: recessed group wells replace border-l indent ladders,
+  two-surface cap, arrays unified; FORM.rhythm 4/8/12 codified; group headings
+  inverted to the eyebrow tier)
+- [x] **D2** `mapgen-studio-footer-consoles` — `design/footer-consoles`
+  (centered Studio console merges the two studio bars; named modular
+  `GameConsole` right-docked under a Civ7 eyebrow — live chip + sync bridge,
+  autoplay, Run in Game + status/retry/diagnostics, save-deploy chip; exact
+  centering while space allows, yield-not-overlap verified at 1199px)
+- [x] **D3** `mapgen-studio-explore-toolbar-groups` — `design/explore-toolbar-groups`
+  (VIEW vs LAYER clusters by control target; debug toggle relocated to the
+  Data list header it actually filters — verified filtering live)
+
+**Pass-3 closure (2026-06-11):** all five slices implemented + visually
+verified on :5173 (dark + light screenshots; DOM-computed spacing proof
+px-3 ⇒ 12px; footer centering measured 860==860 @1720px; debug filter
+exercised live 2→3→2). Gates green at tip: tsc, build + worker-bundle,
+146 tests, five strict OpenSpec validations. Stack remains UNSUBMITTED per
+the standing rule.

--- a/openspec/changes/mapgen-studio-explore-toolbar-groups/proposal.md
+++ b/openspec/changes/mapgen-studio-explore-toolbar-groups/proposal.md
@@ -24,8 +24,10 @@ All in `src/ui/components/ExplorePanel.tsx`:
 
 - **Two eyebrow-labeled clusters** replace the zig-zag rows:
   - **VIEW** — Fit to view (camera), Edges overlay toggle (map display).
-  - **DATA** — Render segment, Space segment, then the conditional
+  - **LAYER** — Render segment, Space segment, then the conditional
     data-scoped rows (Era, Variant, Overlay + opacity) under the same cluster.
+    (Named "Layer", not "Data": the Data list section sits directly above and
+    a duplicate eyebrow would read as part of it.)
 - **Consistent row anatomy**: label-left / control-right within each cluster
   (no more right-aligned-label-over-control vs left-aligned variants).
 - **Debug toggle relocates to the DATA section header** (beside the count),

--- a/openspec/changes/mapgen-studio-explore-toolbar-groups/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-explore-toolbar-groups/specs/mapgen-studio/spec.md
@@ -4,17 +4,18 @@
 
 The explore panel's bottom toolbar SHALL group controls into labeled clusters
 by what they act on — a VIEW cluster for camera/map-display controls (fit,
-edges overlay) and a DATA cluster for selected-data presentation controls
-(render mode, space, and the conditional era/variant/overlay rows) — with a
-consistent label/control row anatomy inside each cluster.
+edges overlay) and a LAYER cluster for selected-data presentation controls
+(render mode, space, and the conditional era/variant/overlay rows; named
+"Layer" so it cannot be confused with the Data list section above it) — with
+a consistent label/control row anatomy inside each cluster.
 
 #### Scenario: View controls cluster under a VIEW label
 - **WHEN** the explore toolbar renders
 - **THEN** fit-to-view and the edges overlay toggle render together under a visible VIEW eyebrow label
 
-#### Scenario: Data controls cluster under a DATA label
+#### Scenario: Data controls cluster under a LAYER label
 - **WHEN** the explore toolbar renders for a selected data type
-- **THEN** the render-mode and space segmented controls (and era/variant/overlay rows when applicable) render together under a visible DATA eyebrow label
+- **THEN** the render-mode and space segmented controls (and era/variant/overlay rows when applicable) render together under a visible LAYER eyebrow label
 
 ### Requirement: The Debug Toggle Lives With The Data List It Filters
 

--- a/openspec/changes/mapgen-studio-explore-toolbar-groups/tasks.md
+++ b/openspec/changes/mapgen-studio-explore-toolbar-groups/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Implementation
 
-- [ ] 1.1 Restructure the bottom toolbar into VIEW (fit, edges) and DATA
+- [x] 1.1 Restructure the bottom toolbar into VIEW (fit, edges) and DATA
       (render, space, era, variant, overlay) clusters with eyebrow labels and
       consistent label-left/control-right rows.
-- [ ] 1.2 Move the debug toggle to the DATA section header (same icon/aria/
+- [x] 1.2 Move the debug toggle to the DATA section header (same icon/aria/
       tooltip; `aria-pressed` preserved).
-- [ ] 1.3 Preserve all handlers, segmented-control treatments, and conditional
+- [x] 1.3 Preserve all handlers, segmented-control treatments, and conditional
       rendering (era/variant/overlay).
 
 ## 2. Verification
 
-- [ ] 2.1 `bun run openspec -- validate mapgen-studio-explore-toolbar-groups --strict`
-- [ ] 2.2 tsc + mapgen-studio vitest green
-- [ ] 2.3 Visual on :5173: clusters labeled and aligned; debug toggle on the
+- [x] 2.1 `bun run openspec -- validate mapgen-studio-explore-toolbar-groups --strict`
+- [x] 2.2 tsc + mapgen-studio vitest green
+- [x] 2.3 Visual on :5173: clusters labeled and aligned; debug toggle on the
       DATA header still filters the list (toggle live and verify entries
       change). Screenshot.


### PR DESCRIPTION
Restructures the explore panel's bottom toolbar into two labeled clusters — **View** and **Layer** — grouped by what each control acts on, replacing the previous zig-zag row layout.

**View cluster** contains the fit-to-view and edges overlay toggle (camera and map-display controls). **Layer cluster** contains the render mode and space segmented controls, plus the conditional era, variant, and overlay rows. The cluster is named "Layer" rather than "Data" to avoid visual confusion with the Data list section immediately above it.

The debug toggle is relocated from the view toolbar to the Layers section header, where it belongs — it filters the data list entries (`showDebugLayers`), so it is now a sibling of the disclosure button on that header row rather than grouped with unrelated view controls. `aria-pressed` is added to both the debug toggle and the edges toggle to correctly reflect their pressed state.

Row anatomy within each cluster is standardized to label-left / control-right. A divider separates the View and Layer clusters. Two shared style constants (`clusterHeading`, `rowLabel`) enforce consistent eyebrow typography across both clusters.