### PR TITLE
feat(civ7-control-orpc): propagate bounded failure `detail` to all procedure error data via shared `civ7ControlOrpcFailureDetail`

### DIFF
--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -12,10 +12,18 @@ const Civ7ControlOrpcErrorCorrelationProperties = {
   correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
 };
 
+const Civ7ControlOrpcErrorFailureProperties = {
+  /** Failing wire-atom step within the procedure (e.g. "apply-explore-grant"), when it runs several. */
+  step: Type.Optional(Type.String()),
+  /** Human-readable failure detail from the underlying call. */
+  detail: Type.Optional(Type.String()),
+};
+
 export const Civ7ReadinessCurrentUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("readiness.current"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -38,6 +46,7 @@ export const Civ7AttentionCurrentUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("attention.current"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -60,6 +69,7 @@ export const Civ7AttentionPrioritiesUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("attention.priorities"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -82,6 +92,7 @@ export const Civ7StrategyFrontSummaryUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("strategy.frontSummary"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -108,6 +119,7 @@ export const Civ7StrategyTacticalReadUnavailableErrorDataSchema = Type.Object(
       Type.Literal("strategy.destinationAnalysis"),
     ]),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -133,6 +145,7 @@ export const Civ7StrategyCivilianRouteTriageUnavailableErrorDataSchema =
     {
       procedureKey: Type.Literal("strategy.civilianRouteTriage"),
       source: Type.Literal("direct-control-facade"),
+      ...Civ7ControlOrpcErrorFailureProperties,
       ...Civ7ControlOrpcErrorCorrelationProperties,
     },
     { additionalProperties: false },
@@ -158,6 +171,7 @@ export const Civ7StrategyFormationSnapshotUnavailableErrorDataSchema =
     {
       procedureKey: Type.Literal("strategy.formationSnapshot"),
       source: Type.Literal("direct-control-facade"),
+      ...Civ7ControlOrpcErrorFailureProperties,
       ...Civ7ControlOrpcErrorCorrelationProperties,
     },
     { additionalProperties: false },
@@ -182,6 +196,7 @@ export const Civ7WorldCurrentUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("world.current"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -207,6 +222,7 @@ export const Civ7WorldReadUnavailableErrorDataSchema = Type.Object(
       Type.Literal("world.grid.read"),
     ]),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -232,6 +248,7 @@ export const Civ7DisplayQueueUnavailableErrorDataSchema = Type.Object(
       Type.Literal("display.queue.close"),
     ]),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -254,6 +271,7 @@ export const Civ7ExploreSuspensionUnverifiedErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("display.explore.request"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -276,10 +294,7 @@ export const Civ7ExploreFailedErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("display.explore.request"),
     source: Type.Literal("direct-control-facade"),
-    /** Wire-atom step that failed (e.g. "apply-explore-grant"). */
-    step: Type.Optional(Type.String()),
-    /** Human-readable failure detail from the underlying call. */
-    detail: Type.Optional(Type.String()),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -302,8 +317,7 @@ export const Civ7AppshotErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("view.appshot.capture"),
     source: Type.Literal("direct-control-facade"),
-    /** Human-readable failure detail from the capture pipeline. */
-    detail: Type.Optional(Type.String()),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -359,8 +373,7 @@ export const Civ7ViewCameraErrorDataSchema = Type.Object(
       Type.Literal("view.appshot.capture"),
     ]),
     source: Type.Literal("direct-control-facade"),
-    /** Human-readable failure detail from the camera pipeline. */
-    detail: Type.Optional(Type.String()),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -391,6 +404,7 @@ export const Civ7NotificationDismissalUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("notifications.dismiss.request"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -416,6 +430,7 @@ export const Civ7NotificationAdvisorWarningUnavailableErrorDataSchema =
         "notifications.advisorWarning.viewed.request",
       ),
       source: Type.Literal("direct-control-facade"),
+      ...Civ7ControlOrpcErrorFailureProperties,
       ...Civ7ControlOrpcErrorCorrelationProperties,
     },
     { additionalProperties: false },
@@ -443,6 +458,7 @@ export const Civ7NotificationQueueUnavailableErrorDataSchema = Type.Object(
       Type.Literal("notifications.queue.dismiss.request"),
     ]),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -465,6 +481,7 @@ export const Civ7UnitTargetActionUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("unit.target.action.request"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -490,6 +507,7 @@ export const Civ7UnitRequestUnavailableErrorDataSchema = Type.Object(
       Type.Literal("unit.resettle.request"),
     ]),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -512,6 +530,7 @@ export const Civ7NarrativeChoiceUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("narrative.choice.request"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -534,6 +553,7 @@ export const Civ7DiplomacyResponseUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("diplomacy.response.request"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -556,6 +576,7 @@ export const Civ7FirstMeetResponseUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("diplomacy.firstMeet.response.request"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -581,6 +602,7 @@ export const Civ7GovernmentChoiceUnavailableErrorDataSchema = Type.Object(
       Type.Literal("government.celebration.choice.request"),
     ]),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -606,6 +628,7 @@ export const Civ7ProgressionChoiceUnavailableErrorDataSchema = Type.Object(
       Type.Literal("progression.culture.choice.request"),
     ]),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -628,6 +651,7 @@ export const Civ7ProgressionDashboardUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("progression.dashboard.current"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -652,6 +676,7 @@ export const Civ7ProgressionTraditionsUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("progression.traditions.current"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -682,6 +707,7 @@ export const Civ7ProgressionPlayerChoiceUnavailableErrorDataSchema =
         Type.Literal("progression.tradition.review.request"),
       ]),
       source: Type.Literal("direct-control-facade"),
+      ...Civ7ControlOrpcErrorFailureProperties,
       ...Civ7ControlOrpcErrorCorrelationProperties,
     },
     { additionalProperties: false },
