### PR TITLE
refactor(studio-server): enforce game door invariant

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -373,7 +373,6 @@
         "effect": "3.21.3",
         "effect-orpc": "0.2.2",
         "typebox": "^1.0.80",
-        "zod": "3.25.76",
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
@@ -3161,7 +3160,7 @@
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.20.4", "", { "peerDependencies": { "zod": "^3.20.0" } }, "sha512-Un9+kInJ2Zt63n6Z7mLqBifzzPcOyX+b+Exuzf7L1+xqck9Q2EPByyTRduV3kmSPaXaRer1JCsucubpgL1fipg=="],
 
@@ -3200,8 +3199,6 @@
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "@fission-ai/openspec/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@inquirer/confirm/@inquirer/core": ["@inquirer/core@9.2.1", "", { "dependencies": { "@inquirer/figures": "^1.0.6", "@inquirer/type": "^2.0.0", "@types/mute-stream": "^0.0.4", "@types/node": "^22.5.5", "@types/wrap-ansi": "^3.0.0", "ansi-escapes": "^4.3.2", "cli-width": "^4.1.0", "mute-stream": "^1.0.0", "signal-exit": "^4.1.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.2" } }, "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg=="],
 
@@ -3606,6 +3603,8 @@
     "yargonaut/chalk": ["chalk@1.1.3", "", { "dependencies": { "ansi-styles": "^2.2.1", "escape-string-regexp": "^1.0.2", "has-ansi": "^2.0.0", "strip-ansi": "^3.0.0", "supports-color": "^2.0.0" } }, "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A=="],
 
     "yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "zod-to-json-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@asyncapi/parser/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/docs/system/DEFERRALS.md
+++ b/docs/system/DEFERRALS.md
@@ -132,6 +132,14 @@ live-proof runbook in `MILESTONE-PROOFS.md`).
 **Scope:** Decide which knobs scale with map area (spacing, support radius, density), add declared scaling knobs, predeclare per-size expectation ranges, extend the metrics harness windows.
 **Impact:** Non-standard sizes run with standard-tuned defaults and unverified gate behavior.
 
+## DEF-015: Studio Civ7 restart recovery affordance
+
+**Deferred:** 2026-06-13
+**Trigger:** The next MapGen Studio recovery/UX slice that surfaces daemon health or tuner wedge state to the operator.
+**Context:** The runtime simplification program made tuner wedge state observable through the daemon's shared `Civ7TunerSession` health (`wedgeSuspected`, gate state, consecutive response timeouts). S4.1 closed the ownership invariant by keeping Studio session construction restricted to the shared daemon service and the direct-control package per-flow wrapper; adding a "Restart Civ7" UI/action affordance is a product interaction decision, not part of the runtime ownership closeout. Owner: MapGen Studio product/runtime.
+**Scope:** Design the operator-facing recovery surface, decide whether restart is a button, guided action, or linked run flow, wire it to the existing direct-control restart capability, and prove it against tuner-wedged and game-not-running states.
+**Impact:** Studio can report wedge suspicion, but it does not yet give the operator a first-class one-click recovery affordance from that health signal.
+
 ## Project-scoped deferrals
 
 Some deferrals are intentionally scoped to a specific project/milestone (e.g., Engine Refactor v1) rather than the whole system. Keep those in the project’s deferrals doc:

--- a/docs/system/direct-control/GAME-DOOR-INVARIANT.md
+++ b/docs/system/direct-control/GAME-DOOR-INVARIANT.md
@@ -1,0 +1,45 @@
+# Civ7 Game Door Invariant
+
+## Invariant
+
+**ID:** `studio-runtime/CIV7-GAME-DOOR`
+
+**Owner:** `@civ7/direct-control` owns socket protocol mechanics; `@civ7/studio-server` owns the Studio daemon's shared runtime session.
+
+**Scope:** MapGen Studio daemon runtime, `@civ7/studio-server`, `@civ7/control-orpc` consumers hosted by Studio, and `@civ7/direct-control` session helpers.
+
+**Rule:** Every Studio game-wire call flows through one sanctioned door:
+
+- Long-lived daemon reads use the Effect-scoped `Civ7TunerSession` service in `packages/studio-server/src/services/Civ7TunerSession.ts`.
+- Per-flow direct-control operations use `withCiv7DirectControlSession` in `packages/civ7-direct-control/src/session/session.ts`, which constructs, owns, and closes the bounded session.
+
+## Forbids
+
+- Constructing `Civ7DirectControlSession` directly in app code, router leaves, feature modules, operation engines, or caller-local utility scripts.
+- Adding alternate Studio runtime transports for FireTuner calls.
+- Keeping a second session owner as a compatibility path beside the daemon runtime.
+- Reintroducing client-side polling or request-id recovery that treats the browser as owner of daemon truth.
+
+## Detection
+
+- Guard test: `packages/studio-server/test/gameDoorInvariant.test.ts`.
+- Focused scan:
+
+```bash
+rg -n "new Civ7DirectControlSession" apps packages -g '*.{ts,tsx}'
+```
+
+The only production matches may be:
+
+- `packages/studio-server/src/services/Civ7TunerSession.ts`
+- `packages/civ7-direct-control/src/session/session.ts`
+
+Test-only constructors are allowed when they exercise the session package or assert the shared owner path.
+
+## Remediation
+
+If a new constructor appears outside the sanctioned paths, remove it rather than wrapping it in a second owner. Route daemon reads through `Civ7TunerSession.use(...)`; route bounded direct-control package workflows through `withCiv7DirectControlSession(...)`. If a workflow genuinely needs a new ownership mode, add a dedicated OpenSpec change and update this invariant, the guard test, and the direct-control docs in the same slice before implementation.
+
+## Rationale
+
+The runtime simplification program made the daemon the owner of ephemeral truth. FireTuner socket ownership follows the same rule: the daemon owns shared polling state and pushes observations; bounded package workflows may own a short-lived session only inside the direct-control package wrapper. This keeps descriptor lifetime, backoff, shutdown release, event publishing, and restart behavior visible in one place instead of being redistributed across callers.

--- a/openspec/changes/mapgen-studio-game-door-invariant/design.md
+++ b/openspec/changes/mapgen-studio-game-door-invariant/design.md
@@ -1,0 +1,64 @@
+# Design - Game Door Invariant Closeout
+
+## D1 - Ownership Rule
+
+The runtime program's final invariant is:
+
+> Studio game-wire calls flow through the daemon runtime's shared
+> `Civ7TunerSession`; bounded direct-control package flows may construct a
+> per-flow session only through `withCiv7DirectControlSession`.
+
+This gives the system two owners, each at the right level:
+
+- `@civ7/studio-server`: owns the shared daemon session for long-lived polling,
+  live-game watcher reads, control-oRPC host injection, health/backoff, and
+  daemon shutdown.
+- `@civ7/direct-control`: owns socket protocol mechanics and the per-flow helper
+  that constructs and closes bounded sessions for package workflows.
+
+App code, router leaves, operation engines, and ad-hoc scripts are forbidden
+owners. They may request game work through the sanctioned services; they may not
+construct the socket session.
+
+## D2 - Guard Shape
+
+The guard test is intentionally source-based. The invariant is about ownership
+boundaries, not about one runtime branch. A scan is the smallest test that fails
+when a future implementation reaches around the door.
+
+The scan includes production `apps/` and `packages/` TypeScript and excludes
+tests, generated output, and build artifacts. The allowlist is exact and mirrors
+the invariant doc.
+
+## D3 - Schema Technology Closeout
+
+S1.2 moved error `data` schemas to TypeBox/Standard Schema but left legacy Zod
+success I/O schemas as an explicit S4.1 closeout target. S4.1 migrates the
+remaining `packages/studio-server/src/contract/*` success I/O schemas to
+TypeBox/Standard Schema instead of retaining a mixed stack.
+
+The `toStandardSchema` adapter parses through TypeBox before returning the
+validated value. This preserves the old Zod object behavior that strips closed
+object extras. Query defaults formerly expressed through Zod `.default(...)` are
+moved into router logic so client input types remain optional and default values
+are visible at the procedure interpretation point.
+
+## D4 - Tuner Session Closeout
+
+The old tuner-session OpenSpec change kept two unchecked deferred tasks. S4.1
+dispositions them rather than carrying them forward:
+
+- Run-in-game convergence is intentionally not performed. The invariant names
+  the per-flow wrapper path as sanctioned and forbids Studio-side constructors.
+- The "Restart Civ7" UX affordance is a product recovery surface, so it moves to
+  `docs/system/DEFERRALS.md` as `DEF-015` with trigger and owner.
+
+## D5 - Orphan Sweep
+
+The final sweep is bounded to runtime simplification residue:
+
+- stale comments that describe `/api` coexistence after one-mount are updated;
+- stale comments that claim Save&Deploy status lacks server identity are updated;
+- old browser polling/watchdog/localStorage bridge symbols stay deleted;
+- old satellite mount/client/path symbols stay deleted;
+- no live `RunInGameHttpError` bridge remains.

--- a/openspec/changes/mapgen-studio-game-door-invariant/proposal.md
+++ b/openspec/changes/mapgen-studio-game-door-invariant/proposal.md
@@ -1,0 +1,61 @@
+# S4.1 Game Door Invariant
+
+## Why
+
+The runtime simplification program has already moved Studio to one daemon-owned
+transport, daemon-owned operation truth, and one event spine. The last coherence
+slice turns the remaining runtime philosophy into enforceable closure:
+
+- no unsanctioned `Civ7DirectControlSession` construction;
+- no orphaned tuner-session promises;
+- no stale bridge/coexistence comments that imply deleted runtime paths still
+  exist;
+- no legacy Zod success I/O schemas in `@civ7/studio-server` contracts.
+
+This is a closeout slice, not a feature slice. It proves the daemon is the owner
+of ephemeral runtime truth and that game-wire ownership is narrow enough to keep
+watching.
+
+## What Changes
+
+- Add a Habitat-style game-door invariant document under
+  `docs/system/direct-control/GAME-DOOR-INVARIANT.md`.
+- Add a guard test that scans production `apps/` and `packages/` TypeScript for
+  `new Civ7DirectControlSession(...)` and allows only:
+  - `packages/studio-server/src/services/Civ7TunerSession.ts`
+  - `packages/civ7-direct-control/src/session/session.ts`
+- Migrate remaining `packages/studio-server/src/contract/*` success I/O schemas
+  from Zod to TypeBox/Standard Schema.
+- Preserve request defaults explicitly in router logic where Zod `.default(...)`
+  previously supplied them.
+- Close the `mapgen-studio-tuner-session` unchecked task residue:
+  - run-in-game per-flow sessions remain sanctioned only through the
+    direct-control package wrapper and are documented by the invariant;
+  - the "Restart Civ7" recovery affordance moves to durable deferral `DEF-015`.
+- Remove stale live comments that still describe deleted `/api` coexistence or a
+  missing Save&Deploy status identity echo.
+
+## Non-Goals
+
+- No new runtime transport.
+- No new UI recovery control.
+- No run-in-game engine behavior change.
+- No reintroduction of browser-owned operation or live-game polling.
+- No branch drain before this final stack layer is ready to close.
+
+## Verification
+
+- `bun run openspec -- validate mapgen-studio-game-door-invariant --strict`
+- `bun run openspec -- validate mapgen-studio-tuner-session --strict`
+- `bun run openspec:validate`
+- `bun run --cwd packages/studio-server check`
+- `bun run --cwd packages/studio-server test -- test/gameDoorInvariant.test.ts test/handler.test.ts`
+- `bun run --cwd apps/mapgen-studio check`
+- `bun run --cwd apps/mapgen-studio test -- test/server/oneMount.test.ts test/server/daemonFetch.test.ts`
+- Negative searches for Zod in `packages/studio-server/src/contract`, legacy
+  runtime poll/watchdog/source-storage symbols, and unsanctioned session
+  construction.
+
+## Watcher
+
+Watcher lane: Rawls `019ec217-32d7-7561-9b52-768885b9fed8`.

--- a/openspec/changes/mapgen-studio-game-door-invariant/specs/mapgen-studio/spec.md
+++ b/openspec/changes/mapgen-studio-game-door-invariant/specs/mapgen-studio/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Studio Has One Game Door
+
+MapGen Studio SHALL construct `Civ7DirectControlSession` only in the daemon
+runtime's shared `Civ7TunerSession` owner or in the direct-control package's
+bounded per-flow wrapper.
+
+#### Scenario: Production constructors are allowlisted
+
+- **WHEN** production app and package TypeScript is scanned for
+  `new Civ7DirectControlSession(...)`
+- **THEN** the only allowed Studio runtime owner is
+  `packages/studio-server/src/services/Civ7TunerSession.ts`
+- **AND** the only allowed direct-control package owner is
+  `packages/civ7-direct-control/src/session/session.ts`
+- **AND** app code, router leaves, operation engines, and caller-local scripts
+  do not construct sessions directly
+
+### Requirement: Studio Server Contracts Use TypeBox Success Schemas
+
+The `@civ7/studio-server` contract success I/O schemas SHALL use
+TypeBox/Standard Schema rather than direct Zod schemas.
+
+#### Scenario: Contract schema technology is uniform
+
+- **WHEN** `packages/studio-server/src/contract` is inspected
+- **THEN** no direct `zod` import remains
+- **AND** success I/O schemas are TypeBox artifacts adapted through Standard
+  Schema
+- **AND** request defaults remain visible in router logic rather than hidden in a
+  second schema technology
+
+### Requirement: Tuner Session Follow-Ups Are Dispositioned
+
+The `mapgen-studio-tuner-session` change SHALL not remain open with unchecked
+runtime ownership promises after S4.1.
+
+#### Scenario: Prior follow-ups are closed or durable
+
+- **WHEN** `openspec/changes/mapgen-studio-tuner-session/tasks.md` is inspected
+- **THEN** the run-in-game session convergence item is closed by the game-door
+  invariant
+- **AND** the "Restart Civ7" recovery affordance is tracked in a durable deferral
+  record with owner, trigger, scope, and impact
+
+### Requirement: Runtime Simplification Residue Stays Deleted
+
+S4.1 SHALL leave no live runtime simplification residue that implies the browser
+or legacy mounts still own daemon runtime truth.
+
+#### Scenario: Old runtime residue is absent
+
+- **WHEN** app/package source is scanned for deleted operation polling,
+  live-status polling, daemon watchdog, source-snapshot storage, retired
+  satellite clients, or `RunInGameHttpError`
+- **THEN** only historical docs or explicit guard/proof records may mention
+  those symbols
+- **AND** live code comments do not describe deleted `/api` coexistence as
+  current behavior

