### PR TITLE
`chore: add .nx/ to .gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ apps/docs/public/civ7-official/resources/
 
 # Turbo cache
 .turbo/
+.nx/
 
 # AI-generated artifacts and archives
 .ai/*


### PR DESCRIPTION
Add `.nx/` directory to `.gitignore` to prevent NX cache files from being tracked in version control.