### PR TITLE
`docs(mapgen-studio): close S3.0 stream spike — mark merged via PR #1684, drain branch, update repo state and next action to S3.1`

### DIFF
--- a/openspec/changes/mapgen-studio-stream-spike/tasks.md
+++ b/openspec/changes/mapgen-studio-stream-spike/tasks.md
@@ -43,4 +43,4 @@
 - [x] 5.1 `bun run openspec -- validate mapgen-studio-stream-spike --strict`.
 - [x] 5.2 Focused package/app gates for the reference proofs.
 - [x] 5.3 Watcher/review disposition recorded; no P1/P2 findings unresolved.
-- [ ] 5.4 Graphite submit/merge/drain according to repo rules.
+- [x] 5.4 Graphite submit/merge/drain according to repo rules.

--- a/openspec/changes/mapgen-studio-stream-spike/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-stream-spike/workstream/phase-record.md
@@ -7,7 +7,7 @@
 - Owner: Codex DRA implementation lane
 - Branch/Graphite stack: `codex/stream-spike` stacked on `main`
 - Started: 2026-06-13
-- Status: implemented; final validation and Graphite closure pending
+- Status: closed; merged and drained through Graphite
 
 ## Objective
 
@@ -35,10 +35,10 @@
 
 ## Current State
 
-- Repo/Graphite state: clean `codex/stream-spike` over `main` at
-  `ecd1eed571917db1d1c76d42c7d48f4c89eaa361`.
-- Dirty files and owner: S3.0 OpenSpec/findings, program plan API-name
-  correction, and focused stream/proxy proof tests owned by this branch.
+- Repo/Graphite state: `codex/stream-spike` merged via PR #1684 into `main` at
+  `9c0ba47acea904f2348293d0945e1868a6810ecc`, then retired from the local
+  Graphite stack.
+- Dirty files and owner: none for S3.0 after merge/drain.
 - Current code evidence: one `/rpc` surface exists; `operations.current`
   exists for reconnect adoption; status polls/watchdog remain for S3.2/S3.3.
 - Generated outputs affected: none expected.
@@ -95,7 +95,7 @@
 - Completed tasks: initial S3.0 frame, strict OpenSpec validation, watcher lane
   start/disposition, evidence map, reference proof, findings, and downstream
   plan realignment.
-- Remaining tasks: final strict validation and Graphite drain.
+- Remaining tasks: none for S3.0; continue S3.1.
 - Stop conditions triggered: none.
 
 ## Verification
@@ -127,8 +127,7 @@
 
 ## Next Action
 
-- Exact next step: run final validation/package gates, stage exact S3.0 files,
-  commit/submit/merge through Graphite, then open S3.1 `event-hub`.
+- Exact next step: open S3.1 `event-hub`.
 - First files to inspect for implementation:
   `packages/studio-server/src/handler.ts`,
   `packages/studio-server/src/contract/index.ts`,


### PR DESCRIPTION
Marks task 5.4 (Graphite submit/merge/drain) as complete and updates the phase record to reflect that `codex/stream-spike` has been merged via PR #1684 into `main` and retired from the local Graphite stack. The S3.0 phase is now fully closed with no remaining tasks or dirty files, and the next action is to open S3.1 `event-hub`.