### PR TITLE
fix(mapgen-studio): launch selected map in game

### DIFF
--- a/apps/mapgen-studio/src/server/runInGame/requestValidation.ts
+++ b/apps/mapgen-studio/src/server/runInGame/requestValidation.ts
@@ -54,11 +54,9 @@ export function parseRunInGameSetupRequest(body: {
   }
   const requestedMode = body.materialization?.mode === "durable" ? "durable" : "disposable";
   const selected = body.selectedConfig ?? {};
-  const id = requestedMode === "disposable"
-    ? "studio-current"
-    : typeof selected.id === "string" && /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(selected.id)
-      ? selected.id
-      : "studio-current";
+  const id = typeof selected.id === "string" && /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(selected.id)
+    ? selected.id
+    : "studio-current";
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id)) throw new Error("Run in Game map config id must be kebab-case");
   const seedPolicy = parseCiv7StudioSeed(body.seed);
   if (!seedPolicy.ok) throw new Error(`Run in Game ${formatCiv7StudioSeedError(seedPolicy)}`);

--- a/apps/mapgen-studio/src/server/studio/engines.ts
+++ b/apps/mapgen-studio/src/server/studio/engines.ts
@@ -816,10 +816,7 @@ export function createStudioEngines(options: Readonly<{ repoRoot: string; eventH
         materialized = await materializeRunInGameConfig({
           repoRoot,
           id,
-          sourcePath:
-            requestedMode === "durable" && typeof selected.sourcePath === "string"
-              ? selected.sourcePath
-              : undefined,
+          sourcePath: typeof selected.sourcePath === "string" ? selected.sourcePath : undefined,
           envelope,
           mode: requestedMode,
         });

--- a/apps/mapgen-studio/src/ui/components/GameConsole.tsx
+++ b/apps/mapgen-studio/src/ui/components/GameConsole.tsx
@@ -181,6 +181,7 @@ export const GameConsole: React.FC<GameConsoleProps> = ({
           ? "bg-warning"
           : "bg-muted-foreground";
   const runInGameButtonText = runInGamePrimaryActionLabel(runInGameStatus, runInGameCurrentRelation);
+  const visibleRunInGameButtonText = runInGameStatus ? runInGameButtonText : "Play";
   const liveSyncAvailable =
     liveRuntime?.status === "ok" &&
     liveGameStudioRelation === "stale" &&
@@ -353,7 +354,7 @@ export const GameConsole: React.FC<GameConsoleProps> = ({
         className={isRunInGameRunning ? 'shrink-0 opacity-70 cursor-wait' : 'shrink-0'}>
 
         <Rocket className="w-3 h-3" />
-        <span>{isRunInGameRunning ? 'Playing...' : 'Play'}</span>
+        <span>{isRunInGameRunning ? 'Playing...' : visibleRunInGameButtonText}</span>
       </Button>
 
       {statusOpen ? (

--- a/apps/mapgen-studio/test/runInGame/GameConsole.test.tsx
+++ b/apps/mapgen-studio/test/runInGame/GameConsole.test.tsx
@@ -99,6 +99,7 @@ describe("GameConsole Run in Game status", () => {
     }, "current");
 
     expect(html).toContain("Restart Civ &amp; Run");
+    expect(html).not.toContain(">Play<");
   });
 
   it("keeps map script fatal recovery on retry instead of process restart", () => {

--- a/apps/mapgen-studio/test/runInGame/requestValidation.test.ts
+++ b/apps/mapgen-studio/test/runInGame/requestValidation.test.ts
@@ -25,7 +25,7 @@ describe("Run in Game request validation", () => {
     })).toThrow("raw control commands");
   });
 
-  it("normalizes disposable setup requests to studio-current", () => {
+  it("keeps disposable setup requests on the selected shell-visible config id", () => {
     expect(parseRunInGameSetupRequest({
       recipeId: "mod-swooper-maps/standard",
       seed: "123",
@@ -36,7 +36,7 @@ describe("Run in Game request validation", () => {
       config: { ok: true },
     })).toEqual({
       requestedMode: "disposable",
-      id: "studio-current",
+      id: "swooper-earthlike",
       seed: 123,
       mapSize: "MAPSIZE_STANDARD",
       playerCount: 8,
@@ -45,6 +45,20 @@ describe("Run in Game request validation", () => {
         gameOptions: {},
         playerOptions: [{ playerId: 0, options: {} }],
       },
+    });
+  });
+
+  it("falls disposable setup requests back to studio-current when no selected config id exists", () => {
+    expect(parseRunInGameSetupRequest({
+      recipeId: "mod-swooper-maps/standard",
+      seed: "123",
+      mapSize: "MAPSIZE_STANDARD",
+      materialization: { mode: "disposable" },
+      config: { ok: true },
+    })).toMatchObject({
+      requestedMode: "disposable",
+      id: "studio-current",
+      restartCivProcess: false,
     });
   });
 


### PR DESCRIPTION
Disposable "Run in Game" requests now use the selected config ID (e.g. `swooper-earthlike`) instead of always being forced to `studio-current`. The `studio-current` fallback is still used when no valid config ID is provided.

The same logic now applies to `sourcePath` resolution — it no longer requires durable mode to pass through a selected source path.

The Play button in `GameConsole` now shows the contextual action label (e.g. "Restart Civ & Run") when a run-in-game status is available, rather than always defaulting to "Play" when not actively running.