### PR TITLE
fix(mapgen-studio): dev-watch deploy isolation — source recipe imports, Turbo `--only`, daemon import graph guards (S1.1a)

### DIFF
--- a/apps/mapgen-studio/src/server/mapConfigs/deploy.ts
+++ b/apps/mapgen-studio/src/server/mapConfigs/deploy.ts
@@ -13,7 +13,7 @@ export function buildSwooperMapsStudioDeployPlan(options: {
     : (options.env ?? process.env);
   return {
     buildTask: "mod-swooper-maps#build",
-    buildArgs: ["x", "turbo", "run", "build", "--filter=mod-swooper-maps"],
+    buildArgs: ["x", "turbo", "run", "build", "--filter=mod-swooper-maps", "--only"],
     env,
   };
 }

--- a/apps/mapgen-studio/src/server/recipeDag/service.ts
+++ b/apps/mapgen-studio/src/server/recipeDag/service.ts
@@ -1,10 +1,4 @@
 import { buildRecipeDag, type StageContractAny } from "@swooper/mapgen-core/authoring";
-import {
-  BROWSER_TEST_STAGES,
-} from "mod-swooper-maps/recipes/browser-test";
-import {
-  STANDARD_STAGES,
-} from "mod-swooper-maps/recipes/standard";
 
 import type { RecipeDagResult, RecipeDagService } from "@civ7/studio-server";
 
@@ -16,22 +10,42 @@ type RecipeDagSource = Readonly<{
   stages: readonly StageContractAny[];
 }>;
 
-const DEFAULT_RECIPE_DAG_SOURCES: readonly RecipeDagSource[] = [
-  {
-    id: "mod-swooper-maps/standard",
-    namespace: "mod-swooper-maps",
-    recipeId: "standard",
-    title: "Swooper Maps / Standard",
-    stages: STANDARD_STAGES as readonly StageContractAny[],
-  },
-  {
-    id: "mod-swooper-maps/browser-test",
-    namespace: "mod-swooper-maps",
-    recipeId: "browser-test",
-    title: "Swooper Maps / Browser Test",
-    stages: BROWSER_TEST_STAGES as readonly StageContractAny[],
-  },
-] as const;
+type RecipeDagSourcesProvider = () => Promise<readonly RecipeDagSource[]>;
+
+const swooperRecipeSourceRoot = "../../../../../mods/mod-swooper-maps/src/recipes";
+let defaultRecipeDagSourcesPromise: Promise<readonly RecipeDagSource[]> | undefined;
+
+async function loadDefaultRecipeDagSources(): Promise<readonly RecipeDagSource[]> {
+  const [standardRecipe, browserTestRecipe] = await Promise.all([
+    import(`${swooperRecipeSourceRoot}/standard/recipe.js`) as Promise<{
+      STANDARD_STAGES: readonly StageContractAny[];
+    }>,
+    import(`${swooperRecipeSourceRoot}/browser-test/recipe.js`) as Promise<{
+      BROWSER_TEST_STAGES: readonly StageContractAny[];
+    }>,
+  ]);
+  return [
+    {
+      id: "mod-swooper-maps/standard",
+      namespace: "mod-swooper-maps",
+      recipeId: "standard",
+      title: "Swooper Maps / Standard",
+      stages: standardRecipe.STANDARD_STAGES,
+    },
+    {
+      id: "mod-swooper-maps/browser-test",
+      namespace: "mod-swooper-maps",
+      recipeId: "browser-test",
+      title: "Swooper Maps / Browser Test",
+      stages: browserTestRecipe.BROWSER_TEST_STAGES,
+    },
+  ] as const;
+}
+
+function getDefaultRecipeDagSources(): Promise<readonly RecipeDagSource[]> {
+  defaultRecipeDagSourcesPromise ??= loadDefaultRecipeDagSources();
+  return defaultRecipeDagSourcesPromise;
+}
 
 export class RecipeDagNotFound extends Error {
   constructor(readonly recipeId: string) {
@@ -41,11 +55,12 @@ export class RecipeDagNotFound extends Error {
 }
 
 export function createRecipeDagService(
-  sources: readonly RecipeDagSource[] = DEFAULT_RECIPE_DAG_SOURCES,
+  sources: readonly RecipeDagSource[] | RecipeDagSourcesProvider = getDefaultRecipeDagSources,
 ): RecipeDagService {
-  const byId = new Map(sources.map((source) => [source.id, source]));
   return {
     async getRecipeDag(recipeId: string): Promise<RecipeDagResult> {
+      const resolvedSources = typeof sources === "function" ? await sources() : sources;
+      const byId = new Map(resolvedSources.map((source) => [source.id, source]));
       const source = byId.get(recipeId);
       if (!source) throw new RecipeDagNotFound(recipeId);
       return buildRecipeDag({

--- a/apps/mapgen-studio/test/devServer/daemonDeployIsolation.test.ts
+++ b/apps/mapgen-studio/test/devServer/daemonDeployIsolation.test.ts
@@ -1,0 +1,28 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { buildSwooperMapsStudioDeployPlan } from "../../src/server/mapConfigs/deploy";
+
+const servicePath = fileURLToPath(new URL("../../src/server/recipeDag/service.ts", import.meta.url));
+
+describe("daemon deploy isolation", () => {
+  it("keeps deploy-written recipe dist artifacts out of the daemon recipe-DAG import graph", async () => {
+    const serviceSource = await readFile(servicePath, "utf8");
+
+    expect(serviceSource).not.toMatch(/from\s+["']mod-swooper-maps\/recipes\//);
+    expect(serviceSource).toContain("mods/mod-swooper-maps/src/recipes");
+    expect(serviceSource).toContain("/standard/recipe.js");
+    expect(serviceSource).toContain("/browser-test/recipe.js");
+  });
+
+  it("does not replay dependency build outputs during Play or Save & Deploy", () => {
+    expect(buildSwooperMapsStudioDeployPlan({ env: { PATH: "/bin" } }).buildArgs).toContain("--only");
+    expect(
+      buildSwooperMapsStudioDeployPlan({
+        requestId: "studio-run-in-game-test",
+        env: { PATH: "/bin" },
+      }).buildArgs,
+    ).toContain("--only");
+  });
+});

--- a/apps/mapgen-studio/test/devServer/watchIgnores.test.ts
+++ b/apps/mapgen-studio/test/devServer/watchIgnores.test.ts
@@ -15,11 +15,18 @@ async function loadServeConfig() {
 }
 
 describe("Studio dev server watch ignores", () => {
-  it("ignores Studio-written map config JSON files so Save/Run does not full-reload the tab", async () => {
+  it("ignores Studio-written and deploy-written mod outputs so Save/Run does not full-reload the tab", async () => {
     const config = await loadServeConfig();
     const ignored = config.server?.watch?.ignored;
 
     expect(Array.isArray(ignored)).toBe(true);
-    expect(ignored).toContain("**/mods/mod-swooper-maps/src/maps/configs/*.config.json");
+    expect(ignored).toEqual(
+      expect.arrayContaining([
+        "**/mods/mod-swooper-maps/dist/**",
+        "**/mods/mod-swooper-maps/mod/**",
+        "**/mods/mod-swooper-maps/src/maps/generated/**",
+        "**/mods/mod-swooper-maps/src/maps/configs/*.config.json",
+      ]),
+    );
   });
 });

--- a/apps/mapgen-studio/test/mapConfigSave/deployCommand.test.ts
+++ b/apps/mapgen-studio/test/mapConfigSave/deployCommand.test.ts
@@ -3,11 +3,18 @@ import { describe, expect, it } from "vitest";
 import { buildSwooperMapsStudioDeployPlan } from "../../src/server/mapConfigs/deploy";
 
 describe("Swooper Maps Studio deploy plan", () => {
-  it("uses the root build graph for save/deploy without request markers", () => {
+  it("uses the mod-only build task for save/deploy without request markers", () => {
     const plan = buildSwooperMapsStudioDeployPlan({ env: { PATH: "/bin" } });
 
     expect(plan.buildTask).toBe("mod-swooper-maps#build");
-    expect(plan.buildArgs).toEqual(["x", "turbo", "run", "build", "--filter=mod-swooper-maps"]);
+    expect(plan.buildArgs).toEqual([
+      "x",
+      "turbo",
+      "run",
+      "build",
+      "--filter=mod-swooper-maps",
+      "--only",
+    ]);
     expect(plan.env).not.toHaveProperty("SWOOPER_STUDIO_RUN_ID");
   });
 
@@ -23,6 +30,7 @@ describe("Swooper Maps Studio deploy plan", () => {
       "run",
       "build",
       "--filter=mod-swooper-maps",
+      "--only",
     ]);
     expect(plan.env.SWOOPER_STUDIO_RUN_ID).toBe("studio-run-in-game-test");
   });

--- a/apps/mapgen-studio/test/recipeDag/artifactPresentation.test.ts
+++ b/apps/mapgen-studio/test/recipeDag/artifactPresentation.test.ts
@@ -72,5 +72,5 @@ describe("recipe DAG artifact presentation", () => {
       .filter((artifact) => !artifact.domainId || artifact.domainId === "artifact");
 
     expect(generic).toEqual([]);
-  });
+  }, 15_000);
 });

--- a/apps/mapgen-studio/tsconfig.json
+++ b/apps/mapgen-studio/tsconfig.json
@@ -9,7 +9,10 @@
     "moduleResolution": "bundler",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@mapgen/domain": ["../../mods/mod-swooper-maps/src/domain/index.ts"],
+      "@mapgen/domain/config": ["../../mods/mod-swooper-maps/src/domain/config.ts"],
+      "@mapgen/domain/*": ["../../mods/mod-swooper-maps/src/domain/*"]
     },
     "allowImportingTsExtensions": true,
     "isolatedModules": true,

--- a/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/design.md
+++ b/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/design.md
@@ -1,0 +1,72 @@
+# Design — dev-watch deploy isolation (S1.1a)
+
+## D1. The failure is an import-graph self-trigger
+
+`bun --watch` restarts the daemon when files in its import graph change. S1.1
+made recipe DAG structural inside the one `/rpc` surface, and the app-side
+`defaultRecipeDagService` imported:
+
+```ts
+import { STANDARD_STAGES } from "mod-swooper-maps/recipes/standard";
+import { BROWSER_TEST_STAGES } from "mod-swooper-maps/recipes/browser-test";
+```
+
+Those package exports point at `mods/mod-swooper-maps/dist/recipes/*.js`.
+Play/Save&Deploy runs the mod build, which rewrites the same `dist` tree. The
+operation therefore changes a file the daemon has loaded, so the watcher
+restarts the process that owns the operation registry.
+
+## D2. Source recipe stages are the smallest correct ownership boundary
+
+The recipe-DAG service needs stage contracts, not the deployable recipe
+artifacts. Swooper recipe source owns stage order and authoring metadata;
+`dist/recipes/**` is a generated distribution artifact. Loading the source
+stage modules keeps the daemon aligned with authoring truth while removing
+deploy-written `dist` files from the daemon's watch graph.
+
+The source modules are loaded through a runtime provider rather than static
+top-level imports. That keeps the Studio TypeScript project from becoming the
+compiler owner of the whole mod source tree; the mod package keeps its own
+typecheck rules and Studio pins the integration boundary.
+
+The source recipe graph does not import `mods/mod-swooper-maps/src/maps/configs`
+or `src/maps/generated`; those remain operation-written outputs, but not daemon
+imports. Vite already ignores them for the frontend watcher.
+
+## D3. Deploy builds only the mod package during operations
+
+Turbo's default topological behavior runs `^build` and, on cache hits, may
+replay dependency outputs into package `dist` directories. The daemon imports
+workspace package outputs such as `@swooper/mapgen-core/authoring`, so operation
+deploy must not replay dependency builds while the daemon is alive.
+
+The deploy command adds `--only`:
+
+```text
+bun x turbo run build --filter=mod-swooper-maps --only
+```
+
+That keeps operation-time writes scoped to the mod package outputs. Dev startup
+and normal package gates still build dependencies through the existing Turbo
+graph; S1.1a does not weaken CI or package verification.
+
+## D4. Rejected alternatives
+
+- **Bun watch-ignore bandage:** would encode the current output paths in the
+  runner instead of fixing the owner boundary, and Bun's import graph would
+  still contain generated artifacts.
+- **Lazy import of `dist` recipe modules:** only delays the restart. Once the
+  Pipeline DAG tab is opened, `dist/recipes/**` is loaded and subsequent deploy
+  can still restart the daemon.
+- **Subprocess recipe projection:** valid but larger than needed. It adds an
+  IPC/process boundary to read static authoring metadata that the daemon can
+  safely import from source.
+
+## D5. Verification shape
+
+Unit pins prove the static invariants: no daemon recipe-DAG import from
+`mod-swooper-maps/recipes/*`, deploy build args include `--only`, and Vite
+ignores the operation-written mod outputs. Live proof must falsify the actual
+bug class: start Play and Save&Deploy from the dev app, observe
+`studio.serverInfo.serverInstanceId` before and after the deploy phase, and
+confirm it does not change.

--- a/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/proposal.md
+++ b/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/proposal.md
@@ -1,0 +1,70 @@
+# MapGen Studio dev-watch deploy isolation
+
+## Why
+
+S1.1 `runtime-one-mount` proved the one-mount transport shape, but the live
+Play/Save&Deploy proof exposed a pre-existing dev-mode failure introduced by
+the `bun --watch` daemon topology: the operation build rewrites
+`mods/mod-swooper-maps/dist`, and the daemon imports
+`mod-swooper-maps/recipes/*` for the recipe DAG. Those package exports resolve
+to `dist/recipes/*.js`, so Bun restarts the daemon mid-operation, kills the
+deploy child, and wipes the in-memory operation registries.
+
+This hotfix is S1.1a in the accepted runtime simplification plan. It must land
+before S1.2 because every later live proof depends on Play and Save&Deploy
+surviving their own deploy step.
+
+## Target Authority Refs
+
+- `docs/projects/studio-runtime-simplification/PLAN.md` — S1.1a hotfix,
+  execution discipline, and the program frame: the daemon owns ephemeral truth.
+- `openspec/changes/mapgen-studio-runtime-one-mount/` — S1.1 live proof and
+  the unified recipe-DAG mount that exposed the import graph issue.
+- `apps/mapgen-studio/src/server/daemon/devLive.ts` — dev daemon runs under
+  `bun --watch`; hot restarts are expected for source edits, not for the
+  operation's own deploy outputs.
+- `turbo.json` and `apps/mapgen-studio/src/server/mapConfigs/deploy.ts` — the
+  deploy build graph used by both Play and Save&Deploy.
+
+## What Changes
+
+- The daemon-side recipe-DAG service imports Swooper recipe stages from
+  `mods/mod-swooper-maps/src/recipes/**` source, not from the package exports
+  that resolve to `dist/recipes/**`.
+- App TypeScript/Vitest resolver config explicitly recognizes the mod source's
+  `@mapgen/domain/*` aliases, keeping the source boundary testable without
+  going back through generated package artifacts.
+- The Play/Save&Deploy build command runs the `mod-swooper-maps` build task
+  with Turbo `--only`, relying on dev startup/package gates for dependency
+  builds instead of replaying dependency `dist` outputs during an operation.
+- Tests pin both sides of the isolation: no daemon recipe-DAG import from
+  `mod-swooper-maps/recipes/*`, and deploy build args include `--only`.
+- Vite watch-ignore coverage is broadened to assert all deploy-written mod
+  outputs remain ignored by the frontend dev server.
+
+## Non-Goals
+
+- No operation durability across daemon restart. S2.1 owns daemon-truth
+  adoption; this slice prevents the operation from causing its own restart.
+- No recipe-DAG subprocess/lazy projection unless source import proves
+  insufficient.
+- No changes to recipe contracts, map generation behavior, mod deploy
+  semantics, or the public Studio UI.
+- No S1.2 error-spine changes.
+
+## Impact
+
+- `apps/mapgen-studio/src/server/recipeDag/service.ts`
+- `apps/mapgen-studio/src/server/mapConfigs/deploy.ts`
+- Focused dev-server/deploy tests
+- `openspec/changes/mapgen-studio-runtime-one-mount/tasks.md` stale closure
+  checkbox is corrected to reflect the already-merged S1.1 PR.
+
+## Verification Gates
+
+- `bun run openspec -- validate mapgen-studio-dev-watch-deploy-isolation --strict`
+- Focused app tests for recipe DAG, deploy command, and dev deploy isolation.
+- `bun x turbo run check --filter=mapgen-studio`
+- Live falsification proof: during Play and Save&Deploy, `serverInstanceId`
+  remains stable across the deploy phase and the operation reaches a terminal
+  status without the daemon restarting.

--- a/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/specs/mapgen-studio/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Dev Deploy Does Not Restart The Daemon
+
+In the Studio two-process dev topology, Play and Save&Deploy SHALL NOT mutate
+files in the Bun daemon's watched import graph during their own deploy phase.
+The daemon may hot-restart for developer source edits, but operation-time mod
+build/deploy output writes must stay outside the daemon import graph so the
+daemon-owned operation registry survives until the operation reaches a terminal
+status.
+
+#### Scenario: Recipe DAG does not import deploy-written recipe dist
+
+- **WHEN** the daemon constructs the recipe-DAG service
+- **THEN** it imports Swooper recipe stage contracts from source files under
+  `mods/mod-swooper-maps/src/recipes/**`
+- **AND** it does not import `mod-swooper-maps/recipes/*` package exports that
+  resolve to `mods/mod-swooper-maps/dist/recipes/**`
+
+#### Scenario: Operation deploy avoids dependency output replay
+
+- **WHEN** Play or Save&Deploy builds the Swooper Maps mod during a Studio dev
+  operation
+- **THEN** the build command runs the `mod-swooper-maps` build task only
+- **AND** it does not run or replay dependency build outputs while the daemon
+  process owns the active operation
+
+#### Scenario: Deploy output writes preserve daemon identity
+
+- **WHEN** a developer starts Play or Save&Deploy in Studio dev mode
+- **THEN** the daemon `serverInstanceId` observed before deploy remains the
+  daemon `serverInstanceId` after deploy
+- **AND** the operation registry still reports the active operation until it
+  reaches a terminal status

--- a/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/tasks.md
+++ b/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/tasks.md
@@ -1,0 +1,34 @@
+## 1. Frame
+
+- [x] 1.1 Create S1.1a proposal/design/tasks/spec delta with authority refs,
+      non-goals, and verification gates.
+- [x] 1.2 Correct stale S1.1 closure checkbox so the previous slice reflects
+      the already-merged PR #1678 / main `331534895`.
+
+## 2. Implementation
+
+- [x] 2.1 Retarget daemon-side recipe-DAG stage imports from generated package
+      exports to Swooper recipe source.
+- [x] 2.2 Change Play/Save&Deploy deploy build args so operation-time builds
+      do not replay dependency outputs in the daemon import graph.
+- [x] 2.3 Add focused static/unit guards for daemon import graph and deploy
+      build arguments.
+- [x] 2.4 Keep frontend watcher ignore pins aligned with deploy-written mod
+      outputs.
+
+## 3. Verification
+
+- [x] 3.1 `bun run openspec -- validate mapgen-studio-dev-watch-deploy-isolation --strict`.
+- [x] 3.2 Focused app tests: deploy command, dev deploy isolation, recipe DAG.
+- [x] 3.3 App gate: `bun x turbo run check --filter=mapgen-studio`.
+- [x] 3.4 Live falsification proof: Play deploy does not change
+      `serverInstanceId` mid-operation.
+- [x] 3.5 Live falsification proof: Save&Deploy deploy does not change
+      `serverInstanceId` mid-operation.
+
+## 4. Closure
+
+- [x] 4.1 Update downstream plan/workstream notes with final evidence and any
+      remaining risk.
+- [x] 4.2 Graphite submit/merge/drain according to repo rules with foreign
+      dirty state quarantined; PR #1679 is the S1.1a Graphite closure lane.

--- a/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/workstream/closure-checklist.md
+++ b/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/workstream/closure-checklist.md
@@ -1,0 +1,56 @@
+# Closure Checklist
+
+## Phase
+
+- Project: Studio runtime simplification
+- Phase: S1.1a `dev-watch-deploy-isolation`
+- Phase state: closed by S1.1a Graphite lane PR #1679
+- Artifact path: `openspec/changes/mapgen-studio-dev-watch-deploy-isolation/`
+
+## Review
+
+- Review lanes completed: owner/architecture complete; watcher complete
+- P1/P2 accepted findings repaired: PRE-1 and PRE-2 repaired
+- Rejected/invalidated/waived/deferred findings recorded: none
+- Remaining review risk: none identified
+
+## Verification
+
+- Repo/package gates run: OpenSpec strict; OpenSpec full; focused app tests;
+  expanded one-mount app tests; app Turbo check; package Turbo tests for
+  `@civ7/studio-server`, `@civ7/control-orpc`, `@civ7/direct-control`;
+  `git diff --check`; live Play and Save&Deploy proof.
+- Results: all passed; Play and Save&Deploy held
+  `serverInstanceId=studio-server-mqby0kyi-1zbz` through deploy completion.
+- Skipped gates and rationale: none intended.
+- Evidence boundary: local verification against fresh worktree
+  `331534895` + S1.1a branch.
+
+## Downstream Realignment
+
+- Downstream realignment ledger: not needed unless live proof changes scope
+- Downstream artifacts updated: S1.1 task closure corrected; S1.1a
+  tasks/spec/workstream records updated.
+- Deferrals/triage updated: none
+- Deferred inventory: none
+
+## Agent Fleet State
+
+- Active agents: none
+- Completed agents: watcher lane returned `DONT_NOTIFY`
+- Stale/running agents closed or handed off: watcher closed
+- Assigned write sets reconciled: watcher has no implementation write set
+- Integration owner: Codex DRA implementation lane
+
+## Repo State
+
+- Branch/Graphite stack: `codex/dev-watch-deploy-isolation` on `main`
+- Dirty files: none after commit
+- Untracked files: ignored `node_modules`
+- Commit made: yes
+
+## Handoff
+
+- Next Packet written: not needed; proceed to S1.2 from refreshed `main`
+- Exact next action: open S1.2 `error-spine`
+- Stop condition: `main` cannot fast-forward to the S1.1a merge result

--- a/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/workstream/phase-record.md
@@ -1,0 +1,132 @@
+# Phase Record
+
+## Phase
+
+- Project: Studio runtime simplification
+- Phase: S1.1a `dev-watch-deploy-isolation`
+- Owner: Codex DRA implementation lane
+- Branch/Graphite stack: `codex/dev-watch-deploy-isolation` stacked on `main`
+- Started: 2026-06-13
+- Status: closed by S1.1a Graphite lane PR #1679
+
+## Objective
+
+- Target movement: Prevent Play/Save&Deploy from restarting the Bun daemon by
+  keeping operation-written mod outputs out of the daemon import graph.
+- Non-goals: operation durability across daemon restart; S1.2 error spine;
+  recipe contract or UI changes.
+- Done condition: focused guards and live proof show deploy does not change
+  `serverInstanceId` mid-operation.
+
+## Authority
+
+- Root/subtree `AGENTS.md`: root repo router; `mods/mod-swooper-maps/AGENTS.md`;
+  `mods/mod-swooper-maps/src/AGENTS.md`.
+- Product refs: `docs/projects/studio-runtime-simplification/PLAN.md`.
+- Architecture refs: S1.1 `mapgen-studio-runtime-one-mount`; daemon
+  `bun --watch` topology in `apps/mapgen-studio/src/server/daemon/devLive.ts`.
+- Project refs: this OpenSpec change.
+- Excluded/stale inputs: stale habitat worktree plan; original main checkout
+  foreign staged river/lake files.
+
+## Current State
+
+- Repo/Graphite state: fresh worktree at `331534895`, branch
+  `codex/dev-watch-deploy-isolation`, Graphite parent `main`.
+- Dirty files and owner: only S1.1a implementation/spec files in this
+  worktree; one live-proof JSON formatting residue was reverted before
+  closure.
+- Current code evidence: daemon recipe-DAG service loads Swooper recipe stages
+  from `mods/mod-swooper-maps/src/recipes/**`, not generated package
+  `recipes/*` exports; deploy plan runs Turbo with `--only`.
+- Generated outputs affected: `mods/mod-swooper-maps/dist/**`,
+  `mods/mod-swooper-maps/mod/**`, `mods/mod-swooper-maps/src/maps/generated/**`.
+- Tests/guards affected: deploy command tests, dev watcher tests, recipe-DAG
+  service tests.
+
+## Scope
+
+- Write set: `apps/mapgen-studio/src/server/recipeDag/service.ts`,
+  `apps/mapgen-studio/src/server/mapConfigs/deploy.ts`, focused tests,
+  S1.1a OpenSpec files, stale S1.1 closure checkbox.
+- Protected files: generated `dist/**`, `mod/**`, generated map outputs,
+  foreign dirty/staged river/lake files in original main checkout.
+- Owners: Studio daemon/runtime, Swooper recipe source as authoring truth.
+- Forbidden owners: Bun watch-ignore workaround as primary fix; generated
+  artifacts as source authority.
+- Consumer impact: none outside Studio dev Play/Save&Deploy reliability.
+- Downstream assumptions: later runtime slices can rely on dev live proof.
+
+## Spec/Tasks
+
+- Spec/proposal: `openspec/changes/mapgen-studio-dev-watch-deploy-isolation/`.
+- Tasks: `tasks.md`.
+- Validation status: strict OpenSpec and full OpenSpec validation passed.
+
+## Review
+
+- Review lanes: owner/architecture, watcher, verification.
+- Blocking findings: none remaining.
+- Accepted findings repaired: S1.1a inserted before S1.2 because live proofs
+  were not meaningful while deploy restarted the daemon; PRE-1/PRE-2 repaired
+  by source-owned recipe loading and deploy `--only`.
+- Rejected/invalidated/waived/deferred findings: none yet.
+
+## Agent Fleet State
+
+- Active agents: none.
+- Completed agents: watcher lane `019ebf78-6ce1-71d0-8e78-05d9586bd703`
+  returned `DONT_NOTIFY` on the closure pass.
+- Assigned write sets: watcher has no implementation write set.
+- Latest evidence by agent: watcher closure pass returned `DONT_NOTIFY`; it
+  confirmed source recipe loading, deploy `--only`, guards, one-mount coverage,
+  clean diff whitespace, and no generated/runtime residue.
+- Open findings by agent: none.
+- Running/stale status: watcher closed.
+- Integration owner: Codex DRA implementation lane.
+
+## Implementation
+
+- Completed tasks: implementation, focused guards, package/app gates,
+  OpenSpec validation, and live Play/Save&Deploy falsification proof.
+- Remaining tasks: none.
+- Stop conditions triggered: none.
+
+## Verification
+
+- Commands run:
+  - `bun run openspec -- validate mapgen-studio-dev-watch-deploy-isolation --strict`
+  - `bun run openspec:validate`
+  - `bun run --cwd apps/mapgen-studio test -- test/devServer/daemonDeployIsolation.test.ts test/devServer/watchIgnores.test.ts test/mapConfigSave/deployCommand.test.ts test/recipeDag/artifactPresentation.test.ts`
+  - `bun run --cwd apps/mapgen-studio test -- test/server/oneMount.test.ts test/server/daemonFetch.test.ts test/recipeDag/artifactPresentation.test.ts test/devServer/daemonDeployIsolation.test.ts test/devServer/watchIgnores.test.ts test/mapConfigSave/deployCommand.test.ts`
+  - `bun x turbo run check --filter=mapgen-studio`
+  - `bun x turbo run test --filter=@civ7/studio-server --filter=@civ7/control-orpc --filter=@civ7/direct-control`
+  - `git diff --check`
+- Results: all passed. One-mount guarantees remain covered by the expanded app
+  test set and package gates.
+- Live proof: daemon preloaded recipe DAG (`17` stages), then Save&Deploy
+  accepted `s1-1a-save-mqby26rk` and completed with
+  `serverInstanceId=studio-server-mqby0kyi-1zbz`; Play accepted
+  `studio-run-in-game-mqby28jd-1zbz` and completed with the same
+  `serverInstanceId`.
+- Skipped gates and rationale: no intended skipped gate. Direct
+  `bun run --cwd apps/mapgen-studio check` is not the repo-correct app gate
+  before dependency outputs exist; root Turbo app check was used instead.
+- Evidence boundary: local live daemon proof plus local package/app gates.
+
+## Realignment
+
+- Downstream docs/specs/issues updated: S1.1 stale closure checkbox corrected;
+  S1.1a tasks/spec/workstream evidence updated.
+- Tests/guards updated: daemon import graph, deploy command, watcher ignore,
+  and one-mount guards updated and verified.
+- Deferrals/triage updated: none.
+- Downstream realignment ledger: not needed unless proof changes scope.
+
+## Next Action
+
+- Exact next step: start S1.2 `error-spine` from refreshed `main` after the
+  S1.1a Graphite merge/drain lands.
+- First files to inspect: S1.2 OpenSpec plan and current Studio operation error
+  handling.
+- Stop condition: `main` cannot fast-forward to the S1.1a merge result.

--- a/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/workstream/review-disposition-ledger.md
+++ b/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/workstream/review-disposition-ledger.md
@@ -1,0 +1,17 @@
+# Review Disposition Ledger
+
+| ID | Severity | Reviewer/Lane | Finding | Blocker Class | Disposition | Repair Demand | Evidence | Blocks Closure |
+|---|---|---|---|---|---|---|---|---|
+| PRE-1 | P1 | owner/architecture | Daemon recipe-DAG imported deploy-written recipe `dist` artifacts, causing Bun watch to restart mid-operation. | boundary | accepted-repaired | Move daemon recipe-DAG stage imports to source-owned recipe stage modules and pin no package `recipes/*` imports in the daemon service. | `apps/mapgen-studio/src/server/recipeDag/service.ts`; `apps/mapgen-studio/test/devServer/daemonDeployIsolation.test.ts`; live Save&Deploy/Play proof held `serverInstanceId=studio-server-mqby0kyi-1zbz`. | no |
+| PRE-2 | P1 | owner/architecture | Operation deploy build can replay dependency `dist` outputs that are also daemon imports. | boundary | accepted-repaired | Add Turbo `--only` to operation deploy build args so Play/Save&Deploy write only mod package outputs. | `apps/mapgen-studio/src/server/mapConfigs/deploy.ts`; `apps/mapgen-studio/test/mapConfigSave/deployCommand.test.ts`; `apps/mapgen-studio/test/devServer/daemonDeployIsolation.test.ts`. | no |
+
+## Disposition Rules
+
+- `accepted`: repair before dependent implementation or closure.
+- `rejected`: record source evidence showing the finding does not apply.
+- `invalidated`: record later source evidence that made the finding false.
+- `user-decision`: record the user or authority decision that resolves the finding.
+- `waived`: allowed only for P3/nonblocking findings; record risk, owner, and trigger.
+- `deferred`: allowed only for P3/nonblocking findings; record destination, owner, and context.
+
+No material finding may remain undispositioned at phase closure.

--- a/openspec/changes/mapgen-studio-runtime-one-mount/tasks.md
+++ b/openspec/changes/mapgen-studio-runtime-one-mount/tasks.md
@@ -60,5 +60,6 @@
 - [x] 4.3 Downstream realignment: PLAN.md §3 S1.1 annotated with the two
       grounding corrections (rpcPath/studioServerClient deletions);
       tuner-session change notes the session-port deletion.
-- [ ] 4.4 Graphite submit/merge/drain per repo rules; foreign staged trio
-      preserved; repo clean.
+- [x] 4.4 Graphite submit/merge/drain per repo rules; foreign staged trio
+      preserved; repo clean. Completed by PR #1678; `main` fast-forwarded to
+      `331534895` before S1.1a opened.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,7 +50,31 @@ export default defineConfig({
         root: r('apps/mapgen-studio'),
         // Mirror the app's `@/*` -> src alias (tsconfig + vite) so vitest resolves
         // the shadcn `components/ui` -> `@/lib/utils` import chain.
-        resolve: { alias: { '@': r('apps/mapgen-studio/src') } },
+        resolve: {
+          alias: [
+            { find: '@', replacement: r('apps/mapgen-studio/src') },
+            {
+              find: /^\/mods\/(.+)$/,
+              replacement: `${r('mods')}/$1`,
+            },
+            {
+              find: /^@mapgen\/domain\/config(?:\.js)?$/,
+              replacement: r('mods/mod-swooper-maps/src/domain/config.ts'),
+            },
+            {
+              find: /^@mapgen\/domain$/,
+              replacement: r('mods/mod-swooper-maps/src/domain/index.ts'),
+            },
+            {
+              find: /^@mapgen\/domain\/(.+)\.js$/,
+              replacement: `${r('mods/mod-swooper-maps/src/domain')}/$1.ts`,
+            },
+            {
+              find: /^@mapgen\/domain\/(.+)$/,
+              replacement: `${r('mods/mod-swooper-maps/src/domain')}/$1`,
+            },
+          ],
+        },
         test: { name: 'mapgen-studio' }
       },
       {


### PR DESCRIPTION
Fixes a dev-mode failure where Play and Save & Deploy would restart the Bun daemon mid-operation by rewriting files the daemon had loaded into its import graph.

## Problem

The daemon-side recipe-DAG service imported Swooper recipe stages via the `mod-swooper-maps/recipes/*` package exports, which resolve to `mods/mod-swooper-maps/dist/recipes/*.js`. When Play or Save & Deploy ran the mod build, it rewrote those same `dist` files, causing `bun --watch` to restart the daemon process that owned the active operation registry — killing the deploy child and wiping in-memory operation state.

A secondary issue: Turbo's default topological behavior could replay dependency `dist` outputs during an operation build, touching additional files that the daemon had loaded.

## Changes

**Recipe DAG source loading** — The daemon recipe-DAG service now loads Swooper recipe stage contracts from `mods/mod-swooper-maps/src/recipes/**` source files via a lazy async provider rather than static top-level imports from the generated package exports. The provider is memoized so the source modules are only loaded once. This keeps deploy-written `dist` artifacts entirely out of the daemon's watched import graph.

**Deploy build isolation** — The Play and Save & Deploy build command now passes `--only` to Turbo, restricting the operation-time build to the `mod-swooper-maps` package task without replaying dependency build outputs into their `dist` directories while the daemon is alive.

**Resolver alignment** — The root Vitest config and the `mapgen-studio` `tsconfig.json` now include aliases for `@mapgen/domain/*` pointing at the mod source tree, so the source import boundary is testable without going through generated package artifacts.

**Test guards** — A new `daemonDeployIsolation` test suite statically asserts that the recipe-DAG service source contains no `mod-swooper-maps/recipes/*` imports and that deploy build args include `--only`. The existing watch-ignore test is updated to assert all deploy-written mod output paths (`dist/**`, `mod/**`, `src/maps/generated/**`) are covered by the Vite frontend watcher ignore list.

## Verification

Live proof confirmed that `serverInstanceId` remained stable (`studio-server-mqby0kyi-1zbz`) across both a Save & Deploy and a Play operation, with the daemon preloading the recipe DAG (17 stages) and holding its identity through deploy completion.