@@ -709,6 +735,7 @@ export const Civ7ProgressionTargetUnavailableErrorDataSchema = Type.Object(
       Type.Literal("progression.culture.target.request"),
     ]),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -731,6 +758,7 @@ export const Civ7TurnCompletionUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("turn.complete.request"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -756,6 +784,7 @@ export const Civ7MutationReadinessRequiredErrorDataSchema = Type.Object(
     risk: Type.Literal("mutation"),
     playable: Type.Literal(false),
     readiness: Type.String(),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -779,6 +808,7 @@ export const Civ7MutationReadinessUnavailableErrorDataSchema = Type.Object(
     procedureKey: Type.String(),
     source: Type.Literal("direct-control-facade"),
     risk: Type.Literal("mutation"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -809,6 +839,7 @@ export const Civ7MutationProofBoundaryInvalidErrorDataSchema = Type.Object(
       Type.Literal("sent-unverified-without-do-not-repeat"),
       Type.Literal("sent-guarded-without-do-not-repeat"),
     ]),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -831,6 +862,7 @@ export const Civ7ProductionChoiceUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("city.production.choice.request"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -856,6 +888,7 @@ export const Civ7TownFocusUnavailableErrorDataSchema = Type.Object(
       Type.Literal("city.townFocus.review.request"),
     ]),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },
@@ -878,6 +911,7 @@ export const Civ7PopulationPlacementUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("city.population.place.request"),
     source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorFailureProperties,
     ...Civ7ControlOrpcErrorCorrelationProperties,
   },
   { additionalProperties: false },

--- a/packages/civ7-control-orpc/src/model/correlation.ts
+++ b/packages/civ7-control-orpc/src/model/correlation.ts
@@ -1,3 +1,4 @@
+import { Civ7DirectControlError } from "@civ7/direct-control";
 import { Type, type Static } from "typebox";
 
 export const Civ7ControlOrpcCorrelationIdSchema = Type.String({
@@ -25,4 +26,20 @@ export function civ7ControlOrpcErrorCorrelationData(
   return isCiv7ControlOrpcCorrelationId(correlationId)
     ? { correlationId }
     : {};
+}
+
+/**
+ * Bounded failure detail for a defined-error `detail` field. NEVER the raw
+ * cause message: tuner failure messages embed raw commands and endpoint
+ * details, and error data is a wire contract (pinned by the "without raw
+ * details" leak tests). Civ7DirectControlError causes surface their bounded
+ * code ("direct-control/response-timeout"); anything else surfaces only its
+ * constructor name.
+ */
+export function civ7ControlOrpcFailureDetail(cause: unknown): string {
+  if (cause instanceof Civ7DirectControlError) {
+    return `direct-control/${cause.code}`;
+  }
+  if (cause instanceof Error) return cause.name;
+  return typeof cause;
 }

--- a/packages/civ7-control-orpc/src/modules/attention/procedures/current.ts
+++ b/packages/civ7-control-orpc/src/modules/attention/procedures/current.ts
@@ -13,7 +13,10 @@ import type {
   Civ7ControlOrpcReadyUnitViewResult,
   Civ7ControlOrpcTurnCompletionStatusResult,
 } from "../../../dependencies/direct-control";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
   Civ7AttentionCurrentInput,
@@ -86,9 +89,10 @@ export const attentionCurrentProcedure =
           },
         });
       },
