### PR TITLE
feat(mapgen-studio): daemon-restart watchdog + busy-gate toasts for Run in Game

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -114,6 +114,7 @@ import { useAuthoringStore } from "../stores/authoringStore";
 import { useRunStore } from "../stores/runStore";
 import { useSetupDataQueries } from "./hooks/useSetupDataQueries";
 import { useOperationStatusPolls } from "./hooks/useOperationStatusPolls";
+import { useDaemonInstanceWatchdog } from "./hooks/useDaemonInstanceWatchdog";
 import { isAbortLikeError } from "../shared/async";
 import { clampNumber } from "../shared/number";
 import {
@@ -472,6 +473,9 @@ export function StudioShell(props: StudioShellProps) {
   // defaults), replacing the prior hand-rolled load/retry/focus effect; the derived view
   // shapes are unchanged so `setupControlOptions` below consumes them as before.
   const { savedSetupConfigs, setupCatalog } = useSetupDataQueries();
+  // Auto-reload the tab when the daemon restarts under it — the user should
+  // never need a manual hard refresh to get back to a coherent session.
+  useDaemonInstanceWatchdog();
   const [autoplayActionRunning, setAutoplayActionRunning] = useState(false);
   const [exploreActionRunning, setExploreActionRunning] = useState(false);
   const saveDeployRunning = saveDeployOperation?.status === "running";
@@ -1530,7 +1534,17 @@ export function StudioShell(props: StudioShellProps) {
   });
 
   const handleRunInGame = useCallback(async (options?: { restartCivProcess?: boolean }) => {
-    if (runInGameRunning || saveDeployRunning) return;
+    // Busy gate must never be silent — a click that does nothing is
+    // indistinguishable from a broken launch path.
+    if (runInGameRunning || saveDeployRunning) {
+      toast(
+        runInGameRunning
+          ? "Run in Game is already running — check the status chip in the Game bar."
+          : "Save & Deploy is in progress; wait for it to finish before launching.",
+        { variant: "info" },
+      );
+      return;
+    }
     setLocalError(null);
     const seedPolicy = parseCiv7StudioSeed(recipeSettings.seed);
     if (!seedPolicy.ok) {

--- a/apps/mapgen-studio/src/app/hooks/useDaemonInstanceWatchdog.ts
+++ b/apps/mapgen-studio/src/app/hooks/useDaemonInstanceWatchdog.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { orpc } from "../../lib/orpc";
+
+/**
+ * Daemon-restart watchdog: the studio tab is only coherent against the daemon
+ * instance it booted with — run-in-game/save-deploy operation registries live
+ * in daemon process memory, so after a daemon restart the tab's resumed
+ * request ids, query caches, and live-runtime state are stale in ways no
+ * in-place invalidation can fully cover. When `serverInstanceId` changes under
+ * a live tab, reload the document for a clean boot instead of letting the
+ * session silently rot (the user should never need a manual hard refresh).
+ */
+export function useDaemonInstanceWatchdog(): void {
+  const serverInfoQuery = useQuery({
+    ...orpc.studio.serverInfo.queryOptions({ input: {} }),
+    refetchInterval: 10_000,
+    refetchIntervalInBackground: true,
+  });
+  const bootInstanceIdRef = useRef<string | null>(null);
+  const serverInstanceId = serverInfoQuery.data?.ok ? serverInfoQuery.data.serverInstanceId : null;
+
+  useEffect(() => {
+    if (!serverInstanceId) return;
+    if (bootInstanceIdRef.current === null) {
+      bootInstanceIdRef.current = serverInstanceId;
+      return;
+    }
+    if (bootInstanceIdRef.current !== serverInstanceId) {
+      window.location.reload();
+    }
+  }, [serverInstanceId]);
+}


### PR DESCRIPTION
Adds a daemon-restart watchdog that automatically reloads the Studio tab when the underlying daemon process restarts. Since operation registries (run-in-game, save-deploy) live in daemon process memory, a restarted daemon leaves the tab's request IDs, query caches, and live-runtime state stale in ways that cannot be recovered through cache invalidation alone. The watchdog polls `serverInfo` every 10 seconds, records the `serverInstanceId` seen at boot, and triggers `window.location.reload()` if the ID ever changes — giving the user a clean session without requiring a manual hard refresh.

Also improves the busy-gate behavior in `handleRunInGame`: previously, clicking the button while an operation was already in progress would silently do nothing. It now shows an informational toast explaining whether Run in Game is already running or Save & Deploy needs to finish first, making the blocked state visible rather than appearing as a broken launch path.