### PR TITLE
docs(mapgen-studio): tuner-session workstream frame — Effect-scoped shared tuner session (strict valid)

### DIFF
--- a/openspec/changes/mapgen-studio-tuner-session/design.md
+++ b/openspec/changes/mapgen-studio-tuner-session/design.md
@@ -1,0 +1,160 @@
+# Design — Effect-scoped shared tuner session
+
+## The resource model (proportionality decision)
+
+Research verdict (effect@3.21.3 source + effect-orpc source + repo prior
+art): the canonical Effect shape for "one shared long-lived connection,
+released on shutdown" is a `Context.Tag` service built with
+`Layer.scoped`/`Effect.Service({ scoped: ... })` whose constructor uses
+`Effect.acquireRelease`; `ManagedRuntime.make(layer)` extends the layer
+into a closeable scope and `dispose()` runs the finalizers
+(`internal/managedRuntime.ts`: `disposeEffect = Scope.close(scope)`).
+effect-orpc executes every `.effect` handler via
+`runtime.runPromiseExit(effect, { signal })` — services come from the
+runtime layer; there is no per-request scope, so the service encapsulates
+any scoping internally.
+
+`RcRef`/`Pool` were evaluated and rejected: `RcRef.invalidate` exists
+(3.19.6, `@experimental`) for replace-on-failure resources, and a size-1
+`Pool` would serialize use — but `Civ7DirectControlSession` multiplexes
+concurrent requests over one socket (listenerId routing) and `connect()`
+is reuse-idempotent (a dead socket reconnects on the next `request()`).
+The instance never needs replacement, so the proportional model is **one
+instance, `acquireRelease`, self-healing inside**. No semaphore: only
+acquisition would need serializing, and the session class already guards
+that. (Effect core has no circuit breaker — issue #2843 — so the gate is
+a `Ref` cooldown, the documented minimal idiom.)
+
+## Ownership topology (one owner, three consumers)
+
+```
+ManagedRuntime (makeStudioRuntime, daemon-lifetime, dispose() on SIGINT/SIGTERM)
+  └─ Civ7TunerSession (Layer.scoped: acquireRelease ONE Civ7DirectControlSession)
+       ├─ Civ7TunerClient (Effect dep): every /rpc read → use(run, {session})
+       ├─ control-oRPC facade: daemon injects `session` into endpointDefaults
+       │    (Civ7ControlOrpcContext.endpointDefaults is ALREADY typed as
+       │     Civ7DirectControlOptions — the new options field flows through
+       │     the entire router with zero control-orpc changes)
+       └─ healthz: tuner.health() → { consecutiveResponseTimeouts, gate }
+Run-in-game engines: untouched (per-flow sessions, serialized queue) — they
+gain graceful close from the package fix but do NOT share the socket.
+```
+
+Layer memoization guarantees one instance: `Civ7TunerClient.Default`
+declares `dependencies: [Civ7TunerSession.Default]`, and the runtime layer
+also merges `Civ7TunerSession.Default` to expose it — the same layer
+reference is memoized within one `ManagedRuntime`, so the client and the
+host port see the same session.
+
+## The seam in `@civ7/direct-control` (no Effect dependency)
+
+```ts
+// session/types.ts
+interface Civ7DirectControlOptions {
+  // ...existing host/port/timeoutMs/state
+  /** Caller-owned session: reused, NOT closed by the callee. */
+  session?: Civ7DirectControlSession;
+}
+
+// session/session.ts
+export async function withCiv7DirectControlSession(options, run) {
+  if (options.session) return await run(options.session); // caller owns lifecycle
+  const session = new Civ7DirectControlSession(options);
+  try { return await run(session); } finally { await session.close(); }
+}
+```
+
+All ~60 procedures funnel through this wrapper (via `execute.ts`), so the
+single field converges every read path. Long-flow procedures
+(`startPreparedCiv7SinglePlayerGame`, `restartCiv7Game`,
+`runCiv7SinglePlayerFromSetup`) hold their own sessions via a separate
+`withSession` dependency pattern and are deliberately not converged.
+
+**Graceful close** (leak mitigation at the root, benefits all paths):
+`close()` rejects pending, then `socket.end()` (FIN) and awaits the
+`close` event with a 1s timeout falling back to `destroy()`; idempotent;
+release-path errors are swallowed (finalizers must not fail).
+
+**Session stats** (the only point that observes ALL shared-socket
+traffic, control reads included): `consecutiveResponseTimeouts`
+incremented on each `response-timeout` rejection, reset to zero on every
+successfully resolved frame; exposed read-only as `session.stats`.
+
+## `Civ7TunerSession` service (studio-server)
+
+```ts
+class Civ7TunerSession extends Effect.Service<Civ7TunerSession>()(
+  "@civ7/studio-server/Civ7TunerSession",
+  {
+    scoped: Effect.gen(function* () {
+      const session = yield* Effect.acquireRelease(
+        Effect.sync(() => new Civ7DirectControlSession()),   // lazy: connects on first request
+        (s) => Effect.promise(() => s.close()),              // graceful FIN on dispose()
+      );
+      const gate = yield* Ref.make({ openUntil: 0 });
+      const use = <A>(run: (o: { session: Civ7DirectControlSession }) => Promise<A>) =>
+        gateCheck.pipe(Effect.zipRight(Effect.tryPromise({
+          try: () => run({ session }),
+          catch: classify,                                    // typed error union
+        })));
+      return { use, session, health };
+    }),
+  },
+) {}
+```
+
+- **Gate policy**: opens when `session.stats.consecutiveResponseTimeouts
+  >= 4` (set `openUntil = now + 15s`); while open, `use` fails fast with
+  `Civ7TunerBackoffError` (Data.TaggedError carrying
+  `consecutiveResponseTimeouts`, `retryAt`) without touching the socket;
+  after expiry the next request flows (natural half-open: a timeout
+  re-opens, a success resets the counter). Trigger is `response-timeout`
+  ONLY — `connection-failed`/refused (game not running) is fast, leak-free
+  and must keep flowing for readiness UX.
+- **Error channel**: one strategy at the boundary — `use` surfaces
+  `Civ7TunerBackoffError | UnknownException`; the existing router error
+  mapping is unchanged in shape (live.status keeps 200 + per-field
+  embedded `{error}`; non-uniform status codes preserved — only failure
+  message TEXT differs when the gate fails fast, which was never pinned).
+- `Civ7TunerClient` accessors change mechanically:
+  `Effect.tryPromise(() => fn(args, { timeoutMs }))` →
+  `tuner.use((o) => fn(args, { timeoutMs, ...o }))`.
+- `StudioRpcHandle` gains `tuner: { session(): Promise<Civ7DirectControlSession>;
+  health(): Promise<Civ7TunerSessionHealth> }` and `dispose(): Promise<void>`
+  (delegating to `runtime.dispose()`). **Today nothing disposes the
+  runtime** — finalizers never ran; the daemon now does on
+  SIGINT/SIGTERM.
+
+## Daemon wiring
+
+- `createStudioCiv7ControlOrpcContext/RpcHandler/Middleware` options gain
+  `session?: Civ7DirectControlSession` → merged into `endpointDefaults`.
+- `daemon.ts`: builds the handler, resolves `await studioRpc.tuner.session()`
+  once at startup, passes it to the control handler; `/healthz` gains a
+  `tuner` block (`consecutiveResponseTimeouts`, `gateOpenUntil`,
+  `wedgeSuspected: consecutive >= 4`); SIGINT/SIGTERM → `dispose()` →
+  `server.stop()`.
+
+## Migration order (strangler fig)
+
+1. Package seam + graceful close + stats (independently valuable; no
+   consumer change).
+2. Effect service + Civ7TunerClient convergence (the /rpc poll surface).
+3. Daemon wiring (control facade shares the socket; health; dispose).
+4. Run-in-game convergence: explicitly deferred — out of scope.
+
+## Verification
+
+- direct-control tests (package has a fake-tuner-server fixture):
+  injected session reused and NOT closed by the wrapper; graceful close
+  delivers FIN (server observes `end`, not abrupt RST); stats counter
+  increments on response-timeout and resets on success.
+- studio-server: gate behavior unit-tested against a stub session
+  (fail-fast while open, half-open after cooldown); dispose runs the
+  release (session.close called once).
+- daemon route tests unchanged; live: `bun run dev` → app polls readiness
+  and live status → **exactly ONE established connection on :4318 from
+  the daemon, reused across polls** (`lsof -nP -iTCP:4318 | grep
+  ESTABLISHED`), CLOSED-fd count stays flat during a soak; healthz tuner
+  block present; Ctrl-C/daemon stop sends FIN (game-side fd count does
+  not grow).