--- a/openspec/changes/mapgen-studio-game-door-invariant/tasks.md
+++ b/openspec/changes/mapgen-studio-game-door-invariant/tasks.md
@@ -1,0 +1,40 @@
+## 1. Frame
+
+- [x] 1.1 Re-ground S4.1 in `docs/projects/studio-runtime-simplification/PLAN.md`
+      and the open `mapgen-studio-tuner-session` change.
+- [x] 1.2 Confirm clean Graphite branch `codex/game-door-invariant` from current
+      `main`.
+- [x] 1.3 Start watcher lane Rawls
+      `019ec217-32d7-7561-9b52-768885b9fed8`.
+
+## 2. Implementation
+
+- [x] 2.1 Add the Habitat-style game-door invariant document.
+- [x] 2.2 Add the production-source guard test for
+      `Civ7DirectControlSession` construction.
+- [x] 2.3 Migrate `packages/studio-server/src/contract/*` success I/O schemas
+      from Zod to TypeBox/Standard Schema.
+- [x] 2.4 Preserve former Zod request defaults in router logic.
+- [x] 2.5 Close `mapgen-studio-tuner-session` deferred tasks with invariant and
+      deferral records.
+- [x] 2.6 Update stale coexistence / Save&Deploy identity comments.
+- [x] 2.7 Remove the direct `zod` dependency from `@civ7/studio-server`.
+
+## 3. Verification
+
+- [x] 3.1 Strict-validate this OpenSpec change.
+- [x] 3.2 Strict-validate `mapgen-studio-tuner-session`.
+- [x] 3.3 Run all OpenSpec validation.
+- [x] 3.4 Run focused and full studio-server package checks/tests/build.
+- [x] 3.5 Run focused and full mapgen-studio app checks/tests/build.
+- [x] 3.6 Run negative searches for orphaned runtime simplification symbols,
+      unsanctioned session construction, and contract Zod imports.
+
+## 4. Closure
+
+- [x] 4.1 Record watcher findings and dispositions.
+- [x] 4.2 Record verification evidence and downstream realignment.
+- [x] 4.3 Submit the S4.1 Graphite branch as the final runtime simplification
+      stack layer.
+- [ ] 4.4 Audit the full runtime simplification program before marking the
+      overarching goal complete.

--- a/openspec/changes/mapgen-studio-game-door-invariant/workstream/closure-checklist.md
+++ b/openspec/changes/mapgen-studio-game-door-invariant/workstream/closure-checklist.md
@@ -1,0 +1,11 @@
+# Closure Checklist - S4.1 Game Door Invariant
+
+- [x] Tasks complete.
+- [x] Watcher findings dispositioned.
+- [x] Strict OpenSpec validation passes for `mapgen-studio-game-door-invariant`.
+- [x] Strict OpenSpec validation passes for `mapgen-studio-tuner-session`.
+- [x] Root OpenSpec validation passes.
+- [x] Focused package and app gates pass.
+- [x] Negative searches prove no live residue.
+- [x] Graphite branch submitted in the runtime simplification stack.
+- [x] Repo clean or handed off with explicit ownership.

--- a/openspec/changes/mapgen-studio-game-door-invariant/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/mapgen-studio-game-door-invariant/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,9 @@
+# Downstream Realignment Ledger - S4.1 Game Door Invariant
+
+| Surface | Impact | Disposition | Evidence |
+|---|---|---|---|
+| `mapgen-studio-tuner-session` | Two unchecked follow-ups no longer belong in the OpenSpec task list. | patched | Tasks 5.1/5.2 closed via invariant and `DEF-015`. |
+| Direct-control docs | Runtime ownership needs an evergreen invariant outside OpenSpec. | patched | `docs/system/direct-control/GAME-DOOR-INVARIANT.md`. |
+| System deferrals | Restart Civ7 recovery affordance needs durable tracking. | patched | `docs/system/DEFERRALS.md` `DEF-015`. |
+| Studio-server contract package | Mixed Zod/TypeBox success schema surface conflicted with S4.1 closeout. | patched | Contract modules migrated to TypeBox/Standard Schema. |
+| Runtime simplification plan | Historical program plan stays as accepted direction; no patch needed. | no patch | S4.1 change records closeout evidence. |

--- a/openspec/changes/mapgen-studio-game-door-invariant/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-game-door-invariant/workstream/phase-record.md
@@ -1,0 +1,59 @@
+# Phase Record - S4.1 Game Door Invariant
+
+## State
+
+- Change: `mapgen-studio-game-door-invariant`
+- Graphite branch: `codex/game-door-invariant`
+- Parent: `main` at `b4cc968f9`
+- Watcher: Rawls `019ec217-32d7-7561-9b52-768885b9fed8`
+- Status: implemented, locally verified, and submitted for review
+- Graphite PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1692
+
+## Authority
+
+- Direct user rule: no "for now" / fallback / bridge exit without durable
+  rationale or deletion target.
+- Graphite correction: use stack dependency normally; merge/drain only when the
+  stack closes or another independent stack needs trunk integration.
+- `docs/projects/studio-runtime-simplification/PLAN.md` S4.1.
+- `openspec/changes/mapgen-studio-tuner-session`.
+- `docs/system/direct-control/GAME-DOOR-INVARIANT.md` after this slice.
+
+## Scope
+
+- Docs: direct-control invariant, deferrals, S4.1 OpenSpec artifacts.
+- Code: `packages/studio-server/src/contract/*`,
+  `packages/studio-server/src/typeboxStandardSchema.ts`,
+  `packages/studio-server/src/router/index.ts`,
+  `packages/studio-server/src/context.ts`.
+- Tests: `packages/studio-server/test/gameDoorInvariant.test.ts`.
+- Package metadata: `packages/studio-server/package.json`, generated lock
+  update through `bun install`.
+
+## Verification Log
+
+- `bun run --cwd packages/studio-server check` - passed.
+- `bun run --cwd packages/studio-server test -- test/gameDoorInvariant.test.ts test/handler.test.ts` - passed, 2 files / 8 tests.
+- `bun run --cwd packages/studio-server test` - passed, 3 files / 9 tests.
+- `bun run --cwd packages/studio-server build` - passed; `tsup` emitted package JS and DTS.
+- `bun run --cwd apps/mapgen-studio check` - passed.
+- `bun run --cwd apps/mapgen-studio test -- test/server/oneMount.test.ts test/server/daemonFetch.test.ts` - passed, 2 files / 10 tests.
+- `bun run --cwd apps/mapgen-studio test` - passed, 51 files / 249 tests. Existing React key warnings and expected oRPC negative-path stderr appeared; tests passed.
+- `bun run --cwd apps/mapgen-studio build` - passed; Vite emitted the existing large chunk warning and `check-worker-bundle` passed.
+- `bun run openspec -- validate mapgen-studio-game-door-invariant --strict` - passed.
+- `bun run openspec -- validate mapgen-studio-tuner-session --strict` - passed.
+- `bun run openspec:validate` - passed, 147 items.
+- Negative search `rg -n "from ['\"]zod['\"]|\bz\." packages/studio-server/src/contract packages/studio-server/src -g '*.{ts,tsx}'` - no matches.
+- Negative search `rg -n "RunInGameHttpError|useOperationStatusPolls|useDaemonInstanceWatchdog|nextLiveRuntimePollDelayMs|sourceSnapshotStorage|liveStatusFailureCountRef|setTimeout\(poll|civ7\.live\.status\(\{\}|liveControlPort\.readiness\.current\(|civ7ControlOrpcClient|studioServerClient|nodeWebBridge|rpcPath" apps/mapgen-studio/src packages/studio-server/src packages/studio-server/test apps/mapgen-studio/test -g '*.{ts,tsx}'` - no matches.
+- Session-constructor search `rg -n "new\s+Civ7DirectControlSession\s*\(" apps packages -g '*.{ts,tsx}'` - production matches only in `packages/studio-server/src/services/Civ7TunerSession.ts` and `packages/civ7-direct-control/src/session/session.ts`; remaining matches are direct-control package tests.
+- `git diff --check` - passed.
+- `gt submit --stack --ai --no-interactive` - created draft PR #1692.
+- `gt submit --stack --publish --no-interactive --ai` - published PR #1692 for review.
+
+## Live Proof Disposition
+
+S4.1 does not change operation execution, deploy execution, daemon watch
+isolation, or browser event adoption. Live Play / Save&Deploy proof remains the
+responsibility of the execution-changing slices already completed; this slice's
+proof is source invariants, schema checks, focused handler tests, and negative
+searches.

--- a/openspec/changes/mapgen-studio-game-door-invariant/workstream/review-disposition-ledger.md
+++ b/openspec/changes/mapgen-studio-game-door-invariant/workstream/review-disposition-ledger.md
@@ -1,0 +1,19 @@
+# Review Disposition Ledger - S4.1 Game Door Invariant
+
+| ID | Severity | Source | Finding | Disposition | Repair Evidence | Blocks Closure |
+|---|---:|---|---|---|---|---|
+| S4.1-W1 | P1 | watcher Rawls `019ec217-32d7-7561-9b52-768885b9fed8` | S4.1 invariant deliverables absent: guard test and Habitat-style invariant doc required. | accepted-repaired | Added `docs/system/direct-control/GAME-DOOR-INVARIANT.md` and `packages/studio-server/test/gameDoorInvariant.test.ts`. | No |
+| S4.1-W2 | P1 | watcher Rawls | Legacy Zod success schemas remained without S4.1 closeout. | accepted-repaired | Migrated `packages/studio-server/src/contract/{shared,studio,civ7,live,runInGame,mapConfigs}.ts` to TypeBox/Standard Schema and removed direct `zod` dependency from `@civ7/studio-server`. | No |
+| S4.1-W3 | P1 | watcher Rawls | `mapgen-studio-tuner-session` still had unresolved task closeout. | accepted-repaired | Updated tuner-session tasks: per-flow sessions closed by game-door invariant; Restart Civ7 affordance moved to `DEF-015`. | No |
+| S4.1-W4 | P2 | watcher Rawls | Stale coexistence/bridge comments remained in live code. | accepted-repaired | Updated `packages/studio-server/src/context.ts` and `packages/studio-server/src/router/index.ts` comments. | No |
+
+## Cleared Watcher Checks
+
+- No production `new Civ7DirectControlSession` outside the shared session owner
+  and direct-control package wrapper.
+- No live `RunInGameHttpError` symbol in current app/package code.
+- No old satellite client/source files for `civ7ControlOrpcClient`,
+  `recipeDag/client`, `studioServerClient`, `nodeWebBridge`, or `rpcPath`.
+- No operation polling hook, daemon watchdog hook, live runtime poll delay, live
+  status timer, or localStorage request-id bridge in current app/package source.
+- Vite dev proxy is a single `/rpc` rule.

--- a/openspec/changes/mapgen-studio-tuner-session/tasks.md
+++ b/openspec/changes/mapgen-studio-tuner-session/tasks.md
@@ -5,10 +5,10 @@
 
 ## 2. direct-control seam (`design/tuner-session-seam`)
 
-- [x] 2.1 `Civ7DirectControlOptions.session?` — caller-owned session;
-      `withCiv7DirectControlSession` reuses without closing; absent →
+- [x] 2.1 `Civ7DirectControlOptions.session?` - caller-owned session;
+      `withCiv7DirectControlSession` reuses without closing; absent ->
       unchanged behavior.
-- [x] 2.2 Graceful `close()`: reject pending → `end()` (FIN) → await
+- [x] 2.2 Graceful `close()`: reject pending -> `end()` (FIN) -> await
       `close` with 1s fallback `destroy()`; idempotent.
 - [x] 2.3 `session.stats`: consecutive response-timeouts (increment on
       response-timeout, reset on any resolved frame).
@@ -33,11 +33,11 @@
 
 ## 4. Daemon wiring (`design/tuner-daemon-wiring`)
 
-- [x] 4.1 Control mount options gain `session?` → merged into
+- [x] 4.1 Control mount options gain `session?` -> merged into
       `endpointDefaults` (no control-orpc package changes).
 - [x] 4.2 `daemon.ts`: inject the shared session into the control
       handler; `/healthz` tuner block (consecutive timeouts, gate,
-      `wedgeSuspected`); SIGINT/SIGTERM → `dispose()` → stop.
+      `wedgeSuspected`); SIGINT/SIGTERM -> `dispose()` -> stop.
 - [x] 4.3 Tests: daemon health/dispatch updates; existing pins green.
 - [x] 4.4 Gates: tsc, studio tests, mod tests, build + worker bundle,
       `--strict` valid.
