### PR TITLE
`feat(mapgen-studio): daemon live-game watcher, live-game event push, delete client status setTimeout loop (S3.3)`

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -61,13 +61,11 @@ import {
   type MapConfigSaveDeployStatus,
 } from "../features/mapConfigSave/status";
 import {
-  buildLiveRuntimeErrorState,
   buildLiveRuntimeSnapshotRequest,
   buildLiveRuntimeSnapshotState,
-  buildLiveRuntimeStatusState,
   buildLiveRuntimeSuggestionRecords,
-  nextLiveRuntimePollDelayMs,
   shouldCommitLiveRuntimeSnapshot,
+  type LiveRuntimeSnapshotRequest,
   type LiveRuntimeSnapshotState,
   type LiveRuntimeStatusState,
   type LiveRuntimeSuggestionRecord,
@@ -487,10 +485,11 @@ export function StudioShell(props: StudioShellProps) {
   const lastSaveDeployConfig = useRunStore((s) => s.lastSaveDeployConfig);
   const setLastSaveDeployConfig = useRunStore((s) => s.setLastSaveDeployConfig);
   const lastRunInGameToastRef = useRef<string | null>(null);
-  const liveStatusFailureCountRef = useRef(0);
   const liveSnapshotFailureCountRef = useRef(0);
   const activeLiveSnapshotRequestKeyRef = useRef<string | null>(null);
   const liveSnapshotAbortRef = useRef<AbortController | null>(null);
+  const liveSetupAbortRef = useRef<AbortController | null>(null);
+  const liveRuntimeMountedRef = useRef(true);
   const [liveRuntime, setLiveRuntime] = useState<LiveRuntimeStatusState>({
     status: "idle",
     snapshotStatus: "idle",
@@ -505,6 +504,15 @@ export function StudioShell(props: StudioShellProps) {
     updatedAt?: string;
     error?: string;
   }>({ status: "idle" });
+
+  useEffect(() => {
+    liveRuntimeMountedRef.current = true;
+    return () => {
+      liveRuntimeMountedRef.current = false;
+      liveSnapshotAbortRef.current?.abort();
+      liveSetupAbortRef.current?.abort();
+    };
+  }, []);
   useEffect(() => {
     saveDeployOperationRef.current = saveDeployOperation;
     if (!saveDeployOperation || !isSaveDeployTerminal(saveDeployOperation)) return;
@@ -585,206 +593,148 @@ export function StudioShell(props: StudioShellProps) {
     localError ??
     browserRunner.state.error;
 
-  useEffect(() => {
-    let cancelled = false;
-    let timer: number | null = null;
-    let statusAbortController: AbortController | null = null;
+  const readLiveRuntimeSnapshot = useCallback(async (request: LiveRuntimeSnapshotRequest) => {
+    liveSnapshotAbortRef.current?.abort();
+    const snapshotAbortController = new AbortController();
+    liveSnapshotAbortRef.current = snapshotAbortController;
+    activeLiveSnapshotRequestKeyRef.current = request.key;
 
-    const scheduleNextPoll = () => {
-      const failureCount = Math.max(liveStatusFailureCountRef.current, liveSnapshotFailureCountRef.current);
-      timer = window.setTimeout(
-        poll,
-        nextLiveRuntimePollDelayMs({ failureCount, documentHidden: document.hidden }),
-      );
-    };
-
-    const readSnapshot = async (request: NonNullable<ReturnType<typeof buildLiveRuntimeSnapshotRequest>>) => {
-      liveSnapshotAbortRef.current?.abort();
-      const snapshotAbortController = new AbortController();
-      liveSnapshotAbortRef.current = snapshotAbortController;
-      activeLiveSnapshotRequestKeyRef.current = request.key;
-
+    try {
+      // Snapshot remains request/response. The event stream tells us when live
+      // status changed; the existing request-key guard still owns stale result
+      // rejection.
+      let body: unknown;
       try {
-        // EVERYTHING talks oRPC: the snapshot read now goes through the typed
-        // client instead of a manual `fetch`. Parity is preserved exactly — the
-        // live/snapshot procedure returns the 200 body on success and throws an
-        // `ORPCError` (status 400) on a bad request, which maps to the SAME
-        // `{ ok:false, error }` shape the legacy `res.ok ? body : {...}` branch
-        // produced. The request-key staleness gate (`shouldCommitLiveRuntimeSnapshot`)
-        // and the abort plumbing below are untouched.
-        let body: unknown;
-        try {
-          body = await orpcClient.civ7.live.snapshot(
-            {
-              x: request.bounds.x,
-              y: request.bounds.y,
-              width: request.bounds.width,
-              height: request.bounds.height,
-              fields: request.fields.join(","),
-              maxPlots: request.maxPlots,
-              ...(request.playerId === undefined ? {} : { playerId: request.playerId }),
-            },
-            { signal: snapshotAbortController.signal },
-          );
-        } catch (snapshotErr) {
-          if (cancelled || isAbortLikeError(snapshotErr)) throw snapshotErr;
-          body = {
-            ok: false,
-            error: snapshotErr instanceof Error ? snapshotErr.message : "Live snapshot unavailable",
-          };
-        }
-        if (cancelled) return;
-        if (!shouldCommitLiveRuntimeSnapshot({
-          activeRequestKey: activeLiveSnapshotRequestKeyRef.current,
-          resultRequestKey: request.key,
-          aborted: snapshotAbortController.signal.aborted,
-        })) {
-          return;
-        }
-        const snapshotState = buildLiveRuntimeSnapshotState({
-          request,
-          // `body` is already the procedure output (success) or the `{ ok:false,
-          // error }` envelope built from the thrown `ORPCError` above — the legacy
-          // `res.ok ? … : …` discrimination now lives in the try/catch.
-          body,
-          observedAtFallback: new Date().toISOString(),
-        });
-        liveSnapshotFailureCountRef.current = snapshotState.status === "ok" ? 0 : liveSnapshotFailureCountRef.current + 1;
-        setLiveRuntimeSnapshot(snapshotState);
-        setLiveRuntime((current) => ({
-          ...current,
-          snapshotStatus: snapshotState.status,
-          snapshotHash: snapshotState.snapshotHash ?? current.snapshotHash,
-          bindingStatus: snapshotState.status === "ok" ? current.bindingStatus : "partial",
-          failureCount: Math.max(liveStatusFailureCountRef.current, liveSnapshotFailureCountRef.current),
-          error: snapshotState.status === "ok" ? current.error : snapshotState.error,
-        }));
-      } catch (err) {
-        if (cancelled || isAbortLikeError(err)) return;
-        if (!shouldCommitLiveRuntimeSnapshot({
-          activeRequestKey: activeLiveSnapshotRequestKeyRef.current,
-          resultRequestKey: request.key,
-        })) {
-          return;
-        }
-        liveSnapshotFailureCountRef.current += 1;
-        const snapshotState: LiveRuntimeSnapshotState = {
-          status: "error",
-          requestKey: request.key,
-          error: err instanceof Error ? err.message : "Live snapshot unavailable",
+        body = await orpcClient.civ7.live.snapshot(
+          {
+            x: request.bounds.x,
+            y: request.bounds.y,
+            width: request.bounds.width,
+            height: request.bounds.height,
+            fields: request.fields.join(","),
+            maxPlots: request.maxPlots,
+            ...(request.playerId === undefined ? {} : { playerId: request.playerId }),
+          },
+          { signal: snapshotAbortController.signal },
+        );
+      } catch (snapshotErr) {
+        if (!liveRuntimeMountedRef.current || isAbortLikeError(snapshotErr)) throw snapshotErr;
+        body = {
+          ok: false,
+          error: snapshotErr instanceof Error ? snapshotErr.message : "Live snapshot unavailable",
         };
-        setLiveRuntimeSnapshot(snapshotState);
-        setLiveRuntime((current) => ({
-          ...current,
-          snapshotStatus: "error",
-          bindingStatus: "partial",
-          failureCount: Math.max(liveStatusFailureCountRef.current, liveSnapshotFailureCountRef.current),
-          error: snapshotState.error,
-        }));
       }
-    };
+      if (!liveRuntimeMountedRef.current) return;
+      if (!shouldCommitLiveRuntimeSnapshot({
+        activeRequestKey: activeLiveSnapshotRequestKeyRef.current,
+        resultRequestKey: request.key,
+        aborted: snapshotAbortController.signal.aborted,
+      })) {
+        return;
+      }
+      const snapshotState = buildLiveRuntimeSnapshotState({
+        request,
+        body,
+        observedAtFallback: new Date().toISOString(),
+      });
+      liveSnapshotFailureCountRef.current = snapshotState.status === "ok" ? 0 : liveSnapshotFailureCountRef.current + 1;
+      setLiveRuntimeSnapshot(snapshotState);
+      setLiveRuntime((current) => ({
+        ...current,
+        snapshotStatus: snapshotState.status,
+        snapshotHash: snapshotState.snapshotHash ?? current.snapshotHash,
+        bindingStatus: snapshotState.status === "ok" ? current.bindingStatus : "partial",
+        failureCount: Math.max(current.failureCount ?? 0, liveSnapshotFailureCountRef.current),
+        error: snapshotState.status === "ok" ? current.error : snapshotState.error,
+      }));
+    } catch (err) {
+      if (!liveRuntimeMountedRef.current || isAbortLikeError(err)) return;
+      if (!shouldCommitLiveRuntimeSnapshot({
+        activeRequestKey: activeLiveSnapshotRequestKeyRef.current,
+        resultRequestKey: request.key,
+      })) {
+        return;
+      }
+      liveSnapshotFailureCountRef.current += 1;
+      const snapshotState: LiveRuntimeSnapshotState = {
+        status: "error",
+        requestKey: request.key,
+        error: err instanceof Error ? err.message : "Live snapshot unavailable",
+      };
+      setLiveRuntimeSnapshot(snapshotState);
+      setLiveRuntime((current) => ({
+        ...current,
+        snapshotStatus: "error",
+        bindingStatus: "partial",
+        failureCount: Math.max(current.failureCount ?? 0, liveSnapshotFailureCountRef.current),
+        error: snapshotState.error,
+      }));
+    }
+  }, []);
 
-    const poll = async () => {
-      statusAbortController?.abort();
-      statusAbortController = new AbortController();
-      try {
-        // EVERYTHING talks oRPC: the live-status read now goes through the typed
-        // client. Parity preserved exactly — live/status returns 200 (with per-field
-        // embedded `{ error }` via allSettled) on partial failure and only throws an
-        // `ORPCError` (status 500) on an outer defect. That throw maps to the SAME
-        // outer-catch path the legacy `!res.ok` branch hit (rethrown as an `Error`
-        // carrying the message), so the adaptive-backoff failure accounting below is
-        // unchanged.
-        let body: unknown;
-        try {
-          const [liveStatus, readinessResult] = await Promise.all([
-            orpcClient.civ7.live.status({}, { signal: statusAbortController.signal }),
-            liveControlPort.readiness.current(),
-          ]);
-          body = isPlainObject(liveStatus)
-            ? {
-                ...liveStatus,
-                status: {
-                  ...(isPlainObject(liveStatus.status) ? liveStatus.status : {}),
-                  readiness: readinessResult.readiness,
-                },
-              }
-            : liveStatus;
-        } catch (statusErr) {
-          if (cancelled || isAbortLikeError(statusErr)) throw statusErr;
-          throw new Error(statusErr instanceof Error ? statusErr.message : "Live status unavailable");
-        }
-        if (cancelled) return;
-        if (!body) throw new Error("Live status unavailable");
+  const refreshLiveSetupFromEvent = useCallback(async (statusState: LiveRuntimeStatusState) => {
+    liveSetupAbortRef.current?.abort();
+    const setupAbortController = new AbortController();
+    liveSetupAbortRef.current = setupAbortController;
 
-        const statusState = buildLiveRuntimeStatusState({
-          body,
-          observedAtFallback: new Date().toISOString(),
-          failureCount: 0,
-        });
-        liveStatusFailureCountRef.current = statusState.status === "ok" ? 0 : liveStatusFailureCountRef.current + 1;
-        const snapshotRequest = buildLiveRuntimeSnapshotRequest({ status: statusState });
-        setLiveRuntime((current) => ({
-          ...statusState,
-          snapshotStatus:
-            snapshotRequest === null
-              ? statusState.snapshotStatus
-              : current.snapshotId === statusState.snapshotId && current.snapshotStatus === "ok"
-                ? current.snapshotStatus
-                : "loading",
-          failureCount: Math.max(liveStatusFailureCountRef.current, liveSnapshotFailureCountRef.current),
-        }));
-
-        const setup = await fetchCiv7SetupConfig({ signal: statusAbortController.signal });
-        if (cancelled) return;
-        const suggestedSetupConfig = setup.ok
-          ? normalizeStudioSetupConfig(studioSetupConfigFromLiveSnapshot(setup.setup))
-          : undefined;
-        if (setup.ok) {
-          setLiveSetup({ status: "ok", setup: setup.setup, updatedAt: setup.observedAt });
-        } else {
-          setLiveSetup({
-            status: "error",
-            error: setup.error,
-            updatedAt: setup.observedAt ?? new Date().toISOString(),
-          });
-        }
-        setLiveRuntimeSuggestions(buildLiveRuntimeSuggestionRecords({
-          sourceSnapshotId: statusState.snapshotId,
-          seed: statusState.seed,
-          setupConfig: suggestedSetupConfig,
-          provedStudioRun: false,
-        }));
-
-        if (snapshotRequest) await readSnapshot(snapshotRequest);
-      } catch (err) {
-        if (cancelled || isAbortLikeError(err)) return;
-        liveStatusFailureCountRef.current += 1;
-        const errorState = buildLiveRuntimeErrorState({
-          error: err,
-          observedAt: new Date().toISOString(),
-          failureCount: liveStatusFailureCountRef.current,
-        });
-        setLiveRuntime(errorState);
+    try {
+      const setup = await fetchCiv7SetupConfig({ signal: setupAbortController.signal });
+      if (!liveRuntimeMountedRef.current || setupAbortController.signal.aborted) return;
+      const suggestedSetupConfig = setup.ok
+        ? normalizeStudioSetupConfig(studioSetupConfigFromLiveSnapshot(setup.setup))
+        : undefined;
+      if (setup.ok) {
+        setLiveSetup({ status: "ok", setup: setup.setup, updatedAt: setup.observedAt });
+      } else {
         setLiveSetup({
           status: "error",
-          error: errorState.error ?? "Live setup unavailable",
-          updatedAt: errorState.updatedAt,
+          error: setup.error,
+          updatedAt: setup.observedAt ?? new Date().toISOString(),
         });
-        setLiveRuntimeSuggestions([]);
-      } finally {
-        if (!cancelled) scheduleNextPoll();
       }
-    };
-
-    timer = window.setTimeout(poll, 250);
-    return () => {
-      cancelled = true;
-      statusAbortController?.abort();
-      liveSnapshotAbortRef.current?.abort();
-      if (timer !== null) window.clearTimeout(timer);
-    };
+      setLiveRuntimeSuggestions(buildLiveRuntimeSuggestionRecords({
+        sourceSnapshotId: statusState.snapshotId,
+        seed: statusState.seed,
+        setupConfig: suggestedSetupConfig,
+        provedStudioRun: false,
+      }));
+    } catch (err) {
+      if (!liveRuntimeMountedRef.current || isAbortLikeError(err)) return;
+      const observedAt = new Date().toISOString();
+      setLiveSetup({
+        status: "error",
+        error: err instanceof Error ? err.message : "Live setup unavailable",
+        updatedAt: observedAt,
+      });
+      setLiveRuntimeSuggestions(buildLiveRuntimeSuggestionRecords({
+        sourceSnapshotId: statusState.snapshotId,
+        seed: statusState.seed,
+        provedStudioRun: false,
+        now: () => new Date(observedAt),
+      }));
+    }
   }, []);
+
+  const applyLiveGameState = useCallback((statusState: LiveRuntimeStatusState) => {
+    const snapshotRequest = buildLiveRuntimeSnapshotRequest({ status: statusState });
+    if (!snapshotRequest) {
+      activeLiveSnapshotRequestKeyRef.current = null;
+      liveSnapshotAbortRef.current?.abort();
+    }
+
+    setLiveRuntime((current) => ({
+      ...statusState,
+      snapshotStatus:
+        snapshotRequest === null
+          ? statusState.snapshotStatus
+          : current.snapshotId === statusState.snapshotId && current.snapshotStatus === "ok"
+            ? current.snapshotStatus
+            : "loading",
+      failureCount: Math.max(statusState.failureCount ?? 0, liveSnapshotFailureCountRef.current),
+    }));
+    void refreshLiveSetupFromEvent(statusState);
+    if (snapshotRequest) void readLiveRuntimeSnapshot(snapshotRequest);
+  }, [readLiveRuntimeSnapshot, refreshLiveSetupFromEvent]);
 
   // Saved configs + setup catalog now load via `useSetupDataQueries` (TanStack Query);
   // the prior hand-rolled load/retry/focus-refetch effect is replaced by the query
@@ -1555,6 +1505,7 @@ export function StudioShell(props: StudioShellProps) {
   }, [markRunInGameToastHandled]);
 
   useStudioEvents({
+    applyLiveGameState,
     setRunInGameOperation,
     setSaveDeployOperation,
     markRunInGameToastHandled,

--- a/apps/mapgen-studio/src/app/hooks/useStudioEvents.ts
+++ b/apps/mapgen-studio/src/app/hooks/useStudioEvents.ts
@@ -5,10 +5,12 @@ import type { StudioEvent } from "@civ7/studio-server";
 
 import { orpc, orpcClient } from "../../lib/orpc";
 import {
+  applyStudioLiveGameEvent,
   applyStudioOperationEvent,
   readAndAdoptStudioOperationsCurrent,
   type StudioOperationAdoptionTargets,
 } from "../operationAdoption";
+import type { LiveRuntimeStatusState } from "../../features/liveRuntime/model";
 
 export const STUDIO_EVENT_STREAM_RETRY_ATTEMPTS = Number.POSITIVE_INFINITY;
 
@@ -30,9 +32,11 @@ export function studioEventsWatchLiveOptions() {
 }
 
 export function useStudioEvents(args: StudioOperationAdoptionTargets & {
+  applyLiveGameState(state: LiveRuntimeStatusState): void;
   setLocalError(message: string | null): void;
 }): void {
   const {
+    applyLiveGameState,
     setRunInGameOperation,
     setSaveDeployOperation,
     markRunInGameToastHandled,
@@ -45,6 +49,9 @@ export function useStudioEvents(args: StudioOperationAdoptionTargets & {
     : null;
   const operationKey = event?.type === "operation"
     ? `${event.kind}:${event.status.requestId}:${event.observedAt}`
+    : null;
+  const liveGameKey = event?.type === "live-game"
+    ? `${event.state.snapshotId ?? event.state.snapshotHash ?? event.state.status}:${event.observedAt}`
     : null;
 
   useEffect(() => {
@@ -72,6 +79,13 @@ export function useStudioEvents(args: StudioOperationAdoptionTargets & {
       setSaveDeployOperation,
     });
   }, [event, operationKey, setRunInGameOperation, setSaveDeployOperation]);
+
+  useEffect(() => {
+    if (!liveGameKey || event?.type !== "live-game") return;
+    applyStudioLiveGameEvent(event, {
+      applyLiveGameState,
+    });
+  }, [applyLiveGameState, event, liveGameKey]);
 
   useEffect(() => {
     if (!eventQuery.error) return;

--- a/apps/mapgen-studio/src/app/operationAdoption.ts
+++ b/apps/mapgen-studio/src/app/operationAdoption.ts
@@ -1,6 +1,11 @@
-import type { StudioOperationEvent, StudioOperationsCurrent } from "@civ7/studio-server";
+import type {
+  StudioLiveGameEvent,
+  StudioOperationEvent,
+  StudioOperationsCurrent,
+} from "@civ7/studio-server";
 
 import type { MapConfigSaveDeployStatus } from "../features/mapConfigSave/status";
+import type { LiveRuntimeStatusState } from "../features/liveRuntime/model";
 import {
   isRunInGameTerminalPhase,
   type RunInGameOperationStatus,
@@ -40,6 +45,13 @@ export function applyStudioOperationEvent(
     return;
   }
   targets.setSaveDeployOperation(event.status as MapConfigSaveDeployStatus);
+}
+
+export function applyStudioLiveGameEvent(
+  event: StudioLiveGameEvent,
+  targets: { applyLiveGameState(state: LiveRuntimeStatusState): void },
+): void {
+  targets.applyLiveGameState(event.state as LiveRuntimeStatusState);
 }
 
 export async function readAndAdoptStudioOperationsCurrent(args: Readonly<{

--- a/apps/mapgen-studio/src/features/liveRuntime/model.ts
+++ b/apps/mapgen-studio/src/features/liveRuntime/model.ts
@@ -1,30 +1,22 @@
-export type LiveRuntimeStatusKind = "idle" | "ok" | "error";
+import {
+  buildLiveGameErrorState,
+  buildLiveGameState,
+  hashLiveGameValue,
+  stableLiveGameStringify,
+  type LiveGameBindingStatus,
+  type LiveGameSnapshotStatus,
+  type LiveGameState,
+  type LiveGameStatusBody,
+  type LiveGameStatusKind,
+} from "@civ7/studio-server/live-game";
 
-export type LiveRuntimeSnapshotStatus = "idle" | "loading" | "ok" | "stale" | "error";
+export type LiveRuntimeStatusKind = LiveGameStatusKind;
 
-export type LiveRuntimeBindingStatus =
-  | "unbound-runtime"
-  | "proven-studio-run"
-  | "stale"
-  | "partial"
-  | "failed";
+export type LiveRuntimeSnapshotStatus = LiveGameSnapshotStatus;
 
-export type LiveRuntimeStatusState = Readonly<{
-  status: LiveRuntimeStatusKind;
-  turn?: number;
-  gameHash?: number;
-  seed?: number;
-  readiness?: string;
-  autoplayActive?: boolean;
-  autoplayPaused?: boolean;
-  updatedAt?: string;
-  error?: string;
-  snapshotStatus?: LiveRuntimeSnapshotStatus;
-  snapshotId?: string;
-  snapshotHash?: string;
-  bindingStatus?: LiveRuntimeBindingStatus;
-  failureCount?: number;
-}>;
+export type LiveRuntimeBindingStatus = LiveGameBindingStatus;
+
+export type LiveRuntimeStatusState = LiveGameState;
 
 export type LiveRuntimeSnapshotBounds = Readonly<{
   x: number;
@@ -62,32 +54,7 @@ export type LiveRuntimeSuggestionRecord = Readonly<{
   applyPath: "visible-studio-control";
 }>;
 
-type LiveStatusBody = Readonly<{
-  ok?: boolean;
-  observedAt?: string;
-  status?: {
-    readiness?: string;
-    error?: string;
-  };
-  mapSummary?: {
-    error?: string;
-    map?: {
-      randomSeed?: { ok?: boolean; value?: number };
-      width?: { ok?: boolean; value?: number };
-      height?: { ok?: boolean; value?: number };
-    };
-    game?: {
-      turn?: { ok?: boolean; value?: number };
-      hash?: { ok?: boolean; value?: number };
-    };
-  };
-  autoplay?: {
-    autoplay?: {
-      isActive?: boolean;
-      isPaused?: boolean;
-    };
-  };
-}>;
+type LiveStatusBody = LiveGameStatusBody;
 
 const DEFAULT_VISIBLE_SNAPSHOT_BOUNDS: LiveRuntimeSnapshotBounds = {
   x: 0,
@@ -99,17 +66,11 @@ const DEFAULT_VISIBLE_SNAPSHOT_BOUNDS: LiveRuntimeSnapshotBounds = {
 const DEFAULT_VISIBLE_SNAPSHOT_FIELDS = ["terrain", "biome", "feature", "resource"] as const;
 
 export function stableLiveRuntimeStringify(value: unknown): string {
-  return JSON.stringify(canonicalize(value));
+  return stableLiveGameStringify(value);
 }
 
 export function hashLiveRuntimeValue(value: unknown): string {
-  const input = stableLiveRuntimeStringify(value);
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < input.length; i += 1) {
-    hash ^= input.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return (hash >>> 0).toString(16).padStart(8, "0");
+  return hashLiveGameValue(value);
 }
 
 export function buildLiveRuntimeStatusState(args: {
@@ -118,36 +79,7 @@ export function buildLiveRuntimeStatusState(args: {
   failureCount?: number;
   bindingStatus?: LiveRuntimeBindingStatus;
 }): LiveRuntimeStatusState {
-  const observedAt = args.body.observedAt ?? args.observedAtFallback;
-  const turn = args.body.mapSummary?.game?.turn?.ok ? args.body.mapSummary.game.turn.value : undefined;
-  const gameHash = args.body.mapSummary?.game?.hash?.ok ? args.body.mapSummary.game.hash.value : undefined;
-  const seed = args.body.mapSummary?.map?.randomSeed?.ok ? args.body.mapSummary.map.randomSeed.value : undefined;
-  const readiness = args.body.status?.readiness;
-  const ok = Boolean(args.body.ok);
-  const snapshotHash = hashLiveRuntimeValue({
-    turn,
-    gameHash,
-    seed,
-    readiness,
-    map: args.body.mapSummary?.map,
-    autoplay: args.body.autoplay?.autoplay,
-  });
-  return {
-    status: ok ? "ok" : "error",
-    ...(turn === undefined ? {} : { turn }),
-    ...(gameHash === undefined ? {} : { gameHash }),
-    ...(seed === undefined ? {} : { seed }),
-    ...(readiness === undefined ? {} : { readiness }),
-    autoplayActive: args.body.autoplay?.autoplay?.isActive,
-    autoplayPaused: args.body.autoplay?.autoplay?.isPaused,
-    updatedAt: observedAt,
-    snapshotStatus: ok ? "idle" : "error",
-    snapshotHash,
-    snapshotId: `status:${turn ?? "unknown"}:${snapshotHash}`,
-    bindingStatus: ok ? args.bindingStatus ?? "unbound-runtime" : "failed",
-    failureCount: args.failureCount ?? 0,
-    error: ok ? undefined : args.body.status?.error ?? args.body.mapSummary?.error ?? "Live status unavailable",
-  };
+  return buildLiveGameState(args);
 }
 
 export function buildLiveRuntimeErrorState(args: {
@@ -155,23 +87,7 @@ export function buildLiveRuntimeErrorState(args: {
   observedAt: string;
   failureCount: number;
 }): LiveRuntimeStatusState {
-  return {
-    status: "error",
-    updatedAt: args.observedAt,
-    error: args.error instanceof Error ? args.error.message : "Live status unavailable",
-    snapshotStatus: "error",
-    bindingStatus: "failed",
-    failureCount: args.failureCount,
-  };
-}
-
-export function nextLiveRuntimePollDelayMs(args: {
-  failureCount: number;
-  documentHidden: boolean;
-}): number {
-  if (args.documentHidden) return Math.min(30_000, 5_000 * Math.max(1, args.failureCount + 1));
-  if (args.failureCount <= 0) return 3_000;
-  return Math.min(30_000, 3_000 * 2 ** Math.min(args.failureCount - 1, 4));
+  return buildLiveGameErrorState(args);
 }
 
 export function buildLiveRuntimeSnapshotRequest(args: {
@@ -289,17 +205,4 @@ export function buildLiveRuntimeSuggestionRecords(args: {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (value && typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-      const item = (value as Record<string, unknown>)[key];
-      if (item !== undefined) out[key] = canonicalize(item);
-    }
-    return out;
-  }
-  return value;
 }

--- a/apps/mapgen-studio/src/server/daemon/daemon.ts
+++ b/apps/mapgen-studio/src/server/daemon/daemon.ts
@@ -160,7 +160,7 @@ export async function createStudioDaemon(args: StudioDaemonArgs) {
   // threads it into every control procedure's endpointDefaults — every
   // polling read multiplexes over that socket instead of opening its own
   // (the churn that wedged the game).
-  const studioRpc = createStudioRpcHandler(context);
+  const studioRpc = createStudioRpcHandler(context, { liveGameWatch: {} });
   const deps: StudioDaemonDeps = {
     studioRpc,
     health: async () => ({

--- a/apps/mapgen-studio/test/liveRuntime/model.test.ts
+++ b/apps/mapgen-studio/test/liveRuntime/model.test.ts
@@ -6,7 +6,6 @@ import {
   buildLiveRuntimeSnapshotState,
   buildLiveRuntimeStatusState,
   buildLiveRuntimeSuggestionRecords,
-  nextLiveRuntimePollDelayMs,
   shouldCommitLiveRuntimeSnapshot,
 } from "../../src/features/liveRuntime/model";
 
@@ -153,12 +152,6 @@ describe("live runtime model", () => {
     expect(snapshot.status).toBe("ok");
     expect(snapshot.requestKey).toBe(request.key);
     expect(snapshot.snapshotId).toMatch(/^snapshot:8:/);
-  });
-
-  it("backs off repeated failures without changing the healthy cadence", () => {
-    expect(nextLiveRuntimePollDelayMs({ failureCount: 0, documentHidden: false })).toBe(3000);
-    expect(nextLiveRuntimePollDelayMs({ failureCount: 2, documentHidden: false })).toBe(6000);
-    expect(nextLiveRuntimePollDelayMs({ failureCount: 4, documentHidden: true })).toBe(25000);
   });
 
   it("emits explicit suggestion records for live-to-Studio translation", () => {

--- a/apps/mapgen-studio/test/studioEvents/operationAdoption.test.ts
+++ b/apps/mapgen-studio/test/studioEvents/operationAdoption.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 
-import type { StudioOperationEvent, StudioOperationsCurrent } from "@civ7/studio-server";
+import type {
+  StudioLiveGameEvent,
+  StudioOperationEvent,
+  StudioOperationsCurrent,
+} from "@civ7/studio-server";
 
 import {
   STUDIO_EVENT_STREAM_RETRY_ATTEMPTS,
@@ -8,9 +12,11 @@ import {
   studioEventsWatchLiveOptions,
 } from "../../src/app/hooks/useStudioEvents";
 import {
+  applyStudioLiveGameEvent,
   adoptStudioOperationsCurrent,
   applyStudioOperationEvent,
 } from "../../src/app/operationAdoption";
+import type { LiveRuntimeStatusState } from "../../src/features/liveRuntime/model";
 import type { MapConfigSaveDeployStatus } from "../../src/features/mapConfigSave/status";
 import type { RunInGameOperationStatus } from "../../src/features/runInGame/status";
 
@@ -129,6 +135,34 @@ describe("Studio event operation adoption", () => {
     expect(state.saveDeploy?.requestId).toBe("save-pushed-1");
   });
 
+  test("applies pushed live-game events", () => {
+    let liveRuntime: LiveRuntimeStatusState | null = null;
+
+    applyStudioLiveGameEvent(
+      liveGameEvent({
+        status: "ok",
+        turn: 12,
+        gameHash: 987654,
+        seed: 123,
+        readiness: "ready",
+        snapshotStatus: "idle",
+        snapshotId: "status:12:abcdef01",
+        snapshotHash: "abcdef01",
+        bindingStatus: "unbound-runtime",
+        failureCount: 0,
+      }),
+      {
+        applyLiveGameState(state) {
+          liveRuntime = state;
+        },
+      },
+    );
+
+    expect(liveRuntime?.status).toBe("ok");
+    expect(liveRuntime?.turn).toBe(12);
+    expect(liveRuntime?.snapshotId).toBe("status:12:abcdef01");
+  });
+
   test("builds live event query options with scoped stream retry context", () => {
     const options = studioEventsWatchLiveOptions();
 
@@ -175,6 +209,14 @@ function operationEvent(
     observedAt: "2026-06-13T00:00:02.000Z",
     ...event,
   } as StudioOperationEvent;
+}
+
+function liveGameEvent(state: StudioLiveGameEvent["state"]): StudioLiveGameEvent {
+  return {
+    type: "live-game",
+    observedAt: "2026-06-13T00:00:02.000Z",
+    state,
+  };
 }
 
 function currentOperations(overrides?: Partial<StudioOperationsCurrent>): StudioOperationsCurrent {

--- a/openspec/changes/mapgen-studio-live-game-watch/.openspec.yaml
+++ b/openspec/changes/mapgen-studio-live-game-watch/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-06-13
+status: draft

--- a/openspec/changes/mapgen-studio-live-game-watch/design.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/design.md
@@ -1,0 +1,77 @@
+# Design - live game watch (S3.3)
+
+## D1. Event contract ownership
+
+`live-game` stays inside the S3.1 `StudioEvent` union and is expressed with
+TypeBox/Standard Schema. The event payload is:
+
+- `type: "live-game"`;
+- `state`: daemon-owned live runtime state;
+- `observedAt`: the watcher observation timestamp.
+
+The state is the same category the client already renders: status, turn, Civ
+game hash, seed, readiness, autoplay flags, snapshot id/hash, binding status,
+failure count, and error when unavailable. This is not a raw FireTuner response
+and not a second client model.
+
+## D2. Shared keying model
+
+The live-game key excludes `observedAt` and other clock-only data. For healthy
+states it is based on the existing snapshot id derived from turn plus a stable
+hash of Civ game hash, seed, readiness, map metadata, and autoplay state. For
+error states it is based on status plus error content, not the incrementing
+failure count. Repeated identical observations stay quiet.
+
+The app's existing `liveRuntime/model.test.ts` durable pins remain the proof
+for turn/hash identity and snapshot commit gating. The package watcher uses the
+same helper rather than duplicating a second keying algorithm.
+
+## D3. Watcher lifecycle and shared session
+
+The watcher starts from `createStudioRpcHandler` only when the host enables it.
+MapGen Studio's daemon enables it; package handler tests and non-daemon hosts
+default to disabled.
+
+Each tick reads the same logical live status as `civ7.live.status` through the
+runtime's `Civ7TunerClient`, so every FireTuner call routes through the runtime
+`Civ7TunerSession`. The watcher publishes through the already injected
+EventHub. Disposal stops the timer before disposing the runtime and shutting
+down the EventHub.
+
+## D4. Client event application
+
+The single `useStudioEvents` subscription remains the only event consumer. It
+keeps `hello` reconnect adoption and `operation` handling, and adds `live-game`
+application through a callback supplied by `StudioShell`.
+
+On a live-game event, `StudioShell` updates displayed live runtime state. If
+the pushed state has a snapshot request and the current snapshot is not already
+fresh for that state, it reads `civ7.live.snapshot` request/response and
+commits the result through the existing request-key guard. Setup config is read
+request/response after a pushed event for live-to-Studio suggestions. Neither
+read has its own cadence loop.
+
+## D5. Deletion boundary
+
+S3.3 deletes client live status scheduling:
+
+- `nextLiveRuntimePollDelayMs`;
+- the browser `setTimeout(poll, ...)` live status loop in `StudioShell`;
+- background readiness overlay calls from that loop.
+
+`liveControlPort` may remain for deliberate user-triggered control actions such
+as Explore. Snapshot reads remain on oRPC request/response. Operation events
+and `hello` identity behavior are unchanged.
+
+## D6. Falsification proof
+
+The primary watcher pin is quiet/loud behavior:
+
+- first observation publishes;
+- changed turn/hash publishes;
+- unchanged key does not publish.
+
+If the watcher publishes every tick, stops publishing changes, bypasses the
+EventHub, or uses clock-only keying, the focused test must fail. Negative
+search closes the deletion target because removing a scheduler is an
+architectural claim.

--- a/openspec/changes/mapgen-studio-live-game-watch/proposal.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/proposal.md
@@ -1,0 +1,79 @@
+# MapGen Studio live game watch
+
+## Why
+
+S3.2 moved operation freshness onto `studio.events.watch`, but live Civ7 state
+still uses a browser-owned `setTimeout` loop. That leaves the client as a
+runtime scheduler and keeps FireTuner status reads split across browser
+visibility/backoff behavior instead of the daemon's shared session.
+
+S3.3 makes live-game freshness a daemon responsibility. The server polls Civ7
+over the unified runtime's shared `Civ7TunerSession`, publishes `live-game`
+deltas through the existing EventHub, and the client renders those events. The
+snapshot read remains request/response; only the status cadence moves.
+
+## Target Authority Refs
+
+- `docs/projects/studio-runtime-simplification/PLAN.md` — WS-3 S3.3 requires a
+  daemon-side watcher loop, `live-game` events keyed by turn/hash, deletion of
+  the client status `setTimeout` loop, and a quiet/loud watcher pin.
+- `openspec/changes/mapgen-studio-event-hub/` — S3.1 provides the sealed
+  `hello | operation | live-game` event category, EventHub, and one
+  `studio.events.watch` transport.
+- `openspec/changes/mapgen-studio-operations-push/` — S3.2 proves client state
+  can consume pushed daemon events without reintroducing operation polling.
+- Direct user decision: new event contracts use TypeBox/Standard Schema here;
+  do not add new Zod schemas for this event surface.
+
+## What Changes
+
+- Define the `live-game` event payload as a TypeBox state object under the
+  existing `StudioEvent` union.
+- Add a package-side live-game state builder/keying helper so the daemon
+  watcher and client model share the turn/hash/snapshot-id semantics pinned by
+  existing live runtime tests.
+- Add a daemon live-game watcher inside the unified studio-server runtime
+  lifecycle. It polls Civ7 status over the shared `Civ7TunerSession` and
+  publishes only when the live-game key changes.
+- Enable that watcher from the MapGen Studio daemon; dispose it with the
+  unified RPC handler/runtime.
+- Extend the Studio event hook to apply `live-game` events.
+- Delete the client live status `setTimeout` loop and the
+  `nextLiveRuntimePollDelayMs` model/test pin.
+- Preserve snapshot and setup reads as request/response calls triggered by
+  pushed live-game events, not by a browser cadence loop.
+
+## Non-Goals
+
+- No second event route, SSE endpoint, or live-game-specific transport.
+- No operation polling, `serverInfo` identity polling, or localStorage recovery
+  reintroduction.
+- No migration of the snapshot endpoint onto the event stream.
+- No broad migration of all legacy success schemas away from Zod; S4.1 owns
+  the final schema-technology closeout. New S3.3 event schemas are TypeBox.
+
+## Impact
+
+- `packages/studio-server/src/contract/studio.ts`
+- `packages/studio-server/src/liveGame/**`
+- `packages/studio-server/src/handler.ts`
+- `packages/studio-server/src/router/index.ts`
+- `packages/studio-server/src/index.ts`
+- `apps/mapgen-studio/src/server/daemon/daemon.ts`
+- `apps/mapgen-studio/src/app/hooks/useStudioEvents.ts`
+- `apps/mapgen-studio/src/app/StudioShell.tsx`
+- `apps/mapgen-studio/src/features/liveRuntime/model.ts`
+- focused package/app tests and deletion of client poll-delay pins
+
+## Verification Gates
+
+- `bun run openspec -- validate mapgen-studio-live-game-watch --strict`
+- Focused package test: watcher publishes first/change events and stays quiet
+  when the live-game key is unchanged.
+- Focused app/model tests: turn/hash keying and snapshot commit gates remain
+  green; poll-delay pin is deleted.
+- Focused client event test: `live-game` events update live runtime state
+  without operation-event regressions.
+- Negative search/proof: no `nextLiveRuntimePollDelayMs` or client live status
+  `setTimeout` loop remains.
+- Package/app gates selected by blast radius.

--- a/openspec/changes/mapgen-studio-live-game-watch/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/specs/mapgen-studio/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Daemon Publishes Live-Game State Deltas
+
+MapGen Studio SHALL publish live Civ7 status changes to `studio.events.watch`
+as `live-game` events from the daemon.
+
+#### Scenario: First live-game observation publishes
+
+- **WHEN** the daemon live-game watcher observes Civ7 live state for the first
+  time in a process
+- **THEN** it publishes a `studio.events.watch` event with `type: "live-game"`
+- **AND** the event contains a TypeBox-defined `state` payload
+- **AND** the read uses the unified runtime's shared `Civ7TunerSession`
+
+#### Scenario: Changed turn or game hash publishes
+
+- **WHEN** a later watcher observation has a different live-game key derived
+  from turn, Civ game hash, or stable status content
+- **THEN** the daemon publishes a new `live-game` event
+- **AND** the event reaches subscribers through the existing EventHub
+
+#### Scenario: Unchanged live-game key stays quiet
+
+- **WHEN** a later watcher observation has the same live-game key as the last
+  published observation
+- **THEN** the watcher does not publish another `live-game` event
+- **AND** clock-only changes do not create a new event
+
+### Requirement: Client Applies Live-Game Events Without Status Polling
+
+MapGen Studio SHALL render live Civ7 state from pushed `live-game` events
+instead of a browser status polling loop.
+
+#### Scenario: Live-game event updates displayed runtime state
+
+- **WHEN** the client receives a `live-game` event
+- **THEN** it updates the displayed live runtime state from the event payload
+- **AND** it uses the same snapshot id/keying semantics as the durable live
+  runtime model tests
+
+#### Scenario: Snapshot read remains request/response
+
+- **WHEN** a pushed live-game state requires a visible snapshot refresh
+- **THEN** the client may call `civ7.live.snapshot` request/response
+- **AND** the existing request-key stale commit guard still decides whether the
+  snapshot result may update state
+- **AND** the snapshot read is not an event-stream payload
+
+#### Scenario: Setup suggestions are event-triggered
+
+- **WHEN** a pushed live-game state is applied
+- **THEN** setup suggestion reads may run request/response from that event
+- **AND** no independent browser cadence loop is introduced for setup/live
+  status freshness
+
+### Requirement: Client Live Status Polling Is Deleted
+
+MapGen Studio SHALL remove client-owned live status scheduling after daemon
+`live-game` events own live status freshness.
+
+#### Scenario: Poll delay helper is gone
+
+- **WHEN** S3.3 is complete
+- **THEN** no `nextLiveRuntimePollDelayMs` helper, import, or test remains
+- **AND** no poll-cadence pin remains for deleted client status polling
+
+#### Scenario: Browser status setTimeout loop is gone
+
+- **WHEN** S3.3 is complete
+- **THEN** `StudioShell` no longer schedules a live status `setTimeout` loop
+- **AND** background live status reads no longer call `civ7.live.status` from
+  the browser
+- **AND** deliberate request/response actions such as Explore can remain

--- a/openspec/changes/mapgen-studio-live-game-watch/tasks.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/tasks.md
@@ -1,0 +1,44 @@
+## 1. Frame
+
+- [x] 1.1 Create S3.3 proposal/design/tasks/spec delta from the accepted plan,
+      S3.1/S3.2 changes, and watcher context.
+- [x] 1.2 Run strict OpenSpec validation before implementation.
+- [x] 1.3 Keep watcher/review lane active through implementation and record
+      dispositions.
+
+## 2. Server Live-Game Watcher
+
+- [x] 2.1 Define the TypeBox `live-game` event state contract without adding
+      new Zod schemas.
+- [x] 2.2 Add shared live-game state/keying helpers used by both watcher and
+      client model.
+- [x] 2.3 Add a daemon-enabled watcher that polls through the unified runtime's
+      shared `Civ7TunerSession`.
+- [x] 2.4 Publish `live-game` events only when the live-game key changes.
+- [x] 2.5 Dispose the watcher with the unified handler/runtime.
+- [x] 2.6 Add focused package tests for publish-on-change and quiet-when-unchanged.
+
+## 3. Client Live-Game Events
+
+- [x] 3.1 Extend the single Studio event hook to dispatch `live-game` events.
+- [x] 3.2 Apply pushed live-game state in `StudioShell` and preserve event-driven
+      request/response snapshot reads.
+- [x] 3.3 Preserve event-triggered setup suggestions without adding a background
+      setup/status cadence.
+- [x] 3.4 Add/adjust focused client tests for live-game event application.
+
+## 4. Delete Client Status Polling
+
+- [x] 4.1 Delete `nextLiveRuntimePollDelayMs` and its poll-cadence test.
+- [x] 4.2 Delete the live status `setTimeout` loop from `StudioShell`.
+- [x] 4.3 Remove background readiness overlay calls from the deleted loop while
+      keeping deliberate control actions intact.
+
+## 5. Verification + Closure
+
+- [x] 5.1 `bun run openspec -- validate mapgen-studio-live-game-watch --strict`.
+- [x] 5.2 Focused package/app tests for watcher and event application.
+- [x] 5.3 Negative search proofs for deleted live status polling paths.
+- [x] 5.4 Package/app check gates selected by blast radius.
+- [ ] 5.5 Watcher findings dispositioned, downstream realignment recorded, and
+      Graphite submit/merge/drain complete.

--- a/openspec/changes/mapgen-studio-live-game-watch/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/workstream/phase-record.md
@@ -1,0 +1,146 @@
+# Phase Record
+
+## Phase
+
+- Project: Studio runtime simplification
+- Phase: S3.3 `live-game-watch`
+- Owner: Codex DRA implementation lane
+- Branch/Graphite stack: `codex/live-game-watch` stacked on `main`
+- Started: 2026-06-13
+- Status: implementation verified; Graphite closure pending
+
+## Objective
+
+- Target movement: live Civ7 status freshness moves from a browser
+  `setTimeout` loop to daemon `live-game` events over the existing EventHub,
+  with snapshot reads remaining request/response.
+- Non-goals: new event route/transport, operation poll reintroduction,
+  localStorage recovery, event-stream snapshot payloads, broad legacy Zod
+  migration.
+- Done condition: daemon watcher publishes only on live-game key changes,
+  client applies pushed state without status polling, strict OpenSpec validates,
+  focused package/app gates pass, watcher findings are dispositioned, and
+  Graphite closes cleanly.
+
+## Authority
+
+- Root `AGENTS.md`: exact staging, Graphite process, no dirty closure.
+- Product refs: `docs/projects/studio-runtime-simplification/PLAN.md` WS-3
+  S3.3 and DP-3/DP-4.
+- Upstream refs: S3.1 EventHub and event watch; S3.2 operation push and
+  identity/poll deletion.
+- User refs: "for now" is not a cheap exit; TypeBox is required for this new
+  event contract.
+- Watcher refs: S3.3 watcher `019ec1b3-1ab3-7910-8466-6c20bae12f4a`.
+- Excluded/stale inputs: client live status polling as fallback, new Zod event
+  schemas, alternate live-game transport.
+
+## Current State
+
+- Repo/Graphite state: `codex/live-game-watch` at `main`
+  `b063f51b061b9247508f0be6f68fe91e2f01f64f`; worktree clean at phase entry.
+- Dirty files and owner: S3.3 OpenSpec/code/test/package metadata files owned
+  by this slice.
+- Current code evidence: package runtime owns the daemon live-game watcher and
+  TypeBox event state; app consumes pushed live-game state and no client live
+  status polling/backoff symbols remain.
+- Generated outputs affected: none expected.
+- Tests/guards affected: package event/watcher tests, app live runtime model
+  tests, app event adoption tests, focused checks.
+
+## Scope
+
+- Write set: `openspec/changes/mapgen-studio-live-game-watch/**`,
+  `packages/studio-server/src/contract/studio.ts`,
+  `packages/studio-server/src/liveGame/**`,
+  `packages/studio-server/src/handler.ts`,
+  `packages/studio-server/src/router/index.ts`,
+  `packages/studio-server/src/index.ts`,
+  `apps/mapgen-studio/src/server/daemon/daemon.ts`,
+  `apps/mapgen-studio/src/app/hooks/useStudioEvents.ts`,
+  `apps/mapgen-studio/src/app/StudioShell.tsx`,
+  `apps/mapgen-studio/src/features/liveRuntime/model.ts`, focused tests.
+- Protected files: generated outputs, unrelated operation state, unrelated
+  status contracts, localStorage recovery surfaces, non-daemon package hosts
+  unless guarded by explicit watcher enablement.
+- Owners: package runtime owns shared-session live status reads; EventHub owns
+  publication; client event hook owns event dispatch; `StudioShell` owns
+  request/response snapshot/setup follow-up.
+- Forbidden owners: browser status cadence, second transport, new Zod event
+  schemas, fallback polling without deletion target.
+
+## Spec/Tasks
+
+- Spec/proposal: `openspec/changes/mapgen-studio-live-game-watch/`.
+- Tasks: `tasks.md`.
+- Validation status: `bun run openspec -- validate mapgen-studio-live-game-watch --strict`
+  passed before implementation.
+
+## Review
+
+- Review lanes: watcher lane `019ec1b3-1ab3-7910-8466-6c20bae12f4a`.
+- Blocking findings: none after repair.
+- Accepted findings repaired: `S3.3-W1` through `S3.3-W4`.
+- Rejected/invalidated/waived/deferred findings: none yet.
+
+## Agent Fleet State
+
+- Active agents: none after watcher completion.
+- Completed agents: watcher `019ec1b3-1ab3-7910-8466-6c20bae12f4a`.
+- Assigned write sets: watcher is read-only.
+- Latest evidence by agent: watcher reported browser-owned live status/backoff,
+  inert live-game client events, setup/suggestion coupling to the old poll, and
+  snapshot read coupling to the old poll.
+- Open findings by agent: none after accepted-repaired dispositions.
+- Integration owner: Codex DRA implementation lane.
+
+## Implementation
+
+- Completed tasks: OpenSpec frame, watcher disposition, package watcher,
+  TypeBox live-game event state, client event application, client poll deletion,
+  focused tests, app/package checks, negative search proofs.
+- Remaining tasks: Graphite closure.
+- Stop conditions triggered: none.
+
+## Verification
+
+- Commands run:
+- `bun run openspec -- validate mapgen-studio-live-game-watch --strict`
+- `bun run openspec:validate`
+- `bun run --cwd packages/studio-server check`
+- `bun run --cwd packages/studio-server build`
+- `bun run --cwd packages/studio-server test -- test/liveGameWatcher.test.ts test/handler.test.ts`
+- `bun run --cwd apps/mapgen-studio test -- test/liveRuntime/model.test.ts test/studioEvents/operationAdoption.test.ts`
+- `bun run --cwd apps/mapgen-studio check`
+- `bun run --cwd apps/mapgen-studio test -- test/server/oneMount.test.ts`
+- `rg "nextLiveRuntimePollDelayMs|liveStatusFailureCountRef|setTimeout\\(poll|civ7\\.live\\.status\\(\\{\\}|liveControlPort\\.readiness\\.current\\(" apps/mapgen-studio/src apps/mapgen-studio/test packages/studio-server/src packages/studio-server/test -g '*.{ts,tsx}'`
+- `git diff --check`
+- `bun run openspec -- validate mapgen-studio-live-game-watch --strict`
+- Results: listed checks passed; repo-wide OpenSpec validation reported 146
+  passed and 0 failed; negative search returned no matches; package build
+  regenerated ignored `packages/studio-server/dist` for app subpath type
+  availability.
+- Gate disposition: green; Graphite closure pending.
+- Evidence boundary: live Civ7 click-through is expected only if local runtime
+  conditions permit; focused tests and negative searches are required either
+  way.
+
+## Realignment
+
+- Downstream docs/specs/issues updated: S3.3 OpenSpec, phase record, and
+  review ledger.
+- Tests/guards updated: package watcher quiet/loud test; client live-game
+  adoption test; live-runtime model poll-delay pin deleted while turn/hash and
+  snapshot commit gates remain.
+- Deferrals/triage updated: S4.1 still owns final game-door invariant and
+  schema-tech closeout.
+- Downstream realignment ledger: S4.1 still owns final game-door invariant and
+  schema-tech closeout; S3.3 closes only the live-game event publisher/client
+  poll deletion boundary.
+
+## Next Action
+
+- Exact next step: exact-stage S3.3 files, commit via Graphite, submit/merge,
+  then proceed to S4.1 `game-door-invariant`.
+- Stop condition: do not keep or reintroduce browser live status polling as a
+  backup path.

--- a/openspec/changes/mapgen-studio-live-game-watch/workstream/review-disposition-ledger.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/workstream/review-disposition-ledger.md
@@ -1,0 +1,24 @@
+# Review Disposition Ledger
+
+| ID | Severity | Reviewer/Lane | Finding | Blocker Class | Disposition | Repair Demand | Evidence | Blocks Closure |
+|---|---|---|---|---|---|---|---|---|
+| S3.3-W1 | P1 | watcher `019ec1b3-1ab3-7910-8466-6c20bae12f4a` | Live-game status/backoff is still browser-owned through `StudioShell`'s status timer, `civ7.live.status` + `liveControlPort.readiness.current()`, and `nextLiveRuntimePollDelayMs` coverage. | client scheduler still authoritative | accepted-repaired | Move status cadence to daemon/package runtime over the existing `Civ7TunerClient` shared session; publish through EventHub; delete client timer and poll-delay coverage. | `packages/studio-server/src/liveGame/watcher.ts` starts a daemon-enabled watcher through `createStudioRpcHandler(..., { liveGameWatch: {} })`; it reads via `readLiveGameStatusBody`/`Civ7TunerClient` in the package runtime and publishes through EventHub only when `liveGameStateKey` changes. `apps/mapgen-studio/src/app/StudioShell.tsx` no longer schedules the live status poll. Negative `rg "nextLiveRuntimePollDelayMs|liveStatusFailureCountRef|setTimeout\\(poll|civ7\\.live\\.status\\(\\{\\}|liveControlPort\\.readiness\\.current\\(" ...` returned no matches. | No |
+| S3.3-W2 | P1 | watcher `019ec1b3-1ab3-7910-8466-6c20bae12f4a` | `live-game` events are inert on the client; `useStudioEvents` only handles `hello` and `operation`. | event subscriber incomplete | accepted-repaired | Add explicit `live-game` handling through the single subscription hook; no second stream, localStorage recovery, or new Zod event schema. | `apps/mapgen-studio/src/app/hooks/useStudioEvents.ts` derives a `liveGameKey` and dispatches through `applyStudioLiveGameEvent`; focused app test `test/studioEvents/operationAdoption.test.ts` proves pushed live-game state is applied. The `live-game` contract uses TypeBox `liveGameStateSchema`; no `packages/studio-server/src/liveGame/**` Zod schema was added. | No |
+| S3.3-W3 | P2 | watcher `019ec1b3-1ab3-7910-8466-6c20bae12f4a` | Live setup and suggestion UX is coupled to the old status poll. | UX owner hidden in deleted loop | accepted-repaired | Give setup/suggestions an event-triggered request/response owner after poll deletion, preserving stale/current and sync semantics. | `StudioShell` now refreshes setup/suggestion state from `refreshLiveSetupFromEvent(statusState)` after a pushed live-game state. The request remains request/response and is aborted on newer events/unmount; no independent setup/status cadence remains. | No |
+| S3.3-W4 | P2 | watcher `019ec1b3-1ab3-7910-8466-6c20bae12f4a` | Automatic snapshot reads are still coupled to the poll loop. | snapshot follow-up tied to deleted scheduler | accepted-repaired | Preserve request-key commit gating, but trigger snapshot reads from pushed live-game state instead of background status polling/backoff. | `StudioShell` extracts `readLiveRuntimeSnapshot(request)` and calls it only from `applyLiveGameState`; `shouldCommitLiveRuntimeSnapshot` still gates stale commits, and `test/liveRuntime/model.test.ts` keeps the durable request-key pins. | No |
+
+## Disposition Rules
+
+- `accepted`: repair before dependent implementation or closure.
+- `rejected`: record source evidence showing the finding does not apply.
+- `invalidated`: record later source evidence that made the finding false.
+- `user-decision`: record the user or authority decision that resolves the
+  finding.
+- `waived`: allowed only for P3/nonblocking findings; record risk, owner, and
+  trigger.
+- `deferred`: allowed only for P3/nonblocking findings; record destination,
+  owner, and context.
+- `accepted-repaired`: accepted material finding repaired inside this slice
+  with evidence and no remaining closure block.
+
+No material finding may remain undispositioned at phase closure.

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -18,6 +18,10 @@
     "./contract": {
       "types": "./dist/contract/index.d.ts",
       "import": "./dist/contract/index.js"
+    },
+    "./live-game": {
+      "types": "./dist/liveGame/model.d.ts",
+      "import": "./dist/liveGame/model.js"
     }
   },
   "scripts": {

--- a/packages/studio-server/src/contract/studio.ts
+++ b/packages/studio-server/src/contract/studio.ts
@@ -3,6 +3,7 @@ import { Type, type Static } from "typebox";
 import { z } from "zod";
 
 import { toStandardSchema } from "../typeboxStandardSchema.js";
+import { liveGameStateSchema } from "../liveGame/model.js";
 import { isoTimestamp } from "./shared.js";
 
 /**
@@ -176,11 +177,8 @@ const studioOperationEventSchema = Type.Union([
 const studioLiveGameEventSchema = Type.Object(
   {
     type: Type.Literal("live-game"),
-    status: Type.Union([Type.Literal("ok"), Type.Literal("unavailable"), Type.Literal("error")]),
+    state: liveGameStateSchema,
     observedAt: Type.String(),
-    snapshot: Type.Optional(Type.Unknown()),
-    error: Type.Optional(Type.String()),
-    details: Type.Optional(Type.Unknown()),
   },
   { additionalProperties: false },
 );

--- a/packages/studio-server/src/handler.ts
+++ b/packages/studio-server/src/handler.ts
@@ -9,6 +9,11 @@ import {
 
 import type { StudioContract, StudioEffectContract } from "./contract/index.js";
 import type { StudioServerContext } from "./context.js";
+import {
+  createRuntimeLiveGameWatcher,
+  type LiveGameWatcher,
+  type LiveGameWatcherOptions,
+} from "./liveGame/watcher.js";
 import { createStudioRouter } from "./router/index.js";
 import { makeStudioRuntime } from "./runtime.js";
 import {
@@ -56,7 +61,14 @@ export interface StudioRpcHandle {
   dispose(): Promise<void>;
 }
 
-export function createStudioRpcHandler(context: StudioServerContext): StudioRpcHandle {
+export interface StudioRpcHandlerOptions {
+  liveGameWatch?: LiveGameWatcherOptions;
+}
+
+export function createStudioRpcHandler(
+  context: StudioServerContext,
+  options: StudioRpcHandlerOptions = {},
+): StudioRpcHandle {
   const runtime = makeStudioRuntime(context);
   const effectRouter = createStudioRouter(runtime);
   // `Router<…>` types every node as `Lazyable<…>`; our effect router never
@@ -96,6 +108,16 @@ export function createStudioRpcHandler(context: StudioServerContext): StudioRpcH
   // the session object itself is acquired without I/O — but the memo must
   // not be the thing that makes a failure sticky).
   let sessionPromise: Promise<Civ7ControlOrpcContext["endpointDefaults"]> | undefined;
+  let liveGameWatcher: LiveGameWatcher | undefined;
+  if (options.liveGameWatch) {
+    liveGameWatcher = createRuntimeLiveGameWatcher({
+      runtime,
+      eventHub: context.eventHub,
+      options: options.liveGameWatch,
+    });
+    liveGameWatcher.start();
+  }
+
   const controlEndpointDefaults = () =>
     (sessionPromise ??= runtime
       .runPromise(Effect.map(Civ7TunerSession, (tuner) => tuner.session))
@@ -121,6 +143,9 @@ export function createStudioRpcHandler(context: StudioServerContext): StudioRpcH
       health: () =>
         runtime.runPromise(Effect.flatMap(Civ7TunerSession, (tuner) => tuner.health)),
     },
-    dispose: () => runtime.dispose(),
+    dispose: async () => {
+      liveGameWatcher?.stop();
+      await runtime.dispose();
+    },
   };
 }

--- a/packages/studio-server/src/index.ts
+++ b/packages/studio-server/src/index.ts
@@ -63,3 +63,24 @@ export {
   StudioEventHub,
   type StudioEventHubApi,
 } from "./services/StudioEventHub.js";
+export {
+  buildLiveGameErrorState,
+  buildLiveGameState,
+  hashLiveGameValue,
+  liveGameStateKey,
+  liveGameStateSchema,
+  stableLiveGameStringify,
+  type LiveGameBindingStatus,
+  type LiveGameSnapshotStatus,
+  type LiveGameState,
+  type LiveGameStatusBody,
+  type LiveGameStatusKind,
+} from "./liveGame/model.js";
+export {
+  createLiveGameWatcher,
+  createRuntimeLiveGameWatcher,
+  LIVE_GAME_WATCH_INITIAL_DELAY_MS,
+  LIVE_GAME_WATCH_INTERVAL_MS,
+  type LiveGameWatcher,
+  type LiveGameWatcherOptions,
+} from "./liveGame/watcher.js";

--- a/packages/studio-server/src/liveGame/model.ts
+++ b/packages/studio-server/src/liveGame/model.ts
@@ -1,0 +1,167 @@
+import { Type, type Static } from "typebox";
+
+export const liveGameStatusKindSchema = Type.Union([
+  Type.Literal("idle"),
+  Type.Literal("ok"),
+  Type.Literal("error"),
+]);
+
+export const liveGameSnapshotStatusSchema = Type.Union([
+  Type.Literal("idle"),
+  Type.Literal("loading"),
+  Type.Literal("ok"),
+  Type.Literal("stale"),
+  Type.Literal("error"),
+]);
+
+export const liveGameBindingStatusSchema = Type.Union([
+  Type.Literal("unbound-runtime"),
+  Type.Literal("proven-studio-run"),
+  Type.Literal("stale"),
+  Type.Literal("partial"),
+  Type.Literal("failed"),
+]);
+
+export const liveGameStateSchema = Type.Object(
+  {
+    status: liveGameStatusKindSchema,
+    turn: Type.Optional(Type.Number()),
+    gameHash: Type.Optional(Type.Number()),
+    seed: Type.Optional(Type.Number()),
+    readiness: Type.Optional(Type.String()),
+    autoplayActive: Type.Optional(Type.Boolean()),
+    autoplayPaused: Type.Optional(Type.Boolean()),
+    updatedAt: Type.Optional(Type.String()),
+    error: Type.Optional(Type.String()),
+    snapshotStatus: Type.Optional(liveGameSnapshotStatusSchema),
+    snapshotId: Type.Optional(Type.String()),
+    snapshotHash: Type.Optional(Type.String()),
+    bindingStatus: Type.Optional(liveGameBindingStatusSchema),
+    failureCount: Type.Optional(Type.Number()),
+  },
+  { additionalProperties: false },
+);
+
+export type LiveGameStatusKind = Static<typeof liveGameStatusKindSchema>;
+export type LiveGameSnapshotStatus = Static<typeof liveGameSnapshotStatusSchema>;
+export type LiveGameBindingStatus = Static<typeof liveGameBindingStatusSchema>;
+export type LiveGameState = Readonly<Static<typeof liveGameStateSchema>>;
+
+export type LiveGameStatusBody = Readonly<{
+  ok?: boolean;
+  observedAt?: string;
+  status?: {
+    readiness?: string;
+    error?: string;
+  };
+  mapSummary?: {
+    error?: string;
+    map?: {
+      randomSeed?: { ok?: boolean; value?: number };
+      width?: { ok?: boolean; value?: number };
+      height?: { ok?: boolean; value?: number };
+    };
+    game?: {
+      turn?: { ok?: boolean; value?: number };
+      hash?: { ok?: boolean; value?: number };
+    };
+  };
+  autoplay?: {
+    autoplay?: {
+      isActive?: boolean;
+      isPaused?: boolean;
+    };
+  };
+}>;
+
+export function stableLiveGameStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function hashLiveGameValue(value: unknown): string {
+  const input = stableLiveGameStringify(value);
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+export function buildLiveGameState(args: {
+  body: LiveGameStatusBody;
+  observedAtFallback: string;
+  failureCount?: number;
+  bindingStatus?: LiveGameBindingStatus;
+}): LiveGameState {
+  const observedAt = args.body.observedAt ?? args.observedAtFallback;
+  const turn = args.body.mapSummary?.game?.turn?.ok ? args.body.mapSummary.game.turn.value : undefined;
+  const gameHash = args.body.mapSummary?.game?.hash?.ok ? args.body.mapSummary.game.hash.value : undefined;
+  const seed = args.body.mapSummary?.map?.randomSeed?.ok ? args.body.mapSummary.map.randomSeed.value : undefined;
+  const readiness = args.body.status?.readiness;
+  const ok = Boolean(args.body.ok);
+  const snapshotHash = hashLiveGameValue({
+    turn,
+    gameHash,
+    seed,
+    readiness,
+    map: args.body.mapSummary?.map,
+    autoplay: args.body.autoplay?.autoplay,
+  });
+  return {
+    status: ok ? "ok" : "error",
+    ...(turn === undefined ? {} : { turn }),
+    ...(gameHash === undefined ? {} : { gameHash }),
+    ...(seed === undefined ? {} : { seed }),
+    ...(readiness === undefined ? {} : { readiness }),
+    autoplayActive: args.body.autoplay?.autoplay?.isActive,
+    autoplayPaused: args.body.autoplay?.autoplay?.isPaused,
+    updatedAt: observedAt,
+    snapshotStatus: ok ? "idle" : "error",
+    snapshotHash,
+    snapshotId: `status:${turn ?? "unknown"}:${snapshotHash}`,
+    bindingStatus: ok ? args.bindingStatus ?? "unbound-runtime" : "failed",
+    failureCount: args.failureCount ?? 0,
+    error: ok ? undefined : args.body.status?.error ?? args.body.mapSummary?.error ?? "Live status unavailable",
+  };
+}
+
+export function buildLiveGameErrorState(args: {
+  error: unknown;
+  observedAt: string;
+  failureCount: number;
+}): LiveGameState {
+  return {
+    status: "error",
+    updatedAt: args.observedAt,
+    error: args.error instanceof Error ? args.error.message : "Live status unavailable",
+    snapshotStatus: "error",
+    bindingStatus: "failed",
+    failureCount: args.failureCount,
+  };
+}
+
+export function liveGameStateKey(state: LiveGameState): string {
+  if (state.status === "ok" && state.snapshotId) return `ok:${state.snapshotId}`;
+  return stableLiveGameStringify({
+    status: state.status,
+    error: state.error,
+    readiness: state.readiness,
+    snapshotId: state.snapshotId,
+    snapshotHash: state.snapshotHash,
+    bindingStatus: state.bindingStatus,
+  });
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const item = (value as Record<string, unknown>)[key];
+      if (item !== undefined) out[key] = canonicalize(item);
+    }
+    return out;
+  }
+  return value;
+}

--- a/packages/studio-server/src/liveGame/statusRead.ts
+++ b/packages/studio-server/src/liveGame/statusRead.ts
@@ -1,0 +1,50 @@
+import { Effect } from "effect";
+
+import type { LiveGameStatusBody } from "./model.js";
+import { Civ7TunerClient } from "../services/Civ7TunerClient.js";
+
+export type LiveGameStatusOutput = LiveGameStatusBody & Readonly<{
+  ok: boolean;
+  playable: boolean;
+  observedAt: string;
+  status: Record<string, unknown> | { error: string };
+  appUi: Record<string, unknown> | { error: string };
+  mapSummary: Record<string, unknown> | { error: string };
+  autoplay: Record<string, unknown> | { error: string };
+}>;
+
+export const readLiveGameStatusBody: Effect.Effect<LiveGameStatusOutput, never, Civ7TunerClient> =
+  Effect.gen(function* () {
+    const settled = yield* Effect.all(
+      {
+        status: Civ7TunerClient.playableStatus().pipe(Effect.either),
+        appUi: Civ7TunerClient.appUiSnapshot().pipe(Effect.either),
+        mapSummary: Civ7TunerClient.liveMapSummary().pipe(Effect.either),
+        autoplay: Civ7TunerClient.autoplayStatus().pipe(Effect.either),
+      },
+      { concurrency: "unbounded" },
+    );
+    const playableStatus = settled.status._tag === "Right" ? settled.status.right : undefined;
+    return {
+      ok: Boolean(playableStatus && playableStatus.readiness !== "unavailable"),
+      playable: playableStatus?.playable ?? false,
+      observedAt: new Date().toISOString(),
+      status: fieldOrError(settled.status, playableStatus),
+      appUi: fieldOrError(settled.appUi),
+      mapSummary: fieldOrError(settled.mapSummary),
+      autoplay: fieldOrError(settled.autoplay),
+    };
+  });
+
+/**
+ * Map a `civ7.live.status` per-field result to the contract's
+ * `unknownRecord | { error }` union, matching the legacy `allSettled` body:
+ * a fulfilled value passes through; a rejection becomes `{ error: String(reason) }`.
+ */
+export function fieldOrError<A>(
+  either: { _tag: "Left"; left: unknown } | { _tag: "Right"; right: A },
+  override?: A,
+): Record<string, unknown> | { error: string } {
+  if (either._tag === "Right") return (override ?? either.right) as Record<string, unknown>;
+  return { error: String(either.left) };
+}

--- a/packages/studio-server/src/liveGame/watcher.ts
+++ b/packages/studio-server/src/liveGame/watcher.ts
@@ -1,0 +1,123 @@
+import type { StudioEventHubApi } from "../services/StudioEventHub.js";
+import type { StudioRuntime } from "../runtime.js";
+import {
+  buildLiveGameErrorState,
+  buildLiveGameState,
+  liveGameStateKey,
+  type LiveGameState,
+  type LiveGameStatusBody,
+} from "./model.js";
+import { readLiveGameStatusBody } from "./statusRead.js";
+
+export const LIVE_GAME_WATCH_INITIAL_DELAY_MS = 250;
+export const LIVE_GAME_WATCH_INTERVAL_MS = 3_000;
+
+export interface LiveGameWatcher {
+  start(): void;
+  stop(): void;
+  tick(): Promise<void>;
+}
+
+export interface LiveGameWatcherOptions {
+  initialDelayMs?: number;
+  intervalMs?: number;
+  now?: () => Date;
+}
+
+export interface LiveGameWatcherDeps {
+  eventHub: Pick<StudioEventHubApi, "publish">;
+  readLiveStatus(): Promise<LiveGameStatusBody>;
+  options?: LiveGameWatcherOptions;
+}
+
+export function createRuntimeLiveGameWatcher(args: {
+  runtime: StudioRuntime;
+  eventHub: Pick<StudioEventHubApi, "publish">;
+  options?: LiveGameWatcherOptions;
+}): LiveGameWatcher {
+  return createLiveGameWatcher({
+    eventHub: args.eventHub,
+    readLiveStatus: () => args.runtime.runPromise(readLiveGameStatusBody),
+    options: args.options,
+  });
+}
+
+export function createLiveGameWatcher(args: LiveGameWatcherDeps): LiveGameWatcher {
+  const initialDelayMs = args.options?.initialDelayMs ?? LIVE_GAME_WATCH_INITIAL_DELAY_MS;
+  const intervalMs = args.options?.intervalMs ?? LIVE_GAME_WATCH_INTERVAL_MS;
+  const now = args.options?.now ?? (() => new Date());
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let running = false;
+  let stopped = false;
+  let started = false;
+  let lastPublishedKey: string | null = null;
+  let failureCount = 0;
+
+  const schedule = (delayMs: number) => {
+    if (stopped) return;
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      void tick();
+    }, delayMs);
+  };
+
+  const publishIfChanged = async (state: LiveGameState) => {
+    const key = liveGameStateKey(state);
+    if (key === lastPublishedKey) return;
+    lastPublishedKey = key;
+    await args.eventHub.publish({
+      type: "live-game",
+      state,
+      observedAt: state.updatedAt ?? now().toISOString(),
+    });
+  };
+
+  const tick = async () => {
+    if (running || stopped) return;
+    running = true;
+    try {
+      const body = await args.readLiveStatus();
+      const baseState = buildLiveGameState({
+        body,
+        observedAtFallback: now().toISOString(),
+        failureCount: 0,
+      });
+      failureCount = baseState.status === "ok" ? 0 : failureCount + 1;
+      const state = {
+        ...baseState,
+        failureCount,
+      };
+      await publishIfChanged(state);
+    } catch (err) {
+      failureCount += 1;
+      await publishIfChanged(
+        buildLiveGameErrorState({
+          error: err,
+          observedAt: now().toISOString(),
+          failureCount,
+        }),
+      );
+    } finally {
+      running = false;
+      if (started && !stopped) schedule(intervalMs);
+    }
+  };
+
+  return {
+    start() {
+      if (started) return;
+      started = true;
+      stopped = false;
+      schedule(initialDelayMs);
+    },
+    stop() {
+      stopped = true;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+    tick,
+  };
+}

--- a/packages/studio-server/src/router/index.ts
+++ b/packages/studio-server/src/router/index.ts
@@ -5,6 +5,7 @@ import { implementEffect } from "effect-orpc";
 
 import { studioEffectContract, type StudioEffectContract } from "../contract/index.js";
 import { errorMessage } from "../errors.js";
+import { readLiveGameStatusBody } from "../liveGame/statusRead.js";
 import type { StudioRuntime } from "../runtime.js";
 import { Civ7TunerClient } from "../services/Civ7TunerClient.js";
 import { StudioConfig } from "../services/StudioConfig.js";
@@ -158,25 +159,7 @@ export function createStudioRouter(
       live: {
         // #4 GET /api/civ7/live/status — 200-with-embedded-{error}; allSettled
         status: oe.civ7.live.status.effect(function* () {
-          const settled = yield* Effect.all(
-            {
-              status: Civ7TunerClient.playableStatus().pipe(Effect.either),
-              appUi: Civ7TunerClient.appUiSnapshot().pipe(Effect.either),
-              mapSummary: Civ7TunerClient.liveMapSummary().pipe(Effect.either),
-              autoplay: Civ7TunerClient.autoplayStatus().pipe(Effect.either),
-            },
-            { concurrency: "unbounded" },
-          );
-          const playableStatus = settled.status._tag === "Right" ? settled.status.right : undefined;
-          return {
-            ok: Boolean(playableStatus && playableStatus.readiness !== "unavailable"),
-            playable: playableStatus?.playable ?? false,
-            observedAt: new Date().toISOString(),
-            status: fieldOrError(settled.status, playableStatus),
-            appUi: fieldOrError(settled.appUi),
-            mapSummary: fieldOrError(settled.mapSummary),
-            autoplay: fieldOrError(settled.autoplay),
-          };
+          return yield* readLiveGameStatusBody;
         }),
 
         // #5 GET /api/civ7/live/snapshot — error 400; clamps + csv parse parity
@@ -418,16 +401,3 @@ export function createStudioRouter(
  * bound), and the handler module re-exports it.
  */
 export type StudioRouter = ReturnType<typeof createStudioRouter>;
-
-/**
- * Map a `civ7.live.status` per-field result to the contract's
- * `unknownRecord | { error }` union, matching the legacy `allSettled` body:
- * a fulfilled value passes through; a rejection becomes `{ error: String(reason) }`.
- */
-function fieldOrError<A>(
-  either: { _tag: "Left"; left: unknown } | { _tag: "Right"; right: A },
-  override?: A,
-): Record<string, unknown> | { error: string } {
-  if (either._tag === "Right") return (override ?? either.right) as Record<string, unknown>;
-  return { error: String(either.left) };
-}

--- a/packages/studio-server/test/liveGameWatcher.test.ts
+++ b/packages/studio-server/test/liveGameWatcher.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  createLiveGameWatcher,
+  type LiveGameStatusBody,
+  type StudioEvent,
+  type StudioLiveGameEvent,
+} from "../src/index";
+
+describe("live-game watcher", () => {
+  test("publishes first and changed live-game states, and stays quiet when unchanged", async () => {
+    const events: StudioEvent[] = [];
+    const bodies = [
+      liveStatusBody({ observedAt: "2026-06-13T00:00:00.000Z", turn: 12, gameHash: 111 }),
+      liveStatusBody({ observedAt: "2026-06-13T00:00:03.000Z", turn: 12, gameHash: 111 }),
+      liveStatusBody({ observedAt: "2026-06-13T00:00:06.000Z", turn: 12, gameHash: 222 }),
+    ];
+    const watcher = createLiveGameWatcher({
+      eventHub: {
+        publish: async (event) => {
+          events.push(event);
+        },
+      },
+      readLiveStatus: async () => {
+        const body = bodies.shift();
+        if (!body) throw new Error("unexpected extra read");
+        return body;
+      },
+      options: {
+        now: () => new Date("2026-06-13T00:00:00.000Z"),
+      },
+    });
+
+    await watcher.tick();
+    await watcher.tick();
+    await watcher.tick();
+
+    const liveGameEvents = events.filter((event): event is StudioLiveGameEvent => event.type === "live-game");
+    expect(liveGameEvents).toHaveLength(2);
+    expect(liveGameEvents[0]?.state.gameHash).toBe(111);
+    expect(liveGameEvents[1]?.state.gameHash).toBe(222);
+    expect(liveGameEvents[0]?.state.snapshotId).not.toBe(liveGameEvents[1]?.state.snapshotId);
+  });
+});
+
+function liveStatusBody(args: {
+  observedAt: string;
+  turn: number;
+  gameHash: number;
+}): LiveGameStatusBody {
+  return {
+    ok: true,
+    observedAt: args.observedAt,
+    status: { readiness: "ready" },
+    mapSummary: {
+      game: {
+        turn: { ok: true, value: args.turn },
+        hash: { ok: true, value: args.gameHash },
+      },
+      map: {
+        randomSeed: { ok: true, value: 123 },
+        width: { ok: true, value: 96 },
+        height: { ok: true, value: 60 },
+      },
+    },
+    autoplay: { autoplay: { isActive: false, isPaused: false } },
+  };
+}

--- a/packages/studio-server/tsup.config.ts
+++ b/packages/studio-server/tsup.config.ts
@@ -13,7 +13,7 @@ import { defineConfig } from "tsup";
  * `zod` ship proper JS and stay external.
  */
 export default defineConfig({
-  entry: ["src/index.ts", "src/contract/index.ts"],
+  entry: ["src/index.ts", "src/contract/index.ts", "src/liveGame/model.ts"],
   format: ["esm"],
   dts: true,
   clean: true,


### PR DESCRIPTION
Live Civ7 game state freshness moves from a browser-owned `setTimeout` polling loop to daemon-pushed `live-game` events over the existing `studio.events.watch` EventHub.

A new daemon-side watcher (`packages/studio-server/src/liveGame/watcher.ts`) polls Civ7 status through the unified runtime's shared `Civ7TunerSession` and publishes `live-game` events only when the live-game key changes (derived from turn, game hash, seed, readiness, and autoplay state). Repeated identical observations are suppressed. The watcher is enabled from the MapGen Studio daemon via a new `liveGameWatch` option on `createStudioRpcHandler` and is disposed alongside the runtime.

A shared `liveGame/model.ts` module in `studio-server` defines the TypeBox `liveGameStateSchema` and exports state builders (`buildLiveGameState`, `buildLiveGameErrorState`), the stable hash/stringify helpers, and the keying function (`liveGameStateKey`). The client's `liveRuntime/model.ts` now delegates to these shared helpers rather than maintaining its own duplicated implementations.

On the client, `useStudioEvents` is extended to dispatch `live-game` events through a new `applyLiveGameState` callback supplied by `StudioShell`. When a live-game event arrives, `StudioShell` updates displayed runtime state, triggers a request/response `civ7.live.snapshot` call if the snapshot needs refreshing (still gated by the existing request-key staleness guard), and fetches setup config for live-to-Studio suggestions — all without any independent browser cadence loop.

The client live status `setTimeout` loop, `nextLiveRuntimePollDelayMs`, `liveStatusFailureCountRef`, and the background `civ7.live.status` + `liveControlPort.readiness.current()` calls are deleted. The poll-delay backoff test pin is removed alongside them. Snapshot and setup reads remain request/response, triggered only by pushed events.