### PR TITLE
feat(mapgen-studio): Water proof inspector — river/lake/floodplain truth lanes re-expressed in the ExplorePanel

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -75,6 +75,11 @@ import {
 import { type DeckCanvasApi } from "../features/viz/DeckCanvas";
 import { useVizState } from "../features/viz/useVizState";
 import {
+  buildRiverLakeFloodplainInspectorSummary,
+  type RiverLakeInspectorLayerRef,
+} from "../features/viz/riverLakeInspector";
+import { applyRiverLakeInspectorSelection } from "../features/viz/inspectorSelection";
+import {
   findVariantIdForEra,
   findVariantKeyForEra,
   listEraVariants,
@@ -237,6 +242,8 @@ export function StudioShell(props: StudioShellProps) {
   const setExploreStepExpanded = useViewStore((s) => s.setExploreStepExpanded);
   const exploreLayersExpanded = useViewStore((s) => s.exploreLayersExpanded);
   const setExploreLayersExpanded = useViewStore((s) => s.setExploreLayersExpanded);
+  const exploreWaterProofExpanded = useViewStore((s) => s.exploreWaterProofExpanded);
+  const setExploreWaterProofExpanded = useViewStore((s) => s.setExploreWaterProofExpanded);
   const stageView = useViewStore((s) => s.stageView);
   const setStageView = useViewStore((s) => s.setStageView);
   const pipelineSelectedStageId = useViewStore((s) => s.pipelineSelectedStageId);
@@ -1761,6 +1768,11 @@ export function StudioShell(props: StudioShellProps) {
     return dataTypeModel.dataTypes.map((dt) => ({ value: dt.dataTypeId, label: dt.label, group: dt.group }));
   }, [dataTypeModel]);
 
+  const riverLakeInspectorSummary = useMemo(
+    () => buildRiverLakeFloodplainInspectorSummary(viz.manifest),
+    [viz.manifest]
+  );
+
   const selection = useMemo(() => {
     if (!dataTypeModel) return null;
     for (const dt of dataTypeModel.dataTypes) {
@@ -1962,6 +1974,20 @@ export function StudioShell(props: StudioShellProps) {
 
   const handleStepChange = useCallback((stepId: string) => setSelectedStepId(stepId), []);
 
+  const handleRiverLakeInspectorLayerSelect = useCallback(
+    (ref: RiverLakeInspectorLayerRef) => {
+      applyRiverLakeInspectorSelection(ref, {
+        stages: recipeArtifacts.uiMeta.stages,
+        setSelectedStageId,
+        setSelectedStepId,
+        setShowDebugLayers: viz.setShowDebugLayers,
+        setVizSelectedStepId: viz.setSelectedStepId,
+        setVizSelectedLayerKey: viz.setSelectedLayerKey,
+      });
+    },
+    [recipeArtifacts.uiMeta.stages, viz]
+  );
+
   const handleDataTypeChange = useCallback(
     (next: string) => {
       if (!dataTypeModel) return;
@@ -2093,11 +2119,16 @@ export function StudioShell(props: StudioShellProps) {
     run: triggerRun,
     reroll,
     toggleRightPanel: () => {
-      const rightCollapsed = !exploreStageExpanded && !exploreStepExpanded && !exploreLayersExpanded;
+      const rightCollapsed =
+        !exploreStageExpanded &&
+        !exploreStepExpanded &&
+        !exploreLayersExpanded &&
+        !exploreWaterProofExpanded;
       const next = rightCollapsed;
       setExploreStageExpanded(next);
       setExploreStepExpanded(next);
       setExploreLayersExpanded(next);
+      setExploreWaterProofExpanded(next);
     },
     toggleLeftPanel: () => {
       const leftCollapsed = recipeSectionCollapsed && configSectionCollapsed;
@@ -2377,6 +2408,10 @@ export function StudioShell(props: StudioShellProps) {
       onStepExpandedChange={setExploreStepExpanded}
       layersExpanded={exploreLayersExpanded}
       onLayersExpandedChange={setExploreLayersExpanded}
+      riverLakeInspectorSummary={riverLakeInspectorSummary}
+      onRiverLakeInspectorLayerSelect={handleRiverLakeInspectorLayerSelect}
+      waterProofExpanded={exploreWaterProofExpanded}
+      onWaterProofExpandedChange={setExploreWaterProofExpanded}
     />
   );
 

--- a/apps/mapgen-studio/src/features/viz/inspectorSelection.ts
+++ b/apps/mapgen-studio/src/features/viz/inspectorSelection.ts
@@ -1,0 +1,46 @@
+import type { RiverLakeInspectorLayerRef } from "./riverLakeInspector";
+
+/**
+ * Ports the water-proof navigator needs to move the explore selection. Kept as
+ * a plain object so the helper stays pure and pinnable without React or store
+ * imports (StudioShell supplies viewStore setters + `useVizState` setters).
+ */
+export interface RiverLakeInspectorSelectionPorts {
+  stages:
+    | ReadonlyArray<{ stageId: string; steps: ReadonlyArray<{ fullStepId?: string; id?: string }> }>
+    | undefined;
+  setSelectedStageId: (id: string) => void;
+  setSelectedStepId: (id: string) => void;
+  setShowDebugLayers: (show: boolean) => void;
+  setVizSelectedStepId: (id: string) => void;
+  setVizSelectedLayerKey: (key: string) => void;
+}
+
+/**
+ * Proof navigator: jumps the explore selection to a water-proof evidence layer.
+ *
+ * The inspector row's layer chips are claims about pipeline evidence; clicking
+ * one must land the user ON that evidence. That means (1) re-pointing the
+ * stage/step lists at the stage whose steps contain the layer's step (matched
+ * by `fullStepId`, the id the explore step list uses as its option value),
+ * (2) forcing debug layers visible when the evidence is debug-class —
+ * otherwise the jump would select a layer the data list is filtering out — and
+ * (3) selecting the viz step + concrete layer key so the canvas renders it.
+ * When no stage contains the step (e.g. a stale manifest from another recipe),
+ * the stage/step lists are left alone but the viz layer is still selected.
+ */
+export function applyRiverLakeInspectorSelection(
+  ref: RiverLakeInspectorLayerRef,
+  ports: RiverLakeInspectorSelectionPorts
+): void {
+  const stage = ports.stages?.find((candidate) =>
+    candidate.steps.some((step) => step.fullStepId === ref.stepId)
+  );
+  if (stage) {
+    ports.setSelectedStageId(stage.stageId);
+    ports.setSelectedStepId(ref.stepId);
+  }
+  if (ref.visibility === "debug") ports.setShowDebugLayers(true);
+  ports.setVizSelectedStepId(ref.stepId);
+  ports.setVizSelectedLayerKey(ref.layerKey);
+}

--- a/apps/mapgen-studio/src/stores/viewStore.ts
+++ b/apps/mapgen-studio/src/stores/viewStore.ts
@@ -47,6 +47,7 @@ export type ViewState = {
   exploreStageExpanded: boolean;
   exploreStepExpanded: boolean;
   exploreLayersExpanded: boolean;
+  exploreWaterProofExpanded: boolean;
   // Explore selection (single owner; App no longer mirrors these)
   selectedStageId: string;
   selectedStepId: string;
@@ -70,6 +71,7 @@ export type ViewState = {
   setExploreStageExpanded: (next: Updater<boolean>) => void;
   setExploreStepExpanded: (next: Updater<boolean>) => void;
   setExploreLayersExpanded: (next: Updater<boolean>) => void;
+  setExploreWaterProofExpanded: (next: Updater<boolean>) => void;
   setSelectedStageId: (next: Updater<string>) => void;
   setSelectedStepId: (next: Updater<string>) => void;
   setStageView: (next: Updater<StageView>) => void;
@@ -90,6 +92,7 @@ export const useViewStore = create<ViewState>((set) => ({
   exploreStageExpanded: true,
   exploreStepExpanded: true,
   exploreLayersExpanded: true,
+  exploreWaterProofExpanded: false,
   selectedStageId: "",
   selectedStepId: "",
   stageView: "map",
@@ -115,6 +118,8 @@ export const useViewStore = create<ViewState>((set) => ({
     set((s) => ({ exploreStepExpanded: resolve(next, s.exploreStepExpanded) })),
   setExploreLayersExpanded: (next) =>
     set((s) => ({ exploreLayersExpanded: resolve(next, s.exploreLayersExpanded) })),
+  setExploreWaterProofExpanded: (next) =>
+    set((s) => ({ exploreWaterProofExpanded: resolve(next, s.exploreWaterProofExpanded) })),
   setSelectedStageId: (next) => set((s) => ({ selectedStageId: resolve(next, s.selectedStageId) })),
   setSelectedStepId: (next) => set((s) => ({ selectedStepId: resolve(next, s.selectedStepId) })),
   setStageView: (next) => set((s) => ({ stageView: resolve(next, s.stageView) })),

--- a/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
+++ b/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
@@ -19,6 +19,11 @@ import {
   Flame } from
 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/ui';
+import { WaterProofSection } from './WaterProofSection';
+import type {
+  RiverLakeFloodplainInspectorSummary,
+  RiverLakeInspectorLayerRef } from
+'../../features/viz/riverLakeInspector';
 import { LAYOUT } from '../constants';
 import type {
   StageOption,
@@ -115,6 +120,14 @@ export interface ExplorePanelProps {
   layersExpanded?: boolean;
   /** Callback when layersExpanded changes (optional controlled mode) */
   onLayersExpandedChange?: (expanded: boolean) => void;
+  /** River/Lake/Floodplain inspector summary (Water proof section) */
+  riverLakeInspectorSummary?: RiverLakeFloodplainInspectorSummary | null;
+  /** Callback when a water-proof evidence layer chip is clicked */
+  onRiverLakeInspectorLayerSelect?: (ref: RiverLakeInspectorLayerRef) => void;
+  /** Whether the water-proof section is expanded (optional controlled mode) */
+  waterProofExpanded?: boolean;
+  /** Callback when waterProofExpanded changes (optional controlled mode) */
+  onWaterProofExpandedChange?: (expanded: boolean) => void;
 }
 // ============================================================================
 // Component
@@ -160,11 +173,16 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
   stepExpanded: stepExpandedProp,
   onStepExpandedChange,
   layersExpanded: layersExpandedProp,
-  onLayersExpandedChange
+  onLayersExpandedChange,
+  riverLakeInspectorSummary,
+  onRiverLakeInspectorLayerSelect,
+  waterProofExpanded: waterProofExpandedProp,
+  onWaterProofExpandedChange
 }) => {
   const [localStageExpanded, setLocalStageExpanded] = useState(true);
   const [localStepExpanded, setLocalStepExpanded] = useState(true);
   const [localLayersExpanded, setLocalLayersExpanded] = useState(true);
+  const [localWaterProofExpanded, setLocalWaterProofExpanded] = useState(false);
   const [groupOpen, setGroupOpen] = useState<Record<string, boolean>>({});
 
   const isStageExpanded = stageExpandedProp ?? localStageExpanded;
@@ -183,6 +201,12 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
   const setIsLayersExpanded = (next: boolean) => {
     onLayersExpandedChange?.(next);
     if (layersExpandedProp === undefined) setLocalLayersExpanded(next);
+  };
+
+  const isWaterProofExpanded = waterProofExpandedProp ?? localWaterProofExpanded;
+  const setIsWaterProofExpanded = (next: boolean) => {
+    onWaterProofExpandedChange?.(next);
+    if (waterProofExpandedProp === undefined) setLocalWaterProofExpanded(next);
   };
   const currentStage = stages.find((s) => s.value === selectedStage);
   const currentStep = steps.find((s) => s.value === selectedStep);
@@ -434,6 +458,14 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
           )}
         </div>
       ) : null}
+
+      {/* WATER PROOF SECTION — River/Lake/Floodplain inspector rows */}
+      <WaterProofSection
+        summary={riverLakeInspectorSummary}
+        onLayerSelect={onRiverLakeInspectorLayerSelect}
+        expanded={isWaterProofExpanded}
+        onExpandedChange={setIsWaterProofExpanded}
+      />
 
       {/* 3. LAYERS SECTION. The debug toggle lives on this header — it filters
           which entries the data list shows (`includeDebug`), so it belongs to

--- a/apps/mapgen-studio/src/ui/components/WaterProofSection.tsx
+++ b/apps/mapgen-studio/src/ui/components/WaterProofSection.tsx
@@ -1,0 +1,216 @@
+import React from 'react';
+// ============================================================================
+// WATER PROOF SECTION
+// ============================================================================
+// River/Lake/Floodplain inspector rows inside the ExplorePanel dock.
+// Presentational only — the semantic summary is built by
+// features/viz/riverLakeInspector and passed in fully formed.
+// ============================================================================
+import { ChevronDown, Droplets } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/ui';
+import type {
+  RiverLakeFloodplainInspectorSummary,
+  RiverLakeInspectorClaimStatus,
+  RiverLakeInspectorLayerRef } from
+'../../features/viz/riverLakeInspector';
+
+// ============================================================================
+// Props
+// ============================================================================
+export interface WaterProofSectionProps {
+  /** Inspector summary built from the current viz manifest (null = no run). */
+  summary: RiverLakeFloodplainInspectorSummary | null | undefined;
+  /** Jump the explore selection to an evidence layer. */
+  onLayerSelect?: (ref: RiverLakeInspectorLayerRef) => void;
+  /** Whether the row list is expanded (controlled). */
+  expanded: boolean;
+  /** Callback when the disclosure toggles. */
+  onExpandedChange: (expanded: boolean) => void;
+}
+
+// ============================================================================
+// Claim-status presentation (status-dot idiom, GameConsole vocabulary)
+// ============================================================================
+// HARD RULE (anti-masquerade): status comes ONLY from `row.claimStatus` — the
+// semantic module's verdict. Never derive status from layer presence (a row
+// can have plenty of layers and still be unresolved; a debug mask being
+// present proves nothing). The dot is aria-hidden; the WORD is the accessible
+// signal.
+const CLAIM_STATUS_DOT: Readonly<Record<RiverLakeInspectorClaimStatus, string>> = {
+  pass: 'bg-success',
+  available: 'bg-primary',
+  fail: 'bg-destructive',
+  unresolved: 'bg-warning',
+  'out-of-scope': 'bg-muted-foreground'
+};
+const CLAIM_STATUS_WORD: Readonly<Record<RiverLakeInspectorClaimStatus, string>> = {
+  pass: 'ready',
+  available: 'inspect',
+  fail: 'fail',
+  unresolved: 'open',
+  'out-of-scope': 'skip'
+};
+
+const formatCountLabel = (key: string): string => {
+  switch (key) {
+    case 'layers':
+      return 'layers';
+    case 'default':
+      return 'shown';
+    case 'debug':
+      return 'debug';
+    default:
+      return key;
+  }
+};
+
+const formatLayerButtonLabel = (ref: RiverLakeInspectorLayerRef): string => {
+  if (ref.dataTypeKey.includes('projectedRiverMask')) return 'projected';
+  if (ref.dataTypeKey.includes('plannedMinorRiverMask')) return 'minor';
+  if (ref.dataTypeKey.includes('plannedMajorRiverMask')) return 'major';
+  if (ref.dataTypeKey.includes('engineRiverMask')) return 'terrain';
+  if (ref.dataTypeKey.includes('Metadata')) return 'metadata';
+  if (ref.dataTypeKey.includes('engineMinorRiverMask')) return 'minor meta';
+  if (ref.dataTypeKey.includes('riverMismatchMask')) return 'mismatch';
+  if (ref.dataTypeKey.includes('lakePlan')) return 'lake plan';
+  if (ref.dataTypeKey.includes('plannedLakeMask')) return 'planned';
+  if (ref.dataTypeKey.includes('engineLakeMask')) return 'engine';
+  if (ref.dataTypeKey.includes('rejectedLakeMask')) return 'rejected';
+  if (ref.dataTypeKey.includes('featureType')) return 'features';
+  if (ref.dataTypeKey.includes('rejectionMask')) return 'rejects';
+  const parts = ref.dataTypeKey.split('.');
+  return parts[parts.length - 1] ?? ref.dataTypeKey;
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+/**
+ * Water-proof inspector: one row per truth-class claim about rivers, lakes,
+ * and floodplains, grouped into 8 lanes (Hydrology, Projection, Terrain,
+ * Metadata, Lakes, Floodplains, Rendered, Acceptance). Each lane answers a
+ * DIFFERENT question — "did Hydrology compute rivers?" is not "did the engine
+ * accept them?" is not "does the player see them?" — so a green check on one
+ * lane must never masquerade as proof of another.
+ *
+ * That is why projection-class evidence never renders success-green: a
+ * projection plan being PRESENT only makes it `available` (inspectable,
+ * `bg-primary`); `pass`/`bg-success` is reserved for claims the semantic
+ * module actually verified. Rows whose proof cannot come from Studio manifest
+ * layers at all (rendered Civ visibility, product acceptance) stay
+ * `unresolved`/`open` until same-run external evidence closes them.
+ */
+export const WaterProofSection: React.FC<WaterProofSectionProps> = ({
+  summary,
+  onLayerSelect,
+  expanded,
+  onExpandedChange
+}) => {
+  const rows = summary?.rows ?? [];
+  if (!summary || rows.length === 0) return null;
+
+  const textSecondary = 'text-muted-foreground';
+  const textMuted = 'text-muted-foreground/70';
+  const borderSubtle = 'border-border-subtle';
+  const hoverBg = 'hover:bg-accent';
+
+  const evidenceCount = rows.filter(
+    (row) => row.claimStatus === 'available' || row.claimStatus === 'pass'
+  ).length;
+  const openCount = rows.filter(
+    (row) => row.claimStatus === 'unresolved' || row.claimStatus === 'fail'
+  ).length;
+  const collapsedSummary = `${evidenceCount} evidence · ${openCount} open`;
+
+  return (
+    <>
+      <div className={`flex-shrink-0 border-b ${borderSubtle}`}>
+        <button
+          type="button"
+          onClick={() => onExpandedChange(!expanded)}
+          aria-expanded={expanded}
+          aria-controls="explore-water-proof-list"
+          className={`w-full flex items-center justify-between px-3 py-2 transition-colors ${hoverBg}`}>
+
+          <div className="flex items-center gap-2 min-w-0 overflow-hidden">
+            <Droplets className={`w-3.5 h-3.5 shrink-0 ${textSecondary}`} />
+            <span className={`text-data font-semibold ${textSecondary} uppercase tracking-wider`}>
+              Water proof
+            </span>
+            {!expanded ? (
+              <span className={`text-label ${textMuted} truncate`}>
+                {collapsedSummary}
+              </span>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <span className={`text-label ${textMuted}`}>{rows.length}</span>
+            <ChevronDown className={`w-3.5 h-3.5 ${textMuted} transition-transform ${expanded ? "rotate-180" : ""}`} />
+          </div>
+        </button>
+      </div>
+      {expanded ? (
+        <div
+          id="explore-water-proof-list"
+          className={`flex-shrink-0 border-b ${borderSubtle} max-h-[260px] overflow-y-auto custom-scrollbar`}>
+          {rows.map((row) => (
+            <div key={row.rowKey} className={`px-3 py-2 border-b last:border-b-0 ${borderSubtle}`}>
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className={`text-label uppercase tracking-wider ${textMuted}`}>
+                    {row.laneLabel}
+                  </div>
+                  <div className="text-data font-medium text-foreground truncate" title={row.displayStatus}>
+                    {row.label}
+                  </div>
+                </div>
+                <span className="flex items-center gap-1.5 shrink-0 pt-0.5">
+                  <span
+                    aria-hidden="true"
+                    className={`h-1.5 w-1.5 rounded-full ${CLAIM_STATUS_DOT[row.claimStatus]}`}
+                  />
+                  <span className={`text-label font-semibold uppercase tracking-wider ${textSecondary}`}>
+                    {CLAIM_STATUS_WORD[row.claimStatus]}
+                  </span>
+                </span>
+              </div>
+              <div className="mt-1 flex flex-wrap items-center gap-1">
+                {Object.entries(row.counts).map(([key, value]) => (
+                  <span key={key} className="rounded px-1.5 py-0.5 text-label bg-muted/50 text-muted-foreground">
+                    {formatCountLabel(key)} {value}
+                  </span>
+                ))}
+                {row.layerRefs.slice(0, 4).map((ref) => {
+                  const refTitle = `${ref.label} · ${ref.presentation.categoryLabel} · ${row.proofClass}`;
+                  return (
+                    <Tooltip key={ref.layerKey}>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => onLayerSelect?.(ref)}
+                          aria-label={refTitle}
+                          className="inline-flex max-w-[112px] items-center gap-1 truncate rounded px-1.5 py-0.5 text-label transition-colors bg-input-background border border-border-subtle text-muted-foreground hover:bg-accent hover:text-foreground">
+                          {/* Module-owned DATA color: the palette hue travels with
+                              the semantic layer ref (it matches how the mask renders
+                              on the map), so an inline style is legal here per the
+                              system.md data-color rule — it is matter, not chrome. */}
+                          <span
+                            aria-hidden="true"
+                            className="h-1.5 w-1.5 shrink-0 rounded-full"
+                            style={{ background: ref.presentation.palette.activeColor }}
+                          />
+                          <span className="truncate">{formatLayerButtonLabel(ref)}</span>
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>{refTitle}</TooltipContent>
+                    </Tooltip>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </>);
+
+};

--- a/apps/mapgen-studio/src/ui/components/index.ts
+++ b/apps/mapgen-studio/src/ui/components/index.ts
@@ -13,6 +13,7 @@ export { GameConsole, type GameConsoleProps, type GameConsoleLiveRuntime } from 
 // Panel components
 export { RecipePanel, type RecipePanelProps } from './RecipePanel';
 export { ExplorePanel, type ExplorePanelProps } from './ExplorePanel';
+export { WaterProofSection, type WaterProofSectionProps } from './WaterProofSection';
 
 // Form components
 export { ViewControls, type ViewControlsProps } from './ViewControls';

--- a/apps/mapgen-studio/test/viz/inspectorSelection.test.ts
+++ b/apps/mapgen-studio/test/viz/inspectorSelection.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  applyRiverLakeInspectorSelection,
+  type RiverLakeInspectorSelectionPorts,
+} from "../../src/features/viz/inspectorSelection";
+import type { RiverLakeInspectorLayerRef } from "../../src/features/viz/riverLakeInspector";
+
+function makeRef(overrides: Partial<RiverLakeInspectorLayerRef> = {}): RiverLakeInspectorLayerRef {
+  return {
+    dataTypeKey: "map.rivers.projectedRiverMask",
+    layerKey: "step-a::map.rivers.projectedRiverMask::tile.hexOddQ::grid",
+    stepId: "stage-1.step-a",
+    stepIndex: 1,
+    spaceId: "tile.hexOddQ",
+    kind: "grid",
+    role: "projection",
+    variantKey: null,
+    visibility: "default",
+    label: "Projected river mask",
+    renderModeId: "grid:projection",
+    nonZeroCount: 12,
+    sampleCount: 100,
+    presentation: {
+      category: "navigable-projection",
+      categoryLabel: "Projection plan",
+      palette: {
+        paletteId: "river-projection-teal",
+        label: "Projection plan",
+        activeColor: "#0f766e",
+        inactiveColor: "#ccfbf1",
+        debugColor: "#134e4a",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makePorts(
+  stages: RiverLakeInspectorSelectionPorts["stages"]
+): RiverLakeInspectorSelectionPorts & {
+  setSelectedStageId: ReturnType<typeof vi.fn>;
+  setSelectedStepId: ReturnType<typeof vi.fn>;
+  setShowDebugLayers: ReturnType<typeof vi.fn>;
+  setVizSelectedStepId: ReturnType<typeof vi.fn>;
+  setVizSelectedLayerKey: ReturnType<typeof vi.fn>;
+} {
+  return {
+    stages,
+    setSelectedStageId: vi.fn(),
+    setSelectedStepId: vi.fn(),
+    setShowDebugLayers: vi.fn(),
+    setVizSelectedStepId: vi.fn(),
+    setVizSelectedLayerKey: vi.fn(),
+  };
+}
+
+const STAGES = [
+  { stageId: "stage-0", steps: [{ fullStepId: "stage-0.other" }] },
+  { stageId: "stage-1", steps: [{ fullStepId: "stage-1.step-a" }, { fullStepId: "stage-1.step-b" }] },
+];
+
+describe("applyRiverLakeInspectorSelection", () => {
+  it("sets the stage, step, viz step, and viz layer for the evidence layer", () => {
+    const ports = makePorts(STAGES);
+    const ref = makeRef();
+
+    applyRiverLakeInspectorSelection(ref, ports);
+
+    expect(ports.setSelectedStageId).toHaveBeenCalledWith("stage-1");
+    expect(ports.setSelectedStepId).toHaveBeenCalledWith("stage-1.step-a");
+    expect(ports.setVizSelectedStepId).toHaveBeenCalledWith("stage-1.step-a");
+    expect(ports.setVizSelectedLayerKey).toHaveBeenCalledWith(ref.layerKey);
+    expect(ports.setShowDebugLayers).not.toHaveBeenCalled();
+  });
+
+  it("forces debug layers visible ONLY for debug-class evidence", () => {
+    const debugPorts = makePorts(STAGES);
+    applyRiverLakeInspectorSelection(makeRef({ visibility: "debug" }), debugPorts);
+    expect(debugPorts.setShowDebugLayers).toHaveBeenCalledWith(true);
+
+    const hiddenPorts = makePorts(STAGES);
+    applyRiverLakeInspectorSelection(makeRef({ visibility: "hidden" }), hiddenPorts);
+    expect(hiddenPorts.setShowDebugLayers).not.toHaveBeenCalled();
+  });
+
+  it("skips stage/step selection when no stage contains the step but still selects the viz layer", () => {
+    const ports = makePorts(STAGES);
+    const ref = makeRef({ stepId: "stale-recipe.unknown-step" });
+
+    applyRiverLakeInspectorSelection(ref, ports);
+
+    expect(ports.setSelectedStageId).not.toHaveBeenCalled();
+    expect(ports.setSelectedStepId).not.toHaveBeenCalled();
+    expect(ports.setVizSelectedStepId).toHaveBeenCalledWith("stale-recipe.unknown-step");
+    expect(ports.setVizSelectedLayerKey).toHaveBeenCalledWith(ref.layerKey);
+
+    const noStagesPorts = makePorts(undefined);
+    applyRiverLakeInspectorSelection(makeRef(), noStagesPorts);
+    expect(noStagesPorts.setSelectedStageId).not.toHaveBeenCalled();
+    expect(noStagesPorts.setVizSelectedLayerKey).toHaveBeenCalledWith(makeRef().layerKey);
+  });
+});

--- a/apps/mapgen-studio/test/viz/waterProofSection.test.tsx
+++ b/apps/mapgen-studio/test/viz/waterProofSection.test.tsx
@@ -1,0 +1,161 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { WaterProofSection, type WaterProofSectionProps } from "../../src/ui/components/WaterProofSection";
+import { TooltipProvider } from "../../src/components/ui/tooltip";
+import type {
+  RiverLakeFloodplainInspectorSummary,
+  RiverLakeInspectorClaimStatus,
+  RiverLakeInspectorLayerRef,
+  RiverLakeInspectorRow,
+} from "../../src/features/viz/riverLakeInspector";
+
+// The water-proof section is the redesigned ExplorePanel's home for the
+// River/Lake/Floodplain inspector. These pins guard the anti-masquerade rule:
+// the status WORD + dot derive ONLY from `row.claimStatus`, never from layer
+// presence, and `available` (evidence present, unverified) must never wear
+// success-green.
+
+function makeRef(overrides: Partial<RiverLakeInspectorLayerRef> = {}): RiverLakeInspectorLayerRef {
+  return {
+    dataTypeKey: "map.rivers.projectedRiverMask",
+    layerKey: "step-a::map.rivers.projectedRiverMask::tile.hexOddQ::grid",
+    stepId: "step-a",
+    stepIndex: 1,
+    spaceId: "tile.hexOddQ",
+    kind: "grid",
+    role: "projection",
+    variantKey: null,
+    visibility: "default",
+    label: "Projected river mask",
+    renderModeId: "grid:projection",
+    nonZeroCount: 12,
+    sampleCount: 100,
+    presentation: {
+      category: "navigable-projection",
+      categoryLabel: "Projection plan",
+      palette: {
+        paletteId: "river-projection-teal",
+        label: "Projection plan",
+        activeColor: "#0f766e",
+        inactiveColor: "#ccfbf1",
+        debugColor: "#134e4a",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeRow(overrides: Partial<RiverLakeInspectorRow> = {}): RiverLakeInspectorRow {
+  return {
+    rowKey: "projection-plan",
+    lane: "projection",
+    laneLabel: "Projection",
+    label: "Navigable river plan",
+    proofClass: "projection-plan",
+    claimStatus: "available",
+    displayStatus: "projection-plan-present",
+    counts: { layers: 1, projected: 12 },
+    layerRefs: [makeRef()],
+    evidence: ["The projected navigable-river mask is present."],
+    ...overrides,
+  };
+}
+
+function makeSummary(rows: readonly RiverLakeInspectorRow[]): RiverLakeFloodplainInspectorSummary {
+  return { version: 1, rows };
+}
+
+function renderSection(overrides: Partial<WaterProofSectionProps> = {}) {
+  return renderToStaticMarkup(
+    <TooltipProvider>
+      <WaterProofSection
+        summary={makeSummary([makeRow()])}
+        onLayerSelect={vi.fn()}
+        expanded
+        onExpandedChange={vi.fn()}
+        {...overrides}
+      />
+    </TooltipProvider>
+  );
+}
+
+function singleStatusRow(claimStatus: RiverLakeInspectorClaimStatus) {
+  return renderSection({ summary: makeSummary([makeRow({ claimStatus })]) });
+}
+
+describe("WaterProofSection", () => {
+  it("renders the lane eyebrow and row label for each row", () => {
+    const html = renderSection({
+      summary: makeSummary([
+        makeRow(),
+        makeRow({
+          rowKey: "hydrology-truth",
+          lane: "hydrology",
+          laneLabel: "Hydrology",
+          label: "Drainage truth",
+          proofClass: "hydrology-truth",
+        }),
+      ]),
+    });
+
+    expect(html).toContain("Projection");
+    expect(html).toContain("Navigable river plan");
+    expect(html).toContain("Hydrology");
+    expect(html).toContain("Drainage truth");
+  });
+
+  it("renders available as the word inspect and never masquerades as success", () => {
+    const html = singleStatusRow("available");
+    expect(html).toContain("inspect");
+    // Anti-masquerade pin: evidence being PRESENT is not a verified pass.
+    expect(html).not.toContain("bg-success");
+  });
+
+  it("renders unresolved as open with the warning dot", () => {
+    const html = singleStatusRow("unresolved");
+    expect(html).toContain("open");
+    expect(html).toContain("bg-warning");
+  });
+
+  it("renders fail with the destructive dot", () => {
+    const html = singleStatusRow("fail");
+    expect(html).toContain(">fail<");
+    expect(html).toContain("bg-destructive");
+  });
+
+  it("renders pass as ready with the success dot", () => {
+    const html = singleStatusRow("pass");
+    expect(html).toContain("ready");
+    expect(html).toContain("bg-success");
+  });
+
+  it("renders nothing when the summary is null or empty", () => {
+    expect(renderSection({ summary: null })).toBe("");
+    expect(renderSection({ summary: makeSummary([]) })).toBe("");
+  });
+
+  it("hides the row list when collapsed but keeps the header inline summary", () => {
+    const html = renderSection({
+      expanded: false,
+      summary: makeSummary([
+        makeRow(),
+        makeRow({ rowKey: "civ-rendered", laneLabel: "Rendered", label: "In-game visible rivers", claimStatus: "unresolved" }),
+      ]),
+    });
+
+    expect(html).toContain("Water proof");
+    expect(html).toContain("1 evidence · 1 open");
+    // The header keeps aria-controls pointing at the list id; the list element
+    // itself (and its rows) must be gone when collapsed.
+    expect(html).not.toContain('id="explore-water-proof-list"');
+    expect(html).not.toContain("Navigable river plan");
+  });
+
+  it("gives layer chips an accessible name carrying the category label", () => {
+    const html = renderSection();
+    expect(html).toContain(
+      'aria-label="Projected river mask · Projection plan · projection-plan"'
+    );
+  });
+});


### PR DESCRIPTION
Re-expresses main's River/Lake/Floodplain inspector surface in the design
system (restack handoff §1.4): 11 truth-lane rows (Hydrology / Projection /
Terrain / Metadata / Lakes / Floodplains / Rendered / Acceptance) rendered
as a collapsible Water proof section between Step and Layers, status-dot +
word per claim status with the anti-masquerade rule (projection evidence
renders 'inspect', never success-green), module-owned data-color layer
chips that jump explore selection to the evidence layer (debug layers
force-shown for debug-class refs). Live-verified: 11 rows, layer jump
Mesh→Rivers with Hydrology layers loaded.