-      catch: () =>
+      catch: (cause) =>
         errors.ATTENTION_CURRENT_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "attention.current",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/attention/procedures/priorities.ts
+++ b/packages/civ7-control-orpc/src/modules/attention/procedures/priorities.ts
@@ -14,7 +14,10 @@ import type {
   Civ7ControlOrpcReadyUnitViewResult,
   Civ7ControlOrpcTurnCompletionStatusResult,
 } from "../../../dependencies/direct-control";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import type { Civ7ControlOrpcMapLocation } from "../../../model/primitives";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
@@ -99,9 +102,10 @@ export const attentionPrioritiesProcedure =
           },
         });
       },
-      catch: () =>
+      catch: (cause) =>
         errors.ATTENTION_PRIORITIES_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "attention.priorities",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/city/procedures/population-place-request.ts
+++ b/packages/civ7-control-orpc/src/modules/city/procedures/population-place-request.ts
@@ -3,7 +3,10 @@ import { Effect } from "effect";
 
 import type { Civ7ControlOrpcContext } from "../../../context";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7MutationNextSteps,
   civ7MutationRequestStatus,
@@ -57,9 +60,10 @@ export const cityPopulationPlaceRequestProcedure =
           );
         return cityPopulationPlacementResult(runtimeInput, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.POPULATION_PLACEMENT_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "city.population.place.request",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/city/procedures/production-choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/city/procedures/production-choice-request.ts
@@ -6,7 +6,10 @@ import { Effect } from "effect";
 
 import type { Civ7ControlOrpcProductionChoiceResult } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7MutationNextSteps,
   civ7MutationRequestStatusWithoutGuarded,
@@ -30,9 +33,10 @@ export const cityProductionChoiceRequestProcedure =
         );
         return cityProductionChoiceResult(input, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.PRODUCTION_CHOICE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "city.production.choice.request",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/city/procedures/town-focus-request.ts
+++ b/packages/civ7-control-orpc/src/modules/city/procedures/town-focus-request.ts
@@ -4,7 +4,10 @@ import { Effect } from "effect";
 import type { Civ7ControlOrpcContext } from "../../../context";
 import type { Civ7ControlOrpcDirectControlFacade } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7CloseoutMutationProjection,
 } from "../../../policy/mutation-result";
@@ -44,9 +47,10 @@ export const cityTownFocusChangeRequestProcedure =
         );
         return townFocusResult(source, input, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.TOWN_FOCUS_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: source,
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),
@@ -72,9 +76,10 @@ export const cityTownFocusReviewRequestProcedure =
         );
         return townFocusResult(source, input, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.TOWN_FOCUS_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: source,
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/diplomacy/procedures/first-meet-response-request.ts
+++ b/packages/civ7-control-orpc/src/modules/diplomacy/procedures/first-meet-response-request.ts
@@ -4,7 +4,10 @@ import { Effect } from "effect";
 import type { Civ7ControlOrpcContext } from "../../../context";
 import type { Civ7ControlOrpcFirstMeetResponseResult } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7CloseoutMutationProjection,
 } from "../../../policy/mutation-result";
