### PR TITLE
feat(studio): dock game console beneath world bar, remove it from footer

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -6,6 +6,7 @@ import {
 
 import { AppHeader } from "../ui/components/AppHeader";
 import { AppFooter } from "../ui/components/AppFooter";
+import { GameConsole } from "../ui/components/GameConsole";
 import { ExplorePanel } from "../ui/components/ExplorePanel";
 import { RecipePanel } from "../ui/components/RecipePanel";
 import { configsEqual, recipeSettingsEqual, worldSettingsEqual } from "../ui/utils/config";
@@ -2206,6 +2207,27 @@ export function StudioShell(props: StudioShellProps) {
       onSetupConfigChange={setSetupConfig}
       onSavedConfigChange={handleSavedSetupConfigChange}
       onHeaderHeightChange={handleHeaderHeightChange}
+      gameConsole={
+        <GameConsole
+          liveRuntime={liveRuntime}
+          liveGameStudioRelation={liveGameStudioRelation}
+          onSyncFromLiveGame={syncStudioFromLiveGame}
+          isAutoplayActionRunning={autoplayActionRunning}
+          onToggleAutoplay={handleToggleAutoplay}
+          operationControlsDisabled={browserRunning || runInGameRunning || saveDeployRunning}
+          isRunInGameRunning={runInGameRunning}
+          runInGameStatus={runInGameOperation}
+          runInGameCurrentRelation={runInGameCurrentRelation}
+          onRunInGame={() => {
+            void handleRunInGame({ restartCivProcess: runInGameRequiresProcessRestart(runInGameOperation) });
+          }}
+          onRunInGameRetryStatus={() => {
+            if (runInGameOperation) void refreshRunInGameStatus(runInGameOperation.requestId);
+          }}
+          onCopyRunInGameDiagnostics={copyRunInGameDiagnostics}
+          saveDeployStatus={saveDeployOperation}
+        />
+      }
     />
   );
 
@@ -2309,26 +2331,11 @@ export function StudioShell(props: StudioShellProps) {
       currentSettings={recipeSettings}
       onSettingsChange={setRecipeSettings}
       onRun={triggerRun}
-      onRunInGame={() => {
-        void handleRunInGame({ restartCivProcess: runInGameRequiresProcessRestart(runInGameOperation) });
-      }}
-      onRunInGameRetryStatus={() => {
-        if (runInGameOperation) void refreshRunInGameStatus(runInGameOperation.requestId);
-      }}
-      onCopyRunInGameDiagnostics={copyRunInGameDiagnostics}
       onReroll={reroll}
       isRunning={browserRunning}
       isRunInGameRunning={runInGameRunning}
       isSaveDeployRunning={saveDeployRunning}
-      isAutoplayActionRunning={autoplayActionRunning}
-      saveDeployStatus={saveDeployOperation}
-      runInGameStatus={runInGameOperation}
-      runInGameCurrentRelation={runInGameCurrentRelation}
       isDirty={isDirty}
-      liveRuntime={liveRuntime}
-      liveGameStudioRelation={liveGameStudioRelation}
-      onSyncFromLiveGame={syncStudioFromLiveGame}
-      onToggleAutoplay={handleToggleAutoplay}
       onToast={(message) => toast(message, { variant: "success" })}
       autoRunEnabled={autoRunEnabled}
       onAutoRunEnabledChange={setAutoRunEnabled}

--- a/apps/mapgen-studio/src/ui/components/AppFooter.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppFooter.tsx
@@ -4,21 +4,17 @@ import { Button, Input, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger
 import { MAP_SIZE_SHORT, LAYOUT } from '../constants';
 import { formatResourceMode } from '../utils';
 import type { RecipeSettings, WorldSettings, GenerationStatus } from '../types';
-import type { RunInGameOperationStatus } from '../../features/runInGame/status';
-import type { RunInGameCurrentRelation } from '../../features/runInGame/clientState';
 import { CIV7_STUDIO_SEED_MAX, CIV7_STUDIO_SEED_MIN } from '../../features/civ7Setup/seedPolicy';
-import type { MapConfigSaveDeployStatus } from '../../features/mapConfigSave/status';
-import { GameConsole, type GameConsoleLiveRuntime } from './GameConsole';
 
 // ============================================================================
-// APP FOOTER — two consoles (Pass-3 footer-consoles spec)
+// APP FOOTER — the studio console (Pass-4 game-console-dock spec)
 // ============================================================================
-// The footer separates ownership domains: the centered STUDIO console carries
-// studio-runtime status and run controls (status · last run · seed · reroll ·
-// auto-run · Run); the right-docked GAME console (`GameConsole`) carries
-// everything that observes or commands live Civ7. Equal flex side zones keep
-// the studio console exactly centered while space allows; when the game
-// console needs more room, the studio console yields left, never overlaps.
+// The footer is the STUDIO zone: one centered console carrying studio-runtime
+// status and run controls (status · last run · seed · reroll · auto-run ·
+// Run). Everything that observes or commands live Civ7 lives in `GameConsole`,
+// docked beneath the world bar in the header (top = game, bottom = studio).
+// The footer still receives the game-side in-flight booleans because seed/
+// reroll/run share one operation gate across both zones (behavior parity).
 // ============================================================================
 
 export interface AppFooterProps {
@@ -34,38 +30,16 @@ export interface AppFooterProps {
   onSettingsChange: (settings: RecipeSettings) => void;
   /** Callback to start a generation run */
   onRun: () => void;
-  /** Callback to launch the current map config in Civ7 */
-  onRunInGame: () => void;
-  /** Callback to refresh the current Civ7 Run in Game operation status */
-  onRunInGameRetryStatus?: () => void;
-  /** Callback to copy current Civ7 Run in Game diagnostics */
-  onCopyRunInGameDiagnostics?: () => void;
   /** Callback to reroll (new seed + run) */
   onReroll: () => void;
   /** Whether generation is currently running */
   isRunning: boolean;
-  /** Whether Civ7 Run in Game is currently running */
+  /** Whether Civ7 Run in Game is currently running (shared operation gate) */
   isRunInGameRunning: boolean;
-  /** Whether config save/deploy is currently running */
+  /** Whether config save/deploy is currently running (shared operation gate) */
   isSaveDeployRunning?: boolean;
-  /** Current config save/deploy status */
-  saveDeployStatus?: MapConfigSaveDeployStatus | null;
-  /** Request-correlated Civ7 Run in Game status */
-  runInGameStatus?: RunInGameOperationStatus | null;
-  /** Whether the recorded operation matches the current authored Studio state */
-  runInGameCurrentRelation?: RunInGameCurrentRelation;
   /** Whether current settings differ from last run */
   isDirty: boolean;
-  /** Read-only live Civ7 runtime status */
-  liveRuntime?: GameConsoleLiveRuntime;
-  /** Whether the current Studio config/seed matches the proved live game source. */
-  liveGameStudioRelation?: "current" | "stale" | "unknown";
-  /** Callback to apply a visible live-runtime or proved-run suggestion back into Studio. */
-  onSyncFromLiveGame?: () => void;
-  /** Whether a Civ7 autoplay start/stop request is in flight */
-  isAutoplayActionRunning?: boolean;
-  /** Callback to start or stop Civ7 native autoplay */
-  onToggleAutoplay?: () => void;
   /** Toast function for notifications */
   onToast?: (message: string) => void;
   /** When enabled, config changes auto-run the current seed */
@@ -81,22 +55,11 @@ export const AppFooter: React.FC<AppFooterProps> = ({
   currentSettings,
   onSettingsChange,
   onRun,
-  onRunInGame,
-  onRunInGameRetryStatus,
-  onCopyRunInGameDiagnostics,
   onReroll,
   isRunning,
   isRunInGameRunning,
   isSaveDeployRunning = false,
-  saveDeployStatus,
-  runInGameStatus,
-  runInGameCurrentRelation = "unknown",
   isDirty,
-  liveRuntime,
-  liveGameStudioRelation = "unknown",
-  onSyncFromLiveGame,
-  isAutoplayActionRunning = false,
-  onToggleAutoplay,
   onToast,
   autoRunEnabled,
   onAutoRunEnabledChange
@@ -158,15 +121,10 @@ export const AppFooter: React.FC<AppFooterProps> = ({
     // for the static markup — not hidden inside hover-only Tooltip content.
     <TooltipProvider>
     <footer
-      className="absolute bottom-4 left-4 right-4 z-20 flex items-center gap-2"
+      className="absolute bottom-4 left-4 right-4 z-20 flex items-center justify-center"
       style={{
         height: FOOTER_HEIGHT
       }}>
-
-      {/* Equal flex-1 side zones center the studio console exactly while space
-          allows; when the game console needs more than its share, its zone
-          grows and the studio console yields left instead of overlapping. */}
-      <div className="flex-1 min-w-0" />
 
       {/* Studio console — studio-runtime status + run controls, centered. */}
 
@@ -286,25 +244,6 @@ export const AppFooter: React.FC<AppFooterProps> = ({
           <Play className="w-3 h-3" />
           <span>{isRunning ? 'Running...' : 'Run'}</span>
         </Button>
-      </div>
-
-      {/* Game console — everything live-Civ7, right-docked, free to grow. */}
-      <div className="flex-1 flex items-center justify-end">
-        <GameConsole
-          liveRuntime={liveRuntime}
-          liveGameStudioRelation={liveGameStudioRelation}
-          onSyncFromLiveGame={onSyncFromLiveGame}
-          isAutoplayActionRunning={isAutoplayActionRunning}
-          onToggleAutoplay={onToggleAutoplay}
-          operationControlsDisabled={operationControlsDisabled}
-          isRunInGameRunning={isRunInGameRunning}
-          runInGameStatus={runInGameStatus}
-          runInGameCurrentRelation={runInGameCurrentRelation}
-          onRunInGame={onRunInGame}
-          onRunInGameRetryStatus={onRunInGameRetryStatus}
-          onCopyRunInGameDiagnostics={onCopyRunInGameDiagnostics}
-          saveDeployStatus={saveDeployStatus}
-        />
       </div>
     </footer>
     </TooltipProvider>);

--- a/apps/mapgen-studio/src/ui/components/AppHeader.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppHeader.tsx
@@ -33,6 +33,12 @@ export interface AppHeaderProps {
   onSetupConfigChange: (config: Civ7StudioSetupConfig) => void;
   onSavedConfigChange: (configId: string) => void;
   onHeaderHeightChange?: (height: number) => void;
+  /**
+   * The live-game console (Pass-4 vertical zoning: top = game, bottom =
+   * studio). Rendered as a centered row beneath the world bar — after the
+   * transient setup panel, so the disclosure stays attached to its button.
+   */
+  gameConsole?: React.ReactNode;
 }
 export const AppHeader: React.FC<AppHeaderProps> = ({
   themePreference,
@@ -45,7 +51,8 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   setupOptions,
   onSetupConfigChange,
   onSavedConfigChange,
-  onHeaderHeightChange
+  onHeaderHeightChange,
+  gameConsole
 }) => {
   const headerRef = React.useRef<HTMLElement | null>(null);
   const [setupOpen, setSetupOpen] = React.useState(false);
@@ -262,6 +269,14 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
                 className="w-28" />
             </div>
           </div>
+        ) : null}
+
+        {gameConsole ? (
+          // Live-game console docked beneath the world bar (and beneath the
+          // open setup panel): the header zone is the GAME zone, the footer
+          // is the studio zone. Growth here reflows the side panels through
+          // the measured-header mechanism above.
+          <div className="max-w-full">{gameConsole}</div>
         ) : null}
       </div>
 

--- a/apps/mapgen-studio/test/runInGame/AppFooter.test.tsx
+++ b/apps/mapgen-studio/test/runInGame/AppFooter.test.tsx
@@ -4,7 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 import { AppFooter } from "../../src/ui/components/AppFooter";
 import { TooltipProvider } from "../../src/components/ui/tooltip";
 import type { RecipeSettings, WorldSettings } from "../../src/ui/types";
-import type { RunInGameOperationStatus } from "../../src/features/runInGame/status";
+
+// The footer is the STUDIO console (Pass-4 game-console-dock spec). Live-game
+// markup is covered by GameConsole.test.tsx; the footer keeps the shared
+// operation gate: game-side operations disable studio run controls.
 
 const recipeSettings: RecipeSettings = {
   recipe: "standard",
@@ -18,251 +21,48 @@ const worldSettings: WorldSettings = {
   resources: "balanced",
 };
 
-function renderFooter(status: RunInGameOperationStatus, relation: "current" | "stale" | "unknown" = "unknown") {
+function renderFooter(overrides: Partial<Parameters<typeof AppFooter>[0]> = {}) {
   return renderToStaticMarkup(
     <TooltipProvider>
       <AppFooter
         status="ready"
-      lastRunSettings={recipeSettings}
-      lastGlobalSettings={worldSettings}
-      currentSettings={recipeSettings}
-      onSettingsChange={vi.fn()}
-      onRun={vi.fn()}
-      onRunInGame={vi.fn()}
-      onRunInGameRetryStatus={vi.fn()}
-      onCopyRunInGameDiagnostics={vi.fn()}
-      onReroll={vi.fn()}
-      isRunning={false}
-      isRunInGameRunning={status.status === "running"}
-      runInGameStatus={status}
-      runInGameCurrentRelation={relation}
-      isDirty={false}
-      lightMode={false}
-      liveRuntime={{ status: "ok", readiness: "shell" }}
-      autoRunEnabled={false}
-      onAutoRunEnabledChange={vi.fn()}
+        lastRunSettings={recipeSettings}
+        lastGlobalSettings={worldSettings}
+        currentSettings={recipeSettings}
+        onSettingsChange={vi.fn()}
+        onRun={vi.fn()}
+        onReroll={vi.fn()}
+        isRunning={false}
+        isRunInGameRunning={false}
+        isDirty={false}
+        autoRunEnabled={false}
+        onAutoRunEnabledChange={vi.fn()}
+        {...overrides}
       />
     </TooltipProvider>
   );
 }
 
-describe("AppFooter Run in Game status", () => {
-  it("renders active Run in Game phase separately from browser run status", () => {
-    const html = renderFooter({
-      ok: true,
-      requestId: "studio-run-in-game-test",
-      phase: "waiting-for-proof",
-      status: "running",
-      startedAt: "2026-06-01T00:00:00.000Z",
-      updatedAt: "2026-06-01T00:00:01.000Z",
-      completedPhases: ["materializing", "deploying", "checking-civ7", "preparing-setup", "starting-game"],
-      materialization: {
-        mode: "disposable",
-        mapScript: "{swooper-maps}/maps/studio-current.js",
-      },
-    });
+describe("AppFooter studio console", () => {
+  it("renders studio status and run controls without any live-game markup", () => {
+    const html = renderFooter();
 
-    expect(html).toContain("Waiting for Proof");
-    expect(html).toContain("studio-run-in-game-test");
-    expect(html).toContain("Copy Run in Game diagnostics");
     expect(html).toContain("Ready");
+    expect(html).toContain("Re-roll: New seed and run");
+    expect(html).toContain("Generation seed");
+    expect(html).not.toContain("Run in Game");
+    expect(html).not.toContain("Civ7");
   });
 
-  it("renders retry status and retry run affordances for failed operations", () => {
-    const html = renderFooter({
-      ok: false,
-      requestId: "studio-run-in-game-failed",
-      phase: "failed",
-      status: "failed",
-      startedAt: "2026-06-01T00:00:00.000Z",
-      updatedAt: "2026-06-01T00:00:01.000Z",
-      completedPhases: ["materializing", "deploying"],
-      error: "Civ7 setup cannot see {swooper-maps}/maps/studio-current.js",
-      details: {
-        code: "setup-map-row-not-visible",
-        reloadRequired: true,
-      },
-    });
+  it("disables run controls while Run in Game is running (shared operation gate)", () => {
+    const html = renderFooter({ isRunInGameRunning: true });
 
-    expect(html).toContain("Refresh Run in Game status");
-    expect(html).toContain("Retry Run");
-    expect(html).toContain("setup cannot see");
-  });
-
-  it("renders restart-Civ recovery as the primary Run in Game action", () => {
-    const html = renderFooter({
-      ok: false,
-      requestId: "studio-run-in-game-restart-needed",
-      phase: "blocked",
-      status: "blocked",
-      startedAt: "2026-06-01T00:00:00.000Z",
-      updatedAt: "2026-06-01T00:00:01.000Z",
-      completedPhases: ["materializing", "deploying", "checking-civ7"],
-      error: "Civ7 setup cannot see {swooper-maps}/maps/studio-current.js",
-      details: {
-        code: "setup-map-row-not-visible",
-        reloadBoundary: "process-restart-required",
-      },
-    }, "current");
-
-    expect(html).toContain("Restart Civ &amp; Run");
-  });
-
-  it("keeps map script fatal recovery on retry instead of process restart", () => {
-    const html = renderFooter({
-      ok: false,
-      requestId: "studio-run-in-game-map-script-failed",
-      phase: "failed",
-      status: "failed",
-      startedAt: "2026-06-01T00:00:00.000Z",
-      updatedAt: "2026-06-01T00:00:01.000Z",
-      completedPhases: ["materializing", "deploying", "preparing-setup", "starting-game", "waiting-for-proof"],
-      error: "Civ7 could not load generated map script",
-      details: {
-        code: "map-script-load-failed",
-        dismissNotificationRequired: true,
-        recoveryBoundary: "civ-notification-dismiss",
-        recoveryHint: "Dismiss the Civ fatal notification, fix or regenerate the map script, then retry Run in Game.",
-      },
-    }, "current");
-
-    expect(html).toContain("Retry Run");
-    expect(html).not.toContain("Restart Civ &amp; Run");
-    expect(html).toContain("Dismiss the Civ fatal notification");
-  });
-
-  it("marks a previous operation stale when the authored Studio state has changed", () => {
-    const html = renderFooter({
-      ok: true,
-      requestId: "studio-run-in-game-complete",
-      phase: "complete",
-      status: "complete",
-      startedAt: "2026-06-01T00:00:00.000Z",
-      updatedAt: "2026-06-01T00:00:01.000Z",
-      completedPhases: ["materializing", "deploying", "checking-civ7", "preparing-setup", "starting-game", "waiting-for-proof"],
-    }, "stale");
-
-    expect(html).toContain("Stale");
-    expect(html).toContain("Studio state: Stale");
-  });
-
-  it("renders save/deploy status separately and disables browser run controls", () => {
-    const html = renderToStaticMarkup(
-      <AppFooter
-        status="ready"
-        lastRunSettings={recipeSettings}
-        lastGlobalSettings={worldSettings}
-        currentSettings={recipeSettings}
-        onSettingsChange={vi.fn()}
-        onRun={vi.fn()}
-        onRunInGame={vi.fn()}
-        onReroll={vi.fn()}
-        isRunning={false}
-        isRunInGameRunning={false}
-        isSaveDeployRunning={true}
-        saveDeployStatus={{
-          ok: true,
-          requestId: "studio-save-deploy-test",
-          phase: "deploying",
-          status: "running",
-          startedAt: "2026-06-01T00:00:00.000Z",
-          updatedAt: "2026-06-01T00:00:01.000Z",
-          path: "mods/mod-swooper-maps/src/maps/configs/studio-current.config.json",
-        }}
-        isDirty={false}
-        lightMode={false}
-        autoRunEnabled={false}
-        onAutoRunEnabledChange={vi.fn()}
-      />
-    );
-
-    expect(html).toContain("Save/Deploy: Deploying");
-    expect(html).toContain("studio-save-deploy-test");
     expect(html).toContain("disabled");
   });
 
-  it("renders a Civ7 autoplay start button from live runtime status", () => {
-    const html = renderToStaticMarkup(
-      <AppFooter
-        status="ready"
-        lastRunSettings={recipeSettings}
-        lastGlobalSettings={worldSettings}
-        currentSettings={recipeSettings}
-        onSettingsChange={vi.fn()}
-        onRun={vi.fn()}
-        onRunInGame={vi.fn()}
-        onReroll={vi.fn()}
-        isRunning={false}
-        isRunInGameRunning={false}
-        isDirty={false}
-        lightMode={false}
-        liveRuntime={{ status: "ok", readiness: "ready", autoplayActive: false }}
-        onToggleAutoplay={vi.fn()}
-        autoRunEnabled={false}
-        onAutoRunEnabledChange={vi.fn()}
-      />
-    );
+  it("disables run controls while config save/deploy is running (shared operation gate)", () => {
+    const html = renderFooter({ isSaveDeployRunning: true });
 
-    expect(html).toContain("Start Auto");
-    expect(html).toContain("Start Civ7 autoplay");
-  });
-
-  it("renders a Civ7 autoplay stop button when autoplay is active", () => {
-    const html = renderToStaticMarkup(
-      <AppFooter
-        status="ready"
-        lastRunSettings={recipeSettings}
-        lastGlobalSettings={worldSettings}
-        currentSettings={recipeSettings}
-        onSettingsChange={vi.fn()}
-        onRun={vi.fn()}
-        onRunInGame={vi.fn()}
-        onReroll={vi.fn()}
-        isRunning={false}
-        isRunInGameRunning={false}
-        isDirty={false}
-        lightMode={false}
-        liveRuntime={{ status: "ok", readiness: "ready", autoplayActive: true }}
-        onToggleAutoplay={vi.fn()}
-        autoRunEnabled={false}
-        onAutoRunEnabledChange={vi.fn()}
-      />
-    );
-
-    expect(html).toContain("Stop Auto");
-    expect(html).toContain("Stop Civ7 autoplay");
-    expect(html).toContain("Auto");
-  });
-
-  it("highlights live seed status when a proved live game is out of sync with Studio", () => {
-    const html = renderToStaticMarkup(
-      <AppFooter
-        status="ready"
-        lastRunSettings={recipeSettings}
-        lastGlobalSettings={worldSettings}
-        currentSettings={{ ...recipeSettings, seed: "456" }}
-        onSettingsChange={vi.fn()}
-        onRun={vi.fn()}
-        onRunInGame={vi.fn()}
-        onReroll={vi.fn()}
-        isRunning={false}
-        isRunInGameRunning={false}
-        isDirty={true}
-        lightMode={false}
-        liveRuntime={{ status: "ok", turn: 12, seed: 123 }}
-        liveGameStudioRelation="stale"
-        onSyncFromLiveGame={vi.fn()}
-        autoRunEnabled={false}
-        onAutoRunEnabledChange={vi.fn()}
-      />
-    );
-
-    expect(html).toContain("Apply live game suggestion to Studio");
-    // The stale-live-game emphasis is token-driven (`warning`), not a raw
-    // `border-orange-400` palette class — the design system forbids hardcoded
-    // hex/named-color utilities. The assertion still verifies the stale ring is
-    // present, now via the token.
-    expect(html).toContain("border-warning");
-    expect(html).toContain("Seed 123");
+    expect(html).toContain("disabled");
   });
 });

--- a/apps/mapgen-studio/test/runInGame/GameConsole.test.tsx
+++ b/apps/mapgen-studio/test/runInGame/GameConsole.test.tsx
@@ -1,0 +1,191 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { GameConsole, type GameConsoleProps } from "../../src/ui/components/GameConsole";
+import { TooltipProvider } from "../../src/components/ui/tooltip";
+import type { RunInGameOperationStatus } from "../../src/features/runInGame/status";
+
+// The game console owns all live-Civ7 markup (Pass-4 game-console-dock spec:
+// it docks under the world bar in the header). These scenarios moved here
+// from AppFooter.test.tsx when the console left the footer.
+
+function renderConsole(overrides: Partial<GameConsoleProps> = {}) {
+  return renderToStaticMarkup(
+    <TooltipProvider>
+      <GameConsole
+        operationControlsDisabled={false}
+        isRunInGameRunning={false}
+        onRunInGame={vi.fn()}
+        liveRuntime={{ status: "ok", readiness: "shell" }}
+        {...overrides}
+      />
+    </TooltipProvider>
+  );
+}
+
+function renderWithStatus(
+  status: RunInGameOperationStatus,
+  relation: "current" | "stale" | "unknown" = "unknown"
+) {
+  return renderConsole({
+    isRunInGameRunning: status.status === "running",
+    runInGameStatus: status,
+    runInGameCurrentRelation: relation,
+    onRunInGameRetryStatus: vi.fn(),
+    onCopyRunInGameDiagnostics: vi.fn(),
+  });
+}
+
+describe("GameConsole Run in Game status", () => {
+  it("renders the active Run in Game phase with its diagnostics affordance", () => {
+    const html = renderWithStatus({
+      ok: true,
+      requestId: "studio-run-in-game-test",
+      phase: "waiting-for-proof",
+      status: "running",
+      startedAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:01.000Z",
+      completedPhases: ["materializing", "deploying", "checking-civ7", "preparing-setup", "starting-game"],
+      materialization: {
+        mode: "disposable",
+        mapScript: "{swooper-maps}/maps/studio-current.js",
+      },
+    });
+
+    expect(html).toContain("Waiting for Proof");
+    expect(html).toContain("studio-run-in-game-test");
+    expect(html).toContain("Copy Run in Game diagnostics");
+  });
+
+  it("renders retry status and retry run affordances for failed operations", () => {
+    const html = renderWithStatus({
+      ok: false,
+      requestId: "studio-run-in-game-failed",
+      phase: "failed",
+      status: "failed",
+      startedAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:01.000Z",
+      completedPhases: ["materializing", "deploying"],
+      error: "Civ7 setup cannot see {swooper-maps}/maps/studio-current.js",
+      details: {
+        code: "setup-map-row-not-visible",
+        reloadRequired: true,
+      },
+    });
+
+    expect(html).toContain("Refresh Run in Game status");
+    expect(html).toContain("Retry Run");
+    expect(html).toContain("setup cannot see");
+  });
+
+  it("renders restart-Civ recovery as the primary Run in Game action", () => {
+    const html = renderWithStatus({
+      ok: false,
+      requestId: "studio-run-in-game-restart-needed",
+      phase: "blocked",
+      status: "blocked",
+      startedAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:01.000Z",
+      completedPhases: ["materializing", "deploying", "checking-civ7"],
+      error: "Civ7 setup cannot see {swooper-maps}/maps/studio-current.js",
+      details: {
+        code: "setup-map-row-not-visible",
+        reloadBoundary: "process-restart-required",
+      },
+    }, "current");
+
+    expect(html).toContain("Restart Civ &amp; Run");
+  });
+
+  it("keeps map script fatal recovery on retry instead of process restart", () => {
+    const html = renderWithStatus({
+      ok: false,
+      requestId: "studio-run-in-game-map-script-failed",
+      phase: "failed",
+      status: "failed",
+      startedAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:01.000Z",
+      completedPhases: ["materializing", "deploying", "preparing-setup", "starting-game", "waiting-for-proof"],
+      error: "Civ7 could not load generated map script",
+      details: {
+        code: "map-script-load-failed",
+        dismissNotificationRequired: true,
+        recoveryBoundary: "civ-notification-dismiss",
+        recoveryHint: "Dismiss the Civ fatal notification, fix or regenerate the map script, then retry Run in Game.",
+      },
+    }, "current");
+
+    expect(html).toContain("Retry Run");
+    expect(html).not.toContain("Restart Civ &amp; Run");
+    expect(html).toContain("Dismiss the Civ fatal notification");
+  });
+
+  it("marks a previous operation stale when the authored Studio state has changed", () => {
+    const html = renderWithStatus({
+      ok: true,
+      requestId: "studio-run-in-game-complete",
+      phase: "complete",
+      status: "complete",
+      startedAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:01.000Z",
+      completedPhases: ["materializing", "deploying", "checking-civ7", "preparing-setup", "starting-game", "waiting-for-proof"],
+    }, "stale");
+
+    expect(html).toContain("Stale");
+    expect(html).toContain("Studio state: Stale");
+  });
+});
+
+describe("GameConsole live runtime and save/deploy", () => {
+  it("renders save/deploy status with its request id", () => {
+    const html = renderConsole({
+      operationControlsDisabled: true,
+      saveDeployStatus: {
+        ok: true,
+        requestId: "studio-save-deploy-test",
+        phase: "deploying",
+        status: "running",
+        startedAt: "2026-06-01T00:00:00.000Z",
+        updatedAt: "2026-06-01T00:00:01.000Z",
+        path: "mods/mod-swooper-maps/src/maps/configs/studio-current.config.json",
+      },
+    });
+
+    expect(html).toContain("Save/Deploy: Deploying");
+    expect(html).toContain("studio-save-deploy-test");
+    expect(html).toContain("disabled");
+  });
+
+  it("renders a Civ7 autoplay start button from live runtime status", () => {
+    const html = renderConsole({
+      liveRuntime: { status: "ok", readiness: "ready", autoplayActive: false },
+      onToggleAutoplay: vi.fn(),
+    });
+
+    expect(html).toContain("Start Civ7 autoplay");
+  });
+
+  it("renders a Civ7 autoplay stop button when autoplay is active", () => {
+    const html = renderConsole({
+      liveRuntime: { status: "ok", readiness: "ready", autoplayActive: true },
+      onToggleAutoplay: vi.fn(),
+    });
+
+    expect(html).toContain("Stop Civ7 autoplay");
+    expect(html).toContain("Auto");
+  });
+
+  it("highlights live seed status when a proved live game is out of sync with Studio", () => {
+    const html = renderConsole({
+      liveRuntime: { status: "ok", turn: 12, seed: 123 },
+      liveGameStudioRelation: "stale",
+      onSyncFromLiveGame: vi.fn(),
+    });
+
+    expect(html).toContain("Apply live game suggestion to Studio");
+    // The stale-live-game emphasis is token-driven (`warning`), not a raw
+    // palette class — the design system forbids hardcoded color utilities.
+    expect(html).toContain("border-warning");
+    expect(html).toContain("Seed 123");
+  });
+});

--- a/openspec/changes/mapgen-studio-game-console-dock/proposal.md
+++ b/openspec/changes/mapgen-studio-game-console-dock/proposal.md
@@ -1,0 +1,47 @@
+# Game console docks beneath the world bar (vertical zoning)
+
+## Why
+
+The user flagged the bottom-right Game console as misplaced: run-in-game
+controls belong near the world-config toolbar that parameterizes the launch.
+Deliberation (Pass-4 frame, E1) chose **colocation over merge**: the world bar
+is an input strip while the Game console is live status + commands — merging
+them mixes readouts into a settings row, and measured widths (world bar
+≈930px + console ≈580px at 1600px viewport) make a single row impossible
+anyway. Colocation yields clean vertical zoning: **top = game** (world
+definition + live-game console), **bottom = studio** (iteration loop). This
+supersedes the *placement* scenarios of `mapgen-studio-footer-consoles`
+(right-docked-in-footer, centering-independence, no-overlap); the console
+*split* and every state-legibility requirement from that change carry forward
+unchanged.
+
+## Target Authority Refs
+
+- `docs/projects/mapgen-studio-redesign/pass-4-design-fixes.md` (E1 decision)
+- `apps/mapgen-studio/.interface-design/system.md` (§Pass-4 amendment:
+  vertical zoning)
+
+## What Changes
+
+- `AppHeader` gains a `gameConsole` slot (ReactNode) rendered as a centered
+  row in the header's center column, **after** the transient setup panel (the
+  disclosure stays attached to its button). Side panels reflow automatically
+  via the existing measured-header mechanism (`onHeaderHeightChange` →
+  `panelTop`).
+- `StudioShell` composes `GameConsole` into that slot with the same props it
+  passed through `AppFooter`.
+- `AppFooter` drops the game console and its right zone; the studio console
+  is simply centered. The shared operation-gating booleans
+  (`isRunInGameRunning`, `isSaveDeployRunning`) stay on the footer — seed/
+  reroll/run disabling during game operations is behavior parity.
+- Tests: game-console scenarios move from `AppFooter.test.tsx` to a
+  `GameConsole.test.tsx` that mounts the component that owns the markup;
+  footer tests keep studio-console + gating assertions. Stale `lightMode`
+  props (removed from the component in P4) are swept from test mounts.
+
+## Impact
+
+- Affected specs: `mapgen-studio`
+- Affected code: `apps/mapgen-studio/src/ui/components/AppHeader.tsx`,
+  `AppFooter.tsx`, `apps/mapgen-studio/src/app/StudioShell.tsx`,
+  `apps/mapgen-studio/test/runInGame/{AppFooter,GameConsole}.test.tsx`

--- a/openspec/changes/mapgen-studio-game-console-dock/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-game-console-dock/specs/mapgen-studio/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: The Game Console Docks Beneath The World Bar
+
+The game console SHALL render in the header zone as a centered row directly
+associated with the world-config bar (after the transient setup panel when it
+is open), expressing the vertical zoning top = game, bottom = studio. This
+supersedes the footer placement scenarios of the Pass-3 console split; the
+console's content, identity label, and modularity are unchanged.
+
+#### Scenario: Game console renders under the world bar
+- **WHEN** the app shell renders
+- **THEN** the game console (identity label, live chip, autoplay, Run in Game and its status affordances, save-deploy chip) renders in the header zone beneath the world-config bar
+- **AND** no live-game control or chip renders in the footer
+
+#### Scenario: Setup panel stays attached to its disclosure
+- **WHEN** the Setup disclosure is opened
+- **THEN** the setup panel renders directly beneath the world bar, above the game console
+
+#### Scenario: Side panels reflow under the taller header
+- **WHEN** the game console row (or open setup panel) increases the header height
+- **THEN** the left and right docks begin below the measured header, without overlap
+
+### Requirement: The Footer Carries Only The Studio Console
+
+The footer SHALL render exactly one console: the centered studio console
+(status, last-run summary, seed, reroll, auto-run, Run), and SHALL keep
+disabling its operation controls while a game-side operation (Run in Game,
+save/deploy) is in flight.
+
+#### Scenario: Studio console is centered alone
+- **WHEN** the footer renders
+- **THEN** the studio console renders horizontally centered and is the footer's only console
+
+#### Scenario: Shared operation gating is preserved
+- **WHEN** Run in Game or config save/deploy is running
+- **THEN** the seed input, reroll, auto-run, and Run controls are disabled exactly as before the dock move

--- a/openspec/changes/mapgen-studio-game-console-dock/tasks.md
+++ b/openspec/changes/mapgen-studio-game-console-dock/tasks.md
@@ -1,0 +1,19 @@
+## 1. Implementation
+
+- [x] 1.1 Add a `gameConsole` slot to `AppHeader`, rendered as a centered row
+      in the center column after the setup panel.
+- [x] 1.2 Compose `GameConsole` into the header slot from `StudioShell`,
+      passing the props previously routed through `AppFooter`.
+- [x] 1.3 Remove the game console and right zone from `AppFooter`; center the
+      studio console; keep `isRunInGameRunning`/`isSaveDeployRunning` gating.
+- [x] 1.4 Move game-console test scenarios into `GameConsole.test.tsx`; keep
+      studio + gating assertions in `AppFooter.test.tsx`; sweep stale
+      `lightMode` props from test mounts.
+
+## 2. Verification
+
+- [x] 2.1 `bun run openspec -- validate mapgen-studio-game-console-dock --strict`
+- [x] 2.2 tsc + mapgen-studio vitest green
+- [x] 2.3 Visual on :5173: game console sits under the world bar; setup panel
+      opens between them; footer shows only the centered studio console; side
+      panels start below the taller header. Screenshot (dark + light).


### PR DESCRIPTION
The `GameConsole` component has been relocated from the bottom-right of the footer to a dedicated slot in the header, docked as a centered row beneath the world-config bar. This establishes a clear vertical zoning model: the header zone owns everything related to live Civ7 (world definition + game console), while the footer zone owns the studio iteration loop exclusively (status, seed, reroll, auto-run, Run).

`AppHeader` gains a `gameConsole` prop (ReactNode) that renders after the transient setup panel, keeping the setup disclosure attached to its button. The existing measured-header mechanism (`onHeaderHeightChange` → `panelTop`) automatically reflows the side panels to begin below the taller header. `StudioShell` now composes `GameConsole` directly into that slot with the props previously threaded through `AppFooter`.

`AppFooter` drops the game console, its right flex zone, and all associated props (`onRunInGame`, `runInGameStatus`, `liveRuntime`, `onToggleAutoplay`, etc.). The studio console is now simply centered. The shared operation-gating booleans (`isRunInGameRunning`, `isSaveDeployRunning`) remain on the footer to preserve the behavior that disables seed/reroll/run controls while a game-side operation is in flight.

Test coverage is reorganized to match ownership: all live-game scenarios (Run in Game phases, retry/restart recovery, autoplay, stale live seed, save/deploy status) move from `AppFooter.test.tsx` into a new `GameConsole.test.tsx` that mounts the component that actually renders that markup. `AppFooter.test.tsx` is trimmed to studio-console rendering and shared operation-gating assertions.