### PR TITLE
feat(mapgen-studio): wire the shared tuner session through the daemon — one connection, health surface, scoped shutdown

### DIFF
--- a/apps/mapgen-studio/src/server/civ7ControlOrpc.ts
+++ b/apps/mapgen-studio/src/server/civ7ControlOrpc.ts
@@ -7,7 +7,10 @@ import {
   liveCiv7ControlOrpcDirectControlFacade,
   type Civ7ControlOrpcDirectControlFacade,
 } from "@civ7/control-orpc/runtime";
-import { DEFAULT_CIV7_TUNER_TIMEOUT_MS } from "@civ7/direct-control";
+import {
+  DEFAULT_CIV7_TUNER_TIMEOUT_MS,
+  type Civ7DirectControlSession,
+} from "@civ7/direct-control";
 import { RPCHandler } from "@orpc/server/fetch";
 
 import { STUDIO_CIV7_CONTROL_ORPC_PATH } from "../shared/civ7ControlOrpc";
@@ -30,6 +33,15 @@ export function createStudioCiv7ControlOrpcContext(
   options: Readonly<{
     directControl?: Civ7ControlOrpcDirectControlFacade;
     timeoutMs?: number;
+    /**
+     * The daemon's shared tuner session (owned by the studio runtime's
+     * `Civ7TunerSession`). `endpointDefaults` is `Civ7DirectControlOptions`,
+     * so the session flows through every router procedure → every
+     * direct-control call reuses the one multiplexed connection instead of
+     * opening its own. Lifecycle stays with the owner — the facade never
+     * closes it.
+     */
+    session?: Civ7DirectControlSession;
   }> = {},
 ): Civ7ControlOrpcContext {
   return {
@@ -37,6 +49,7 @@ export function createStudioCiv7ControlOrpcContext(
       ?? liveCiv7ControlOrpcDirectControlFacade,
     endpointDefaults: {
       timeoutMs: options.timeoutMs ?? DEFAULT_CIV7_TUNER_TIMEOUT_MS,
+      ...(options.session ? { session: options.session } : {}),
     },
   };
 }
@@ -50,6 +63,7 @@ export function createStudioCiv7ControlRpcHandler(
   options: Readonly<{
     directControl?: Civ7ControlOrpcDirectControlFacade;
     timeoutMs?: number;
+    session?: Civ7DirectControlSession;
   }> = {},
 ): StudioCiv7ControlRpcHandle {
   const handler = new RPCHandler(Civ7ControlOrpcRouter);
@@ -72,6 +86,7 @@ export function createStudioCiv7ControlOrpcMiddleware(
   options: Readonly<{
     directControl?: Civ7ControlOrpcDirectControlFacade;
     timeoutMs?: number;
+    session?: Civ7DirectControlSession;
   }> = {},
 ): (
   req: IncomingMessage,

--- a/apps/mapgen-studio/src/server/daemon/daemon.ts
+++ b/apps/mapgen-studio/src/server/daemon/daemon.ts
@@ -122,7 +122,9 @@ export interface StudioDaemonDeps {
   };
   controlRpc: { handle(request: Request): Promise<{ matched: boolean; response?: Response }> };
   recipeDagRpc: { handle(request: Request): Promise<{ matched: boolean; response?: Response }> };
-  health(): { ok: boolean } & Record<string, unknown>;
+  health():
+    | ({ ok: boolean } & Record<string, unknown>)
+    | Promise<{ ok: boolean } & Record<string, unknown>>;
   assetsRoot?: string;
 }
 
@@ -135,7 +137,7 @@ export function createStudioDaemonFetch(
     const pathname = url.pathname;
 
     if (pathname === "/healthz") {
-      const health = deps.health();
+      const health = await deps.health();
       return Response.json(health, { status: health.ok ? 200 : 503 });
     }
 
@@ -170,20 +172,29 @@ export function createStudioDaemonFetch(
   };
 }
 
-export function createStudioDaemon(args: StudioDaemonArgs) {
+export async function createStudioDaemon(args: StudioDaemonArgs) {
   const engines = createStudioEngines({ repoRoot: args.repoRoot });
   const context = createStudioServerContext({ engines, hostCommand: "daemon" });
+  const studioRpc = createStudioRpcHandler(context);
+  // The ONE shared tuner connection (Effect-scoped in the studio runtime;
+  // resolving it builds the runtime layer). The control mount reuses it via
+  // endpointDefaults — every polling read multiplexes over this socket
+  // instead of opening its own (the churn that wedged the game).
+  const tunerSession = await studioRpc.tuner.session();
   const deps: StudioDaemonDeps = {
-    studioRpc: createStudioRpcHandler(context),
-    controlRpc: createStudioCiv7ControlRpcHandler(),
+    studioRpc,
+    controlRpc: createStudioCiv7ControlRpcHandler({ session: tunerSession }),
     recipeDagRpc: createStudioRecipeDagRpcHandler(),
-    health: () => ({
+    health: async () => ({
       ok: true,
       serverInstanceId: engines.serverInstanceId,
       startedAt: engines.serverStartedAt,
       repoRoot: args.repoRoot,
       assetsRoot: args.assetsRoot ?? null,
       runtimeMode: "studio-daemon-effect-orpc",
+      // Wedge observability: consecutive response-timeouts on the shared
+      // socket + backoff gate state (tuner-session workstream).
+      tuner: await studioRpc.tuner.health(),
     }),
     ...(args.assetsRoot ? { assetsRoot: args.assetsRoot } : {}),
   };
@@ -191,6 +202,8 @@ export function createStudioDaemon(args: StudioDaemonArgs) {
 
   return {
     engines,
+    /** Closes the studio runtime scope — graceful FIN to the game. */
+    dispose: () => studioRpc.dispose(),
     start() {
       const server = Bun.serve({
         hostname: args.host,
@@ -212,8 +225,23 @@ function defaultRepoRoot(): string {
 
 if ((import.meta as { main?: boolean }).main) {
   const args = parseStudioDaemonArgs(process.argv.slice(2), { repoRoot: defaultRepoRoot() });
-  const daemon = createStudioDaemon(args);
+  const daemon = await createStudioDaemon(args);
   const server = daemon.start();
+  // Shutdown = dispose the runtime scope FIRST (graceful FIN on the shared
+  // tuner socket — the whole point of scoped release), then stop serving.
+  let shuttingDown = false;
+  const shutdown = async () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    try {
+      await daemon.dispose();
+    } finally {
+      server.stop(true);
+      process.exit(0);
+    }
+  };
+  process.once("SIGINT", () => void shutdown());
+  process.once("SIGTERM", () => void shutdown());
   process.stdout.write(
     `mapgen-studio daemon listening on http://${server.hostname}:${server.port} (repoRoot ${args.repoRoot})\n`,
   );

--- a/docs/projects/mapgen-studio-redesign/00-GOAL.md
+++ b/docs/projects/mapgen-studio-redesign/00-GOAL.md
@@ -433,3 +433,20 @@ addressed to this lane
   pins ported to `PipelineStage.test.tsx`. Verified live dark + light:
   17-stage standard-recipe graph, selection/expansion/label focus,
   generation run completed WHILE the pipeline view was active.
+
+## Tuner-session workstream (2026-06-12, post-P5)
+
+- [x] **Shared tuner session (Effect)** — OpenSpec `mapgen-studio-tuner-session`,
+  slices `design/tuner-session-frame` → `design/tuner-session-seam` →
+  `design/tuner-effect-session` → `design/tuner-daemon-wiring`. Root cause of
+  the tuner wedge (game-side fd leak from connect-per-request churn) closed:
+  `Civ7DirectControlOptions.session` seam + graceful FIN close + connect-race
+  dedup in `@civ7/direct-control`; `Civ7TunerSession` Effect service
+  (Layer.scoped acquireRelease, backoff gate on consecutive response-timeouts,
+  typed `Civ7TunerBackoffError`, health port) owns the ONE connection in the
+  studio runtime; daemon injects it into the control mount, reports tuner
+  health on `/healthz` (`wedgeSuspected`), and disposes the runtime on
+  shutdown. Live soak: exactly 1 established tuner connection across
+  sustained polling, zero leaked fds, game releases its descriptor on daemon
+  stop. Run-in-game flows untouched (parity). Deferred: run-flow convergence;
+  "restart Civ7" UI affordance.

--- a/openspec/changes/mapgen-studio-tuner-session/design.md
+++ b/openspec/changes/mapgen-studio-tuner-session/design.md
@@ -143,6 +143,26 @@ class Civ7TunerSession extends Effect.Service<Civ7TunerSession>()(
 3. Daemon wiring (control facade shares the socket; health; dispose).
 4. Run-in-game convergence: explicitly deferred — out of scope.
 
+## Implementation addenda (as built)
+
+- The service is a `Context.Tag` + `Layer.scoped` pair
+  (`makeCiv7TunerSessionLayer(options)`) rather than the `Effect.Service`
+  `scoped:` sketch above — the layer must be parameterizable (tests inject
+  a fake tuner endpoint + short gate timings); `Civ7TunerSessionLive` is
+  the zero-config production reference that both `Civ7TunerClient`'s
+  dependencies and the runtime merge share (memoized single instance).
+- **Connect race found by the live soak (not the unit tests):** the
+  session's `connect()` was only reuse-idempotent for sequential callers.
+  A page-load burst (~13 concurrent reads through the shared session) made
+  every caller see "no socket", dial its own, and leak all but the last —
+  observed as 13 stable ESTABLISHED connections. Fixed at the root in
+  `@civ7/direct-control`: in-flight connect deduplication (`connecting`
+  promise memo), pinned by a concurrent-burst package test. Post-fix soak:
+  exactly ONE established connection across sustained polling.
+- The workspace `effect` versions were skewed (app + control-orpc pinned
+  3.21.2, studio-server 3.21.3 → mixed-runtime warning when the layers
+  crossed); deduped to 3.21.3 everywhere.
+
 ## Verification
 
 - direct-control tests (package has a fake-tuner-server fixture):

--- a/openspec/changes/mapgen-studio-tuner-session/tasks.md
+++ b/openspec/changes/mapgen-studio-tuner-session/tasks.md
@@ -1,51 +1,51 @@
 ## 1. Frame
 
-- [ ] 1.1 Workstream record + proposal/design/tasks/spec deltas committed
+- [x] 1.1 Workstream record + proposal/design/tasks/spec deltas committed
       (`design/tuner-session-frame`), `--strict` valid.
 
 ## 2. direct-control seam (`design/tuner-session-seam`)
 
-- [ ] 2.1 `Civ7DirectControlOptions.session?` — caller-owned session;
+- [x] 2.1 `Civ7DirectControlOptions.session?` — caller-owned session;
       `withCiv7DirectControlSession` reuses without closing; absent →
       unchanged behavior.
-- [ ] 2.2 Graceful `close()`: reject pending → `end()` (FIN) → await
+- [x] 2.2 Graceful `close()`: reject pending → `end()` (FIN) → await
       `close` with 1s fallback `destroy()`; idempotent.
-- [ ] 2.3 `session.stats`: consecutive response-timeouts (increment on
+- [x] 2.3 `session.stats`: consecutive response-timeouts (increment on
       response-timeout, reset on any resolved frame).
-- [ ] 2.4 Package tests (fake tuner server): injected session reused +
+- [x] 2.4 Package tests (fake tuner server): injected session reused +
       not closed; FIN observed on graceful close; stats counter behavior.
-- [ ] 2.5 Gates: direct-control tests, tsc, dependents build.
+- [x] 2.5 Gates: direct-control tests, tsc, dependents build.
 
 ## 3. Effect service (`design/tuner-effect-session`)
 
-- [ ] 3.1 `Civ7TunerSession` (studio-server): `scoped:` acquireRelease of
+- [x] 3.1 `Civ7TunerSession` (studio-server): `scoped:` acquireRelease of
       one session; `use(run)` with cooldown gate (threshold 4, 15s,
       response-timeout only) + typed `Civ7TunerBackoffError`; `session` +
       `health()` ports.
-- [ ] 3.2 `Civ7TunerClient`: `dependencies: [Civ7TunerSession.Default]`;
+- [x] 3.2 `Civ7TunerClient`: `dependencies: [Civ7TunerSession.Default]`;
       accessors route through `use` with the shared session injected.
-- [ ] 3.3 `runtime.ts` merges the session layer (memoized single
+- [x] 3.3 `runtime.ts` merges the session layer (memoized single
       instance); `handler.ts` exposes `tuner.{session,health}` +
       `dispose()`.
-- [ ] 3.4 Tests: gate fail-fast/half-open/reset against a stub session;
+- [x] 3.4 Tests: gate fail-fast/half-open/reset against a stub session;
       dispose closes the session exactly once.
-- [ ] 3.5 Gates: studio-server build + tests, studio app tsc/tests.
+- [x] 3.5 Gates: studio-server build + tests, studio app tsc/tests.
 
 ## 4. Daemon wiring (`design/tuner-daemon-wiring`)
 
-- [ ] 4.1 Control mount options gain `session?` → merged into
+- [x] 4.1 Control mount options gain `session?` → merged into
       `endpointDefaults` (no control-orpc package changes).
-- [ ] 4.2 `daemon.ts`: inject the shared session into the control
+- [x] 4.2 `daemon.ts`: inject the shared session into the control
       handler; `/healthz` tuner block (consecutive timeouts, gate,
       `wedgeSuspected`); SIGINT/SIGTERM → `dispose()` → stop.
-- [ ] 4.3 Tests: daemon health/dispatch updates; existing pins green.
-- [ ] 4.4 Gates: tsc, studio tests, mod tests, build + worker bundle,
+- [x] 4.3 Tests: daemon health/dispatch updates; existing pins green.
+- [x] 4.4 Gates: tsc, studio tests, mod tests, build + worker bundle,
       `--strict` valid.
-- [ ] 4.5 Live verification (fresh processes, Civ7 in shell): readiness +
+- [x] 4.5 Live verification (fresh processes, Civ7 in shell): readiness +
       live polls work; `lsof -nP -iTCP:4318` shows ONE established
       connection reused across polls and a flat CLOSED count during a
       soak; healthz tuner block live; daemon stop sends FIN.
-- [ ] 4.6 Workstream record closed with evidence; goal-ledger entry.
+- [x] 4.6 Workstream record closed with evidence; goal-ledger entry.
 
 ## 5. Deferred (explicit)
 

--- a/openspec/changes/mapgen-studio-tuner-session/workstream/workstream-record.md
+++ b/openspec/changes/mapgen-studio-tuner-session/workstream/workstream-record.md
@@ -53,4 +53,31 @@
 
 ## Evidence
 
-- (per phase, appended as slices close)
+- Phase 1 (`design/tuner-session-frame`, de06d0e4a): docs committed;
+  `--strict` valid. Research wave first: effect 3.21.3 + effect-orpc +
+  oRPC source verification (ManagedRuntime dispose runs Layer.scoped
+  finalizers; effect-orpc has no per-request scope; no core circuit
+  breaker), full consumer map of every session creation point, /typescript
+  pattern sweep (ports/adapters, strangler fig, proportionality → no
+  RcRef/pool: the session self-heals).
+- Phase 2 (`design/tuner-session-seam`, abec11ab7): options.session seam +
+  graceful FIN close + stats; 389/389 package tests (incl. 5 new pins);
+  package tsc + build.
+- Phase 3 (`design/tuner-effect-session`, 644d1e9db): `Civ7TunerSession`
+  (Context.Tag + Layer.scoped, parameterized), gate, client convergence,
+  handler `tuner.*` + `dispose()`; effect deduped to 3.21.3; studio 204
+  tests incl. 3 new pins (one shared connection + FIN on dispose; gate
+  fail-fast → half-open → reset; wedge-suspicion health).
+- Phase 4 (`design/tuner-daemon-wiring`): control mount session injection;
+  healthz tuner block; SIGINT/SIGTERM dispose. **Live soak found a real
+  bug the units missed**: 13 stable ESTABLISHED tuner connections — the
+  page-load burst raced `connect()` (only sequentially idempotent); fixed
+  with in-flight connect dedup in the session class + concurrent-burst
+  pin (390 package tests). Post-fix live evidence (fresh processes, Civ7
+  in shell): healthz `tuner: { consecutiveResponseTimeouts: 0,
+  gateOpenUntil: null, wedgeSuspected: false }`; readiness 200 with the
+  `shell` chip live in the Game bar; **exactly 1 established connection on
+  :4318 across 30s+ of app polling, zero CLOSED-state fds**; after daemon
+  stop the game holds ONLY its listener (descriptor fully released —
+  the wedge signature's exact inverse). Gates: tsc, studio 204, mod 471,
+  build + worker bundle, `--strict` valid.

--- a/packages/civ7-direct-control/src/session/session.ts
+++ b/packages/civ7-direct-control/src/session/session.ts
@@ -41,6 +41,7 @@ export class Civ7DirectControlSession {
   private buffer = Buffer.alloc(0);
   private readonly pending = new Map<number, PendingCiv7TunerRequest>();
   private consecutiveResponseTimeouts = 0;
+  private connecting: Promise<Civ7DirectControlEndpoint> | undefined;
 
   constructor(options: Civ7DirectControlOptions = {}) {
     this.config = resolveCiv7DirectControlConfig(options);
@@ -60,11 +61,27 @@ export class Civ7DirectControlSession {
     return { consecutiveResponseTimeouts: this.consecutiveResponseTimeouts };
   }
 
+  /**
+   * Concurrency-safe: parallel callers (a shared session's first burst of
+   * polls) await ONE in-flight attempt instead of each opening a socket —
+   * without this, every concurrent `connect()` saw "no socket", dialed its
+   * own, the last assignment won, and the rest leaked open.
+   */
   async connect(): Promise<Civ7DirectControlEndpoint> {
     if (this.socket && !this.socket.destroyed && this.endpointValue) {
       return this.endpointValue;
     }
+    if (this.connecting) return await this.connecting;
+    const attempt = this.establishConnection();
+    this.connecting = attempt;
+    try {
+      return await attempt;
+    } finally {
+      if (this.connecting === attempt) this.connecting = undefined;
+    }
+  }
 
+  private async establishConnection(): Promise<Civ7DirectControlEndpoint> {
     await this.close();
     const errors: Array<{ host: string; error: string }> = [];
     for (const host of this.config.hosts) {

--- a/packages/civ7-direct-control/test/shared-session.test.ts
+++ b/packages/civ7-direct-control/test/shared-session.test.ts
@@ -50,6 +50,30 @@ describe("caller-owned shared tuner session", () => {
     }
   });
 
+  test("a concurrent first burst shares ONE connection (connect dedup)", async () => {
+    const server = await startSharedSessionServer();
+    const session = new Civ7DirectControlSession({ host: "127.0.0.1", port: server.port });
+    try {
+      const results = await Promise.all(
+        Array.from({ length: 8 }, (_, i) =>
+          executeCiv7Command({
+            port: server.port,
+            session,
+            command: `burst-${i}`,
+            timeoutMs: 1_000,
+          }),
+        ),
+      );
+      expect(results).toHaveLength(8);
+      // Without in-flight connect dedup, every concurrent caller dialed its
+      // own socket and all but the last leaked open (observed live: a page
+      // load burst held 13 established tuner connections).
+      expect(server.connections()).toBe(1);
+    } finally {
+      await session.close();
+    }
+  });
+
   test("without an injected session, each call opens and closes its own connection", async () => {
     const server = await startSharedSessionServer();
     await executeCiv7Command({


### PR DESCRIPTION
The daemon resolves the studio runtime's Civ7TunerSession once and injects
it into the control-oRPC mount via endpointDefaults (the field is typed
Civ7DirectControlOptions — zero control-orpc package changes), so every
polling read multiplexes over the ONE managed connection. /healthz gains
the tuner block (consecutiveResponseTimeouts, gateOpenUntil,
wedgeSuspected); SIGINT/SIGTERM dispose the runtime scope first (graceful
FIN) then stop serving.

The live soak caught a race the units missed: connect() was only
sequentially idempotent — a page-load burst of ~13 concurrent reads each
dialed its own socket and leaked all but the last (13 stable ESTABLISHED
connections observed). Fixed at the root in @civ7/direct-control with
in-flight connect dedup + a concurrent-burst pin (390 package tests).

Live evidence post-fix (Civ7 in shell): exactly 1 established tuner
connection across 30s+ of app polling, zero CLOSED fds, readiness 'shell'
chip live, and on daemon stop the game releases its descriptor entirely
(only the LISTEN remains) — the wedge signature's exact inverse. Gates:
tsc, studio 204, mod 471, build + worker bundle, OpenSpec --strict.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>