@@ -40,9 +43,10 @@ export const firstMeetResponseRequestProcedure =
         );
         return firstMeetResponseResult(requestInput, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.FIRST_MEET_RESPONSE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "diplomacy.firstMeet.response.request",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/diplomacy/procedures/response-request.ts
+++ b/packages/civ7-control-orpc/src/modules/diplomacy/procedures/response-request.ts
@@ -4,7 +4,10 @@ import { Effect } from "effect";
 import type { Civ7ControlOrpcContext } from "../../../context";
 import type { Civ7ControlOrpcDiplomacyResponseResult } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7CloseoutMutationProjection,
 } from "../../../policy/mutation-result";
@@ -43,9 +46,10 @@ export const diplomacyResponseRequestProcedure =
         );
         return diplomacyResponseResult(requestInput, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.DIPLOMACY_RESPONSE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "diplomacy.response.request",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/display/procedures/explore-request.ts
+++ b/packages/civ7-control-orpc/src/modules/display/procedures/explore-request.ts
@@ -5,7 +5,10 @@ import {
 import { Effect, Ref } from "effect";
 
 import type { Civ7ControlOrpcVisibilitySummaryResult } from "../../../dependencies/direct-control";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type { Civ7DisplayExploreRequestResult } from "../contract";
 
@@ -69,7 +72,7 @@ export const displayExploreRequestProcedure =
             data: {
               ...errorData,
               step,
-              detail: cause instanceof Error ? cause.message : String(cause),
+              detail: civ7ControlOrpcFailureDetail(cause),
             },
           }),
       });

--- a/packages/civ7-control-orpc/src/modules/display/procedures/queue.ts
+++ b/packages/civ7-control-orpc/src/modules/display/procedures/queue.ts
@@ -4,7 +4,10 @@ import type {
   Civ7ControlOrpcCloseDisplaysResult,
   Civ7ControlOrpcDisplayQueueSnapshotResult,
 } from "../../../dependencies/direct-control";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
   Civ7DisplayQueueCloseResult,
@@ -23,9 +26,10 @@ export const displayQueueCurrentProcedure =
             context.endpointDefaults,
           ),
         ),
-      catch: () =>
+      catch: (cause) =>
         errors.DISPLAY_QUEUE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "display.queue.current",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),
@@ -48,9 +52,10 @@ export const displayQueueCloseProcedure =
             context.endpointDefaults,
           ),
         ),
-      catch: () =>
+      catch: (cause) =>
         errors.DISPLAY_QUEUE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "display.queue.close",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/government/procedures/choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/government/procedures/choice-request.ts
@@ -4,7 +4,10 @@ import { Effect } from "effect";
 import type { Civ7ControlOrpcContext } from "../../../context";
 import type { Civ7ControlOrpcGovernmentChoiceResult } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7CloseoutMutationProjection,
 } from "../../../policy/mutation-result";
@@ -49,9 +52,10 @@ export const governmentChoiceRequestProcedure =
         );
         return governmentChoiceResult(source, requestInput, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.GOVERNMENT_CHOICE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: source,
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),
@@ -82,9 +86,10 @@ export const governmentCelebrationChoiceRequestProcedure =
         );
         return governmentChoiceResult(source, requestInput, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.GOVERNMENT_CHOICE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: source,
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/narrative/procedures/choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/narrative/procedures/choice-request.ts
@@ -4,7 +4,10 @@ import { Effect } from "effect";
 import type { Civ7ControlOrpcContext } from "../../../context";
 import type { Civ7ControlOrpcNarrativeChoiceResult } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7CloseoutMutationProjection,
 } from "../../../policy/mutation-result";
