### PR TITLE
refactor(studio-server): oRPC-native typed contract errors — declared .errors() maps, host-context defined-error mapping, client safe()/isDefinedError; delete all error wrappers

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -1454,7 +1454,7 @@ export function StudioShell(props: StudioShellProps) {
           recoveryActions: ["copy-diagnostics", "retry-status", "retry-run"],
           details: {
             failureClass: "uncertain",
-            code: result.statusCode === 404 ? "operation-status-missing" : "operation-status-unavailable",
+            code: result.code === "RUN_IN_GAME_STATUS_NOT_FOUND" ? "operation-status-missing" : "operation-status-unavailable",
             phase: "uncertain",
             completedPhases: prev.completedPhases,
           },
@@ -1477,7 +1477,7 @@ export function StudioShell(props: StudioShellProps) {
           phase: "failed",
           error: result.error,
           details: {
-            code: result.statusCode === 404 ? "operation-status-missing" : "operation-status-unavailable",
+            code: result.code === "SAVE_DEPLOY_STATUS_NOT_FOUND" ? "operation-status-missing" : "operation-status-unavailable",
           },
         });
       });

--- a/apps/mapgen-studio/src/app/hooks/useSetupDataQueries.ts
+++ b/apps/mapgen-studio/src/app/hooks/useSetupDataQueries.ts
@@ -20,9 +20,13 @@ import { orpc } from "../../lib/orpc";
  *   then `"ok"` / `"error"`; `updatedAt`/`observedAt` fall back to the body value then
  *   `new Date().toISOString()`, exactly as the prior wrappers did.
  *