@@ -47,13 +47,18 @@
       soak; healthz tuner block live; daemon stop sends FIN.
 - [x] 4.6 Workstream record closed with evidence; goal-ledger entry.
 
-## 5. Deferred (explicit)
+## 5. S4.1 closeout dispositions
 
-- [ ] 5.1 Run-in-game flow convergence onto the shared session — OUT OF
-      SCOPE (behavior parity); revisit only with a dedicated parity
-      harness.
-- [ ] 5.2 "Restart Civ7" recovery affordance in the Studio UI driven by
-      `wedgeSuspected` — follow-up surface work.
+- [x] 5.1 Run-in-game flow convergence onto the shared session is closed by
+      the S4.1 `studio-runtime/CIV7-GAME-DOOR` invariant rather than by
+      convergence: Studio code may not construct sessions, and bounded
+      per-flow sessions remain sanctioned only through
+      `withCiv7DirectControlSession` in `@civ7/direct-control`. Evidence:
+      `docs/system/direct-control/GAME-DOOR-INVARIANT.md` and
+      `packages/studio-server/test/gameDoorInvariant.test.ts`.
+- [x] 5.2 "Restart Civ7" recovery affordance in the Studio UI driven by
+      `wedgeSuspected` moved to durable deferral `DEF-015` in
+      `docs/system/DEFERRALS.md` with owner, trigger, scope, and impact.
 
 ## 6. Superseded by runtime-one-mount (2026-06-12)
 
@@ -61,5 +66,5 @@
       was DELETED by `mapgen-studio-runtime-one-mount`: the unified
       handler now resolves the shared session from its own runtime and
       builds the control per-request context internally (structural
-      session sharing — no daemon-side injection seam remains).
+      session sharing - no daemon-side injection seam remains).
       `tuner.health()` and `dispose()` are unchanged.

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -42,8 +42,7 @@
     "@orpc/server": "1.14.5",
     "@orpc/tanstack-query": "1.14.5",
     "effect": "3.21.3",
-    "effect-orpc": "0.2.2",
-    "zod": "3.25.76"
+    "effect-orpc": "0.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/packages/studio-server/src/context.ts
+++ b/packages/studio-server/src/context.ts
@@ -18,30 +18,28 @@ export type StudioOutputs = InferContractRouterOutputs<typeof contract>;
 export type SetupCatalog = StudioOutputs["civ7"]["setupCatalog"]["catalog"];
 
 /**
- * `StudioServerContext` — the dependency seam the host (the Vite dev middleware,
+ * `StudioServerContext` - the dependency seam the host (the Vite dev middleware,
  * later a Bun server) supplies to the studio-server oRPC router.
  *
- * WHY a context seam instead of fully self-owned services: this run keeps the
- * legacy `/api/*` handlers **alive alongside** `/rpc` (coexistence; cutover is a
- * later supervised step). The stateful run-in-game / save-deploy / autoplay
- * surface shares ONE serialized operation queue and ONE pair of operation stores
- * (the dual-store 409 mutex, architecture/10 §7). If the oRPC router instantiated
- * its own stores, `/api` and `/rpc` would diverge and the cross-mutex parity would
- * break. So the host owns the singletons and the verbatim engine bodies, and
- * injects them here; the package owns the oRPC/Effect wiring + the read surface.
+ * WHY a context seam instead of fully self-owned services: the stateful
+ * run-in-game / save-deploy / autoplay surface shares ONE serialized operation
+ * queue and ONE pair of operation stores (the dual-store 409 mutex,
+ * architecture/10 section 7). The daemon is now one `/rpc` surface; the host
+ * still owns those process-lifetime singletons and injects them here so the
+ * package owns the oRPC/Effect wiring without duplicating engine state.
  *
  * The read surface (status, mapSummary, gameInfo, live.*, setupConfig,
  * savedConfigs, serverInfo) is implemented inside the package from
- * `@civ7/direct-control` directly — only the catalog loader and the three
+ * `@civ7/direct-control` directly - only the catalog loader and the three
  * stateful engines cross this seam.
  *
  * Each engine fn returns the SAME success shape its `/api` handler wrote, OR
  * throws an `ORPCError` whose code/status/data MATCH the procedure's DECLARED
- * contract errors (./contract/errors.ts) — `AUTOPLAY_BLOCKED`/
+ * contract errors (./contract/errors.ts) - `AUTOPLAY_BLOCKED`/
  * `AUTOPLAY_UNAVAILABLE`/`AUTOPLAY_FAILED`,
  * `RUN_IN_GAME_BLOCKED`/`_INVALID`/`_FAILED`/`_UNAVAILABLE`/`_STATUS_NOT_FOUND`,
  * `SAVE_DEPLOY_BLOCKED`/`_INVALID`/`_UNAVAILABLE`/`_FAILED`/
- * `_STATUS_NOT_FOUND` — so oRPC
+ * `_STATUS_NOT_FOUND` - so oRPC
  * validates them into DEFINED typed errors client-side. The package re-throws
  * engine `ORPCError`s unchanged.
  */