@@ -41,9 +44,10 @@ export const narrativeChoiceRequestProcedure =
         );
         return narrativeChoiceResult(requestInput, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.NARRATIVE_CHOICE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "narrative.choice.request",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/notifications/procedures/advisor-warning-request.ts
+++ b/packages/civ7-control-orpc/src/modules/notifications/procedures/advisor-warning-request.ts
@@ -6,7 +6,10 @@ import { Effect } from "effect";
 import type { Civ7ControlOrpcContext } from "../../../context";
 import type { Civ7ControlOrpcAdvisorWarningViewedResult } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7CloseoutMutationProjection,
 } from "../../../policy/mutation-result";
@@ -39,9 +42,10 @@ export const notificationsAdvisorWarningViewedRequestProcedure =
           );
         return advisorWarningViewedResult(input, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.NOTIFICATION_ADVISOR_WARNING_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: source,
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/notifications/procedures/dismiss-request.ts
+++ b/packages/civ7-control-orpc/src/modules/notifications/procedures/dismiss-request.ts
@@ -5,7 +5,10 @@ import { Effect } from "effect";
 
 import type { Civ7ControlOrpcNotificationDismissalResult } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7CloseoutMutationProjection,
 } from "../../../policy/mutation-result";
@@ -29,9 +32,10 @@ export const notificationsDismissRequestProcedure =
           );
         return notificationDismissalResult(result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.NOTIFICATION_DISMISSAL_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "notifications.dismiss.request",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/notifications/procedures/queue.ts
+++ b/packages/civ7-control-orpc/src/modules/notifications/procedures/queue.ts
@@ -5,7 +5,10 @@ import type {
   Civ7ControlOrpcPlayNotificationViewResult,
 } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
   Civ7NotificationQueueDismissResult,
@@ -34,9 +37,10 @@ export const notificationsQueueCurrentProcedure =
         });
         return notificationQueueResult(view);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.NOTIFICATION_QUEUE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "notifications.queue.current",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),
@@ -87,9 +91,10 @@ export const notificationsQueueDismissRequestProcedure =
           maxDismissals,
         });
       },
-      catch: () =>
+      catch: (cause) =>
         errors.NOTIFICATION_QUEUE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "notifications.queue.dismiss.request",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/progression/procedures/choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/procedures/choice-request.ts
@@ -13,7 +13,10 @@ import type {
   Civ7ControlOrpcTechnologyChoiceCloseoutResult,
 } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7CloseoutMutationProjection,
   type Civ7MutationProofPostcondition,
@@ -75,9 +78,10 @@ export const progressionTechnologyChoiceRequestProcedure =
         const after = await readAfterProgressionChoice(context, result);
         return progressionChoiceResult(kind, source, requestInput, result, before, after);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.PROGRESSION_CHOICE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: source,
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),
@@ -108,9 +112,10 @@ export const progressionCultureChoiceRequestProcedure =
         const after = await readAfterProgressionChoice(context, result);
         return progressionChoiceResult(kind, source, requestInput, result, before, after);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.PROGRESSION_CHOICE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: source,
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/progression/procedures/dashboard-current.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/procedures/dashboard-current.ts
@@ -2,7 +2,10 @@ import { Effect } from "effect";
 
 import type { Civ7ControlOrpcContext } from "../../../context";
 import type { Civ7ControlOrpcProgressDashboardResult } from "../../../dependencies/direct-control";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
   Civ7ProgressionDashboardInput,
@@ -27,9 +30,10 @@ export const progressionDashboardCurrentProcedure =
         );
         return progressionDashboardResult(input, dashboard);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.PROGRESSION_DASHBOARD_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "progression.dashboard.current",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/progression/procedures/player-choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/procedures/player-choice-request.ts
@@ -4,7 +4,10 @@ import { Effect } from "effect";
 import type { Civ7ControlOrpcContext } from "../../../context";
 import type { Civ7ControlOrpcProgressionPlayerChoiceResult } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7CloseoutMutationProjection,
 } from "../../../policy/mutation-result";