- * The oRPC client throws `ORPCError` on failure, which `useQuery` surfaces as `error`;
- * the non-uniform status code is not consumed by these reads (the legacy wrappers only
- * read `error`/`observedAt` here), so it is intentionally not threaded through.
+ * The oRPC client throws the contract's DEFINED errors on failure
+ * (SAVED_CONFIGS_UNAVAILABLE / SETUP_CATALOG_UNAVAILABLE — see
+ * packages/studio-server/src/contract/errors.ts), which `useQuery` surfaces as
+ * `error`. These views only consume the message (the legacy wrappers only read
+ * `error`/`observedAt` here), so the typed code/data are intentionally not
+ * threaded through — `errorMessage` below is a plain message fallback, not an
+ * oRPC extraction wrapper.
  */
 
 export type SavedSetupConfigsView = {

--- a/apps/mapgen-studio/src/features/civ7Setup/api.ts
+++ b/apps/mapgen-studio/src/features/civ7Setup/api.ts
@@ -3,16 +3,15 @@
 //
 // EVERYTHING talks oRPC (FRAME §4.7): these callers speak the studio's own
 // `@civ7/studio-server` contract through the typed oRPC client (`src/lib/orpc.ts`)
-// — there is NO manual `fetch` of `/api/*` here anymore. The request shapes, the
-// optional abort signal, and the per-endpoint error/status-code RESULT shapes are
-// preserved verbatim from the previous hand-rolled fetch wrappers: the transport
-// moved from `fetch` to the oRPC client, the returned `{ ok, error, statusCode,
-// observedAt }` envelopes did not. The non-uniform per-procedure status codes
-// (setup-config → 503, saved-configs/setup-catalog → 500) survive because the
-// router maps them onto `ORPCError.status`, which we read back below.
-import { ORPCError } from "@orpc/client";
+// — there is NO manual `fetch` of `/api/*` here anymore. Failures are read through
+// oRPC's NATIVE typed contract errors: `safe(...)` + `isDefinedError(...)` expose
+// the DECLARED code (e.g. `SETUP_CONFIG_UNAVAILABLE`, status 503 pinned in
+// packages/studio-server/src/contract/errors.ts) and its typed `data`
+// (`observedAt`), so the failure envelope carries `{ error, code?, observedAt? }`
+// instead of a raw transport status code.
+import { isDefinedError, safe } from "@orpc/client";
 
-import { orpcClient, readErrorData } from "../../lib/orpc";
+import { orpcClient } from "../../lib/orpc";
 import type { Civ7SetupSnapshotLike } from "./setupConfig";
 
 export type Civ7SetupCatalogOption = Readonly<{
@@ -30,50 +29,37 @@ export type Civ7SetupCatalog = Readonly<{
   gameSpeeds: ReadonlyArray<Civ7SetupCatalogOption>;
 }>;
 
-/**
- * Translate a thrown oRPC client error into the legacy failure envelope fields.
- *
- * The studio-server router re-throws per-procedure `ORPCError`s whose `status`
- * pins the legacy HTTP code and whose `data` carries the extra body fields
- * (`observedAt`, …). A non-`ORPCError` throw (e.g. the link could not reach the
- * dev server) maps to the same `err instanceof Error ? err.message : fallback`
- * shape the old `catch` blocks used, with no `statusCode`.
- */
-function orpcFailure(
-  err: unknown,
-  fallback: string,
-): { error: string; statusCode?: number; observedAt?: string } {
-  if (err instanceof ORPCError) {
-    // `observedAt` rides in the error body for setupConfig (503) and savedConfigs
-    // (500) — the router attaches it via `orpcError(…, { observedAt })`.
-    const data = readErrorData<{ observedAt: string }>(err);
-    return {
-      error: err.message || `HTTP ${err.status}`,
-      statusCode: err.status,
-      ...(typeof data?.observedAt === "string" ? { observedAt: data.observedAt } : {}),
-    };
-  }
-  return { error: err instanceof Error ? err.message : fallback };
-}
-
 export async function fetchCiv7SetupConfig(options: { signal?: AbortSignal } = {}): Promise<
   | { ok: true; observedAt: string; setup: Civ7SetupSnapshotLike }
-  | { ok: false; error: string; observedAt?: string; statusCode?: number }
+  | { ok: false; error: string; observedAt?: string; code?: string }
 > {
-  try {
-    const body = await orpcClient.civ7.setupConfig(
-      {},
-      options.signal ? { signal: options.signal } : undefined,
-    );
+  const { error, data } = await safe(
+    orpcClient.civ7.setupConfig({}, options.signal ? { signal: options.signal } : undefined),
+  );
+  if (error) {
+    if (isDefinedError(error)) {
+      // `observedAt` rides in the typed error data for the DECLARED
+      // SETUP_CONFIG_UNAVAILABLE (503) failure.
+      return {
+        ok: false,
+        error: error.message || "Civ7 setup config unavailable",
+        code: error.code,
+        ...(typeof error.data?.observedAt === "string"
+          ? { observedAt: error.data.observedAt }
+          : {}),
+      };
+    }
     return {
-      ok: true,
-      // Contract-required on the success body (civ7.setupConfig output: isoTimestamp).
-      observedAt: body.observedAt,
-      setup: body.setup as Civ7SetupSnapshotLike,
+      ok: false,
+      error: error instanceof Error && error.message ? error.message : "Civ7 setup config unavailable",
     };
-  } catch (err) {
-    return { ok: false, ...orpcFailure(err, "Civ7 setup config unavailable") };
   }
+  return {
+    ok: true,
+    // Contract-required on the success body (civ7.setupConfig output: isoTimestamp).
+    observedAt: data.observedAt,
+    setup: data.setup as Civ7SetupSnapshotLike,
+  };
 }
 
 // NOTE: The saved-configs and setup-catalog READS are served directly by the
@@ -91,25 +77,28 @@ export async function requestCiv7Autoplay(action: "start" | "stop"): Promise<{
   game?: { turn?: { ok?: boolean; value?: number } };
   error?: string;
 }> {
-  try {
-    const body = await orpcClient.civ7.autoplay({ action });
-    // Parity: the autoplay procedure returns 200 with `ok = result.verified`, so a
-    // succeeded-transport-but-unverified action still surfaces as `{ ok:false }`
-    // (the legacy handler returned `{ ok:false, error }` when `body.ok` was falsy).
-    if (!body.ok) {
-      return { ok: false, error: "Civ7 autoplay request failed" };
-    }
+  const { error, data: body } = await safe(orpcClient.civ7.autoplay({ action }));
+  if (error) {
     return {
-      ok: true,
-      action: body.action,
-      autoplay: body.autoplay as {
-        isActive?: boolean;
-        isPaused?: boolean;
-        isPausedOrPending?: boolean;
-      },
-      game: body.game as { turn?: { ok?: boolean; value?: number } },
+      ok: false,
+      error:
+        error instanceof Error && error.message ? error.message : "Civ7 autoplay request failed",
     };
-  } catch (err) {
-    return { ok: false, error: orpcFailure(err, "Civ7 autoplay request failed").error };
   }
+  // Parity: the autoplay procedure returns 200 with `ok = result.verified`, so a
+  // succeeded-transport-but-unverified action still surfaces as `{ ok:false }`
+  // (the legacy handler returned `{ ok:false, error }` when `body.ok` was falsy).
+  if (!body.ok) {
+    return { ok: false, error: "Civ7 autoplay request failed" };
+  }
+  return {
+    ok: true,
+    action: body.action,
+    autoplay: body.autoplay as {
+      isActive?: boolean;
+      isPaused?: boolean;
+      isPausedOrPending?: boolean;
+    },
+    game: body.game as { turn?: { ok?: boolean; value?: number } },
+  };
 }

--- a/apps/mapgen-studio/src/features/mapConfigSave/api.ts
+++ b/apps/mapgen-studio/src/features/mapConfigSave/api.ts
@@ -3,12 +3,14 @@
 // EVERYTHING talks oRPC (FRAME §4.7): these callers speak the studio's own
 // `@civ7/studio-server` contract through the typed oRPC client (`src/lib/orpc.ts`)
 // — there is NO manual `fetch` of `/api/map-configs*` here anymore. The request
-// shapes, the running-status poll loop, the error handling, and the localStorage
-// key string are preserved verbatim (localStorage contract is hard-core parity):
-// only the transport moved from `fetch` to the oRPC client. The non-uniform error
-// codes (saveDeploy validation → 400, status miss → 404) survive on
-// `ORPCError.status`.
-import { ORPCError } from "@orpc/client";
+// shapes, the running-status poll loop, and the localStorage key string are
+// preserved verbatim (localStorage contract is hard-core parity). Failures are
+// read through oRPC's NATIVE typed contract errors: `safe(...)` +
+// `isDefinedError(...)` expose the DECLARED code
+// (SAVE_DEPLOY_BLOCKED/INVALID/FAILED/STATUS_NOT_FOUND, statuses pinned in
+// packages/studio-server/src/contract/errors.ts) — the status-miss branch is
+// `code === "SAVE_DEPLOY_STATUS_NOT_FOUND"` instead of a raw 404.
+import { isDefinedError, safe } from "@orpc/client";
 
 import { orpcClient } from "../../lib/orpc";
 import { delay } from "../../shared/async";
@@ -25,23 +27,21 @@ export function toConfigId(label: string): string {
   return id || `map-config-${Date.now()}`;
 }
 
-/** Map a thrown oRPC client error to `{ error, statusCode }` (legacy code via `ORPCError.status`). */
-function saveDeployFailure(err: unknown, fallback: string): { error: string; statusCode?: number } {
-  if (err instanceof ORPCError) {
-    return { error: err.message || `HTTP ${err.status}`, statusCode: err.status };
-  }
-  return { error: err instanceof Error ? err.message : fallback };
-}
-
 export async function fetchMapConfigSaveDeployStatus(
   requestId: string,
-): Promise<MapConfigSaveDeployStatus | { ok: false; error: string; statusCode?: number }> {
-  try {
-    const body = await orpcClient.mapConfigs.status({ requestId });
-    return body as MapConfigSaveDeployStatus;
-  } catch (err) {
-    return { ok: false, ...saveDeployFailure(err, "Save/Deploy status unavailable") };
+): Promise<MapConfigSaveDeployStatus | { ok: false; error: string; code?: string }> {
+  const { error, data } = await safe(orpcClient.mapConfigs.status({ requestId }));
+  if (error) {
+    return {
+      ok: false,
+      error:
+        error instanceof Error && error.message
+          ? error.message
+          : "Save/Deploy status unavailable",
+      ...(isDefinedError(error) ? { code: error.code } : {}),
+    };
   }
+  return data as MapConfigSaveDeployStatus;
 }
 
 export async function saveRepoBackedConfig(args: {
@@ -72,20 +72,27 @@ export async function saveRepoBackedConfig(args: {
     config: args.config,
   };
   try {
-    let status: MapConfigSaveDeployStatus;
-    try {
-      status = (await orpcClient.mapConfigs.saveDeploy({
+    const saveResult = await safe(
+      orpcClient.mapConfigs.saveDeploy({
         requestId: args.requestId,
         id: args.id,
         sourcePath: args.sourcePath,
         envelope,
-      })) as MapConfigSaveDeployStatus;
-    } catch (err) {
+      }),
+    );
+    if (saveResult.error) {
       // Parity: a saveDeploy throw carried `path` in the legacy body when present;
       // the oRPC error data does not, so we surface the failure without a path
       // (the engine only attaches `path` to the in-progress status, polled below).
-      return { ok: false, ...saveDeployFailure(err, "Repo config save failed") };
+      return {
+        ok: false,
+        error:
+          saveResult.error instanceof Error && saveResult.error.message
+            ? saveResult.error.message
+            : "Repo config save failed",
+      };
     }
+    let status: MapConfigSaveDeployStatus = saveResult.data as MapConfigSaveDeployStatus;
     args.onStatus?.(status);
     while (status.status === "running") {
       await delay(500);

--- a/apps/mapgen-studio/src/features/runInGame/api.ts
+++ b/apps/mapgen-studio/src/features/runInGame/api.ts
@@ -3,41 +3,31 @@
 // EVERYTHING talks oRPC (FRAME §4.7): these callers speak the studio's own
 // `@civ7/studio-server` contract through the typed oRPC client (`src/lib/orpc.ts`)
 // — there is NO manual `fetch` of `/api/*` here anymore. The request body shape
-// (including the `assertNoRawControlFields`-protected payload assembled here), the
-// non-uniform error handling, and the status-code propagation are preserved
-// verbatim: the transport moved from `fetch` to the oRPC client; the request
-// envelope, the result shapes, and the 404 `statusCode` the caller uses for
-// server-restart detection did not. The router pins the legacy HTTP code on
-// `ORPCError.status` and carries `details` (and the 404 server-id echo) in
-// `ORPCError.data`, which we read back below.
-import { ORPCError } from "@orpc/client";
+// (including the `assertNoRawControlFields`-protected payload assembled here) is
+// preserved verbatim; failures are read through oRPC's NATIVE typed contract
+// errors: `safe(...)` + `isDefinedError(...)` expose the DECLARED code
+// (RUN_IN_GAME_BLOCKED/INVALID/FAILED/UNAVAILABLE/STATUS_NOT_FOUND, statuses
+// pinned in packages/studio-server/src/contract/errors.ts) and its typed `data`
+// (`details`, and the STATUS_NOT_FOUND server-identity echo). The caller's
+// server-restart detection branches on `code === "RUN_IN_GAME_STATUS_NOT_FOUND"`
+// instead of a raw 404 status code.
+import { isDefinedError, safe } from "@orpc/client";
 
-import { orpcClient, readErrorData } from "../../lib/orpc";
+import { orpcClient } from "../../lib/orpc";
 import { normalizeStudioSetupConfig, type Civ7StudioSetupConfig } from "../civ7Setup/setupConfig";
 import type { RunInGameFailureDetails, RunInGameOperationStatus } from "./status";
 
 /**
- * Translate a thrown oRPC client error into the legacy run-in-game failure
- * envelope. `ORPCError.status` is the pinned legacy HTTP code (used for the 404
- * restart-detection branch in `App.tsx`); `ORPCError.data.details` carries the
- * `RunInGameFailureDetails` the engine attached. A non-`ORPCError` throw maps to
- * the bare `err.message` shape the old `catch` block produced (no `statusCode`).
+ * Read the engine-attached `RunInGameFailureDetails` from a defined error's typed
+ * `data`. The runInGame error map's `data` is a union (`{ details? }` for the
+ * engine failures, the server-identity echo for STATUS_NOT_FOUND), so the read is
+ * runtime-guarded rather than property-accessed across the union.
  */
-function runInGameFailure(
-  err: unknown,
-  fallback: string,
-): { error: string; details?: RunInGameFailureDetails; statusCode?: number } {
-  if (err instanceof ORPCError) {
-    // `details` (the `RunInGameFailureDetails` the engine attached) rides in the
-    // error body; the router carries it via `ORPCError.data`.
-    const data = readErrorData<{ details: RunInGameFailureDetails }>(err);
-    return {
-      error: err.message || `HTTP ${err.status}`,
-      statusCode: err.status,
-      ...(data?.details !== undefined ? { details: data.details } : {}),
-    };
+function definedErrorDetails(data: unknown): RunInGameFailureDetails | undefined {
+  if (data && typeof data === "object" && "details" in data) {
+    return (data as { details?: RunInGameFailureDetails }).details;
   }
-  return { error: err instanceof Error ? err.message : fallback };
+  return undefined;
 }
 
 export async function runCurrentConfigInGame(args: {
@@ -64,50 +54,64 @@ export async function runCurrentConfigInGame(args: {
   sourceSnapshot?: unknown;
 }): Promise<
   | RunInGameOperationStatus
-  | { ok: false; error: string; details?: RunInGameFailureDetails; statusCode?: number }
+  | { ok: false; error: string; details?: RunInGameFailureDetails; code?: string }
 > {
-  try {
-    // The request envelope is assembled exactly as before (the server runs
-    // `assertNoRawControlFields` over it); only the transport is the oRPC client.
-    // The legacy handler posted `selectedConfig` verbatim (its `id` may be absent
-    // for disposable runs) and `parseRunInGameSetupRequest` tolerates that, so we
-    // pass it through the permissive (`.catchall`) start input unchanged.
-    // The request envelope type-checks directly against the start input now that
-    // `selectedConfig.id` is optional in the contract (a disposable run sends
-    // `selectedConfig` without an `id`). No `as unknown as Parameters<…>` cast — the
-    // `assertNoRawControlFields`-protected payload is fully input-typed end to end.
-    const request: Parameters<typeof orpcClient.runInGame.start>[0] = {
-      recipeId: args.recipeId,
-      seed: args.seed,
-      mapSize: args.mapSize,
-      playerCount: args.playerCount,
-      resources: args.resources,
-      setupConfig: normalizeStudioSetupConfig(args.setupConfig),
-      materialization: { mode: args.materializationMode },
-      ...(args.restartCivProcess ? { recovery: { restartCivProcess: true } } : {}),
-      ...(args.selectedConfig ? { selectedConfig: args.selectedConfig } : {}),
-      config: args.config,
-      sourceSnapshot: args.sourceSnapshot,
+  // The request envelope is assembled exactly as before (the server runs
+  // `assertNoRawControlFields` over it); only the transport is the oRPC client.
+  // The legacy handler posted `selectedConfig` verbatim (its `id` may be absent
+  // for disposable runs) and `parseRunInGameSetupRequest` tolerates that, so we
+  // pass it through the permissive (`.catchall`) start input unchanged.
+  // The request envelope type-checks directly against the start input now that
+  // `selectedConfig.id` is optional in the contract (a disposable run sends
+  // `selectedConfig` without an `id`). No `as unknown as Parameters<…>` cast — the
+  // `assertNoRawControlFields`-protected payload is fully input-typed end to end.
+  const request: Parameters<typeof orpcClient.runInGame.start>[0] = {
+    recipeId: args.recipeId,
+    seed: args.seed,
+    mapSize: args.mapSize,
+    playerCount: args.playerCount,
+    resources: args.resources,
+    setupConfig: normalizeStudioSetupConfig(args.setupConfig),
+    materialization: { mode: args.materializationMode },
+    ...(args.restartCivProcess ? { recovery: { restartCivProcess: true } } : {}),
+    ...(args.selectedConfig ? { selectedConfig: args.selectedConfig } : {}),
+    config: args.config,
+    sourceSnapshot: args.sourceSnapshot,
+  };
+  const { error, data } = await safe(orpcClient.runInGame.start(request));
+  if (error) {
+    if (isDefinedError(error)) {
+      const details = definedErrorDetails(error.data);
+      return {
+        ok: false,
+        error: error.message || "Run in Game failed",
+        code: error.code,
+        ...(details !== undefined ? { details } : {}),
+      };
+    }
+    return {
+      ok: false,
+      error: error instanceof Error && error.message ? error.message : "Run in Game failed",
     };
-    const body = await orpcClient.runInGame.start(request);
-    return body as RunInGameOperationStatus;
-  } catch (err) {
-    return { ok: false, ...runInGameFailure(err, "Run in Game failed") };
   }
+  return data as RunInGameOperationStatus;
 }
 
 export async function fetchRunInGameStatus(
   requestId: string,
-): Promise<RunInGameOperationStatus | { ok: false; error: string; statusCode?: number }> {
-  try {
-    const body = await orpcClient.runInGame.status({ requestId });
-    return body as RunInGameOperationStatus;
-  } catch (err) {
-    const failure = runInGameFailure(err, "Run in Game status unavailable");
+): Promise<RunInGameOperationStatus | { ok: false; error: string; code?: string }> {
+  const { error, data } = await safe(orpcClient.runInGame.status({ requestId }));
+  if (error) {
     return {
       ok: false,
-      error: failure.error,
-      ...(failure.statusCode !== undefined ? { statusCode: failure.statusCode } : {}),
+      error:
+        error instanceof Error && error.message
+          ? error.message
+          : "Run in Game status unavailable",
+      // `code === "RUN_IN_GAME_STATUS_NOT_FOUND"` is the restart-detection signal
+      // (the former `statusCode === 404` branch in StudioShell).
+      ...(isDefinedError(error) ? { code: error.code } : {}),
     };
   }
+  return data as RunInGameOperationStatus;
 }

--- a/apps/mapgen-studio/src/features/studioServer/studioServerClient.ts
+++ b/apps/mapgen-studio/src/features/studioServer/studioServerClient.ts
@@ -7,12 +7,6 @@ export const STUDIO_SERVER_ORPC_PATH = "/rpc";
 
 export type StudioServerOrpcClient = RouterClient<StudioRouter>;
 
-export type StudioServerOrpcFailure = Readonly<{
-  error: string;
-  statusCode?: number;
-  data?: Record<string, unknown>;
-}>;
-
 export function createStudioServerOrpcClient(
   options: Readonly<{
     url?: string;
@@ -31,23 +25,9 @@ export function createStudioServerOrpcClient(
   return createORPCClient<StudioServerOrpcClient>(link);
 }
 
-export function studioServerOrpcFailure(err: unknown, fallback: string): StudioServerOrpcFailure {
-  const record = isRecord(err) ? err : {};
-  const data = isRecord(record.data) ? record.data : undefined;
-  return {
-    error: typeof record.message === "string" ? record.message : fallback,
-    ...(typeof record.status === "number" ? { statusCode: record.status } : {}),
-    ...(data ? { data } : {}),
-  };
-}
-
 function resolveStudioServerOrpcUrl(): string {
   if (typeof globalThis.location?.origin === "string") {
     return new URL(STUDIO_SERVER_ORPC_PATH, globalThis.location.origin).toString();
   }
   return STUDIO_SERVER_ORPC_PATH;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object");
 }

--- a/apps/mapgen-studio/src/lib/orpc.ts
+++ b/apps/mapgen-studio/src/lib/orpc.ts
@@ -1,4 +1,4 @@
-import { createORPCClient, ORPCError } from "@orpc/client";
+import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import type { ContractRouterClient } from "@orpc/contract";
@@ -38,29 +38,11 @@ export const orpcClient: ContractRouterClient<StudioContract> =
  */
 export const orpc = createTanstackQueryUtils(orpcClient);
 
-/**
- * Read the extra-body `data` an `ORPCError` carried back from the studio router.
- *
- * The router pins each procedure's legacy HTTP code on `ORPCError.status` and
- * tucks the legacy body's side fields (`observedAt`, `details`, …) into
- * `ORPCError.data` (see `packages/studio-server/src/router` + `errors.ts`). The
- * contract does not declare an `errorMap`, so on the client `err.data` is typed
- * `unknown` — every caller would otherwise repeat the same inline
- * `(err.data ?? undefined) as { … }` cast to recover one field.
- *
- * This is the single typed accessor for that recovery: it narrows `data` to a
- * `Partial<T>` (each field still treated as possibly-absent, because the wire
- * shape is not statically guaranteed) and returns `undefined` when there is no
- * usable object. Callers read individual fields with their own runtime guard,
- * exactly as the previous hand-rolled casts did — only the cast is centralized.
- */
-export function readErrorData<T extends Record<string, unknown>>(
-  err: ORPCError<string, unknown>,
-): Partial<T> | undefined {
-  return typeof err.data === "object" && err.data !== null
-    ? (err.data as Partial<T>)
-    : undefined;
-}
+// NOTE: error payloads are CONTRACT-TYPED now. Every procedure declares its error
+// codes via `oc.errors(...)` (packages/studio-server/src/contract/errors.ts), so
+// call sites use `safe(...)` + `isDefinedError(...)` from `@orpc/client` and read
+// `error.code` / `error.data` with full types — the former `readErrorData` cast
+// helper is gone.
 
 export { contract };
 export type { StudioContract };

--- a/apps/mapgen-studio/src/server/recipeDag/procedure.ts
+++ b/apps/mapgen-studio/src/server/recipeDag/procedure.ts
@@ -1,4 +1,3 @@
-import { ORPCError } from "@orpc/server";
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { implementEffect, type EffectImplementer, type EffectImplementerInternal } from "effect-orpc";
 
@@ -7,7 +6,12 @@ import type { RecipeDagContext } from "./context";
 
 export const recipeDagEffectRuntime = ManagedRuntime.make(Layer.empty);
 
-const recipeDagBaseImplementer =
+// NOTE: no error-sanitizing middleware — oRPC already wraps unknown throws/defects
+// as INTERNAL_SERVER_ERROR (effect-orpc's `toORPCErrorFromCause` + the handler's
+// `toORPCError`), and declared failures are raised through the typed
+// `errors.RECIPE_DAG_*` constructors below, so the former
+// `recipeDagSafeErrorMiddleware`/`publicRecipeDagError` pair was redundant.
+export const recipeDagImplementer =
   implementEffect(RecipeDagContract, recipeDagEffectRuntime).$context<RecipeDagContext>() satisfies EffectImplementer<
     typeof RecipeDagContract,
     RecipeDagContext & Record<never, never>,
@@ -16,14 +20,6 @@ const recipeDagBaseImplementer =
     never
   >;
 
-const recipeDagSafeErrorMiddleware = recipeDagBaseImplementer.middleware(async ({ next }) => {
-  try {
-    return await next();
-  } catch (err) {
-    throw publicRecipeDagError(err);
-  }
-});
-
 export type RecipeDagImplementer = EffectImplementerInternal<
   typeof RecipeDagContract,
   RecipeDagContext & Record<never, never>,
@@ -31,9 +27,6 @@ export type RecipeDagImplementer = EffectImplementerInternal<
   never,
   never
 >;
-
-export const recipeDagImplementer: RecipeDagImplementer =
-  recipeDagBaseImplementer.use(recipeDagSafeErrorMiddleware);
 
 export const recipeDagGetProcedure =
   recipeDagImplementer.recipeDag.get.effect(function* ({ input, context, errors }) {
@@ -58,10 +51,3 @@ export const recipeDagGetProcedure =
       },
     });
   });
-
-function publicRecipeDagError(err: unknown): ORPCError<any, any> {
-  if (err instanceof ORPCError) return err;
-  return new ORPCError("INTERNAL_SERVER_ERROR", {
-    message: "Recipe DAG procedure failed.",
-  });
-}

--- a/apps/mapgen-studio/src/server/studio/context.ts
+++ b/apps/mapgen-studio/src/server/studio/context.ts
@@ -1,35 +1,85 @@
-import {
-  orpcError,
-  type StudioServerContext,
-} from "@civ7/studio-server";
+import { ORPCError } from "@orpc/client";
+import type { StudioServerContext } from "@civ7/studio-server";
 
 import { loadCiv7SetupCatalog } from "../civ7Resources/catalog";
 import { RunInGameHttpError } from "../runInGame/operationState";
 import type { StudioEngines } from "./engines";
 
 /**
+ * Per-namespace mapping from an engine `RunInGameHttpError.statusCode` to the
+ * DECLARED contract error code (packages/studio-server/src/contract/errors.ts).
+ * Absent slots fall through to `failed` (500).
+ */
+type EngineErrorCodes = Readonly<{
+  /** 409 — dual-store mutex. */
+  blocked?: string;
+  /** 400 — request validation. */
+  invalid?: string;
+  /** 503 — downstream dependency unavailable. */
+  unavailable?: string;
+  /** Everything else (500 fallback). */
+  failed: string;
+}>;
+
+const AUTOPLAY_CODES: EngineErrorCodes = {
+  blocked: "AUTOPLAY_BLOCKED",
+  failed: "AUTOPLAY_FAILED",
+};
+
+const RUN_IN_GAME_CODES: EngineErrorCodes = {
+  blocked: "RUN_IN_GAME_BLOCKED",
+  invalid: "RUN_IN_GAME_INVALID",
+  unavailable: "RUN_IN_GAME_UNAVAILABLE",
+  failed: "RUN_IN_GAME_FAILED",
+};
+
+const SAVE_DEPLOY_CODES: EngineErrorCodes = {
+  blocked: "SAVE_DEPLOY_BLOCKED",
+  invalid: "SAVE_DEPLOY_INVALID",
+  failed: "SAVE_DEPLOY_FAILED",
+};
+
+/**
  * Build the `StudioServerContext` the oRPC router consumes over the process's
- * one engines instance. Engine `RunInGameHttpError`s are converted to
- * `ORPCError` with the historical status + `details` payload so the
- * non-uniform codes survive the oRPC boundary (architecture/10 §1). Moved
- * verbatim from `vite.config.ts` (`createStudioServerContextForApp`) in the
- * bun-server engine-extraction slice; the host (the Bun daemon) injects the
- * engines and its command label.
+ * one engines instance. Engine `RunInGameHttpError`s are converted to raw
+ * `ORPCError`s whose code/status/data MATCH the contract's DECLARED errors
+ * (packages/studio-server/src/contract/errors.ts) — 409→`*_BLOCKED`,
+ * 400→`*_INVALID`, 404→`*_STATUS_NOT_FOUND`, 503→`*_UNAVAILABLE`, else
+ * `*_FAILED` — so oRPC validates them into DEFINED typed errors at the client
+ * without this module importing the contract. Moved verbatim from
+ * `vite.config.ts` (`createStudioServerContextForApp`) in the bun-server
+ * engine-extraction slice; the host (the Bun daemon) injects the engines and
+ * its command label.
  */
 export function createStudioServerContext(options: Readonly<{
   engines: StudioEngines;
   hostCommand: string;
 }>): StudioServerContext {
   const { engines, hostCommand } = options;
-  const toOrpc = (err: unknown, fallbackStatus: number, fallbackMessage: string) => {
+  const toOrpc = (
+    err: unknown,
+    codes: EngineErrorCodes,
+    fallbackMessage: string,
+  ): ORPCError<string, unknown> => {
     if (err instanceof RunInGameHttpError) {
-      return orpcError(
-        err.statusCode,
-        err.message,
-        err.details === undefined ? undefined : { details: err.details },
-      );
+      const declared =
+        err.statusCode === 409 && codes.blocked
+          ? { code: codes.blocked, status: 409 }
+          : err.statusCode === 400 && codes.invalid
+            ? { code: codes.invalid, status: 400 }
+            : err.statusCode === 503 && codes.unavailable
+              ? { code: codes.unavailable, status: 503 }
+              : { code: codes.failed, status: 500 };
+      return new ORPCError(declared.code, {
+        status: declared.status,
+        message: err.message,
+        ...(err.details === undefined ? {} : { data: { details: err.details } }),
+      });
     }
-    return orpcError(fallbackStatus, err instanceof Error ? err.message : fallbackMessage);
+    return new ORPCError(codes.failed, {
+      status: 500,
+      message: err instanceof Error ? err.message : fallbackMessage,
+    });
   };
   return {
     serverInstanceId: engines.serverInstanceId,
@@ -49,7 +99,7 @@ export function createStudioServerContext(options: Readonly<{
           ReturnType<StudioServerContext["autoplay"]>
         >;
       } catch (err) {
-        throw toOrpc(err, 500, "Civ7 autoplay request failed");
+        throw toOrpc(err, AUTOPLAY_CODES, "Civ7 autoplay request failed");
       }
     },
     runInGameStart: async (input) => {
@@ -57,7 +107,7 @@ export function createStudioServerContext(options: Readonly<{
         const result = await engines.runRunInGameStartEngine(input);
         return result.operation as Awaited<ReturnType<StudioServerContext["runInGameStart"]>>;
       } catch (err) {
-        throw toOrpc(err, 500, "Run in Game failed");
+        throw toOrpc(err, RUN_IN_GAME_CODES, "Run in Game failed");
       }
     },
     runInGameStatus: async (input) => {
@@ -67,13 +117,18 @@ export function createStudioServerContext(options: Readonly<{
         >;
       } catch (err) {
         if (err instanceof RunInGameHttpError && err.statusCode === 404) {
-          // Parity: run-in-game status 404 echoes serverInstanceId/serverStartedAt.
-          throw orpcError(404, err.message, {
-            serverInstanceId: engines.serverInstanceId,
-            serverStartedAt: engines.serverStartedAt,
+          // Parity: run-in-game status 404 echoes serverInstanceId/serverStartedAt
+          // (restart detection) — the RUN_IN_GAME_STATUS_NOT_FOUND data shape.
+          throw new ORPCError("RUN_IN_GAME_STATUS_NOT_FOUND", {
+            status: 404,
+            message: err.message,
+            data: {
+              serverInstanceId: engines.serverInstanceId,
+              serverStartedAt: engines.serverStartedAt,
+            },
           });
         }
-        throw toOrpc(err, 500, "Run in Game status failed");
+        throw toOrpc(err, RUN_IN_GAME_CODES, "Run in Game status failed");
       }
     },
     mapConfigSaveDeploy: async (input) => {
@@ -82,8 +137,15 @@ export function createStudioServerContext(options: Readonly<{
           ReturnType<StudioServerContext["mapConfigSaveDeploy"]>
         >;
       } catch (err) {
-        // Parity: save/deploy validation failures map to 400 (not 500).
-        throw toOrpc(err, 400, "Save failed");
+        // Parity: save/deploy validation failures (plain Errors from the request
+        // parser / envelope asserts / path jail) map to 400 (not 500).
+        if (!(err instanceof RunInGameHttpError)) {
+          throw new ORPCError("SAVE_DEPLOY_INVALID", {
+            status: 400,
+            message: err instanceof Error ? err.message : "Save failed",
+          });
+        }
+        throw toOrpc(err, SAVE_DEPLOY_CODES, "Save failed");
       }
     },
     mapConfigStatus: async (input) => {
@@ -92,8 +154,15 @@ export function createStudioServerContext(options: Readonly<{
           ReturnType<StudioServerContext["mapConfigStatus"]>
         >;
       } catch (err) {
-        // Parity: save/deploy status 404 does NOT echo serverInstanceId.
-        throw toOrpc(err, 500, "Save/Deploy status failed");
+        if (err instanceof RunInGameHttpError && err.statusCode === 404) {
+          // Parity: save/deploy status 404 does NOT echo serverInstanceId
+          // (documented asymmetry vs runInGame.status).
+          throw new ORPCError("SAVE_DEPLOY_STATUS_NOT_FOUND", {
+            status: 404,
+            message: err.message,
+          });
+        }
+        throw toOrpc(err, SAVE_DEPLOY_CODES, "Save/Deploy status failed");
       }
     },
   };

--- a/apps/mapgen-studio/src/server/studio/engines.ts
+++ b/apps/mapgen-studio/src/server/studio/engines.ts
@@ -62,8 +62,10 @@ import { buildLiveRuntimeStatusState } from "../../features/liveRuntime/model";
 //   - `RunInGameHttpError` (carries statusCode + details) — preserves the
 //     non-uniform legacy status codes (409 mutex, run-in-game/save-deploy 404).
 //   - a plain `Error` — validation/save failures (mapped to 400 by the caller).
-// The oRPC context adapts return/throw → value/ORPCError (./context.ts,
-// `orpcError` mapping), keeping those statuses across the oRPC boundary.
+// The oRPC context adapts return/throw → value/ORPCError (./context.ts), mapping
+// each status onto the contract's DECLARED error codes (409→*_BLOCKED,
+// 400→*_INVALID, 404→*_STATUS_NOT_FOUND, 503→*_UNAVAILABLE, else *_FAILED) so
+// those statuses survive the oRPC boundary as defined typed errors.
 // ============================================================================
 
 const execFileAsync = promisify(execFile);

--- a/packages/studio-server/src/context.ts
+++ b/packages/studio-server/src/context.ts
@@ -33,8 +33,12 @@ export type SetupCatalog = StudioOutputs["civ7"]["setupCatalog"]["catalog"];
  * stateful engines cross this seam.
  *
  * Each engine fn returns the SAME success shape its `/api` handler wrote, OR
- * throws an `ORPCError` (built via ./errors) carrying the legacy non-uniform
- * status code + body. The package re-throws engine `ORPCError`s unchanged.
+ * throws an `ORPCError` whose code/status/data MATCH the procedure's DECLARED
+ * contract errors (./contract/errors.ts) — `AUTOPLAY_BLOCKED`/`AUTOPLAY_FAILED`,
+ * `RUN_IN_GAME_BLOCKED`/`_INVALID`/`_FAILED`/`_UNAVAILABLE`/`_STATUS_NOT_FOUND`,
+ * `SAVE_DEPLOY_BLOCKED`/`_INVALID`/`_FAILED`/`_STATUS_NOT_FOUND` — so oRPC
+ * validates them into DEFINED typed errors client-side. The package re-throws
+ * engine `ORPCError`s unchanged.
  */
 export interface StudioServerContext {
   /** Process-lifetime singletons surfaced by `studio.serverInfo` + run-in-game 404 echo. */

--- a/packages/studio-server/src/contract/civ7.ts
+++ b/packages/studio-server/src/contract/civ7.ts
@@ -1,6 +1,15 @@
 import { oc } from "@orpc/contract";
 import { z } from "zod";
 
+import {
+  autoplayErrors,
+  civ7GameInfoErrors,
+  civ7MapSummaryErrors,
+  civ7StatusErrors,
+  savedConfigsErrors,
+  setupCatalogErrors,
+  setupConfigErrors,
+} from "./errors.js";
 import { isoTimestamp, unknownRecord } from "./shared.js";
 
 /**
@@ -9,10 +18,11 @@ import { isoTimestamp, unknownRecord } from "./shared.js";
  * Source of truth: audit/05-server-contracts.md endpoints #1, #2, #3, #8, #10,
  * #11, #12 (and the `civ7.live.*` sub-namespace lives in ./live.ts).
  *
- * Parity note (errorMap, lands A3): error status codes are NON-UNIFORM across
- * these procedures (gameInfo→400, setupConfig→503, savedConfigs/setupCatalog→500,
- * status/mapSummary→500, autoplay→400/409/500). The success `output` schemas below
- * are the contract surface; per-procedure error semantics are documented inline.
+ * Parity note: error status codes are NON-UNIFORM across these procedures
+ * (gameInfo→400, setupConfig→503, savedConfigs/setupCatalog→500,
+ * status/mapSummary→500, autoplay→409/500). Each procedure DECLARES its codes
+ * via `.errors(...)` (./errors.ts), so the legacy statuses are contract-typed
+ * and arrive client-side as oRPC defined errors.
  */
 
 // ---------------------------------------------------------------------------
@@ -21,6 +31,7 @@ import { isoTimestamp, unknownRecord } from "./shared.js";
 // Request: none. Success 200: { ok: status.playable, status: PlayableStatus }.
 // Error 500: { ok:false, error }. Reads FireTuner socket (getCiv7PlayableStatus).
 export const status = oc
+  .errors(civ7StatusErrors)
   .input(z.object({}))
   .output(
     z.object({
@@ -36,6 +47,7 @@ export const status = oc
 // Request: none (server calls with { includeAreaRegionCounts: true }).
 // Success 200: { ok:true, summary: MapSummary }. Error 500: { ok:false, error }.
 export const mapSummary = oc
+  .errors(civ7MapSummaryErrors)
   .input(z.object({}))
   .output(
     z.object({
@@ -59,6 +71,7 @@ export const mapSummary = oc
 // `array(gameInfoRow)`, which does not match `/api`. Refined to the opaque result
 // record to preserve current behavior (the deep payload is internal, per shared.ts).
 export const gameInfo = oc
+  .errors(civ7GameInfoErrors)
   .input(
     z.object({
       table: z.string().min(1),
@@ -82,6 +95,7 @@ export const gameInfo = oc
 // details.code); 500 { ok:false, error }. Mutates game state; waits on scripting
 // log markers (waitTimeoutMs≈90s). Dual-store 409 mutex + approval object land A3.
 export const autoplay = oc
+  .errors(autoplayErrors)
   .input(
     z.object({
       action: z.enum(["start", "stop"]),
@@ -106,6 +120,7 @@ export const autoplay = oc
 // Request: none. Success 200: { ok:true, observedAt, setup, state, host, port }.
 // Error 503 (UNIQUE): { ok:false, error, observedAt }. Reads FireTuner socket.
 export const setupConfig = oc
+  .errors(setupConfigErrors)
   .input(z.object({}))
   .output(
     z.object({
@@ -126,6 +141,7 @@ export const setupConfig = oc
 // (spread of listCiv7SavedGameConfigurations listResult). Error 500:
 // { ok:false, error, observedAt }. Reads filesystem (Civ7 saved-config dir).
 export const savedConfigs = oc
+  .errors(savedConfigsErrors)
   .input(z.object({}))
   .output(
     z.object({
@@ -167,7 +183,7 @@ export const setupCatalogSchema = z.object({
   gameSpeeds: z.array(setupCatalogOption),
 });
 
-export const setupCatalog = oc.input(z.object({})).output(
+export const setupCatalog = oc.errors(setupCatalogErrors).input(z.object({})).output(
   z.object({
     ok: z.literal(true),
     catalog: setupCatalogSchema,

--- a/packages/studio-server/src/contract/errors.ts
+++ b/packages/studio-server/src/contract/errors.ts
@@ -1,0 +1,201 @@
+import { z } from "zod";
+
+/**
+ * Typed contract error maps for `@civ7/studio-server` — oRPC NATIVE defined errors.
+ *
+ * Each procedure attaches the error codes it can emit via `oc.errors(...)`, so the
+ * non-uniform legacy HTTP statuses (architecture/10 §7 do-not-break registry) are
+ * pinned on DECLARED codes instead of ad-hoc `ORPCError` construction:
+ *   - reads: gameInfo/live.* → 400, setupConfig → 503, everything else → 500
+ *   - engines: 409 *_BLOCKED / 400 *_INVALID / 404 *_STATUS_NOT_FOUND /
+ *     503 *_UNAVAILABLE / 500 *_FAILED
+ *
+ * Two emission paths resolve to the SAME defined wire errors:
+ *   1. Router procedures throw via the typed `errors.CODE({ message, data })`
+ *      constructor param (effect-orpc forwards oRPC's native constructor map).
+ *   2. The host context (apps/mapgen-studio/src/server/studio/context.ts) maps
+ *      engine `RunInGameHttpError`s to raw `new ORPCError(code, { status, … })`;
+ *      because code/status/data match a declared entry, oRPC validates and
+ *      delivers them client-side as DEFINED errors (the "combining both
+ *      approaches" rule) without importing this module.
+ *
+ * All `data` schemas are PERMISSIVE (optional fields, open `details` records,
+ * optional top level) so engine payload evolution can never flunk validation and
+ * silently downgrade a defined error to an undefined one.
+ */
+
+/** `observedAt` echo carried by the read failures that historically included it. */
+const observedAtData = z
+  .object({
+    observedAt: z.string().optional(),
+  })
+  .optional();
+
+/**
+ * Engine failure payload: the `RunInGameHttpError.details` open record
+ * (`code`, `activeRequestId`, `materialization`, recovery boundaries, …).
+ */
+const engineDetailsData = z
+  .object({
+    details: z.object({}).catchall(z.unknown()).optional(),
+  })
+  .optional();
+
+/**
+ * Run-in-game status-miss echo: the server identity the client uses for
+ * restart detection (PARITY INVARIANT, audit/05 #13).
+ */
+const serverIdentityEchoData = z
+  .object({
+    serverInstanceId: z.string().optional(),
+    serverStartedAt: z.string().optional(),
+  })
+  .optional();
+
+// ---------------------------------------------------------------------------
+// civ7.* reads — per-procedure codes (legacy statuses preserved exactly)
+// ---------------------------------------------------------------------------
+
+export const civ7StatusErrors = {
+  CIV7_STATUS_UNAVAILABLE: {
+    status: 500,
+    message: "Civ7 status request failed",
+  },
+} as const;
+
+export const civ7MapSummaryErrors = {
+  CIV7_MAP_SUMMARY_UNAVAILABLE: {
+    status: 500,
+    message: "Civ7 map summary request failed",
+  },
+} as const;
+
+export const civ7GameInfoErrors = {
+  CIV7_GAMEINFO_FAILED: {
+    status: 400,
+    message: "Civ7 GameInfo request failed",
+  },
+} as const;
+
+export const liveSnapshotErrors = {
+  CIV7_LIVE_SNAPSHOT_FAILED: {
+    status: 400,
+    message: "Civ7 live snapshot request failed",
+  },
+} as const;
+
+export const liveEntitiesErrors = {
+  CIV7_LIVE_ENTITIES_FAILED: {
+    status: 400,
+    message: "Civ7 live entities request failed",
+  },
+} as const;
+
+export const liveGameInfoErrors = {
+  CIV7_LIVE_GAMEINFO_FAILED: {
+    status: 400,
+    message: "Civ7 live GameInfo request failed",
+  },
+} as const;
+
+export const setupConfigErrors = {
+  SETUP_CONFIG_UNAVAILABLE: {
+    status: 503,
+    message: "Civ7 setup config unavailable",
+    data: observedAtData,
+  },
+} as const;
+
+export const savedConfigsErrors = {
+  SAVED_CONFIGS_UNAVAILABLE: {
+    status: 500,
+    message: "Civ7 saved configurations unavailable",
+    data: observedAtData,
+  },
+} as const;
+
+export const setupCatalogErrors = {
+  SETUP_CATALOG_UNAVAILABLE: {
+    status: 500,
+    message: "Civ7 setup catalog unavailable",
+    data: observedAtData,
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// civ7.autoplay — host engine (409 dual-store mutex / 500 fallback)
+// ---------------------------------------------------------------------------
+
+export const autoplayErrors = {
+  AUTOPLAY_BLOCKED: {
+    status: 409,
+    message: "Civ7 autoplay is blocked by an active operation",
+    data: engineDetailsData,
+  },
+  AUTOPLAY_FAILED: {
+    status: 500,
+    message: "Civ7 autoplay request failed",
+    data: engineDetailsData,
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// runInGame.* — host engine (409/400/500/503; 404 with server-identity echo)
+// ---------------------------------------------------------------------------
+
+export const runInGameErrors = {
+  RUN_IN_GAME_BLOCKED: {
+    status: 409,
+    message: "Run in Game is blocked by an active operation",
+    data: engineDetailsData,
+  },
+  RUN_IN_GAME_INVALID: {
+    status: 400,
+    message: "Invalid Run in Game request",
+    data: engineDetailsData,
+  },
+  RUN_IN_GAME_FAILED: {
+    status: 500,
+    message: "Run in Game failed",
+    data: engineDetailsData,
+  },
+  RUN_IN_GAME_UNAVAILABLE: {
+    status: 503,
+    message: "Run in Game dependencies are unavailable",
+    data: engineDetailsData,
+  },
+  RUN_IN_GAME_STATUS_NOT_FOUND: {
+    status: 404,
+    message: "Run in Game request not found",
+    data: serverIdentityEchoData,
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// mapConfigs.* — host engine (409 mutex / 400 validation; 404 WITHOUT echo)
+// ---------------------------------------------------------------------------
+
+export const mapConfigsErrors = {
+  SAVE_DEPLOY_BLOCKED: {
+    status: 409,
+    message: "Save/Deploy is blocked by an active operation",
+    data: engineDetailsData,
+  },
+  SAVE_DEPLOY_INVALID: {
+    status: 400,
+    message: "Invalid Save/Deploy request",
+    data: engineDetailsData,
+  },
+  SAVE_DEPLOY_FAILED: {
+    status: 500,
+    message: "Save failed",
+    data: engineDetailsData,
+  },
+  // PARITY NOTE (audit/05 #15): unlike RUN_IN_GAME_STATUS_NOT_FOUND, this 404
+  // carries NO serverInstanceId/serverStartedAt echo — the documented asymmetry
+  // is preserved (no echo data schema here, and the host context never adds one).
+  SAVE_DEPLOY_STATUS_NOT_FOUND: {
+    status: 404,
+    message: "Save/Deploy request not found",
+  },
+} as const;

--- a/packages/studio-server/src/contract/live.ts
+++ b/packages/studio-server/src/contract/live.ts
@@ -1,6 +1,11 @@
 import { oc } from "@orpc/contract";
 import { z } from "zod";
 
+import {
+  liveEntitiesErrors,
+  liveGameInfoErrors,
+  liveSnapshotErrors,
+} from "./errors.js";
 import { isoTimestamp, unknownRecord } from "./shared.js";
 
 /**
@@ -16,9 +21,9 @@ import { isoTimestamp, unknownRecord } from "./shared.js";
  * PARITY INVARIANT (audit/05 #4, line 29; target-arch §1 invariants): `live.status`
  * returns **200** even on partial failure — each of the four aggregated reads runs
  * under `Promise.allSettled`, and a rejected read is surfaced in-band as
- * `{ error: String(reason) }` for that field. These are NOT transport-layer errors;
- * the errorMap middleware (A3) must leave them as 200-body fields. Only an outer
- * throw yields `500 { ok:false, error }`.
+ * `{ error: String(reason) }` for that field. These are NOT transport-layer errors —
+ * `live.status` therefore declares NO contract error codes (only an outer defect
+ * yields a transport-level 500).
  */
 const fieldOrError = z.union([unknownRecord, z.object({ error: z.string() })]);
 
@@ -56,6 +61,7 @@ export const status = oc
 // Contract input defaults below document the wire defaults; clamping is applied
 // server-side. `fields` is accepted as the raw csv string to preserve parsing parity.
 export const snapshot = oc
+  .errors(liveSnapshotErrors)
   .input(
     z.object({
       x: z.number().int().default(0),
@@ -84,6 +90,7 @@ export const snapshot = oc
 // Error 400: { ok:false, error }. Reads FireTuner (3× Promise.all — any failure
 // → whole 400, NOT allSettled).
 export const entities = oc
+  .errors(liveEntitiesErrors)
   .input(
     z.object({
       playerId: z.number().int().optional(),
@@ -114,6 +121,7 @@ export const entities = oc
 // `civ7.gameInfo` (#3). Refined from `array(gameInfoRow)` to the opaque result
 // record to preserve current `/api` behavior.
 export const gameInfo = oc
+  .errors(liveGameInfoErrors)
   .input(
     z.object({
       tables: z.string().default("Terrains,Biomes,Features,Resources,Maps,MapSizes"),

--- a/packages/studio-server/src/contract/mapConfigs.ts
+++ b/packages/studio-server/src/contract/mapConfigs.ts
@@ -1,6 +1,8 @@
 import { oc } from "@orpc/contract";
 import { z } from "zod";
 
+import { mapConfigsErrors } from "./errors.js";
+
 /**
  * `mapConfigs.*` namespace — save config to repo + deploy (no Civ restart).
  *
@@ -56,8 +58,11 @@ export const saveDeployStatusSchema = z.object({
 // Errors: 400 (missing); 404 { ok:false, error }.
 //
 // PARITY NOTE (audit/05 #15): the 404 here does NOT include serverInstanceId/
-// serverStartedAt (asymmetry vs runInGame.status #13) — preserve in errorMap (A3).
+// serverStartedAt (asymmetry vs runInGame.status #13) — the defined
+// `SAVE_DEPLOY_STATUS_NOT_FOUND` error (./errors.ts) deliberately declares NO
+// echo `data`, and the host context never attaches one.
 export const status = oc
+  .errors(mapConfigsErrors)
   .input(
     z.object({
       requestId: z.string().min(1),
@@ -72,7 +77,8 @@ export const status = oc
 // `restart`/`verifyRestart` MUST be falsy → else 400.
 // Success 202: MapConfigSaveDeployStatus (async). 202 idempotent (same active
 // requestId returns current). Errors: 409 (run-in-game active OR different save/
-// deploy active); 400 { ok:false, error } on validation.
+// deploy active); 400 on validation — declared as the defined
+// SAVE_DEPLOY_BLOCKED/INVALID/FAILED codes (./errors.ts).
 //
 // PARITY NOTE (audit/05 #16): write-then-deploy with ROLLBACK on deploy-phase
 // failure; idempotent requestId reuse; path-jail (configRoot prefix + .config.json
@@ -81,6 +87,7 @@ export const status = oc
 // are typed as optional booleans here; the falsy-only enforcement lives in
 // `parseMapConfigSaveRequest`.
 export const saveDeploy = oc
+  .errors(mapConfigsErrors)
   .input(
     z.object({
       requestId: z.string().optional(),

--- a/packages/studio-server/src/contract/runInGame.ts
+++ b/packages/studio-server/src/contract/runInGame.ts
@@ -1,6 +1,7 @@
 import { oc } from "@orpc/contract";
 import { z } from "zod";
 
+import { runInGameErrors } from "./errors.js";
 import { unknownRecord } from "./shared.js";
 
 /**
@@ -212,9 +213,10 @@ export const operationStatusSchema = z.object({
 //
 // PARITY INVARIANT (audit/05 #13, target-arch §1): the 404 echoes
 // `serverInstanceId`/`serverStartedAt` so the client detects a server restart that
-// lost the op. TTL pruning (30min) → pruned op yields 404. Status→code mapping
-// (200/400/404) + the 404 echo body land in errorMap (A3).
+// lost the op. TTL pruning (30min) → pruned op yields 404. The miss is the defined
+// `RUN_IN_GAME_STATUS_NOT_FOUND` error (./errors.ts), whose `data` carries the echo.
 export const status = oc
+  .errors(runInGameErrors)
   .input(
     z.object({
       requestId: z.string().min(1),
@@ -228,7 +230,8 @@ export const status = oc
 // Body: the full setup request. Success 202: RunInGameOperationState (async).
 // 202 dup (same fingerprint → details.duplicateRequest). Errors: 409 (run-in-game
 // OR save/deploy active), 400/500/503 via RunInGameHttpError (details carries
-// code/materialization/recovery boundaries).
+// code/materialization/recovery boundaries) — declared as the defined
+// RUN_IN_GAME_BLOCKED/INVALID/FAILED/UNAVAILABLE codes (./errors.ts).
 //
 // SECURITY BOUNDARY (target-arch §1): the handler runs `assertNoRawControlFields`
 // — a deep scan rejecting `command|script|javascript|rawJs|rawCommand` keys. The
@@ -237,6 +240,7 @@ export const status = oc
 // `parseRunInGameSetupRequest`, ported in A2/A3). Known top-level fields are typed;
 // the body is otherwise passed through for the validator to reject raw-control keys.
 export const start = oc
+  .errors(runInGameErrors)
   .input(
     z
       .object({

--- a/packages/studio-server/src/errors.ts
+++ b/packages/studio-server/src/errors.ts
@@ -1,64 +1,24 @@
-import { ORPCError } from "@orpc/server";
-
 /**
- * `@civ7/studio-server` — error mapping helpers (parity registry, A3).
+ * `@civ7/studio-server` — error helpers (contract-errors regime).
  *
- * The legacy `/api/*` handlers emit **non-uniform** HTTP status codes
+ * Error mapping is CONTRACT-FIRST: every failure a procedure can emit is a
+ * DECLARED oRPC error in `./contract/errors.ts` (attached per procedure via
+ * `oc.errors(...)`), carrying the legacy non-uniform status code
  * (architecture/10 §1 + §7 "Do-not-break registry"):
  *   - civ7.gameInfo / live.* → 400
  *   - civ7.setupConfig → 503
- *   - civ7.autoplay → 400 (bad action) / 409 (mutex) / 500 (other)
- *   - runInGame.start → 400/409/500/503 via RunInGameHttpError; 404 on status miss
- *   - mapConfigs.saveDeploy → 409 (mutex) / 400 (validation); 404 on status miss
+ *   - civ7.autoplay → 409 (mutex) / 500 (other)
+ *   - runInGame.* → 409/400/500/503; 404 status miss (with server-identity echo)
+ *   - mapConfigs.* → 409 (mutex) / 400 (validation); 404 status miss (no echo)
  *   - everything else (status / mapSummary / savedConfigs / setupCatalog) → 500
  *
- * effect-orpc converts a thrown `ORPCError` (or a failing Effect carrying one) into
- * the transport error verbatim, preserving `status`, `code`, `message` and `data`.
- * These helpers build those `ORPCError`s so the procedures (router/*) reproduce the
- * exact per-procedure status code + payload of the corresponding `/api` handler.
- *
- * The `data` payload carries the legacy body's extra fields (`details`,
- * `observedAt`, `serverInstanceId`, …) so no parity information is lost across the
- * oRPC boundary; the `{ ok:false, error }` wire wrapper is the old `/api` handler's
- * concern (kept alive this run) — the oRPC client reads `error.status`/`error.data`.
+ * Procedures throw via the typed `errors.CODE({ message, data })` constructor the
+ * effect handler receives (router/*); the host context throws raw `ORPCError`s
+ * matching the declared entries, which oRPC validates into DEFINED errors. There
+ * is no ad-hoc status→code construction left here — only the message fallback.
  */
 
 /** Map an arbitrary thrown value to its message, matching `err instanceof Error ? err.message : fallback`. */
 export function errorMessage(err: unknown, fallback: string): string {
   return err instanceof Error ? err.message : fallback;
-}
-
-/**
- * Construct an `ORPCError` with an explicit HTTP `status` and optional `data`
- * payload. `code` is a CONSTANT_CASE label; oRPC also derives a default status
- * from well-known codes, but we pass `status` explicitly to pin the legacy value.
- */
-export function orpcError(
-  status: number,
-  message: string,
-  data?: Record<string, unknown>,
-): ORPCError<string, Record<string, unknown> | undefined> {
-  const code = statusToCode(status);
-  return new ORPCError(code, {
-    status,
-    message,
-    ...(data === undefined ? {} : { data }),
-  });
-}
-
-function statusToCode(status: number): string {
-  switch (status) {
-    case 400:
-      return "BAD_REQUEST";
-    case 404:
-      return "NOT_FOUND";
-    case 409:
-      return "CONFLICT";
-    case 500:
-      return "INTERNAL_SERVER_ERROR";
-    case 503:
-      return "SERVICE_UNAVAILABLE";
-    default:
-      return "INTERNAL_SERVER_ERROR";
-  }
 }

--- a/packages/studio-server/src/index.ts
+++ b/packages/studio-server/src/index.ts
@@ -23,7 +23,6 @@ export type {
   StudioOutputs,
   SetupCatalog,
 } from "./context.js";
-export { errorMessage, orpcError } from "./errors.js";
 export { createStudioRpcHandler, type StudioRpcHandle } from "./handler.js";
 export { createStudioRouter, type StudioRouter } from "./router/index.js";
 export { makeStudioRuntime, type StudioRuntime } from "./runtime.js";

--- a/packages/studio-server/src/router/index.ts
+++ b/packages/studio-server/src/router/index.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect";
 import { implementEffect } from "effect-orpc";
 
 import { contract, type StudioContract } from "../contract/index.js";
-import { errorMessage, orpcError } from "../errors.js";
+import { errorMessage } from "../errors.js";
 import type { StudioRuntime } from "../runtime.js";
 import { Civ7TunerClient } from "../services/Civ7TunerClient.js";
 import { StudioConfig } from "../services/StudioConfig.js";
@@ -18,16 +18,19 @@ import { StudioConfig } from "../services/StudioConfig.js";
  * `apps/mapgen-studio/vite.config.ts` verbatim:
  *
  *   - Read procedures call `Civ7TunerClient` (→ `@civ7/direct-control`) and map a
- *     failure to the EXACT legacy status code via `orpcError(...)`. The codes are
- *     NON-UNIFORM (gameInfo/live.* → 400, setupConfig → 503, most → 500) — the
- *     do-not-break registry (architecture/10 §7).
+ *     failure to its DECLARED contract error via the typed `errors.CODE(...)`
+ *     constructor param (contract/errors.ts). The codes pin the EXACT legacy
+ *     status — they are NON-UNIFORM (gameInfo/live.* → 400, setupConfig → 503,
+ *     most → 500), the do-not-break registry (architecture/10 §7).
  *   - `civ7.live.status` runs the four reads under `Effect.all({ mode: "either" })`
  *     (the `Promise.allSettled` analogue) and embeds `{ error }` per field at 200;
  *     only an outer defect yields a transport error. PARITY INVARIANT.
  *   - The three stateful engines (autoplay #8, runInGame #13/#14, mapConfigs
  *     #15/#16) delegate to the host-injected `StudioConfig` fns (shared queue +
- *     dual-store mutex live host-side; see ../context.ts) and re-throw the engine's
- *     `ORPCError` unchanged so its 409/400/404/500/503 status + `data` survive.
+ *     dual-store mutex live host-side; see ../context.ts). The host throws raw
+ *     `ORPCError`s whose code/status/data MATCH the declared contract entries, so
+ *     re-throwing them unchanged still yields DEFINED errors client-side; any
+ *     non-ORPCError throw falls back to the namespace `*_FAILED` code.
  *
  * Query parsing parity (clamps, csv split/trim/filter, playerId omit) that the
  * legacy handlers did from the URL is reproduced here against the typed input.
@@ -46,49 +49,66 @@ export function createStudioRouter(
   return oe.router({
     civ7: {
       // #1 GET /api/civ7/status — error 500
-      status: oe.civ7.status.effect(function* () {
+      status: oe.civ7.status.effect(function* ({ errors }) {
         const status = yield* Civ7TunerClient.playableStatus().pipe(
-          Effect.mapError((err) => orpcError(500, errorMessage(err, "Civ7 status request failed"))),
+          Effect.mapError((err) =>
+            errors.CIV7_STATUS_UNAVAILABLE({
+              message: errorMessage(err, "Civ7 status request failed"),
+            }),
+          ),
         );
         return { ok: status.playable, status: status as Record<string, unknown> };
       }),
 
       // #2 GET /api/civ7/map-summary — error 500
-      mapSummary: oe.civ7.mapSummary.effect(function* () {
+      mapSummary: oe.civ7.mapSummary.effect(function* ({ errors }) {
         const summary = yield* Civ7TunerClient.mapSummary().pipe(
           Effect.mapError((err) =>
-            orpcError(500, errorMessage(err, "Civ7 map summary request failed")),
+            errors.CIV7_MAP_SUMMARY_UNAVAILABLE({
+              message: errorMessage(err, "Civ7 map summary request failed"),
+            }),
           ),
         );
         return { ok: true as const, summary: summary as Record<string, unknown> };
       }),
 
       // #3 GET /api/civ7/gameinfo?table=&limit= — error 400 (NOT 500)
-      gameInfo: oe.civ7.gameInfo.effect(function* ({ input }) {
+      gameInfo: oe.civ7.gameInfo.effect(function* ({ input, errors }) {
         const rows = yield* Civ7TunerClient.gameInfoRows(input.table, input.limit).pipe(
           Effect.mapError((err) =>
-            orpcError(400, errorMessage(err, "Civ7 GameInfo request failed")),
+            errors.CIV7_GAMEINFO_FAILED({
+              message: errorMessage(err, "Civ7 GameInfo request failed"),
+            }),
           ),
         );
         // Parity: legacy `/api` writes the WHOLE result object under `rows`.
         return { ok: true as const, rows: rows as unknown as Record<string, unknown> };
       }),
 
-      // #8 POST /api/civ7/autoplay — host engine; 409 mutex / 400 / 500
-      autoplay: oe.civ7.autoplay.effect(function* ({ input }) {
+      // #8 POST /api/civ7/autoplay — host engine; 409 mutex / 500
+      autoplay: oe.civ7.autoplay.effect(function* ({ input, errors }) {
         const config = yield* StudioConfig;
         return yield* Effect.tryPromise({
           try: () => config.autoplay(input),
           catch: (err) => err,
-        }).pipe(Effect.mapError(rethrowEngineError("Civ7 autoplay request failed", 500)));
+        }).pipe(
+          Effect.mapError((err) =>
+            err instanceof ORPCError
+              ? err
+              : errors.AUTOPLAY_FAILED({
+                  message: errorMessage(err, "Civ7 autoplay request failed"),
+                }),
+          ),
+        );
       }),
 
       // #10 GET /api/civ7/setup-config — error 503 (UNIQUE), body carries observedAt
-      setupConfig: oe.civ7.setupConfig.effect(function* () {
+      setupConfig: oe.civ7.setupConfig.effect(function* ({ errors }) {
         const snapshot = yield* Civ7TunerClient.setupSnapshot().pipe(
           Effect.mapError((err) =>
-            orpcError(503, errorMessage(err, "Civ7 setup config unavailable"), {
-              observedAt: new Date().toISOString(),
+            errors.SETUP_CONFIG_UNAVAILABLE({
+              message: errorMessage(err, "Civ7 setup config unavailable"),
+              data: { observedAt: new Date().toISOString() },
             }),
           ),
         );
@@ -103,11 +123,12 @@ export function createStudioRouter(
       }),
 
       // #11 GET /api/civ7/saved-configs — error 500, body carries observedAt
-      savedConfigs: oe.civ7.savedConfigs.effect(function* () {
+      savedConfigs: oe.civ7.savedConfigs.effect(function* ({ errors }) {
         const result = yield* Civ7TunerClient.savedConfigurations().pipe(
           Effect.mapError((err) =>
-            orpcError(500, errorMessage(err, "Civ7 saved configurations unavailable"), {
-              observedAt: new Date().toISOString(),
+            errors.SAVED_CONFIGS_UNAVAILABLE({
+              message: errorMessage(err, "Civ7 saved configurations unavailable"),
+              data: { observedAt: new Date().toISOString() },
             }),
           ),
         );
@@ -120,12 +141,13 @@ export function createStudioRouter(
       }),
 
       // #12 GET /api/civ7/setup-catalog — host loader; error 500
-      setupCatalog: oe.civ7.setupCatalog.effect(function* () {
+      setupCatalog: oe.civ7.setupCatalog.effect(function* ({ errors }) {
         const config = yield* StudioConfig;
         const catalog = yield* Effect.tryPromise(() => config.loadSetupCatalog()).pipe(
           Effect.mapError((err) =>
-            orpcError(500, errorMessage(err, "Civ7 setup catalog unavailable"), {
-              observedAt: new Date().toISOString(),
+            errors.SETUP_CATALOG_UNAVAILABLE({
+              message: errorMessage(err, "Civ7 setup catalog unavailable"),
+              data: { observedAt: new Date().toISOString() },
             }),
           ),
         );
@@ -157,7 +179,7 @@ export function createStudioRouter(
         }),
 
         // #5 GET /api/civ7/live/snapshot — error 400; clamps + csv parse parity
-        snapshot: oe.civ7.live.snapshot.effect(function* ({ input }) {
+        snapshot: oe.civ7.live.snapshot.effect(function* ({ input, errors }) {
           const fields = input.fields
             .split(",")
             .map((field) => field.trim())
@@ -170,7 +192,9 @@ export function createStudioRouter(
             ...(input.playerId === undefined ? {} : { playerId: input.playerId }),
           }).pipe(
             Effect.mapError((err) =>
-              orpcError(400, errorMessage(err, "Civ7 live snapshot request failed")),
+              errors.CIV7_LIVE_SNAPSHOT_FAILED({
+                message: errorMessage(err, "Civ7 live snapshot request failed"),
+              }),
             ),
           );
           return {
@@ -181,7 +205,7 @@ export function createStudioRouter(
         }),
 
         // #6 GET /api/civ7/live/entities — error 400; Promise.all (any failure → 400)
-        entities: oe.civ7.live.entities.effect(function* ({ input }) {
+        entities: oe.civ7.live.entities.effect(function* ({ input, errors }) {
           const maxItems = Math.min(128, Math.max(1, input.maxItems));
           const playerId = input.playerId;
           const result = yield* Effect.all(
@@ -202,7 +226,9 @@ export function createStudioRouter(
             { concurrency: "unbounded" },
           ).pipe(
             Effect.mapError((err) =>
-              orpcError(400, errorMessage(err, "Civ7 live entities request failed")),
+              errors.CIV7_LIVE_ENTITIES_FAILED({
+                message: errorMessage(err, "Civ7 live entities request failed"),
+              }),
             ),
           );
           return {
@@ -215,7 +241,7 @@ export function createStudioRouter(
         }),
 
         // #7 GET /api/civ7/live/gameinfo — error 400; 8-table cap, N parallel reads
-        gameInfo: oe.civ7.live.gameInfo.effect(function* ({ input }) {
+        gameInfo: oe.civ7.live.gameInfo.effect(function* ({ input, errors }) {
           const tables = input.tables
             .split(",")
             .map((table) => table.trim())
@@ -231,7 +257,9 @@ export function createStudioRouter(
             { concurrency: "unbounded" },
           ).pipe(
             Effect.mapError((err) =>
-              orpcError(400, errorMessage(err, "Civ7 live GameInfo request failed")),
+              errors.CIV7_LIVE_GAMEINFO_FAILED({
+                message: errorMessage(err, "Civ7 live GameInfo request failed"),
+              }),
             ),
           );
           // Parity: each table value is the WHOLE result object (legacy behavior).
@@ -249,41 +277,69 @@ export function createStudioRouter(
 
     runInGame: {
       // #14 POST /api/civ7/run-in-game — host engine; 409/400/500/503
-      start: oe.runInGame.start.effect(function* ({ input }) {
+      start: oe.runInGame.start.effect(function* ({ input, errors }) {
         const config = yield* StudioConfig;
         return yield* Effect.tryPromise({
           try: () => config.runInGameStart(input),
           catch: (err) => err,
-        }).pipe(Effect.mapError(rethrowEngineError("Run in Game failed", 500)));
+        }).pipe(
+          Effect.mapError((err) =>
+            err instanceof ORPCError
+              ? err
+              : errors.RUN_IN_GAME_FAILED({ message: errorMessage(err, "Run in Game failed") }),
+          ),
+        );
       }),
 
       // #13 GET /api/civ7/run-in-game/status — host store; 404 echoes server id
-      status: oe.runInGame.status.effect(function* ({ input }) {
+      status: oe.runInGame.status.effect(function* ({ input, errors }) {
         const config = yield* StudioConfig;
         return yield* Effect.tryPromise({
           try: () => config.runInGameStatus(input),
           catch: (err) => err,
-        }).pipe(Effect.mapError(rethrowEngineError("Run in Game status failed", 500)));
+        }).pipe(
+          Effect.mapError((err) =>
+            err instanceof ORPCError
+              ? err
+              : errors.RUN_IN_GAME_FAILED({
+                  message: errorMessage(err, "Run in Game status failed"),
+                }),
+          ),
+        );
       }),
     },
 
     mapConfigs: {
       // #16 POST /api/map-configs — host engine; 409 mutex / 400 validation
-      saveDeploy: oe.mapConfigs.saveDeploy.effect(function* ({ input }) {
+      saveDeploy: oe.mapConfigs.saveDeploy.effect(function* ({ input, errors }) {
         const config = yield* StudioConfig;
         return yield* Effect.tryPromise({
           try: () => config.mapConfigSaveDeploy(input),
           catch: (err) => err,
-        }).pipe(Effect.mapError(rethrowEngineError("Save failed", 400)));
+        }).pipe(
+          Effect.mapError((err) =>
+            err instanceof ORPCError
+              ? err
+              : errors.SAVE_DEPLOY_FAILED({ message: errorMessage(err, "Save failed") }),
+          ),
+        );
       }),
 
       // #15 GET /api/map-configs/status — host store; 404 (no server id echo)
-      status: oe.mapConfigs.status.effect(function* ({ input }) {
+      status: oe.mapConfigs.status.effect(function* ({ input, errors }) {
         const config = yield* StudioConfig;
         return yield* Effect.tryPromise({
           try: () => config.mapConfigStatus(input),
           catch: (err) => err,
-        }).pipe(Effect.mapError(rethrowEngineError("Save/Deploy status failed", 500)));
+        }).pipe(
+          Effect.mapError((err) =>
+            err instanceof ORPCError
+              ? err
+              : errors.SAVE_DEPLOY_FAILED({
+                  message: errorMessage(err, "Save/Deploy status failed"),
+                }),
+          ),
+        );
       }),
     },
 
@@ -321,17 +377,4 @@ function fieldOrError<A>(
 ): Record<string, unknown> | { error: string } {
   if (either._tag === "Right") return (override ?? either.right) as Record<string, unknown>;
   return { error: String(either.left) };
-}
-
-/**
- * Re-throw a host-engine error: if it is already an `ORPCError` (the engine maps
- * its 409/400/404/500/503 + `data` via ../errors) pass it through verbatim;
- * otherwise wrap in a uniform fallback status. Used in `Effect.mapError`, so it
- * returns the resolved `ORPCError` (the effect handler's error channel).
- */
-function rethrowEngineError(fallbackMessage: string, fallbackStatus: number) {
-  return (err: unknown): ORPCError<string, unknown> => {
-    if (err instanceof ORPCError) return err;
-    return orpcError(fallbackStatus, errorMessage(err, fallbackMessage));
-  };
 }

--- a/packages/studio-server/test/handler.test.ts
+++ b/packages/studio-server/test/handler.test.ts
@@ -1,5 +1,5 @@
 import { createServer, type Server } from "node:http";
-import { createORPCClient } from "@orpc/client";
+import { createORPCClient, isDefinedError, safe, ORPCError } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
 import type { RouterClient } from "@orpc/server";
 import { afterEach, describe, expect, test } from "vitest";
@@ -52,6 +52,91 @@ describe("studio-server RPC handler", () => {
       deployed: true,
     });
     expect(calls).toEqual(["status:save-1"]);
+  });
+
+  test("delivers an engine 409 as the DEFINED SAVE_DEPLOY_BLOCKED error", async () => {
+    // The host context throws a RAW ORPCError whose code/status/data match the
+    // declared contract entry (contract/errors.ts) — oRPC must validate it into
+    // a defined error client-side (the "combining both approaches" rule).
+    const context = makeContext({
+      mapConfigSaveDeploy: async () => {
+        throw new ORPCError("SAVE_DEPLOY_BLOCKED", {
+          status: 409,
+          message: "Save/Deploy is already running.",
+          data: {
+            details: {
+              code: "save-deploy-operation-active",
+              activeRequestId: "save-0",
+            },
+          },
+        });
+      },
+    });
+    const client = await listenWithClient(context);
+
+    const { error } = await safe(
+      client.mapConfigs.saveDeploy({ requestId: "save-1", id: "test-config", envelope: {} }),
+    );
+
+    expect(error).toBeInstanceOf(ORPCError);
+    if (!(error instanceof ORPCError)) throw new Error("expected an ORPCError");
+    expect(isDefinedError(error)).toBe(true);
+    expect(error.code).toBe("SAVE_DEPLOY_BLOCKED");
+    expect(error.status).toBe(409);
+    expect(error.message).toBe("Save/Deploy is already running.");
+    expect(error.data).toEqual({
+      details: {
+        code: "save-deploy-operation-active",
+        activeRequestId: "save-0",
+      },
+    });
+  });
+
+  test("delivers a run-in-game status miss as RUN_IN_GAME_STATUS_NOT_FOUND with the server-identity echo", async () => {
+    const context = makeContext({
+      runInGameStatus: async () => {
+        throw new ORPCError("RUN_IN_GAME_STATUS_NOT_FOUND", {
+          status: 404,
+          message: "Run in Game request not found: run-1",
+          data: {
+            serverInstanceId: "studio-server-test",
+            serverStartedAt: "2026-06-10T00:00:00.000Z",
+          },
+        });
+      },
+    });
+    const client = await listenWithClient(context);
+
+    const { error } = await safe(client.runInGame.status({ requestId: "run-1" }));
+
+    expect(error).toBeInstanceOf(ORPCError);
+    if (!(error instanceof ORPCError)) throw new Error("expected an ORPCError");
+    expect(isDefinedError(error)).toBe(true);
+    expect(error.code).toBe("RUN_IN_GAME_STATUS_NOT_FOUND");
+    expect(error.status).toBe(404);
+    // PARITY INVARIANT: the 404 echoes the server identity for restart detection.
+    expect(error.data).toEqual({
+      serverInstanceId: "studio-server-test",
+      serverStartedAt: "2026-06-10T00:00:00.000Z",
+    });
+  });
+
+  test("wraps an unmapped engine throw as the namespace FAILED defined error", async () => {
+    const context = makeContext({
+      runInGameStart: async () => {
+        throw new Error("engine exploded");
+      },
+    });
+    const client = await listenWithClient(context);
+
+    const { error } = await safe(client.runInGame.start({ recipeId: "mod-swooper-maps/standard" }));
+
+    expect(error).toBeInstanceOf(ORPCError);
+    if (!(error instanceof ORPCError)) throw new Error("expected an ORPCError");
+    expect(isDefinedError(error)).toBe(true);
+    expect(error.code).toBe("RUN_IN_GAME_FAILED");
+    expect(error.status).toBe(500);
+    expect(error.message).toBe("engine exploded");
   });
 
   test("passes non-rpc paths through for host fallback middleware", async () => {


### PR DESCRIPTION
Contract declares per-procedure error maps (packages/studio-server/src/contract/errors.ts) pinning the legacy non-uniform statuses on DECLARED codes (CIV7_*/SETUP_*/SAVED_*, AUTOPLAY_*, RUN_IN_GAME_* incl. 404 server-identity echo, SAVE_DEPLOY_* incl. the documented no-echo 404 asymmetry). Router throws typed errors.CODE(...); the studio host context maps engine RunInGameHttpError statuses to matching raw ORPCErrors that arrive client-side as defined errors. Clients read failures via safe() + isDefinedError() and branch on codes, not raw status numbers.

Deleted as architectural dead weight: orpcError/statusToCode/rethrowEngineError (studio-server), orpcFailure/runInGameFailure/saveDeployFailure/readErrorData/StudioServerOrpcFailure/recipeDagSafeErrorMiddleware (studio). RunInGameHttpError-to-contract migration inside the engines (~18 throw sites) is a recorded deferred follow-up.

Gates: studio-server build/check/test (5) green; studio tsc clean; studio bun run test 239/50 green; turbo builds 15/15.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>