### PR TITLE
feat(mapgen-studio): add Pipeline stage view with Map|Pipeline switcher, TanStack Query DAG data layer, and token-driven PipelineStage chrome

### DIFF
--- a/apps/mapgen-studio/.interface-design/system.md
+++ b/apps/mapgen-studio/.interface-design/system.md
@@ -255,3 +255,26 @@ supersedes the Pass-4 dock placement, keeps the console split + icon contract:
   look it produced). Tile borders use ONE graphite ink (`#0d0d11`, α200) in
   both themes — dark seams against the fills; never a mid-luminance color
   that competes with the data palette. Unfilled tiles draw nothing.
+
+## DAG-tab amendment (2026-06-12, handoff-mandated): stage views
+
+Decisions (see `openspec/changes/mapgen-studio-dag-tab/design.md`):
+
+- **Stage-view furniture rule:** what the center stage presents (Map vs
+  Pipeline) is the STAGE's own concern — not Game bar (not a game setting),
+  not World console (not a map parameter), not a dock (not authoring or
+  map inspection). View switchers float at the stage's top edge, centered,
+  in the popover-tier pill chrome, using the segmented-control idiom
+  (active segment lifts one surface tier).
+- **Pipeline stage (recipe DAG):** chrome is token-driven (no `lightMode`
+  forks); the ONLY surviving light/dark fork is the preserved
+  `domainPresentation` data palette (domain accents ARE data color). The
+  neutral connector ink is `PIPELINE_EDGE_INK` (muted-foreground luminance
+  token). The map canvas stays mounted-but-invisible under the pipeline so
+  deck camera state and in-flight runs survive view flips; the Explore
+  dock (map-scoped) leaves the stage in pipeline view; Recipe dock, Game
+  bar, World console stay.
+- **Pipeline data:** TanStack Query (`["recipeDag", recipeId]`, enabled on
+  view activation, staleTime ∞) — fetch on first activation, cached per
+  recipe; pipeline selection/expansion live in `viewStore` as
+  pipeline-prefixed fields, distinct from map-explore selection.

--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -138,6 +138,10 @@ import { mergeBuiltInPresets, toRepoBackedPreset } from "../features/presets/rep
 import type { PresetErrorState } from "../features/presets/dialogState";
 import { liveControlPort } from "../lib/control/liveControlPort";
 
+import { PipelineStage } from "../features/recipeDag/PipelineStage";
+import { useRecipeDagQuery } from "../features/recipeDag/useRecipeDagQuery";
+import { StageViewTabs } from "../ui/components/StageViewTabs";
+
 import { CanvasStage } from "./CanvasStage";
 import { ErrorBanner } from "./ErrorBanner";
 import { LeftDock } from "./LeftDock";