@@ -53,9 +56,10 @@ export const progressionAttributePurchaseRequestProcedure =
         );
         return progressionPlayerChoiceResult(source, requestInput, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.PROGRESSION_PLAYER_CHOICE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: source,
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),
@@ -82,9 +86,10 @@ export const progressionAttributeReviewRequestProcedure =
         );
         return progressionPlayerChoiceResult(source, requestInput, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.PROGRESSION_PLAYER_CHOICE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: source,
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),
@@ -116,9 +121,10 @@ export const progressionTraditionChangeRequestProcedure =
         );
         return progressionPlayerChoiceResult(source, requestInput, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.PROGRESSION_PLAYER_CHOICE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: source,
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),
@@ -145,9 +151,10 @@ export const progressionTraditionReviewRequestProcedure =
         );
         return progressionPlayerChoiceResult(source, requestInput, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.PROGRESSION_PLAYER_CHOICE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: source,
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/progression/procedures/target-request.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/procedures/target-request.ts
@@ -4,7 +4,10 @@ import { Effect } from "effect";
 import type { Civ7ControlOrpcContext } from "../../../context";
 import type { Civ7ControlOrpcProgressionTargetResult } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7CloseoutMutationProjection,
 } from "../../../policy/mutation-result";
@@ -42,9 +45,10 @@ export const progressionTechnologyTargetRequestProcedure =
         const result = await requestProgressionTarget(kind, requestInput, context);
         return progressionTargetResult(source, requestInput, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.PROGRESSION_TARGET_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: source,
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),
@@ -70,9 +74,10 @@ export const progressionCultureTargetRequestProcedure =
         const result = await requestProgressionTarget(kind, requestInput, context);
         return progressionTargetResult(source, requestInput, result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.PROGRESSION_TARGET_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: source,
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/progression/procedures/traditions-current.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/procedures/traditions-current.ts
@@ -1,7 +1,10 @@
 import { Effect } from "effect";
 
 import type { Civ7ControlOrpcTraditionsViewResult } from "../../../dependencies/direct-control";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
   Civ7ProgressionTraditionsInput,
@@ -22,9 +25,10 @@ export const progressionTraditionsCurrentProcedure =
         );
         return progressionTraditionsResult(input, traditions);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.PROGRESSION_TRADITIONS_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "progression.traditions.current",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/readiness/procedures/current.ts
+++ b/packages/civ7-control-orpc/src/modules/readiness/procedures/current.ts
@@ -3,7 +3,10 @@ import { Effect } from "effect";
 
 import type { Civ7ControlOrpcContext } from "../../../context";
 import type { Civ7ControlOrpcPlayableStatusResult } from "../../../dependencies/direct-control";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type { Civ7ReadinessCurrentResult } from "../contract";
 
@@ -20,9 +23,10 @@ export const readinessCurrentProcedure =
           ),
           context,
         ),
-      catch: () =>
+      catch: (cause) =>
         errors.READINESS_CURRENT_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "readiness.current",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/strategy/procedures/civilian-route-triage.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/procedures/civilian-route-triage.ts
@@ -7,7 +7,10 @@ import type {
   Civ7ControlOrpcReadyUnitViewResult,
   Civ7ControlOrpcSettlementRecommendationsResult,
 } from "../../../dependencies/direct-control";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import type { Civ7ControlOrpcMapLocation } from "../../../model/primitives";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
@@ -82,9 +85,10 @@ export const strategyCivilianRouteTriageProcedure =
           destination,
         });
       },
-      catch: () =>
+      catch: (cause) =>
         errors.STRATEGY_CIVILIAN_ROUTE_TRIAGE_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "strategy.civilianRouteTriage",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/strategy/procedures/formation-snapshot.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/procedures/formation-snapshot.ts
