### PR TITLE
fix(mapgen-studio): tile grid reads at every zoom — fill-derived border ink + grid-preferring layer default

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -2236,12 +2236,17 @@ export function StudioShell(props: StudioShellProps) {
 
   const backgroundGridEnabled = useMemo(() => {
     if (!showGrid) return false;
-    const layer = viz.effectiveLayer;
-    if (!layer) return false;
-    if (!(layer.kind === "points" || layer.kind === "segments")) return false;
-    if (layer.meta?.showGrid === false) return false;
+    // The graticule is CANVAS substrate, not layer furniture: once a manifest
+    // exists it follows the user's grid toggle on EVERY stage — including
+    // steps with no visible layers (the canvas stays a ready survey field,
+    // not dead space). A layer may still opt out via meta. The old
+    // points/segments-only gate made the grid vanish the moment a tile/mesh
+    // layer was selected — i.e. on most stage switches. Pre-manifest, the
+    // awaiting-matter overlay carries its own graticule.
+    if (!viz.manifest) return false;
+    if (viz.effectiveLayer?.meta?.showGrid === false) return false;
     return true;
-  }, [showGrid, viz.effectiveLayer]);
+  }, [showGrid, viz.effectiveLayer, viz.manifest]);
 
   const lastRunSettings = lastRunSnapshot?.recipeSettings ?? recipeSettings;
   const lastGlobalSettings = lastRunSnapshot?.worldSettings ?? worldSettings;

