### PR TITLE
docs(mapgen-studio): record Pass-5 design fixes (toolbar v2, tile orientation, grid icon, flash guard, pre-run cursor)

### DIFF
--- a/docs/projects/mapgen-studio-redesign/00-GOAL.md
+++ b/docs/projects/mapgen-studio-redesign/00-GOAL.md
@@ -317,3 +317,54 @@ verified on :5173 (dark + light; focused/unfocused collapse, persistence,
 and the sticky chain walk exercised live). Gates green at tip: tsc, build +
 worker-bundle, 162 tests, three strict OpenSpec validations. Stack remains
 UNSUBMITTED per the standing rule.
+
+## Pass-5 design fixes (2026-06-11, night) — COMPLETE
+
+User-grounded wave five (`pass-5-design-fixes.md`): the Game/World toolbar
+architecture v2 (user-specified, supersedes Pass-4's colocation), tile
+rendering correctness, and canvas affordance honesty. New standing rule
+recorded (saved to agent memory): for complex UI patterns, search existing
+component libraries (shadcn/ui first) before building from scratch — without
+forcing a library where the in-repo solution is better. OpenSpec slices
+stacked on `design/config-collapse`:
+
+- [x] **X1** `mapgen-studio-toolbar-architecture-v2` —
+  `design/toolbar-architecture-v2` (top bar = THE Game toolbar: Gamepad2
+  identity, saved-config selector, the GameConsole cluster inlined without
+  panel chrome, and a trailing icon-only game-setup disclosure expanding
+  Leader/Civ/Difficulty/Speed only; bottom bar = THE World/Map console:
+  Globe identity, Size/Players/Resources left of Seed riding the shared
+  operation gate; last-run stats compressed into a History icon whose
+  tooltip + accessible name carry the run and whose click copies the seed)
+- [x] **X2** `mapgen-studio-grid-icon` — `design/grid-icon` (ViewControls
+  grid toggle rendered an empty `w-4 h-4` div — restored `Grid3x3`;
+  categorical sweep found no other empty placeholders, inline svgs, or
+  non-lucide icons; live-DOM scan confirms only the overrides Switch is
+  legitimately glyph-less)
+- [x] **X3** `mapgen-studio-tile-orientation` — `design/tile-orientation`
+  (odd-Q tiles were drawn pointy-top on a sheared pointy-axial lattice;
+  they now render flat-top on the model's CANONICAL hex space —
+  `projectOddqToHexSpace`, the frame the Delaunay/world.xy layers live in —
+  with the lattice's exact tiling hexagon; mesh contract: noData/non-finite
+  tiles fully transparent with stroke following fill alpha, one
+  `TILE_BORDER_COLOR` ink legible on white/black/graphite. Flagged
+  upstream, out of scope: mapgen-core models odd-q column-offset while
+  Civ7's native adjacency is pointy-top row-offset)
+- [x] **X4** `mapgen-studio-flash-fix` — `design/flash-fix` (instrumented
+  reloads with an earliest-inline-script sampler: the root element sat
+  unstyled — transparent background, `color-scheme: normal` — until
+  JS-injected CSS landed ~138ms in, so the navigation clear color was
+  white; the flash guard now puts background + color-scheme on `:root` for
+  both theme branches; after: dark root by the first animation frame ~8ms)
+- [x] **X5** `mapgen-studio-prerun-cursor` — `design/prerun-cursor`
+  (pre-run the deck controller was live but only the DOM graticule was
+  visible — a grab cursor promising an invisible drag; the canvas is now
+  inert with a default cursor until a manifest exists, restoring
+  grab/grabbing + the controller post-run via setProps without remount)
+
+**Pass-5 closure (2026-06-11):** all five slices implemented + verified on
+:5173 (dark + light; setup disclosure, History affordance, footer
+authoring, tile lattice zoom inspection, cursor states, and the flash
+sampler before/after exercised live). Gates green at tip: tsc, build +
+worker-bundle, 167 tests, five strict OpenSpec validations. Stack remains
+UNSUBMITTED per the standing rule.


### PR DESCRIPTION
Records the completion of Pass-5 design fixes for the mapgen studio redesign, covering five implemented slices:

- **Toolbar architecture v2**: Top bar restructured as the Game toolbar with a Gamepad2 identity, saved-config selector, inlined GameConsole cluster, and a game-setup disclosure for Leader/Civ/Difficulty/Speed; bottom bar established as the World/Map console with Globe identity, Size/Players/Resources alongside Seed, and a History icon compressing last-run stats
- **Grid icon restoration**: Fixed a `ViewControls` grid toggle that was rendering an empty div instead of the `Grid3x3` icon, with a categorical sweep confirming no other empty placeholders exist
- **Tile orientation correction**: Odd-Q tiles were drawing pointy-top on a sheared lattice and now render flat-top on the canonical hex space used by the Delaunay/world.xy layers, with correct transparency and border behavior for noData/non-finite tiles
- **Flash fix**: Eliminated an unstyled root element during reload (~138ms window) by placing background and `color-scheme` on `:root` for both theme branches inline, bringing dark root rendering down to ~8ms
- **Pre-run cursor honesty**: Canvas is now inert with a default cursor before a manifest exists, replacing a grab cursor that promised an invisible drag; grab/grabbing and the deck controller are restored post-run via `setProps` without remounting

Also records a new standing rule: search existing component libraries (shadcn/ui first) before building custom UI patterns from scratch. All five slices verified on `:5173` with 167 passing tests and five strict OpenSpec validations.