--- a/openspec/changes/mapgen-studio-tuner-session/proposal.md
+++ b/openspec/changes/mapgen-studio-tuner-session/proposal.md
@@ -1,0 +1,103 @@
+# Shared Civ7 tuner session — Effect-scoped acquisition/release in the daemon
+
+## Why
+
+The Civ7 FireTuner endpoint (port 4318) wedges after long Studio sessions:
+the game process accumulates leaked TCP descriptors (observed: 187
+CLOSED-state fds held by CivilizationVII), after which ALL tuner reads time
+out until the game is restarted. The client side drives this: every
+direct-control procedure opens a fresh TCP connection and `destroy()`s it
+(`withCiv7DirectControlSession` connect-per-request), and the Studio polls
+several read endpoints every few seconds through the daemon — thousands of
+connect/RST cycles per session, with the leak concentrating when polls
+time out against a busy game (in-game mapgen, loading screens). Clean
+reads leak zero fds (verified under node and Bun: sequential, concurrent,
+forced-timeout matrices), so the fix is to stop the churn, not to chase a
+runtime bug.
+
+The session protocol already supports the fix: `Civ7DirectControlSession`
+multiplexes concurrent requests over one socket via listenerIds and
+self-heals (`connect()` is reuse-idempotent). What is missing is an owner:
+a scoped, shared session whose lifetime is managed — acquired lazily,
+released gracefully — and a polite failure mode when the game stops
+answering. The daemon (P5 cutover) is the natural owner, and the
+studio-server's Effect `ManagedRuntime` is the natural lifecycle host
+(user direction: solve this with Effect — scoped release/acquisition as a
+layer).
+
+## Target Authority Refs
+
+- `openspec/changes/mapgen-studio-bun-server/workstream/workstream-record.md`
+  (Phase 4 addendum — incident evidence + isolation matrix)
+- `packages/studio-server/src/{runtime,services/Civ7TunerClient}.ts`
+  (Effect service idiom; `ManagedRuntime` host seam)
+- effect@3.21.3 source (verified): `ManagedRuntime.make` builds the layer
+  into a closeable scope; `dispose()` runs `Layer.scoped` finalizers;
+  `Effect.Service` supports `scoped:` constructors and `dependencies`,
+  with layer memoization deduplicating a shared service
+- `packages/civ7-direct-control/src/session/*` (session class: listenerId
+  multiplexing, idempotent `connect()`, `withCiv7DirectControlSession`
+  funnel — the single low-churn seam all ~60 procedures pass through)
+- TypeScript skill (`/typescript`): ports/adapters seam, strangler-fig
+  migration (polling reads first, run-in-game untouched), functional
+  gate state, proportional complexity (no pool/RcRef — the session
+  instance self-heals and never needs replacement)
+
+## What Changes
+
+- **`@civ7/direct-control` — injection seam + graceful close + stats**
+  (no Effect dependency added):
+  - `Civ7DirectControlOptions.session?: Civ7DirectControlSession` —
+    `withCiv7DirectControlSession` uses a caller-owned session without
+    closing it; absent, behavior is unchanged. One field converges all
+    ~60 procedures (they all funnel through `execute.ts`).
+  - `Civ7DirectControlSession.close()` becomes graceful: reject pending,
+    then `socket.end()` (FIN) and wait for `close` with a short timeout
+    falling back to `destroy()`. Benefits every path, including
+    run-in-game per-flow sessions, without semantic change.
+  - Session-level health counters (`session.stats`): consecutive
+    response-timeouts (reset on any successful frame) — the one place
+    that observes ALL traffic on the shared socket.
+- **`@civ7/studio-server` — `Civ7TunerSession` Effect service** (new):
+  `scoped:` constructor acquiring ONE `Civ7DirectControlSession` via
+  `Effect.acquireRelease` (lazy connect on first request; release =
+  graceful close on `runtime.dispose()`), exposing `use(run)` (gated
+  execution with typed fail-fast `Civ7TunerBackoffError` while the
+  cooldown gate is open), `session` (for host injection into the
+  control-oRPC context), and `health()`. Gate policy: opens after N
+  consecutive response-timeouts (read from `session.stats`, so control
+  traffic counts too), fixed cooldown, naturally half-open after expiry.
+  `Civ7TunerClient` gains `dependencies: [Civ7TunerSession.Default]` and
+  routes every accessor through `use` with the shared session injected.
+  `StudioRpcHandle` gains `tuner.{session,health}` promise ports and
+  `dispose()` (today nothing closes the runtime scope — finalizers never
+  ran).
+- **Daemon wiring** (`apps/mapgen-studio`): the control-oRPC context
+  builders accept `session?` and merge it into `endpointDefaults`
+  (`Civ7DirectControlOptions` already typed there — zero control-orpc
+  package changes); the daemon injects the shared session from the
+  studio runtime, reports tuner health (consecutive timeouts, gate
+  state, wedge suspicion) on `/healthz`, and disposes the runtime on
+  SIGINT/SIGTERM so the socket gets a clean FIN.
+- **Run-in-game flows: UNTOUCHED** (strangler order; behavior-parity hard
+  core). Engines keep their per-flow sessions — bounded, serialized by
+  the operation queue, and now graceful-closing via the package fix.
+
+## Non-Goals
+
+- No connection pooling / RcRef / request serialization — the session
+  multiplexes and self-heals; one instance for the runtime's life.
+- No change to run-in-game semantics (queue, proofs, reconnect flows).
+- No "restart Civ7" UI affordance this change (healthz + typed errors
+  expose the wedge signal; UI surfacing is a follow-up).
+- No control-orpc package changes beyond what the existing
+  `endpointDefaults` type already permits.
+
+## Impact
+
+- Affected specs: `mapgen-studio`
+- Affected code: `packages/civ7-direct-control/src/session/{types,session}.ts`
+  (+ tests), `packages/studio-server/src/{services/Civ7TunerSession.ts
+  (new), services/Civ7TunerClient.ts, runtime.ts, handler.ts, index.ts}`
+  (+ tests), `apps/mapgen-studio/src/server/civ7ControlOrpc.ts`,
+  `apps/mapgen-studio/src/server/daemon/daemon.ts` (+ tests)

