### PR TITLE
feat(civ7-control-orpc): idempotent explore short-circuit — skip suspend/grant/drain when full-map grant already held, add `mapPlotCount` probe + `step`/`detail` error fields

### DIFF
--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -276,6 +276,10 @@ export const Civ7ExploreFailedErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("display.explore.request"),
     source: Type.Literal("direct-control-facade"),
+    /** Wire-atom step that failed (e.g. "apply-explore-grant"). */
+    step: Type.Optional(Type.String()),
+    /** Human-readable failure detail from the underlying call. */
+    detail: Type.Optional(Type.String()),
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },

--- a/packages/civ7-control-orpc/src/modules/display/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/display/contract.ts
@@ -99,9 +99,30 @@ const Civ7DisplayExploreVisibilityProbeSchema = Type.Object(
   { additionalProperties: false },
 );
 
-const Civ7DisplayExploreRequestResultSchema = Type.Object(
+/**
+ * Idempotent short-circuit shape: the pre-grant visibility read already shows
+ * every plot revealed AND visible (a prior explore grant is still held), so
+ * the procedure skips suspend/grant/drain entirely — re-running
+ * `Visibility.setTrackedVisibilityGrant` against an already-held full-map
+ * grant is the known second-click failure mode. `before`/`after` echo the
+ * same read: nothing mutated.
+ */
+const Civ7DisplayExploreSkippedResultSchema = Type.Object(
   {
     playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
+    skipped: Type.Literal(true),
+    before: Civ7DisplayExploreVisibilityProbeSchema,
+    after: Civ7DisplayExploreVisibilityProbeSchema,
+    mapPlotCount: Type.Number(),
+    classification: Type.Literal("already-explored"),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7DisplayExploreFullResultSchema = Type.Object(
+  {
+    playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
+    skipped: Type.Literal(false),
     before: Civ7DisplayExploreVisibilityProbeSchema,
     after: Civ7DisplayExploreVisibilityProbeSchema,
     grantId: Type.Number(),
@@ -123,6 +144,11 @@ const Civ7DisplayExploreRequestResultSchema = Type.Object(
   },
   { additionalProperties: false },
 );
+
+const Civ7DisplayExploreRequestResultSchema = Type.Union([
+  Civ7DisplayExploreSkippedResultSchema,
+  Civ7DisplayExploreFullResultSchema,
+]);
 export type Civ7DisplayExploreRequestResult = Static<
   typeof Civ7DisplayExploreRequestResultSchema
 >;

--- a/packages/civ7-control-orpc/src/modules/display/procedures/explore-request.ts
+++ b/packages/civ7-control-orpc/src/modules/display/procedures/explore-request.ts
@@ -27,6 +27,10 @@ type ExploreDrainState = Readonly<{
  * fogged) without granting live vision — by orchestrating the direct-control
  * wire atoms as one Effect state machine:
  *
+ *   0. read the visibility summary; when every plot is already revealed AND
+ *      visible (a prior grant is still held) and fog restore was not
+ *      requested, return a skipped already-explored result — re-granting
+ *      against a held full-map grant is the second-call failure mode,
  *   1. suspend the DisplayQueueManager (App UI) so nothing can mount —
  *      verified by readback before anything mutates,
  *   2. applyCiv7ExploreGrant (Visibility.setTrackedVisibilityGrant over every
@@ -57,13 +61,20 @@ export const displayExploreRequestProcedure =
       source: "direct-control-facade" as const,
       ...civ7ControlOrpcErrorCorrelationData(context),
     };
-    const facadeCall = <T>(call: () => Promise<T>) =>
+    const facadeCall = <T>(step: string, call: () => Promise<T>) =>
       Effect.tryPromise({
         try: call,
-        catch: () => errors.EXPLORE_FAILED({ data: errorData }),
+        catch: (cause) =>
+          errors.EXPLORE_FAILED({
+            data: {
+              ...errorData,
+              step,
+              detail: cause instanceof Error ? cause.message : String(cause),
+            },
+          }),
       });
-    const readVisibilitySummary = () =>
-      facadeCall(() =>
+    const readVisibilitySummary = (step: string) =>
+      facadeCall(step, () =>
         context.directControl.getCiv7VisibilitySummary(
           { playerId: input.playerId },
           context.endpointDefaults,
@@ -75,14 +86,42 @@ export const displayExploreRequestProcedure =
     const maxExtraWaitMs = input.maxExtraWaitMs
       ?? DEFAULT_EXPLORE_MAX_EXTRA_WAIT_MS;
 
-    const before = yield* readVisibilitySummary();
+    const before = yield* readVisibilitySummary("read-visibility-before");
+
+    // Idempotent short-circuit: when the pre-grant read already shows every
+    // plot revealed AND visible, a prior explore grant is still held —
+    // re-running Visibility.setTrackedVisibilityGrant against it is the
+    // second-click failure mode, and there is nothing left to reveal. Skipped
+    // when restoreFog is requested: that caller wants the release path.
+    const beforeRevealed = probeValue(before.numPlotsRevealed);
+    const beforeVisible = probeValue(before.numPlotsVisible);
+    const mapPlotCount = probeValue(before.mapPlotCount);
+    if (
+      input.restoreFog !== true
+      && beforeRevealed != null
+      && beforeVisible != null
+      && mapPlotCount != null
+      && mapPlotCount > 0
+      && beforeRevealed >= mapPlotCount
+      && beforeVisible >= mapPlotCount
+    ) {
+      return {
+        playerId: input.playerId,
+        skipped: true,
+        before: visibilityProbe(before),
+        after: visibilityProbe(before),
+        mapPlotCount,
+        classification: "already-explored",
+      } satisfies Civ7DisplayExploreRequestResult;
+    }
+
     const resumedInline = yield* Ref.make(false);
 
     return yield* Effect.acquireUseRelease(
       // Acquire: suspend the display queue, verified by readback — the state
       // machine gate before any mutation runs.
       Effect.gen(function* () {
-        const suspend = yield* facadeCall(() =>
+        const suspend = yield* facadeCall("suspend-display-queue", () =>
           context.directControl.suspendCiv7DisplayQueue(
             context.endpointDefaults,
           )
@@ -96,7 +135,7 @@ export const displayExploreRequestProcedure =
       }),
       () =>
         Effect.gen(function* () {
-          const grant = yield* facadeCall(() =>
+          const grant = yield* facadeCall("apply-explore-grant", () =>
             context.directControl.applyCiv7ExploreGrant(
               { playerId: input.playerId },
               context.endpointDefaults,
@@ -122,7 +161,7 @@ export const displayExploreRequestProcedure =
               body: (state) =>
                 Effect.gen(function* () {
                   yield* Effect.sleep(pollMs);
-                  const purge = yield* facadeCall(() =>
+                  const purge = yield* facadeCall("drain-close-displays", () =>
                     context.directControl.closeCiv7Displays(
                       {},
                       context.endpointDefaults,
@@ -156,21 +195,21 @@ export const displayExploreRequestProcedure =
 
           // Resume precedes the grant release so late displays cannot
           // re-queue mid-flight.
-          const resume = yield* facadeCall(() =>
+          const resume = yield* facadeCall("resume-display-queue", () =>
             context.directControl.resumeCiv7DisplayQueue(
               context.endpointDefaults,
             )
           );
           yield* Ref.set(resumedInline, true);
           const release = input.restoreFog === true
-            ? yield* facadeCall(() =>
+            ? yield* facadeCall("release-explore-grant", () =>
               context.directControl.releaseCiv7ExploreGrant(
                 { playerId: input.playerId, grantId: grant.grantId },
                 context.endpointDefaults,
               )
             )
             : null;
-          const after = yield* readVisibilitySummary();
+          const after = yield* readVisibilitySummary("read-visibility-after");
 
           return displayExploreRequestResult({
             playerId: input.playerId,
@@ -222,6 +261,7 @@ function displayExploreRequestResult(input: Readonly<{
       : "unverified";
   return {
     playerId: input.playerId,
+    skipped: false,
     before: visibilityProbe(input.before),
     after: visibilityProbe(input.after),
     grantId: input.grantId,

--- a/packages/civ7-control-orpc/test/display-explore-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/display-explore-procedure.test.ts
@@ -143,9 +143,51 @@ describe("display.explore.request control-oRPC procedure", () => {
       data: {
         procedureKey: "display.explore.request",
         source: "direct-control-facade",
+        step: "apply-explore-grant",
+        detail: "tuner down",
       },
     });
     expect(fake.calls).toEqual(["summary", "suspend", "grant", "resume"]);
+  });
+
+  test("short-circuits to a skipped already-explored result when every plot is revealed and visible", async () => {
+    // Fully revealed AND fully visible: a prior explore grant is still held.
+    // The procedure must NOT suspend/grant/drain — re-granting against a
+    // held full-map grant is the second-call failure mode.
+    const fake = fakeContext({
+      summaries: [visibilitySummary(6996, 6996)],
+    });
+    const result = await call(
+      Civ7ControlOrpcRouter.display.explore.request,
+      { playerId: 0, ...fastDrain },
+      { context: fake.context },
+    );
+    expect(fake.calls).toEqual(["summary"]);
+    expect(result).toEqual({
+      playerId: 0,
+      skipped: true,
+      before: { revealed: 6996, visible: 6996 },
+      after: { revealed: 6996, visible: 6996 },
+      mapPlotCount: 6996,
+      classification: "already-explored",
+    });
+    expectSafeExploreOutput(result);
+  });
+
+  test("runs the full machine despite full visibility when restoreFog is set", async () => {
+    // restoreFog callers want the release path — the short-circuit would
+    // silently skip it, so it must not engage.
+    const fake = fakeContext({
+      summaries: [visibilitySummary(6996, 6996), visibilitySummary(6996, 7)],
+    });
+    const result = await call(
+      Civ7ControlOrpcRouter.display.explore.request,
+      { playerId: 0, restoreFog: true, ...fastDrain },
+      { context: fake.context },
+    );
+    expect(fake.calls).toContain("grant");
+    expect(fake.calls).toContain("release");
+    expect(result).toMatchObject({ skipped: false, grantReleased: true });
   });
 
   test("classifies an unchanged revealed count as already-explored", async () => {
@@ -306,6 +348,7 @@ function fakeContext(options: {
 
 function visibilitySummary(
   revealed: number,
+  visible = 7,
 ): Civ7ControlOrpcVisibilitySummaryResult {
   return {
     host: "127.0.0.1",
@@ -313,7 +356,8 @@ function visibilitySummary(
     state: { id: "1", name: "Tuner" },
     playerId: 0,
     numPlotsRevealed: { ok: true, value: revealed },
-    numPlotsVisible: { ok: true, value: 7 },
+    numPlotsVisible: { ok: true, value: visible },
+    mapPlotCount: { ok: true, value: 6996 },
     counts: {},
   };
 }

--- a/packages/civ7-direct-control/src/play/map/visibility-procedure.ts
+++ b/packages/civ7-direct-control/src/play/map/visibility-procedure.ts
@@ -44,6 +44,7 @@ export const Civ7VisibilitySummaryProcedureDescriptor = createCiv7ProcedureCoreD
     "playerId",
     "numPlotsRevealed",
     "numPlotsVisible",
+    "mapPlotCount",
     "counts",
     "grid",
   ],

--- a/packages/civ7-direct-control/src/play/map/visibility.ts
+++ b/packages/civ7-direct-control/src/play/map/visibility.ts
@@ -65,6 +65,7 @@ export const Civ7VisibilitySummaryResultSchema = Type.Object({
   playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
   numPlotsRevealed: Civ7RuntimeProbeSchema(Type.Number()),
   numPlotsVisible: Civ7RuntimeProbeSchema(Type.Number()),
+  mapPlotCount: Civ7RuntimeProbeSchema(Type.Number()),
   counts: Type.Record(Type.String(), Type.Number()),
   grid: Type.Optional(Type.Object({
     bounds: Civ7MapBoundsSchema,
@@ -81,6 +82,7 @@ export type Civ7VisibilitySummaryResult = Readonly<{
   playerId: number;
   numPlotsRevealed: Civ7RuntimeProbe<number>;
   numPlotsVisible: Civ7RuntimeProbe<number>;
+  mapPlotCount: Civ7RuntimeProbe<number>;
   counts: Record<string, number>;
   grid?: Readonly<{
     bounds: Civ7MapBounds;
@@ -355,6 +357,7 @@ function buildVisibilitySummaryCommand(
       numPlotsVisible: probe(() => typeof Visibility !== "undefined" && typeof Visibility.getPlotsVisibleCount === "function"
         ? Visibility.getPlotsVisibleCount(input.playerId)
         : 0),
+      mapPlotCount: probe(() => GameplayMap.getGridWidth() * GameplayMap.getGridHeight()),
       counts,
       ...(input.includeGrid ? {
         grid: {

--- a/packages/civ7-direct-control/test/map-and-visibility.test.ts
+++ b/packages/civ7-direct-control/test/map-and-visibility.test.ts
@@ -638,6 +638,7 @@ function visibilityPayload(revealedCount: number) {
     playerId: 0,
     numPlotsRevealed: { ok: true, value: revealedCount },
     numPlotsVisible: { ok: true, value: revealedCount },
+    mapPlotCount: { ok: true, value: revealedCount },
     counts: { "1": 2 },
     grid: {
       bounds: { x: 0, y: 0, width: 2, height: 1 },

--- a/packages/civ7-direct-control/test/public-api.test.ts
+++ b/packages/civ7-direct-control/test/public-api.test.ts
@@ -339,6 +339,7 @@ describe("Civ7 direct control public API", () => {
         "playerId",
         "numPlotsRevealed",
         "numPlotsVisible",
+        "mapPlotCount",
         "counts",
       ]),
     });

--- a/packages/civ7-direct-control/test/visibility-summary-procedure.test.ts
+++ b/packages/civ7-direct-control/test/visibility-summary-procedure.test.ts
@@ -201,6 +201,7 @@ function visibilitySummaryResult() {
     playerId: 0,
     numPlotsRevealed: { ok: true as const, value: 10 },
     numPlotsVisible: { ok: true as const, value: 2 },
+    mapPlotCount: { ok: true as const, value: 2 },
     counts: { "1": 2 },
     grid: {
       bounds: { x: 0, y: 0, width: 2, height: 1 },


### PR DESCRIPTION
Adds an idempotent short-circuit to `display.explore.request` that detects when a prior explore grant is still held (every plot already revealed **and** visible) and returns a `skipped: true / classification: "already-explored"` result immediately, without executing the suspend → grant → drain → resume pipeline. Re-running `Visibility.setTrackedVisibilityGrant` against an already-held full-map grant is the known second-click failure mode this prevents. The short-circuit is bypassed when `restoreFog: true` is set, since those callers require the release path.

To support the detection logic, `mapPlotCount` (derived from `GameplayMap.getGridWidth() * GameplayMap.getGridHeight()`) is added to the visibility summary result and included in the procedure descriptor's field list.

The explore result type is split into a discriminated union on `skipped: true | false` — `Civ7DisplayExploreSkippedResultSchema` for the short-circuit path and `Civ7DisplayExploreFullResultSchema` for the normal path — and the full-path result now carries `skipped: false` explicitly.

Error data from `facadeCall` is enriched with a `step` label (e.g. `"apply-explore-grant"`) and a `detail` string extracted from the caught error, surfaced through `Civ7ExploreFailedErrorDataSchema`. Each internal call site now passes its step name.