--- a/apps/mapgen-studio/src/features/viz/DeckCanvas.tsx
+++ b/apps/mapgen-studio/src/features/viz/DeckCanvas.tsx
@@ -79,7 +79,9 @@ export function DeckCanvas(props: DeckCanvasProps) {
   const gridEnabled = useMemo(() => {
     if (!showBackgroundGrid) return false;
     if (!effectiveLayer) return false;
-    if (!(effectiveLayer.kind === 'points' || effectiveLayer.kind === 'segments')) return false;
+    // Canvas substrate, not layer furniture: the grid follows the caller's
+    // toggle for every rendered layer (kind-independent; layers may opt out
+    // via meta). Mirrors `backgroundGridEnabled` in StudioShell.
     if (effectiveLayer.meta?.showGrid === false) return false;
     return true;
   }, [effectiveLayer, showBackgroundGrid]);

--- a/apps/mapgen-studio/src/features/viz/deckgl/render.ts
+++ b/apps/mapgen-studio/src/features/viz/deckgl/render.ts
@@ -1,8 +1,8 @@
 import type { Layer } from "@deck.gl/core";
 import { LineLayer, ScatterplotLayer, PolygonLayer } from "@deck.gl/layers";
 import {
-  TILE_BORDER_COLOR,
   buildCategoricalColorMap,
+  tileBorderColorForFill,
   writeColorForScalarValue,
 } from "../presentation";
 import type { Bounds, VizAssetResolver, VizLayerEntryV1, VizManifestV1 } from "../model";
@@ -372,9 +372,14 @@ async function renderSingleLayer(options: RenderSingleLayerArgs): Promise<Render
           stroked: true,
           // Mesh contract: unfilled tiles draw nothing — the border follows
           // the fill's alpha so transparent tiles leave no phantom mesh.
+          // Filled tiles grout with their OWN fill darkened (the one
+          // tile-border rule) so the lattice stays legible at fit zoom.
           getLineColor: (i) => {
-            const alpha = colors[Number(i) * 4 + 3] ?? 0;
-            return alpha === 0 ? [0, 0, 0, 0] : TILE_BORDER_COLOR;
+            const base = Number(i) * 4;
+            const alpha = colors[base + 3] ?? 0;
+            return alpha === 0
+              ? [0, 0, 0, 0]
+              : tileBorderColorForFill(colors[base] ?? 0, colors[base + 1] ?? 0, colors[base + 2] ?? 0);
           },
           getLineWidth: 1,
           lineWidthUnits: "pixels",
@@ -625,9 +630,14 @@ async function renderSingleLayer(options: RenderSingleLayerArgs): Promise<Render
         stroked: true,
         // Mesh contract: unfilled tiles draw nothing — the border follows
         // the fill's alpha so transparent tiles leave no phantom mesh.
+        // Filled tiles grout with their OWN fill darkened (the one
+        // tile-border rule) so the lattice stays legible at fit zoom.
         getLineColor: (i) => {
-          const alpha = colors[Number(i) * 4 + 3] ?? 0;
-          return alpha === 0 ? [0, 0, 0, 0] : TILE_BORDER_COLOR;
+          const base = Number(i) * 4;
+          const alpha = colors[base + 3] ?? 0;
+          return alpha === 0
+            ? [0, 0, 0, 0]
+            : tileBorderColorForFill(colors[base] ?? 0, colors[base + 1] ?? 0, colors[base + 2] ?? 0);
         },
         getLineWidth: 1,
         lineWidthUnits: "pixels",

--- a/apps/mapgen-studio/src/features/viz/presentation.ts
+++ b/apps/mapgen-studio/src/features/viz/presentation.ts
@@ -383,15 +383,29 @@ const VALUE_RAMP: ReadonlyArray<RgbaColor> = [
 const UNKNOWN_COLOR: RgbaColor = [0, 0, 0, 0];
 
 /**
- * The one tile-border ink (Pass-5 tile-orientation spec, retuned on user
- * feedback): graphite — the dark page substrate (#0d0d11), one ink in BOTH
- * themes. Borders only ever separate FILLED tiles (unfilled tiles draw
- * nothing), so a dark seam reads against the fills everywhere: in dark mode
- * it recedes into the canvas like grout; in light mode it is a crisp
- * graphite grid. All tile-space polygon strokes use this — no per-call
- * border literals, no mid-luminance slate (it clashed with the palette).
+ * The one tile-border RULE (Pass-5 tile-orientation spec, retuned twice on
+ * user feedback): the border is the tile's OWN fill pulled toward black —
+ * self-grout. The previous constant graphite ink (#0d0d11, the page
+ * substrate) vanished at map scale: at fit zoom a Huge map's tiles are a few
+ * pixels wide, and a page-colored 1px seam between dark fills dissolved the
+ * tessellation into disconnected dots — the grid disappeared everywhere the
+ * Delaunay mesh (its own slate ink) wasn't drawn. A fill-derived seam is
+ * darker than its fill BY CONSTRUCTION, so the hex lattice reads at every
+ * zoom, in both themes, for every palette — and up close it still recedes
+ * like etched grout instead of glowing slate. Unfilled tiles draw nothing
+ * (mesh contract — stroke alpha follows fill alpha). All tile-space polygon
+ * strokes use this rule — no per-call border literals.
  */
-export const TILE_BORDER_COLOR: RgbaColor = [13, 13, 17, 200];
+export const TILE_BORDER_FILL_RATIO = 0.55;
+
+export function tileBorderColorForFill(r: number, g: number, b: number): RgbaColor {
+  return [
+    Math.round(r * TILE_BORDER_FILL_RATIO),
+    Math.round(g * TILE_BORDER_FILL_RATIO),
+    Math.round(b * TILE_BORDER_FILL_RATIO),
+    255,
+  ];
+}
 
 type ColorOut = { [index: number]: number };
 

--- a/apps/mapgen-studio/src/features/viz/useVizState.ts
+++ b/apps/mapgen-studio/src/features/viz/useVizState.ts
@@ -179,7 +179,14 @@ export function useVizState(args: UseVizStateArgs): UseVizStateResult {
     if (selectedLayerKey && (allowPendingSelection || layersForStep.some((l) => l.key === selectedLayerKey))) {
       return selectedLayerKey;
     }
-    return layersForStep[0]?.key ?? null;
+    // Default preference: the map studio defaults to the MAP. When a step has
+    // a tile-space grid layer, land there instead of whichever layer the
+    // worker happened to emit first (points/mesh) — switching stages keeps
+    // showing the hex grid wherever the step can draw one.
+    const tileGrid = layersForStep.find(
+      (l) => l.layer.kind === "grid" && l.layer.spaceId.startsWith("tile.")
+    );
+    return tileGrid?.key ?? layersForStep[0]?.key ?? null;
   }, [allowPendingSelection, layersForStep, selectedLayerKey]);
 
   const selectableLayers = useMemo(

--- a/apps/mapgen-studio/test/viz/tileOrientation.test.ts
+++ b/apps/mapgen-studio/test/viz/tileOrientation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { Layer } from "@deck.gl/core";
 import type { VizLayerEntryV1, VizManifestV1 } from "../../src/features/viz/model";
 import { boundsForTileGrid, renderDeckLayers } from "../../src/features/viz/deckgl/render";
+import { TILE_BORDER_FILL_RATIO } from "../../src/features/viz/presentation";
 
 function polygonCenterY(layer: Layer, index: number): number {
   const polygon = (layer as any).props.getPolygon(index) as Array<[number, number]>;
@@ -145,5 +146,34 @@ describe("tile-space rendering orientation", () => {
     // A filled neighbor keeps its border (the shared tile ink).
     const filledLine = (hexLayer as any).props.getLineColor(0) as number[];
     expect(filledLine[3]).toBeGreaterThan(0);
+  });
+
+  it("grouts each filled tile with its OWN fill darkened (the one border rule)", async () => {
+    const layer = gridLayer("tile.hexOddR");
+    const manifest: VizManifestV1 = {
+      runId: "test-run",
+      outputRoot: "browser://viz",
+      steps: [{ stepId: "test.step", stepIndex: 0 }],
+      layers: [layer],
+    };
+    const result = await renderDeckLayers({ manifest, layer, showEdgeOverlay: false });
+    const hexLayer = result.layers.find((candidate) => String(candidate.id).endsWith("::hex"));
+    if (!hexLayer) throw new Error("missing rendered hex layer");
+
+    // The previous CONSTANT graphite ink matched the page substrate, so at
+    // fit zoom the lattice dissolved into dots ("the grid disappeared" for
+    // every tile layer). The border must now derive from the tile's fill —
+    // strictly darker than it, fully opaque, and different per tile.
+    for (const index of [0, 1]) {
+      const fill = (hexLayer as any).props.getFillColor(index) as number[];
+      const line = (hexLayer as any).props.getLineColor(index) as number[];
+      expect(line[3]).toBe(255);
+      for (const channel of [0, 1, 2]) {
+        expect(line[channel]).toBe(Math.round((fill[channel] ?? 0) * TILE_BORDER_FILL_RATIO));
+      }
+    }
+    const line0 = (hexLayer as any).props.getLineColor(0) as number[];
+    const line1 = (hexLayer as any).props.getLineColor(1) as number[];
+    expect(line0).not.toEqual(line1);
   });
 });


### PR DESCRIPTION
The grid disappeared for every stage besides the first: X6's constant
graphite border ink (#0d0d11 — the page substrate) is invisible between
dark fills at fit zoom, where Huge-map tiles are a few pixels wide; the
tessellation dissolved into disconnected dots. Only the Delaunay mesh
(its own slate ink) still read as a grid, hence 'first stage only'.

- The one tile-border RULE replaces the constant ink: border = the tile's
  OWN fill x 0.55, fully opaque (tileBorderColorForFill) — darker than its
  fill BY CONSTRUCTION, legible at every zoom, both themes, every palette,
  and still etched-grout up close. Mesh contract unchanged (unfilled tiles
  draw nothing). Applied to both grid and gridFields strokes.
- Layer-selection default prefers the step's tile-space GRID layer over
  whichever layer the worker emitted first (points/mesh): the map studio
  defaults to the map when selection resets across stage/step switches.

New border-rule pin in tileOrientation.test.ts (per-tile derived stroke,
opaque, distinct between tiles). Verified live across stages 2/10/13:
contiguous hex lattice at fit zoom; stage 10 now defaults to the Biome
Index grid instead of centroid points.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>