--- a/openspec/changes/mapgen-studio-tuner-session/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-tuner-session/specs/mapgen-studio/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Studio Polling Reads Share One Managed Tuner Session
+
+The Studio daemon SHALL serve all polling tuner reads (the studio-server
+`/rpc` read surface and the control-oRPC mount) over a single shared
+`Civ7DirectControlSession` owned by an Effect scoped service in the
+studio runtime — acquired lazily, multiplexed across concurrent requests,
+self-healing on reconnect, and released with a graceful FIN when the
+daemon disposes its runtime on shutdown. Run-in-game flows keep their
+per-flow sessions (serialized by the operation queue) and are unchanged.
+
+#### Scenario: One connection across polls
+
+- **WHEN** the Studio polls readiness and live status repeatedly through
+  the daemon
+- **THEN** at most one established client connection to the tuner port
+  exists for those reads, reused across polls, and the game-side
+  descriptor count does not grow with poll count
+
+#### Scenario: Graceful release on shutdown
+
+- **WHEN** the daemon receives SIGINT or SIGTERM
+- **THEN** the runtime scope closes, the shared session ends with a FIN
+  handshake (destroy only as a timeout fallback), and the process exits
+
+#### Scenario: Self-healing after a dropped socket
+
+- **WHEN** the tuner socket drops (game restart) and a later read arrives
+- **THEN** the shared session reconnects on that request without daemon
+  restart and the read succeeds once the tuner answers
+
+### Requirement: Tuner Reads Back Off When The Game Stops Answering
+
+The shared session service SHALL track consecutive response-timeouts
+observed on the shared socket and, past a threshold, fail polling reads
+fast with a typed backoff error for a fixed cooldown instead of issuing
+new tuner requests — recovering automatically (half-open) after the
+cooldown, with the counter reset by any successful response. Connection
+failures (game not running) are not gated. Response shapes and status
+codes of the read surface are unchanged; only failure message text may
+differ while the gate is open.
+
+#### Scenario: Gate opens under sustained timeouts
+
+- **WHEN** consecutive tuner reads exceed the response-timeout threshold
+- **THEN** subsequent reads fail fast with the typed backoff error during
+  the cooldown and no new requests are written to the tuner socket
+
+#### Scenario: Gate recovers
+
+- **WHEN** the cooldown elapses and the next read receives a successful
+  response
+- **THEN** the counter resets and reads flow normally again
+
+### Requirement: The Daemon Reports Tuner Session Health
+
+The daemon's health endpoint SHALL report the shared tuner session state —
+consecutive response-timeouts, gate status, and a wedge-suspicion flag —
+so a wedged game (process alive, tuner silent) is observable without log
+archaeology.
+
+#### Scenario: Wedge suspicion is visible
+
+- **WHEN** the tuner stops answering while the game process is running
+  and the timeout threshold is crossed
+- **THEN** the health endpoint reports the elevated consecutive-timeout
+  count and wedge suspicion

