### PR TITLE
docs(mapgen-studio): close runtime simplification audit

### DIFF
--- a/openspec/changes/mapgen-studio-game-door-invariant/tasks.md
+++ b/openspec/changes/mapgen-studio-game-door-invariant/tasks.md
@@ -36,5 +36,5 @@
 - [x] 4.2 Record verification evidence and downstream realignment.
 - [x] 4.3 Submit the S4.1 Graphite branch as the final runtime simplification
       stack layer.
-- [ ] 4.4 Audit the full runtime simplification program before marking the
+- [x] 4.4 Audit the full runtime simplification program before marking the
       overarching goal complete.

--- a/openspec/changes/mapgen-studio-game-door-invariant/workstream/closure-checklist.md
+++ b/openspec/changes/mapgen-studio-game-door-invariant/workstream/closure-checklist.md
@@ -7,5 +7,6 @@
 - [x] Root OpenSpec validation passes.
 - [x] Focused package and app gates pass.
 - [x] Negative searches prove no live residue.
-- [x] Graphite branch submitted in the runtime simplification stack.
+- [x] Graphite branch submitted, merged, and locally drained in the runtime
+      simplification stack.
 - [x] Repo clean or handed off with explicit ownership.

--- a/openspec/changes/mapgen-studio-game-door-invariant/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-game-door-invariant/workstream/phase-record.md
@@ -6,7 +6,8 @@
 - Graphite branch: `codex/game-door-invariant`
 - Parent: `main` at `b4cc968f9`
 - Watcher: Rawls `019ec217-32d7-7561-9b52-768885b9fed8`
-- Status: implemented, locally verified, and submitted for review
+- Status: implemented, verified, submitted, merged, drained, and audited for
+  program closeout
 - Graphite PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1692
 
 ## Authority
@@ -49,6 +50,17 @@
 - `git diff --check` - passed.
 - `gt submit --stack --ai --no-interactive` - created draft PR #1692.
 - `gt submit --stack --publish --no-interactive --ai` - published PR #1692 for review.
+- PR metadata normalized to `refactor(studio-server): enforce game door invariant`
+  with the verification list in the PR body.
+- `gt merge --dry-run --no-interactive` - passed; Graphite reported only
+  `codex/game-door-invariant` ready to merge.
+- `gt merge --no-interactive` - merged PR #1692 at
+  `88048fe52e736f84c46afd2a9ad5f7d83a09abfe`.
+- `gt sync --no-restack --no-interactive --force` after detaching this worktree
+  from the merged branch - deleted local `codex/game-door-invariant`.
+- Program closeout audit - all runtime simplification OpenSpec slices report
+  complete, runtime residue searches are clean, and `mapgen-studio-game-door-invariant`
+  now reports 20/20 tasks.
 
 ## Live Proof Disposition
 


### PR DESCRIPTION
Marks the final S4.1 audit task complete after the game-door invariant PR (#1692) merged and the local branch was drained with `gt sync --no-restack --no-interactive --force`.

## What Changed

- Marks `mapgen-studio-game-door-invariant` task 4.4 complete.
- Updates the S4.1 closure checklist to say the Graphite branch was submitted, merged, and locally drained.
- Updates the phase record with PR #1692 merge evidence, PR metadata cleanup, Graphite dry-run/merge evidence, no-restack cleanup evidence, and the final program audit result.

## Verification

- `bun run openspec -- list` reports `mapgen-studio-game-door-invariant` complete.
- `bun run openspec -- validate mapgen-studio-game-door-invariant --strict`
- `bun run openspec:validate`
- `git diff --check`
- Negative scans for runtime simplification residue, studio-server contract Zod usage, and unsanctioned direct-control session construction.