### PR TITLE
fix(mapgen-studio): replace empty grid toggle placeholder with Grid3x3 lucide icon

### DIFF
--- a/apps/mapgen-studio/src/ui/components/ViewControls.tsx
+++ b/apps/mapgen-studio/src/ui/components/ViewControls.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 // `bg-accent` on hover / `bg-muted` when active. Native `title=` hints are now
 // the shadcn Tooltip (token-styled, delay-grouped under the shell provider).
 // ============================================================================
-import { Sun, Moon, Monitor } from 'lucide-react';
+import { Grid3x3, Sun, Moon, Monitor } from 'lucide-react';
 import { cn } from '../utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/ui';
 import type { ThemePreference } from '../types';
@@ -106,7 +106,7 @@ export const ViewControls: React.FC<ViewControlsProps> = ({
             aria-pressed={showGrid}
             className={showGrid ? iconBtnActive : iconBtn}>
 
-            <div className="w-4 h-4" />
+            <Grid3x3 className="w-4 h-4" />
           </button>
         </TooltipTrigger>
         <TooltipContent>{gridTooltip}</TooltipContent>

--- a/openspec/changes/mapgen-studio-grid-icon/proposal.md
+++ b/openspec/changes/mapgen-studio-grid-icon/proposal.md
@@ -1,0 +1,28 @@
+# Grid toggle icon + icon-rendering consistency
+
+## Why
+
+The ViewControls grid toggle rendered a literal empty `<div className="w-4
+h-4" />` where its glyph belongs — an invisible button body (the user saw an
+empty "Hide grid" control). Treated categorically per the standing rule:
+icons must render through the one icon system, with no empty placeholders.
+
+## Target Authority Refs
+
+- `docs/projects/mapgen-studio-redesign/pass-5-design-fixes.md` (X2)
+- `apps/mapgen-studio/.interface-design/system.md` (icon contract: lucide-react
+  is the sole icon system)
+
+## What Changes
+
+- `ViewControls` grid toggle renders `Grid3x3` (lucide, `w-4 h-4` matching
+  its cluster).
+- Categorical sweep (src + live DOM): no other empty icon-sized
+  placeholders, no inline `<svg>`, no non-lucide icon libraries. The only
+  other glyph-less visible button is the overrides `Switch`, whose thumb is
+  its body by design.
+
+## Impact
+
+- Affected specs: `mapgen-studio`
+- Affected code: `apps/mapgen-studio/src/ui/components/ViewControls.tsx`

--- a/openspec/changes/mapgen-studio-grid-icon/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-grid-icon/specs/mapgen-studio/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Icon Controls Always Render A Glyph From The Icon System
+
+Every icon-only control SHALL render a visible lucide-react glyph — no empty
+icon-sized placeholders and no second icon system — with the grid visibility
+toggle rendering the grid glyph.
+
+#### Scenario: Grid toggle shows its glyph
+
+- **WHEN** the view controls render
+- **THEN** the grid visibility toggle contains a lucide grid icon sized to
+  its cluster (`w-4 h-4`)
+
+#### Scenario: No empty icon placeholders anywhere
+
+- **WHEN** the app shell renders
+- **THEN** no visible icon-only button has an empty body (excluding switch
+  primitives, whose thumb is the body)

--- a/openspec/changes/mapgen-studio-grid-icon/tasks.md
+++ b/openspec/changes/mapgen-studio-grid-icon/tasks.md
@@ -1,0 +1,12 @@
+## 1. Implementation
+
+- [x] 1.1 `ViewControls`: grid toggle renders `Grid3x3` (lucide, `w-4 h-4`).
+- [x] 1.2 Categorical sweep: src grep (empty icon-sized divs, inline svg,
+      non-lucide libs) + live-DOM scan for glyph-less visible buttons.
+
+## 2. Verification
+
+- [x] 2.1 `bun run openspec -- validate mapgen-studio-grid-icon --strict`
+- [x] 2.2 tsc + vitest green
+- [x] 2.3 Live DOM: grid toggle contains an `svg`; only the overrides
+      Switch is legitimately glyph-less.


### PR DESCRIPTION
The grid visibility toggle in `ViewControls` was rendering an empty `<div className="w-4 h-4" />` in place of its icon, making the button body invisible to users. This replaces that placeholder with the `Grid3x3` lucide icon, consistent with the established rule that all icon-only controls must render a visible glyph from lucide-react with no empty placeholders or alternative icon systems.

A categorical sweep of the source and live DOM confirmed no other empty icon-sized placeholders exist — the only legitimately glyph-less visible button is the overrides `Switch`, whose thumb serves as its body by design.