### PR TITLE
feat(mapgen-studio): toolbar architecture v2 — top = Game bar, bottom = World/Map console with History affordance

### DIFF
--- a/apps/mapgen-studio/.interface-design/system.md
+++ b/apps/mapgen-studio/.interface-design/system.md
@@ -219,3 +219,23 @@ Decisions (see `docs/projects/mapgen-studio-redesign/pass-4-design-fixes.md`):
   Reset/Show-JSON); collapsed by default, manual expand; optional sticky
   auto-expand-on-scroll toggle in the config toolbar, default OFF; identical in
   focused and unfocused modes.
+
+## Pass-5 amendment (2026-06-11, user-grounded): zoning v2 — Game bar / World console
+
+Decisions (see `docs/projects/mapgen-studio-redesign/pass-5-design-fixes.md`);
+supersedes the Pass-4 dock placement, keeps the console split + icon contract:
+
+- **Top bar = THE Game toolbar.** One bar (identity `Gamepad2` + "Game")
+  unifies the saved-config selector, the GameConsole command cluster (inline,
+  no panel chrome or "Civ7" label of its own), and a trailing **icon-only**
+  game-setup disclosure (`SlidersHorizontal` + chevron — the dropdown row is
+  the label) expanding pure game setup: Leader · Civ · Difficulty · Speed.
+  **No map/world settings in the top bar, ever.**
+- **Bottom bar = THE World/Map console** (identity `Globe` + "World"): studio
+  status · History · Size · Players · Resources · Seed · reroll · auto-run ·
+  Run. Map settings author here; the relocated selects ride the shared
+  operation gate. Resources is a map setting (`WorldSettings`), not game setup.
+- **History affordance:** the last-run cluster compresses into one icon button
+  (`History`); hover tooltip presents the run (seed/size/players/resources),
+  the accessible name mirrors it, click copies the last seed (the affordance
+  the old inline seed button carried). Tooltip, never a popup.

