### PR TITLE
fix(mapgen-studio): apply flash guard to `:root` for between-navigations clear color

### DIFF
--- a/apps/mapgen-studio/index.html
+++ b/apps/mapgen-studio/index.html
@@ -11,6 +11,17 @@
          cause). Element resets come from Tailwind preflight in index.css.
          Colors match the dark page tokens (index.css --background/--foreground);
          the theme script below out-cascades them for light users. */
+      /* The ROOT must carry background + color-scheme (X4 flash fix): the
+         browser's between-navigations clear color comes from the root
+         element's background and the document color-scheme. Styling only
+         <body> leaves a window — navigation commit until body exists — where
+         the canvas clears to the scheme default (white), which is the bright
+         flash on refresh. index.css re-declares color-scheme later; these two
+         must stay in sync with it. */
+      :root {
+        color-scheme: dark;
+        background: #0d0d11;
+      }
       body {
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
         background: #0d0d11;
@@ -38,7 +49,9 @@
             // specificity, later source order) so light users don't get a
             // dark pre-React flash (index.css :root --background/--foreground).
             var s = document.createElement("style");
-            s.textContent = "body { background: #f2f2f7; color: #1f2937; }";
+            s.textContent =
+              ":root { color-scheme: light; background: #f2f2f7; } " +
+              "body { background: #f2f2f7; color: #1f2937; }";
             document.head.appendChild(s);
           }
         } catch (e) {

--- a/openspec/changes/mapgen-studio-flash-fix/proposal.md
+++ b/openspec/changes/mapgen-studio-flash-fix/proposal.md
@@ -1,0 +1,37 @@
+# Refresh flash fix: the root carries the navigation clear color
+
+## Why
+
+Refreshing the studio flashed bright white before the dark UI painted. The
+user asked for an instrumented investigation ("record what renders when").
+An earliest-inline-script sampler (sessionStorage, pre-guard placement)
+captured the new document's paint-relevant state across reloads:
+
+- **Before:** at parse-start the root element had `background: transparent`
+  and `color-scheme: normal`, and stayed that way until Vite's JS-injected
+  CSS landed (~138ms, DOMContentLoaded) — the flash-guard `<style>` only
+  styled `<body>`. The browser's between-navigations clear color comes from
+  the ROOT element's background and the document `color-scheme`; with both
+  unset, every paintable moment in that window cleared to white. (The
+  lingering "DeckGL background" the user noticed is the old page's
+  GPU-composited canvas layer, released last during teardown.)
+- **After:** by the first animation frame (~8ms) the root computes
+  `rgb(13,13,17)` + `color-scheme: dark` — the unstyled window is gone
+  before any paint opportunity.
+
+## Target Authority Refs
+
+- `docs/projects/mapgen-studio-redesign/pass-5-design-fixes.md` (X4)
+
+## What Changes
+
+- `index.html` flash guard gains `:root { color-scheme: dark; background:
+  #0d0d11; }` (the guard previously styled only `body`); the theme script's
+  light branch appends the matching root override (`color-scheme: light;
+  background: #f2f2f7`), keeping light users symmetric. The guard stays
+  unlayered-minimal (Pass-3 constraint) and in sync with index.css tokens.
+
+## Impact
+
+- Affected specs: `mapgen-studio`
+- Affected code: `apps/mapgen-studio/index.html`

--- a/openspec/changes/mapgen-studio-flash-fix/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-flash-fix/specs/mapgen-studio/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: The Document Root Carries The Pre-Paint Theme
+
+The flash guard SHALL set both the background color and `color-scheme` on
+the root element (not only `body`) before any stylesheet loads, in the
+theme the user will resolve to, so the browser's between-navigations clear
+color matches the app theme and a refresh never flashes the opposite
+luminance.
+
+#### Scenario: Dark user refreshes without a white flash
+
+- **WHEN** a dark-theme user reloads the studio
+- **THEN** the root element computes the dark page background and
+  `color-scheme: dark` before the first paintable frame
+
+#### Scenario: Light user refreshes without a dark flash
+
+- **WHEN** a light-theme user reloads the studio
+- **THEN** the theme script's root override (light background +
+  `color-scheme: light`) applies during head parsing, before first paint

--- a/openspec/changes/mapgen-studio-flash-fix/tasks.md
+++ b/openspec/changes/mapgen-studio-flash-fix/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] 1.1 Instrument: earliest-inline-script paint sampler → sessionStorage
+      (parse-start / rAF / DCL / load snapshots), before vs after.
+- [x] 1.2 Guard `:root { color-scheme: dark; background }` + light-branch
+      root override in the theme script; remove the sampler.
+
+## 2. Verification
+
+- [x] 2.1 `bun run openspec -- validate mapgen-studio-flash-fix --strict`
+- [x] 2.2 Sampler evidence: before — root transparent + `color-scheme:
+      normal` until ~138ms (JS-injected CSS); after — dark root by the
+      first animation frame (~8ms), no regression across 40 frames.
+- [x] 2.3 Reload renders normally in both themes (guard stays
+      unlayered-minimal; no cascade regressions).


### PR DESCRIPTION
Fixes the bright white flash that appeared when refreshing the studio in dark mode.

The browser's between-navigations clear color is determined by the **root element's** background and `color-scheme`, not `<body>`. The existing flash guard only styled `body`, leaving a window from navigation commit until body paint where the root had `background: transparent` and `color-scheme: normal` — causing every paintable moment in that gap to clear to white.

The fix adds `:root { color-scheme: dark; background: #0d0d11; }` to the inline flash guard so the dark background is established before any paint opportunity (~8ms vs ~138ms previously). The theme script's light-mode branch is updated symmetrically to also override `:root` with `color-scheme: light` and the light background, so light users receive the same guarantee.