@@ -54,7 +52,7 @@ export interface StudioServerContext {
 
   /**
    * Recipe-DAG projection service (runtime-one-mount slice). The
-   * implementation stays host-side — it imports `mod-swooper-maps` recipe
+   * implementation stays host-side - it imports `mod-swooper-maps` recipe
    * stages, a dependency this package must not take. `recipeDag.get` reads
    * it through the `StudioConfig` layer.
    */
@@ -63,7 +61,7 @@ export interface StudioServerContext {
   /**
    * Civ7 control-oRPC dependencies (runtime-one-mount slice). The handler
    * builds the control procedures' per-request context from these plus the
-   * runtime's shared `Civ7TunerSession` — session sharing is structural,
+   * runtime's shared `Civ7TunerSession` - session sharing is structural,
    * not a host-side patch. Hosts pass the live facade; tests pass fakes.
    */
   readonly civ7Control: Readonly<{

--- a/packages/studio-server/src/contract/civ7.ts
+++ b/packages/studio-server/src/contract/civ7.ts
@@ -1,5 +1,5 @@
 import { oc } from "@orpc/contract";
-import { z } from "zod";
+import { Type } from "typebox";
 
 import {
   autoplayErrors,
@@ -10,184 +10,250 @@ import {
   setupCatalogErrors,
   setupConfigErrors,
 } from "./errors.js";
-import { isoTimestamp, unknownRecord } from "./shared.js";
+import {
+  contractSchema,
+  emptyInputSchema,
+  isoTimestampSchema,
+  unknownRecordSchema,
+} from "./shared.js";
 
 /**
- * `civ7.*` namespace — FireTuner socket reads + autoplay mutation.
+ * `civ7.*` namespace - FireTuner socket reads + autoplay mutation.
  *
  * Source of truth: audit/05-server-contracts.md endpoints #1, #2, #3, #8, #10,
  * #11, #12 (and the `civ7.live.*` sub-namespace lives in ./live.ts).
  *
  * Parity note: error status codes are NON-UNIFORM across these procedures
- * (gameInfo→400, setupConfig→503, savedConfigs/setupCatalog→500,
- * status/mapSummary→500, autoplay→409/503/500). Each procedure DECLARES its codes
+ * (gameInfo->400, setupConfig->503, savedConfigs/setupCatalog->500,
+ * status/mapSummary->500, autoplay->409/503/500). Each procedure DECLARES its codes
  * via `.errors(...)` (./errors.ts), so the legacy statuses are contract-typed
  * and arrive client-side as oRPC defined errors.
  */
 
+const setupCatalogSourceSchema = Type.Union([
+  Type.Literal("official-resource-mirror"),
+  Type.Literal("app-resources"),
+]);
+
 // ---------------------------------------------------------------------------
-// #1 civ7.status — GET /api/civ7/status
+// #1 civ7.status - GET /api/civ7/status
 // ---------------------------------------------------------------------------
 // Request: none. Success 200: { ok: status.playable, status: PlayableStatus }.
 // Error 500: { ok:false, error }. Reads FireTuner socket (getCiv7PlayableStatus).
 export const status = oc
   .errors(civ7StatusErrors)
-  .input(z.object({}))
+  .input(emptyInputSchema)
   .output(
-    z.object({
-      ok: z.boolean(),
-      // Civ7PlayableStatusResult (@civ7/direct-control). Opaque payload — see shared.ts.
-      status: unknownRecord,
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          ok: Type.Boolean(),
+          // Civ7PlayableStatusResult (@civ7/direct-control). Opaque payload - see shared.ts.
+          status: unknownRecordSchema,
+        },
+        { additionalProperties: false },
+      ),
+    ),
   );
 
 // ---------------------------------------------------------------------------
-// #2 civ7.mapSummary — GET /api/civ7/map-summary
+// #2 civ7.mapSummary - GET /api/civ7/map-summary
 // ---------------------------------------------------------------------------
 // Request: none (server calls with { includeAreaRegionCounts: true }).
 // Success 200: { ok:true, summary: MapSummary }. Error 500: { ok:false, error }.
 export const mapSummary = oc
   .errors(civ7MapSummaryErrors)
-  .input(z.object({}))
+  .input(emptyInputSchema)
   .output(
-    z.object({
-      ok: z.literal(true),
-      // Civ7MapSummaryResult (@civ7/direct-control). Opaque payload.
-      summary: unknownRecord,
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          ok: Type.Literal(true),
+          // Civ7MapSummaryResult (@civ7/direct-control). Opaque payload.
+          summary: unknownRecordSchema,
+        },
+        { additionalProperties: false },
+      ),
+    ),
   );
 
 // ---------------------------------------------------------------------------
-// #3 civ7.gameInfo — GET /api/civ7/gameinfo?table=&limit=
+// #3 civ7.gameInfo - GET /api/civ7/gameinfo?table=&limit=
 // ---------------------------------------------------------------------------
 // Query: table (string, REQUIRED), limit (number, default 100).
 // Success 200: { ok:true, rows }. Error 400 (incl. missing table): { ok:false, error }.
 // NOTE: error status is 400 here, NOT 500.
 //
 // PARITY REFINEMENT (A3): the legacy handler assigns `rows = await
-// getCiv7GameInfoRows(...)` and writes `{ ok:true, rows }` — i.e. `rows` is the
+// getCiv7GameInfoRows(...)` and writes `{ ok:true, rows }` - i.e. `rows` is the
 // WHOLE `Civ7GameInfoRowsResult` object (`{ host, port, table, source, rows,
-// total, … }`), NOT a bare row array. The A1 contract modelled it as
+// total, ... }`), NOT a bare row array. The A1 contract modelled it as
 // `array(gameInfoRow)`, which does not match `/api`. Refined to the opaque result
 // record to preserve current behavior (the deep payload is internal, per shared.ts).
 export const gameInfo = oc
   .errors(civ7GameInfoErrors)
   .input(
-    z.object({
-      table: z.string().min(1),
-      limit: z.number().int().default(100),
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          table: Type.String({ minLength: 1 }),
+          limit: Type.Optional(Type.Integer()),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   )
   .output(
-    z.object({
-      ok: z.literal(true),
-      // Civ7GameInfoRowsResult (@civ7/direct-control). Opaque payload (see shared.ts).
-      rows: unknownRecord,
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          ok: Type.Literal(true),
+          // Civ7GameInfoRowsResult (@civ7/direct-control). Opaque payload (see shared.ts).
+          rows: unknownRecordSchema,
+        },
+        { additionalProperties: false },
+      ),
+    ),
   );
 
 // ---------------------------------------------------------------------------
-// #8 civ7.autoplay — POST /api/civ7/autoplay
+// #8 civ7.autoplay - POST /api/civ7/autoplay
 // ---------------------------------------------------------------------------
 // Body: { action: "start" | "stop" }.
 // Success 200: { ok: result.verified, action, autoplay, game, gameContext, result }.
 // Errors: 400 (bad action/invalid engine request); 409 (run-in-game OR
 // save/deploy active, with details.code); 503 direct-control unavailable; 500
 // unexpected failure.
-// Mutates game state; waits on scripting log markers (waitTimeoutMs≈90s).
+// Mutates game state; waits on scripting log markers (waitTimeoutMs around 90s).
 // Dual-store 409 mutex + approval object land A3.
+const autoplayActionSchema = Type.Union([Type.Literal("start"), Type.Literal("stop")]);
+
 export const autoplay = oc
   .errors(autoplayErrors)
   .input(
-    z.object({
-      action: z.enum(["start", "stop"]),
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          action: autoplayActionSchema,
+        },
+        { additionalProperties: false },
+      ),
+    ),
   )
   .output(
-    z.object({
-      ok: z.boolean(),
-      action: z.enum(["start", "stop"]),
-      // The following mirror Civ7AutoplayStatusResult fields + the action result.
-      autoplay: unknownRecord,
-      game: unknownRecord,
-      gameContext: unknownRecord,
-      // Civ7AutoplayActionResult (@civ7/direct-control). Opaque payload.
-      result: unknownRecord,
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          ok: Type.Boolean(),
+          action: autoplayActionSchema,
+          // The following mirror Civ7AutoplayStatusResult fields + the action result.
+          autoplay: unknownRecordSchema,
+          game: unknownRecordSchema,
+          gameContext: unknownRecordSchema,
+          // Civ7AutoplayActionResult (@civ7/direct-control). Opaque payload.
+          result: unknownRecordSchema,
+        },
+        { additionalProperties: false },
+      ),
+    ),
   );
 
 // ---------------------------------------------------------------------------
-// #10 civ7.setupConfig — GET /api/civ7/setup-config
+// #10 civ7.setupConfig - GET /api/civ7/setup-config
 // ---------------------------------------------------------------------------
 // Request: none. Success 200: { ok:true, observedAt, setup, state, host, port }.
 // Error 503 (UNIQUE): { ok:false, error, observedAt }. Reads FireTuner socket.
 export const setupConfig = oc
   .errors(setupConfigErrors)
-  .input(z.object({}))
+  .input(emptyInputSchema)
   .output(
-    z.object({
-      ok: z.literal(true),
-      observedAt: isoTimestamp,
-      // Civ7SetupSnapshot (@civ7/direct-control). Opaque payload.
-      setup: unknownRecord,
-      state: unknownRecord,
-      host: z.string(),
-      port: z.number(),
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          ok: Type.Literal(true),
+          observedAt: isoTimestampSchema,
+          // Civ7SetupSnapshot (@civ7/direct-control). Opaque payload.
+          setup: unknownRecordSchema,
+          state: unknownRecordSchema,
+          host: Type.String(),
+          port: Type.Number(),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   );
 
 // ---------------------------------------------------------------------------
-// #11 civ7.savedConfigs — GET /api/civ7/saved-configs
+// #11 civ7.savedConfigs - GET /api/civ7/saved-configs
 // ---------------------------------------------------------------------------
 // Request: none. Success 200: { ok:true, observedAt, directory, configurations }
 // (spread of listCiv7SavedGameConfigurations listResult). Error 500:
 // { ok:false, error, observedAt }. Reads filesystem (Civ7 saved-config dir).
 export const savedConfigs = oc
   .errors(savedConfigsErrors)
-  .input(z.object({}))
+  .input(emptyInputSchema)
   .output(
-    z.object({
-      ok: z.literal(true),
-      observedAt: isoTimestamp,
-      directory: z.string(),
-      configurations: z.array(unknownRecord),
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          ok: Type.Literal(true),
+          observedAt: isoTimestampSchema,
+          directory: Type.String(),
+          configurations: Type.Array(unknownRecordSchema),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   );
 
 // ---------------------------------------------------------------------------
-// #12 civ7.setupCatalog — GET /api/civ7/setup-catalog
+// #12 civ7.setupCatalog - GET /api/civ7/setup-catalog
 // ---------------------------------------------------------------------------
 // Request: none. Success 200: { ok:true, catalog: Civ7SetupCatalog }.
 // Error 500: { ok:false, error, observedAt }. Reads filesystem (repo mirror +
 // macOS Steam app Resources). `catalog` reproduces the Civ7SetupCatalog type from
 // apps/mapgen-studio/src/server/civ7Resources/catalog.ts faithfully.
 
-const setupCatalogOption = z.object({
-  value: z.string(),
-  label: z.string(),
-  source: z.enum(["official-resource-mirror", "app-resources"]),
-  sourcePath: z.string(),
-});
+const setupCatalogOptionSchema = Type.Object(
+  {
+    value: Type.String(),
+    label: Type.String(),
+    source: setupCatalogSourceSchema,
+    sourcePath: Type.String(),
+  },
+  { additionalProperties: false },
+);
 
-export const setupCatalogSchema = z.object({
-  observedAt: isoTimestamp,
-  roots: z.array(
-    z.object({
-      source: z.enum(["official-resource-mirror", "app-resources"]),
-      path: z.string(),
-      exists: z.boolean(),
-    }),
+export const setupCatalogSchema = Type.Object(
+  {
+    observedAt: isoTimestampSchema,
+    roots: Type.Array(
+      Type.Object(
+        {
+          source: setupCatalogSourceSchema,
+          path: Type.String(),
+          exists: Type.Boolean(),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+    sourceFileCount: Type.Number(),
+    leaders: Type.Array(setupCatalogOptionSchema),
+    civilizations: Type.Array(setupCatalogOptionSchema),
+    difficulties: Type.Array(setupCatalogOptionSchema),
+    gameSpeeds: Type.Array(setupCatalogOptionSchema),
+  },
+  { additionalProperties: false },
+);
+
+export const setupCatalog = oc.errors(setupCatalogErrors).input(emptyInputSchema).output(
+  contractSchema(
+    Type.Object(
+      {
+        ok: Type.Literal(true),
+        catalog: setupCatalogSchema,
+      },
+      { additionalProperties: false },
+    ),
   ),
-  sourceFileCount: z.number(),
-  leaders: z.array(setupCatalogOption),
-  civilizations: z.array(setupCatalogOption),
-  difficulties: z.array(setupCatalogOption),
-  gameSpeeds: z.array(setupCatalogOption),
-});
-
-export const setupCatalog = oc.errors(setupCatalogErrors).input(z.object({})).output(
-  z.object({
-    ok: z.literal(true),
-    catalog: setupCatalogSchema,
-  }),
 );

--- a/packages/studio-server/src/contract/live.ts
+++ b/packages/studio-server/src/contract/live.ts
@@ -1,15 +1,20 @@
 import { oc } from "@orpc/contract";
-import { z } from "zod";
+import { Type } from "typebox";
 
 import {
   liveEntitiesErrors,
   liveGameInfoErrors,
   liveSnapshotErrors,
 } from "./errors.js";
-import { isoTimestamp, unknownRecord } from "./shared.js";
+import {
+  contractSchema,
+  emptyInputSchema,
+  isoTimestampSchema,
+  unknownRecordSchema,
+} from "./shared.js";
 
 /**
- * `civ7.live.*` sub-namespace — aggregated live runtime reads.
+ * `civ7.live.*` sub-namespace - aggregated live runtime reads.
  *
  * Source of truth: audit/05-server-contracts.md endpoints #4 (status), #5
  * (snapshot), #6 (entities), #7 (gameInfo).
@@ -18,120 +23,158 @@ import { isoTimestamp, unknownRecord } from "./shared.js";
 /**
  * A field that is either the live payload or an embedded `{ error }` marker.
  *
- * PARITY INVARIANT (audit/05 #4, line 29; target-arch §1 invariants): `live.status`
- * returns **200** even on partial failure — each of the four aggregated reads runs
+ * PARITY INVARIANT (audit/05 #4, line 29; target-arch section 1 invariants): `live.status`
+ * returns **200** even on partial failure - each of the four aggregated reads runs
  * under `Promise.allSettled`, and a rejected read is surfaced in-band as
- * `{ error: String(reason) }` for that field. These are NOT transport-layer errors —
+ * `{ error: String(reason) }` for that field. These are NOT transport-layer errors -
  * `live.status` therefore declares NO contract error codes (only an outer defect
  * yields a transport-level 500).
  */
-const fieldOrError = z.union([unknownRecord, z.object({ error: z.string() })]);
+const fieldOrErrorSchema = Type.Union([
+  unknownRecordSchema,
+  Type.Object({ error: Type.String() }, { additionalProperties: false }),
+]);
 
 // ---------------------------------------------------------------------------
-// #4 civ7.live.status — GET /api/civ7/live/status
+// #4 civ7.live.status - GET /api/civ7/live/status
 // ---------------------------------------------------------------------------
 // Request: none. Success 200: { ok, playable, observedAt, status, appUi,
 // mapSummary, autoplay } where ok = playableStatus && readiness !== "unavailable",
 // and each of status/appUi/mapSummary/autoplay may be the payload OR { error }
 // (Promise.allSettled). Error 500 ONLY on outer throw.
 export const status = oc
-  .input(z.object({}))
+  .input(emptyInputSchema)
   .output(
-    z.object({
-      ok: z.boolean(),
-      playable: z.boolean(),
-      observedAt: isoTimestamp,
-      status: fieldOrError,
-      appUi: fieldOrError,
-      mapSummary: fieldOrError,
-      autoplay: fieldOrError,
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          ok: Type.Boolean(),
+          playable: Type.Boolean(),
+          observedAt: isoTimestampSchema,
+          status: fieldOrErrorSchema,
+          appUi: fieldOrErrorSchema,
+          mapSummary: fieldOrErrorSchema,
+          autoplay: fieldOrErrorSchema,
+        },
+        { additionalProperties: false },
+      ),
+    ),
   );
 
 // ---------------------------------------------------------------------------
-// #5 civ7.live.snapshot — GET /api/civ7/live/snapshot
+// #5 civ7.live.snapshot - GET /api/civ7/live/snapshot
 // ---------------------------------------------------------------------------
 // Query: x(0), y(0), width(24), height(18),
 //   fields(csv, default "terrain,biome,feature,resource,visibility,owner"),
-//   playerId(opt → number or omitted), maxPlots(clamp 1..512, default 512).
+//   playerId(opt -> number or omitted), maxPlots(clamp 1..512, default 512).
 // Success 200: { ok:true, observedAt, grid }. Error 400: { ok:false, error }.
 //
-// PARITY NOTE (audit/05 #5): the exact query parsing — `maxPlots` clamp to 1..512,
-// `fields` csv split/trim/filter, `playerId` null→omit — lives in the handler (A3).
-// Contract input defaults below document the wire defaults; clamping is applied
+// PARITY NOTE (audit/05 #5): the exact query parsing - `maxPlots` clamp to 1..512,
+// `fields` csv split/trim/filter, `playerId` null->omit - lives in the handler.
+// Contract input optionality documents the wire defaults; clamping is applied
 // server-side. `fields` is accepted as the raw csv string to preserve parsing parity.
 export const snapshot = oc
   .errors(liveSnapshotErrors)
   .input(
-    z.object({
-      x: z.number().int().default(0),
-      y: z.number().int().default(0),
-      width: z.number().int().default(24),
-      height: z.number().int().default(18),
-      fields: z.string().default("terrain,biome,feature,resource,visibility,owner"),
-      playerId: z.number().int().optional(),
-      maxPlots: z.number().int().default(512),
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          x: Type.Optional(Type.Integer()),
+          y: Type.Optional(Type.Integer()),
+          width: Type.Optional(Type.Integer()),
+          height: Type.Optional(Type.Integer()),
+          fields: Type.Optional(Type.String()),
+          playerId: Type.Optional(Type.Integer()),
+          maxPlots: Type.Optional(Type.Integer()),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   )
   .output(
-    z.object({
-      ok: z.literal(true),
-      observedAt: isoTimestamp,
-      // Civ7MapGridResult (@civ7/direct-control). Opaque payload.
-      grid: unknownRecord,
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          ok: Type.Literal(true),
+          observedAt: isoTimestampSchema,
+          // Civ7MapGridResult (@civ7/direct-control). Opaque payload.
+          grid: unknownRecordSchema,
+        },
+        { additionalProperties: false },
+      ),
+    ),
   );
 
 // ---------------------------------------------------------------------------
-// #6 civ7.live.entities — GET /api/civ7/live/entities
+// #6 civ7.live.entities - GET /api/civ7/live/entities
 // ---------------------------------------------------------------------------
-// Query: playerId(opt → number/omit), maxItems(clamp 1..128, default 128).
+// Query: playerId(opt -> number/omit), maxItems(clamp 1..128, default 128).
 // Success 200: { ok:true, observedAt, players, units, cities }.
-// Error 400: { ok:false, error }. Reads FireTuner (3× Promise.all — any failure
-// → whole 400, NOT allSettled).
+// Error 400: { ok:false, error }. Reads FireTuner (3x Promise.all - any failure
+// -> whole 400, NOT allSettled).
 export const entities = oc
   .errors(liveEntitiesErrors)
   .input(
-    z.object({
-      playerId: z.number().int().optional(),
-      maxItems: z.number().int().default(128),
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          playerId: Type.Optional(Type.Integer()),
+          maxItems: Type.Optional(Type.Integer()),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   )
   .output(
-    z.object({
-      ok: z.literal(true),
-      observedAt: isoTimestamp,
-      players: unknownRecord,
-      units: unknownRecord,
-      cities: unknownRecord,
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          ok: Type.Literal(true),
+          observedAt: isoTimestampSchema,
+          players: unknownRecordSchema,
+          units: unknownRecordSchema,
+          cities: unknownRecordSchema,
+        },
+        { additionalProperties: false },
+      ),
+    ),
   );
 
 // ---------------------------------------------------------------------------
-// #7 civ7.live.gameInfo — GET /api/civ7/live/gameinfo
+// #7 civ7.live.gameInfo - GET /api/civ7/live/gameinfo
 // ---------------------------------------------------------------------------
 // Query: tables(csv, default "Terrains,Biomes,Features,Resources,Maps,MapSizes",
-//   slice(0,8) — 8-table cap), limit(clamp 1..200, default 100).
+//   slice(0,8) - 8-table cap), limit(clamp 1..200, default 100).
 // Success 200: { ok:true, observedAt, tables: Record<table, rows> }.
 // Error 400: { ok:false, error }. N parallel reads.
 //
 // PARITY REFINEMENT (A3): each `tables[table]` value is the WHOLE
 // `Civ7GameInfoRowsResult` object (legacy maps `[table, await
-// getCiv7GameInfoRows(...)]`), not a bare row array — same mismatch as
+// getCiv7GameInfoRows(...)]`), not a bare row array - same mismatch as
 // `civ7.gameInfo` (#3). Refined from `array(gameInfoRow)` to the opaque result
 // record to preserve current `/api` behavior.
 export const gameInfo = oc
   .errors(liveGameInfoErrors)
   .input(
-    z.object({
-      tables: z.string().default("Terrains,Biomes,Features,Resources,Maps,MapSizes"),
-      limit: z.number().int().default(100),
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          tables: Type.Optional(Type.String()),
+          limit: Type.Optional(Type.Integer()),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   )
   .output(
-    z.object({
-      ok: z.literal(true),
-      observedAt: isoTimestamp,
-      tables: z.record(z.string(), unknownRecord),
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          ok: Type.Literal(true),
+          observedAt: isoTimestampSchema,
+          tables: Type.Record(Type.String(), unknownRecordSchema),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   );

--- a/packages/studio-server/src/contract/mapConfigs.ts
+++ b/packages/studio-server/src/contract/mapConfigs.ts
@@ -1,59 +1,76 @@
 import { oc } from "@orpc/contract";
-import { z } from "zod";
+import { Type } from "typebox";
 
 import { mapConfigsErrors } from "./errors.js";
+import { contractSchema } from "./shared.js";
 
 /**
- * `mapConfigs.*` namespace — save config to repo + deploy (no Civ restart).
+ * `mapConfigs.*` namespace - save config to repo + deploy (no Civ restart).
  *
  * Source of truth: audit/05-server-contracts.md endpoints #15 (status) and #16
  * (saveDeploy). The output schema reproduces `MapConfigSaveDeployStatus` from
  * apps/mapgen-studio/src/features/mapConfigSave/status.ts faithfully.
  */
 
-const saveDeployPhase = z.enum([
-  "idle",
-  "queued",
-  "saving",
-  "deploying",
-  "complete",
-  "failed",
+const saveDeployPhase = Type.Union([
+  Type.Literal("idle"),
+  Type.Literal("queued"),
+  Type.Literal("saving"),
+  Type.Literal("deploying"),
+  Type.Literal("complete"),
+  Type.Literal("failed"),
 ]);
 
-const saveDeployKind = z.enum(["idle", "running", "complete", "failed"]);
+const saveDeployKind = Type.Union([
+  Type.Literal("idle"),
+  Type.Literal("running"),
+  Type.Literal("complete"),
+  Type.Literal("failed"),
+]);
 
-/** `MapConfigSaveDeployStatus` — returned by both saveDeploy (#16, 202) and status (#15, 200). */
-export const saveDeployStatusSchema = z.object({
-  ok: z.boolean(),
-  requestId: z.string(),
-  phase: saveDeployPhase,
-  status: saveDeployKind,
-  startedAt: z.string(),
-  updatedAt: z.string(),
-  path: z.string().optional(),
-  saved: z.boolean().optional(),
-  deployed: z.boolean().optional(),
-  error: z.string().optional(),
-  deploy: z
-    .object({
-      build: z
-        .object({
-          task: z.string().optional(),
-          stdout: z.string().optional(),
-          stderr: z.string().optional(),
-        })
-        .optional(),
-      targetDir: z.string().optional(),
-      modsDir: z.string().optional(),
-      filesCopied: z.number().optional(),
-    })
-    .optional(),
-  details: z.record(z.string(), z.unknown()).optional(),
-  recoveryActions: z.array(z.string()).optional(),
-});
+/** `MapConfigSaveDeployStatus` - returned by both saveDeploy (#16, 202) and status (#15, 200). */
+const saveDeployStatusTypeSchema = Type.Object(
+  {
+    ok: Type.Boolean(),
+    requestId: Type.String(),
+    phase: saveDeployPhase,
+    status: saveDeployKind,
+    startedAt: Type.String(),
+    updatedAt: Type.String(),
+    path: Type.Optional(Type.String()),
+    saved: Type.Optional(Type.Boolean()),
+    deployed: Type.Optional(Type.Boolean()),
+    error: Type.Optional(Type.String()),
+    deploy: Type.Optional(
+      Type.Object(
+        {
+          build: Type.Optional(
+            Type.Object(
+              {
+                task: Type.Optional(Type.String()),
+                stdout: Type.Optional(Type.String()),
+                stderr: Type.Optional(Type.String()),
+              },
+              { additionalProperties: false },
+            ),
+          ),
+          targetDir: Type.Optional(Type.String()),
+          modsDir: Type.Optional(Type.String()),
+          filesCopied: Type.Optional(Type.Number()),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+    details: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+    recoveryActions: Type.Optional(Type.Array(Type.String())),
+  },
+  { additionalProperties: false },
+);
+
+export const saveDeployStatusSchema = contractSchema(saveDeployStatusTypeSchema);
 
 // ---------------------------------------------------------------------------
-// #15 mapConfigs.status — GET /api/map-configs/status?requestId=
+// #15 mapConfigs.status - GET /api/map-configs/status?requestId=
 // ---------------------------------------------------------------------------
 // Query: requestId (REQUIRED). Success 200: MapConfigSaveDeployStatus.
 // Errors: 400 (missing); 404 { ok:false, error, serverInstanceId,
@@ -65,20 +82,25 @@ export const saveDeployStatusSchema = z.object({
 export const status = oc
   .errors(mapConfigsErrors)
   .input(
-    z.object({
-      requestId: z.string().min(1),
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          requestId: Type.String({ minLength: 1 }),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   )
   .output(saveDeployStatusSchema);
 
 // ---------------------------------------------------------------------------
-// #16 mapConfigs.saveDeploy — POST /api/map-configs
+// #16 mapConfigs.saveDeploy - POST /api/map-configs
 // ---------------------------------------------------------------------------
 // Body: { requestId?, id, sourcePath?, envelope, restart?, verifyRestart? }.
-// `restart`/`verifyRestart` MUST be falsy → else 400.
+// `restart`/`verifyRestart` MUST be falsy -> else 400.
 // Success 202: MapConfigSaveDeployStatus (async). 202 idempotent (same active
 // requestId returns current). Errors: 409 (run-in-game active OR different save/
-// deploy active); 400 on validation — declared as the defined
+// deploy active); 400 on validation - declared as the defined
 // SAVE_DEPLOY_BLOCKED/INVALID/UNAVAILABLE/FAILED codes (./errors.ts).
 //
 // PARITY NOTE (audit/05 #16): write-then-deploy with ROLLBACK on deploy-phase
@@ -90,13 +112,18 @@ export const status = oc
 export const saveDeploy = oc
   .errors(mapConfigsErrors)
   .input(
-    z.object({
-      requestId: z.string().optional(),
-      id: z.string(),
-      sourcePath: z.string().optional(),
-      envelope: z.unknown(),
-      restart: z.boolean().optional(),
-      verifyRestart: z.boolean().optional(),
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          requestId: Type.Optional(Type.String()),
+          id: Type.String(),
+          sourcePath: Type.Optional(Type.String()),
+          envelope: Type.Unknown(),
+          restart: Type.Optional(Type.Boolean()),
+          verifyRestart: Type.Optional(Type.Boolean()),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   )
   .output(saveDeployStatusSchema);

--- a/packages/studio-server/src/contract/runInGame.ts
+++ b/packages/studio-server/src/contract/runInGame.ts
@@ -1,240 +1,278 @@
 import { oc } from "@orpc/contract";
-import { z } from "zod";
+import { Type } from "typebox";
 
 import { runInGameErrors } from "./errors.js";
-import { unknownRecord } from "./shared.js";
+import { contractSchema, unknownRecordSchema } from "./shared.js";
 
 /**
- * `runInGame.*` namespace — launch + poll the run-current-config-in-Civ7 pipeline.
+ * `runInGame.*` namespace - launch + poll the run-current-config-in-Civ7 pipeline.
  *
  * Source of truth: audit/05-server-contracts.md endpoints #13 (status) and #14
  * (start). The output schema reproduces `RunInGameOperationStatus` from
  * apps/mapgen-studio/src/features/runInGame/status.ts faithfully (the package must
- * NOT import app code — the schema is mirrored here).
+ * NOT import app code - the schema is mirrored here).
  */
 
 // --- enums mirrored from features/runInGame/status.ts -----------------------
 
-const runInGamePhase = z.enum([
-  "idle",
-  "materializing",
-  "deploying",
-  "restarting-civ",
-  "checking-civ7",
-  "reload-needed",
-  "preparing-setup",
-  "starting-game",
-  "waiting-for-proof",
-  "complete",
-  "blocked",
-  "failed",
-  "uncertain",
+const runInGamePhase = Type.Union([
+  Type.Literal("idle"),
+  Type.Literal("materializing"),
+  Type.Literal("deploying"),
+  Type.Literal("restarting-civ"),
+  Type.Literal("checking-civ7"),
+  Type.Literal("reload-needed"),
+  Type.Literal("preparing-setup"),
+  Type.Literal("starting-game"),
+  Type.Literal("waiting-for-proof"),
+  Type.Literal("complete"),
+  Type.Literal("blocked"),
+  Type.Literal("failed"),
+  Type.Literal("uncertain"),
 ]);
 
-const runInGameOperationKind = z.enum([
-  "idle",
-  "running",
-  "complete",
-  "blocked",
-  "failed",
-  "uncertain",
+const runInGameOperationKind = Type.Union([
+  Type.Literal("idle"),
+  Type.Literal("running"),
+  Type.Literal("complete"),
+  Type.Literal("blocked"),
+  Type.Literal("failed"),
+  Type.Literal("uncertain"),
 ]);
 
 // RunInGameFileIdentity
-const fileIdentity = z.object({
-  path: z.string(),
-  sha256: z.string(),
-  sizeBytes: z.number(),
-  mtimeMs: z.number(),
-  mtimeIso: z.string(),
-});
+const fileIdentity = Type.Object(
+  {
+    path: Type.String(),
+    sha256: Type.String(),
+    sizeBytes: Type.Number(),
+    mtimeMs: Type.Number(),
+    mtimeIso: Type.String(),
+  },
+  { additionalProperties: false },
+);
 
-const contentMarkerProof = z.object({
-  id: z.string(),
-  marker: z.string(),
-  present: z.boolean(),
-});
+const contentMarkerProof = Type.Object(
+  {
+    id: Type.String(),
+    marker: Type.String(),
+    present: Type.Boolean(),
+  },
+  { additionalProperties: false },
+);
 
-const fileContentProof = z.object({
-  path: z.string(),
-  markers: z.array(contentMarkerProof),
-});
+const fileContentProof = Type.Object(
+  {
+    path: Type.String(),
+    markers: Type.Array(contentMarkerProof),
+  },
+  { additionalProperties: false },
+);
 
 // RunInGameSourceSnapshotProof
-const sourceSnapshotProof = z.object({
-  identityHash: z.string(),
-  requestId: z.string(),
-  recipeSettings: z.unknown().optional(),
-  worldSettings: z.unknown().optional(),
-  pipelineConfig: z.unknown().optional(),
-  setupConfig: z.unknown().optional(),
-  materializationMode: z.string().optional(),
-  selectedConfig: z.unknown().optional(),
-  configHash: z.string().optional(),
-  envelopeHash: z.string().optional(),
-});
+const sourceSnapshotProof = Type.Object(
+  {
+    identityHash: Type.String(),
+    requestId: Type.String(),
+    recipeSettings: Type.Optional(Type.Unknown()),
+    worldSettings: Type.Optional(Type.Unknown()),
+    pipelineConfig: Type.Optional(Type.Unknown()),
+    setupConfig: Type.Optional(Type.Unknown()),
+    materializationMode: Type.Optional(Type.String()),
+    selectedConfig: Type.Optional(Type.Unknown()),
+    configHash: Type.Optional(Type.String()),
+    envelopeHash: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
 
 // RunInGameMaterializationStatus
-const materializationStatus = z.object({
-  mode: z.string().optional(),
-  path: z.string().optional(),
-  mapScript: z.string().optional(),
-  configHash: z.string().optional(),
-  envelopeHash: z.string().optional(),
-  sourceConfig: fileIdentity.optional(),
-  generatedSourceScript: fileIdentity.optional(),
-  localModScript: fileIdentity.optional(),
-  deployedModScript: fileIdentity.optional(),
-  localModScriptContent: fileContentProof.optional(),
-  deployedModScriptContent: fileContentProof.optional(),
-});
+const materializationStatus = Type.Object(
+  {
+    mode: Type.Optional(Type.String()),
+    path: Type.Optional(Type.String()),
+    mapScript: Type.Optional(Type.String()),
+    configHash: Type.Optional(Type.String()),
+    envelopeHash: Type.Optional(Type.String()),
+    sourceConfig: Type.Optional(fileIdentity),
+    generatedSourceScript: Type.Optional(fileIdentity),
+    localModScript: Type.Optional(fileIdentity),
+    deployedModScript: Type.Optional(fileIdentity),
+    localModScriptContent: Type.Optional(fileContentProof),
+    deployedModScriptContent: Type.Optional(fileContentProof),
+  },
+  { additionalProperties: false },
+);
 
 // RunInGameRequestStatus
-const requestStatus = z.object({
-  recipeId: z.string().optional(),
-  seed: z.number().optional(),
-  mapSize: z.string().optional(),
-  playerCount: z.number().optional(),
-  resources: z.string().optional(),
-  selectedConfigId: z.string().optional(),
-  setupConfig: z.unknown().optional(),
-  setupConfigSource: z.string().optional(),
-  materializationMode: z.string().optional(),
-  restartCivProcess: z.boolean().optional(),
-  fingerprint: z.string().optional(),
-  sourceSnapshot: sourceSnapshotProof.optional(),
-});
+const requestStatus = Type.Object(
+  {
+    recipeId: Type.Optional(Type.String()),
+    seed: Type.Optional(Type.Number()),
+    mapSize: Type.Optional(Type.String()),
+    playerCount: Type.Optional(Type.Number()),
+    resources: Type.Optional(Type.String()),
+    selectedConfigId: Type.Optional(Type.String()),
+    setupConfig: Type.Optional(Type.Unknown()),
+    setupConfigSource: Type.Optional(Type.String()),
+    materializationMode: Type.Optional(Type.String()),
+    restartCivProcess: Type.Optional(Type.Boolean()),
+    fingerprint: Type.Optional(Type.String()),
+    sourceSnapshot: Type.Optional(sourceSnapshotProof),
+  },
+  { additionalProperties: false },
+);
 
-// RunInGameProcessRestartStatus — { command?, launchAttempts?, [key]: unknown }
-const processRestartStatus = z
-  .object({
-    command: z.string().optional(),
-    launchAttempts: z.unknown().optional(),
-  })
-  .catchall(z.unknown());
+// RunInGameProcessRestartStatus - { command?, launchAttempts?, [key]: unknown }
+const processRestartStatus = Type.Object(
+  {
+    command: Type.Optional(Type.String()),
+    launchAttempts: Type.Optional(Type.Unknown()),
+  },
+  { additionalProperties: Type.Unknown() },
+);
 
-// RunInGameFailureDetails — open record with known optional fields.
-const failureDetails = z
-  .object({
-    failureClass: z.string().optional(),
-    code: z.string().optional(),
-    phase: runInGamePhase.optional(),
-    mapScript: z.string().optional(),
-    materialization: materializationStatus.optional(),
-    reloadRequired: z.boolean().optional(),
-    reloadBoundary: z.string().optional(),
-    reloadAttempted: z.boolean().optional(),
-    dismissNotificationRequired: z.boolean().optional(),
-    recoveryBoundary: z.string().optional(),
-    recoveryHint: z.string().optional(),
-    completedPhases: z.array(runInGamePhase).optional(),
-    directControlCode: z.string().optional(),
-    cause: z.unknown().optional(),
-  })
-  .catchall(z.unknown());
+// RunInGameFailureDetails - open record with known optional fields.
+const failureDetails = Type.Object(
+  {
+    failureClass: Type.Optional(Type.String()),
+    code: Type.Optional(Type.String()),
+    phase: Type.Optional(runInGamePhase),
+    mapScript: Type.Optional(Type.String()),
+    materialization: Type.Optional(materializationStatus),
+    reloadRequired: Type.Optional(Type.Boolean()),
+    reloadBoundary: Type.Optional(Type.String()),
+    reloadAttempted: Type.Optional(Type.Boolean()),
+    dismissNotificationRequired: Type.Optional(Type.Boolean()),
+    recoveryBoundary: Type.Optional(Type.String()),
+    recoveryHint: Type.Optional(Type.String()),
+    completedPhases: Type.Optional(Type.Array(runInGamePhase)),
+    directControlCode: Type.Optional(Type.String()),
+    cause: Type.Optional(Type.Unknown()),
+  },
+  { additionalProperties: Type.Unknown() },
+);
 
-// RunInGameExactAuthorshipProof — large nested proof. The `log` sub-tree is deep
-// and opaque (proof markers, per-domain stats) — modelled permissively; the stable
+// RunInGameExactAuthorshipProof - large nested proof. The `log` sub-tree is deep
+// and opaque (proof markers, per-domain stats) - modelled permissively; the stable
 // top-level shape (status/requestId/createdAt/request/materialization/civSetup/
 // runtime/unresolvedLinks) is reproduced.
-const exactAuthorshipProof = z.object({
-  status: z.enum(["complete", "unresolved"]),
-  requestId: z.string(),
-  createdAt: z.string(),
-  sourceSnapshot: sourceSnapshotProof.optional(),
-  request: z.object({
-    recipeId: z.string().optional(),
-    seed: z.number().optional(),
-    mapSize: z.string().optional(),
-    playerCount: z.number().optional(),
-    resources: z.string().optional(),
-    selectedConfigId: z.string().optional(),
-    setupConfigSource: z.string().optional(),
-    fingerprint: z.string().optional(),
-  }),
-  materialization: materializationStatus,
-  civSetup: z
-    .object({
-      mapScript: z.string().optional(),
-      mapSize: z.unknown().optional(),
-      mapSeed: z.unknown().optional(),
-      gameSeed: z.unknown().optional(),
-      playerCount: z.unknown().optional(),
-      rowCount: z.number().optional(),
-    })
-    .catchall(z.unknown()),
-  runtime: z
-    .object({
-      seed: z.number().optional(),
-      width: z.number().optional(),
-      height: z.number().optional(),
-      plotCount: z.number().optional(),
-      turn: z.number().optional(),
-      gameHash: z.number().optional(),
-      sourceSnapshotId: z.string().optional(),
-      snapshotHash: z.string().optional(),
-    })
-    .catchall(z.unknown()),
-  // RunInGameExactAuthorshipProof["log"] — deep proof payload. Opaque (see shared.ts).
-  log: unknownRecord.optional(),
-  unresolvedLinks: z.array(z.string()),
-});
+const exactAuthorshipProof = Type.Object(
+  {
+    status: Type.Union([Type.Literal("complete"), Type.Literal("unresolved")]),
+    requestId: Type.String(),
+    createdAt: Type.String(),
+    sourceSnapshot: Type.Optional(sourceSnapshotProof),
+    request: Type.Object(
+      {
+        recipeId: Type.Optional(Type.String()),
+        seed: Type.Optional(Type.Number()),
+        mapSize: Type.Optional(Type.String()),
+        playerCount: Type.Optional(Type.Number()),
+        resources: Type.Optional(Type.String()),
+        selectedConfigId: Type.Optional(Type.String()),
+        setupConfigSource: Type.Optional(Type.String()),
+        fingerprint: Type.Optional(Type.String()),
+      },
+      { additionalProperties: false },
+    ),
+    materialization: materializationStatus,
+    civSetup: Type.Object(
+      {
+        mapScript: Type.Optional(Type.String()),
+        mapSize: Type.Optional(Type.Unknown()),
+        mapSeed: Type.Optional(Type.Unknown()),
+        gameSeed: Type.Optional(Type.Unknown()),
+        playerCount: Type.Optional(Type.Unknown()),
+        rowCount: Type.Optional(Type.Number()),
+      },
+      { additionalProperties: Type.Unknown() },
+    ),
+    runtime: Type.Object(
+      {
+        seed: Type.Optional(Type.Number()),
+        width: Type.Optional(Type.Number()),
+        height: Type.Optional(Type.Number()),
+        plotCount: Type.Optional(Type.Number()),
+        turn: Type.Optional(Type.Number()),
+        gameHash: Type.Optional(Type.Number()),
+        sourceSnapshotId: Type.Optional(Type.String()),
+        snapshotHash: Type.Optional(Type.String()),
+      },
+      { additionalProperties: Type.Unknown() },
+    ),
+    // RunInGameExactAuthorshipProof["log"] - deep proof payload. Opaque (see shared.ts).
+    log: Type.Optional(unknownRecordSchema),
+    unresolvedLinks: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
 
 /**
- * `RunInGameOperationStatus` — the operation state returned by BOTH start (#14,
+ * `RunInGameOperationStatus` - the operation state returned by BOTH start (#14,
  * 202) and status-poll (#13, 200), reproduced from features/runInGame/status.ts.
  */
-export const operationStatusSchema = z.object({
-  ok: z.boolean(),
-  requestId: z.string(),
-  phase: runInGamePhase,
-  status: runInGameOperationKind,
-  startedAt: z.string(),
-  updatedAt: z.string(),
-  serverInstanceId: z.string().optional(),
-  serverStartedAt: z.string().optional(),
-  completedPhases: z.array(runInGamePhase),
-  request: requestStatus.optional(),
-  materialization: materializationStatus.optional(),
-  processRestart: processRestartStatus.optional(),
-  exactAuthorshipProof: exactAuthorshipProof.optional(),
-  error: z.string().optional(),
-  details: failureDetails.optional(),
-  result: z.unknown().optional(),
-  recoveryActions: z.array(z.string()).optional(),
-});
+const operationStatusTypeSchema = Type.Object(
+  {
+    ok: Type.Boolean(),
+    requestId: Type.String(),
+    phase: runInGamePhase,
+    status: runInGameOperationKind,
+    startedAt: Type.String(),
+    updatedAt: Type.String(),
+    serverInstanceId: Type.Optional(Type.String()),
+    serverStartedAt: Type.Optional(Type.String()),
+    completedPhases: Type.Array(runInGamePhase),
+    request: Type.Optional(requestStatus),
+    materialization: Type.Optional(materializationStatus),
+    processRestart: Type.Optional(processRestartStatus),
+    exactAuthorshipProof: Type.Optional(exactAuthorshipProof),
+    error: Type.Optional(Type.String()),
+    details: Type.Optional(failureDetails),
+    result: Type.Optional(Type.Unknown()),
+    recoveryActions: Type.Optional(Type.Array(Type.String())),
+  },
+  { additionalProperties: false },
+);
+
+export const operationStatusSchema = contractSchema(operationStatusTypeSchema);
 
 // ---------------------------------------------------------------------------
-// #13 runInGame.status — GET /api/civ7/run-in-game/status?requestId=
+// #13 runInGame.status - GET /api/civ7/run-in-game/status?requestId=
 // ---------------------------------------------------------------------------
 // Query: requestId (REQUIRED). Success 200: RunInGameOperationState.
 // Errors: 400 { ok:false, error:"Missing requestId" };
 //         404 { ok:false, error, serverInstanceId, serverStartedAt }.
 //
-// PARITY INVARIANT (audit/05 #13, target-arch §1): the 404 echoes
+// PARITY INVARIANT (audit/05 #13, target-arch section 1): the 404 echoes
 // `serverInstanceId`/`serverStartedAt` so the client detects a server restart that
-// lost the op. TTL pruning (30min) → pruned op yields 404. The miss is the defined
+// lost the op. TTL pruning (30min) -> pruned op yields 404. The miss is the defined
 // `RUN_IN_GAME_STATUS_NOT_FOUND` error (./errors.ts), whose `data` carries the echo.
 export const status = oc
   .errors(runInGameErrors)
   .input(
-    z.object({
-      requestId: z.string().min(1),
-    }),
+    contractSchema(
+      Type.Object(
+        {
+          requestId: Type.String({ minLength: 1 }),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   )
   .output(operationStatusSchema);
 
 // ---------------------------------------------------------------------------
-// #14 runInGame.start — POST /api/civ7/run-in-game
+// #14 runInGame.start - POST /api/civ7/run-in-game
 // ---------------------------------------------------------------------------
 // Body: the full setup request. Success 202: RunInGameOperationState (async).
-// 202 dup (same fingerprint → details.duplicateRequest). Errors: 409 (run-in-game
+// 202 dup (same fingerprint -> details.duplicateRequest). Errors: 409 (run-in-game
 // OR save/deploy active), 400/500/503 via StudioEngineError (details carries
-// code/materialization/recovery boundaries) — declared as the defined
+// code/materialization/recovery boundaries) - declared as the defined
 // RUN_IN_GAME_BLOCKED/INVALID/FAILED/UNAVAILABLE codes (./errors.ts).
 //
-// SECURITY BOUNDARY (target-arch §1): the handler runs `assertNoRawControlFields`
-// — a deep scan rejecting `command|script|javascript|rawJs|rawCommand` keys. The
+// SECURITY BOUNDARY (target-arch section 1): the handler runs `assertNoRawControlFields`
+// - a deep scan rejecting `command|script|javascript|rawJs|rawCommand` keys. The
 // input is therefore intentionally permissive at the contract layer (the deep scan
 // + recipe pinning + kebab-case id + seed/mapSize/playerCount validation live in
 // `parseRunInGameSetupRequest`, ported in A2/A3). Known top-level fields are typed;
@@ -242,46 +280,52 @@ export const status = oc
 export const start = oc
   .errors(runInGameErrors)
   .input(
-    z
-      .object({
-        recipeId: z.string().optional(),
-        seed: z.union([z.number(), z.string()]).optional(),
-        mapSize: z.string().optional(),
-        playerCount: z.number().int().optional(),
-        resources: z.string().optional(),
-        materialization: z
-          .object({
-            mode: z.string(),
-          })
-          .optional(),
-        recovery: z
-          .object({
-            restartCivProcess: z.boolean().optional(),
-          })
-          .optional(),
-        setupConfig: z.unknown().optional(),
-        config: z.unknown().optional(),
-        sourceSnapshot: z.unknown().optional(),
-        selectedConfig: z
-          .object({
-            // `id` is OPTIONAL: disposable runs send `selectedConfig` without one,
-            // and `parseRunInGameSetupRequest` (apps/.../server/runInGame/
-            // requestValidation.ts) reads `selected.id` defensively (defaulting to
-            // "studio-current" when absent). Declaring it required forced the caller
-            // to launder the request through an `as unknown as Parameters<…>` cast;
-            // making it optional here aligns the contract with the validator + engine
-            // and restores end-to-end input type safety on the
-            // `assertNoRawControlFields`-protected start path.
-            id: z.string().optional(),
-            label: z.string().optional(),
-            description: z.string().optional(),
-            sourcePath: z.string().optional(),
-            sortIndex: z.number().optional(),
-            latitudeBounds: z.unknown().optional(),
-          })
-          .optional(),
-      })
-      // Preserve unknown keys so `assertNoRawControlFields` can inspect/reject them.
-      .catchall(z.unknown()),
+    contractSchema(
+      Type.Object(
+        {
+          recipeId: Type.Optional(Type.String()),
+          seed: Type.Optional(Type.Union([Type.Number(), Type.String()])),
+          mapSize: Type.Optional(Type.String()),
+          playerCount: Type.Optional(Type.Integer()),
+          resources: Type.Optional(Type.String()),
+          materialization: Type.Optional(
+            Type.Object(
+              {
+                mode: Type.String(),
+              },
+              { additionalProperties: false },
+            ),
+          ),
+          recovery: Type.Optional(
+            Type.Object(
+              {
+                restartCivProcess: Type.Optional(Type.Boolean()),
+              },
+              { additionalProperties: false },
+            ),
+          ),
+          setupConfig: Type.Optional(Type.Unknown()),
+          config: Type.Optional(Type.Unknown()),
+          sourceSnapshot: Type.Optional(Type.Unknown()),
+          selectedConfig: Type.Optional(
+            Type.Object(
+              {
+                // `id` is OPTIONAL: disposable runs send `selectedConfig` without one,
+                // and `parseRunInGameSetupRequest` reads `selected.id` defensively.
+                id: Type.Optional(Type.String()),
+                label: Type.Optional(Type.String()),
+                description: Type.Optional(Type.String()),
+                sourcePath: Type.Optional(Type.String()),
+                sortIndex: Type.Optional(Type.Number()),
+                latitudeBounds: Type.Optional(Type.Unknown()),
+              },
+              { additionalProperties: false },
+            ),
+          ),
+        },
+        // Preserve unknown keys so `assertNoRawControlFields` can inspect/reject them.
+        { additionalProperties: Type.Unknown() },
+      ),
+    ),
   )
   .output(operationStatusSchema);

--- a/packages/studio-server/src/contract/shared.ts
+++ b/packages/studio-server/src/contract/shared.ts
@@ -1,44 +1,41 @@
-import { z } from "zod";
+import { Type, type TSchema } from "typebox";
+
+import { toStandardSchema } from "../typeboxStandardSchema.js";
 
 /**
- * Shared Zod building blocks for the legacy studio-server success I/O
- * contracts. New durable contract schema surfaces should prefer
- * TypeBox/Standard Schema unless a slice records a different schema-tech
- * decision.
+ * Shared TypeBox building blocks for the studio-server success I/O contracts.
  *
- * Contract-first design note: the studio API's *stable surface* is the response
- * envelope (the `{ ok, ... }` wrappers, `observedAt`, status-code semantics). The
- * deep payloads returned by `@civ7/direct-control` (map summaries, app-UI snapshots,
- * map grids, GameInfo rows, etc.) are large, internal result types that are NOT
- * anchored to any app `status.ts` type and are not part of the contract's drift
- * surface. They are modelled here as permissive schemas (`unknownRecord` /
- * `z.unknown()`); reproducing ~500 lines of direct-control internals here would be
- * brittle and is explicitly out of scope for slice A1 (contracts only, no logic).
- *
- * Where the audit (audit/05-server-contracts.md) anchors an output to an existing
- * app type (`RunInGameOperationStatus`, `MapConfigSaveDeployStatus`,
- * `Civ7SetupCatalog`), the schema is reproduced faithfully in the relevant module.
+ * Contract-first design note: the studio API's stable surface is the response
+ * envelope (`{ ok, ... }`, `observedAt`, status-code semantics). Deep payloads
+ * returned by `@civ7/direct-control` are large internal result types, so the
+ * contract models those payloads as permissive records instead of duplicating
+ * their internals here.
  */
 
-/** A JSON object with unknown values — used for opaque direct-control payloads. */
-export const unknownRecord = z.record(z.string(), z.unknown());
-
-/** A single GameInfo DB row (column name → value). */
-export const gameInfoRow = z.record(z.string(), z.unknown());
+/** A JSON object with unknown values, used for opaque direct-control payloads. */
+export const unknownRecordSchema = Type.Record(Type.String(), Type.Unknown());
 
 /** ISO-8601 timestamp string (`new Date().toISOString()` on the server). */
-export const isoTimestamp = z.string();
+export const isoTimestampSchema = Type.String();
+
+/** Empty request body/query object. */
+export const emptyInputSchema = toStandardSchema(
+  Type.Object({}, { additionalProperties: false }),
+);
+
+/** Convert a TypeBox schema to the Standard Schema artifact oRPC consumes. */
+export function contractSchema<TypeSchema extends TSchema>(schema: TypeSchema) {
+  return toStandardSchema(schema);
+}
 
 /**
- * The uniform failure body most endpoints emit: `{ ok: false, error }`. Some
- * endpoints additionally include `observedAt` and/or `details` — those are added
- * per-procedure. NOTE: these are documentation of the *current* HTTP error bodies;
- * the actual Effect-failure → status-code mapping lands in slice A3 (errorMap
- * middleware), where the NON-UNIFORM status codes (400/409/500/503) are reproduced
- * per procedure. Contracts here capture the success outputs; error shapes are noted
- * as comments on each procedure.
+ * The uniform failure body most endpoints emit: `{ ok: false, error }`.
+ * Procedure-specific transport errors are declared in `errors.ts`.
  */
-export const errorEnvelope = z.object({
-  ok: z.literal(false),
-  error: z.string(),
-});
+export const errorEnvelopeSchema = Type.Object(
+  {
+    ok: Type.Literal(false),
+    error: Type.String(),
+  },
+  { additionalProperties: false },
+);

--- a/packages/studio-server/src/contract/studio.ts
+++ b/packages/studio-server/src/contract/studio.ts
@@ -1,37 +1,39 @@
 import { eventIterator, oc } from "@orpc/contract";
 import { Type, type Static } from "typebox";
-import { z } from "zod";
 
 import { toStandardSchema } from "../typeboxStandardSchema.js";
 import { liveGameStateSchema } from "../liveGame/model.js";
-import { isoTimestamp } from "./shared.js";
+import { contractSchema, emptyInputSchema, isoTimestampSchema } from "./shared.js";
 
 /**
- * `studio.*` namespace — server identity / API version.
+ * `studio.*` namespace - server identity / API version.
  *
  * Source of truth: audit/05-server-contracts.md endpoint #9.
  */
 
 // ---------------------------------------------------------------------------
-// #9 studio.serverInfo — GET /api/studio/server-info
+// #9 studio.serverInfo - GET /api/studio/server-info
 // ---------------------------------------------------------------------------
 // Request: none. Success 200: { ok:true, serverInstanceId, startedAt,
 // runInGameApiVersion: 2, viteCommand }. No errors (pure).
 //
-// PARITY NOTE (audit/05 #9, target-arch §1): `serverInstanceId`/`startedAt` are
+// PARITY NOTE (audit/05 #9, target-arch section 1): `serverInstanceId`/`startedAt` are
 // process-lifetime singletons; clients reconcile run-in-game state against them
 // (restart detection). `runInGameApiVersion` is the fixed literal 2.
-export const serverInfo = oc.input(z.object({})).output(
-  z.object({
-    ok: z.literal(true),
-    serverInstanceId: z.string(),
-    startedAt: isoTimestamp,
-    runInGameApiVersion: z.literal(2),
-    viteCommand: z.string(),
-  }),
+export const serverInfo = oc.input(emptyInputSchema).output(
+  contractSchema(
+    Type.Object(
+      {
+        ok: Type.Literal(true),
+        serverInstanceId: Type.String(),
+        startedAt: isoTimestampSchema,
+        runInGameApiVersion: Type.Literal(2),
+        viteCommand: Type.String(),
+      },
+      { additionalProperties: false },
+    ),
+  ),
 );
-
-const operationsCurrentInputSchema = toStandardSchema(Type.Object({}, { additionalProperties: false }));
 
 const runInGamePhaseSchema = Type.Union([
   Type.Literal("idle"),
@@ -196,20 +198,20 @@ export type StudioLiveGameEvent = Static<typeof studioLiveGameEventSchema>;
 export type StudioEvent = Static<typeof studioEventSchema>;
 
 // ---------------------------------------------------------------------------
-// S2.1 studio.operations.current — daemon-owned operation recovery
+// S2.1 studio.operations.current - daemon-owned operation recovery
 // ---------------------------------------------------------------------------
 // Request: none. Success 200: daemon identity + active/recent Run in Game and
 // Save&Deploy operation snapshots. Fresh daemon truthfully returns empty
 // registries; operation durability across restart is out of scope by design.
 export const operationsCurrent = oc
-  .input(operationsCurrentInputSchema)
+  .input(emptyInputSchema)
   .output(operationsCurrentOutputStandardSchema);
 
 // ---------------------------------------------------------------------------
-// S3.1 studio.events.watch — daemon-owned runtime event stream
+// S3.1 studio.events.watch - daemon-owned runtime event stream
 // ---------------------------------------------------------------------------
 // Request: none. Output: event iterator over the sealed TypeBox event category.
 // The router emits an immediate `hello`, then yields the daemon-owned EventHub.
 export const eventsWatch = oc
-  .input(operationsCurrentInputSchema)
+  .input(emptyInputSchema)
   .output(studioEventIteratorSchema);

--- a/packages/studio-server/src/router/index.ts
+++ b/packages/studio-server/src/router/index.ts
@@ -14,16 +14,16 @@ import { StudioEventHub } from "../services/StudioEventHub.js";
 /**
  * effect-orpc router for `@civ7/studio-server` (slice A3).
  *
- * This is the ONLY module that imports `effect-orpc` (research/01 §6 isolation
- * rule). Each leaf is `implementEffect(...).<ns>.<proc>.effect(function*(){…})`.
+ * This is the ONLY module that imports `effect-orpc` (research/01 section 6 isolation
+ * rule). Each leaf is `implementEffect(...).<ns>.<proc>.effect(function*(){...})`.
  * The procedure bodies lift the corresponding `/api/*` handler logic from
  * `apps/mapgen-studio/vite.config.ts` verbatim:
  *
- *   - Read procedures call `Civ7TunerClient` (→ `@civ7/direct-control`) and map a
+ *   - Read procedures call `Civ7TunerClient` (-> `@civ7/direct-control`) and map a
  *     failure to its DECLARED contract error via the typed `errors.CODE(...)`
  *     constructor param (contract/errors.ts). The codes pin the EXACT legacy
- *     status — they are NON-UNIFORM (gameInfo/live.* → 400, setupConfig → 503,
- *     most → 500), the do-not-break registry (architecture/10 §7).
+ *     status - they are NON-UNIFORM (gameInfo/live.* -> 400, setupConfig -> 503,
+ *     most -> 500), the do-not-break registry (architecture/10 section 7).
  *   - `civ7.live.status` runs the four reads under `Effect.all({ mode: "either" })`
  *     (the `Promise.allSettled` analogue) and embeds `{ error }` per field at 200;
  *     only an outer defect yields a transport error. PARITY INVARIANT.
@@ -37,11 +37,11 @@ import { StudioEventHub } from "../services/StudioEventHub.js";
  * Query parsing parity (clamps, csv split/trim/filter, playerId omit) that the
  * legacy handlers did from the URL is reproduced here against the typed input.
  */
-// Return type is the CONTRACT-DERIVED `Router<StudioContract, …>` rather than the
+// Return type is the CONTRACT-DERIVED `Router<StudioContract, ...>` rather than the
 // lossy `AnyRouter`: the effect-orpc `oe.router(...)` result is pinned to
 // `StudioContract`, and its initial context is fully provided by the injected
 // `ManagedRuntime` (so `Record<never, never>`). Annotating it portably (instead of
-// inferring `EnhancedRouter<…>`, which would reference effect-orpc internals and
+// inferring `EnhancedRouter<...>`, which would reference effect-orpc internals and
 // trip TS2742 in the emitted `.d.ts`) keeps `StudioRouter` contract-typed.
 export function createStudioRouter(
   runtime: StudioRuntime,
@@ -50,7 +50,7 @@ export function createStudioRouter(
 
   return oe.router({
     civ7: {
-      // #1 GET /api/civ7/status — error 500
+      // #1 GET /api/civ7/status - error 500
       status: oe.civ7.status.effect(function* ({ errors }) {
         const status = yield* Civ7TunerClient.playableStatus().pipe(
           Effect.mapError((err) =>
@@ -62,7 +62,7 @@ export function createStudioRouter(
         return { ok: status.playable, status: status as Record<string, unknown> };
       }),
 
-      // #2 GET /api/civ7/map-summary — error 500
+      // #2 GET /api/civ7/map-summary - error 500
       mapSummary: oe.civ7.mapSummary.effect(function* ({ errors }) {
         const summary = yield* Civ7TunerClient.mapSummary().pipe(
           Effect.mapError((err) =>
@@ -74,9 +74,9 @@ export function createStudioRouter(
         return { ok: true as const, summary: summary as Record<string, unknown> };
       }),
 
-      // #3 GET /api/civ7/gameinfo?table=&limit= — error 400 (NOT 500)
+      // #3 GET /api/civ7/gameinfo?table=&limit= - error 400 (NOT 500)
       gameInfo: oe.civ7.gameInfo.effect(function* ({ input, errors }) {
-        const rows = yield* Civ7TunerClient.gameInfoRows(input.table, input.limit).pipe(
+        const rows = yield* Civ7TunerClient.gameInfoRows(input.table, input.limit ?? 100).pipe(
           Effect.mapError((err) =>
             errors.CIV7_GAMEINFO_FAILED({
               message: errorMessage(err, "Civ7 GameInfo request failed"),
@@ -87,7 +87,7 @@ export function createStudioRouter(
         return { ok: true as const, rows: rows as unknown as Record<string, unknown> };
       }),
 
-      // #8 POST /api/civ7/autoplay — host engine; 409 mutex / 500
+      // #8 POST /api/civ7/autoplay - host engine; 409 mutex / 500
       autoplay: oe.civ7.autoplay.effect(function* ({ input, errors }) {
         const config = yield* StudioConfig;
         return yield* Effect.tryPromise({
@@ -104,7 +104,7 @@ export function createStudioRouter(
         );
       }),
 
-      // #10 GET /api/civ7/setup-config — error 503 (UNIQUE), body carries observedAt
+      // #10 GET /api/civ7/setup-config - error 503 (UNIQUE), body carries observedAt
       setupConfig: oe.civ7.setupConfig.effect(function* ({ errors }) {
         const snapshot = yield* Civ7TunerClient.setupSnapshot().pipe(
           Effect.mapError((err) =>
@@ -124,7 +124,7 @@ export function createStudioRouter(
         };
       }),
 
-      // #11 GET /api/civ7/saved-configs — error 500, body carries observedAt
+      // #11 GET /api/civ7/saved-configs - error 500, body carries observedAt
       savedConfigs: oe.civ7.savedConfigs.effect(function* ({ errors }) {
         const result = yield* Civ7TunerClient.savedConfigurations().pipe(
           Effect.mapError((err) =>
@@ -142,7 +142,7 @@ export function createStudioRouter(
         };
       }),
 
-      // #12 GET /api/civ7/setup-catalog — host loader; error 500
+      // #12 GET /api/civ7/setup-catalog - host loader; error 500
       setupCatalog: oe.civ7.setupCatalog.effect(function* ({ errors }) {
         const config = yield* StudioConfig;
         const catalog = yield* Effect.tryPromise(() => config.loadSetupCatalog()).pipe(
@@ -157,20 +157,25 @@ export function createStudioRouter(
       }),
 
       live: {
-        // #4 GET /api/civ7/live/status — 200-with-embedded-{error}; allSettled
+        // #4 GET /api/civ7/live/status - 200-with-embedded-{error}; allSettled
         status: oe.civ7.live.status.effect(function* () {
           return yield* readLiveGameStatusBody;
         }),
 
-        // #5 GET /api/civ7/live/snapshot — error 400; clamps + csv parse parity
+        // #5 GET /api/civ7/live/snapshot - error 400; clamps + csv parse parity
         snapshot: oe.civ7.live.snapshot.effect(function* ({ input, errors }) {
-          const fields = input.fields
+          const fields = (input.fields ?? "terrain,biome,feature,resource,visibility,owner")
             .split(",")
             .map((field) => field.trim())
             .filter(Boolean) as Parameters<Civ7TunerClient["mapGrid"]>[0]["fields"];
-          const maxPlots = Math.min(512, Math.max(1, input.maxPlots));
+          const maxPlots = Math.min(512, Math.max(1, input.maxPlots ?? 512));
           const grid = yield* Civ7TunerClient.mapGrid({
-            bounds: { x: input.x, y: input.y, width: input.width, height: input.height },
+            bounds: {
+              x: input.x ?? 0,
+              y: input.y ?? 0,
+              width: input.width ?? 24,
+              height: input.height ?? 18,
+            },
             fields,
             maxPlots,
             ...(input.playerId === undefined ? {} : { playerId: input.playerId }),
@@ -188,9 +193,9 @@ export function createStudioRouter(
           };
         }),
 
-        // #6 GET /api/civ7/live/entities — error 400; Promise.all (any failure → 400)
+        // #6 GET /api/civ7/live/entities - error 400; Promise.all (any failure -> 400)
         entities: oe.civ7.live.entities.effect(function* ({ input, errors }) {
-          const maxItems = Math.min(128, Math.max(1, input.maxItems));
+          const maxItems = Math.min(128, Math.max(1, input.maxItems ?? 128));
           const playerId = input.playerId;
           const result = yield* Effect.all(
             {
@@ -224,14 +229,14 @@ export function createStudioRouter(
           };
         }),
 
-        // #7 GET /api/civ7/live/gameinfo — error 400; 8-table cap, N parallel reads
+        // #7 GET /api/civ7/live/gameinfo - error 400; 8-table cap, N parallel reads
         gameInfo: oe.civ7.live.gameInfo.effect(function* ({ input, errors }) {
-          const tables = input.tables
+          const tables = (input.tables ?? "Terrains,Biomes,Features,Resources,Maps,MapSizes")
             .split(",")
             .map((table) => table.trim())
             .filter(Boolean)
             .slice(0, 8);
-          const limit = Math.min(200, Math.max(1, input.limit));
+          const limit = Math.min(200, Math.max(1, input.limit ?? 100));
           const entries = yield* Effect.all(
             tables.map((table) =>
               Civ7TunerClient.gameInfoRows(table, limit).pipe(
@@ -260,7 +265,7 @@ export function createStudioRouter(
     },
 
     runInGame: {
-      // #14 POST /api/civ7/run-in-game — host engine; 409/400/500/503
+      // #14 POST /api/civ7/run-in-game - host engine; 409/400/500/503
       start: oe.runInGame.start.effect(function* ({ input, errors }) {
         const config = yield* StudioConfig;
         return yield* Effect.tryPromise({
@@ -275,7 +280,7 @@ export function createStudioRouter(
         );
       }),
 
-      // #13 GET /api/civ7/run-in-game/status — host store; 404 echoes server id
+      // #13 GET /api/civ7/run-in-game/status - host store; 404 echoes server id
       status: oe.runInGame.status.effect(function* ({ input, errors }) {
         const config = yield* StudioConfig;
         return yield* Effect.tryPromise({
@@ -294,7 +299,7 @@ export function createStudioRouter(
     },
 
     mapConfigs: {
-      // #16 POST /api/map-configs — host engine; 409 mutex / 400 validation
+      // #16 POST /api/map-configs - host engine; 409 mutex / 400 validation
       saveDeploy: oe.mapConfigs.saveDeploy.effect(function* ({ input, errors }) {
         const config = yield* StudioConfig;
         return yield* Effect.tryPromise({
@@ -309,7 +314,7 @@ export function createStudioRouter(
         );
       }),
 
-      // #15 GET /api/map-configs/status — host store; 404 (no server id echo)
+      // #15 GET /api/map-configs/status - host store; 404 echoes server id
       status: oe.mapConfigs.status.effect(function* ({ input, errors }) {
         const config = yield* StudioConfig;
         return yield* Effect.tryPromise({
@@ -328,7 +333,7 @@ export function createStudioRouter(
     },
 
     studio: {
-      // #9 GET /api/studio/server-info — pure; no errors
+      // #9 GET /api/studio/server-info - pure; no errors
       serverInfo: oe.studio.serverInfo.effect(function* () {
         const config = yield* StudioConfig;
         return {
@@ -366,7 +371,7 @@ export function createStudioRouter(
     recipeDag: {
       // Recipe-DAG projection (runtime-one-mount slice; formerly the
       // `/api/recipe-dag/rpc` satellite mount). The service is host-injected
-      // through the StudioConfig layer — the ONE runtime serves this
+      // through the StudioConfig layer - the ONE runtime serves this
       // namespace too; the former private empty ManagedRuntime is gone.
       get: oe.recipeDag.get.effect(function* ({ input, errors }) {
         const config = yield* StudioConfig;
@@ -396,7 +401,7 @@ export function createStudioRouter(
 }
 
 /**
- * The studio router type, contract-derived (`Router<StudioContract, …>`) rather
+ * The studio router type, contract-derived (`Router<StudioContract, ...>`) rather
  * than the lossy `AnyRouter`. `RPCHandler` accepts it (`AnyRouter` is its lower
  * bound), and the handler module re-exports it.
  */

--- a/packages/studio-server/src/typeboxStandardSchema.ts
+++ b/packages/studio-server/src/typeboxStandardSchema.ts
@@ -1,6 +1,7 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { Compile } from "typebox/compile";
 import type { Static, TSchema } from "typebox";
+import { Value } from "typebox/value";
 
 export function toStandardSchema<TypeSchema extends TSchema>(
   schema: TypeSchema,
@@ -12,7 +13,13 @@ export function toStandardSchema<TypeSchema extends TSchema>(
       version: 1,
       vendor: "typebox",
       validate(value) {
-        if (validator.Check(value)) return { value: value as Static<TypeSchema> };
+        try {
+          return { value: Value.Parse(schema, value) as Static<TypeSchema> };
+        } catch {
+          // Fall through to TypeBox's structural errors. `Value.Parse` is used
+          // first so contract schemas retain parser behavior such as stripping
+          // closed-object extras, matching the legacy Zod surface.
+        }
         return {
           issues: [...validator.Errors(value)].map((error) => ({
             message: error.message,

--- a/packages/studio-server/test/gameDoorInvariant.test.ts
+++ b/packages/studio-server/test/gameDoorInvariant.test.ts
@@ -1,0 +1,83 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const allowedConstructors = new Set([
+  "packages/studio-server/src/services/Civ7TunerSession.ts",
+  "packages/civ7-direct-control/src/session/session.ts",
+]);
+
+const scannedRoots = ["apps", "packages"] as const;
+const ignoredDirectoryNames = new Set([
+  ".git",
+  "coverage",
+  "dist",
+  "mod",
+  "node_modules",
+  "test",
+  "tests",
+  "types",
+]);
+
+describe("Civ7 game-door invariant", () => {
+  test("constructs Civ7DirectControlSession only at sanctioned owner paths", () => {
+    const repoRoot = findRepoRoot(dirname(fileURLToPath(import.meta.url)));
+    const violations: string[] = [];
+
+    for (const root of scannedRoots) {
+      for (const file of collectTsFiles(join(repoRoot, root))) {
+        const rel = normalizePath(relative(repoRoot, file));
+        if (allowedConstructors.has(rel)) continue;
+
+        const text = readFileSync(file, "utf8");
+        if (/\bnew\s+Civ7DirectControlSession\s*\(/.test(text)) {
+          violations.push(rel);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});
+
+function findRepoRoot(start: string): string {
+  let current = start;
+  while (current !== dirname(current)) {
+    if (fileExists(join(current, "pnpm-workspace.yaml")) || fileExists(join(current, "bun.lock"))) {
+      return current;
+    }
+    current = dirname(current);
+  }
+  throw new Error(`Could not resolve repo root from ${start}`);
+}
+
+function collectTsFiles(root: string): string[] {
+  const out: string[] = [];
+  collect(root, out);
+  return out;
+}
+
+function collect(path: string, out: string[]): void {
+  const stats = statSync(path);
+  if (stats.isDirectory()) {
+    const name = path.split("/").at(-1);
+    if (name && ignoredDirectoryNames.has(name)) return;
+    for (const entry of readdirSync(path)) collect(join(path, entry), out);
+    return;
+  }
+  if (!stats.isFile()) return;
+  if (path.endsWith(".ts") || path.endsWith(".tsx")) out.push(path);
+}
+
+function fileExists(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function normalizePath(path: string): string {
+  return path.split("\\").join("/");
+}

--- a/packages/studio-server/tsup.config.ts
+++ b/packages/studio-server/tsup.config.ts
@@ -10,7 +10,7 @@ import { defineConfig } from "tsup";
  * Node) would crash on `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`. We therefore
  * BUNDLE `effect-orpc` into this package's `dist` (`noExternal`) so the shipped
  * `dist/index.js` is self-contained for that dependency. `@orpc/*`, `effect`, and
- * `zod` ship proper JS and stay external.
+ * TypeBox ship proper JS and stay external.
  */
 export default defineConfig({
   entry: ["src/index.ts", "src/contract/index.ts", "src/liveGame/model.ts"],


### PR DESCRIPTION
Closes the S4.1 runtime simplification slice by making Studio's game-wire ownership explicit and mechanically guarded.

## What Changed

- Added `docs/system/direct-control/GAME-DOOR-INVARIANT.md`, declaring that Studio may reach the game only through the daemon-owned `Civ7TunerSession` service or the bounded `withCiv7DirectControlSession` helper in `@civ7/direct-control`.
- Added `packages/studio-server/test/gameDoorInvariant.test.ts`, which fails on production `new Civ7DirectControlSession(...)` usage outside those two sanctioned owners.
- Migrated the remaining `@civ7/studio-server` contract schemas from Zod to TypeBox/Standard Schema and removed the package's direct `zod` dependency.
- Moved former Zod input defaults into router procedure logic, and updated `toStandardSchema` to parse with TypeBox first so closed-object extras are still stripped.
- Closed the leftover tuner-session work: the run-in-game convergence item is resolved by the invariant, and the restart recovery affordance is recorded as `DEF-015` in `docs/system/DEFERRALS.md`.
- Removed stale comments that still described the deleted `/api` coexistence path or browser-owned daemon truth.

## Behavior

Studio app code, router leaves, operation engines, and ad-hoc scripts no longer get to create direct-control sessions implicitly. Any future attempt to add a third game door should fail in the studio-server test suite and point back to the invariant doc.

## Verification

- `bun run --cwd packages/studio-server check`
- `bun run --cwd packages/studio-server test -- test/gameDoorInvariant.test.ts test/handler.test.ts`
- `bun run --cwd packages/studio-server test`
- `bun run --cwd packages/studio-server build`
- `bun run --cwd apps/mapgen-studio check`
- `bun run --cwd apps/mapgen-studio test -- test/server/oneMount.test.ts test/server/daemonFetch.test.ts`
- `bun run --cwd apps/mapgen-studio test`
- `bun run --cwd apps/mapgen-studio build`
- `bun run openspec -- validate mapgen-studio-game-door-invariant --strict`
- `bun run openspec -- validate mapgen-studio-tuner-session --strict`
- `bun run openspec:validate`
- `git diff --check`
- Negative source scans for `RunInGameHttpError`, deleted polling/watchdog bridges, satellite clients, stale RPC proxy paths, and direct Zod usage in studio-server contracts.