--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -2200,8 +2200,6 @@ export function StudioShell(props: StudioShellProps) {
       onThemeCycle={cyclePreference}
       showGrid={showGrid}
       onShowGridChange={setShowGrid}
-      globalSettings={worldSettings}
-      onGlobalSettingsChange={setWorldSettings}
       setupConfig={setupConfig}
       setupOptions={setupControlOptions}
       onSetupConfigChange={setSetupConfig}
@@ -2328,6 +2326,8 @@ export function StudioShell(props: StudioShellProps) {
       status={status}
       lastRunSettings={lastRunSettings}
       lastGlobalSettings={lastGlobalSettings}
+      globalSettings={worldSettings}
+      onGlobalSettingsChange={setWorldSettings}
       currentSettings={recipeSettings}
       onSettingsChange={setRecipeSettings}
       onRun={triggerRun}

--- a/apps/mapgen-studio/src/ui/components/AppFooter.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppFooter.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
-import { Bolt, Clock, Dices, Play } from 'lucide-react';
+import { Bolt, Dices, Globe, History, Play } from 'lucide-react';
 import { Button, Input, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../components/ui';
-import { MAP_SIZE_SHORT, LAYOUT } from '../constants';
+import { OptionSelect } from './OptionSelect';
+import { MAP_SIZE_OPTIONS, MAP_SIZE_SHORT, PLAYER_COUNT_OPTIONS, RESOURCE_MODE_OPTIONS, LAYOUT } from '../constants';
 import { formatResourceMode } from '../utils';
 import type { RecipeSettings, WorldSettings, GenerationStatus } from '../types';
 import { CIV7_STUDIO_SEED_MAX, CIV7_STUDIO_SEED_MIN } from '../../features/civ7Setup/seedPolicy';
 
 // ============================================================================
-// APP FOOTER — the studio console (Pass-4 game-console-dock spec)
+// APP FOOTER — the World/Map console (Pass-5 toolbar-architecture-v2 spec)
 // ============================================================================
-// The footer is the STUDIO zone: one centered console carrying studio-runtime
-// status and run controls (status · last run · seed · reroll · auto-run ·
-// Run). Everything that observes or commands live Civ7 lives in `GameConsole`,
-// docked beneath the world bar in the header (top = game, bottom = studio).
-// The footer still receives the game-side in-flight booleans because seed/
-// reroll/run share one operation gate across both zones (behavior parity).
+// The footer is the WORLD/MAP zone: one centered console authoring the map
+// (size · players · resources · seed) and driving the studio iteration loop
+// (status · History · reroll · auto-run · Run). Everything that observes or
+// commands live Civ7 lives in `GameConsole`, composed into the header's Game
+// bar (top = game, bottom = world/map). The footer still receives the
+// game-side in-flight booleans because its authoring/run controls share one
+// operation gate across both zones (behavior parity).
 // ============================================================================
 
 export interface AppFooterProps {
@@ -24,6 +26,10 @@ export interface AppFooterProps {
   lastRunSettings: RecipeSettings;
   /** World settings from the last completed run */
   lastGlobalSettings: WorldSettings;
+  /** Current world settings (size, players, resources) */
+  globalSettings: WorldSettings;
+  /** Callback when world settings change */
+  onGlobalSettingsChange: (settings: WorldSettings) => void;
   /** Current recipe settings (for seed input) */
   currentSettings: RecipeSettings;
   /** Callback when recipe settings change */
@@ -52,6 +58,8 @@ export const AppFooter: React.FC<AppFooterProps> = ({
   status,
   lastRunSettings,
   lastGlobalSettings,
+  globalSettings,
+  onGlobalSettingsChange,
   currentSettings,
   onSettingsChange,
   onRun,
@@ -104,6 +112,20 @@ export const AppFooter: React.FC<AppFooterProps> = ({
       [key]: value
     });
   };
+  const updateWorldSetting = <K extends keyof WorldSettings,>(
+  key: K,
+  value: WorldSettings[K]) =>
+  {
+    onGlobalSettingsChange({
+      ...globalSettings,
+      [key]: value
+    });
+  };
+  // The History affordance compresses the old inline last-run cluster: the
+  // tooltip presents the run, the accessible name mirrors it (a11y + static
+  // markup parity), and the click keeps the copy-seed behavior the inline
+  // seed button used to carry.
+  const historyLabel = `Run history — last run: seed ${lastRunSettings.seed}, ${displaySize}, ${lastGlobalSettings.playerCount} players, ${displayResources} resources. Click to copy seed.`;
   const handleCopySeed = async () => {
     try {
       await navigator.clipboard.writeText(lastRunSettings.seed);
@@ -126,10 +148,20 @@ export const AppFooter: React.FC<AppFooterProps> = ({
         height: FOOTER_HEIGHT
       }}>
 
-      {/* Studio console — studio-runtime status + run controls, centered. */}
+      {/* World/Map console — map authoring + studio iteration loop, centered. */}
 
       <div
         className={`h-10 shrink-0 inline-flex items-center gap-3 px-3 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}>
+
+        {/* Console identity: the map/world zone, mirroring the Game bar. */}
+        <div className="flex items-center gap-1.5">
+          <Globe className={`w-4 h-4 ${textMuted}`} />
+          <span className={`text-label font-semibold uppercase tracking-wider ${textSecondary}`}>
+            World
+          </span>
+        </div>
+
+        <div className={`w-px h-5 ${dividerColor}`} />
 
         {/* Status indicator */}
         <div className="flex items-center gap-2">
@@ -139,37 +171,88 @@ export const AppFooter: React.FC<AppFooterProps> = ({
           </span>
         </div>
 
+        {/* Run history — the collapsed last-run cluster. */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={handleCopySeed}
+              aria-label={historyLabel}
+              title={historyLabel}>
+
+              <History className="w-3.5 h-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <div className="flex flex-col gap-0.5">
+              <span className="text-label font-medium uppercase tracking-wider opacity-70">
+                Last run
+              </span>
+              <span className="font-mono">{lastRunSettings.seed}</span>
+              <span>
+                {displaySize} · {lastGlobalSettings.playerCount}p · {displayResources}
+              </span>
+              <span className="opacity-70">Click to copy seed</span>
+            </div>
+          </TooltipContent>
+        </Tooltip>
+
         <div className={`w-px h-5 ${dividerColor}`} />
 
-        {/* Last Run label */}
-        <div className="flex items-center gap-1.5">
-          <Clock className={`w-3.5 h-3.5 ${textMuted}`} />
-          <span
-            className={`text-label font-medium uppercase tracking-wider ${textSecondary}`}>
-
-            Last
+        {/* Map settings (Pass-5: no map settings in the top bar) */}
+        <div className="flex items-center gap-2">
+          <span className={`text-label font-medium uppercase tracking-wider shrink-0 ${textMuted}`}>
+            Size
           </span>
+          <OptionSelect
+            value={globalSettings.mapSize}
+            onValueChange={(value) =>
+              updateWorldSetting('mapSize', value as WorldSettings['mapSize'])
+            }
+            options={MAP_SIZE_OPTIONS.map((opt) => ({
+              value: opt.value,
+              label: opt.label
+            }))}
+            ariaLabel="World size"
+            disabled={operationControlsDisabled}
+            className="w-24" />
         </div>
 
-        {/* Last run info */}
-        <div className="flex items-center gap-2 text-data">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={handleCopySeed}
-                className={`font-mono ${textPrimary} hover:text-primary hover:underline transition-colors cursor-pointer`}>
+        <div className="flex items-center gap-2">
+          <span className={`text-label font-medium uppercase tracking-wider shrink-0 ${textMuted}`}>
+            Players
+          </span>
+          <OptionSelect
+            value={globalSettings.playerCount.toString()}
+            onValueChange={(value) =>
+              updateWorldSetting('playerCount', parseInt(value, 10))
+            }
+            options={PLAYER_COUNT_OPTIONS.map((count) => ({
+              value: count.toString(),
+              label: count.toString()
+            }))}
+            ariaLabel="Players"
+            disabled={operationControlsDisabled}
+            className="w-14" />
+        </div>
 
-                {lastRunSettings.seed}
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>Click to copy seed</TooltipContent>
-          </Tooltip>
-          <span className={textMuted}>·</span>
-          <span className={textPrimary}>{displaySize}</span>
-          <span className={textMuted}>·</span>
-          <span className={textPrimary}>{lastGlobalSettings.playerCount}p</span>
-          <span className={textMuted}>·</span>
-          <span className={textPrimary}>{displayResources}</span>
+        <div className="flex items-center gap-2">
+          <span className={`text-label font-medium uppercase tracking-wider shrink-0 ${textMuted}`}>
+            Resources
+          </span>
+          <OptionSelect
+            value={globalSettings.resources}
+            onValueChange={(value) =>
+              updateWorldSetting('resources', value as WorldSettings['resources'])
+            }
+            options={RESOURCE_MODE_OPTIONS.map((opt) => ({
+              value: opt.value,
+              label: opt.label
+            }))}
+            ariaLabel="Resources"
+            disabled={operationControlsDisabled}
+            className="w-24" />
         </div>
 
         <div className={`w-px h-5 ${dividerColor}`} />

--- a/apps/mapgen-studio/src/ui/components/AppHeader.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ChevronDown, Globe, SlidersHorizontal } from 'lucide-react';
+import { ChevronDown, Gamepad2, SlidersHorizontal } from 'lucide-react';
 import { AppBrand } from './AppBrand';
 import { ViewControls } from './ViewControls';
 import { OptionSelect } from './OptionSelect';
@@ -9,19 +9,12 @@ import {
   updateStudioSetupPlayerOption,
   type Civ7StudioSetupConfig
 } from '../../features/civ7Setup/setupConfig';
-import {
-  MAP_SIZE_OPTIONS,
-  PLAYER_COUNT_OPTIONS,
-  RESOURCE_MODE_OPTIONS } from
-'../constants';
-import type { ThemePreference, WorldSettings } from '../types';
+import type { ThemePreference } from '../types';
 export interface AppHeaderProps {
   themePreference: ThemePreference;
   onThemeCycle: () => void;
   showGrid: boolean;
   onShowGridChange: (show: boolean) => void;
-  globalSettings: WorldSettings;
-  onGlobalSettingsChange: (settings: WorldSettings) => void;
   setupConfig: Civ7StudioSetupConfig;
   setupOptions: {
     savedConfigOptions: ReadonlyArray<{ value: string; label: string }>;
@@ -34,9 +27,9 @@ export interface AppHeaderProps {
   onSavedConfigChange: (configId: string) => void;
   onHeaderHeightChange?: (height: number) => void;
   /**
-   * The live-game console (Pass-4 vertical zoning: top = game, bottom =
-   * studio). Rendered as a centered row beneath the world bar — after the
-   * transient setup panel, so the disclosure stays attached to its button.
+   * The live-game command cluster (Pass-5 zoning v2: top = Game, bottom =
+   * World/Map). Composed INLINE into the Game bar row, between the
+   * saved-config selector and the trailing setup disclosure.
    */
   gameConsole?: React.ReactNode;
 }
@@ -45,8 +38,6 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   onThemeCycle,
   showGrid,
   onShowGridChange,
-  globalSettings,
-  onGlobalSettingsChange,
   setupConfig,
   setupOptions,
   onSetupConfigChange,
@@ -64,16 +55,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   const textMuted = 'text-muted-foreground/70';
   const dividerColor = 'bg-border';
   const setupButtonClassName =
-    'flex h-7 shrink-0 items-center gap-1.5 rounded border border-input bg-input-background px-2.5 text-data font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring';
-  const updateSetting = <K extends keyof WorldSettings,>(
-  key: K,
-  value: WorldSettings[K]) =>
-  {
-    onGlobalSettingsChange({
-      ...globalSettings,
-      [key]: value
-    });
-  };
+    'flex h-7 shrink-0 items-center gap-1.5 rounded border border-input bg-input-background px-2 text-data font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring';
   const localPlayerSetup = getLocalPlayerSetup(setupConfig);
   const updateLeader = (value: string) => {
     onSetupConfigChange(updateStudioSetupPlayerOption(setupConfig, 'PlayerLeader', value || undefined));
@@ -113,54 +95,18 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
         <AppBrand />
       </div>
 
-      {/* Center: World Settings */}
+      {/* Center: the Game bar — config selector, live command cluster, and
+          the trailing game-setup disclosure. Map/world settings live in the
+          footer's World/Map console (Pass-5 zoning v2). */}
       <div className="min-w-0 flex flex-col items-center gap-2 overflow-visible">
         <div
           className={`flex min-h-10 max-w-full flex-wrap items-center justify-center gap-x-3 gap-y-2 px-3 py-1.5 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}>
 
           <div className="flex items-center gap-1.5">
-            <Globe className={`w-4 h-4 ${textMuted}`} />
+            <Gamepad2 className={`w-4 h-4 ${textMuted}`} />
             <span className={`text-label font-semibold uppercase tracking-wider ${textSecondary}`}>
-              World
+              Game
             </span>
-          </div>
-
-          <div className={`w-px h-5 shrink-0 ${dividerColor}`} />
-
-          <div className="flex items-center gap-2">
-            <span className={`text-label font-medium uppercase tracking-wider shrink-0 ${textMuted}`}>
-              Size
-            </span>
-            <OptionSelect
-              value={globalSettings.mapSize}
-              onValueChange={(value) =>
-                updateSetting('mapSize', value as WorldSettings['mapSize'])
-              }
-              options={MAP_SIZE_OPTIONS.map((opt) => ({
-                value: opt.value,
-                label: opt.label
-              }))}
-              ariaLabel="World size"
-              className="w-24" />
-          </div>
-
-          <div className={`w-px h-5 shrink-0 ${dividerColor}`} />
-
-          <div className="flex items-center gap-2">
-            <span className={`text-label font-medium uppercase tracking-wider shrink-0 ${textMuted}`}>
-              Players
-            </span>
-            <OptionSelect
-              value={globalSettings.playerCount.toString()}
-              onValueChange={(value) =>
-                updateSetting('playerCount', parseInt(value, 10))
-              }
-              options={PLAYER_COUNT_OPTIONS.map((count) => ({
-                value: count.toString(),
-                label: count.toString()
-              }))}
-              ariaLabel="Players"
-              className="w-14" />
           </div>
 
           <div className={`w-px h-5 shrink-0 ${dividerColor}`} />
@@ -177,16 +123,26 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
               className="w-44 max-w-[34vw]" />
           </div>
 
+          {gameConsole ? (
+            <>
+              <div className={`w-px h-5 shrink-0 ${dividerColor}`} />
+              {gameConsole}
+            </>
+          ) : null}
+
           <div className={`w-px h-5 shrink-0 ${dividerColor}`} />
 
+          {/* Game-setup disclosure: icon-only (the dropdown row IS the
+              label), pinned last in the bar per the Pass-5 spec. */}
           <button
             type="button"
             className={setupButtonClassName}
             aria-expanded={setupOpen}
             aria-controls="app-header-setup-panel"
+            aria-label="Game setup"
+            title="Game setup"
             onClick={() => setSetupOpen((open) => !open)}>
             <SlidersHorizontal className="w-3.5 h-3.5" />
-            <span>Setup</span>
             <ChevronDown className={`w-3.5 h-3.5 transition-transform ${setupOpen ? 'rotate-180' : ''}`} />
           </button>
         </div>
@@ -195,25 +151,6 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           <div
             id="app-header-setup-panel"
             className={`flex min-h-10 max-w-full flex-wrap items-center justify-center gap-x-3 gap-y-2 px-3 py-1.5 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}>
-
-            <div className="flex items-center gap-2">
-              <span className={`text-label font-medium uppercase tracking-wider shrink-0 ${textMuted}`}>
-                Resources
-              </span>
-              <OptionSelect
-                value={globalSettings.resources}
-                onValueChange={(value) =>
-                  updateSetting('resources', value as WorldSettings['resources'])
-                }
-                options={RESOURCE_MODE_OPTIONS.map((opt) => ({
-                  value: opt.value,
-                  label: opt.label
-                }))}
-                ariaLabel="Resources"
-                className="w-24" />
-            </div>
-
-            <div className={`w-px h-5 shrink-0 ${dividerColor}`} />
 
             <div className="flex items-center gap-2">
               <span className={`text-label font-medium uppercase tracking-wider shrink-0 ${textMuted}`}>
@@ -269,14 +206,6 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
                 className="w-28" />
             </div>
           </div>
-        ) : null}
-
-        {gameConsole ? (
-          // Live-game console docked beneath the world bar (and beneath the
-          // open setup panel): the header zone is the GAME zone, the footer
-          // is the studio zone. Growth here reflows the side panels through
-          // the measured-header mechanism above.
-          <div className="max-w-full">{gameConsole}</div>
         ) : null}
       </div>
 

--- a/apps/mapgen-studio/src/ui/components/GameConsole.tsx
+++ b/apps/mapgen-studio/src/ui/components/GameConsole.tsx
@@ -16,13 +16,16 @@ import {
 // ============================================================================
 // GAME CONSOLE
 // ============================================================================
-// The footer's live-Civ7 area (Pass-3 footer-consoles spec): every control and
-// readout that observes or commands the LIVE GAME lives here — live runtime
-// chip + apply-suggestion bridge, autoplay, Run in Game with its status/retry/
-// diagnostics, and the save-deploy chip. New live-game controls belong in this
-// unit, not in the studio console. The studio↔game bridge cues (stale warning
-// ring, Current/Stale/Previous relation chip) are computed against the current
-// authored Studio state and surface here, beside the controls they qualify.
+// The Game bar's command cluster (Pass-5 toolbar-architecture-v2 spec): every
+// control and readout that observes or commands the LIVE GAME lives here —
+// live runtime chip + apply-suggestion bridge, autoplay, Run in Game with its
+// status/retry/diagnostics, and the save-deploy chip. New live-game controls
+// belong in this unit, not in the studio console. The cluster renders inline
+// with NO panel chrome or identity label of its own: AppHeader composes it
+// into the Game bar row, whose "Game" identity covers it. The studio↔game
+// bridge cues (stale warning ring, Current/Stale/Previous relation chip) are
+// computed against the current authored Studio state and surface here, beside
+// the controls they qualify.
 // ============================================================================
 
 /** Read-only live Civ7 runtime snapshot the console renders. */
@@ -87,9 +90,6 @@ export const GameConsole: React.FC<GameConsoleProps> = ({
   onCopyRunInGameDiagnostics,
   saveDeployStatus,
 }) => {
-  // Token-driven chrome; the console floats over the map on the popover tier.
-  const panelBg = 'bg-popover/95';
-  const panelBorder = 'border-border';
   const textPrimary = 'text-foreground';
   const textMuted = 'text-muted-foreground/70';
   // The "stale vs live game" emphasis is a warning about data, so it uses the
@@ -165,15 +165,7 @@ export const GameConsole: React.FC<GameConsoleProps> = ({
   ].filter(Boolean).join("\n");
 
   return (
-    <div
-      className={`h-10 inline-flex min-w-0 max-w-full items-center gap-2 px-3 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}>
-
-      {/* Console identity: this is the live-game area, named so it can grow. */}
-      <span className={`text-label font-semibold uppercase tracking-wider shrink-0 ${textMuted}`}>
-        Civ7
-      </span>
-      <div className="w-px h-5 shrink-0 bg-border" />
-
+    <div className="inline-flex min-w-0 max-w-full items-center gap-2">
       <Tooltip>
         <TooltipTrigger asChild>
           <button

--- a/apps/mapgen-studio/test/runInGame/AppFooter.test.tsx
+++ b/apps/mapgen-studio/test/runInGame/AppFooter.test.tsx
@@ -5,9 +5,11 @@ import { AppFooter } from "../../src/ui/components/AppFooter";
 import { TooltipProvider } from "../../src/components/ui/tooltip";
 import type { RecipeSettings, WorldSettings } from "../../src/ui/types";
 
-// The footer is the STUDIO console (Pass-4 game-console-dock spec). Live-game
+// The footer is the WORLD/MAP console (Pass-5 toolbar-architecture-v2 spec):
+// map authoring (size · players · resources · seed) + the studio iteration
+// loop, with the last run compressed into the History affordance. Live-game
 // markup is covered by GameConsole.test.tsx; the footer keeps the shared
-// operation gate: game-side operations disable studio run controls.
+// operation gate: game-side operations disable the authoring/run controls.
 
 const recipeSettings: RecipeSettings = {
   recipe: "standard",
@@ -28,6 +30,8 @@ function renderFooter(overrides: Partial<Parameters<typeof AppFooter>[0]> = {}) 
         status="ready"
         lastRunSettings={recipeSettings}
         lastGlobalSettings={worldSettings}
+        globalSettings={worldSettings}
+        onGlobalSettingsChange={vi.fn()}
         currentSettings={recipeSettings}
         onSettingsChange={vi.fn()}
         onRun={vi.fn()}
@@ -43,21 +47,37 @@ function renderFooter(overrides: Partial<Parameters<typeof AppFooter>[0]> = {}) 
   );
 }
 
-describe("AppFooter studio console", () => {
-  it("renders studio status and run controls without any live-game markup", () => {
+describe("AppFooter world/map console", () => {
+  it("renders status, map settings, and run controls without any live-game markup", () => {
     const html = renderFooter();
 
     expect(html).toContain("Ready");
+    expect(html).toContain('aria-label="World size"');
+    expect(html).toContain('aria-label="Players"');
+    expect(html).toContain('aria-label="Resources"');
     expect(html).toContain("Re-roll: New seed and run");
     expect(html).toContain("Generation seed");
     expect(html).not.toContain("Run in Game");
     expect(html).not.toContain("Civ7");
   });
 
-  it("disables run controls while Run in Game is running (shared operation gate)", () => {
+  it("compresses the last run into the History control's accessible name", () => {
+    const html = renderFooter();
+
+    // The old inline cluster is gone; its data rides the History affordance.
+    expect(html).toContain("Run history");
+    expect(html).toContain("seed 123");
+    expect(html).toContain("8 players");
+    expect(html).toContain("Click to copy seed");
+  });
+
+  it("disables map settings and run controls while Run in Game is running (shared operation gate)", () => {
     const html = renderFooter({ isRunInGameRunning: true });
 
     expect(html).toContain("disabled");
+    // The relocated selects ride the same gate as seed/reroll/run.
+    const sizeTrigger = html.match(/<button[^>]*aria-label="World size"[^>]*>/)?.[0] ?? "";
+    expect(sizeTrigger).toContain("disabled");
   });
 
   it("disables run controls while config save/deploy is running (shared operation gate)", () => {

--- a/apps/mapgen-studio/test/runInGame/GameConsole.test.tsx
+++ b/apps/mapgen-studio/test/runInGame/GameConsole.test.tsx
@@ -5,9 +5,10 @@ import { GameConsole, type GameConsoleProps } from "../../src/ui/components/Game
 import { TooltipProvider } from "../../src/components/ui/tooltip";
 import type { RunInGameOperationStatus } from "../../src/features/runInGame/status";
 
-// The game console owns all live-Civ7 markup (Pass-4 game-console-dock spec:
-// it docks under the world bar in the header). These scenarios moved here
-// from AppFooter.test.tsx when the console left the footer.
+// The game console owns all live-Civ7 markup (Pass-5 toolbar-architecture-v2
+// spec: it renders as the command cluster inside the header's Game bar).
+// These scenarios moved here from AppFooter.test.tsx when the console left
+// the footer.
 
 function renderConsole(overrides: Partial<GameConsoleProps> = {}) {
   return renderToStaticMarkup(

--- a/openspec/changes/mapgen-studio-toolbar-architecture-v2/proposal.md
+++ b/openspec/changes/mapgen-studio-toolbar-architecture-v2/proposal.md
@@ -1,0 +1,49 @@
+# Toolbar architecture v2: top = Game bar, bottom = World/Map console
+
+## Why
+
+The user refined Pass-4's vertical zoning after seeing it live: instead of a
+world-config bar with a game console docked beneath it, the top bar IS the
+single Game toolbar and the bottom bar IS the World/Map console. Map
+settings (size, players, resources) move down next to Seed — "no map
+settings in the top bar at all" — which dissolves the width problem that
+forced Pass-4's two-row colocation. The last-run stats compress into a
+History affordance with a hover tooltip. This supersedes the *placement*
+scenarios of `mapgen-studio-game-console-dock`; every state-legibility,
+gating, and behavior-parity requirement carries forward unchanged.
+
+## Target Authority Refs
+
+- `docs/projects/mapgen-studio-redesign/pass-5-design-fixes.md` (X1)
+- `apps/mapgen-studio/.interface-design/system.md` (Pass-5 amendment:
+  Game/World zoning v2)
+
+## What Changes
+
+- `AppHeader` center bar becomes the **Game bar**: identity renames World →
+  Game; Size/Players/Resources selects leave; the bar carries the
+  saved-config selector, the game command cluster (live chip + autoplay +
+  Explore + status chips + retry/diagnostics + Run in Game), and an
+  icon-only setup disclosure (`SlidersHorizontal`, no "Setup" text) LAST in
+  the bar, dropping down the game-setup row (Leader · Civ · Difficulty ·
+  Speed only).
+- `GameConsole` loses its own panel chrome and identity label and renders as
+  an inline command cluster composed INTO the Game bar row (component
+  boundary, props, and behavior unchanged).
+- `AppFooter` becomes the **World/Map console**: gains
+  `globalSettings`/`onGlobalSettingsChange` and renders Size · Players ·
+  Resources selects left of Seed; the last-run text cluster is replaced by a
+  History icon button whose tooltip (mirrored to `aria-label`/`title`)
+  carries the last run (seed · size · players · resources) and whose click
+  copies the last seed.
+- `StudioShell` reroutes the `WorldSettings` wiring (header keeps
+  `setupConfig` + saved-config only) and composes the console into the bar.
+- Tests: AppHeader/AppFooter/GameConsole assertions follow the moved
+  controls; operation-gating coverage extends to the relocated selects.
+
+## Impact
+
+- Affected specs: `mapgen-studio`
+- Affected code: `apps/mapgen-studio/src/ui/components/AppHeader.tsx`,
+  `AppFooter.tsx`, `GameConsole.tsx`, `apps/mapgen-studio/src/app/StudioShell.tsx`,
+  `apps/mapgen-studio/test/runInGame/{AppFooter,GameConsole}.test.tsx`

--- a/openspec/changes/mapgen-studio-toolbar-architecture-v2/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-toolbar-architecture-v2/specs/mapgen-studio/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: The Top Bar Is The Single Game Toolbar
+
+The header SHALL render one Game bar carrying everything that configures,
+commands, or observes the live Civ7 game — the saved-config selector, the
+live runtime chip with its sync-suggestion bridge, autoplay, Explore, the
+save-deploy and run-status chips with retry/diagnostics, Run in Game, and a
+trailing icon-only disclosure that expands the game-setup row — and SHALL
+render no map/world settings (size, players, resources). This supersedes the
+docked-console placement of `mapgen-studio-game-console-dock`; console
+content, gating, and state legibility are unchanged.
+
+#### Scenario: Game bar unifies config, status, and commands
+
+- **WHEN** the app shell renders
+- **THEN** the header bar contains the saved-config selector, the live
+  runtime chip, the autoplay/Explore/Run-in-Game commands and their status
+  affordances, in one row with a Game identity
+- **AND** no separate game console panel renders anywhere
+
+#### Scenario: No map settings in the top bar
+
+- **WHEN** the header renders
+- **THEN** it contains no Size, Players, or Resources controls
+
+#### Scenario: Setup disclosure sits last and expands game setup only
+
+- **WHEN** the trailing setup disclosure (icon-only, accessibly named) is
+  activated
+- **THEN** a row with Leader, Civilization, Difficulty, and Game speed
+  expands beneath the bar (`aria-expanded`/`aria-controls` wired)
+- **AND** the expanded row contains no map/world settings
+
+### Requirement: The Bottom Bar Is The World/Map Console
+
+The footer SHALL carry the map authoring controls — Size, Players, and
+Resources selects placed left of the Seed input — alongside seed, reroll,
+auto-run, Run, and the studio status, and SHALL disable its operation
+controls while any studio or game operation is in flight (behavior parity
+with the previous placement).
+
+#### Scenario: Map settings author from the footer
+
+- **WHEN** the user changes Size, Players, or Resources in the footer
+- **THEN** the same `WorldSettings` state updates as when these selects
+  lived in the header
+
+#### Scenario: Shared operation gating extends to the moved selects
+
+- **WHEN** a browser run, Run in Game, or save/deploy is in flight
+- **THEN** the Size, Players, and Resources selects are disabled together
+  with seed, reroll, auto-run, and Run
+
+### Requirement: Last-Run Stats Collapse Into A History Affordance
+
+The footer SHALL replace the inline last-run text cluster with a single
+History control whose hover tooltip presents the last run (seed, size,
+players, resources), mirrored onto the control's accessible name, and whose
+activation copies the last run's seed to the clipboard.
+
+#### Scenario: History tooltip carries the last run
+
+- **WHEN** the user hovers or focuses the History control after a run
+- **THEN** a tooltip presents the last run's seed, size, players, and
+  resources
+- **AND** the same content is exposed via the control's accessible name
+
+#### Scenario: History click copies the seed
+
+- **WHEN** the user activates the History control
+- **THEN** the last run's seed is copied to the clipboard with a toast
+  confirmation

--- a/openspec/changes/mapgen-studio-toolbar-architecture-v2/tasks.md
+++ b/openspec/changes/mapgen-studio-toolbar-architecture-v2/tasks.md
@@ -1,0 +1,21 @@
+## 1. Implementation
+
+- [x] 1.1 `GameConsole` sheds panel chrome + "Civ7" identity label; renders
+      an inline command cluster safe to compose into a bar row.
+- [x] 1.2 `AppHeader`: World → Game identity; remove Size/Players selects;
+      setup dropdown loses Resources and its "Setup" label (icon-only,
+      trailing); compose the game cluster into the bar row.
+- [x] 1.3 `AppFooter`: gain `globalSettings`/`onGlobalSettingsChange`;
+      Size/Players/Resources selects left of Seed; last-run cluster →
+      History icon button (tooltip = last run, click = copy seed).
+- [x] 1.4 `StudioShell`: reroute WorldSettings wiring; bar composition.
+- [x] 1.5 Tests: header/footer/console assertions follow the moved
+      controls; gating coverage on relocated selects.
+
+## 2. Verification
+
+- [x] 2.1 `bun run openspec -- validate mapgen-studio-toolbar-architecture-v2 --strict`
+- [x] 2.2 tsc + mapgen-studio vitest green
+- [x] 2.3 Visual on :5173 (dark + light): one Game bar (no console panel),
+      setup disclosure last + game-setup-only row, footer authoring
+      Size/Players/Resources/Seed, History tooltip + copy. Screenshot.


### PR DESCRIPTION
Implements toolbar architecture v2 (Pass-5), regrounding the vertical zoning so the top bar is exclusively the **Game toolbar** and the bottom bar is exclusively the **World/Map console**.

**Game bar (header)**
- Renames the center bar identity from "World" to "Game" (`Globe` → `Gamepad2`).
- Removes Size, Players, and Resources selects from the header entirely — no map settings in the top bar.
- Composes `GameConsole` inline into the Game bar row rather than docking it as a separate panel beneath the bar; the component sheds its own panel chrome and "Civ7" identity label.
- Collapses the setup disclosure to icon-only (`SlidersHorizontal` + chevron, no "Setup" text label), pinned last in the bar, expanding a game-setup-only row (Leader · Civ · Difficulty · Speed). Resources is removed from the setup dropdown.

**World/Map console (footer)**
- Adds `globalSettings`/`onGlobalSettingsChange` props and renders Size, Players, and Resources selects left of the Seed input, so all map authoring lives in one place.
- Replaces the inline last-run text cluster with a single **History** icon button: hover tooltip presents the last run (seed · size · players · resources), mirrored onto `aria-label`/`title` for accessibility, and click copies the last seed — preserving the behavior the old inline seed button carried.
- The shared operation gate extends to the relocated selects: Size, Players, and Resources disable together with seed, reroll, auto-run, and Run while any studio or game operation is in flight.

**Wiring**
- `StudioShell` reroutes `WorldSettings` props from the header to the footer.
- Tests updated to assert map-setting controls in the footer, the History affordance's accessible name and tooltip content, and that the operation gate covers the relocated selects.