--- a/openspec/changes/mapgen-studio-tuner-session/tasks.md
+++ b/openspec/changes/mapgen-studio-tuner-session/tasks.md
@@ -1,0 +1,56 @@
+## 1. Frame
+
+- [ ] 1.1 Workstream record + proposal/design/tasks/spec deltas committed
+      (`design/tuner-session-frame`), `--strict` valid.
+
+## 2. direct-control seam (`design/tuner-session-seam`)
+
+- [ ] 2.1 `Civ7DirectControlOptions.session?` — caller-owned session;
+      `withCiv7DirectControlSession` reuses without closing; absent →
+      unchanged behavior.
+- [ ] 2.2 Graceful `close()`: reject pending → `end()` (FIN) → await
+      `close` with 1s fallback `destroy()`; idempotent.
+- [ ] 2.3 `session.stats`: consecutive response-timeouts (increment on
+      response-timeout, reset on any resolved frame).
+- [ ] 2.4 Package tests (fake tuner server): injected session reused +
+      not closed; FIN observed on graceful close; stats counter behavior.
+- [ ] 2.5 Gates: direct-control tests, tsc, dependents build.
+
+## 3. Effect service (`design/tuner-effect-session`)
+
+- [ ] 3.1 `Civ7TunerSession` (studio-server): `scoped:` acquireRelease of
+      one session; `use(run)` with cooldown gate (threshold 4, 15s,
+      response-timeout only) + typed `Civ7TunerBackoffError`; `session` +
+      `health()` ports.
+- [ ] 3.2 `Civ7TunerClient`: `dependencies: [Civ7TunerSession.Default]`;
+      accessors route through `use` with the shared session injected.
+- [ ] 3.3 `runtime.ts` merges the session layer (memoized single
+      instance); `handler.ts` exposes `tuner.{session,health}` +
+      `dispose()`.
+- [ ] 3.4 Tests: gate fail-fast/half-open/reset against a stub session;
+      dispose closes the session exactly once.
+- [ ] 3.5 Gates: studio-server build + tests, studio app tsc/tests.
+
+## 4. Daemon wiring (`design/tuner-daemon-wiring`)
+
+- [ ] 4.1 Control mount options gain `session?` → merged into
+      `endpointDefaults` (no control-orpc package changes).
+- [ ] 4.2 `daemon.ts`: inject the shared session into the control
+      handler; `/healthz` tuner block (consecutive timeouts, gate,
+      `wedgeSuspected`); SIGINT/SIGTERM → `dispose()` → stop.
+- [ ] 4.3 Tests: daemon health/dispatch updates; existing pins green.
+- [ ] 4.4 Gates: tsc, studio tests, mod tests, build + worker bundle,
+      `--strict` valid.
+- [ ] 4.5 Live verification (fresh processes, Civ7 in shell): readiness +
+      live polls work; `lsof -nP -iTCP:4318` shows ONE established
+      connection reused across polls and a flat CLOSED count during a
+      soak; healthz tuner block live; daemon stop sends FIN.
+- [ ] 4.6 Workstream record closed with evidence; goal-ledger entry.
+
+## 5. Deferred (explicit)
+
+- [ ] 5.1 Run-in-game flow convergence onto the shared session — OUT OF
+      SCOPE (behavior parity); revisit only with a dedicated parity
+      harness.
+- [ ] 5.2 "Restart Civ7" recovery affordance in the Studio UI driven by
+      `wedgeSuspected` — follow-up surface work.

