### PR TITLE
`feat(mapgen-studio): enable bun --watch hot-restart for dev daemon`

### DIFF
--- a/apps/mapgen-studio/src/server/daemon/devLive.ts
+++ b/apps/mapgen-studio/src/server/daemon/devLive.ts
@@ -79,7 +79,13 @@ export function makeDevLivePlan(args: DevLiveArgs): DevLivePlan {
     rpcProxyTarget: backendUrl,
     daemon: {
       command: bunExecutable,
+      // --watch: bun tracks the daemon's full import graph (including
+      // workspace package sources) and restarts the process on change. The
+      // restart stays inside this child process, so the "either child exits
+      // stops the other" teardown below never fires for a hot restart; the
+      // studio tab recovers via the daemon-instance watchdog reload.
       args: [
+        "--watch",
         "src/server/daemon/daemon.ts",
         "--host",
         args.host,

--- a/apps/mapgen-studio/test/server/devLivePlan.test.ts
+++ b/apps/mapgen-studio/test/server/devLivePlan.test.ts
@@ -9,6 +9,7 @@ describe("dev-live plan", () => {
     expect(plan.rpcProxyTarget).toBe(plan.backendUrl);
     expect(plan.frontendUrl).toBe("http://127.0.0.1:5173/");
     expect(plan.daemon.args).toEqual([
+      "--watch",
       "src/server/daemon/daemon.ts",
       "--host",
       "127.0.0.1",


### PR DESCRIPTION
Enables hot-reloading of the daemon process during local development by passing Bun's `--watch` flag when spawning the daemon child process. With this flag, Bun tracks the daemon's full import graph—including workspace package sources—and automatically restarts the process when any of those files change. Because the restart is handled internally by Bun within the existing child process, the "either child exits stops the other" teardown logic is not triggered on a hot restart; the studio tab recovers through the existing daemon-instance watchdog reload mechanism.