@@ -231,9 +235,43 @@ export function StudioShell(props: StudioShellProps) {
   const setExploreStepExpanded = useViewStore((s) => s.setExploreStepExpanded);
   const exploreLayersExpanded = useViewStore((s) => s.exploreLayersExpanded);
   const setExploreLayersExpanded = useViewStore((s) => s.setExploreLayersExpanded);
+  const stageView = useViewStore((s) => s.stageView);
+  const setStageView = useViewStore((s) => s.setStageView);
+  const pipelineSelectedStageId = useViewStore((s) => s.pipelineSelectedStageId);
+  const setPipelineSelectedStageId = useViewStore((s) => s.setPipelineSelectedStageId);
+  const pipelineExpandedStageIds = useViewStore((s) => s.pipelineExpandedStageIds);
+  const setPipelineExpandedStageIds = useViewStore((s) => s.setPipelineExpandedStageIds);
   const [autoRunEnabled, setAutoRunEnabled] = useState(false);
   const autoRunTimerRef = useRef<number | null>(null);
   const autoRunPendingRef = useRef(false);
+
+  // Pipeline (recipe DAG) stage view — data via TanStack Query, gated on the
+  // view being active (fetch on first activation, cached per recipe).
+  const recipeDag = useRecipeDagQuery(recipeSettings.recipe, {
+    enabled: stageView === "pipeline",
+  });
+  // Prune pipeline expansion to stages that exist in the loaded DAG (the
+  // merged feature did the same on fetch success) — switching recipes must
+  // not carry phantom expanded ids across graphs.
+  useEffect(() => {
+    if (!recipeDag.dag) return;
+    const known = new Set(recipeDag.dag.stages.map((stage) => stage.stageId));
+    setPipelineExpandedStageIds((prev) => {
+      const kept = [...prev].filter((id) => known.has(id));
+      return kept.length === prev.size ? prev : new Set(kept);
+    });
+  }, [recipeDag.dag, setPipelineExpandedStageIds]);
+  const handlePipelineStageToggle = useCallback(
+    (stageId: string) => {
+      setPipelineExpandedStageIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(stageId)) next.delete(stageId);
+        else next.add(stageId);
+        return next;
+      });
+    },
+    [setPipelineExpandedStageIds]
+  );
 
   const [presetError, setPresetError] = useState<PresetErrorState | null>(null);
   const [saveDialogState, setSaveDialogState] = useState<{ open: boolean; label: string; description?: string }>({
@@ -2413,18 +2451,43 @@ export function StudioShell(props: StudioShellProps) {
         wraps), keeping it in the a11y tree and focusable via `tabIndex={-1}`
         without changing the visual layout.
       */}
-      <main id="map-preview" aria-label="Map preview" tabIndex={-1} className="absolute inset-0">
-        <CanvasStage
-          apiRef={deckApiRef}
-          onApiReady={handleDeckApiReady}
-          layers={viz.deck.layers}
-          effectiveLayer={viz.effectiveLayer}
-          viewportSize={viewportSize}
-          activeBounds={viz.activeBounds}
-          lightMode={isLightMode}
-          backgroundGridEnabled={backgroundGridEnabled}
-          hasManifest={Boolean(viz.manifest)}
-        />
+      <main
+        id="map-preview"
+        aria-label={stageView === "pipeline" ? "Recipe pipeline" : "Map preview"}
+        tabIndex={-1}
+        className="absolute inset-0"
+      >
+        {/* The map stage stays MOUNTED (just not painted) while the pipeline
+            view is up: deck camera state and in-flight run/poll loops are
+            untouched — behavior parity (mapgen-studio-dag-tab). */}
+        <div className={`absolute inset-0 ${stageView === "pipeline" ? "invisible" : ""}`}>
+          <CanvasStage
+            apiRef={deckApiRef}
+            onApiReady={handleDeckApiReady}
+            layers={viz.deck.layers}
+            effectiveLayer={viz.effectiveLayer}
+            viewportSize={viewportSize}
+            activeBounds={viz.activeBounds}
+            lightMode={isLightMode}
+            backgroundGridEnabled={backgroundGridEnabled}
+            hasManifest={Boolean(viz.manifest)}
+          />
+        </div>
+        {stageView === "pipeline" ? (
+          <PipelineStage
+            recipeId={recipeSettings.recipe}
+            dag={recipeDag.dag}
+            status={recipeDag.status}
+            error={recipeDag.error}
+            isLightMode={isLightMode}
+            expandedStageIds={pipelineExpandedStageIds}
+            selectedStageId={pipelineSelectedStageId || null}
+            onToggleStage={handlePipelineStageToggle}
+            onSelectStage={setPipelineSelectedStageId}
+            topInset={panelTop}
+            bottomInset={panelBottom}
+          />
+        ) : null}
       </main>
       {presetDialogs}
       <input
@@ -2436,7 +2499,13 @@ export function StudioShell(props: StudioShellProps) {
       />
 
       <LeftDock top={panelTop} bottom={panelBottom}>{leftPanel}</LeftDock>
-      <RightDock top={panelTop} bottom={panelBottom}>{rightPanel}</RightDock>
+      {/* The Explore dock is map-scoped (run stage/step navigation, layers,
+          camera); it leaves the stage when the pipeline view is active. */}
+      {stageView === "map" ? (
+        <RightDock top={panelTop} bottom={panelBottom}>{rightPanel}</RightDock>
+      ) : null}
+
+      <StageViewTabs value={stageView} onValueChange={setStageView} top={panelTop} />
 
       {header}
       {footer}

--- a/apps/mapgen-studio/src/features/recipeDag/PipelineStage.tsx
+++ b/apps/mapgen-studio/src/features/recipeDag/PipelineStage.tsx
@@ -1,14 +1,14 @@
 import React, { useMemo, useState } from "react";
-import {
-  AlertTriangle,
-  ChevronDown,
-  GitBranch,
-  Loader2,
-} from "lucide-react";
+import { AlertTriangle, ChevronDown, Loader2, Workflow } from "lucide-react";
 
 import type { RecipeDagResult } from "./client";
+import type { RecipeDagLoadStatus } from "./useRecipeDagQuery";
 import { formatArtifactLabel, resolveArtifactGroupDomainId } from "./artifactPresentation";
-import { chooseRecipeDagDomainId, getRecipeDagDomainPresentation, getRecipeDagPhaseLaneColors } from "./domainPresentation";
+import {
+  chooseRecipeDagDomainId,
+  getRecipeDagDomainPresentation,
+  getRecipeDagPhaseLaneColors,
+} from "./domainPresentation";
 import {
   buildArtifactEdgeLabels,
   buildRecipeDagLayout,
@@ -16,36 +16,62 @@ import {
   type RoutedStageEdgeGroup,
 } from "./layout";
 
-type RecipeDagLoadStatus = "idle" | "loading" | "ready" | "error";
+// ============================================================================
+// PIPELINE STAGE — the recipe DAG as a first-class stage view
+// (mapgen-studio-dag-tab; re-expresses the merged RecipeDagView chrome)
+// ============================================================================
+// Chrome is token-driven (single `.dark` class; no lightMode palette forks);
+// the ONLY place `isLightMode` survives is the preserved domain presentation
+// module, whose lane fills/accents are data color with explicit light/dark
+// variants (handoff §2.4 — domain drives color, not phase order).
+//
+// Everything the handoff lists under §2.3–§2.6 is consumed or reproduced
+// verbatim: the headless layout (dependency rank × phase-lane waterfall,
+// bundled trunks, deterministic label fanning), the one-icon contract across
+// nodes/lanes/pills/chips/diagnostics, stage selection separate from step
+// expansion (click-again unselects), selectable per-artifact connector
+// labels, focus dimming with active elements rising, and diagnostics.
+// ============================================================================
 
-export interface RecipeDagViewProps {
+/**
+ * Neutral connector ink — the idle-graph chrome color for edges and the SVG
+ * furniture. A luminance token (not a hex fork) so it follows the theme;
+ * exported for the static-markup behavioral pins.
+ */
+export const PIPELINE_EDGE_INK = "hsl(var(--muted-foreground) / 0.55)";
+
+export interface PipelineStageProps {
   recipeId: string;
   dag: RecipeDagResult | null;
   status: RecipeDagLoadStatus;
   error: string | null;
-  lightMode: boolean;
+  /** Forwarded ONLY to the preserved domain palette (data color variants). */
+  isLightMode: boolean;
   expandedStageIds: ReadonlySet<string>;
   selectedStageId: string | null;
   onToggleStage: (stageId: string) => void;
   onSelectStage: (stageId: string) => void;
+  /** Clearance (px) under the floating header for the scroll content. */
   topInset: number;
+  /** Clearance (px) above the floating footer for the scroll content. */
+  bottomInset: number;
 }
 
-export function RecipeDagView(props: RecipeDagViewProps) {
+export function PipelineStage(props: PipelineStageProps) {
   const {
     recipeId,
     dag,
     status,
     error,
-    lightMode,
+    isLightMode,
     expandedStageIds,
     selectedStageId,
     onToggleStage,
     onSelectStage,
     topInset,
+    bottomInset,
   } = props;
   const [selectedLabelId, setSelectedLabelId] = useState<string | null>(null);
-  const palette = useMemo(() => createPalette(lightMode), [lightMode]);
   const layout = useMemo(() => (dag ? buildRecipeDagLayout(dag) : null), [dag]);
   const phaseIdByStageId = useMemo(() => {
     const ids = new Map<string, string | null>();
@@ -88,7 +114,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
   }, [edgeLayerGroups, selectedLabel, selectedStageId]);
   const focusActive = Boolean(selectedLabel || selectedStageId);
   const getStageAccent = (stageId: string) =>
-    getRecipeDagPhaseLaneColors(phaseIdByStageId.get(stageId) ?? null, lightMode).accent;
+    getRecipeDagPhaseLaneColors(phaseIdByStageId.get(stageId) ?? null, isLightMode).accent;
   const handleSelectStage = (stageId: string, options?: { keepSelected?: boolean }) => {
     setSelectedLabelId(null);
     if (!options?.keepSelected && !selectedLabel && selectedStageId === stageId) {
@@ -100,27 +126,54 @@ export function RecipeDagView(props: RecipeDagViewProps) {
 
   return (
     <section
-      className={`absolute inset-0 overflow-hidden ${palette.surface}`}
-      style={{ paddingTop: topInset }}
+      className="absolute inset-0 overflow-hidden bg-background"
       aria-label={`Recipe dependency graph for ${recipeId}`}
     >
-      <div className={`absolute inset-0 pointer-events-none ${palette.grid}`} aria-hidden="true" />
-      <div className="relative flex h-full min-h-0 flex-col">
-        <div className="relative min-h-0 flex-1 overflow-auto px-4 pb-4">
+      {/* Luminance grid — same substrate treatment as the map stage. */}
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          backgroundImage: `
+            linear-gradient(hsl(var(--muted-foreground) / 0.06) 1px, transparent 1px),
+            linear-gradient(90deg, hsl(var(--muted-foreground) / 0.06) 1px, transparent 1px)
+          `,
+          backgroundSize: "48px 48px",
+        }}
+        aria-hidden="true"
+      />
+
+      {/* Pipeline console — the instrument strip (identity + projection counts). */}
+      <div
+        className="absolute right-4 z-20 inline-flex h-10 items-center gap-3 rounded-lg border border-border bg-popover/95 px-3 backdrop-blur-sm"
+        style={{ top: topInset }}
+      >
+        <div className="flex min-w-0 items-center gap-1.5">
+          <Workflow className="h-4 w-4 shrink-0 text-muted-foreground/70" />
+          <span className="max-w-[220px] truncate text-label font-semibold uppercase tracking-wider text-muted-foreground">
+            {dag?.title ?? recipeId}
+          </span>
+        </div>
+        <div className="w-px h-5 bg-border" />
+        <PipelineMetric label="Phases" value={dag?.phases.length ?? 0} />
+        <PipelineMetric label="Stages" value={dag?.stages.length ?? 0} />
+        <PipelineMetric label="Edges" value={dag?.edges.length ?? 0} />
+        <PipelineMetric label="Issues" value={dag?.diagnostics.length ?? 0} warn={Boolean(dag?.diagnostics.length)} />
+      </div>
+
+      <div className="relative flex h-full min-h-0 flex-col" style={{ paddingTop: topInset, paddingBottom: bottomInset }}>
+        <div className="relative min-h-0 flex-1 overflow-auto px-4 pb-4 pt-14 custom-scrollbar">
           {status === "loading" || status === "idle" ? (
             <CenteredState
-              lightMode={lightMode}
               icon={<Loader2 className="h-5 w-5 animate-spin" />}
-              title="Loading recipe DAG"
+              title="Loading recipe pipeline"
               message="Reading authored artifact contracts for the selected recipe."
             />
           ) : null}
 
           {status === "error" ? (
             <CenteredState
-              lightMode={lightMode}
               icon={<AlertTriangle className="h-5 w-5" />}
-              title="Recipe DAG unavailable"
+              title="Recipe pipeline unavailable"
               message={error ?? "Studio could not load the dependency graph for this recipe."}
             />
           ) : null}
@@ -169,14 +222,14 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                       y1={48}
                       x2={column.x + 124}
                       y2={layout.height - 58}
-                      stroke={palette.rankLine}
+                      stroke="hsl(var(--muted-foreground) / 0.25)"
                       strokeWidth="1"
                       strokeDasharray="3 8"
                     />
                     <text
                       x={column.x}
                       y={28}
-                      fill={palette.phaseText}
+                      fill="hsl(var(--muted-foreground))"
                       fontSize="10"
                       fontWeight="700"
                     >
@@ -185,7 +238,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                   </g>
                 ))}
                 {layout.phaseBands.map((phase) => {
-                  const lane = getRecipeDagPhaseLaneColors(phase.id, lightMode);
+                  const lane = getRecipeDagPhaseLaneColors(phase.id, isLightMode);
                   return (
                     <g key={phase.id}>
                       <rect
@@ -195,7 +248,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                         height={phase.height}
                         rx={8}
                         fill={lane.fill}
-                        stroke={palette.phaseStroke}
+                        stroke="hsl(var(--border))"
                       />
                       <rect
                         x={32}
@@ -216,7 +269,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                     ? selected
                     : !selectedStageId || edge.fromStageId === selectedStageId || edge.toStageId === selectedStageId;
                   const edgeAccent = getStageAccent(edge.fromStageId);
-                  const stroke = focusActive && related ? edgeAccent : palette.edge;
+                  const stroke = focusActive && related ? edgeAccent : PIPELINE_EDGE_INK;
                   return (
                     <g key={edge.id}>
                       <path
@@ -252,8 +305,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                     related={related}
                     selected={selected}
                     focused={focusActive}
-                    accent={focusActive && (selected || related) ? edgeAccent : palette.edge}
-                    lightMode={lightMode}
+                    accent={focusActive && (selected || related) ? edgeAccent : PIPELINE_EDGE_INK}
                     onSelect={() => setSelectedLabelId(label.id)}
                   />
                 );
@@ -265,8 +317,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                   phaseId={phase.id}
                   x={52}
                   y={phase.y + 16}
-                  accent={getRecipeDagPhaseLaneColors(phase.id, lightMode).accent}
-                  lightMode={lightMode}
+                  accent={getRecipeDagPhaseLaneColors(phase.id, isLightMode).accent}
                 />
               ))}
 
@@ -277,12 +328,14 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                 const selected = !selectedLabel && selectedStageId === stage.stageId;
                 const edgeActive = Boolean(selectedLabel && neighborStageIds?.has(stage.stageId));
                 const dimmed = Boolean(neighborStageIds && !neighborStageIds.has(stage.stageId));
-                const stageClass = selected || edgeActive ? palette.stageSelected : dimmed ? palette.stageDimmed : palette.stage;
-                const headingClass = dimmed ? palette.headingDimmed : palette.heading;
-                const bodyClass = dimmed ? palette.bodyDimmed : palette.body;
-                const iconClass = dimmed ? palette.iconDimmed : palette.icon;
+                const stageClass = dimmed
+                  ? "border-border/60 bg-card/70 shadow-none"
+                  : "border-border bg-card";
+                const headingClass = dimmed ? "text-muted-foreground/70" : "text-foreground";
+                const bodyClass = dimmed ? "text-muted-foreground/50" : "text-muted-foreground";
+                const iconClass = dimmed ? "text-muted-foreground/50" : "text-muted-foreground";
                 const stageDomainId = chooseRecipeDagDomainId(stage.phases);
-                const stageAccent = getRecipeDagPhaseLaneColors(stageDomainId, lightMode).accent;
+                const stageAccent = getRecipeDagPhaseLaneColors(stageDomainId, isLightMode).accent;
                 const activeNodeAccent = selected || edgeActive ? stageAccent : null;
                 const zIndex = selected || edgeActive ? (expanded ? 95 : 85) : expanded ? 70 : dimmed ? 20 : 30;
                 const expandedPanelId = `recipe-dag-stage-${stage.stageId}-steps`;
@@ -316,15 +369,15 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                           style={activeNodeAccent ? { color: activeNodeAccent } : undefined}
                         />
                         <span className="min-w-0 flex-1">
-                          <span className={`block truncate text-[13px] font-semibold ${headingClass}`}>{stage.stageId}</span>
-                          <span className={`mt-0.5 block truncate text-[11px] ${bodyClass}`}>
+                          <span className={`block truncate text-data font-semibold ${headingClass}`}>{stage.stageId}</span>
+                          <span className={`mt-0.5 block truncate text-label ${bodyClass}`}>
                             Runs {stage.steps.length} {stage.steps.length === 1 ? "step" : "steps"}; creates {stage.artifactProvides.length}; needs {stage.artifactRequires.length}
                           </span>
                         </span>
                       </button>
                       <button
                         type="button"
-                        className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md border transition ${palette.expandButton}`}
+                        className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-border bg-card text-muted-foreground transition hover:bg-accent hover:text-foreground"
                         aria-expanded={expanded}
                         aria-controls={expandedPanelId}
                         aria-label={`${expanded ? "Collapse" : "Expand"} ${stage.stageId} steps`}
@@ -337,7 +390,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                       </button>
                     </div>
 
-                    <div className={`grid grid-cols-3 border-t text-center text-[10px] ${palette.rule}`}>
+                    <div className="grid grid-cols-3 border-t border-border text-center text-label text-muted-foreground">
                       <StageCounter label="In" value={stage.inboundArtifactEdgeCount} />
                       <StageCounter label="Out" value={stage.outboundArtifactEdgeCount} />
                       <StageCounter label="Internal" value={stage.internalArtifactEdgeCount} />
@@ -346,23 +399,23 @@ export function RecipeDagView(props: RecipeDagViewProps) {
                     <div
                       id={expandedPanelId}
                       aria-hidden={!expanded}
-                      className={`origin-top overflow-hidden border-t transition-[max-height,opacity,transform] duration-200 ${palette.rule} ${
+                      className={`origin-top overflow-hidden border-t border-border transition-[max-height,opacity,transform] duration-200 ${
                         expanded ? "max-h-[340px] opacity-100 translate-y-0" : "max-h-0 opacity-0 -translate-y-1"
                       }`}
                     >
-                      <div className="max-h-[320px] overflow-auto px-3 py-2">
+                      <div className="max-h-[320px] overflow-auto px-3 py-2 custom-scrollbar">
                         <ol className="space-y-2">
                           {stage.steps.map((step) => (
-                            <li key={step.fullStepId} className={`rounded border px-2 py-1.5 ${palette.step}`}>
-                              <div className={`truncate text-[11px] font-medium ${headingClass}`}>
+                            <li key={step.fullStepId} className="rounded border border-border bg-muted/40 px-2 py-1.5">
+                              <div className={`truncate text-label font-medium ${headingClass}`}>
                                 Step {step.orderInStage + 1}: {step.stepId}
                               </div>
-                              <div className={`mt-1 flex items-center gap-1 truncate text-[10px] ${bodyClass}`}>
+                              <div className={`mt-1 flex items-center gap-1 truncate text-label ${bodyClass}`}>
                                 <DomainInlineIcon domainId={step.phase} className="h-2.5 w-2.5" />
                                 <span className="truncate">Phase: {step.phase}</span>
                               </div>
-                              <ArtifactList label="Needs" values={step.artifactRequires.map((artifact) => artifact.id)} lightMode={lightMode} />
-                              <ArtifactList label="Creates" values={step.artifactProvides.map((artifact) => artifact.id)} lightMode={lightMode} />
+                              <ArtifactList label="Needs" values={step.artifactRequires.map((artifact) => artifact.id)} />
+                              <ArtifactList label="Creates" values={step.artifactProvides.map((artifact) => artifact.id)} />
                             </li>
                           ))}
                         </ol>
@@ -373,7 +426,7 @@ export function RecipeDagView(props: RecipeDagViewProps) {
               })}
 
               {dag.diagnostics.length ? (
-                <div className={`absolute left-[72px] right-[72px] bottom-6 rounded-lg border px-3 py-2 text-[11px] ${palette.diagnostic}`}>
+                <div className="absolute left-[72px] right-[72px] bottom-6 rounded-lg border border-warning/40 bg-warning/10 px-3 py-2 text-label text-foreground">
                   <div className="mb-1 flex items-center gap-1.5 font-semibold">
                     <AlertTriangle className="h-3.5 w-3.5" />
                     Artifact diagnostics
@@ -397,35 +450,13 @@ export function RecipeDagView(props: RecipeDagViewProps) {
   );
 }
 
-export function RecipeDagStatsBar(props: { dag: RecipeDagResult | null; recipeId: string; lightMode: boolean }) {
-  const palette = createPalette(props.lightMode);
+function PipelineMetric(props: { label: string; value: number; warn?: boolean }) {
   return (
-    <div className={`flex max-w-[min(760px,calc(100vw-260px))] items-center gap-2 rounded-lg border px-2 py-1 backdrop-blur-md ${palette.panel}`}>
-      <div className={`hidden min-w-0 items-center gap-1.5 px-2 text-[11px] font-semibold uppercase md:flex ${palette.kicker}`}>
-        <GitBranch className="h-3.5 w-3.5" />
-        <span className="truncate">{props.dag?.title ?? props.recipeId}</span>
-      </div>
-      <Metric label="Phases" value={props.dag?.phases.length ?? 0} lightMode={props.lightMode} />
-      <Metric label="Stages" value={props.dag?.stages.length ?? 0} lightMode={props.lightMode} />
-      <Metric label="Edges" value={props.dag?.edges.length ?? 0} lightMode={props.lightMode} />
-      <Metric label="Issues" value={props.dag?.diagnostics.length ?? 0} lightMode={props.lightMode} tone={props.dag?.diagnostics.length ? "warn" : "normal"} />
-    </div>
-  );
-}
-
-function Metric(props: { label: string; value: number; lightMode: boolean; tone?: "normal" | "warn" }) {
-  const tone = props.tone ?? "normal";
-  const className = props.lightMode
-    ? tone === "warn"
-      ? "border-amber-300 bg-amber-50 text-amber-900"
-      : "border-gray-200 bg-white text-gray-800"
-    : tone === "warn"
-      ? "border-amber-500/40 bg-amber-500/10 text-amber-200"
-      : "border-[#2a2a32] bg-[#111116] text-[#e8e8ed]";
-  return (
-    <div className={`min-w-[64px] rounded border px-2 py-1 text-right ${className}`}>
-      <div className="text-[13px] font-semibold leading-4">{props.value}</div>
-      <div className="text-[9px] uppercase">{props.label}</div>
+    <div className="flex items-baseline gap-1.5">
+      <span className={`text-data font-semibold ${props.warn ? "text-warning" : "text-foreground"}`}>
+        {props.value}
+      </span>
+      <span className="text-label uppercase tracking-wider text-muted-foreground/70">{props.label}</span>
     </div>
   );
 }
@@ -433,7 +464,7 @@ function Metric(props: { label: string; value: number; lightMode: boolean; tone?
 function StageCounter(props: { label: string; value: number }) {
   return (
     <div className="px-1.5 py-1">
-      <div className="text-[12px] font-semibold">{props.value}</div>
+      <div className="text-data font-semibold text-foreground">{props.value}</div>
       <div className="uppercase">{props.label}</div>
     </div>
   );
@@ -449,19 +480,17 @@ function ArtifactEdgeLabel(props: {
   selected: boolean;
   focused: boolean;
   accent: string;
-  lightMode: boolean;
   onSelect: () => void;
 }) {
-  const palette = createPalette(props.lightMode);
   const className = props.focused
     ? props.related
-      ? palette.edgeLabelPill
-      : palette.edgeLabelPillDimmed
-    : palette.edgeLabelPillNeutral;
+      ? "border-border bg-popover text-foreground"
+      : "border-border/60 bg-popover/70 text-muted-foreground/60"
+    : "border-border bg-popover text-muted-foreground";
   return (
     <button
       type="button"
-      className={`absolute flex max-w-[190px] cursor-pointer items-center gap-1 rounded-full border px-[6.5px] py-0.5 text-[9.5px] font-semibold shadow-sm transition-[left,top,border-color,box-shadow,color,background-color] duration-200 ${className}`}
+      className={`absolute flex max-w-[190px] cursor-pointer items-center gap-1 rounded-full border px-[6.5px] py-0.5 text-label font-semibold shadow-sm transition-[left,top,border-color,box-shadow,color,background-color] duration-200 ${className}`}
       style={{
         left: props.x,
         top: props.y,
@@ -483,19 +512,17 @@ function ArtifactEdgeLabel(props: {
   );
 }
 
-function ArtifactList(props: { label: string; values: readonly string[]; lightMode: boolean }) {
+function ArtifactList(props: { label: string; values: readonly string[] }) {
   if (props.values.length === 0) return null;
-  const chip = props.lightMode
-    ? "border-gray-200 bg-gray-50 text-gray-600"
-    : "border-[#30303a] bg-[#16161c] text-[#a9a9b5]";
+  const chip = "border-border bg-muted/40 text-muted-foreground";
   return (
     <div className="mt-1.5">
-      <div className="mb-1 text-[9px] font-semibold uppercase opacity-70">{props.label}</div>
+      <div className="mb-1 text-label font-semibold uppercase opacity-70">{props.label}</div>
       <div className="flex flex-wrap gap-1">
         {props.values.slice(0, 5).map((value) => (
           <span
             key={value}
-            className={`flex max-w-full items-center gap-1 truncate rounded border px-1 py-0.5 text-[9px] ${chip}`}
+            className={`flex max-w-full items-center gap-1 truncate rounded border px-1 py-0.5 text-label ${chip}`}
             title={value}
           >
             <DomainInlineIcon domainId={resolveArtifactGroupDomainId([value])} className="h-2.5 w-2.5" />
@@ -503,7 +530,7 @@ function ArtifactList(props: { label: string; values: readonly string[]; lightMo
           </span>
         ))}
         {props.values.length > 5 ? (
-          <span className={`rounded border px-1 py-0.5 text-[9px] ${chip}`}>+{props.values.length - 5}</span>
+          <span className={`rounded border px-1 py-0.5 text-label ${chip}`}>+{props.values.length - 5}</span>
         ) : null}
       </div>
     </div>
@@ -520,15 +547,11 @@ function PhaseLaneLabel(props: {
   x: number;
   y: number;
   accent: string;
-  lightMode: boolean;
 }) {
   const { Icon, label, strokeWidth } = getRecipeDagDomainPresentation(props.phaseId);
-  const className = props.lightMode
-    ? "border-white/80 bg-white/88 text-slate-700"
-    : "border-white/10 bg-[#0d0d11]/88 text-[#d4d4dc]";
   return (
     <div
-      className={`absolute z-10 flex items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] font-semibold uppercase tracking-normal shadow-sm backdrop-blur-sm ${className}`}
+      className="absolute z-10 flex items-center gap-1.5 rounded-full border border-border bg-popover/90 px-2 py-1 text-label font-semibold uppercase tracking-normal text-foreground shadow-sm backdrop-blur-sm"
       style={{ left: props.x, top: props.y }}
       title={`Phase ${label}`}
     >
@@ -539,80 +562,19 @@ function PhaseLaneLabel(props: {
 }
 
 function CenteredState(props: {
-  lightMode: boolean;
   icon: React.ReactNode;
   title: string;
   message: string;
 }) {
-  const className = props.lightMode
-    ? "border-gray-200 bg-white/95 text-gray-700"
-    : "border-[#2a2a32] bg-[#141418]/95 text-[#d4d4dc]";
   return (
     <div className="absolute inset-0 flex items-center justify-center px-4">
-      <div className={`max-w-[420px] rounded-lg border p-4 text-center shadow-sm ${className}`}>
-        <div className="mx-auto mb-2 flex h-9 w-9 items-center justify-center rounded-full border border-current/20">
+      <div className="flex max-w-[420px] flex-col items-center gap-3 rounded-xl border border-border/60 bg-popover/40 px-8 py-6 text-center backdrop-blur-sm">
+        <div className="flex h-9 w-9 items-center justify-center rounded-full border border-border text-muted-foreground">
           {props.icon}
         </div>
-        <div className="text-[14px] font-semibold">{props.title}</div>
-        <div className="mt-1 text-[12px] opacity-75">{props.message}</div>
+        <span className="text-data font-medium text-foreground">{props.title}</span>
+        <span className="text-label text-muted-foreground">{props.message}</span>
       </div>
     </div>
   );
-}
-
-function createPalette(lightMode: boolean) {
-  if (lightMode) {
-    return {
-      surface: "bg-[#f5f5f7]",
-      grid: "bg-[linear-gradient(rgba(0,0,0,0.045)_1px,transparent_1px),linear-gradient(90deg,rgba(0,0,0,0.045)_1px,transparent_1px)] bg-[length:48px_48px]",
-      panel: "border-white/80 bg-white/78",
-      stage: "border-gray-200 bg-white",
-      stageSelected: "border-gray-200 bg-white",
-      stageDimmed: "border-gray-200 bg-[#f8fafc] shadow-none",
-      step: "border-gray-200 bg-gray-50",
-      rule: "border-gray-200 text-gray-500",
-      diagnostic: "border-amber-300 bg-amber-50 text-amber-900",
-      heading: "text-gray-900",
-      headingDimmed: "text-gray-500",
-      body: "text-gray-600",
-      bodyDimmed: "text-gray-400",
-      kicker: "text-cyan-700",
-      icon: "text-cyan-700",
-      iconDimmed: "text-gray-400",
-      expandButton: "border-gray-200 bg-white text-gray-500 hover:border-cyan-300 hover:text-cyan-700",
-      edge: "#64748b",
-      edgeLabelPill: "border-cyan-200 bg-white text-cyan-800",
-      edgeLabelPillNeutral: "border-slate-200 bg-white text-slate-600",
-      edgeLabelPillDimmed: "border-slate-200 bg-slate-50 text-slate-500",
-      rankLine: "rgba(71,85,105,0.22)",
-      phaseStroke: "rgba(100,116,139,0.42)",
-      phaseText: "#334155",
-    } as const;
-  }
-  return {
-    surface: "bg-[#0a0a12]",
-    grid: "bg-[linear-gradient(rgba(255,255,255,0.035)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.035)_1px,transparent_1px)] bg-[length:48px_48px]",
-    panel: "border-white/10 bg-[#141418]/72",
-    stage: "border-[#2a2a32] bg-[#101014]",
-    stageSelected: "border-[#2a2a32] bg-[#101014]",
-    stageDimmed: "border-[#24242c] bg-[#0d0d11] shadow-none",
-    step: "border-[#30303a] bg-[#15151a]",
-    rule: "border-[#2a2a32] text-[#8a8a96]",
-    diagnostic: "border-amber-500/40 bg-amber-500/10 text-amber-200",
-    heading: "text-[#f0f0f4]",
-    headingDimmed: "text-[#747482]",
-    body: "text-[#a9a9b5]",
-    bodyDimmed: "text-[#696976]",
-    kicker: "text-cyan-300",
-    icon: "text-cyan-300",
-    iconDimmed: "text-[#5f6570]",
-    expandButton: "border-[#30303a] bg-[#15151a] text-[#8a8a96] hover:border-cyan-400/50 hover:text-cyan-200",
-    edge: "#5f6570",
-    edgeLabelPill: "border-cyan-400/35 bg-[#101014] text-cyan-200",
-    edgeLabelPillNeutral: "border-[#2a2a32] bg-[#101014] text-[#a7a7b2]",
-    edgeLabelPillDimmed: "border-[#24242c] bg-[#101014] text-[#6f7480]",
-    rankLine: "rgba(148,163,184,0.16)",
-    phaseStroke: "rgba(100,116,139,0.42)",
-    phaseText: "#d4d4dc",
-  } as const;
 }

--- a/apps/mapgen-studio/src/features/recipeDag/useRecipeDagQuery.ts
+++ b/apps/mapgen-studio/src/features/recipeDag/useRecipeDagQuery.ts
@@ -1,0 +1,50 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { createStudioRecipeDagClient, type RecipeDagResult } from "./client";
+
+/**
+ * `useRecipeDagQuery` — the pipeline view's READ surface on TanStack Query
+ * (mapgen-studio-dag-tab). It re-homes the pre-redesign App.tsx lazy-fetch
+ * behavior in the client-data layer: the DAG is fetched on first activation
+ * per recipe (`enabled` gates on the pipeline view being visible), cached by
+ * recipe id, and never considered stale — the projection only changes when
+ * authored code changes, which in dev means a page reload anyway. Stale
+ * responses and cancellation, hand-rolled in the monolith, fall out of the
+ * query cache keying.
+ *
+ * Transport is the PRESERVED oRPC client at `STUDIO_RECIPE_DAG_ORPC_PATH`
+ * (handoff §2.2: the client never imports recipe modules). One module-scoped
+ * client instance, matching the merged code.
+ */
+const recipeDagClient = createStudioRecipeDagClient();
+
+export type RecipeDagLoadStatus = "idle" | "loading" | "ready" | "error";
+
+export type RecipeDagQueryView = Readonly<{
+  dag: RecipeDagResult | null;
+  status: RecipeDagLoadStatus;
+  error: string | null;
+}>;
+
+export function useRecipeDagQuery(
+  recipeId: string,
+  options: Readonly<{ enabled: boolean }>,
+): RecipeDagQueryView {
+  const query = useQuery<RecipeDagResult, Error>({
+    queryKey: ["recipeDag", recipeId],
+    queryFn: () => recipeDagClient.recipeDag.get({ recipeId }),
+    enabled: options.enabled,
+    staleTime: Infinity,
+  });
+
+  if (query.data) return { dag: query.data, status: "ready", error: null };
+  if (query.isError) {
+    return {
+      dag: null,
+      status: "error",
+      error: query.error.message || "Failed to load the recipe pipeline.",
+    };
+  }
+  if (!options.enabled) return { dag: null, status: "idle", error: null };
+  return { dag: null, status: "loading", error: null };
+}

--- a/apps/mapgen-studio/src/stores/viewStore.ts
+++ b/apps/mapgen-studio/src/stores/viewStore.ts
@@ -23,6 +23,13 @@ function resolve<T>(updater: Updater<T>, prev: T): T {
 
 export type EraMode = "auto" | "fixed";
 
+/**
+ * Which view the center stage presents: the generated map, or the authored
+ * recipe's dependency pipeline (mapgen-studio-dag-tab). Stage furniture —
+ * not a Game-bar or World-console concern.
+ */
+export type StageView = "map" | "pipeline";
+
 export type ViewState = {
   // Canvas layer toggles
   showGrid: boolean;
@@ -43,6 +50,13 @@ export type ViewState = {
   // Explore selection (single owner; App no longer mirrors these)
   selectedStageId: string;
   selectedStepId: string;
+  // Stage view + pipeline (recipe DAG) view state. Pipeline selection and
+  // expansion are deliberately separate from the map-explore `selectedStageId`
+  // above — a pipeline stage node and an explore run-stage are different
+  // concepts that happen to share a word. "" = no pipeline stage selected.
+  stageView: StageView;
+  pipelineSelectedStageId: string;
+  pipelineExpandedStageIds: ReadonlySet<string>;
 
   setShowGrid: (next: Updater<boolean>) => void;
   setShowEdges: (next: Updater<boolean>) => void;
@@ -58,6 +72,9 @@ export type ViewState = {
   setExploreLayersExpanded: (next: Updater<boolean>) => void;
   setSelectedStageId: (next: Updater<string>) => void;
   setSelectedStepId: (next: Updater<string>) => void;
+  setStageView: (next: Updater<StageView>) => void;
+  setPipelineSelectedStageId: (next: Updater<string>) => void;
+  setPipelineExpandedStageIds: (next: Updater<ReadonlySet<string>>) => void;
 };
 
 export const useViewStore = create<ViewState>((set) => ({
@@ -75,6 +92,9 @@ export const useViewStore = create<ViewState>((set) => ({
   exploreLayersExpanded: true,
   selectedStageId: "",
   selectedStepId: "",
+  stageView: "map",
+  pipelineSelectedStageId: "",
+  pipelineExpandedStageIds: new Set<string>(),
 
   setShowGrid: (next) => set((s) => ({ showGrid: resolve(next, s.showGrid) })),
   setShowEdges: (next) => set((s) => ({ showEdges: resolve(next, s.showEdges) })),
@@ -97,4 +117,9 @@ export const useViewStore = create<ViewState>((set) => ({
     set((s) => ({ exploreLayersExpanded: resolve(next, s.exploreLayersExpanded) })),
   setSelectedStageId: (next) => set((s) => ({ selectedStageId: resolve(next, s.selectedStageId) })),
   setSelectedStepId: (next) => set((s) => ({ selectedStepId: resolve(next, s.selectedStepId) })),
+  setStageView: (next) => set((s) => ({ stageView: resolve(next, s.stageView) })),
+  setPipelineSelectedStageId: (next) =>
+    set((s) => ({ pipelineSelectedStageId: resolve(next, s.pipelineSelectedStageId) })),
+  setPipelineExpandedStageIds: (next) =>
+    set((s) => ({ pipelineExpandedStageIds: resolve(next, s.pipelineExpandedStageIds) })),
 }));

--- a/apps/mapgen-studio/src/ui/components/StageViewTabs.tsx
+++ b/apps/mapgen-studio/src/ui/components/StageViewTabs.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Map as MapIcon, Workflow } from 'lucide-react';
+import type { StageView } from '../../stores/viewStore';
+
+// ============================================================================
+// STAGE VIEW TABS — the stage's own view switcher (mapgen-studio-dag-tab)
+// ============================================================================
+// Which view the center stage presents is STAGE FURNITURE: it is not a game
+// setting (Game bar), not a map parameter (World console), not authoring
+// (Recipe dock), and not map inspection (Explore dock). So the switcher
+// floats at the stage's top edge, centered, in the same popover-tier pill
+// chrome as the consoles, using the segmented-control idiom (Pass-2
+// explore-toolbar): an inset group on the control background, the active
+// segment lifted one surface tier.
+// ============================================================================
+
+const VIEWS: ReadonlyArray<{
+  id: StageView;
+  label: string;
+  description: string;
+  Icon: typeof MapIcon;
+}> = [
+  { id: 'map', label: 'Map', description: 'Generated map view', Icon: MapIcon },
+  {
+    id: 'pipeline',
+    label: 'Pipeline',
+    description: 'Recipe dependency graph',
+    Icon: Workflow,
+  },
+];
+
+export interface StageViewTabsProps {
+  /** The active stage view. */
+  value: StageView;
+  /** Callback when the user switches views. */
+  onValueChange: (view: StageView) => void;
+  /** Top offset (px) so the pill clears the floating header. */
+  top: number;
+}
+
+export const StageViewTabs: React.FC<StageViewTabsProps> = ({ value, onValueChange, top }) => {
+  return (
+    <div
+      role="group"
+      aria-label="Stage view"
+      className="absolute left-1/2 z-20 -translate-x-1/2 inline-flex items-center rounded-lg border border-border bg-popover/95 p-1 backdrop-blur-sm"
+      style={{ top }}
+    >
+      {VIEWS.map(({ id, label, description, Icon }) => {
+        const active = value === id;
+        return (
+          <button
+            key={id}
+            type="button"
+            aria-pressed={active}
+            title={description}
+            onClick={() => onValueChange(id)}
+            className={`inline-flex h-7 items-center gap-1.5 rounded-md px-2.5 text-data font-medium transition-colors ${
+              active
+                ? 'bg-muted text-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            <Icon className="h-3.5 w-3.5 shrink-0" />
+            <span>{label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/mapgen-studio/test/recipeDag/PipelineStage.test.tsx
+++ b/apps/mapgen-studio/test/recipeDag/PipelineStage.test.tsx
@@ -1,23 +1,30 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
-import { RecipeDagView } from "../../src/features/recipeDag/RecipeDagView";
+import { PipelineStage, PIPELINE_EDGE_INK } from "../../src/features/recipeDag/PipelineStage";
 import type { RecipeDagResult } from "../../src/features/recipeDag/client";
 
-describe("RecipeDagView", () => {
+// Behavioral pins PORTED from the merged feature's RecipeDagView.test.tsx
+// (handoff §1/§4: the chrome was re-expressed in the redesign's language, so
+// the semantic assertions move here — selection vs expansion, label
+// selectability, focus accents, z-order — while palette literals become the
+// token-driven equivalents).
+
+describe("PipelineStage", () => {
   it("renders phase bands, stage nodes, artifact edge labels, and expanded sequential steps", () => {
     const html = renderToStaticMarkup(
-      <RecipeDagView
+      <PipelineStage
         recipeId="mod-swooper-maps/standard"
         dag={recipeDag()}
         status="ready"
         error={null}
-        lightMode={false}
+        isLightMode={false}
         expandedStageIds={new Set(["shape"])}
         selectedStageId="shape"
         onToggleStage={vi.fn()}
         onSelectStage={vi.fn()}
         topInset={96}
+        bottomInset={88}
       />
     );
 
@@ -35,32 +42,65 @@ describe("RecipeDagView", () => {
     expect(html).toContain("stroke=\"#f59e0b\"");
     expect(html).toContain("aria-label=\"Select dependency hydrography\"");
     expect(html).toContain("data-edge-label-selected=\"false\"");
-    expect(html).toContain("text-[9.5px]");
     expect(html).toContain("Step 1: seed");
     expect(html).toContain("Creates");
-    expect(html).not.toContain("opacity-45");
   });
 
   it("keeps connector paths and labels neutral before selection", () => {
     const html = renderToStaticMarkup(
-      <RecipeDagView
+      <PipelineStage
         recipeId="mod-swooper-maps/standard"
         dag={recipeDag()}
         status="ready"
         error={null}
-        lightMode={false}
+        isLightMode={false}
         expandedStageIds={new Set()}
         selectedStageId={null}
         onToggleStage={vi.fn()}
         onSelectStage={vi.fn()}
         topInset={96}
+        bottomInset={88}
       />
     );
 
-    expect(html).toContain("stroke=\"#5f6570\"");
-    expect(html).toContain("border-[#2a2a32] bg-[#101014] text-[#a7a7b2]");
+    // Idle graph: connectors carry the neutral token ink, labels ride the
+    // neutral popover pill, no domain accent leaks into inline styles.
+    expect(html).toContain(`stroke="${PIPELINE_EDGE_INK}"`);
+    expect(html).toContain("border-border bg-popover text-muted-foreground");
     expect(html).toContain(" L ");
+    expect(html).toContain("marker-end=\"url(#recipe-dag-arrow)\"");
     expect(html).not.toContain("border-color:#f59e0b");
+  });
+
+  it("surfaces projection diagnostics in the warning panel", () => {
+    const dag = recipeDag();
+    const withDiagnostics: RecipeDagResult = {
+      ...dag,
+      diagnostics: [
+        {
+          kind: "artifact-consumer-missing",
+          artifact: { id: "artifact:hydrology.hydrography", name: "Hydrology hydrography" },
+        } as RecipeDagResult["diagnostics"][number],
+      ],
+    };
+    const html = renderToStaticMarkup(
+      <PipelineStage
+        recipeId="mod-swooper-maps/standard"
+        dag={withDiagnostics}
+        status="ready"
+        error={null}
+        isLightMode={false}
+        expandedStageIds={new Set()}
+        selectedStageId={null}
+        onToggleStage={vi.fn()}
+        onSelectStage={vi.fn()}
+        topInset={96}
+        bottomInset={88}
+      />
+    );
+
+    expect(html).toContain("Artifact diagnostics");
+    expect(html).toContain("artifact-consumer-missing");
   });
 });
 

--- a/apps/mapgen-studio/test/recipeDag/domainPresentation.test.ts
+++ b/apps/mapgen-studio/test/recipeDag/domainPresentation.test.ts
@@ -86,13 +86,13 @@ describe("recipe DAG domain presentation", () => {
   });
 
   it("keeps domain lucide imports centralized outside the view", () => {
-    const source = readFileSync(new URL("../../src/features/recipeDag/RecipeDagView.tsx", import.meta.url), "utf8");
+    const source = readFileSync(new URL("../../src/features/recipeDag/PipelineStage.tsx", import.meta.url), "utf8");
     const lucideImport = source.match(/import\s*{([\s\S]*?)}\s*from "lucide-react";/)?.[1] ?? "";
     const importedNames = lucideImport
       .split(",")
       .map((name) => name.trim())
       .filter(Boolean);
 
-    expect(importedNames).toEqual(["AlertTriangle", "ChevronDown", "GitBranch", "Loader2"]);
+    expect(importedNames).toEqual(["AlertTriangle", "ChevronDown", "Loader2", "Workflow"]);
   });
 });

--- a/docs/projects/mapgen-studio-redesign/00-GOAL.md
+++ b/docs/projects/mapgen-studio-redesign/00-GOAL.md
@@ -391,3 +391,32 @@ Two user-flagged follow-up slices landed the same night:
   worker's `StudioResourcesMode` write, the wire deliberately reserved for
   the placement stack's resources vertical; verified no reader exists on
   any branch before touching the UI)
+
+## DAG handoff (2026-06-12) — restack + pipeline tab — COMPLETE
+
+The recipe-DAG feature merged to main (PRs #1587–#1591) with a handoff spec
+addressed to this lane
+(`docs/projects/graphite-stack-integration/DAG-STUDIO-REDESIGN-HANDOFF.md`):
+
+- [x] **Restack onto post-DAG main** (main @ 6adfc9ec3, 19 commits
+  absorbed). §4 resolutions: App.tsx/AppHeader/ViewControls/layout.ts —
+  this lane's versions win (old DAG chrome not ported); vite.config.ts —
+  recipe-dag oRPC middleware preserved; package.json/bun.lock — dep union
+  (+ `design/post-dag-restack-lockfile` reconcile). All §1 "preserve"
+  items intact: `features/recipeDag/*` headless modules,
+  `server/recipeDag/*`, `shared/recipeDagOrpc.ts`, mapgen-core
+  `recipe-dag.ts`. Gates at tip post-restack: tsc, 192 studio tests
+  (incl. 5 recipeDag suites), 103 mapgen-core, build + worker bundle.
+- [x] **`mapgen-studio-dag-tab`** — `design/dag-tab-frame` (OpenSpec
+  workstream: proposal/design/tasks/spec/workstream record) +
+  `design/dag-tab-stage` (implementation): the DAG re-expressed as the
+  **Pipeline stage view** — floating Map|Pipeline segmented switcher
+  (stage-furniture rule, codified in system.md), `PipelineStage`
+  token-driven chrome preserving all handoff §2.6 interaction semantics,
+  pipeline console strip, TanStack Query data layer
+  (`useRecipeDagQuery`), viewStore pipeline fields, Explore dock scoped to
+  map view, map canvas mounted-but-invisible under the pipeline (camera +
+  in-flight runs survive). `RecipeDagView.tsx` deleted; its behavioral
+  pins ported to `PipelineStage.test.tsx`. Verified live dark + light:
+  17-stage standard-recipe graph, selection/expansion/label focus,
+  generation run completed WHILE the pipeline view was active.

--- a/openspec/changes/mapgen-studio-dag-tab/tasks.md
+++ b/openspec/changes/mapgen-studio-dag-tab/tasks.md
@@ -5,29 +5,29 @@
 
 ## 2. Implementation (`design/dag-tab-stage`)
 
-- [ ] 2.1 `viewStore`: `stageView` ("map" | "pipeline"),
+- [x] 2.1 `viewStore`: `stageView` ("map" | "pipeline"),
       `pipelineSelectedStageId`, `pipelineExpandedStageIds` (+ setters).
-- [ ] 2.2 `useRecipeDagQuery` on TanStack Query (fetch on activation,
+- [x] 2.2 `useRecipeDagQuery` on TanStack Query (fetch on activation,
       cache per recipe, typed error; transport via preserved client).
-- [ ] 2.3 `StageViewTabs` segmented switcher (Map | Pipeline), popover-tier
+- [x] 2.3 `StageViewTabs` segmented switcher (Map | Pipeline), popover-tier
       pill, top-center of the stage area.
-- [ ] 2.4 `PipelineStage`: token-driven re-expression of the DAG chrome
+- [x] 2.4 `PipelineStage`: token-driven re-expression of the DAG chrome
       preserving all §2.6 interaction semantics; floating pipeline console
       strip (identity + counts); diagnostics panel.
-- [ ] 2.5 `StudioShell` wiring: switcher mount; map stage hidden-not-
+- [x] 2.5 `StudioShell` wiring: switcher mount; map stage hidden-not-
       unmounted in pipeline view; Explore dock scoped to map view.
-- [ ] 2.6 Delete `RecipeDagView.tsx` + its test; port semantic pins to
+- [x] 2.6 Delete `RecipeDagView.tsx` + its test; port semantic pins to
       `test/recipeDag/PipelineStage.test.tsx` (same fixture).
-- [ ] 2.7 `system.md` amendment: stage-view furniture rule + pipeline-stage
+- [x] 2.7 `system.md` amendment: stage-view furniture rule + pipeline-stage
       decisions; goal-ledger entry.
 
 ## 3. Verification
 
-- [ ] 3.1 `bun run openspec -- validate mapgen-studio-dag-tab --strict`
-- [ ] 3.2 tsc clean; studio vitest green (recipeDag suites incl. ported
+- [x] 3.1 `bun run openspec -- validate mapgen-studio-dag-tab --strict`
+- [x] 3.2 tsc clean; studio vitest green (recipeDag suites incl. ported
       pins); mapgen-core tests green; build + worker-bundle green.
-- [ ] 3.3 Visual on :5173 (dark + light): switcher; pipeline loads for the
+- [x] 3.3 Visual on :5173 (dark + light): switcher; pipeline loads for the
       standard recipe; selection/expansion/label-focus interactions; map
       view returns with camera intact; run loop works while pipeline view
       is active.
-- [ ] 3.4 Workstream/phase record closed with evidence.
+- [x] 3.4 Workstream/phase record closed with evidence.

--- a/openspec/changes/mapgen-studio-dag-tab/workstream/workstream-record.md
+++ b/openspec/changes/mapgen-studio-dag-tab/workstream/workstream-record.md
@@ -48,4 +48,14 @@
 - Started: 2026-06-12 (post-restack onto main @ 6adfc9ec3; restack absorbed
   the merged feature with the §4 resolutions — chrome trio taken from this
   lane, vite middleware + headless/server modules preserved, dep union)
-- Current: Phase 1 — frame committed; Phase 2 implementation next.
+- Current: Phase 2 complete (`design/dag-tab-stage`). Gates: strict
+  validation; tsc clean; 193 studio tests (recipeDag suites incl. the
+  ported `PipelineStage` pins); mapgen-core 103; build + worker bundle.
+  Visual evidence (dark + light, :5173): Map|Pipeline switcher; 17-stage
+  standard-recipe pipeline with console strip (6 phases / 17 stages /
+  157 edges / 21 issues, warn tone); stage selection + dimming + active
+  edges; expansion shelf (10 foundation steps); click-again unselect;
+  label selection focusing to its branches; Explore dock absent in
+  pipeline view and restored on return; a full generation run completed
+  WHILE the pipeline view was active (no reload, footer → Ready); map
+  view returned with the run's layers live.


### PR DESCRIPTION
Promotes the recipe DAG from a secondary panel widget into a first-class **Pipeline stage view**, switchable from the existing map view via a floating Map | Pipeline segmented control centered at the top of the stage area.

**What changed:**

- `RecipeDagView.tsx` is replaced by `PipelineStage`, a token-driven re-expression of the same DAG chrome. All hardcoded light/dark hex palette forks (`createPalette`) are removed; colors now resolve through CSS custom property tokens (`bg-background`, `border-border`, `text-muted-foreground`, etc.). The only surviving `isLightMode` fork is the domain presentation module, whose lane fills and accents are intentional data color with explicit light/dark variants.
- A `PIPELINE_EDGE_INK` constant (`hsl(var(--muted-foreground) / 0.55)`) replaces the two previously hardcoded neutral edge hex values and is exported for test assertions.
- The pipeline console strip (recipe title, phase/stage/edge/issue counts) floats at the top-right of the stage, replacing the old `RecipeDagStatsBar` component that lived in the header.
- `useRecipeDagQuery` wraps TanStack Query with `staleTime: Infinity`, keyed on `["recipeDag", recipeId]`, and gated on the pipeline view being active — the DAG is fetched on first activation and cached per recipe for the session.
- `viewStore` gains `stageView`, `pipelineSelectedStageId`, and `pipelineExpandedStageIds` (plus setters), kept deliberately separate from the existing map-explore `selectedStageId`.
- `StageViewTabs` renders the Map | Pipeline switcher as a popover-tier pill floating at the stage's top center, positioned below the header via a `top` inset prop.
- In `StudioShell`, the map `CanvasStage` stays mounted but is hidden (`invisible`) while the pipeline view is active, preserving deck camera state and any in-flight generation runs. The Explore dock is unmounted in pipeline view and restored on return. The pipeline expansion set is pruned whenever the loaded DAG changes to prevent phantom expanded IDs carrying across recipe switches.
- `PipelineStage.test.tsx` ports the behavioral pins from the deleted `RecipeDagView.test.tsx` — selection vs. expansion semantics, neutral connector ink, label selectability, focus accents — and adds a new assertion covering the diagnostics warning panel.