--- a/openspec/changes/mapgen-studio-tuner-session/workstream/workstream-record.md
+++ b/openspec/changes/mapgen-studio-tuner-session/workstream/workstream-record.md
@@ -1,0 +1,56 @@
+# Systematic Workstream Record
+
+## Frame
+
+- Objective: Stop the Civ7 tuner connection churn that wedges the game
+  (leaked game-side fds → all reads time out) by making the daemon's
+  polling read surface share ONE Effect-managed `Civ7DirectControlSession`
+  — scoped acquisition/release in the studio `ManagedRuntime`, graceful
+  FIN on shutdown, typed backoff when the game stops answering, wedge
+  signal on healthz. User direction: solve with Effect; follow the
+  /typescript skill's design disciplines.
+- Future state: a long Studio session keeps at most one established tuner
+  connection for polls; the daemon disposes its runtime on shutdown (FIN
+  to the game); when the game goes silent the Studio backs off with a
+  typed error instead of hammering; the wedge state is observable.
+- Non-goals: pooling/RcRef; run-in-game flow changes; "restart Civ7" UI;
+  control-orpc package changes.
+- Hard core: behavior parity for run-in-game (serialized queue, proof
+  markers, per-flow sessions untouched); read-surface response shapes +
+  non-uniform status codes unchanged (failure message text may differ
+  while the gate is open); `Civ7DirectControlOptions.session` absent →
+  byte-identical legacy behavior; no Effect dependency enters
+  `@civ7/direct-control`.
+- Exterior: `codex/*` branches; CLI consumers of direct-control (the new
+  options field is additive).
+
+## Authority
+
+- `openspec/changes/mapgen-studio-bun-server/workstream/workstream-record.md`
+  Phase 4 addendum (incident: 187 leaked fds; isolation matrix: clean
+  reads leak zero under node AND Bun)
+- effect@3.21.3 source (ManagedRuntime scope/dispose semantics;
+  Effect.Service `scoped:`/`dependencies`; layer memoization; no core
+  circuit breaker — Effect-TS/effect#2843)
+- effect-orpc@0.2.2 source (`runtime.runPromiseExit` per handler; no
+  per-request scope — app-scope services live in the runtime layer)
+- `packages/civ7-direct-control/src/session/*` (listenerId multiplexing,
+  idempotent connect, the `withCiv7DirectControlSession` funnel)
+- TypeScript skill references (ports/adapters, strangler fig, typed error
+  contracts, proportional complexity)
+
+## Plan
+
+- Phase 1 (`design/tuner-session-frame`): this record + docs, `--strict`.
+- Phase 2 (`design/tuner-session-seam`): direct-control injection seam +
+  graceful close + stats (+ package tests).
+- Phase 3 (`design/tuner-effect-session`): `Civ7TunerSession` scoped
+  service + gate; `Civ7TunerClient` convergence; handler `tuner` ports +
+  `dispose()`.
+- Phase 4 (`design/tuner-daemon-wiring`): control mount session
+  injection; healthz tuner block; signal-driven dispose; live soak
+  verification (one established connection; flat CLOSED count).
+
+## Evidence
+
+- (per phase, appended as slices close)


### PR DESCRIPTION
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>