### PR TITLE
feat(mapgen-studio): disable canvas controller and grab cursor pre-run

### DIFF
--- a/apps/mapgen-studio/src/app/CanvasStage.tsx
+++ b/apps/mapgen-studio/src/app/CanvasStage.tsx
@@ -84,6 +84,7 @@ export function CanvasStage(props: CanvasStageProps) {
         showBackgroundGrid={false}
         lightMode={lightMode}
         activeBounds={activeBounds}
+        interactive={hasManifest}
       />
       {/* Awaiting matter: a graticule field + a centered contour frame so the
           empty stage reads as a survey console that is ready, not dead space. */}

--- a/apps/mapgen-studio/src/features/viz/DeckCanvas.tsx
+++ b/apps/mapgen-studio/src/features/viz/DeckCanvas.tsx
@@ -29,15 +29,50 @@ export type DeckCanvasProps = {
   activeBounds: Bounds | null;
   apiRef?: MutableRefObject<DeckCanvasApi | null>;
   onApiReady?: () => void;
+  /**
+   * Camera interaction gate (Pass-5 prerun-cursor spec). Pre-run the only
+   * visible texture is the DOM CSS graticule behind the canvas — panning
+   * moves nothing the user can see, so the controller is disabled and the
+   * cursor stays default until there is matter to drag. Defaults to true.
+   */
+  interactive?: boolean;
 };
 
+// Controller config shared by the constructor and the interactivity effect.
+const CONTROLLER_OPTIONS = {
+  keyboard: {
+    // Make arrow-key motion feel less "stuck" while keeping the eased camera
+    // transition. Default for Orthographic/Orbit state is ~50px; we want ~3x.
+    moveSpeed: 150,
+  },
+} as const;
+
+function cursorForInteractivity(interactive: boolean) {
+  return interactive
+    ? ({ isDragging }: { isDragging: boolean }) => (isDragging ? "grabbing" : "grab")
+    : () => "default";
+}
+
 export function DeckCanvas(props: DeckCanvasProps) {
-  const { layers, effectiveLayer, viewportSize, showBackgroundGrid = true, lightMode = false, activeBounds, apiRef, onApiReady } = props;
+  const {
+    layers,
+    effectiveLayer,
+    viewportSize,
+    showBackgroundGrid = true,
+    lightMode = false,
+    activeBounds,
+    apiRef,
+    onApiReady,
+    interactive = true,
+  } = props;
 
   // Using the core Deck instance avoids React-driven rerenders on every pointer interaction.
   // (The @deck.gl/react wrapper can schedule React updates during camera changes.)
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const deckRef = useRef<Deck<any> | null>(null);
+  // Mirrors `interactive` for the mount effect (which must not re-run on
+  // toggles — the interactivity effect below handles those via setProps).
+  const interactiveRef = useRef(interactive);
 
   const views = useMemo(() => new OrthographicView({ id: 'ortho' }), []);
 
@@ -160,13 +195,8 @@ export function DeckCanvas(props: DeckCanvasProps) {
     const deck = new Deck({
       canvas,
       views,
-      controller: {
-        keyboard: {
-          // Make arrow-key motion feel less "stuck" while keeping the eased camera transition.
-          // Default for Orthographic/Orbit state is ~50px; we want ~3x.
-          moveSpeed: 150,
-        },
-      },
+      controller: interactiveRef.current ? CONTROLLER_OPTIONS : false,
+      getCursor: cursorForInteractivity(interactiveRef.current),
       initialViewState: {
         target: [...DEFAULT_VIEW_STATE.target],
         zoom: DEFAULT_VIEW_STATE.zoom,
@@ -183,6 +213,16 @@ export function DeckCanvas(props: DeckCanvasProps) {
     };
     // deckLayers intentionally excluded: we update via setProps below.
   }, [views]);
+
+  // Toggle camera interactivity (and the cursor that advertises it) without
+  // remounting the Deck instance.
+  useEffect(() => {
+    interactiveRef.current = interactive;
+    deckRef.current?.setProps({
+      controller: interactive ? CONTROLLER_OPTIONS : false,
+      getCursor: cursorForInteractivity(interactive),
+    });
+  }, [interactive]);
 
   // Keep layers in sync without remounting the Deck instance.
   useEffect(() => {

--- a/openspec/changes/mapgen-studio-prerun-cursor/proposal.md
+++ b/openspec/changes/mapgen-studio-prerun-cursor/proposal.md
@@ -1,0 +1,32 @@
+# Pre-run canvas: no grab cursor, no dead drag
+
+## Why
+
+In the "Awaiting matter" state the canvas showed a grab cursor but dragging
+appeared to do nothing: the deck controller was always live, yet the only
+visible pre-run texture is the DOM CSS graticule behind the canvas — the
+camera moved an empty scene. The cursor advertised an affordance the user
+couldn't perceive. The user offered two options (make pre-run drag real, or
+suppress the affordance) and delegated the call: suppressing wins — making
+pre-run drag visibly real would require moving the background texture into
+deck layers, unjustified now (X3's mesh standardization is the natural
+future hook if ever wanted).
+
+## Target Authority Refs
+
+- `docs/projects/mapgen-studio-redesign/pass-5-design-fixes.md` (X5)
+
+## What Changes
+
+- `DeckCanvas` gains an `interactive` prop (default true): when false, the
+  deck controller is off and `getCursor` returns `default`; when true, the
+  controller (with the keyboard moveSpeed tuning) and the grab/grabbing
+  cursor return. Toggles apply via `setProps` without remounting Deck.
+- `CanvasStage` passes `interactive={hasManifest}` — the same gate as the
+  "Awaiting matter" overlay.
+
+## Impact
+
+- Affected specs: `mapgen-studio`
+- Affected code: `apps/mapgen-studio/src/features/viz/DeckCanvas.tsx`,
+  `apps/mapgen-studio/src/app/CanvasStage.tsx`

--- a/openspec/changes/mapgen-studio-prerun-cursor/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-prerun-cursor/specs/mapgen-studio/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: The Canvas Cursor Advertises Only Real Interactions
+
+The map canvas SHALL disable camera interaction and show the default cursor
+until a run has produced a manifest, and SHALL restore the camera controller
+with the grab/grabbing cursor once matter exists.
+
+#### Scenario: Pre-run canvas is inert
+
+- **WHEN** the studio renders before any run ("Awaiting matter")
+- **THEN** the canvas cursor is `default` and drag/zoom camera interaction
+  is disabled
+
+#### Scenario: Post-run canvas is draggable
+
+- **WHEN** a run completes and the manifest exists
+- **THEN** the canvas cursor is `grab` (and `grabbing` while dragging) and
+  camera pan/zoom behave exactly as before this change

--- a/openspec/changes/mapgen-studio-prerun-cursor/tasks.md
+++ b/openspec/changes/mapgen-studio-prerun-cursor/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+
+- [x] 1.1 `DeckCanvas`: `interactive` prop gates controller + `getCursor`;
+      toggles via `setProps`, no Deck remount.
+- [x] 1.2 `CanvasStage`: `interactive={hasManifest}` (same gate as the
+      "Awaiting matter" overlay).
+
+## 2. Verification
+
+- [x] 2.1 `bun run openspec -- validate mapgen-studio-prerun-cursor --strict`
+- [x] 2.2 tsc + vitest green
+- [x] 2.3 Live: pre-run cursor `default`; post-run cursor `grab`, zoom/pan
+      working (zoom inspection during X3 verification used the live wheel).


### PR DESCRIPTION
Before a run completes, the map canvas displayed a grab cursor even though dragging moved nothing visible — the deck controller was active but the only pre-run texture is a CSS graticule behind the canvas, not a deck layer. This gave users a misleading affordance.

`DeckCanvas` now accepts an `interactive` prop (defaults to `true`) that gates both the deck controller and the cursor. When `false`, the controller is disabled and the cursor is `default`; when `true`, the controller (including the `moveSpeed: 150` keyboard tuning) and the grab/grabbing cursor are active. Transitions between states apply via `setProps` so the Deck instance is never remounted.

`CanvasStage` passes `interactive={hasManifest}`, using the same boolean gate that controls the "Awaiting matter" overlay, so the cursor and camera interactivity become live exactly when there is rendered matter to interact with.