### PR TITLE
`feat(mapgen-studio): S3.0 stream spike — effect-orpc eventIterator proof, PubSub cleanup, Vite proxy SSE guard, findings`

### DIFF
--- a/apps/mapgen-studio/test/devServer/viteProxyStream.test.ts
+++ b/apps/mapgen-studio/test/devServer/viteProxyStream.test.ts
@@ -1,0 +1,133 @@
+import { createServer as createHttpServer, type Server } from "node:http";
+import { createServer as createViteServer, type ViteDevServer } from "vite";
+import { afterEach, describe, expect, it } from "vitest";
+
+const openHttpServers: Server[] = [];
+const openViteServers: ViteDevServer[] = [];
+
+afterEach(async () => {
+  await Promise.all(openViteServers.splice(0).map((server) => server.close()));
+  await Promise.all(openHttpServers.splice(0).map((server) => closeHttpServer(server)));
+});
+
+describe("Vite /rpc dev proxy streaming", () => {
+  it("passes event-stream chunks through before the upstream response closes", async () => {
+    const secondChunkWritten = deferred<void>();
+    const releaseUpstream = deferred<void>();
+    const upstream = await listenHttpServer((req, res) => {
+      if (!req.url?.startsWith("/rpc")) {
+        res.writeHead(404);
+        res.end("not found");
+        return;
+      }
+
+      res.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+      });
+      res.write("data: first\n\n");
+      setTimeout(() => {
+        res.write("data: second\n\n");
+        secondChunkWritten.resolve();
+      }, 250);
+      releaseUpstream.promise.finally(() => res.end());
+    });
+
+    const vite = await createViteServer({
+      configFile: false,
+      logLevel: "silent",
+      server: {
+        host: "127.0.0.1",
+        port: 0,
+        strictPort: false,
+        proxy: {
+          "/rpc": { target: upstream.origin },
+        },
+      },
+    });
+    openViteServers.push(vite);
+    await vite.listen();
+
+    const response = await fetch(`${viteOrigin(vite)}/rpc/stream`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(response.body).not.toBeNull();
+
+    const reader = response.body!.getReader();
+    const firstRead = await withTimeout(reader.read(), 1_000, "first proxied SSE chunk");
+    const firstText = new TextDecoder().decode(firstRead.value);
+    expect(firstText).toContain("data: first");
+
+    await expect(secondChunkWritten.promise).resolves.toBeUndefined();
+    releaseUpstream.resolve();
+    await reader.cancel();
+  });
+});
+
+async function listenHttpServer(
+  handler: Parameters<typeof createHttpServer>[0],
+): Promise<{ server: Server; origin: string }> {
+  const server = createHttpServer(handler);
+  openHttpServers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected TCP server address");
+  }
+  return { server, origin: `http://127.0.0.1:${address.port}` };
+}
+
+async function closeHttpServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function viteOrigin(server: ViteDevServer): string {
+  const address = server.httpServer?.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected Vite TCP server address");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}

--- a/docs/projects/studio-runtime-simplification/PLAN.md
+++ b/docs/projects/studio-runtime-simplification/PLAN.md
@@ -2,7 +2,7 @@
 
 **Status:** accepted direction (operator, 2026-06-12); execution-ready
 **Method anchors:** dev:architecture (current/target/transition separation, spine-first ordering, deletion targets), cognition:system-design (leverage points), cognition:testing-design (falsification-first test relayering), dev:spike-methodology (evidence discipline), civ7-open-spec-workstream (slice mechanics), Habitat harness philosophy (categories before instances; invariants as enforceable records).
-**Evidence base:** three agent evidence packs (2026-06-12): runtime inventory + smell audit (7 seams, file:line), effect/oRPC/SSE capability pack, test-suite audit (50 files classified). Direct verification: `eventIterator` exists in @orpc/contract 1.14.5; `@orpc/tanstack-query` 1.14.5 ships non-experimental `streamedOptions`/`streamedQuery` + `experimental_liveOptions`; client plugins include `ClientRetryPlugin` (event-iterator reconnect), `BatchLinkPlugin`, `DedupeRequestsPlugin`.
+**Evidence base:** three agent evidence packs (2026-06-12): runtime inventory + smell audit (7 seams, file:line), effect/oRPC/SSE capability pack, test-suite audit (50 files classified). Direct verification: `eventIterator` exists in @orpc/contract 1.14.5; S3.0 corrected the installed `@orpc/tanstack-query` 1.14.5 helper names to `experimental_streamedOptions` and `experimental_liveOptions`, with `experimental_liveOptions` selected for the event spine because it keeps latest state instead of accumulating an unbounded chunk array; client plugins include `ClientRetryPlugin` (event-iterator reconnect), `BatchLinkPlugin`, `DedupeRequestsPlugin`.
 
 ## 1. The frame
 
@@ -66,9 +66,11 @@ built as a CATEGORY first: `{ type: "hello", serverInstanceId, startedAt } |
 { type: "operation", kind: "run-in-game" | "save-deploy", status } |
 { type: "live-game", state }`. Daemon side: one Effect `PubSub` in the runtime
 layer (the EventHub service); publishers are instances filling the category.
-Client side: one subscription via `streamedOptions` (TanStack Query) +
+Client side: one subscription via `experimental_liveOptions` (TanStack Query) +
 `ClientRetryPlugin` for reconnect; `hello` events replace the watchdog and
-serverInfo poll; reconnect triggers `operations.current` re-adoption.
+serverInfo poll; reconnect triggers `operations.current` re-adoption. The
+older `streamedOptions` wording is stale for this installed package and would
+accumulate events rather than model latest daemon state.
 
 **DP-4 Civ7 interface hybrid — RESOLVED (coherence, not rewrite).** The
 inventory verdict: the shape is right (one shared socket multiplexing
@@ -166,7 +168,7 @@ slices — run BEFORE S1.2.
   (the one unverified bridge — `.effect()` handlers returning async
   iterables/Streams); Effect `PubSub` → async-iterable adapter with
   scope-tied unsubscribe on client disconnect; vite dev proxy SSE passthrough
-  (no buffering); `streamedOptions` consumption + `ClientRetryPlugin`
+  (no buffering); `experimental_liveOptions` consumption + `ClientRetryPlugin`
   reconnect. Output: working reference procedure + findings note. If
   effect-orpc cannot express it, fallback: plain oRPC `.handler()` for the
   watch procedure calling into the runtime — decided in the spike, not during

--- a/openspec/changes/mapgen-studio-stream-spike/.openspec.yaml
+++ b/openspec/changes/mapgen-studio-stream-spike/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-06-13
+status: draft

--- a/openspec/changes/mapgen-studio-stream-spike/design.md
+++ b/openspec/changes/mapgen-studio-stream-spike/design.md
@@ -1,0 +1,80 @@
+# Design — stream spike (S3.0)
+
+## D1. Spike boundary
+
+S3.0 is a feasibility slice. It may add test-local reference code, focused
+fixtures, and spike artifacts. It does not introduce the production
+`EventHub`, the production `studio.events.watch` procedure, or client store
+feed rewrites. Production implementation starts in S3.1 after this slice names
+the selected bridge.
+
+The reference code has one of two terminal dispositions:
+
+- promoted by S3.1 into the production `studio.events.watch` path; or
+- deleted by S3.1 when it has served as proof-only scaffolding.
+
+No spike reference may remain as an unused route, shim, or compatibility path.
+
+## D2. Contract proof
+
+The contract proof answers whether the current installed packages can express:
+
+```ts
+studio.events.watch -> eventIterator(StudioEventSchema)
+```
+
+where the handler is implemented through the same `effect-orpc`
+`implementEffect` pattern used by `packages/studio-server`. The evidence must
+include the installed type/runtime source that makes the verdict true or false.
+
+If `.effect()` cannot return an event iterator safely, S3.1 shall implement the
+watch procedure with a plain oRPC `.handler()` that calls into the Effect
+runtime boundary. That is a selected implementation path, not a retained
+fallback.
+
+## D3. PubSub adapter proof
+
+The daemon-side event category is Effect-native. The spike must prove a small
+adapter from `PubSub` subscription to async iterator consumption:
+
+- every published event is yielded in order for one subscriber;
+- closing the iterator or aborting the client releases the subscription;
+- cleanup is observable by a focused test, not inferred from code review.
+
+The adapter may be test-local in S3.0. S3.1 owns the production EventHub
+service and final adapter placement.
+
+## D4. Transport proof
+
+The future watch procedure must use the existing one `/rpc` surface. The spike
+must prove that the server handler and development proxy path preserve streaming
+semantics. Evidence can be a focused app-level test, a Bun fetch proof against
+the handler, or a source-backed disposition if the current test harness cannot
+exercise vite without adding brittle infrastructure.
+
+The proof must name what it falsifies: buffering all events until close,
+dropping later events, or failing to run cleanup on client disconnect.
+
+## D5. Client proof
+
+The plan named `streamedOptions`, but the installed client package is the
+authority for exact API names. The spike records the actual API exposed by the
+installed `@orpc/tanstack-query` version and demonstrates the consumption shape
+or records the source-backed correction for S3.1.
+
+The reconnect proof must inspect `ClientRetryPlugin` behavior for event
+iterator retries and record whether S3.1 can rely on it directly. If a live
+network retry test is impractical in S3.0, the findings must state the boundary
+and the minimal S3.1 test that closes it.
+
+## D6. Findings format
+
+`workstream/findings.md` is the durable output. It must contain:
+
+- verdict: feasible, feasible with caveats, risky, or rejected;
+- selected S3.1 procedure bridge;
+- evidence map with file/package pointers;
+- integration touchpoints;
+- constraints and risks;
+- deletion/promotion targets for any spike-only reference;
+- exact next tests S3.1 must keep or add.

--- a/openspec/changes/mapgen-studio-stream-spike/proposal.md
+++ b/openspec/changes/mapgen-studio-stream-spike/proposal.md
@@ -1,0 +1,80 @@
+# MapGen Studio stream spike
+
+## Why
+
+The runtime simplification program's event spine depends on one typed daemon
+event channel: `studio.events.watch`. S3.1 should implement that channel as
+execution, not discovery. S3.0 proves the unknown transport bridge first:
+
+- whether `effect-orpc` `implementEffect` can serve an `eventIterator` output
+  from an Effect handler;
+- whether an Effect `PubSub` can be adapted to an async iterator with
+  disconnect-tied cleanup;
+- whether the Studio daemon/vite development path preserves SSE/event-iterator
+  streaming without buffering;
+- whether the installed TanStack oRPC client helpers and `ClientRetryPlugin`
+  support the intended client consumption and reconnect behavior.
+
+The product outcome is simple: the daemon owns ephemeral truth and pushes it;
+the browser renders and re-adopts on reconnect. This spike prevents the event
+spine from inheriting a speculative API assumption.
+
+## Target Authority Refs
+
+- `docs/projects/studio-runtime-simplification/PLAN.md` — WS-3 S3.0 requires
+  a small stream feasibility spike before `event-hub`.
+- `openspec/changes/mapgen-studio-runtime-one-mount/` — the one `/rpc` surface
+  that the future watch procedure must use.
+- `openspec/changes/mapgen-studio-operations-current/` — `operations.current`
+  remains the reconnect/re-adoption source after stream reconnects.
+- Installed package evidence in this repo:
+  `@orpc/contract`, `@orpc/tanstack-query`, `@orpc/client/plugins`, and
+  `effect-orpc`.
+- Current daemon/vite development routing under `apps/mapgen-studio/src/server`
+  and `apps/mapgen-studio` tests.
+
+## What Changes
+
+- Add a working reference proof for the selected watch-procedure bridge. The
+  reference may be test-local or spike-scoped, but it must not become a hidden
+  production route outside S3.1. S3.1 either promotes the selected approach into
+  `studio.events.watch` or deletes the spike-only reference.
+- Prove or reject `effect-orpc` `.effect()` returning an `eventIterator`
+  async iterator.
+- Prove Effect `PubSub` subscription cleanup when the client stops reading.
+- Prove server transport and dev proxy behavior for event streaming.
+- Prove client consumption against the installed oRPC TanStack API names and
+  `ClientRetryPlugin` behavior, or record a bounded incompatibility with source
+  evidence.
+- Produce `workstream/findings.md` with the verdict, integration touchpoints,
+  constraints, selected S3.1 path, and any deletion/promotion target.
+
+## Non-Goals
+
+- No production EventHub service in this slice.
+- No deletion of operation polls, watchdog, or live-game polling in this slice.
+  S3.2/S3.3 own those deletions.
+- No second runtime surface or alternate transport.
+- No Zod expansion for new event contracts; any new durable schema introduced
+  after the spike uses TypeBox/Standard Schema.
+- No long-lived dual path. If the spike selects plain oRPC `.handler()` for
+  `studio.events.watch`, that is the S3.1 implementation path and the
+  `.effect()` route remains rejected evidence, not a compatibility lane.
+
+## Impact
+
+- `openspec/changes/mapgen-studio-stream-spike/**`
+- Focused reference/test files under `packages/studio-server/test/**` and/or
+  `apps/mapgen-studio/test/**`
+- Minimal spike-only helper code if required to exercise the real handler
+  stack; any such helper must name its S3.1 promotion or deletion target.
+
+## Verification Gates
+
+- `bun run openspec -- validate mapgen-studio-stream-spike --strict`
+- Focused package/app test proving event-iterator server behavior.
+- Focused adapter test proving unsubscribe/finalizer cleanup.
+- Focused transport/client proof or source-backed disposition for the dev proxy
+  and TanStack client/retry pieces.
+- `workstream/findings.md` cites the files/package declarations that support
+  the final S3.1 decision.

--- a/openspec/changes/mapgen-studio-stream-spike/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-stream-spike/specs/mapgen-studio/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Stream Spike Records Event Iterator Feasibility
+
+MapGen Studio SHALL record an evidence-backed feasibility verdict before
+implementing the production `studio.events.watch` event channel.
+
+#### Scenario: Selected watch bridge is decided before EventHub implementation
+
+- **WHEN** S3.0 closes
+- **THEN** the stream findings identify whether S3.1 should implement
+  `studio.events.watch` through `effect-orpc` `.effect()` or through a plain
+  oRPC `.handler()` calling into the Effect runtime
+- **AND** the rejected path, if any, is recorded as evidence rather than
+  retained as a compatibility route
+
+#### Scenario: Spike-only reference code has a terminal disposition
+
+- **WHEN** S3.0 adds a working reference procedure, helper, or test fixture
+- **THEN** the findings name whether S3.1 promotes it into production code or
+  deletes it after use
+- **AND** no unused spike route is allowed to survive as a hidden runtime path
+
+### Requirement: Stream Spike Proves Subscription Cleanup
+
+MapGen Studio SHALL prove that the daemon event subscription model can clean up
+when a client disconnects or stops reading.
+
+#### Scenario: Closing the iterator releases the subscription
+
+- **WHEN** a test subscriber reads from the reference event iterator
+- **AND** the subscriber closes or aborts the iterator
+- **THEN** the underlying Effect subscription is released
+- **AND** the cleanup is asserted by the proof instead of inferred
+
+### Requirement: Stream Spike Records Client API Corrections
+
+MapGen Studio SHALL base the S3.1 client stream implementation on the installed
+oRPC client package APIs, not stale plan vocabulary.
+
+#### Scenario: Installed stream helper names are recorded
+
+- **WHEN** S3.0 inspects `@orpc/tanstack-query`
+- **THEN** the findings record the actual stream helper API names available in
+  the installed version
+- **AND** any mismatch with the project plan is carried into the S3.1
+  implementation notes before production code is written

--- a/openspec/changes/mapgen-studio-stream-spike/tasks.md
+++ b/openspec/changes/mapgen-studio-stream-spike/tasks.md
@@ -1,0 +1,46 @@
+## 1. Frame
+
+- [x] 1.1 Create S3.0 proposal/design/tasks/spec delta from the accepted
+      runtime simplification plan and merged S1/S2 context.
+- [x] 1.2 Run strict OpenSpec validation before reference proof work.
+- [x] 1.3 Start watcher/review lane before code changes.
+
+## 2. Evidence Map
+
+- [x] 2.1 Inspect installed `@orpc/contract` eventIterator schema/runtime
+      support.
+- [x] 2.2 Inspect `effect-orpc` procedure implementation types/runtime for
+      eventIterator output compatibility.
+- [x] 2.3 Inspect installed `@orpc/tanstack-query` stream helper API names and
+      event-iterator requirements.
+- [x] 2.4 Inspect `ClientRetryPlugin` event-iterator retry behavior.
+- [x] 2.5 Inspect current Studio daemon/vite `/rpc` transport path for stream
+      passthrough constraints.
+
+## 3. Working Reference Proof
+
+- [x] 3.1 Add a bounded reference contract/procedure proof for eventIterator
+      output.
+- [x] 3.2 Add an Effect `PubSub` to async-iterator adapter proof with
+      observable cleanup on iterator close/client disconnect.
+- [x] 3.3 Add or run a focused transport/client proof for streaming delivery
+      and reconnection, or record the source-backed boundary that makes a
+      narrower S3.1 proof necessary.
+- [x] 3.4 Keep reference code test-local/spike-scoped, with explicit S3.1
+      promotion or deletion target.
+
+## 4. Findings + Decision
+
+- [x] 4.1 Write `workstream/findings.md` with verdict, selected S3.1 bridge,
+      evidence map, constraints, risks, and deletion/promotion targets.
+- [x] 4.2 Record the installed API-name correction for TanStack oRPC stream
+      helpers if it differs from the accepted plan wording.
+- [x] 4.3 Update downstream plan or follow-on OpenSpec assumptions if the spike
+      changes S3.1/S3.2 requirements.
+
+## 5. Verification + Closure
+
+- [x] 5.1 `bun run openspec -- validate mapgen-studio-stream-spike --strict`.
+- [x] 5.2 Focused package/app gates for the reference proofs.
+- [x] 5.3 Watcher/review disposition recorded; no P1/P2 findings unresolved.
+- [ ] 5.4 Graphite submit/merge/drain according to repo rules.

--- a/openspec/changes/mapgen-studio-stream-spike/workstream/findings.md
+++ b/openspec/changes/mapgen-studio-stream-spike/workstream/findings.md
@@ -1,0 +1,128 @@
+# Stream Spike Findings
+
+## Status
+
+Complete for S3.0. This record is the input to S3.1 `event-hub`.
+
+## Verdict
+
+Feasible with caveats.
+
+S3.1 should implement `studio.events.watch` as an `effect-orpc` `.effect()`
+procedure with `eventIterator(...)` output. The handler should return an async
+iterator backed by an Effect `PubSub` subscription. The client should consume
+the procedure through `experimental_liveOptions` and `ClientRetryPlugin`, not
+through the stale plan wording `streamedOptions`.
+
+## Evidence Map
+
+- `@orpc/contract` 1.14.5 exposes `eventIterator(yields, returns?)` as a schema
+  whose input shape is `AsyncIteratorObject` and whose output shape is
+  `AsyncIteratorClass`
+  (`node_modules/.bun/@orpc+contract@1.14.5/node_modules/@orpc/contract/dist/index.d.mts:300`).
+- `effect-orpc` types `.effect()` output as `InferSchemaInput<TOutputSchema>`;
+  for `eventIterator(...)`, that is the async iterator object the handler must
+  return (`packages/studio-server/node_modules/effect-orpc/src/contract.ts:41`).
+- `effect-orpc` runs the handler effect and returns `exit.value` directly; it
+  does not drain the iterator inside the Effect runtime call
+  (`packages/studio-server/node_modules/effect-orpc/src/effect-runtime.ts:91`).
+- `@orpc/tanstack-query` 1.14.5 exposes
+  `experimental_streamedOptions` and `experimental_liveOptions`, not bare
+  `streamedOptions`
+  (`node_modules/.bun/@orpc+tanstack-query@1.14.5+78905631a608f42d/node_modules/@orpc/tanstack-query/dist/index.d.mts:143`).
+- The TanStack integration checks that the client output is an async iterator
+  before running streamed/live query helpers
+  (`node_modules/.bun/@orpc+tanstack-query@1.14.5+78905631a608f42d/node_modules/@orpc/tanstack-query/dist/index.mjs:155`).
+- `ClientRetryPlugin` defaults retry to `0`, tracks event metadata `id` and
+  `retry`, and reconnects event iterators by re-calling the procedure with the
+  last event id
+  (`node_modules/.bun/@orpc+client@1.14.5/node_modules/@orpc/client/dist/plugins/index.mjs:287`).
+- The daemon routes every `/rpc*` request to one `studioRpc.handle(request,
+  { prefix: "/rpc" })`
+  (`apps/mapgen-studio/src/server/daemon/daemon.ts:137`).
+- Vite dev config proxies exactly `/rpc` to the daemon
+  (`apps/mapgen-studio/vite.config.ts:50`).
+
+## Selected S3.1 Bridge
+
+Implement production `studio.events.watch` through the existing
+`effect-orpc` router:
+
+1. Define the sealed event union with TypeBox/Standard Schema.
+2. Add `studio.events.watch` as `eventIterator(StudioEventSchema)`.
+3. Implement with `.effect()` returning an async iterator object.
+4. Back the iterator with the runtime EventHub service's Effect `PubSub`.
+5. Emit `hello` immediately on connect so `experimental_liveOptions` has an
+   initial value and restart identity is available.
+6. Configure `ClientRetryPlugin` on the Studio client link or call context with
+   a nonzero retry count.
+
+The plain oRPC `.handler()` path is not selected. It remains a rejected
+contingency because `.effect()` is proven type/runtime-feasible in this repo.
+
+## Touchpoints
+
+- Contract insertion: `packages/studio-server/src/contract/index.ts` under
+  `studio.events.watch`, plus a new TypeBox/Standard Schema event contract.
+- Router insertion: `packages/studio-server/src/router/index.ts` under
+  `oe.studio.events.watch.effect(...)`.
+- Runtime service: `packages/studio-server/src/runtime.ts` gains the EventHub
+  layer in S3.1.
+- Client link: `apps/mapgen-studio/src/lib/orpc.ts` gains
+  `ClientRetryPlugin`.
+- Client consumption: S3.1 adds one event subscription hook using
+  `experimental_liveOptions`.
+- Reconnect behavior: reconnect triggers `studio.operations.current` adoption
+  from the S2.1 state spine.
+
+## Constraints And Risks
+
+- New durable schemas must use TypeBox/Standard Schema. The S3.0 proof uses
+  TypeBox and the local `toStandardSchema` adapter.
+- `experimental_liveOptions` is the correct helper for this event spine because
+  it models latest daemon state. `experimental_streamedOptions` accumulates
+  chunks and is the wrong shape for an unbounded daemon event bus.
+- `ClientRetryPlugin` is inert unless configured with retry > 0. S3.1 must wire
+  that deliberately.
+- Event metadata should use oRPC's exported `withEventMeta` helper for ids and
+  retry delay. S3.1 can start without replaying old events because
+  `operations.current` is the reconnect truth source, but ids are still useful
+  for the retry plugin's last-event-id transport.
+- Existing Node HTTP helper tests buffer `Response.body` with `arrayBuffer()`;
+  they do not prove streaming. Streaming tests must read from the response or
+  client iterator directly.
+- Dev proxy stream passthrough is now live-proven by a minimal Vite proxy test,
+  not only inferred from source.
+
+## Spike Reference Disposition
+
+- `packages/studio-server/test/streamSpike.test.ts` is S3.0 proof-only
+  reference code. S3.1 must either promote its assertions into production
+  EventHub/watch tests or delete this spike fixture once production tests cover:
+  `.effect()` eventIterator delivery, PubSub cleanup, and retry last-event-id.
+- `apps/mapgen-studio/test/devServer/viteProxyStream.test.ts` is a durable dev
+  proxy guard. It should remain unless S3.1 replaces it with an equal or
+  stronger proof that the real app dev proxy passes event streams without
+  buffering.
+- No production route, client subscription, EventHub service, or alternate
+  transport was added in S3.0.
+
+## S3.1 Required Tests
+
+- Subscribe to `studio.events.watch` and receive `hello` with
+  `serverInstanceId` and `serverStartedAt`.
+- Closing/aborting the watch iterator releases the underlying PubSub
+  subscription.
+- `ClientRetryPlugin` reconnect path is configured and carries last-event-id
+  when event metadata is present.
+- Reconnect invokes `studio.operations.current` and re-adopts daemon-owned
+  operation truth.
+- Production event tests replace or delete the S3.0 spike fixture.
+
+## Proof Commands
+
+- `bun run --cwd packages/studio-server test -- test/streamSpike.test.ts`
+  passed: `.effect()` eventIterator delivery, PubSub cleanup, and
+  `ClientRetryPlugin` last-event-id reconnect.
+- `bun run --cwd apps/mapgen-studio test -- test/devServer/viteProxyStream.test.ts`
+  passed: Vite `/rpc` proxy delivers the first SSE chunk before upstream close.

--- a/openspec/changes/mapgen-studio-stream-spike/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-stream-spike/workstream/phase-record.md
@@ -1,0 +1,140 @@
+# Phase Record
+
+## Phase
+
+- Project: Studio runtime simplification
+- Phase: S3.0 `stream-spike`
+- Owner: Codex DRA implementation lane
+- Branch/Graphite stack: `codex/stream-spike` stacked on `main`
+- Started: 2026-06-13
+- Status: implemented; final validation and Graphite closure pending
+
+## Objective
+
+- Target movement: decide the stream bridge for WS-3 before production EventHub
+  work begins.
+- Non-goals: production EventHub, operation poll deletion, watchdog deletion,
+  live-game watcher migration, alternate transport surfaces.
+- Done condition: working reference proof and findings note identify the S3.1
+  implementation path, cleanup proof, client API correction, risks, and
+  deletion/promotion targets.
+
+## Authority
+
+- Root/subtree `AGENTS.md`: root repo router, exact staging, Graphite process,
+  no dirty repo closure.
+- Product refs: `docs/projects/studio-runtime-simplification/PLAN.md` WS-3 S3.0.
+- Architecture refs: one `/rpc` surface from S1.1; daemon-owned state from
+  S2.1; event spine target from DP-3.
+- Project refs: `openspec/changes/mapgen-studio-runtime-one-mount/`,
+  `openspec/changes/mapgen-studio-dev-watch-deploy-isolation/`,
+  `openspec/changes/mapgen-studio-error-spine/`,
+  `openspec/changes/mapgen-studio-operations-current/`.
+- Excluded/stale inputs: stale habitat branch, pre-S2 browser recovery bridge,
+  stale plan vocabulary when installed package declarations differ.
+
+## Current State
+
+- Repo/Graphite state: clean `codex/stream-spike` over `main` at
+  `ecd1eed571917db1d1c76d42c7d48f4c89eaa361`.
+- Dirty files and owner: S3.0 OpenSpec/findings, program plan API-name
+  correction, and focused stream/proxy proof tests owned by this branch.
+- Current code evidence: one `/rpc` surface exists; `operations.current`
+  exists for reconnect adoption; status polls/watchdog remain for S3.2/S3.3.
+- Generated outputs affected: none expected.
+- Tests/guards affected: focused package stream reference test and Vite proxy
+  stream passthrough test.
+
+## Scope
+
+- Write set: `openspec/changes/mapgen-studio-stream-spike/**`, focused
+  reference/proof tests under `packages/studio-server/test/**` and/or
+  `apps/mapgen-studio/test/**`, minimal test-local helpers if required.
+- Protected files: production EventHub service, production client store feeds,
+  generated outputs, unrelated OpenSpec changes, operation poll deletion.
+- Owners: S3.0 owns feasibility evidence and reference proof; S3.1 owns
+  production EventHub/watch implementation.
+- Forbidden owners: alternate runtime transport, hidden compatibility route,
+  new Zod success schemas for durable event contracts.
+- Consumer impact: no production runtime behavior change expected from S3.0.
+- Downstream assumptions: S3.1 uses the selected bridge; S3.2/S3.3 delete
+  polls/watchdog only after production events exist.
+
+## Spec/Tasks
+
+- Spec/proposal: `openspec/changes/mapgen-studio-stream-spike/`.
+- Tasks: `tasks.md`.
+- Validation status: `bun run openspec -- validate mapgen-studio-stream-spike --strict`
+  passed.
+
+## Review
+
+- Review lanes: S3.0 watcher lane `019ec079-d523-7e63-9929-0689dc99cd44`.
+- Blocking findings: none known yet.
+- Accepted findings repaired: none.
+- Rejected/invalidated/waived/deferred findings: none.
+
+## Agent Fleet State
+
+- Active agents: package/API evidence explorer `019ec07c-de9d-7973-9b9e-9fe8fa0fa655`;
+  transport evidence explorer `019ec07d-999c-75e2-9b8f-4354b5f40dbe`.
+- Completed agents: watcher `019ec079-d523-7e63-9929-0689dc99cd44`.
+- Assigned write sets: watcher is read-only.
+- Latest evidence by agent: watcher returned `DONT_NOTIFY`; strict OpenSpec
+  validation passed, scope guards were present, and no live watcher
+  note/correction artifact was required. Package/API explorer returned
+  feasible-with-caveats and selected `experimental_liveOptions`. Transport
+  explorer confirmed the `/rpc` path and recommended a test-local proof plus a
+  live Vite proxy guard.
+- Open findings by agent: none.
+- Running/stale status: all S3.0 agents complete/closed.
+- Integration owner: Codex DRA implementation lane.
+
+## Implementation
+
+- Completed tasks: initial S3.0 frame, strict OpenSpec validation, watcher lane
+  start/disposition, evidence map, reference proof, findings, and downstream
+  plan realignment.
+- Remaining tasks: final strict validation and Graphite drain.
+- Stop conditions triggered: none.
+
+## Verification
+
+- Commands run:
+  - `bun run openspec -- validate mapgen-studio-stream-spike --strict`
+- `bun run --cwd packages/studio-server test -- test/streamSpike.test.ts`
+- `bun run --cwd apps/mapgen-studio test -- test/devServer/viteProxyStream.test.ts`
+- `bun x turbo run check --filter=@civ7/studio-server`
+- Results: OpenSpec strict validation passed; stream reference proof passed;
+  Vite proxy stream passthrough proof passed; studio-server package check
+  passed.
+- Gate disposition: package/app proof gates green; studio-server package check
+  green.
+- Evidence boundary: no production EventHub/client subscription implemented;
+  S3.1 must promote/delete the spike package fixture when production tests land.
+
+## Realignment
+
+- Downstream docs/specs/issues updated:
+  `docs/projects/studio-runtime-simplification/PLAN.md` now names
+  `experimental_liveOptions`/`experimental_streamedOptions` and selects live
+  options for latest-state event consumption.
+- Tests/guards updated: `packages/studio-server/test/streamSpike.test.ts` and
+  `apps/mapgen-studio/test/devServer/viteProxyStream.test.ts`.
+- Deferrals/triage updated: S3.1 must promote/delete the spike package fixture;
+  Vite proxy guard may remain as durable stream passthrough coverage.
+- Downstream realignment ledger: captured in `workstream/findings.md`.
+
+## Next Action
+
+- Exact next step: run final validation/package gates, stage exact S3.0 files,
+  commit/submit/merge through Graphite, then open S3.1 `event-hub`.
+- First files to inspect for implementation:
+  `packages/studio-server/src/handler.ts`,
+  `packages/studio-server/src/contract/index.ts`,
+  `packages/studio-server/src/router/index.ts`,
+  `apps/mapgen-studio/src/lib/orpc.ts`,
+  daemon/vite proxy paths under `apps/mapgen-studio/src/server`.
+- Stop condition: if `eventIterator` cannot be served through `effect-orpc`
+  `.effect()`, record the source evidence and select the plain oRPC handler
+  path for S3.1 rather than adding a dual route.

--- a/openspec/changes/mapgen-studio-stream-spike/workstream/review-disposition-ledger.md
+++ b/openspec/changes/mapgen-studio-stream-spike/workstream/review-disposition-ledger.md
@@ -1,0 +1,17 @@
+# Review Disposition Ledger
+
+| ID | Severity | Reviewer/Lane | Finding | Blocker Class | Disposition | Repair Demand | Evidence | Blocks Closure |
+|---|---|---|---|---|---|---|---|---|
+
+## Disposition Rules
+
+- `accepted`: repair before dependent implementation or closure.
+- `rejected`: record source evidence showing the finding does not apply.
+- `invalidated`: record later source evidence that made the finding false.
+- `user-decision`: record the user or authority decision that resolves the finding.
+- `waived`: allowed only for P3/nonblocking findings; record risk, owner, and trigger.
+- `deferred`: allowed only for P3/nonblocking findings; record destination, owner, and context.
+- `accepted-repaired`: accepted material finding repaired inside this slice with
+  evidence and no remaining closure block.
+
+No material finding may remain undispositioned at phase closure.

--- a/packages/studio-server/test/streamSpike.test.ts
+++ b/packages/studio-server/test/streamSpike.test.ts
@@ -1,0 +1,266 @@
+import { createORPCClient, withEventMeta } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import { ClientRetryPlugin } from "@orpc/client/plugins";
+import type { ContractRouterClient } from "@orpc/contract";
+import { eventIterator, oc } from "@orpc/contract";
+import { AsyncIteratorClass, ORPCError } from "@orpc/server";
+import { RPCHandler } from "@orpc/server/fetch";
+import { Effect, Exit, Layer, ManagedRuntime, PubSub, Queue, Scope } from "effect";
+import { implementEffect } from "effect-orpc";
+import { Type, type Static } from "typebox";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { toStandardSchema } from "../src/typeboxStandardSchema.js";
+
+type SpikeEvent = Static<typeof SpikeEventSchema>;
+
+const EmptyInputSchema = Type.Object({}, { additionalProperties: false });
+const SpikeEventSchema = Type.Object(
+  {
+    type: Type.Literal("tick"),
+    value: Type.Number(),
+  },
+  { additionalProperties: false },
+);
+
+const spikeInputSchema = toStandardSchema(EmptyInputSchema);
+const spikeEventSchema = toStandardSchema(SpikeEventSchema);
+const spikeEventIteratorSchema = eventIterator(spikeEventSchema);
+
+const spikeContract = oc.router({
+  studio: {
+    events: {
+      watch: oc.input(spikeInputSchema).output(spikeEventIteratorSchema),
+      retryWatch: oc.input(spikeInputSchema).output(spikeEventIteratorSchema),
+    },
+  },
+});
+
+type SpikeContract = typeof spikeContract;
+
+const openRuntimes: Array<ManagedRuntime.ManagedRuntime<never, never>> = [];
+
+afterEach(async () => {
+  await Promise.all(openRuntimes.splice(0).map((runtime) => runtime.dispose()));
+});
+
+describe("S3.0 stream spike reference proof", () => {
+  test("effect-orpc .effect can serve an eventIterator over the /rpc fetch handler", async () => {
+    const runtime = makeRuntime();
+    const pubsub = await runtime.runPromise(PubSub.unbounded<SpikeEvent>());
+    const subscriptionReady = deferred<void>();
+    const subscriptionClosed = deferred<boolean>();
+
+    const client = makeClient({
+      runtime,
+      watch: () =>
+        pubSubToAsyncIterator(pubsub, runtime, {
+          onReady: () => subscriptionReady.resolve(),
+          onClose: (queueWasShutdown) => subscriptionClosed.resolve(queueWasShutdown),
+        }),
+    });
+
+    const iterator = await client.studio.events.watch({});
+    await subscriptionReady.promise;
+
+    const firstEvent = withTimeout(iterator.next(), 1_000, "first stream event");
+    await runtime.runPromise(PubSub.publish(pubsub, { type: "tick", value: 1 }));
+
+    await expect(firstEvent).resolves.toEqual({
+      done: false,
+      value: { type: "tick", value: 1 },
+    });
+
+    await iterator.return?.();
+    await expect(withTimeout(subscriptionClosed.promise, 1_000, "stream cleanup")).resolves.toBe(
+      true,
+    );
+  });
+
+  test("ClientRetryPlugin reconnects event iterators with last-event-id", async () => {
+    const runtime = makeRuntime();
+    const observedLastEventIds: Array<string | undefined> = [];
+
+    const client = makeClient({
+      runtime,
+      retryWatch: ({ lastEventId }) => {
+        observedLastEventIds.push(lastEventId);
+        if (lastEventId === undefined) {
+          let emitted = false;
+          return new AsyncIteratorClass<SpikeEvent>(
+            async () => {
+              if (!emitted) {
+                emitted = true;
+                return {
+                  done: false,
+                  value: withEventMeta({ type: "tick", value: 1 }, { id: "event-1", retry: 0 }),
+                };
+              }
+              throw new ORPCError("INTERNAL_SERVER_ERROR", { message: "dropped stream" });
+            },
+            async () => {},
+          );
+        }
+
+        return new AsyncIteratorClass<SpikeEvent>(
+          async () => ({
+            done: false,
+            value: { type: "tick", value: 2 },
+          }),
+          async () => {},
+        );
+      },
+    });
+
+    const iterator = await client.studio.events.retryWatch(
+      {},
+      { context: { retry: 1, retryDelay: 0 } },
+    );
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: "tick", value: 1 },
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: "tick", value: 2 },
+    });
+    expect(observedLastEventIds).toEqual([undefined, "event-1"]);
+    await iterator.return?.();
+  });
+});
+
+function makeRuntime(): ManagedRuntime.ManagedRuntime<never, never> {
+  const runtime = ManagedRuntime.make(Layer.empty);
+  openRuntimes.push(runtime);
+  return runtime;
+}
+
+function makeClient(options: {
+  runtime: ManagedRuntime.ManagedRuntime<never, never>;
+  watch?: () => AsyncIteratorObject<SpikeEvent, unknown, void>;
+  retryWatch?: (options: { lastEventId: string | undefined }) => AsyncIteratorObject<
+    SpikeEvent,
+    unknown,
+    void
+  >;
+}): ContractRouterClient<SpikeContract> {
+  const oe = implementEffect(spikeContract, options.runtime);
+  const handler = new RPCHandler(
+    oe.router({
+      studio: {
+        events: {
+          watch: oe.studio.events.watch.effect(function* () {
+            return options.watch?.() ?? emptyIterator();
+          }),
+          retryWatch: oe.studio.events.retryWatch.effect(function* ({ lastEventId }) {
+            return options.retryWatch?.({ lastEventId }) ?? emptyIterator();
+          }),
+        },
+      },
+    }),
+  );
+
+  const link = new RPCLink({
+    url: "http://studio.test/rpc",
+    plugins: [
+      new ClientRetryPlugin({
+        default: {
+          retry: 0,
+          retryDelay: 0,
+        },
+      }),
+    ],
+    fetch: async (request) => {
+      const result = await handler.handle(request, { prefix: "/rpc" });
+      if (!result.matched || !result.response) {
+        return new Response("not found", { status: 404 });
+      }
+      const contentType = result.response.headers.get("content-type");
+      if (!contentType?.startsWith("text/event-stream")) {
+        throw new Error(`Expected event-stream response, received ${contentType ?? "none"}`);
+      }
+      return result.response;
+    },
+  });
+
+  return createORPCClient<ContractRouterClient<SpikeContract>>(link);
+}
+
+function pubSubToAsyncIterator(
+  pubsub: PubSub.PubSub<SpikeEvent>,
+  runtime: ManagedRuntime.ManagedRuntime<never, never>,
+  hooks: {
+    onReady(): void;
+    onClose(queueWasShutdown: boolean): void;
+  },
+): AsyncIteratorObject<SpikeEvent, unknown, void> {
+  let closed = false;
+  const subscription = runtime
+    .runPromise(
+      Effect.flatMap(Scope.make(), (scope) =>
+        Effect.map(PubSub.subscribe(pubsub).pipe(Scope.extend(scope)), (queue) => ({
+          scope,
+          queue,
+        })),
+      ),
+    )
+    .then((state) => {
+      hooks.onReady();
+      return state;
+    });
+
+  return new AsyncIteratorClass<SpikeEvent>(
+    async () => {
+      const { queue } = await subscription;
+      const value = await runtime.runPromise(Queue.take(queue));
+      return { done: false, value };
+    },
+    async () => {
+      if (closed) return;
+      closed = true;
+      const { scope, queue } = await subscription;
+      await runtime.runPromise(Scope.close(scope, Exit.succeed(undefined)));
+      hooks.onClose(await runtime.runPromise(Queue.isShutdown(queue)));
+    },
+  );
+}
+
+function emptyIterator(): AsyncIteratorObject<SpikeEvent, unknown, void> {
+  return new AsyncIteratorClass<SpikeEvent>(
+    async () => ({ done: true, value: undefined }),
+    async () => {},
+  );
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
## S3.0 Stream Spike — feasibility proof for `studio.events.watch`

This slice answers the transport unknowns that must be resolved before S3.1 can implement the production `studio.events.watch` event channel without speculative API assumptions.

### What was proven

**`effect-orpc` `.effect()` can serve an `eventIterator` output.**
A focused reference test in `packages/studio-server/test/streamSpike.test.ts` confirms that an `.effect()` handler returning an async iterator backed by an Effect `PubSub` subscription delivers events through the oRPC fetch handler and that closing the iterator releases the underlying subscription in a way that is asserted, not inferred.

**`ClientRetryPlugin` carries `lastEventId` on reconnect.**
The same test file proves that when an event stream drops, the plugin re-calls the procedure with the last observed event id, enabling the S3.1 reconnect path.

**Vite `/rpc` dev proxy passes event-stream chunks before upstream close.**
A new test in `apps/mapgen-studio/test/devServer/viteProxyStream.test.ts` spins up a real Vite dev server and a local HTTP upstream, confirms the first SSE chunk arrives at the client before the upstream response ends, and guards against buffering regressions.

### API name correction

The accepted plan referenced `streamedOptions`, but the installed `@orpc/tanstack-query` 1.14.5 exposes `experimental_streamedOptions` and `experimental_liveOptions`. The plan is updated to name `experimental_liveOptions` as the selected helper for the event spine, because it models latest daemon state rather than accumulating an unbounded chunk array.

### Selected S3.1 bridge

Implement `studio.events.watch` through the existing `effect-orpc` router using `.effect()` returning an async iterator backed by the runtime EventHub `PubSub`. The plain oRPC `.handler()` contingency is rejected. Full integration touchpoints, constraints, risks, and deletion/promotion targets for the spike-only reference fixture are recorded in `openspec/changes/mapgen-studio-stream-spike/workstream/findings.md`.