### PR TITLE
docs(mapgen-studio): add pipeline DAG stage-view workstream record, proposal, design, spec deltas, and tasks

### DIFF
--- a/openspec/changes/mapgen-studio-dag-tab/design.md
+++ b/openspec/changes/mapgen-studio-dag-tab/design.md
@@ -1,0 +1,97 @@
+# Design — Pipeline stage view
+
+## The boundary question: where does a view switcher live?
+
+Zoning v2 (system.md): top bar = Game, bottom bar = World/Map console, left
+dock = Recipe authoring, right dock = Explore. None of these owns "which
+stage view is showing" — it is not a game setting, not a map parameter, not
+recipe authoring, and not a map-explore control. It is **stage furniture**:
+the stage area itself chooses what it presents. So the switcher floats at
+the stage's top edge, centered, in the same popover-tier pill chrome as the
+docks/consoles, using the segmented-control idiom established for
+Render/Space (C4). Labels: `Map` (Map glyph) and `Pipeline` (Workflow
+glyph) — "Pipeline" is the product noun for what the recipe DAG *is* to a
+map author; the accessible name keeps "recipe dependency graph".
+
+## Stage composition (StudioShell)
+
+- `stageView === "map"`: today's stage, unchanged. The switcher renders
+  above it.
+- `stageView === "pipeline"`: `CanvasStage` stays MOUNTED but visually
+  hidden (`hidden` on its wrapper) — deck camera state and any in-flight
+  run/poll loops are untouched (behavior parity is hard core).
+  `PipelineStage` renders into the same stage rect. The right Explore dock
+  does not render (every control in it is map-scoped); left dock, Game bar,
+  World console persist — running a generation while reading the pipeline
+  is legitimate and keeps working.
+
+## Chrome re-expression (PipelineStage)
+
+| Old (RecipeDagView) | New |
+| --- | --- |
+| `createPalette(lightMode)` hex forks | design tokens + `.dark` (chrome); neutral edge ink exported as `PIPELINE_EDGE_INK` (luminance token string) for the static-markup pins |
+| `topInset` prop + absolute overlay over the whole app | a stage child in the shell's stage rect; shell owns geometry |
+| `RecipeDagStatsBar` in the header accessory slot | floating console strip inside the stage, top-right: `Workflow` identity + recipe title · Phases · Stages · Edges · Issues (warn tone iff > 0) |
+| `CenteredState` loading/error cards (hex) | token cards in the awaiting-matter idiom (border-border, bg-popover, muted text) |
+| cyan kicker/icon accents | slate chrome accent (`--primary`); domain accents stay data-driven from `domainPresentation` |
+
+What does NOT change (handoff §2.3–2.6, verbatim semantics):
+
+- `buildRecipeDagLayout` / `buildArtifactEdgeLabels` /
+  `resolveEdgeLabelPositions` / `pointsToPath` consumed as-is; rank
+  columns, phase bands, bundled-trunk edges, deterministic label fanning.
+- Stage selection vs step expansion; click-again unselects; expansion is a
+  compact animated detail shelf (`aria-expanded`, `aria-controls`,
+  `data-stage-expanded`, max-height transition).
+- Connector labels: one per provided artifact, selectable
+  (`aria-pressed`, `data-edge-label-selected`), selection activates every
+  branch carrying the artifact + endpoints; focus hides unrelated labels;
+  active stages/labels rise (z-order); idle connectors stay neutral;
+  selected-destination pulls split labels toward that branch (this lives in
+  the preserved `layout.ts`).
+- Domain glyph + accent contract across nodes, lane labels, edge pills,
+  step chips, diagnostics (preserved `domainPresentation` /
+  `artifactPresentation`).
+- Diagnostics panel (kind + domain glyph + artifact label, first 6).
+
+## Data: TanStack Query owns the fetch
+
+`useRecipeDagQuery(recipeId, { enabled })` → `queryKey: ["recipeDag",
+recipeId]`, `queryFn: client.recipeDag.get({ recipeId })`, `staleTime:
+Infinity` (the DAG only changes when authored code changes → page reload),
+`enabled: stageView === "pipeline"`. This is the old monolith behavior
+(lazy fetch on tab activation, cache keyed by recipe, error surface) with
+the stale-response guard and cancellation handled by the query cache
+instead of hand-rolled state. The module-root `QueryClientProvider`
+(client-data slice) already hosts it. One oRPC client instance per module
+(same as the merged code's module-scope client).
+
+## State: the crisp rule
+
+`stageView`, `pipelineSelectedStageId`, `pipelineExpandedStageIds` are
+browser-only view state with no server coupling → `viewStore` (Zustand),
+NOT persisted, setters mirror `useState` signatures. They are
+pipeline-scoped names — the existing `selectedStageId` (map-explore
+selection) is a different concept and stays untouched. Connector-label
+selection remains `useState` inside `PipelineStage` (it resets with the
+component, as merged).
+
+## Test porting map (RecipeDagView.test.tsx → PipelineStage.test.tsx)
+
+Kept verbatim (semantics): title render; `aria-pressed="true"` on selected
+stage; `aria-expanded` + `aria-controls` + `data-stage-expanded`; expanded
+z-order above graph; active `marker-end` arrow + domain-accent stroke
+(`#f59e0b` comes from preserved `domainPresentation`, still assertable);
+`aria-label="Select dependency hydrography"` + `data-edge-label-selected`;
+`Step 1: seed` + `Creates` in the shelf; neutral-before-selection (neutral
+ink, no accent border-color, default marker). Re-expressed: hex palette
+assertions become token/`PIPELINE_EDGE_INK` assertions. The shared fixture
+DAG moves over unchanged.
+
+## Slices
+
+1. `design/dag-tab-frame` — this workstream record (docs only).
+2. `design/dag-tab-stage` — implementation + ported tests + old view
+   deletion, gates green, visual verification dark + light.
+3. Ledger/system.md amendments ride slice 2 (decision records are part of
+   the change).

--- a/openspec/changes/mapgen-studio-dag-tab/proposal.md
+++ b/openspec/changes/mapgen-studio-dag-tab/proposal.md
@@ -1,0 +1,78 @@
+# Recipe pipeline (DAG) as a first-class stage view in the redesigned Studio
+
+## Why
+
+The recipe-DAG visualization merged to main (PRs #1587–#1591) against the
+pre-redesign Studio: its chrome mounts through the deleted App.tsx monolith,
+hard-codes a `lightMode` palette, and hangs view state off monolith
+`useState`. The handoff spec
+(`docs/projects/graphite-stack-integration/DAG-STUDIO-REDESIGN-HANDOFF.md`)
+directs this lane to re-express the surface natively in the redesign — "an
+additional tab that shows the recipe DAG" — while preserving the merged
+code's semantics verbatim. The merged code is the semantic source of truth;
+the redesign's design system is the authority on shape.
+
+## Target Authority Refs
+
+- `docs/projects/graphite-stack-integration/DAG-STUDIO-REDESIGN-HANDOFF.md`
+  (§2 invariants, §3 re-express list, §5 non-goals, §6 mandate)
+- `openspec/changes/mapgen-recipe-dag-visualization/` (the merged feature's
+  own workstream — what the feature committed to)
+- `apps/mapgen-studio/.interface-design/system.md` (design-system authority)
+
+## What Changes
+
+- **Stage-view switcher** (new navigation primitive): a floating segmented
+  control at the top-center of the stage area — `Map | Pipeline` — using the
+  established segmented-control idiom (Pass-2 explore-toolbar), popover-tier
+  chrome. The DAG is the *Pipeline* view of the authored recipe; the map is
+  the *Map* view of its output. Zoning v2 is untouched: the switcher is
+  stage furniture, not Game-bar or World-console content.
+- **`features/recipeDag/PipelineStage.tsx`** (new): the redesigned stage
+  component. Re-expresses `RecipeDagView.tsx`'s chrome on design tokens
+  (single `.dark` class, no `lightMode` palette forks for chrome) while
+  preserving every interaction semantic listed in handoff §2.6: stage
+  selection separate from step expansion, click-again unselect, selectable
+  per-artifact connector labels with trunk-before-fan-out projection, focus
+  dimming with active elements rising, context-aware label placement, and
+  diagnostics surfacing. Domain lane fills/accents keep coming from the
+  preserved `domainPresentation.ts` (data color, where real color belongs).
+- **Pipeline console strip**: the old `RecipeDagStatsBar` re-expressed as a
+  floating instrument strip inside the stage (identity + Phases · Stages ·
+  Edges · Issues, warn tone only when issues exist).
+- **Data layer re-home**: `useRecipeDagQuery(recipeId, enabled)` on TanStack
+  Query (`['recipeDag', recipeId]`, fetch on first activation, cached per
+  recipe, typed error surface) replacing the monolith's hand-rolled
+  fetch/cancellation state. Transport unchanged: the preserved oRPC client
+  at `STUDIO_RECIPE_DAG_ORPC_PATH`.
+- **View state re-home**: `viewStore` (Zustand, browser-only view state per
+  the client-data crisp rule) gains `stageView`, `pipelineSelectedStageId`,
+  `pipelineExpandedStageIds`. Connector-label selection stays
+  component-local, as in the merged code.
+- **Explore dock scoping**: the right Explore dock is map-scoped
+  (stage/step run navigation, render/space layers); it hides while the
+  Pipeline view is active. The left Recipe dock (the DAG's input), the Game
+  bar, and the World console stay. The map canvas stays mounted (hidden) so
+  camera state and in-flight runs are unaffected — behavior parity.
+- **`RecipeDagView.tsx` deleted** with its test; the semantic assertions of
+  `RecipeDagView.test.tsx` are ported onto `PipelineStage` in the same
+  change (handoff §4 gate note).
+- **Preserved untouched**: `layout.ts`, `domainPresentation.ts`,
+  `artifactPresentation.ts`, `client.ts`, all of `server/recipeDag/*`,
+  `shared/recipeDagOrpc.ts`, the vite middleware, and
+  `packages/mapgen-core` recipe-dag projection + tests.
+
+## Non-Goals (binding, handoff §5)
+
+- No changes to the projection contract or oRPC schema.
+- No runtime/execution overlay on the DAG.
+- No edits to preserved headless modules beyond imports from new call sites.
+
+## Impact
+
+- Affected specs: `mapgen-studio`
+- Affected code: `apps/mapgen-studio/src/features/recipeDag/{PipelineStage.tsx,useRecipeDagQuery.ts}`
+  (new), `RecipeDagView.tsx` (deleted), `apps/mapgen-studio/src/ui/components/StageViewTabs.tsx`
+  (new), `apps/mapgen-studio/src/stores/viewStore.ts`,
+  `apps/mapgen-studio/src/app/StudioShell.tsx`,
+  `apps/mapgen-studio/test/recipeDag/PipelineStage.test.tsx` (ported pins)

--- a/openspec/changes/mapgen-studio-dag-tab/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-dag-tab/specs/mapgen-studio/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: The Recipe Pipeline Is A First-Class Stage View
+
+The Studio SHALL present the recipe dependency graph as a Pipeline stage
+view, switchable with the Map view via a floating segmented control at the
+stage's top edge, with the map canvas remaining mounted (camera state and
+in-flight operations unaffected) and the map-scoped Explore dock hidden
+while the Pipeline view is active. This re-expresses the merged
+`mapgen-recipe-dag-visualization` chrome inside the redesigned shell; the
+projection contract, oRPC transport, and headless layout/domain/label
+modules are consumed unchanged.
+
+#### Scenario: Switching to the pipeline view
+
+- **WHEN** the user activates the Pipeline tab of the stage-view switcher
+- **THEN** the recipe DAG for the currently selected recipe renders in the
+  stage area, the Explore dock is absent, and the Recipe dock, Game bar,
+  and World console remain
+
+#### Scenario: Returning to the map view
+
+- **WHEN** the user activates the Map tab after viewing the pipeline
+- **THEN** the map canvas reappears with its previous camera state and any
+  in-flight generation continues unaffected
+
+### Requirement: Pipeline Data Loads On Activation And Caches Per Recipe
+
+The pipeline view SHALL fetch the recipe DAG over the preserved oRPC
+transport on first activation per recipe, cache results keyed by recipe id,
+and surface loading and error states in the stage; switching recipes
+re-fetches only for uncached recipes.
+
+#### Scenario: Lazy fetch with cache
+
+- **WHEN** the Pipeline view activates for a recipe already fetched this
+  session
+- **THEN** the cached DAG renders without a new request
+
+#### Scenario: Error surface
+
+- **WHEN** the DAG request fails
+- **THEN** the stage presents an error card naming the failure and the map
+  view remains reachable
+
+### Requirement: Pipeline Interaction Semantics Match The Merged Feature
+
+The Pipeline stage SHALL preserve the merged feature's interaction
+semantics: stage selection separate from step expansion (click-again
+unselects; expansion is an accessible detail shelf), selectable
+per-artifact connector labels whose selection activates every branch
+carrying that artifact and its endpoint stages, focus that dims unrelated
+elements and raises active ones, neutral idle connectors, domain-driven
+accents/glyphs shared across nodes, lane labels, edge pills, step chips,
+and diagnostics, and a diagnostics panel when the projection reports
+issues.
+
+#### Scenario: Selection and expansion stay separate
+
+- **WHEN** a stage node's expand control is activated
+- **THEN** the step shelf opens (`aria-expanded`, `aria-controls`) without
+  toggling the node's selected state semantics, and selecting the same
+  stage again unselects it
+
+#### Scenario: Artifact label selection focuses its branches
+
+- **WHEN** a connector label is selected
+- **THEN** every connector carrying that artifact and its endpoint stages
+  render active with the providing stage's domain accent while unrelated
+  labels hide and unrelated stages dim
+
+#### Scenario: Idle graph stays neutral
+
+- **WHEN** no stage or label is selected
+- **THEN** connectors and labels render in the neutral chrome ink with no
+  domain accent applied

--- a/openspec/changes/mapgen-studio-dag-tab/tasks.md
+++ b/openspec/changes/mapgen-studio-dag-tab/tasks.md
@@ -1,0 +1,33 @@
+## 1. Frame
+
+- [x] 1.1 Workstream record + proposal/design/tasks/spec deltas committed
+      (`design/dag-tab-frame`).
+
+## 2. Implementation (`design/dag-tab-stage`)
+
+- [ ] 2.1 `viewStore`: `stageView` ("map" | "pipeline"),
+      `pipelineSelectedStageId`, `pipelineExpandedStageIds` (+ setters).
+- [ ] 2.2 `useRecipeDagQuery` on TanStack Query (fetch on activation,
+      cache per recipe, typed error; transport via preserved client).
+- [ ] 2.3 `StageViewTabs` segmented switcher (Map | Pipeline), popover-tier
+      pill, top-center of the stage area.
+- [ ] 2.4 `PipelineStage`: token-driven re-expression of the DAG chrome
+      preserving all §2.6 interaction semantics; floating pipeline console
+      strip (identity + counts); diagnostics panel.
+- [ ] 2.5 `StudioShell` wiring: switcher mount; map stage hidden-not-
+      unmounted in pipeline view; Explore dock scoped to map view.
+- [ ] 2.6 Delete `RecipeDagView.tsx` + its test; port semantic pins to
+      `test/recipeDag/PipelineStage.test.tsx` (same fixture).
+- [ ] 2.7 `system.md` amendment: stage-view furniture rule + pipeline-stage
+      decisions; goal-ledger entry.
+
+## 3. Verification
+
+- [ ] 3.1 `bun run openspec -- validate mapgen-studio-dag-tab --strict`
+- [ ] 3.2 tsc clean; studio vitest green (recipeDag suites incl. ported
+      pins); mapgen-core tests green; build + worker-bundle green.
+- [ ] 3.3 Visual on :5173 (dark + light): switcher; pipeline loads for the
+      standard recipe; selection/expansion/label-focus interactions; map
+      view returns with camera intact; run loop works while pipeline view
+      is active.
+- [ ] 3.4 Workstream/phase record closed with evidence.

--- a/openspec/changes/mapgen-studio-dag-tab/workstream/workstream-record.md
+++ b/openspec/changes/mapgen-studio-dag-tab/workstream/workstream-record.md
@@ -1,0 +1,51 @@
+# Systematic Workstream Record
+
+## Frame
+
+- Objective: Re-express the merged recipe-DAG visualization as a
+  first-class Pipeline stage view native to the redesigned Studio —
+  design-system idioms, decomposed-shell mounting, client-data-layer
+  fetching — per the handoff's execution mandate (§6).
+- Future state: a map author flips the stage between Map and Pipeline; the
+  pipeline renders the selected recipe's authored artifact-dependency
+  structure with the same layout, domain, label, and interaction semantics
+  the merged feature shipped, now themed by the token system in both modes.
+- Non-goals (binding, handoff §5): projection/oRPC schema changes; runtime
+  execution overlays; rewrites of the preserved headless modules.
+- Hard core: handoff §2 invariants verbatim — projection contract
+  (`buildRecipeDag`), server boundary (`STUDIO_RECIPE_DAG_ORPC_PATH`, client
+  never imports recipe modules), layout semantics (dependency rank ×
+  phase-lane waterfall, bundled trunks, deterministic label fanning),
+  domain taxonomy + one icon contract, per-artifact label projection,
+  interaction semantics (selection vs expansion, label selection, focus
+  dimming, context-aware placement, diagnostics). Behavior parity of the
+  surrounding shell (run/poll/persistence) is this lane's standing hard
+  core.
+- Exterior: engine-side conventions, placement-stack resources vertical,
+  the integration lane's stack.
+
+## Authority
+
+- `docs/projects/graphite-stack-integration/DAG-STUDIO-REDESIGN-HANDOFF.md`
+  (operator-granted mandate; §1 disposition table, §2 invariants)
+- `openspec/changes/mapgen-recipe-dag-visualization/` (the merged feature's
+  workstream — committed semantics + prior-art record format)
+- `apps/mapgen-studio/.interface-design/system.md` (design decisions of
+  record for this lane)
+- `docs/projects/mapgen-studio-redesign/00-GOAL.md` (lane ledger)
+
+## Plan
+
+- Phase 1 (`design/dag-tab-frame`): this record + proposal/design/tasks +
+  spec deltas, `--strict` valid.
+- Phase 2 (`design/dag-tab-stage`): implementation per design.md, test pins
+  ported in the same change, gates green (tsc; studio vitest incl.
+  recipeDag suites; mapgen-core; build + worker bundle), visual
+  verification dark + light, system.md + ledger amendments.
+
+## Status
+
+- Started: 2026-06-12 (post-restack onto main @ 6adfc9ec3; restack absorbed
+  the merged feature with the §4 resolutions — chrome trio taken from this
+  lane, vite middleware + headless/server modules preserved, dep union)
+- Current: Phase 1 — frame committed; Phase 2 implementation next.


### PR DESCRIPTION
This workstream establishes the planning and specification foundation for integrating the recipe DAG visualization as a first-class **Pipeline** stage view within the redesigned Studio shell.

The merged DAG feature (PRs #1587–#1591) was built against the pre-redesign monolith — hard-coded palette forks, monolith-owned view state, and chrome mounted through the deleted `App.tsx`. This change lays out exactly how that surface gets re-expressed natively in the redesign without touching any of its semantic contracts.

**What the implementation slice will deliver:**

- A floating `Map | Pipeline` segmented switcher at the top edge of the stage area — stage furniture, not Game bar or World console content — using the established popover-tier pill idiom.
- `PipelineStage`, a token-driven replacement for `RecipeDagView` that preserves every interaction semantic from the handoff verbatim: stage selection vs. step expansion, click-again unselect, per-artifact connector label selection with trunk-before-fan-out projection, focus dimming with active elements rising, domain-driven accents, and the diagnostics panel.
- The map canvas stays mounted (hidden) when the Pipeline view is active so camera state and in-flight generation runs are unaffected. The Explore dock hides in Pipeline view; the Recipe dock, Game bar, and World console persist.
- `useRecipeDagQuery` on TanStack Query replaces hand-rolled fetch/cancellation state — lazy fetch on first activation, cached per recipe ID, typed error surface.
- `stageView`, `pipelineSelectedStageId`, and `pipelineExpandedStageIds` land in `viewStore` (Zustand, browser-only). Connector-label selection stays component-local as in the merged code.
- `RecipeDagView.tsx` is deleted; its semantic test assertions are ported onto `PipelineStage.test.tsx` in the same change.

**Preserved untouched:** `layout.ts`, `domainPresentation.ts`, `artifactPresentation.ts`, `client.ts`, all server-side `recipeDag` modules, the oRPC schema, the vite middleware, and all `mapgen-core` recipe-dag projection logic and tests.