@@ -5,7 +5,10 @@ import type {
   Civ7ControlOrpcPlayNotificationViewResult,
   Civ7ControlOrpcReadyUnitViewResult,
 } from "../../../dependencies/direct-control";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import type {
   Civ7ControlOrpcComponentId,
   Civ7ControlOrpcMapLocation,
@@ -61,9 +64,10 @@ export const strategyFormationSnapshotProcedure =
           origin,
         });
       },
-      catch: () =>
+      catch: (cause) =>
         errors.STRATEGY_FORMATION_SNAPSHOT_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "strategy.formationSnapshot",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/strategy/procedures/front-summary.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/procedures/front-summary.ts
@@ -6,7 +6,10 @@ import type {
   Civ7ControlOrpcDestinationAnalysisResult,
   Civ7ControlOrpcTargetCandidatesResult,
 } from "../../../dependencies/direct-control";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
   Civ7StrategyFrontSummaryInput,
@@ -66,9 +69,10 @@ export const strategyFrontSummaryProcedure =
           target,
         });
       },
-      catch: () =>
+      catch: (cause) =>
         errors.STRATEGY_FRONT_SUMMARY_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "strategy.frontSummary",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/strategy/procedures/tactical-reads.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/procedures/tactical-reads.ts
@@ -5,7 +5,10 @@ import type {
   Civ7ControlOrpcDestinationAnalysisResult,
   Civ7ControlOrpcTargetCandidatesResult,
 } from "../../../dependencies/direct-control";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
   Civ7StrategyBattlefieldScanResult,
@@ -29,9 +32,10 @@ export const strategyBattlefieldScanProcedure =
         );
         return battlefieldScanResult(result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.STRATEGY_TACTICAL_READ_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "strategy.battlefieldScan",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),
@@ -54,9 +58,10 @@ export const strategyTargetCandidatesProcedure =
         );
         return targetCandidatesResult(result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.STRATEGY_TACTICAL_READ_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "strategy.targetCandidates",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),
@@ -79,9 +84,10 @@ export const strategyDestinationAnalysisProcedure =
         );
         return destinationAnalysisResult(result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.STRATEGY_TACTICAL_READ_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "strategy.destinationAnalysis",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/turn/procedures/complete-request.ts
+++ b/packages/civ7-control-orpc/src/modules/turn/procedures/complete-request.ts
@@ -6,7 +6,10 @@ import { Effect } from "effect";
 
 import type { Civ7ControlOrpcTurnCompletionRequestResult } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7MutationNextSteps,
   civ7MutationRequestStatus,
@@ -28,9 +31,10 @@ export const turnCompleteRequestProcedure =
         );
         return turnCompletionResult(result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.TURN_COMPLETION_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "turn.complete.request",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/unit/procedures/command-request.ts
+++ b/packages/civ7-control-orpc/src/modules/unit/procedures/command-request.ts
@@ -2,7 +2,10 @@ import { Effect } from "effect";
 
 import type { Civ7ControlOrpcContext } from "../../../context";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7MutationNextSteps,
   civ7MutationRequestStatus,
@@ -37,9 +40,10 @@ export const unitUpgradeRequestProcedure = civ7ControlOrpcMutationProcedure(
         "unit.upgrade.request",
       );
     },
