### PR TITLE
fix(mapgen): projection step phases carry their subject domain, not 'gameplay'

### DIFF
--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/contract.ts
@@ -9,7 +9,7 @@ import { ecologyArtifacts } from "../../../ecology/artifacts.js";
 
 const FeaturesApplyStepContract = defineStep({
   id: "features-apply",
-  phase: "gameplay",
+  phase: "ecology",
   requires: [],
   provides: [
     FIELD_DEPENDENCY_TAGS.field.featureType,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-effects/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-effects/contract.ts
@@ -11,7 +11,7 @@ import { STANDARD_ENGINE_EFFECT_TAGS } from "../../../../tags.js";
  */
 const PlotEffectsStepContract = defineStep({
   id: "plot-effects",
-  phase: "gameplay",
+  phase: "ecology",
   requires: [],
   provides: [STANDARD_ENGINE_EFFECT_TAGS.engine.plotEffectsApplied],
   artifacts: {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plotBiomes.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plotBiomes.contract.ts
@@ -11,7 +11,7 @@ import { morphologyArtifacts } from "../../morphology/artifacts.js";
 
 const PlotBiomesStepContract = defineStep({
   id: "plot-biomes",
-  phase: "gameplay",
+  phase: "ecology",
   requires: [],
   provides: [
     FIELD_DEPENDENCY_TAGS.field.biomeId,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-elevation/steps/buildElevation.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-elevation/steps/buildElevation.contract.ts
@@ -7,7 +7,7 @@ import { mapElevationArtifacts } from "../artifacts.js";
 
 const BuildElevationStepContract = defineStep({
   id: "build-elevation",
-  phase: "gameplay",
+  phase: "morphology",
   requires: [
     MAP_PROJECTION_EFFECT_TAGS.map.mountainsPlotted,
     MAP_PROJECTION_EFFECT_TAGS.map.volcanoesPlotted,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.contract.ts
@@ -27,7 +27,7 @@ const LakesStepConfigSchema = Type.Object(
 
 const LakesStepContract = defineStep({
   id: "lakes",
-  phase: "gameplay",
+  phase: "hydrology",
   requires: [],
   provides: [
     MAP_PROJECTION_EFFECT_TAGS.map.lakesPlotted,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.contract.ts
@@ -6,7 +6,7 @@ import { mapMorphologyArtifacts } from "../artifacts.js";
 
 const PlotCoastsStepContract = defineStep({
   id: "plot-coasts",
-  phase: "gameplay",
+  phase: "morphology",
   requires: [],
   provides: [MAP_PROJECTION_EFFECT_TAGS.map.coastsPlotted],
   artifacts: {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotContinents.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotContinents.contract.ts
@@ -6,7 +6,7 @@ import { morphologyArtifacts } from "../../morphology/artifacts.js";
 
 const PlotContinentsStepContract = defineStep({
   id: "plot-continents",
-  phase: "gameplay",
+  phase: "morphology",
   requires: [MAP_PROJECTION_EFFECT_TAGS.map.coastsPlotted],
   provides: [MAP_PROJECTION_EFFECT_TAGS.map.continentsPlotted],
   artifacts: {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotMountains.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotMountains.contract.ts
@@ -5,7 +5,7 @@ import { morphologyArtifacts } from "../../morphology/artifacts.js";
 
 const PlotMountainsStepContract = defineStep({
   id: "plot-mountains",
-  phase: "gameplay",
+  phase: "morphology",
   requires: [MAP_PROJECTION_EFFECT_TAGS.map.continentsPlotted],
   provides: [MAP_PROJECTION_EFFECT_TAGS.map.mountainsPlotted],
   artifacts: {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotVolcanoes.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotVolcanoes.contract.ts
@@ -5,7 +5,7 @@ import { morphologyArtifacts } from "../../morphology/artifacts.js";
 
 const PlotVolcanoesStepContract = defineStep({
   id: "plot-volcanoes",
-  phase: "gameplay",
+  phase: "morphology",
   requires: [MAP_PROJECTION_EFFECT_TAGS.map.continentsPlotted],
   provides: [MAP_PROJECTION_EFFECT_TAGS.map.volcanoesPlotted],
   artifacts: {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.contract.ts
@@ -13,7 +13,7 @@ const PlotRiversStepConfigSchema = Type.Object({}, {
 
 const PlotRiversStepContract = defineStep({
   id: "plot-rivers",
-  phase: "gameplay",
+  phase: "hydrology",
   requires: [MAP_PROJECTION_EFFECT_TAGS.map.elevationBuilt],
   provides: [
     MAP_PROJECTION_EFFECT_TAGS.map.riversPlotted,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plot-landmass-regions/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plot-landmass-regions/contract.ts
@@ -6,7 +6,7 @@ import { morphologyArtifacts } from "../../../morphology/artifacts.js";
 
 const PlotLandmassRegionsStepContract = defineStep({
   id: "plot-landmass-regions",
-  phase: "gameplay",
+  phase: "placement",
   requires: [],
   provides: [MAP_PROJECTION_EFFECT_TAGS.map.landmassRegionsPlotted],
   artifacts: {

--- a/mods/mod-swooper-maps/src/recipes/standard/tags.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/tags.ts
@@ -17,6 +17,7 @@ export const FIELD_DEPENDENCY_TAGS = {
 
 export const STANDARD_ENGINE_EFFECT_TAGS = {
   engine: {
+    riversModeled: "effect:engine.riversModeled",
     biomesApplied: ENGINE_EFFECT_TAGS.biomesApplied,
     featuresApplied: ENGINE_EFFECT_TAGS.featuresApplied,
     plotEffectsApplied: "effect:engine.plotEffectsApplied",
@@ -73,67 +74,67 @@ const VERIFIED_EFFECT_TAGS = new Set<string>([
 const EFFECT_OWNERS: Record<string, TagOwner> = {
   [MAP_PROJECTION_EFFECT_TAGS.map.coastsPlotted]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "morphology",
     stepId: "plot-coasts",
   },
   [MAP_PROJECTION_EFFECT_TAGS.map.continentsPlotted]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "morphology",
     stepId: "plot-continents",
   },
   [MAP_PROJECTION_EFFECT_TAGS.map.mountainsPlotted]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "morphology",
     stepId: "plot-mountains",
   },
   [MAP_PROJECTION_EFFECT_TAGS.map.volcanoesPlotted]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "morphology",
     stepId: "plot-volcanoes",
   },
   [MAP_PROJECTION_EFFECT_TAGS.map.elevationBuilt]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "morphology",
     stepId: "build-elevation",
   },
   [MAP_PROJECTION_EFFECT_TAGS.map.landmassRegionsPlotted]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "placement",
     stepId: "plot-landmass-regions",
   },
   [MAP_PROJECTION_EFFECT_TAGS.map.lakesPlotted]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "hydrology",
     stepId: "lakes",
   },
   [MAP_PROJECTION_EFFECT_TAGS.map.elevationParityCaptured]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "morphology",
     stepId: "build-elevation",
   },
   [MAP_PROJECTION_EFFECT_TAGS.map.hydrologyLakesParityCaptured]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "hydrology",
     stepId: "lakes",
   },
   [MAP_PROJECTION_EFFECT_TAGS.map.riversParityCaptured]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "hydrology",
     stepId: "plot-rivers",
   },
   [MAP_PROJECTION_EFFECT_TAGS.map.riversPlotted]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "hydrology",
     stepId: "plot-rivers",
   },
   [MAP_PROJECTION_EFFECT_TAGS.map.ecologyBiomesParityCaptured]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "ecology",
     stepId: "plot-biomes",
   },
   [MAP_PROJECTION_EFFECT_TAGS.map.ecologyFeaturesParityCaptured]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "ecology",
     stepId: "features-apply",
   },
   [MAP_PROJECTION_EFFECT_TAGS.map.placementParityCaptured]: {
@@ -181,19 +182,24 @@ const EFFECT_OWNERS: Record<string, TagOwner> = {
     phase: "placement",
     stepId: "assign-advanced-starts",
   },
+  [STANDARD_ENGINE_EFFECT_TAGS.engine.riversModeled]: {
+    pkg: "mod-swooper-maps",
+    phase: "hydrology",
+    stepId: "plot-rivers",
+  },
   [STANDARD_ENGINE_EFFECT_TAGS.engine.biomesApplied]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "ecology",
     stepId: "plot-biomes",
   },
   [STANDARD_ENGINE_EFFECT_TAGS.engine.featuresApplied]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "ecology",
     stepId: "features-apply",
   },
   [STANDARD_ENGINE_EFFECT_TAGS.engine.plotEffectsApplied]: {
     pkg: "mod-swooper-maps",
-    phase: "gameplay",
+    phase: "ecology",
     stepId: "plot-effects",
   },
   [STANDARD_ENGINE_EFFECT_TAGS.engine.placementApplied]: {

--- a/mods/mod-swooper-maps/test/config/standard-authoring-surface-guards.test.ts
+++ b/mods/mod-swooper-maps/test/config/standard-authoring-surface-guards.test.ts
@@ -225,6 +225,10 @@ describe("standard authoring surface guardrails", () => {
       .sort();
     const generatedIds = readdirSync(generatedDir)
       .filter((entry) => entry.endsWith(".ts"))
+      // Transient studio deploys are excluded on BOTH sides: the studio writes
+      // `studio-current.config.json` + its generated entrypoint during runs,
+      // and the guard must not depend on whether a run happened recently.
+      .filter((entry) => !TRANSIENT_STUDIO_CONFIGS.has(entry.replace(/\.ts$/, ".config.json")))
       .map((entry) => entry.replace(/\.ts$/, ""))
       .sort();
 


### PR DESCRIPTION
The map-* projection stages (map-morphology, map-elevation, map-hydrology,
map-rivers, map-ecology) and placement's plot-landmass-regions declared
phase 'gameplay' on every step contract, so the pipeline view grouped them
into a gameplay lane instead of their actual domains. Phase is descriptive
metadata (trace, viz manifest, DAG lanes — execution order is
recipe-owned), so the relabel is observable only in those surfaces:
map-morphology/map-elevation → morphology, map-hydrology/map-rivers →
hydrology, map-ecology → ecology, plot-landmass-regions → placement. Tag
OWNER records in tags.ts follow their owning steps (owner.phase is
descriptive; no engine consumer reads it).

Also fixes a pre-existing guard asymmetry: the generated-entrypoints test
excluded transient studio configs on the configs side but not the
generated side, so an untracked studio-current.ts from any recent studio
run failed the suite.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>