### PR TITLE
chore(studio): post-main-restack reconciliation — regenerate bun.lock, port engines to the rivers deploy plan + content-marker proof gate, retarget save/deploy client types, restore studio-server test script

### DIFF
--- a/apps/mapgen-studio/package.json
+++ b/apps/mapgen-studio/package.json
@@ -20,6 +20,8 @@
     "@civ7/adapter": "workspace:*",
     "@civ7/control-orpc": "workspace:*",
     "@civ7/direct-control": "workspace:*",
+    "@civ7/map-policy": "workspace:*",
+    "@civ7/plugin-mods": "workspace:*",
     "@civ7/studio-server": "workspace:*",
     "@orpc/client": "1.14.5",
     "@orpc/contract": "1.14.5",

--- a/apps/mapgen-studio/src/features/mapConfigSave/api.ts
+++ b/apps/mapgen-studio/src/features/mapConfigSave/api.ts
@@ -58,7 +58,7 @@ export async function saveRepoBackedConfig(args: {
   config: unknown;
   onStatus?: (status: MapConfigSaveDeployStatus) => void;
 }): Promise<
-  | { ok: true; path?: string; deploy?: { command?: string } }
+  | { ok: true; path?: string; deploy?: MapConfigSaveDeployStatus["deploy"] }
   | { ok: false; error: string; saved?: boolean; deployed?: boolean; path?: string }
 > {
   const envelope = {

--- a/apps/mapgen-studio/src/server/studio/engines.ts
+++ b/apps/mapgen-studio/src/server/studio/engines.ts
@@ -28,17 +28,20 @@ import { waitForCiv7MapgenLogFailure } from "../runInGame/logFailure";
 import {
   buildRunInGameExactAuthorshipProof,
   buildRunInGameSourceSnapshotProof,
+  fileContentMarkerProof,
   fileIdentity,
   mapScriptEmbedsRequestId,
-  parseDeployTargetDir,
   parseSwooperMapgenLogProof,
+  runInGameMaterializationScriptUnresolvedLinks,
+  runInGameRequiredMaterializationMarkers,
 } from "../runInGame/proofIdentity";
 import { parseRunInGameSetupRequest } from "../runInGame/requestValidation";
 import {
   launchCiv7MacViaSteamWithRetries,
   shutdownCiv7MacProcess,
 } from "../runInGame/macosProcessRestart";
-import { buildSwooperMapsStudioDeployCommand } from "../mapConfigs/deploy";
+import { deployMod, resolveModsDir } from "@civ7/plugin-mods";
+import { buildSwooperMapsStudioDeployPlan } from "../mapConfigs/deploy";
 import { createMapConfigSaveDeployOperationStore } from "../mapConfigs/operationState";
 import { parseMapConfigSaveRequest } from "../mapConfigs/requestValidation";
 import type { RunInGamePhase, RunInGameRequestStatus } from "../../features/runInGame/status";
@@ -184,44 +187,77 @@ async function restartCiv7ProcessViaSteam(): Promise<{
   };
 }
 
+// Deploy = the Turbo build graph + the @civ7/plugin-mods deploy API (the
+// rivers-era canonical shape; the old parsed-stdout deploy command is gone).
+// `buildSwooperMapsStudioDeployPlan` threads SWOOPER_STUDIO_RUN_ID so the
+// generated bundle embeds the run's request id (the proof-identity contract).
 async function deploySwooperMaps(repoRoot: string): Promise<{
-  command: string;
-  stdout: string;
-  stderr: string;
+  build: {
+    task: string;
+    stdout: string;
+    stderr: string;
+  };
+  targetDir: string;
+  modsDir: string;
+  filesCopied: number;
 }> {
-  const deploy = buildSwooperMapsStudioDeployCommand();
-  const { stdout, stderr } = await execFileAsync("bun", [...deploy.args], {
+  const plan = buildSwooperMapsStudioDeployPlan();
+  const { stdout, stderr } = await execFileAsync("bun", [...plan.buildArgs], {
     cwd: repoRoot,
     timeout: DEPLOY_TIMEOUT_MS,
     maxBuffer: 16 * 1024 * 1024,
-    env: deploy.env,
+    env: plan.env,
+  });
+  const modsDir = resolveModsDir().modsDir;
+  const deployed = deployMod({
+    inputDir: resolve(repoRoot, "mods/mod-swooper-maps/mod"),
+    modId: "mod-swooper-maps",
+    modsDir,
   });
   return {
-    command: deploy.command,
-    stdout: tail(stdout),
-    stderr: tail(stderr),
+    build: {
+      task: plan.buildTask,
+      stdout: tail(stdout),
+      stderr: tail(stderr),
+    },
+    targetDir: deployed.targetDir,
+    modsDir: deployed.modsDir,
+    filesCopied: deployed.filesCopied,
   };
 }
 
 async function deploySwooperMapsForRun(repoRoot: string, requestId: string): Promise<{
-  command: string;
-  stdout: string;
-  stderr: string;
-  targetDir?: string;
+  build: {
+    task: string;
+    stdout: string;
+    stderr: string;
+  };
+  targetDir: string;
+  modsDir: string;
+  filesCopied: number;
 }> {
-  const deploy = buildSwooperMapsStudioDeployCommand({ requestId });
-  const { stdout, stderr } = await execFileAsync("bun", [...deploy.args], {
+  const plan = buildSwooperMapsStudioDeployPlan({ requestId });
+  const { stdout, stderr } = await execFileAsync("bun", [...plan.buildArgs], {
     cwd: repoRoot,
     timeout: DEPLOY_TIMEOUT_MS,
     maxBuffer: 16 * 1024 * 1024,
-    env: deploy.env,
+    env: plan.env,
   });
-  const targetDir = parseDeployTargetDir(stdout);
+  const modsDir = resolveModsDir().modsDir;
+  const deployed = deployMod({
+    inputDir: resolve(repoRoot, "mods/mod-swooper-maps/mod"),
+    modId: "mod-swooper-maps",
+    modsDir,
+  });
   return {
-    command: deploy.command,
-    stdout: tail(stdout),
-    stderr: tail(stderr),
-    ...(targetDir ? { targetDir } : {}),
+    build: {
+      task: plan.buildTask,
+      stdout: tail(stdout),
+      stderr: tail(stderr),
+    },
+    targetDir: deployed.targetDir,
+    modsDir: deployed.modsDir,
+    filesCopied: deployed.filesCopied,
   };
 }
 
@@ -231,6 +267,10 @@ async function optionalFileIdentity(args: {
   exposeAs?: "relative-to-repo" | "absolute";
 }) {
   return await fileIdentity(args).catch(() => undefined);
+}
+
+async function optionalFileContentMarkerProof(args: Parameters<typeof fileContentMarkerProof>[0]) {
+  return await fileContentMarkerProof(args).catch(() => undefined);
 }
 
 function generatedSourceScriptPath(repoRoot: string, id: string): string {
@@ -631,13 +671,54 @@ export function createStudioEngines(options: Readonly<{ repoRoot: string }>): St
               exposeAs: "absolute",
             })
           : undefined;
+        // Materialization CONTENT proof (rivers-era correctness boundary):
+        // the request/config/envelope markers — including the native-river
+        // markers — must be present in the local AND deployed map JS before
+        // Civ launches, or the in-game proof could never bind to this run.
+        const requiredMaterializationMarkers = runInGameRequiredMaterializationMarkers({
+          requestId,
+          configHash,
+          envelopeHash,
+        });
+        const localModScriptContent = await optionalFileContentMarkerProof({
+          repoRoot,
+          path: localModScriptPath(repoRoot, id),
+          markers: requiredMaterializationMarkers,
+        });
+        const deployedModScriptContent = deploy.targetDir
+          ? await optionalFileContentMarkerProof({
+              repoRoot,
+              path: deployedModScriptPath(deploy.targetDir, id),
+              exposeAs: "absolute",
+              markers: requiredMaterializationMarkers,
+            })
+          : undefined;
         materialization = {
           ...materialization,
           ...(generatedSourceScript ? { generatedSourceScript } : {}),
           ...(localModScript ? { localModScript } : {}),
           ...(deployedModScript ? { deployedModScript } : {}),
+          ...(localModScriptContent ? { localModScriptContent } : {}),
+          ...(deployedModScriptContent ? { deployedModScriptContent } : {}),
         };
         runInGameOperations.update(requestId, { phase, materialization });
+        const materializationScriptUnresolvedLinks = runInGameMaterializationScriptUnresolvedLinks({
+          materialization,
+          localModScript,
+          deployedModScript,
+          requiredMarkers: requiredMaterializationMarkers,
+        });
+        if (materializationScriptUnresolvedLinks.length > 0) {
+          throw new RunInGameHttpError(
+            500,
+            "Generated Swooper map script is missing current materialization proof markers",
+            {
+              code: "map-script-materialization-proof-missing",
+              unresolvedLinks: materializationScriptUnresolvedLinks,
+              materialization,
+            },
+          );
+        }
 
         // Fail fast if the freshly built bundle does not embed this request's
         // id. The in-game [mapgen-proof] line echoes the embedded id and the

--- a/bun.lock
+++ b/bun.lock
@@ -45,9 +45,10 @@
         "@deck.gl/react": "^9.0.43",
         "@fontsource/inter": "^5.1.1",
         "@fontsource/jetbrains-mono": "^5.1.1",
-        "@orpc/client": "^1.14.4",
-        "@orpc/contract": "^1.14.4",
-        "@orpc/server": "^1.14.4",
+        "@orpc/client": "1.14.5",
+        "@orpc/contract": "1.14.5",
+        "@orpc/server": "1.14.5",
+        "@orpc/tanstack-query": "1.14.5",
         "@radix-ui/react-checkbox": "1.3.4",
         "@radix-ui/react-dialog": "1.1.16",
         "@radix-ui/react-dropdown-menu": "2.1.17",
@@ -66,6 +67,7 @@
         "@standard-schema/spec": "^1.1.0",
         "@swooper/mapgen-core": "workspace:*",
         "@swooper/mapgen-viz": "workspace:*",
+        "@tanstack/react-query": "5.101.0",
         "class-variance-authority": "latest",
         "clsx": "latest",
         "effect": "3.21.3",
@@ -77,6 +79,7 @@
         "sonner": "2.0.7",
         "tailwind-merge": "latest",
         "typebox": "^1.0.80",
+        "zustand": "5.0.14",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.13",
@@ -1198,6 +1201,8 @@
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.101.0", "", {}, "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.101.0", "", { "dependencies": { "@tanstack/query-core": "5.101.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg=="],
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
@@ -3156,6 +3161,8 @@
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.20.4", "", { "peerDependencies": { "zod": "^3.20.0" } }, "sha512-Un9+kInJ2Zt63n6Z7mLqBifzzPcOyX+b+Exuzf7L1+xqck9Q2EPByyTRduV3kmSPaXaRer1JCsucubpgL1fipg=="],
+
+    "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/docs/projects/mapgen-studio-redesign/00-GOAL.md
+++ b/docs/projects/mapgen-studio-redesign/00-GOAL.md
@@ -545,3 +545,53 @@ because static markup can't click); tsc clean; live-verified dark + light
 measured via computed styles). system.md gained the Z-wave amendment
 (Game bar v3 + console glyph registry v3); Pass-4 glyph registry marked
 superseded.
+
+## Restack onto post-integration main (2026-06-12, operator-mandated)
+
+Per `docs/projects/graphite-stack-integration/STUDIO-REDESIGN-RESTACK-HANDOFF.md`
+(+ DAG handoff §6): the one-time reconciliation of this 62-branch stack onto
+frozen main `1db0dfc4c` (taxonomy + rivers; dag/placement were already in the
+base). `gt sync --no-restack` + `gt restack --downstack` from the leaf; 8
+conflict events (rerere compounded the predicted ~25–30), resolved per the
+handoff's pre-decided dispositions: our decomposition won all chrome
+(App.tsx, ExplorePanel, AppHeader), our `packages/studio-server` won its 8
+shared files (main's `test/handler.test.ts` + `vitest.config.ts` kept and
+green — the reworked handler passes them unchanged; the package regained a
+`test` script so they run in gates), `civ7-direct-control/index.ts` was the
+pure export union (applied clean), main's resources gitlink (`fbc38ef8`)
+taken, `bun.lock` regenerated via `bun install`.
+
+Post-restack semantic reconciliation (the real work, committed as
+`design/post-main-restack-reconcile` + two mid-stack amends):
+
+- **Engines ported to the rivers deploy** (`engines.ts`): the retired
+  stdout-parsed deploy command → `buildSwooperMapsStudioDeployPlan` (Turbo
+  graph, threads `SWOOPER_STUDIO_RUN_ID`) + `@civ7/plugin-mods` `deployMod`;
+  deploy details follow the new `{build, targetDir, modsDir, filesCopied}`
+  shape end-to-end (save/deploy client type included). The rivers
+  **materialization content-marker gate** (request/config/envelope + native
+  river markers proved in local AND deployed map JS before launch) is now
+  enforced in our engine flow, alongside the Y1 request-id embed guard.
+- **tags.ts union repaired** (amend at `design/map-stage-domains`): the
+  blanket lane-wins resolution had dropped main's S5 placement effects
+  (`resourcesPlanned`/`resourcesAdjusted` + owners) and kept two retired
+  `PlacementOutputsV1` fields in the placement satisfier
+  (floodplainsCount/snowTilesCount) — the latter made EVERY recipe run die
+  with `UnsatisfiedProvidesError: effect:engine.placementApplied` (44
+  failures across the mod suite). Union restored; satisfier matches main.
+- **Schema-test pins** (amend at `design/no-hardcoded-defaults`):
+  `defaultConfigSchema.test.ts` reverted to main's canonical version — the
+  lane copy had resurrected the deliberately-dropped legacy default guards
+  (handoff §1.2 forbids) and pinned pre-rivers key lists (`drainageRouting`
+  missing, retired `riverProjection`/`support` groups present).
+- **Stale scratch removed:** the untracked pre-restack
+  `studio-current.config.json` (old-schema keys) broke `gen:maps`; deleted —
+  the studio regenerates it via Save & Deploy with import-time migration.
+
+Gates at tip (all green): mapgen-studio **223** + tsc + build/worker-bundle;
+mod-swooper-maps **569/0 fail** (= handoff baseline); civ7-direct-control
+**433** (427 baseline + our 6 session pins); civ7-control-orpc **345**
+(= baseline; the 4 appshot failures were a stale local direct-control dist —
+rebuild proved it, main-worktree control run cross-checked); mapgen-core
+**103/0 fail**; studio-server **2** (main's handler pins). Deferred to the
+operator: draining the stack (standing never-submit rule vs handoff step 5).

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -25,6 +25,7 @@
     "dev": "tsup --watch",
     "check": "tsc -p tsconfig.json --noEmit",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run --config ./vitest.config.ts",
     "clean": "rimraf dist"
   },
   "dependencies": {

--- a/packages/studio-server/src/contract/mapConfigs.ts
+++ b/packages/studio-server/src/contract/mapConfigs.ts
@@ -34,9 +34,16 @@ export const saveDeployStatusSchema = z.object({
   error: z.string().optional(),
   deploy: z
     .object({
-      command: z.string().optional(),
-      stdout: z.string().optional(),
-      stderr: z.string().optional(),
+      build: z
+        .object({
+          task: z.string().optional(),
+          stdout: z.string().optional(),
+          stderr: z.string().optional(),
+        })
+        .optional(),
+      targetDir: z.string().optional(),
+      modsDir: z.string().optional(),
+      filesCopied: z.number().optional(),
     })
     .optional(),
   details: z.record(z.string(), z.unknown()).optional(),

--- a/packages/studio-server/src/contract/runInGame.ts
+++ b/packages/studio-server/src/contract/runInGame.ts
@@ -48,6 +48,17 @@ const fileIdentity = z.object({
   mtimeIso: z.string(),
 });
 
+const contentMarkerProof = z.object({
+  id: z.string(),
+  marker: z.string(),
+  present: z.boolean(),
+});
+
+const fileContentProof = z.object({
+  path: z.string(),
+  markers: z.array(contentMarkerProof),
+});
+
 // RunInGameSourceSnapshotProof
 const sourceSnapshotProof = z.object({
   identityHash: z.string(),
@@ -73,6 +84,8 @@ const materializationStatus = z.object({
   generatedSourceScript: fileIdentity.optional(),
   localModScript: fileIdentity.optional(),
   deployedModScript: fileIdentity.optional(),
+  localModScriptContent: fileContentProof.optional(),
+  deployedModScriptContent: fileContentProof.optional(),
 });
 
 // RunInGameRequestStatus


### PR DESCRIPTION
The restack onto post-integration main (taxonomy + rivers) left my
decomposed engines.ts calling the retired stdout-parsed deploy command.
Engines now run the Turbo deploy plan + @civ7/plugin-mods deployMod (the
rivers-era canonical deploy), enforce the materialization content-marker
gate (request/config/envelope + native river markers in local AND deployed
map JS) before launch — kept alongside the Y1 request-id embed guard — and
the save/deploy client result type follows the new deploy detail shape.
@civ7/map-policy + @civ7/plugin-mods join the studio's workspace deps;
@civ7/studio-server regains its vitest script so main's handler pins run.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>