-    catch: () =>
+    catch: (cause) =>
       errors.UNIT_REQUEST_UNAVAILABLE({
         data: {
+          detail: civ7ControlOrpcFailureDetail(cause),
           procedureKey: "unit.upgrade.request",
           source: "direct-control-facade",
           ...civ7ControlOrpcErrorCorrelationData(context),
@@ -67,9 +71,10 @@ export const unitResettleRequestProcedure = civ7ControlOrpcMutationProcedure(
         "unit.resettle.request",
       );
     },
-    catch: () =>
+    catch: (cause) =>
       errors.UNIT_REQUEST_UNAVAILABLE({
         data: {
+          detail: civ7ControlOrpcFailureDetail(cause),
           procedureKey: "unit.resettle.request",
           source: "direct-control-facade",
           ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/unit/procedures/target-action-request.ts
+++ b/packages/civ7-control-orpc/src/modules/unit/procedures/target-action-request.ts
@@ -3,7 +3,10 @@ import { Effect } from "effect";
 
 import type { Civ7ControlOrpcUnitTargetActionResult } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import {
   civ7MutationNextSteps,
   civ7MutationRequestStatus,
@@ -27,9 +30,10 @@ export const unitTargetActionRequestProcedure =
         );
         return unitTargetActionResult(result);
       },
-      catch: () =>
+      catch: (cause) =>
         errors.UNIT_TARGET_ACTION_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "unit.target.action.request",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/world/procedures/current.ts
+++ b/packages/civ7-control-orpc/src/modules/world/procedures/current.ts
@@ -3,7 +3,10 @@ import { Effect } from "effect";
 
 import type { Civ7ControlOrpcContext } from "../../../context";
 import type { Civ7ControlOrpcPlayableStatusResult } from "../../../dependencies/direct-control";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type { Civ7WorldCurrentResult } from "../contract";
 
@@ -19,9 +22,10 @@ export const worldCurrentProcedure =
             context.endpointDefaults,
           ),
         ),
-      catch: () =>
+      catch: (cause) =>
         errors.WORLD_CURRENT_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "world.current",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/src/modules/world/procedures/map-reads.ts
+++ b/packages/civ7-control-orpc/src/modules/world/procedures/map-reads.ts
@@ -5,7 +5,10 @@ import type {
   Civ7ControlOrpcMapGridResult,
   Civ7ControlOrpcPlotSnapshotResult,
 } from "../../../dependencies/direct-control";
-import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7ControlOrpcErrorCorrelationData,
+  civ7ControlOrpcFailureDetail,
+} from "../../../model/correlation";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
   Civ7WorldGridReadResult,
@@ -33,9 +36,10 @@ export const worldPlotReadProcedure =
             context.endpointDefaults,
           ),
         ),
-      catch: () =>
+      catch: (cause) =>
         errors.WORLD_READ_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "world.plot.read",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),
@@ -64,9 +68,10 @@ export const worldGridReadProcedure =
             context.endpointDefaults,
           ),
         ),
-      catch: () =>
+      catch: (cause) =>
         errors.WORLD_READ_UNAVAILABLE({
           data: {
+            detail: civ7ControlOrpcFailureDetail(cause),
             procedureKey: "world.grid.read",
             source: "direct-control-facade",
             ...civ7ControlOrpcErrorCorrelationData(context),

--- a/packages/civ7-control-orpc/test/display-explore-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/display-explore-procedure.test.ts
@@ -144,7 +144,7 @@ describe("display.explore.request control-oRPC procedure", () => {
         procedureKey: "display.explore.request",
         source: "direct-control-facade",
         step: "apply-explore-grant",
-        detail: "tuner down",
+        detail: "Error",
       },
     });
     expect(fake.calls).toEqual(["summary", "suspend", "grant", "resume"]);


### PR DESCRIPTION
All error data schemas now include a shared `Civ7ControlOrpcErrorFailureProperties` spread (`step` and `detail`) rather than defining these fields inline on the handful of schemas that previously had them. This makes failure context available uniformly across every procedure error type.

A new `civ7ControlOrpcFailureDetail` helper in `correlation.ts` produces a bounded, safe string from a caught value: `Civ7DirectControlError` instances surface as `direct-control/<code>`, other `Error` instances surface as their constructor name, and non-Error values surface as their `typeof`. Raw error messages are intentionally excluded to prevent tuner internals (which embed commands and endpoint details) from leaking into the wire contract.

Every procedure's `catch` handler is updated from `catch: () =>` to `catch: (cause) =>`, passing the cause through `civ7ControlOrpcFailureDetail` to populate the `detail` field on the emitted error. The explore-request procedure, which previously used `cause.message` directly, is also updated to use the new helper. The corresponding test expectation is updated to reflect that a plain `Error` now surfaces as `"Error"` rather than its raw message.