### PR TITLE
refactor(mapgen-studio): control-oRPC mount on the fetch adapter behind a Connect shim

### DIFF
--- a/apps/mapgen-studio/src/server/civ7ControlOrpc.ts
+++ b/apps/mapgen-studio/src/server/civ7ControlOrpc.ts
@@ -8,9 +8,21 @@ import {
   type Civ7ControlOrpcDirectControlFacade,
 } from "@civ7/control-orpc/runtime";
 import { DEFAULT_CIV7_TUNER_TIMEOUT_MS } from "@civ7/direct-control";
-import { RPCHandler } from "@orpc/server/node";
+import { RPCHandler } from "@orpc/server/fetch";
 
 import { STUDIO_CIV7_CONTROL_ORPC_PATH } from "../shared/civ7ControlOrpc";
+import { nodeRequestToWebRequest, writeWebResponse } from "./http/nodeWebBridge";
+
+// ============================================================================
+// Civ7 control-oRPC edge — fetch adapter behind a Connect shim
+// (bun-server workstream; mirrors ./recipeDag/orpc.ts and @civ7/studio-server)
+// ============================================================================
+// The canonical artifact is the FETCH handler (`Request`/`Response`): it works
+// under the Vite dev middleware via the shared node⇄web bridge and drops
+// verbatim onto the Bun daemon — the same A4-lite seam the studio-server
+// `/rpc` mount rides. The URL is a pinned contract:
+// `STUDIO_CIV7_CONTROL_ORPC_PATH` — the client is untouched by the re-shape.
+// ============================================================================
 
 export type StudioCiv7ControlOrpcNext = (err?: unknown) => void;
 
@@ -29,6 +41,33 @@ export function createStudioCiv7ControlOrpcContext(
   };
 }
 
+export interface StudioCiv7ControlRpcHandle {
+  handle(request: Request): Promise<{ matched: boolean; response?: Response }>;
+}
+
+/** The transport-portable handler (Bun-ready; the Vite mount is a thin shim). */
+export function createStudioCiv7ControlRpcHandler(
+  options: Readonly<{
+    directControl?: Civ7ControlOrpcDirectControlFacade;
+    timeoutMs?: number;
+  }> = {},
+): StudioCiv7ControlRpcHandle {
+  const handler = new RPCHandler(Civ7ControlOrpcRouter);
+  const context = createStudioCiv7ControlOrpcContext(options);
+  return {
+    handle: (request) =>
+      handler.handle(request, {
+        prefix: STUDIO_CIV7_CONTROL_ORPC_PATH,
+        context,
+      }),
+  };
+}
+
+/**
+ * Connect-style adapter over the fetch handler, for the Vite dev middleware
+ * stack and the `node:http` transport tests. The cheap path pre-check keeps
+ * the body-buffering bridge off every other request when mounted unscoped.
+ */
 export function createStudioCiv7ControlOrpcMiddleware(
   options: Readonly<{
     directControl?: Civ7ControlOrpcDirectControlFacade;
@@ -39,15 +78,22 @@ export function createStudioCiv7ControlOrpcMiddleware(
   res: ServerResponse,
   next: StudioCiv7ControlOrpcNext,
 ) => Promise<void> {
-  const rpcHandler = new RPCHandler(Civ7ControlOrpcRouter);
+  const rpcHandler = createStudioCiv7ControlRpcHandler(options);
 
   return async (req, res, next) => {
     try {
-      const result = await rpcHandler.handle(req, res, {
-        prefix: STUDIO_CIV7_CONTROL_ORPC_PATH,
-        context: createStudioCiv7ControlOrpcContext(options),
-      });
-      if (!result.matched) next();
+      const path = (req as { originalUrl?: string }).originalUrl ?? req.url ?? "/";
+      if (!path.startsWith(STUDIO_CIV7_CONTROL_ORPC_PATH)) {
+        next();
+        return;
+      }
+      const request = await nodeRequestToWebRequest(req);
+      const { matched, response } = await rpcHandler.handle(request);
+      if (!matched || !response) {
+        next();
+        return;
+      }
+      await writeWebResponse(res, response);
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
Mirrors recipeDag/orpc.ts: canonical createStudioCiv7ControlRpcHandler
(@orpc/server/fetch, Bun-ready) + thin node shim over the shared
nodeWebBridge with a path pre-check. Path contract /api/civ7/rpc and the
node transport pins unchanged; verified live (readiness.current 200 on a
fresh process).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>