### PR TITLE
`docs(habitat-harness): add workstream frame, corpus, taxonomy, and full OpenSpec change train`

### DIFF
--- a/docs/projects/habitat-harness/FRAME.md
+++ b/docs/projects/habitat-harness/FRAME.md
@@ -147,6 +147,7 @@ file contents, command flags, or task order.
 | Pre-commit scope | Format + cheap grit checks on staged files only; full affected verification at pre-push; auto-restage only formatter-touched files | If multi-lane worktree staging conflicts appear in practice |
 | ESLint survives (minimal) | Only as the runner for `@nx/enforce-module-boundaries`; all other current ESLint rules migrate to Grit/file-layer | When Nx Conformance or a Biome-native boundary integration covers it |
 | Doc-lint scripts (`lint-doc-*`, `lint-mapgen-docs.py`) | Wrapped as habitat-native checks, not force-fitted into a tool layer | If they grow; they are doc tooling, not architecture enforcement |
+| By-design habitat-native set (excluded from the degeneration-trigger count) | Exactly: adr-lint, doc-ambiguity, mapgen-docs (doc tooling); workspace-entrypoints (manifest rule); G6/G7 (semantic doc/code sync). Everything else must live on its tool layer | If this list grows beyond these six, the growth counts toward the degeneration trigger |
 | Nx version | Adopt latest 22.x; do not wait for 23 stable; never 21.5.0/21.6.0 (pulled releases) | `nx migrate` when 23 lands |
 
 ## 4. De-risk evidence (all flags resolved 2026-06-12)
@@ -180,7 +181,7 @@ Gotchas captured for implementation:
   `targetDefaults` (dependsOn/outputs/inputs map 1:1; `cache: true` becomes
   explicit; `persistent` → `continuous`).
   https://nx.dev/docs/guides/adopting-nx/from-turborepo
-- Not auto-mapped (needs a manual pass, our turbo.json is ~6 tasks):
+- Not auto-mapped (needs a manual pass; our turbo.json has 18 task entries):
   `extends`, `passThroughEnv`, `envMode`, `outputLogs`; env vars become cache
   inputs.
 - Bun officially supported as package manager (since Nx 19.1); Nx runs on
@@ -218,7 +219,7 @@ and agent operating procedure. We **amend**:
 
 ## 6. Grounding insights (what the repo actually has)
 
-- **Scale:** 18 workspace packages (3 apps, 11 packages incl. 4 plugins,
+- **Scale:** 21 workspace projects (3 apps, 15 packages incl. 4 plugins,
   3 mods), ~2,200 TS files, ~305k LOC. Bun workspaces + text bun.lock +
   `linker = "isolated"` already (spec-aligned).
 - **Existing enforcement is substantial and mostly green:** 9 lint scripts
@@ -226,10 +227,12 @@ and agent operating procedure. We **amend**:
   recipe imports, normalization guardrails, doc lints, oRPC contract
   ownership), 6+ architecture tests (core purity, recipe import boundary,
   RNG authority, bundle runtime imports, projection band, ecology guardrails),
-  ESLint flat config with 5 families of restricted-import/syntax rules, CI
-  `architecture-strict-core` job. Allowlists exist (adapter boundary: 7
+  ESLint flat config with 8 families of restricted-import/syntax rules, CI
+  `architecture-strict-core` job. Allowlists exist (adapter boundary: 6
   exceptions) — the embryonic ratchet.
-- **What's missing:** no Nx/Biome/Grit/Husky anywhere; no local hooks at all;
+- **What's missing:** no Nx/Biome/Grit/Husky anywhere; no harness-style local
+  hooks (one opt-in `scripts/git-hooks/pre-commit` exists — it publishes the
+  civ7-resources submodule via `core.hooksPath`; dispositioned in slice H7);
   prose-only rules (generated-zone read-only, stage truth/projection
   separation, typed intent usage) have **zero enforcement**; checks emit
   human text, not JSON; no codemod capability at all.

--- a/docs/projects/habitat-harness/FRAME.md
+++ b/docs/projects/habitat-harness/FRAME.md
@@ -1,0 +1,259 @@
+# Habitat Harness Workstream — Frame and Baseline
+
+- **Built:** 2026-06-12
+- **Built by:** workstream owner agent (Fable), with Matei's settled decisions
+- **Mode:** frame-discovery + co-framing, exported for future implementing agents
+- **Object path:** objective-framing (backward from the end state), carried by a solution frame (the harness)
+- **Durability:** standalone — this document must survive compaction and agent handoff
+- **Cynefin read:** complicated (tool composition is known-good engineering), with one complex edge: burn-down volume is unknown until rules go red
+
+This is the stable baseline for the workstream. Iterate from here, not from chat history.
+
+---
+
+## 1. The Frame
+
+### WHAT (the lens)
+
+Treat repository structure as an **executable, ratchetable contract**. Today the
+repo's architecture is enforced by a scattered, partially-prose surface: nine
+custom lint scripts, six architecture tests, an ESLint config of restricted
+imports, CI jobs, and AGENTS.md/doc rules with no enforcement. The harness
+re-homes all of that into one repository-local toolkit (`tools/habitat-harness`)
+with five enforcement layers, each with a single owning tool, plus a ratchet so
+new invariants can land red and be burned down to green without blocking the
+repo.
+
+The harness is **not** product architecture, a framework, or a governance
+layer. It makes whatever architecture the repo already chose enforceable down
+to the file level — and keeps it that shape no matter which agent edits the
+code.
+
+### WHY
+
+- Agents (and humans) currently learn the architecture by reading prose and
+  inferring from code; violations are caught late, by CI scripts, or never.
+- The repo's stated goal ("classify first, generate second, author third,
+  verify continuously") requires structure to be queryable and enforceable,
+  not documented.
+- Matei's operating goal: stay back while agents reshape and continuously
+  enforce project structure — codemods migrate in place, lint rules keep the
+  shape, failures burn down iteratively.
+
+### Selection commitments
+
+**In:**
+- All existing structural enforcement (scripts/lint/*, architecture tests,
+  eslint.config.js restricted-import blocks, CI wiring).
+- Nx adoption (full — graph, tags, affected, targets, cache, local plugin,
+  generators), retiring Turbo.
+- Module-boundary tags derived from current enforcement and docs.
+- GritQL pattern catalog (check + apply) for syntax-shape invariants and codemods.
+- Biome replacing Prettier (format + hygiene lint).
+- Husky hooks (pre-commit, pre-push) delegating to the harness CLI.
+- Ratchet/baseline machinery for red→green burn-down.
+- Doc-vs-code discrepancy logging (logged, not resolved here).
+
+**Foreground:** the migration map (existing check → harness owner), the
+derived taxonomy, the ratchet mechanism, and the slice train.
+
+**Exterior (deliberately out):**
+- Redesigning product/runtime architecture or package splits. The taxonomy
+  encodes the **current implied architecture**, including splits we may not
+  want long-term. Wrong-tag discoveries are future refactors, not this
+  workstream.
+- Resolving doc-vs-code discrepancies. They are **logged** in
+  `discrepancy-log.md` and decided at the end / later.
+- MapGen domain semantics, runtime behavior, game proof. Nothing here touches
+  what the code does — only its shape.
+- Durable work systems, review/governance process (owned by the existing
+  workstream skills and OpenSpec machinery).
+- Publishing the harness as a shared plugin (explicitly later; it starts
+  repo-local).
+
+### Hard core (violating any of these forces a reframe)
+
+1. **Enforcement-only scope.** The harness encodes and enforces the current
+   implied architecture; it never invents target architecture or domain
+   behavior. Codemods rewrite known structure; they fail closed on ambiguity.
+2. **Five layers, one owner each.** Repository layer = Nx graph + tags;
+   import layer = Nx `enforce-module-boundaries` via a minimal, quarantined
+   ESLint config; file layer = path/generated-zone rules; syntax layer =
+   GritQL; hygiene layer = Biome. A concern lives in exactly one layer.
+3. **Ratchet invariant.** Every rule lands with an explicit baseline
+   (violations enumerated, frozen). Baselines only shrink. A rule is "locked"
+   when its baseline is empty; locked rules hard-fail. New rules may land red
+   without blocking unrelated work.
+4. **Derived, lockable, revisable taxonomy.** Tags and constraints are derived
+   from existing enforcement + docs (provenance cited per rule), locked on the
+   ratchet now, revised later as deliberate decisions — not silently.
+5. **CI is authoritative.** Hooks are local friction reduction. Nothing is
+   "verified" because a hook passed.
+
+### Protective belt (can flex without reframe)
+
+- Exact tag names and granularity; exact Grit pattern inventory; hook timing
+  details; whether doc-lint checks stay Python or become harness-native TS;
+  the order of mid-train slices; Nx version (22.x vs 23).
+
+### Falsifier
+
+- If slice H1's verification shows Nx cannot represent the existing
+  turbo.json pipeline + bun workspace graph without breaking `bun run check`
+  / CI parity, the "Nx fully" decision returns to Matei with evidence.
+- If a whole **class** of existing checks (not an instance) cannot be owned by
+  any of the five layers, the layer model is wrong — reframe.
+
+### Degeneration trigger
+
+If three or more invariants that were assigned to a tool layer end up
+implemented as bespoke `habitat-native` scripts ("the tool couldn't express
+it"), the harness is degenerating into a rebranded script wrapper — stop and
+re-evaluate the layer model before adding more rules.
+
+### Structural alternatives considered (and why rejected)
+
+- **Keep Turbo + `eslint-plugin-boundaries` (no Nx).** Rejected by decision
+  (Matei: "go Nx fully"), and confirmed unnecessary caution: Nx documents a
+  native one-command Turborepo migration and official Bun support (see §4).
+- **Pure-CI enforcement (scripts only, no harness CLI/plugin).** Rejected: no
+  remediation path (codemods), no agent-facing classify/generate/fix loop, no
+  graph queryability — it reproduces the current state with more rules.
+
+### NOT how
+
+Implementation steps live in the OpenSpec change sets
+(`openspec/changes/habitat-*`) and nowhere else. This frame does not specify
+file contents, command flags, or task order.
+
+---
+
+## 2. Settled decisions (Matei, 2026-06-12)
+
+| # | Decision | Status |
+|---|---|---|
+| D1 | **Nx fully**, retiring Turbo. No coexistence posture. | Settled |
+| D2 | **GritQL stays** — "just make it work." (It does; see §4.) | Settled |
+| D3 | **Husky + Biome are in-scope and get done** — not deferred for shared-worktree concerns. Pre-commit auto-staging is allowed **only for files the formatter itself touched** (never blanket `git add -A`). | Settled |
+| D4 | **Taxonomy is derived from current state**, lockable on the ratchet; wrong-tag discoveries are future revisions. | Settled |
+| D5 | **Doc-vs-code discrepancies are logged, not resolved** during this workstream; design decisions reviewed at the end. | Settled |
+| D6 | Trade-offs are allowed but must be recorded visibly as revisitable. | Standing rule |
+
+## 3. Trade-offs taken (revisitable, recorded per D6)
+
+| Trade-off | Choice | Revisit when |
+|---|---|---|
+| Biome reformat churn | One dedicated reformat commit + `.git-blame-ignore-revs`; Prettier removed in same slice | Never (one-time cost) |
+| Pre-commit scope | Format + cheap grit checks on staged files only; full affected verification at pre-push; auto-restage only formatter-touched files | If multi-lane worktree staging conflicts appear in practice |
+| ESLint survives (minimal) | Only as the runner for `@nx/enforce-module-boundaries`; all other current ESLint rules migrate to Grit/file-layer | When Nx Conformance or a Biome-native boundary integration covers it |
+| Doc-lint scripts (`lint-doc-*`, `lint-mapgen-docs.py`) | Wrapped as habitat-native checks, not force-fitted into a tool layer | If they grow; they are doc tooling, not architecture enforcement |
+| Nx version | Adopt latest 22.x; do not wait for 23 stable; never 21.5.0/21.6.0 (pulled releases) | `nx migrate` when 23 lands |
+
+## 4. De-risk evidence (all flags resolved 2026-06-12)
+
+### GritQL under Bun — WORKS (proven locally)
+
+Sandbox proof (`/tmp/grit-derisk`, Bun workspace):
+- `bun add -d @getgrit/cli` installs cleanly; `bunx grit --version` → `grit 0.1.1`.
+- `grit apply` performed a correct structural rewrite (`oldBoundary($args)` → `newBoundary($args)`).
+- `grit check` with a repo-local `.grit/patterns/*.md` pattern (level: error,
+  custom message) correctly flagged a deep-domain-import sample mirroring our
+  real `@mapgen/domain/*/ops/*` rule; `--json` emits machine-readable
+  diagnostics (check_id, path, line/col, message, severity).
+
+Gotchas captured for implementation:
+1. `grit init` required before `check` (cache dir).
+2. Regex capture groups bind metavariables — use non-capturing `(?:...)`.
+3. `register_diagnostic` is Biome-plugin GritQL, not grit-CLI; CLI patterns
+   use plain match + frontmatter `level`/message.
+4. **`grit check` exits 0 even with findings** — the harness wrapper must
+   derive pass/fail from `--json` results, never from exit code.
+
+### Biome under Bun — WORKS
+
+`bunx --bun @biomejs/biome --version` → `2.4.16`.
+
+### Nx ⟂ Turbo — NO CONFLICT (verified from official docs)
+
+- Dedicated recipe: **"Migrating from Turborepo to Nx"** — one command,
+  `bunx nx@latest init`, detects `turbo.json` and converts tasks →
+  `targetDefaults` (dependsOn/outputs/inputs map 1:1; `cache: true` becomes
+  explicit; `persistent` → `continuous`).
+  https://nx.dev/docs/guides/adopting-nx/from-turborepo
+- Not auto-mapped (needs a manual pass, our turbo.json is ~6 tasks):
+  `extends`, `passThroughEnv`, `envMode`, `outputLogs`; env vars become cache
+  inputs.
+- Bun officially supported as package manager (since Nx 19.1); Nx runs on
+  Node, invoked via `bunx nx`; pin both runtimes.
+  https://nx.dev/docs/guides/nx-cloud/use-bun
+- Text `bun.lock` graph parsing fixed in Nx 21.x (nrwl/nx#31973); this repo
+  already uses text `bun.lock`. Known foot-guns: don't run Nx on the Bun
+  runtime; don't invoke nx from bun `postinstall`.
+- `@nx/eslint-plugin` `enforce-module-boundaries` is graph-based, supports
+  flat config and **tags in `package.json` (`"nx": {"tags": [...]}`)** — no
+  project.json files needed.
+  https://nx.dev/docs/technologies/eslint/eslint-plugin/guides/enforce-module-boundaries
+- Residual (minor, verified at slice H1): whether the converter handles every
+  field of our specific turbo.json — H1's first task is the init + diff.
+
+## 5. Spec draft disposition
+
+Input: `habitat-harness-spec-draft-input.md` (vendored verbatim from the RAWR
+draft, 2026-06-12). Assessment: sound as a target tool-composition spec
+(~70%); blind to this repo (~30%). We **adopt** its tool ownership model,
+forbidden patterns, invariant-record format, remediation rules, CI posture,
+and agent operating procedure. We **amend**:
+
+| Area | Draft says | We do |
+|---|---|---|
+| Starting point | Greenfield-ish phases | Migration-first: wrap existing 9 scripts + 6 arch tests, then port |
+| Turbo | Not mentioned | Explicit Nx migration slice (native converter) |
+| Taxonomy | "Each repo defines its own" (examples only) | Derived from existing enforcement, provenance per tag (`taxonomy.md`) |
+| Ratchet | Absent | First-class: per-rule baselines, shrink-only, lock-when-empty |
+| Existing ESLint config | Unaware | Current restricted-import/syntax blocks migrate to Grit + file layer; ESLint keeps only the Nx boundary rule |
+| Hooks | Generic pre-commit restage | D3 condition: restage only formatter-touched files; Graphite-aware |
+| Workspaces | `apps/*, packages/*, services/*, tools/*` | This repo's globs + add `tools/*` |
+| mise.toml | Recommended | Adopted (pin node + bun) — new file |
+| `bun ci` | Suggested | Keep `bun install --frozen-lockfile` (already in CI) |
+
+## 6. Grounding insights (what the repo actually has)
+
+- **Scale:** 18 workspace packages (3 apps, 11 packages incl. 4 plugins,
+  3 mods), ~2,200 TS files, ~305k LOC. Bun workspaces + text bun.lock +
+  `linker = "isolated"` already (spec-aligned).
+- **Existing enforcement is substantial and mostly green:** 9 lint scripts
+  (adapter boundary, workspace entrypoints, domain refactor guardrails,
+  recipe imports, normalization guardrails, doc lints, oRPC contract
+  ownership), 6+ architecture tests (core purity, recipe import boundary,
+  RNG authority, bundle runtime imports, projection band, ecology guardrails),
+  ESLint flat config with 5 families of restricted-import/syntax rules, CI
+  `architecture-strict-core` job. Allowlists exist (adapter boundary: 7
+  exceptions) — the embryonic ratchet.
+- **What's missing:** no Nx/Biome/Grit/Husky anywhere; no local hooks at all;
+  prose-only rules (generated-zone read-only, stage truth/projection
+  separation, typed intent usage) have **zero enforcement**; checks emit
+  human text, not JSON; no codemod capability at all.
+- **OpenSpec machinery is mature:** `openspec/config.yaml` authority order,
+  ~141 change records, strict validation via `bun run openspec:validate`.
+  This workstream is a new change train (`habitat-*`), separate from the
+  MapGen normalization train.
+
+## 7. Companion artifacts (this directory)
+
+| File | Contents |
+|---|---|
+| `habitat-harness-spec-draft-input.md` | Vendored input spec draft (read-only baseline) |
+| `taxonomy.md` | Derived tag taxonomy, per-project assignments, dep constraints, initial violation backlog |
+| `invariant-corpus.md` | Complete corpus of existing checks → harness-owner migration map |
+| `discrepancy-log.md` | Doc-vs-code discrepancies (logged per D5, decided later) |
+| `workstream-record.md` | Systematic-workstream record: gates, proof classes, slice state |
+| `../../../openspec/changes/habitat-*` | The change train (one OpenSpec change per slice) |
+
+## 8. Workstream status
+
+- **Branch:** `agent-F-habitat-harness-workstream` (worktree, off `main`, Graphite-tracked)
+- **Phase:** preparation complete, execution not started
+- **Current gate:** systematic-workstream gates 1–7 complete (frame, repo
+  state, diagnosis, corpus, grouping, expectations, architecture translation);
+  gate 8 (slices) recorded in the OpenSpec train; gates 9–12 begin with
+  execution.

--- a/docs/projects/habitat-harness/discrepancy-log.md
+++ b/docs/projects/habitat-harness/discrepancy-log.md
@@ -1,0 +1,33 @@
+# Discrepancy Log — Architecture Docs vs Code
+
+Per Matei's standing instruction (FRAME.md D5): discrepancies between what
+architecture docs say and what code/enforcement actually does are **logged
+here, not resolved** during the harness workstream. Review and disposition at
+workstream end (or fold into later doc-stewardship passes).
+
+Severity: P1 = doc contradicts enforced reality · P2 = enforcement exists but
+docs drift/omit it · P3 = enforced or practiced but entirely undocumented.
+
+Overall finding from the derivation pass: **no code-violates-docs cases were
+found** — the codebase is clean against its own rules. Every entry below is
+documentation lagging enforcement, which is the favorable direction.
+
+| ID | Severity | Where documented | What code/enforcement actually does | Suggested disposition (decide later) |
+|---|---|---|---|---|
+| DL-1 | P1 | `packages/sdk/AGENTS.md` underspecifies mapgen surface | G11 enforces: SDK root must NOT import `./mapgen`; `@civ7/adapter/civ7` only importable under `src/mapgen/` (opt-in `@civ7/sdk/mapgen` subpath) | Update SDK AGENTS.md to state the subpath isolation rule explicitly |
+| DL-2 | P2 | `lint-domain-refactor-guardrails.sh` has `boundary` vs `full` profiles; narrative domain exempt from stage-root rule | Only `boundary` runs in CI; `full` (JSDoc, schema descriptions, config-merge bans) is opt-in local | Document profile split + narrative exemption in `docs/system/TESTING.md`; decide whether `full` becomes a ratcheted harness rule |
+| DL-3 | P2 | not documented | Guardrails full profile forbids op-calls-op imports (ops must not import sibling ops; recipe layer composes) | Document in `docs/system/libs/mapgen/MAPGEN.md` ("Op Structure and Composition") |
+| DL-4 | P2 | not documented | Normalization G5 forbids sibling-stage step imports (stage isolation) | Document in `docs/system/mods/swooper-maps/architecture.md` ("Stage Isolation") |
+| DL-5 | P2 | `docs/system/libs/mapgen/reference/STANDARD-RECIPE.md` stage list | G6 hard-fails when recipe.ts stage order and the doc diverge (docs are enforcement input!) | Keep; document that this doc is lint-checked so agents update both together |
+| DL-6 | P2 | full profile only | TypeBox-runtime ban in mapgen-core engine/core paths enforced only in `full` profile, not CI | Decide: promote to ratcheted CI rule or document as local-only |
+| DL-7 | P3 | not documented | G10 enforces visualization contract ownership (no shared `steps/viz.ts` hubs; no cross-step private viz imports) | Document in swooper-maps architecture.md |
+| DL-8 | P3 | not documented | G8 enforces placement outcome contracts (`resourcePlacementOutcomes`/`discoveryPlacementOutcomes` referenced; legacy generators banned in apply.ts) | Document in swooper-maps architecture.md |
+| DL-9 | P3 | mentioned only inside the script | Adapter-boundary allowlist (6 files, CIV-20/CIV-47) tracked only in `lint-adapter-boundary.sh` output | Becomes the rule's ratchet baseline in the harness (slice H5, `habitat-grit-catalog`); also list in `docs/system/DEFERRALS.md` |
+| DL-10 | P3 | not documented | Guardrails full profile forbids domain-root `export *` facades (ops only via explicit `/ops` surface) | Document in MAPGEN.md ("Domain Public Surface Contract") |
+| DL-11 | P3 | not documented | Recipe import surface is exactly three entrypoints (`@mapgen/domain/<d>`, `/ops`, `/config.js`); contracts vs recipe.ts import different surfaces by rule | Document the surface contract table in MAPGEN.md |
+| DL-12 | P3 | `.prettierrc` exists; no doc or gate mentions formatting | No formatting enforcement anywhere (CI or local) | Resolved by slice H4 (Biome); no decision needed |
+| DL-13 | P3 | root `AGENTS.md`: "treat generated artifacts as read-only; regenerate via scripts" | Zero enforcement on any generated zone | Resolved by slice H5 (file-layer rules); no decision needed |
+| DL-14 | P2 | swooper-maps architecture.md: stage truth/projection separation, typed intent APIs | Prose + partial G-guards only; no general rule | Exterior to this workstream (normalization train owns it); revisit after both trains land |
+
+Maintenance: append new entries during execution slices as agents find them.
+Do not resolve in-slice unless the slice's own scope requires it.

--- a/docs/projects/habitat-harness/habitat-harness-spec-draft-input.md
+++ b/docs/projects/habitat-harness/habitat-harness-spec-draft-input.md
@@ -1,0 +1,1206 @@
+# Habitat Tool Harness Specification — Bun Edition
+
+**Status:** implementation-ready proposal, revised for Bun  
+**Audience:** agents and maintainers implementing the harness inside an existing repository  
+**Scope:** Nx, Biome, ESLint as temporary boundary compatibility, GritQL, Husky, Bun, and the local integration glue that composes them  
+**Non-scope:** product architecture, runtime architecture, durable work systems, review/governance systems, service transport semantics, or any mandatory application ontology
+
+## 1. Executive decision
+
+A Habitat tool harness is a small repository-local development harness that makes structure executable. It lives inside the repository, normally under `tools/habitat-harness/`, and wires together:
+
+```text
+Bun      -> package manager, workspace installer, script runner, local TS harness CLI runtime
+Nx       -> project graph, affected scope, generators, executors, migrations, cache
+Biome    -> formatting, ordinary lint hygiene, import organization where enabled
+ESLint   -> temporary compatibility runner for Nx's open-source module-boundary rule
+GritQL   -> structural source search and rewrite / remediation
+Husky    -> local Git hook dispatch for cheap checks at the right Git moments
+```
+
+The harness is not the product architecture. It is not a framework. It is not a governance layer. It is a toolkit that helps humans and agents keep whatever architecture the repository chooses enforceable down to the file level.
+
+The operating rule is:
+
+```text
+Bun installs, locks, and runs local scripts.
+Nx knows the repository graph.
+Biome knows hygiene.
+ESLint temporarily carries Nx's JS/TS boundary rule.
+GritQL knows source-code shape and can rewrite it.
+Husky knows local Git moments.
+The harness glue decides what to run, where, and in what order.
+```
+
+The north-star is a workflow where most structural work is performed through generation, remediation, formatting, linting, and verification. Humans and agents should spend most manual effort on business logic, domain rules, examples, edge cases, and intentional exceptions. The harness should make the right structure cheaper than improvisation.
+
+## 2. Bun posture and audit result
+
+Switching from pnpm to Bun is not only a command rename. The harness must adopt Bun's package-manager model deliberately:
+
+```text
+lockfile:             bun.lock, committed to git
+workspace file:       package.json workspaces, not pnpm-workspace.yaml
+local workspace refs: workspace:*
+CI install:           bun ci, or bun install --frozen-lockfile
+script execution:     bun run <script>
+package binaries:     bunx <binary>, unless a root script wraps them
+local TS CLI:         bun tools/habitat-harness/src/bin/habitat.ts
+Node CLIs:            Nx, ESLint, and often Grit should run normally through bunx, not forced with --bun unless tested
+Biome CLI:            use bunx --bun @biomejs/biome, matching Biome's Bun docs
+```
+
+The harness should pin both Node and Bun. Bun is the package manager and the runtime for the local `habitat` CLI, but Nx and ESLint remain Node-ecosystem CLIs. Nx's own Bun CI guide pins both `node` and `bun` with `mise.toml`, then runs Nx via `bunx`. That is the posture this spec uses.
+
+Recommended root `mise.toml`:
+
+```toml
+[tools]
+node = "24.11.0"
+bun = "1.3.11"
+```
+
+The exact versions should be updated intentionally by maintainers. The point is not those specific numbers; the point is that the repo pins both runtimes instead of assuming Bun removes the need for Node.
+
+Recommended root `bunfig.toml`:
+
+```toml
+[install]
+linker = "isolated"
+```
+
+For a new Bun workspace/monorepo, isolated installs are the right default because they reduce phantom dependency leakage. If an existing repository cannot yet run isolated, the harness may temporarily use `linker = "hoisted"`, but that should be treated as migration debt because hidden dependencies weaken file-level enforcement.
+
+Bun does not run arbitrary lifecycle scripts for installed dependencies unless they are trusted. The root project's own `prepare` script is still expected to install Husky hooks, but any binary package that relies on dependency lifecycle scripts may require either a different installation route or an explicit `trustedDependencies` entry. Treat this as a supply-chain hardening feature, not as a nuisance.
+
+## 3. Design rationale
+
+A useful agent-facing repository needs more than instructions. It needs executable structure. The reusable Habitat design notes frame this as making the environment enforceable, queryable, generatable, observable, and diagnosable rather than merely documented. The graph/query/diagnostics layer is especially relevant here: agents need to ask what a file is, what may import what, what breaks when a thing changes, and which gates must run. This harness implements that narrow mechanical slice, without adopting the broader coordination or governance layers.
+
+The harness distribution argument is also load-bearing: a harness is a set of generators, rules, structural tests, discovery mechanisms, composition helpers, and migrations. Those map directly onto Nx extension points: generators scaffold, module-boundary rules enforce, executors verify, project graph plugins infer nodes and dependencies, and migrations propagate harness evolution.
+
+The domain-design principle behind the harness is hierarchical composition. A flat repository makes agents investigate first: read files, trace imports, infer conventions, then guess. A structured repository lets agents classify first: what kind of thing is this, what rules apply at this level, and which generated/remediated move is legal. The harness should therefore encode kinds, tags, path rules, import rules, file-shape rules, and repair paths as machinery.
+
+## 4. Installation and repository layout
+
+### 4.1 New repository setup
+
+For a new TypeScript-oriented repository using Bun:
+
+```sh
+bunx create-nx-workspace@latest my-repo --preset=ts --packageManager=bun
+cd my-repo
+
+bun add -d nx @nx/plugin eslint @nx/eslint-plugin husky typescript @types/bun @getgrit/cli
+bun add -d -E @biomejs/biome
+bunx --bun @biomejs/biome init
+bunx husky init
+bunx nx add @nx/plugin
+bunx nx g @nx/plugin:plugin tools/habitat-harness --importPath=@internal/habitat-harness
+```
+
+For an existing repository:
+
+```sh
+bun add -d nx @nx/plugin eslint @nx/eslint-plugin husky typescript @types/bun @getgrit/cli
+bun add -d -E @biomejs/biome
+bunx nx init
+bunx --bun @biomejs/biome init
+bunx husky init
+bunx nx add @nx/plugin
+bunx nx g @nx/plugin:plugin tools/habitat-harness --importPath=@internal/habitat-harness
+```
+
+If the repo is migrating from pnpm, remove `pnpm-lock.yaml` and `pnpm-workspace.yaml` after verifying `bun.lock`, `package.json` workspaces, and the Nx project graph. Do not keep competing lockfiles.
+
+Exact package versions may vary, but the harness must create one local plugin under `tools/`, one root Biome config, one minimal ESLint boundary config, one GritQL pattern catalog, and thin Husky hook delegators.
+
+### 4.2 Required root package fields
+
+```jsonc
+{
+  "private": true,
+  "packageManager": "bun@1.3.11",
+  "workspaces": [
+    "apps/*",
+    "packages/*",
+    "services/*",
+    "tools/*"
+  ],
+  "scripts": {
+    "habitat": "bun tools/habitat-harness/src/bin/habitat.ts",
+    "habitat:init": "bun run habitat init",
+    "habitat:check": "bun run habitat check",
+    "habitat:fix": "bun run habitat fix",
+    "habitat:verify": "bun run habitat verify",
+    "prepare": "husky"
+  }
+}
+```
+
+Use `workspace:*` for local workspace dependencies:
+
+```jsonc
+{
+  "devDependencies": {
+    "@internal/habitat-harness": "workspace:*"
+  }
+}
+```
+
+### 4.3 Required root layout
+
+```text
+repo/
+  apps/                         # optional; repo-defined application projects
+  packages/                     # optional; repo-defined libraries/packages
+  services/                     # optional; repo-defined domain/service projects
+  tools/
+    habitat-harness/
+      package.json
+      project.json
+      src/
+        index.ts
+        plugin.ts               # Nx createNodesV2/createDependencies
+        bin/
+          habitat.ts            # Bun-run CLI entrypoint for humans, agents, hooks
+        rules/
+          architecture.ts       # repo-local rule pack
+          messages.ts           # agent-readable diagnostics
+        lib/
+          graph.ts
+          paths.ts
+          tags.ts
+          spawn.ts
+          diagnostics.ts
+          git.ts
+        executors/
+          biome/
+          eslint-boundaries/
+          grit-check/
+          grit-apply/
+          verify/
+        generators/
+          init/
+          project/
+          boundary/
+          pattern/
+          migration/
+        migrations/
+        patterns/
+          grit/
+            no-internal-import.grit
+            no-deprecated-builder.grit
+            no-generated-zone-edit.grit
+          fixtures/
+  .grit/
+    grit.yaml
+  .husky/
+    pre-commit
+    commit-msg
+    pre-push
+    post-checkout
+    post-merge
+  biome.json
+  bun.lock
+  bunfig.toml
+  eslint.boundaries.config.mjs
+  mise.toml
+  nx.json
+  package.json
+```
+
+This is deliberately local. The harness begins as repository infrastructure, not a published framework. If multiple repositories converge on the same harness, the `tools/habitat-harness` package can later become a shared private or public Nx plugin.
+
+## 5. Per-tool specifications
+
+## 5.1 Bun
+
+### Setup
+
+Install Bun through the official installer, package manager, or CI image, then pin it through `mise.toml` or an equivalent toolchain manager. Commit `bun.lock` and remove other package-manager lockfiles after migration.
+
+Root `bunfig.toml`:
+
+```toml
+[install]
+linker = "isolated"
+```
+
+Root scripts should use `bun run` explicitly. Avoid relying on naked script names in documentation because Bun built-ins can take precedence over same-named scripts.
+
+### Run commands
+
+```sh
+bun install
+bun ci
+bun add -d <package>
+bun add -d -E @biomejs/biome
+bun run habitat verify
+bunx nx graph
+bunx eslint -c eslint.boundaries.config.mjs "**/*.{ts,tsx,js,jsx}"
+```
+
+### Unique capabilities
+
+Bun gives the harness a fast package manager, text lockfile, workspace installation, script runner, TypeScript execution for the local harness CLI, and `bunx` for local/npm package binaries.
+
+### Owns
+
+Bun owns:
+
+```text
+dependency installation
+bun.lock
+package.json workspace linking
+workspace:* local dependency references
+root package scripts
+local TypeScript execution for the habitat CLI
+CI dependency reproducibility through bun ci or --frozen-lockfile
+```
+
+### Does not own
+
+Bun does not own the architecture, project graph, lint semantics, module boundaries, structural rewrites, or Git hook semantics. Bun also does not automatically make every Node CLI a Bun-native runtime. Use normal `bunx` for Node-shebang CLIs unless the CLI's own docs say to use `--bun`.
+
+### Integration glue
+
+The harness owns a Bun-run CLI:
+
+```sh
+bun run habitat <command>
+```
+
+That CLI delegates to Nx, Biome, ESLint, GritQL, Git, and local rule-pack code. It should use safe process spawning with argument arrays, not shell-concatenated command strings.
+
+## 5.2 Nx
+
+### Setup
+
+Register the local plugin in `nx.json`:
+
+```jsonc
+{
+  "plugins": [
+    {
+      "plugin": "./tools/habitat-harness/src/plugin.ts",
+      "options": {
+        "biomeTargetName": "biome:ci",
+        "boundaryTargetName": "boundaries",
+        "gritCheckTargetName": "grit:check"
+      }
+    }
+  ],
+  "targetDefaults": {
+    "biome:ci": { "cache": true },
+    "boundaries": { "cache": true },
+    "grit:check": { "cache": true },
+    "verify": { "dependsOn": ["biome:ci", "boundaries", "grit:check"] }
+  }
+}
+```
+
+The plugin must implement `createNodesV2` for project discovery and target inference. It should identify projects from `project.json`, package-level `package.json`, and any repo-specific marker files declared in `tools/habitat-harness/src/rules/architecture.ts`.
+
+The plugin should implement `createDependencies` only for dependency edges that Nx cannot infer from normal imports but the repository can prove from explicit declarations, manifests, config files, or project metadata.
+
+### Run commands
+
+```sh
+bunx nx graph
+bunx nx graph --affected
+bunx nx show project <project-name>
+bunx nx affected -t biome:ci,boundaries,grit:check,typecheck,test
+bunx nx run-many -t verify --all
+bunx nx g @internal/habitat-harness:project <name> --kind=<kind>
+bunx nx migrate <package-or-version>
+bunx nx sync:check
+```
+
+### Unique capabilities
+
+Nx is authoritative over the repository-level graph and task orchestration. Its unique capabilities in this harness are:
+
+- project graph construction;
+- custom graph node and dependency inference;
+- affected-project calculation;
+- cacheable target execution;
+- local generators;
+- migrations;
+- sync generators;
+- task composition.
+
+### Owns
+
+Nx owns:
+
+```text
+project identity
+project tags
+project dependency graph
+affected-scope calculation
+target wiring
+generators
+executors
+migrations
+cache policy
+module-boundary authority at project level
+```
+
+### Does not own
+
+Nx does not own formatting, ordinary lint rules, source-code structural pattern language, or Git hook timing. It may invoke tools that own those concerns.
+
+### Integration glue
+
+`tools/habitat-harness/src/plugin.ts` is glue. It translates repository-specific architecture rules into Nx graph nodes, dependencies, tags, and targets. It should stay thin and explicit.
+
+## 5.3 Biome
+
+### Setup
+
+Install Biome as an exact-pinned dev dependency:
+
+```sh
+bun add -d -E @biomejs/biome
+bunx --bun @biomejs/biome init
+```
+
+Root `biome.json`:
+
+```jsonc
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "files": {
+    "includes": ["**/*", "!node_modules", "!dist", "!coverage", "!.nx"]
+  },
+  "formatter": { "enabled": true },
+  "linter": { "enabled": true },
+  "assist": { "enabled": true }
+}
+```
+
+### Run commands
+
+```sh
+bunx --bun @biomejs/biome format --write .
+bunx --bun @biomejs/biome lint .
+bunx --bun @biomejs/biome check .
+bunx --bun @biomejs/biome ci .
+bunx nx affected -t biome:ci
+```
+
+### Unique capabilities
+
+Biome is the fast hygiene engine. It provides formatting, ordinary lint checks, import organization through `check`/`ci`, staged/changed-file workflows, reporters, and editor integration.
+
+### Owns
+
+Biome owns:
+
+```text
+formatting
+ordinary lint hygiene
+import organization where enabled
+fast local diagnostics
+CI hygiene posture
+```
+
+### Does not own
+
+Biome does not own project graph law, module-boundary authority, repository migrations, or bulk source-code remediation. Biome can host GritQL diagnostics, but in this harness that is diagnostic integration only, not the full rewrite engine.
+
+### Integration glue
+
+The harness owns Nx targets that call Biome with the right path set:
+
+```text
+biome:format   -> bunx --bun @biomejs/biome format --write <projectRoot>
+biome:lint     -> bunx --bun @biomejs/biome lint <projectRoot>
+biome:check    -> bunx --bun @biomejs/biome check <projectRoot>
+biome:ci       -> bunx --bun @biomejs/biome ci <projectRoot>
+```
+
+The harness may add a batch path for affected projects, but it must preserve clear target names. Do not call the Biome target plain `lint` in this harness, because `lint` becomes ambiguous once ESLint boundary compatibility and structural checks exist.
+
+## 5.4 ESLint
+
+### Setup
+
+ESLint is temporary compatibility glue for Nx's open-source JavaScript/TypeScript module-boundary rule. It must not become the main linter.
+
+Install:
+
+```sh
+bun add -d eslint @nx/eslint-plugin
+```
+
+Create `eslint.boundaries.config.mjs`:
+
+```js
+import nx from "@nx/eslint-plugin"
+
+export default [
+  ...nx.configs["flat/base"],
+  ...nx.configs["flat/typescript"],
+  ...nx.configs["flat/javascript"],
+  {
+    files: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+    rules: {
+      "@nx/enforce-module-boundaries": [
+        "error",
+        {
+          enforceBuildableLibDependency: true,
+          allow: [],
+          depConstraints: [
+            {
+              sourceTag: "kind:app",
+              onlyDependOnLibsWithTags: ["kind:adapter", "kind:domain", "kind:support"]
+            },
+            {
+              sourceTag: "kind:adapter",
+              onlyDependOnLibsWithTags: ["kind:domain", "kind:support"]
+            },
+            {
+              sourceTag: "kind:domain",
+              onlyDependOnLibsWithTags: ["kind:domain", "kind:support"]
+            },
+            {
+              sourceTag: "kind:support",
+              onlyDependOnLibsWithTags: ["kind:support"]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]
+```
+
+These `kind:*` tags are examples. Each repository must define its own tag taxonomy.
+
+### Run commands
+
+```sh
+bunx eslint -c eslint.boundaries.config.mjs "**/*.{ts,tsx,js,jsx}"
+bunx nx affected -t boundaries
+```
+
+Do not run ESLint with `bunx --bun` by default. ESLint officially requires Node, and this harness uses ESLint only as a compatibility runner for the Nx boundary rule.
+
+### Unique capabilities
+
+In this harness, ESLint has exactly one unique reason to exist: Nx's open-source `@nx/enforce-module-boundaries` rule is an ESLint rule for JavaScript/TypeScript repositories.
+
+### Owns
+
+ESLint owns:
+
+```text
+temporary module-boundary compatibility for JS/TS imports
+```
+
+### Does not own
+
+ESLint does not own formatting, ordinary lint hygiene, stylistic rules, architectural source-shape rewrites, or repo-wide task orchestration.
+
+### Integration glue
+
+The harness owns the `boundaries` target. That target invokes ESLint with the minimal boundary config. The target name must be `boundaries`, not `lint`, so the repository does not accidentally treat ESLint as the primary linter.
+
+### Exit path
+
+When the repository has a suitable replacement, this layer may be removed. Valid replacements are:
+
+```text
+Nx Conformance, if the repository is licensed for it;
+a custom graph-boundary executor in tools/habitat-harness;
+a future Biome/Nx boundary integration that fully covers the required rules.
+```
+
+Until then, keep ESLint narrow and boring.
+
+## 5.5 GritQL
+
+### Setup
+
+Install the CLI through the npm package if it works cleanly in the Bun workspace:
+
+```sh
+bun add -d @getgrit/cli
+bunx grit init
+```
+
+If the local package install does not expose the `grit` binary correctly under Bun, use Grit's official install script or a pinned global install. This is acceptable because GritQL is a structural rewrite tool; the harness target is the source of truth for when it runs.
+
+Pattern layout:
+
+```text
+tools/habitat-harness/patterns/grit/
+  no-internal-import.grit
+  no-deprecated-builder.grit
+  no-generated-zone-edit.grit
+  no-raw-cross-layer-call.grit
+  migrate-boundary-v1-to-v2.grit
+  fixtures/
+    no-internal-import.input.ts
+    no-internal-import.output.ts
+```
+
+`.grit/grit.yaml` should load the harness pattern directory.
+
+### Run commands
+
+```sh
+bunx grit check
+bunx grit apply <pattern-name-or-path>
+bunx nx affected -t grit:check
+bunx nx run <project>:grit:apply --pattern=<pattern>
+```
+
+### Unique capabilities
+
+GritQL is the structural source-code engine. It can search for source shapes and rewrite them. This is different from formatting and different from project graph enforcement.
+
+Use it for:
+
+```text
+codemods
+bulk source rewrites
+forbidden code-shape detection
+automated remediation after architecture changes
+deprecated builder/API migrations
+repairing generated file drift
+rewriting deep imports to public imports when mapping is known
+```
+
+### Owns
+
+GritQL owns:
+
+```text
+structural search
+source-shape diagnostics
+source-code rewrites
+codemod patterns
+repair recipes
+```
+
+### Does not own
+
+GritQL does not own the project graph, affected scope, module boundary authority, or normal formatting. Nx decides where and when GritQL runs. Biome cleans after rewrites.
+
+### Integration glue
+
+The harness exposes two targets:
+
+```text
+grit:check  -> detect forbidden source shapes
+grit:apply  -> apply approved structural rewrites, then run Biome format
+```
+
+Every `grit:apply` pattern must be paired with fixtures. If a pattern has no fixture, it may run only in `check` mode.
+
+Illustrative pattern shape:
+
+```grit
+// tools/habitat-harness/patterns/grit/no-deprecated-builder.grit
+`oldBoundary($args)` => `newBoundary($args)`
+```
+
+Illustrative forbidden-import diagnostic shape:
+
+```grit
+// illustrative only; tune to real paths and target language
+language js;
+
+`import $what from "$path"` where {
+  $path <: r".*/internal/.*",
+  register_diagnostic(
+    span = $path,
+    message = "Do not import another project's internal files. Use the public boundary export or add a harness-approved remediation."
+  )
+}
+```
+
+When a safe rewrite is possible, use `grit:apply`. When intent is ambiguous, emit a diagnostic and let the agent/human choose the boundary.
+
+## 5.6 Husky
+
+### Setup
+
+```sh
+bun add -d husky
+bunx husky init
+```
+
+Husky hook files must be thin delegators. The logic belongs in the harness CLI, not in shell scripts.
+
+```sh
+# .husky/pre-commit
+bun run habitat hook pre-commit
+```
+
+```sh
+# .husky/commit-msg
+bun run habitat hook commit-msg "$1"
+```
+
+```sh
+# .husky/pre-push
+bun run habitat hook pre-push
+```
+
+### Run commands
+
+```sh
+bun run habitat hook pre-commit
+bun run habitat hook commit-msg .git/COMMIT_EDITMSG
+bun run habitat hook pre-push
+```
+
+### Unique capabilities
+
+Husky owns local Git hook dispatch. It runs the right local command at the right Git moment.
+
+### Owns
+
+Husky owns:
+
+```text
+pre-commit trigger
+commit-msg trigger
+pre-push trigger
+post-checkout trigger
+post-merge trigger
+optional Git hook trigger points
+```
+
+### Does not own
+
+Husky does not own verification truth. Hooks are local, can be disabled, and can be bypassed. CI must remain authoritative.
+
+### Required hook policy
+
+| Hook | Status | Harness behavior |
+| --- | --- | --- |
+| `pre-commit` | recommended | Run staged Biome formatting/checks, cheap GritQL checks, and optionally a tiny boundary smoke check. Re-stage safe formatter output. Must stay fast. |
+| `commit-msg` | recommended if the repo uses conventions | Validate message shape, issue link, or local context link. Must not inspect the whole repo. |
+| `pre-push` | recommended | Run affected verification against the merge base: `biome:ci`, `boundaries`, `grit:check`, `typecheck`, and tests if configured. |
+| `post-checkout` | optional | Run lightweight sync warnings or dependency/install hints. Do not perform surprising mutations. |
+| `post-merge` | optional | Run `nx sync:check` or dependency drift warnings. Do not perform heavy verification. |
+| `pre-rebase` | optional | Block rebase only for repo-specific safety reasons, such as active generated drift. |
+| `post-rewrite` | optional | Run sync warnings after amend/rebase. |
+| `prepare-commit-msg` | optional | Pre-fill context IDs only if the repo uses them. |
+| `applypatch-msg`, `pre-applypatch`, `post-applypatch` | optional | Use only for patch-based workflows. |
+
+The default hook flow:
+
+```text
+pre-commit:
+  staged files
+    -> biome format/check on staged files
+    -> git update-index / re-stage formatter output
+    -> cheap grit:check on staged files
+    -> optional generated-zone guard
+
+pre-push:
+  merge-base
+    -> nx affected -t biome:ci,boundaries,grit:check,typecheck,test
+```
+
+## 6. Integration behavior
+
+The harness composes the tools as a pipeline:
+
+```text
+intent or change
+  -> classify affected files/projects through Nx graph
+  -> generate missing structure through Nx generators
+  -> rewrite stale structure through GritQL
+  -> clean output through Biome
+  -> prove import/project boundaries through Nx + minimal ESLint
+  -> prove file-shape invariants through GritQL checks
+  -> run affected typecheck/test targets through Nx
+  -> trigger cheap local subsets through Husky
+  -> run full proof in CI
+```
+
+Normative command set:
+
+```sh
+bun run habitat graph        # explain graph, tags, targets, and rule pack
+bun run habitat classify <path-or-diff>
+bun run habitat generate <kind> <name> [...options]
+bun run habitat check        # read-only local verification
+bun run habitat fix          # safe formatter + approved codemods only
+bun run habitat verify       # full affected verification
+bun run habitat hook <name>  # hook entrypoint for Husky
+```
+
+`habitat fix` must never perform semantic design. It may format, organize imports, apply deterministic codemods, update generated indexes, and rewrite known deprecated shapes. If the harness cannot prove the rewrite is safe, it must emit a diagnostic instead.
+
+## 7. Enforcing architecture down to the file level
+
+The harness enforces architecture across five layers:
+
+```text
+repository layer  -> Nx project graph and project tags
+import layer      -> Nx module boundaries through minimal ESLint or replacement executor
+file layer        -> path rules, generated-zone rules, ownership metadata
+syntax layer      -> GritQL structural checks and rewrites
+hygiene layer     -> Biome format/lint/import organization
+```
+
+Every rule must be specified as an enforceable invariant, not a preference.
+
+### 7.1 Rule pack format
+
+```ts
+// tools/habitat-harness/src/rules/architecture.ts
+export default defineHarnessRules({
+  projectKinds: [
+    "app",
+    "domain",
+    "adapter",
+    "support",
+    "tooling",
+    "test-harness"
+  ],
+
+  tagRules: [
+    {
+      id: "support-must-not-import-domain",
+      sourceTag: "kind:support",
+      onlyDependOnTags: ["kind:support"],
+      message:
+        "Support projects must stay reusable. Move domain meaning to a domain project or invert the dependency."
+    },
+    {
+      id: "adapters-do-not-own-domain-truth",
+      sourceTag: "kind:adapter",
+      onlyDependOnTags: ["kind:domain", "kind:support"],
+      message:
+        "Adapters may project domain behavior; they must not become domain truth owners."
+    }
+  ],
+
+  pathRules: [
+    {
+      id: "generated-zone-is-write-protected",
+      glob: "**/__generated__/**",
+      allowedWriters: ["tools/habitat-harness/**"],
+      remediation: "Run bun run habitat fix or the generator that owns this file."
+    }
+  ],
+
+  structuralRules: [
+    {
+      id: "no-internal-import",
+      grit: "tools/habitat-harness/patterns/grit/no-internal-import.grit",
+      mode: "check",
+      remediation: "Use the public boundary export. If no public export exists, generate one or ask for a boundary decision."
+    },
+    {
+      id: "deprecated-boundary-v1",
+      grit: "tools/habitat-harness/patterns/grit/migrate-boundary-v1-to-v2.grit",
+      mode: "apply",
+      remediation: "Run bun run habitat fix."
+    }
+  ]
+})
+```
+
+### 7.2 Invariant record
+
+Each invariant must have:
+
+```text
+id
+owner tool
+scope
+what it forbids
+why it exists
+detection command
+safe remediation command, if any
+failure message written for agents
+exception path, if exceptions are allowed
+```
+
+Example:
+
+```text
+id: no-generated-zone-edit
+owner tool: GritQL + Git staged-file check
+scope: **/__generated__/**
+forbids: manual edits to generated files
+why: generated files should be recreated by the owning generator so drift is reproducible
+detect: bun run habitat check --staged
+remediate: bun run habitat generate <owning-kind> or bun run habitat fix
+failure message: This file is generated. Do not hand-edit it. Run the owning generator or update the source declaration.
+exception path: none by default
+```
+
+## 8. Automated remediation
+
+Automated remediation is a first-class harness capability. Detection without repair is useful, but detection plus safe rewrite is the leverage point.
+
+The harness supports three remediation classes:
+
+```text
+Biome remediation:
+  formatting, import organization, simple safe assists
+
+GritQL remediation:
+  structural source rewrites, deprecated API migration, known import replacement
+
+Nx remediation:
+  generators, migrations, sync generators, project config updates, generated index refresh
+```
+
+Remediation rules:
+
+1. A remediation must be deterministic.
+2. A remediation must be repeatable.
+3. A remediation must have fixtures or snapshot tests.
+4. A remediation must run Biome after it rewrites source.
+5. A remediation must not invent domain behavior.
+6. A remediation must fail closed when intent is ambiguous.
+
+Example remediation flow:
+
+```text
+agent changes API shape
+  -> nx affected identifies impacted projects
+  -> grit:check detects old call shape
+  -> grit:apply rewrites old call shape to new call shape
+  -> biome:format cleans touched files
+  -> boundaries verifies dependency direction
+  -> typecheck/test prove behavior still compiles/runs
+```
+
+## 9. CI posture
+
+CI is authoritative. Husky is only local friction reduction.
+
+Minimum CI command:
+
+```sh
+bun ci
+bunx nx sync:check
+bunx nx affected -t biome:ci,boundaries,grit:check,typecheck,test --base="$NX_BASE" --head="$NX_HEAD"
+```
+
+Equivalent install command:
+
+```sh
+bun install --frozen-lockfile
+```
+
+Full repo fallback:
+
+```sh
+bunx nx run-many -t biome:ci,boundaries,grit:check,typecheck,test --all
+```
+
+CI should upload or retain artifacts for:
+
+```text
+Biome reporter output
+ESLint boundary output
+GritQL diagnostics
+Nx affected project list
+test results
+typecheck output
+```
+
+The harness should emit machine-readable JSON where practical so agents can repair from evidence instead of reading raw logs.
+
+## 10. Agent operating procedure
+
+Agents working in the repository should follow this sequence:
+
+```text
+1. Ask the harness to classify the target path or diff.
+2. Inspect the Nx project graph and relevant tags.
+3. Generate structure with Nx generators rather than hand-creating boilerplate.
+4. Write only the business logic or domain-specific content that the generator cannot know.
+5. Run bun run habitat fix for safe formatting and structural rewrites.
+6. Run bun run habitat check for local read-only diagnostics.
+7. Run bun run habitat verify before handing off substantial changes.
+8. If a rule fails and no remediation exists, explain the violated invariant before changing architecture.
+```
+
+The agent should not begin by searching randomly through files. The harness exists so the agent can classify first, generate second, author third, and verify continuously.
+
+## 11. Implementation sequence
+
+### Phase 1: Tool baseline
+
+```sh
+bun add -d nx @nx/plugin eslint @nx/eslint-plugin husky typescript @types/bun @getgrit/cli
+bun add -d -E @biomejs/biome
+bunx nx init
+bunx --bun @biomejs/biome init
+bunx husky init
+bunx nx add @nx/plugin
+```
+
+Deliverables:
+
+```text
+bun.lock
+bunfig.toml
+biome.json
+eslint.boundaries.config.mjs
+.husky/pre-commit
+.husky/pre-push
+.husky/commit-msg
+```
+
+### Phase 2: Local harness plugin
+
+Create `tools/habitat-harness` and implement:
+
+```text
+createNodesV2 for project discovery
+inferred targets: biome:ci, boundaries, grit:check, verify
+architecture rule pack loader
+basic habitat CLI running under Bun
+```
+
+Exit condition:
+
+```sh
+bun run habitat graph
+bunx nx run-many -t biome:ci,boundaries,grit:check --all
+```
+
+### Phase 3: Boundary rules
+
+Add project tags and minimal dep constraints. Keep the first rule set small.
+
+```text
+kind:app
+kind:domain
+kind:adapter
+kind:support
+kind:tooling
+```
+
+Exit condition:
+
+```sh
+bunx nx affected -t boundaries
+```
+
+### Phase 4: GritQL pattern catalog
+
+Add three patterns first:
+
+```text
+no-internal-import.grit
+no-deprecated-builder.grit
+no-generated-zone-edit.grit
+```
+
+Each pattern gets fixtures and a clear failure message.
+
+Exit condition:
+
+```sh
+bunx nx affected -t grit:check
+bun run habitat fix --dry-run
+```
+
+### Phase 5: Hook closure
+
+Make hooks delegate to the harness:
+
+```text
+pre-commit -> staged hygiene + cheap structural checks
+commit-msg -> message/link policy if used
+pre-push   -> affected verification
+```
+
+Exit condition:
+
+```sh
+bun run habitat hook pre-commit
+bun run habitat hook pre-push
+```
+
+### Phase 6: Generators and migrations
+
+Add generators for the repo's actual project kinds. Add migrations when the harness evolves its own conventions.
+
+Exit condition:
+
+```sh
+bunx nx g @internal/habitat-harness:project example --kind=domain
+bunx nx migrate @internal/habitat-harness
+```
+
+## 12. Forbidden patterns
+
+### 12.1 ESLint becomes the main linter
+
+Forbidden:
+
+```text
+eslint runs broad style, formatting, or ordinary lint rules while Biome also does the same.
+```
+
+Required:
+
+```text
+Biome owns hygiene. ESLint owns temporary boundary compatibility only.
+```
+
+### 12.2 GritQL becomes the graph
+
+Forbidden:
+
+```text
+GritQL searches imports and acts as the project graph authority.
+```
+
+Required:
+
+```text
+Nx owns graph law. GritQL owns source shape and rewrites.
+```
+
+### 12.3 Hooks become CI
+
+Forbidden:
+
+```text
+A change is considered verified because Husky hooks passed locally.
+```
+
+Required:
+
+```text
+Hooks are local feedback. CI is authoritative.
+```
+
+### 12.4 Rules without enforcement
+
+Forbidden:
+
+```text
+A rule exists only in documentation or prompt text.
+```
+
+Required:
+
+```text
+Every hardened rule maps to Nx, Biome, ESLint, GritQL, Husky, or CI enforcement.
+```
+
+### 12.5 Remediation invents meaning
+
+Forbidden:
+
+```text
+A codemod creates new domain behavior because it guessed intent.
+```
+
+Required:
+
+```text
+Codemods rewrite known structure. Humans/agents author business logic.
+```
+
+### 12.6 Bun hides undeclared dependencies
+
+Forbidden:
+
+```text
+The workspace relies on hoisted or phantom dependencies as a normal operating mode.
+```
+
+Required:
+
+```text
+Prefer Bun isolated installs. Declare every dependency in the project that imports it.
+```
+
+## 13. Minimal command reference
+
+```sh
+# graph / orientation
+bun run habitat graph
+bun run habitat classify services/billing/src/index.ts
+bunx nx show project billing
+
+# hygiene
+bunx nx affected -t biome:ci
+bunx --bun @biomejs/biome check .
+bunx --bun @biomejs/biome format --write .
+
+# boundaries
+bunx nx affected -t boundaries
+bunx eslint -c eslint.boundaries.config.mjs "**/*.{ts,tsx,js,jsx}"
+
+# structural checks and rewrites
+bunx nx affected -t grit:check
+bunx grit check
+bunx grit apply tools/habitat-harness/patterns/grit/migrate-boundary-v1-to-v2.grit
+
+# full verification
+bun run habitat verify
+bunx nx affected -t biome:ci,boundaries,grit:check,typecheck,test
+
+# hooks
+bun run habitat hook pre-commit
+bun run habitat hook commit-msg .git/COMMIT_EDITMSG
+bun run habitat hook pre-push
+```
+
+## 14. Final shape
+
+This harness succeeds when a repository gains this behavior:
+
+```text
+Bun owns installs, workspace linking, lockfile, and local script execution
+new structure comes from generators
+stale structure is repaired by codemods
+hygiene is automatic
+boundaries are graph-enforced
+file-level invariants are structurally checked
+local hooks catch cheap mistakes early
+CI proves the real change set
+agents classify before they author
+manual work concentrates on business logic
+```
+
+That is the Habitat tool harness: a compact, composable development toolkit that turns repository structure into an executable container for agent and human work.
+
+## References
+
+- Bun install / CI / lifecycle / workspaces: https://bun.com/docs/pm/cli/install
+- Bun lockfile: https://bun.com/docs/pm/lockfile
+- Bun workspaces: https://bun.com/docs/pm/workspaces
+- Bun isolated installs: https://bun.com/docs/pm/isolated-installs
+- Bun package scripts and local binary resolution: https://bun.com/docs/runtime
+- Bun `bunx`: https://bun.com/docs/pm/bunx
+- Bun TypeScript types: https://bun.com/docs/typescript
+- Nx create-nx-workspace: https://nx.dev/docs/reference/create-nx-workspace
+- Nx setup with Bun on CI: https://nx.dev/docs/guides/nx-cloud/use-bun
+- Nx package-manager workspaces and TypeScript project references: https://nx.dev/docs/technologies/typescript/guides/switch-to-workspaces-project-references
+- Nx Project Graph Plugins: https://nx.dev/docs/extending-nx/project-graph-plugins
+- Nx Affected: https://nx.dev/docs/features/ci-features/affected
+- Nx Enforce Module Boundaries ESLint Rule: https://nx.dev/docs/technologies/eslint/eslint-plugin/guides/enforce-module-boundaries
+- Nx Organization-Specific Plugins: https://nx.dev/docs/extending-nx/recipes/organization-specific-plugin
+- Nx Sync Generators: https://nx.dev/docs/extending-nx/recipes/create-sync-generator
+- Biome Getting Started / Bun commands: https://biomejs.dev/guides/getting-started/
+- Biome CLI: https://biomejs.dev/reference/cli/
+- Biome Linter Plugins / GritQL Diagnostics: https://biomejs.dev/linter/plugins/
+- ESLint Getting Started / Bun commands: https://eslint.org/docs/latest/use/getting-started
+- Grit CLI Quickstart: https://docs.grit.io/cli/quickstart
+- GritQL Language Overview: https://docs.grit.io/language/overview
+- Husky Get Started: https://typicode.github.io/husky/get-started.html
+- Husky How To / skipping hooks: https://typicode.github.io/husky/how-to.html
+- Git Hooks: https://git-scm.com/docs/githooks

--- a/docs/projects/habitat-harness/invariant-corpus.md
+++ b/docs/projects/habitat-harness/invariant-corpus.md
@@ -1,0 +1,90 @@
+# Invariant Corpus — Existing Enforcement → Harness Migration Map
+
+Gate-4 corpus ledger for the habitat-harness workstream (see `FRAME.md`).
+Enumerates every existing enforcement mechanism with its proposed harness
+owner and migration disposition. Derived from code at `main` (2026-06-12).
+
+Disposition legend:
+- **port** — re-home into the named harness layer; retire the original in the same slice.
+- **wrap-then-port** — slice H2 wraps it behind the habitat CLI unchanged (JSON output added); a later slice ports internals to the owning tool and retires the script.
+- **keep-as-test** — genuine behavior/correctness test; stays in `test/`, not harness-owned. The harness may *invoke* it but does not own it.
+- **keep** — orthogonal to the harness (CI orchestration etc.).
+
+Owner-layer legend (frame hard core #2): `nx-boundaries` (tags + enforce-module-boundaries), `grit-check` / `grit-apply` (syntax layer), `biome` (hygiene), `file-layer` (path/generated-zone rules), `habitat-native` (custom TS check inside the harness — budgeted; see degeneration trigger in FRAME.md).
+
+## A. Lint scripts (`scripts/lint/`)
+
+| ID | Implementation | Invariant | Scope | Enforced today | JSON? | Exceptions | Harness owner | Disposition |
+|---|---|---|---|---|---|---|---|---|
+| adapter-boundary | `lint-adapter-boundary.sh` (bash+rg) | `/base-standard/` imports only inside `packages/civ7-adapter` | `packages/**` | root `check` + `ci:architecture-strict-core` | parseable text | 6 allowlisted files (CIV-20, CIV-47, map-policy tables) → becomes the rule's ratchet baseline | grit-check (+ nx tag `kind:adapter` context) | wrap-then-port |
+| domain-refactor-guardrails | `lint-domain-refactor-guardrails.sh` (bash+rg, `boundary`/`full` profiles) | ops don't import adapter/context/map-projection/domain-root config; no cross-domain deep imports; no RNG/engine imports outside runtime layers; full profile adds JSDoc/schema-description rules | `mods/mod-swooper-maps/src/domain/**`, `recipes/standard/**` | root `check` + strict-core (full) | text | 0 | grit-check (+ grit-apply candidates for JSDoc) | wrap-then-port |
+| mapgen-recipe-imports | `lint-mapgen-recipe-imports.sh` (bash+rg) | recipes import domain only via public surfaces (`@mapgen/domain/<d>`, `/ops`, `/config.js`) | `mods/mod-swooper-maps/src/recipes/**` | root `check` | text | 0 | nx-boundaries (package-level) + grit-check (path-level within mod) | wrap-then-port |
+| normalization-guardrails | `lint-normalization-guardrails.mjs` | G1 no milestone-prefixed recipe IDs; G2 no domain-root catalogs; G3 no Civ7 runtime imports in mapgen-core; G5 no sibling stage step imports; G6 recipe/docs stage-order sync; G7 superseded stage IDs in docs; G8 placement outcome contract boundary; G9 no wrapper-only stage config; G10 viz contract ownership; G11 SDK runtime entrypoint isolation | mod recipes/domain, sdk, mapgen-core, docs | root `check` | structured text | 0 | split: grit-check (G1,G2,G5,G9), nx-boundaries (G3,G10,G11), habitat-native (G6,G7 — doc/code sync is semantic) | wrap-then-port |
+| control-orpc-contract-ownership | `lint-control-orpc-contract-ownership.mjs` | no `@civ7/direct-control` imports in service contracts; no schema exports from module contracts; no contract-local re-exports from public surface | `packages/civ7-control-orpc/src/modules/**/contract.ts` | root `check` | text | 0 | grit-check | wrap-then-port |
+| workspace-entrypoints | `lint-workspace-entrypoints.mjs` | package-local scripts must not hide workspace orchestration (`--filter`, `--cwd`, nested turbo→nx) | all `package.json` | root `check` | text | 0 | habitat-native (manifest rule, not source syntax) | wrap-then-port (update for nx in H1) |
+| adr-lint | `lint-doc-adrs.mjs` | ADR frontmatter shape + heading IDs + no hardcoded paths | `docs/projects/*/resources/spec/adr/` | manual | yes (`--json`) | 0 | habitat-native (doc tooling) | wrap (keep semantics; low priority) |
+| doc-ambiguity-lint | `lint-doc-ambiguity.mjs` | vague-language reduction with baseline tracking | `docs/**` | manual/advisory | yes + baseline file | baseline `docs/.doc-ambiguity-lint-baseline.json` (prior art for the ratchet) | habitat-native | wrap (advisory lane) |
+| mapgen-docs-lint | `lint-mapgen-docs.py` (python) | mapgen canonical docs have `<toc>`, ground-truth anchors, anchor paths exist | `docs/system/libs/mapgen/**` | root `check` | stderr text | 0 | habitat-native | wrap (port py→TS only if touched) |
+
+## B. ESLint flat-config blocks (`eslint.config.js`)
+
+| ID | Block | Invariant | Harness owner | Disposition |
+|---|---|---|---|---|
+| eslint-studio-recipe-imports | lines ~27–62 | Studio UI imports recipe *artifacts*, not runtime modules (worker files exempt) | nx-boundaries (tag rule app↔mod-artifacts) | port |
+| eslint-domain-ops-deep-imports | ~65–88 | no deep `@mapgen/domain/*/ops|rules|strategies/*` imports outside domain | grit-check (intra-package path rule; nx can't see within one project) | port |
+| eslint-runtime-typebox-ban | ~91–127 | steps/strategies: no TypeBox `Value.*`/`TypeCompiler`, no `runValidated`, no compiler-normalize imports | grit-check | port |
+| eslint-redefined-helpers | ~129–170 | steps/strategies must not redeclare `clamp01`/`clampChance`/`normalizeRange`/`rollPercent` | grit-check | port |
+| eslint-step-contract-imports | ~174–197 | step contracts import only `@mapgen/domain/<d>` entrypoint | grit-check | port |
+| eslint-recipe-domain-ops | ~199–214 | `recipe.ts` imports domain ops surface, not contract entrypoint | grit-check | port |
+| eslint-contract-export-all | ~216–235 | no bare `export *` in contract/public-surface files (`export type *` ok) | grit-check + grit-apply (named-export codemod) | port |
+| eslint-empty-schema-defaults | ~237–250 | no `{ default: {} }` in contract schemas | grit-check | port |
+
+Note (frame hard core #2): after porting, `eslint.config.js` is replaced by a
+minimal boundary-only config whose sole rule is `@nx/enforce-module-boundaries`.
+No other ESLint rules survive.
+
+## C. Architecture tests (stay as tests)
+
+| ID | File | Invariant | Disposition |
+|---|---|---|---|
+| core-purity | `packages/mapgen-core/test/architecture/core-purity.test.ts` | mapgen-core prod code has no Civ7 runtime refs | keep-as-test; **duplicated intent** with nx-boundaries tag rule (`kind:core` ↛ `kind:adapter`) — once the tag rule is locked, slim the test or retire (decided in H6) |
+| rng-authority-boundary | `mods/.../test/pipeline/rng-authority-boundary.test.ts` | no engine RNG / official generators in standard recipe + domain | keep-as-test (runtime semantics) |
+| recipe-import-boundary | `mods/.../test/pipeline/recipe-import-boundary.test.ts` | recipes use public domain surfaces | keep-as-test until grit-check equivalent is locked, then retire (H6) |
+| ecology-step-import-guardrails | `mods/.../test/ecology/ecology-step-import-guardrails.test.ts` | ecology steps don't deep-import ops/rules; retired stage dirs absent | keep-as-test until grit equivalent locked (H6) |
+| m11-projection-boundary-band | `mods/.../test/foundation/m11-projection-boundary-band.test.ts` | projection algorithm correctness | keep-as-test (domain logic, not structure) |
+| map-bundle-runtime-imports | `mods/.../test/build/map-bundle-runtime-imports.test.ts` | built bundles embed workspace packages; TextEncoder bootstrap; river markers | keep-as-test (build output correctness) |
+
+## D. CI wiring
+
+| ID | Where | Behavior | Disposition |
+|---|---|---|---|
+| pnpm-guard | `.github/workflows/ci.yml` | fail on pnpm artifacts | keep; add habitat-native equivalent locally (cheap pre-commit) |
+| root-check | `package.json` `check` → turbo + 5 lint scripts | aggregator | becomes `habitat check` / nx targets in H1–H2 |
+| architecture-strict-core | ci.yml job | lint + adapter-boundary + cutover tests + guardrails + check | re-pointed at `habitat verify` (nx affected) in H2; job kept |
+
+## E. Generated zones (file layer)
+
+| Zone | Generator | Guard today | Harness action |
+|---|---|---|---|
+| `mods/mod-swooper-maps/src/maps/generated/**` | `gen:maps` (`scripts/generate-map-artifacts.ts`) | none | file-layer write-protection rule + "regenerate, don't edit" remediation |
+| `packages/civ7-types/generated/**` | resources workflow (external) | none | file-layer rule |
+| `packages/civ7-map-policy/src/civ7-tables.gen.ts` | `civ7-map-policy:gen-tables` | adapter-boundary allowlist only | file-layer rule |
+| `dist/**`, `mod/**`, `types/**` build outputs | nx/turbo targets | gitignore (mostly) | out of scope where untracked |
+
+## F. Promised-but-unenforced (candidate NEW invariants)
+
+| Invariant | Source of promise | Today | Workstream slice |
+|---|---|---|---|
+| Generated artifacts are read-only (regenerate via scripts) | root `AGENTS.md` Hygiene | nothing | H5 (file layer, staged-file guard) |
+| Formatting consistency | `.prettierrc` exists; no gate anywhere | nothing | H4 (Biome `format`/`ci`) |
+| Bun-only package manager locally | CI-only pnpm guard | CI only | H7 (pre-commit cheap check) |
+| Stage truth/projection separation (`map-*` projection-only) | normalization packet / openspec config | prose + partial G-guards | logged; future rule after normalization train lands (exterior here) |
+| Typed intent APIs at adapter boundary | swooper-maps architecture.md | prose only | logged in discrepancy-log; future rule |
+
+## Summary counts
+
+- 9 lint scripts → 4 grit-check families, 2 nx-boundaries families, 3 habitat-native (docs/manifest) wraps.
+- 8 ESLint rule families → 1 nx-boundaries, 6 grit-check, 1 grit-apply codemod; ESLint reduced to the single Nx boundary rule.
+- 6 architecture tests → all keep-as-test initially; 3 retire candidates in H6 once equivalent harness rules are locked.
+- 4 generated zones → file-layer rules (new enforcement).
+- 5 promised-but-unenforced invariants → 3 in-scope new rules (H4/H5/H7), 2 logged as future.

--- a/docs/projects/habitat-harness/invariant-corpus.md
+++ b/docs/projects/habitat-harness/invariant-corpus.md
@@ -16,10 +16,10 @@ Owner-layer legend (frame hard core #2): `nx-boundaries` (tags + enforce-module-
 
 | ID | Implementation | Invariant | Scope | Enforced today | JSON? | Exceptions | Harness owner | Disposition |
 |---|---|---|---|---|---|---|---|---|
-| adapter-boundary | `lint-adapter-boundary.sh` (bash+rg) | `/base-standard/` imports only inside `packages/civ7-adapter` | `packages/**` | root `check` + `ci:architecture-strict-core` | parseable text | 6 allowlisted files (CIV-20, CIV-47, map-policy tables) → becomes the rule's ratchet baseline | grit-check (+ nx tag `kind:adapter` context) | wrap-then-port |
+| adapter-boundary | `lint-adapter-boundary.sh` (bash+rg) | `/base-standard/` imports only inside `packages/civ7-adapter` | `packages/**` | `ci:architecture-strict-core` only (root `check` does NOT invoke it) | parseable text | 6 allowlisted files (CIV-20, CIV-47, map-policy tables) → becomes the rule's ratchet baseline | grit-check (+ nx tag `kind:adapter` context) | wrap-then-port |
 | domain-refactor-guardrails | `lint-domain-refactor-guardrails.sh` (bash+rg, `boundary`/`full` profiles) | ops don't import adapter/context/map-projection/domain-root config; no cross-domain deep imports; no RNG/engine imports outside runtime layers; full profile adds JSDoc/schema-description rules | `mods/mod-swooper-maps/src/domain/**`, `recipes/standard/**` | root `check` + strict-core (full) | text | 0 | grit-check (+ grit-apply candidates for JSDoc) | wrap-then-port |
 | mapgen-recipe-imports | `lint-mapgen-recipe-imports.sh` (bash+rg) | recipes import domain only via public surfaces (`@mapgen/domain/<d>`, `/ops`, `/config.js`) | `mods/mod-swooper-maps/src/recipes/**` | root `check` | text | 0 | nx-boundaries (package-level) + grit-check (path-level within mod) | wrap-then-port |
-| normalization-guardrails | `lint-normalization-guardrails.mjs` | G1 no milestone-prefixed recipe IDs; G2 no domain-root catalogs; G3 no Civ7 runtime imports in mapgen-core; G5 no sibling stage step imports; G6 recipe/docs stage-order sync; G7 superseded stage IDs in docs; G8 placement outcome contract boundary; G9 no wrapper-only stage config; G10 viz contract ownership; G11 SDK runtime entrypoint isolation | mod recipes/domain, sdk, mapgen-core, docs | root `check` | structured text | 0 | split: grit-check (G1,G2,G5,G9), nx-boundaries (G3,G10,G11), habitat-native (G6,G7 — doc/code sync is semantic) | wrap-then-port |
+| normalization-guardrails | `lint-normalization-guardrails.mjs` | G1 no milestone-prefixed recipe IDs; G2 no domain-root catalogs; G3 no Civ7 runtime imports in mapgen-core; G5 no sibling stage step imports; G6 recipe/docs stage-order sync; G7 superseded stage IDs in docs; G8 placement outcome contract boundary; G9 no wrapper-only stage config; G10 viz contract ownership; G11 SDK runtime entrypoint isolation | mod recipes/domain, sdk, mapgen-core, docs | root `check` | structured text | 0 | split: grit-check (G1, G2, G5, G8, G9, G10, G11, and the G3 runtime-value ban — all intra-project shapes Nx cannot see), nx-boundaries (G3 project-edge context only, via the `kind:engine` tag rule), habitat-native (G6, G7 — doc/code sync is semantic) | wrap-then-port |
 | control-orpc-contract-ownership | `lint-control-orpc-contract-ownership.mjs` | no `@civ7/direct-control` imports in service contracts; no schema exports from module contracts; no contract-local re-exports from public surface | `packages/civ7-control-orpc/src/modules/**/contract.ts` | root `check` | text | 0 | grit-check | wrap-then-port |
 | workspace-entrypoints | `lint-workspace-entrypoints.mjs` | package-local scripts must not hide workspace orchestration (`--filter`, `--cwd`, nested turbo→nx) | all `package.json` | root `check` | text | 0 | habitat-native (manifest rule, not source syntax) | wrap-then-port (update for nx in H1) |
 | adr-lint | `lint-doc-adrs.mjs` | ADR frontmatter shape + heading IDs + no hardcoded paths | `docs/projects/*/resources/spec/adr/` | manual | yes (`--json`) | 0 | habitat-native (doc tooling) | wrap (keep semantics; low priority) |
@@ -30,7 +30,7 @@ Owner-layer legend (frame hard core #2): `nx-boundaries` (tags + enforce-module-
 
 | ID | Block | Invariant | Harness owner | Disposition |
 |---|---|---|---|---|
-| eslint-studio-recipe-imports | lines ~27–62 | Studio UI imports recipe *artifacts*, not runtime modules (worker files exempt) | nx-boundaries (tag rule app↔mod-artifacts) | port |
+| eslint-studio-recipe-imports | lines ~27–62 | Studio UI imports recipe *artifacts*, not runtime modules (worker files exempt) | grit-check (artifact-vs-runtime split is a subpath distinction within one project — invisible to Nx tags; worker exemptions preserved in the pattern) | port |
 | eslint-domain-ops-deep-imports | ~65–88 | no deep `@mapgen/domain/*/ops|rules|strategies/*` imports outside domain | grit-check (intra-package path rule; nx can't see within one project) | port |
 | eslint-runtime-typebox-ban | ~91–127 | steps/strategies: no TypeBox `Value.*`/`TypeCompiler`, no `runValidated`, no compiler-normalize imports | grit-check | port |
 | eslint-redefined-helpers | ~129–170 | steps/strategies must not redeclare `clamp01`/`clampChance`/`normalizeRange`/`rollPercent` | grit-check | port |
@@ -50,17 +50,18 @@ No other ESLint rules survive.
 | core-purity | `packages/mapgen-core/test/architecture/core-purity.test.ts` | mapgen-core prod code has no Civ7 runtime refs | keep-as-test; **duplicated intent** with nx-boundaries tag rule (`kind:core` ↛ `kind:adapter`) — once the tag rule is locked, slim the test or retire (decided in H6) |
 | rng-authority-boundary | `mods/.../test/pipeline/rng-authority-boundary.test.ts` | no engine RNG / official generators in standard recipe + domain | keep-as-test (runtime semantics) |
 | recipe-import-boundary | `mods/.../test/pipeline/recipe-import-boundary.test.ts` | recipes use public domain surfaces | keep-as-test until grit-check equivalent is locked, then retire (H6) |
-| ecology-step-import-guardrails | `mods/.../test/ecology/ecology-step-import-guardrails.test.ts` | ecology steps don't deep-import ops/rules; retired stage dirs absent | keep-as-test until grit equivalent locked (H6) |
+| ecology-step-import-guardrails | `mods/.../test/ecology/ecology-step-import-guardrails.test.ts` | ecology steps don't deep-import ops/rules; retired stage dirs absent | split in H6: deep-import half retires once the grit equivalent locks; the retired-stage-dirs-absent half stays (test slimmed, not deleted — no grit/file rule covers directory absence) |
 | m11-projection-boundary-band | `mods/.../test/foundation/m11-projection-boundary-band.test.ts` | projection algorithm correctness | keep-as-test (domain logic, not structure) |
 | map-bundle-runtime-imports | `mods/.../test/build/map-bundle-runtime-imports.test.ts` | built bundles embed workspace packages; TextEncoder bootstrap; river markers | keep-as-test (build output correctness) |
+| cutover-tests (×4) | `mods/mod-swooper-maps` `test:architecture-cutover` → `no-op-calls-op-tectonics`, `no-dual-contract-paths`, `no-shim-surfaces`, `foundation-topology-lock` | M-cutover structural invariants (distinct from the six rows above) | keep-as-test; coarse-wrapped via the script target in H2 (the six rows above need per-file `bun test` invocations — see H2 task 2.4) |
 
 ## D. CI wiring
 
 | ID | Where | Behavior | Disposition |
 |---|---|---|---|
-| pnpm-guard | `.github/workflows/ci.yml` | fail on pnpm artifacts | keep; add habitat-native equivalent locally (cheap pre-commit) |
+| pnpm-guard | `.github/workflows/ci.yml` | fail on pnpm artifacts | keep; H7 adds a **registered file-layer rule** (empty baseline, locked) run in pre-commit — not an unregistered native check |
 | root-check | `package.json` `check` → turbo + 5 lint scripts | aggregator | becomes `habitat check` / nx targets in H1–H2 |
-| architecture-strict-core | ci.yml job | lint + adapter-boundary + cutover tests + guardrails + check | re-pointed at `habitat verify` (nx affected) in H2; job kept |
+| architecture-strict-core | ci.yml job | lint + adapter-boundary + cutover tests + guardrails + check | re-pointed at `habitat verify` (nx affected) in **H6** (H2 only adds diagnostics-artifact upload); job kept |
 
 ## E. Generated zones (file layer)
 
@@ -83,8 +84,8 @@ No other ESLint rules survive.
 
 ## Summary counts
 
-- 9 lint scripts → 4 grit-check families, 2 nx-boundaries families, 3 habitat-native (docs/manifest) wraps.
-- 8 ESLint rule families → 1 nx-boundaries, 6 grit-check, 1 grit-apply codemod; ESLint reduced to the single Nx boundary rule.
-- 6 architecture tests → all keep-as-test initially; 3 retire candidates in H6 once equivalent harness rules are locked.
+- 9 lint scripts → 5 grit-check families (normalization split: G1/G2/G3-runtime/G5/G8/G9/G10/G11 grit; G6/G7 native; G3 project-edge via nx tags), 4 habitat-native (docs/manifest) wraps.
+- 8 ESLint rule families → 7 grit-check, 1 grit-apply codemod (+check); ESLint reduced to the single Nx boundary rule.
+- 6 architecture tests (+4 coarse-wrapped cutover tests) → all keep-as-test initially; in H6: 2 retire once equivalent grit rules lock (core-purity slim-or-retire, recipe-import-boundary), ecology test slims (dir-absence half stays).
 - 4 generated zones → file-layer rules (new enforcement).
 - 5 promised-but-unenforced invariants → 3 in-scope new rules (H4/H5/H7), 2 logged as future.

--- a/docs/projects/habitat-harness/review-disposition-ledger.md
+++ b/docs/projects/habitat-harness/review-disposition-ledger.md
@@ -1,0 +1,77 @@
+# Review Disposition Ledger — Pre-Execution Spec Review
+
+- **Lane:** spec review (workstream-record.md review lanes, row 1) — run 2026-06-12, before H1
+- **Reviewers:** 4 fresh framed agents, one lens each: (R1) train coherence & dependencies, (R2) shortcut language & proof inflation, (R3) cold executability vs real repo, (R4) FRAME conformance
+- **Verdicts:** 4× READY-WITH-REPAIRS (no NOT-READY; no reframe trigger)
+- **Disposition key:** ACCEPT (repair applied pre-H1) · ACCEPT-AMENDED (accepted, repair differs from reviewer suggestion — noted) · REJECT (with reason)
+- **Blocking rule:** accepted P1/P2 block H1 start until repaired.
+
+## P1 findings
+
+| ID | Source | Finding | Disposition | Repair |
+|---|---|---|---|---|
+| F1 | R1 | H3∥H4 "disjoint write sets" is false: both touch root `package.json`, `ci.yml`, harness rule pack; H4's repo-wide reformat rewrites the `package.json` files H3 edits tags into | ACCEPT | Serialize: H4 now requires H3; train table + both proposals updated; parallelism claims removed |
+| F2 | R1, R3 | Guardrail G8 (placement outcome contract) orphaned: listed as invariant, assigned to no owner, ported by no slice; H6's "delete whole scripts when emptied" could silently drop it | ACCEPT | G8 assigned to grit-check in corpus split; added to H5 port list; H6 retirement honors it |
+| F3 | R1 | G10/G11 assigned to nx-boundaries in corpus but they are intra-project (Nx cannot see them); H5 ports neither; H6 retires the families citing coverage that would not exist | ACCEPT | Corpus owner → grit-check (taxonomy already said so); G10/G11 added to H5 pattern catalog; H6 retirement list matched |
+| F4 | R2 | Empty-vs-empty parity is vacuous (a pattern matching nothing passes), yet it is the load-bearing precondition for H6 retirement; H6 probes only one per family | ACCEPT | H5 parity now requires injected-violation dual run (original + port both flag a synthetic violation) for every ported rule with empty current-tree findings; H6 probe gate is per retired rule with an enumerated probe matrix |
+| F5 | R2 | H2 baseline-expansion gate: scenario wording garbled and the CI-visible mechanism undefined (a local `--expand-baseline` flag is invisible to CI) — ratchet bypassable while all gates green | ACCEPT | Mechanism defined: baseline additions permitted only when the same change registers a new `ruleId` in the rule pack (self-check cross-references baseline-entry diff vs rule-pack diff against merge-base); spec scenarios rewritten (reject path + permitted rule-introduction path); CI-side probe added |
+| F6 | R3 | Repo already has local hooks (`scripts/git-hooks/pre-commit` → `publish-submodule.sh`, installed via `core.hooksPath` by `setup:git-hooks`); H7 unaware; Husky would silently drop the behavior; FRAME §6 "no local hooks at all" is false | ACCEPT | H7 gains an explicit disposition task for `scripts/git-hooks/*` + `setup:git-hooks` (fold publish-submodule into `habitat hook pre-commit`, retire the setup script); FRAME §6 corrected |
+
+## P2 findings
+
+| ID | Source | Finding | Disposition | Repair |
+|---|---|---|---|---|
+| F7 | R1, R3 | H7 `Requires` omits H3 though pre-push runs the `boundaries` target | ACCEPT | H3 added to H7 Requires (proposal + train table) |
+| F8 | R1, R3 | Corpus assigns `eslint-studio-recipe-imports` to nx-boundaries; only H5's grit pattern actually implements it (artifact-vs-runtime split is intra-target, invisible to tags) | ACCEPT | Corpus row owner → grit-check; summary counts fixed |
+| F9 | R1 | H5's domain-refactor-guardrails port scope unenumerated; H6 deletes "the ported families" without an input list | ACCEPT | H5 tasks enumerate ported families (boundary-profile) vs stay-wrapped (full-profile JSDoc/schema-description); H6 consumes that enumeration |
+| F10 | R1 | H6 retires the ecology test whole, losing its "retired stage dirs absent" half (no grit/file rule covers directory absence) | ACCEPT-AMENDED | H6 slims the test (keeps the dir-absence assertion) instead of adding a new file-layer rule; corpus row updated |
+| F11 | R1, R3 | H6 task 2.1 silently commits to rewriting `lint-mapgen-docs.py` in TS, contradicting corpus ("wrap; port py→TS only if touched") and FRAME §3 | ACCEPT | H6 2.1 changed to relocate/keep-wrapped for the Python linter; no forced rewrite |
+| F12 | R2 | H1 spec claims cacheability parity; no gate observes cache behavior | ACCEPT | Cache gate added: double run → all cache hits; touch one package → only it + dependents miss |
+| F13 | R2 | H1 "correct dependency edges" verified only by spot-check | ACCEPT | Gate rewritten as set comparison: every workspace dep edge in package.jsons present in `graph.json`; spot-checks stay as sanity |
+| F14 | R1, R2, R3 | H3 violation probe direction garbled (the legal direction cannot fail) | ACCEPT | Probe rewritten: `import '@civ7/adapter'` inside `packages/config` scratch file; `kind:foundation` may depend only on `kind:foundation` → must fail naming that constraint |
+| F15 | R2 | H3 spec says "locked" unconditionally while the proposal defines a baselined-red stop-condition path | ACCEPT | Spec reworded: locked when baseline empty (expected at adoption); red edges baselined + logged, lock when emptied |
+| F16 | R2 | H5 design "message guidance only" for zones without generator `--check` contradicts spec "staged hand-edits SHALL fail" | ACCEPT | Design reworded: staged guard always fails on staged paths in a zone; message carries the regenerate command; false-positive cost recorded |
+| F17 | R2 | H5 drift-detection scenario claims all zones; tasks wire regenerate-and-diff for one of three | ACCEPT-AMENDED | Task 4.2 wires regenerate-and-diff for both repo-runnable generators (`gen:maps`, `civ7-map-policy:gen-tables`); `civ7-types/generated` (external resources workflow) gets write-protection only, gap recorded; spec scenario scoped to zones with a repo-runnable generator |
+| F18 | R2 | H2 wrapped-parity fail case probed for one rule; record promises a matrix | ACCEPT | H2 task 4.2 becomes a probe matrix: one synthetic violation per wrapped family with expected rule id + failure text |
+| F19 | R3 | H2 wraps `test:architecture-cutover`, which runs 4 cutover tests — not the corpus §C six; six lack invocation spec; cutover tests missing from corpus | ACCEPT | H2 task 2.4 specifies per-file `bun test` invocations for the corpus six; cutover tests added to corpus §C as keep-as-test (coarse-wrapped) |
+| F20 | R3 | H1 design conversion table covers 7 of 18 turbo.json entries; FRAME says "~6 tasks"; `deploy:mods` path-glob filter has no stated Nx mapping | ACCEPT | Design table marked illustrative with a mandatory enumerate-all-entries instruction naming the notable unmapped entries (env var, studio-recipes deps, `deploy:mods` filter mapping decision); FRAME corrected to 18 |
+| F21 | R3 | H8 `bunx nx migrate @internal/habitat-harness` resolves via npm registry; package is unpublished | ACCEPT | Mechanism specified: hand-authored `migrations.json` + `bunx nx migrate --run-migrations=migrations.json`; gate = no-op migration executes |
+| F22 | R2 | H7 time budgets self-chosen after the fact (gate can never fail); "cheap grit checks" undefined | ACCEPT | Budget derivation fixed: measure baseline on two declared probe sets before wiring, budget = 2× measured, recorded in phase record first; "cheap" = rule-pack attribute `hookScope: 'pre-commit'`, patterns enumerated |
+| F23 | R2 | H4 byte-parity stop condition may fire for benign reasons (unminified bundles preserve formatting) with no disposition; "accepted one-time cost" has no criterion | ACCEPT | Disposition declared: formatting-independent artifacts enumerated; bundle JS compared after minify-normalization if needed (recorded trade-off); reformat delta accepted only if confined to whitespace/quote/trailing-comma classes (`git diff -w` empty + sampled review in phase record) |
+| F24 | R4 | H7's bun-only (pnpm-artifact) guard is a new rule skipping the ratchet, contradicting H7's own "hooks add no new rules" | ACCEPT | Registered as a file-layer rule in the rule pack (empty baseline, locked) via the rule-introduction gate; "no new rules" claim reworded |
+| F25 | R4 | H5's three file-layer generated-zone rules lack the explicit baseline/locked language the grit patterns get | ACCEPT | H5 task 5.2 extended: ratchet entries for every rule introduced in the slice, including the file-layer rules |
+
+## P3 findings (accepted polish)
+
+| ID | Source | Finding | Repair |
+|---|---|---|---|
+| F26 | R1, R2, R3 | FRAME §6 stale facts: "18 workspace packages" (21), "7 exceptions" (6), "no local hooks at all" (false), §4 "~6 tasks" (18) | FRAME corrected |
+| F27 | R1, R3 | Corpus stale cells: strict-core re-point attributed to H2 (it is H6); adapter-boundary "root `check` + ci" (ci job only) | Corpus corrected |
+| F28 | R1, R4 | H6/H7 dangling references to design docs that don't exist | Reworded to point at tasks |
+| F29 | R1 | H3 task 2.1 "(+ eslint if needed by H6 ordering)" opaque; H2/H3 both claim the harness `kind:tooling` tag | Reworded; H3 verifies the pre-seeded tag |
+| F30 | R2 | H2 `habitat fix` with zero fixable rules and `verify` base undefined | One sentence each in design (no-op message + exit 0; base = merge-base with `main`) |
+| F31 | R2 | H6 perf threshold self-chosen | Pre-stated: ≤1.25× retired aggregate wall-clock on CI |
+| F32 | R2 | H8 classify spot-checks lack expected outputs; migration scenario undemonstrable beyond no-op | Four paths enumerated with expected taxonomy outputs; tasks note the demonstrable gate is the no-op run |
+| F33 | R2 | H1 task 4.3 affected probe unnamed; H3 "affected on clean tree" vacuous gate component | Probe names the package + expected affected set; H3 gate states `run-many --all` as the gate, affected as smoke |
+| F34 | R2 | H5 "grit init artifacts committed as appropriate" | Exact: commit `.grit/grit.yaml`; gitignore `.grit/.gritmodules`/cache |
+| F35 | R3 | `scripts/lint/no-legacy-m4-foundation-tokens.txt` orphan data file unowned | Added to H6 deletion-sweep disposition |
+| F36 | R3 | Taxonomy §2 heading says 21, table has 22 rows | Heading clarified (21 projects + new harness package) |
+| F37 | R4 | FRAME §3 by-design habitat-native set narrower than corpus reality (degeneration accounting ambiguity) | FRAME §3 row added enumerating the full by-design native set (doc lints ×3, workspace-entrypoints, G6/G7, H7 bun-only guard) |
+| F38 | R4 | H2 spec "every rule carries a baseline" not literally satisfiable for the wrapped adapter-boundary allowlist until H5 | Design sentence added: wrapped rules may reference a legacy allowlist as transitional exception source until their port migrates it |
+| F39 | R4 | H1 task 2.3 edits a rule pre-ratchet with no ceremony | Task notes expected-green-at-landing, recorded in phase record |
+| F40 | R1 | H7∥H8 "prep" parallelism undefined; both write `AGENTS.md`/README | Parallelism dropped; H8 strictly follows H7 |
+
+## Rejected findings
+
+None. All findings were accepted (two amended). The reviewers' P1s cross-corroborated independently (G8/G10-G11 found by both R1 and R3; the hooks discovery by R3 is verified against `scripts/git-hooks/` in the repo).
+
+## Habitat-native budget (R4 accounting)
+
+Tool-assigned rules falling back to habitat-native across H1–H8: **0 of 3** (degeneration trigger not approached). By-design natives, excluded from the trigger count: G6, G7, adr-lint, doc-ambiguity, mapgen-docs, workspace-entrypoints, H7 bun-only guard (now a registered file-layer rule per F24 — leaves the native list).
+
+## Outcome
+
+All accepted P1/P2 repairs applied 2026-06-12 before H1 start; all 8 changes
+re-validated `--strict` after edits. Spec-review lane CLOSED. Remaining lanes
+(architecture review before H3, implementation/evidence/closure per slice)
+open per workstream-record.md.

--- a/docs/projects/habitat-harness/taxonomy.md
+++ b/docs/projects/habitat-harness/taxonomy.md
@@ -1,0 +1,96 @@
+# Derived Tag Taxonomy
+
+Derived entirely from existing enforcement + docs (frame hard core #4: encode
+the **current implied architecture**, lockable on the ratchet, revisable later
+as deliberate decisions). Every tag cites the existing rule/doc that justifies
+it. Wrong-tag discoveries are future refactors, not blockers (Matei D4).
+
+Two enforcement planes — do not conflate them:
+
+- **Project plane (Nx tags + `enforce-module-boundaries`):** rules between
+  workspace projects. Tags live in each `package.json` under `"nx": {"tags": [...]}`.
+- **Intra-project plane (GritQL / file layer):** rules inside a single project
+  (domain/recipe/steps structure inside `mod-swooper-maps`, contract files,
+  generated zones). Nx cannot see inside one project; these are grit/file rules
+  and are listed here only as `scope:*` rule families for provenance.
+
+## 1. `kind:*` tags (project plane)
+
+| Tag | Definition | Provenance (existing rule/doc) |
+|---|---|---|
+| `kind:app` | User-facing applications and entry surfaces (CLI included): own caller-specific transports/workflows; consume public surfaces only | `apps/*` layout; `docs/system/ARCHITECTURE.md`; `lint-workspace-entrypoints.mjs` |
+| `kind:sdk` | High-level authoring/builder APIs for mod generation; mapgen runtime only via `@civ7/sdk/mapgen` subpath | `packages/sdk/AGENTS.md`; `lint-normalization-guardrails.mjs` G11 |
+| `kind:engine` | Pure TS engine/domain logic (no Civ7 runtime values, no engine globals) | `core-purity.test.ts`; normalization guardrail G3 |
+| `kind:adapter` | Sole owner of Civ7 engine globals and `/base-standard/` imports | `lint-adapter-boundary.sh`; `packages/civ7-adapter/AGENTS.md` |
+| `kind:control` | Runtime control of a live Civ7 instance: socket protocol (`direct-control`) and oRPC service surface (`control-orpc`, `studio-server`) | `packages/civ7-direct-control/AGENTS.md`; `lint-control-orpc-contract-ownership.mjs`; root `AGENTS.md` ("runtime Civ7 control belongs in @civ7/direct-control") |
+| `kind:foundation` | Pure leaf libraries: types, config, policy facts, viz contracts; no domain orchestration, broadly importable | `packages/civ7-types`, `config`, `civ7-map-policy`, `mapgen-viz` package docs |
+| `kind:plugin` | Reusable CLI/SDK helper libraries, leaf-local | `packages/plugins/*`; `packages/cli/AGENTS.md` |
+| `kind:mod` | Game-facing mod packages (recipes, domains, map configs, game runtime wrappers) | `mods/*`; `docs/system/ARCHITECTURE.md` |
+| `kind:tooling` | Repo-local dev tooling (the habitat harness itself) | new with this workstream |
+
+## 2. Per-project assignment (all 21 projects)
+
+| Project | Path | Tags |
+|---|---|---|
+| @mateicanavra/civ7-cli | `packages/cli` | `kind:app` |
+| @civ7/docs | `apps/docs` | `kind:app` |
+| @civ7/playground | `apps/playground` | `kind:app` |
+| mapgen-studio | `apps/mapgen-studio` | `kind:app` |
+| @mateicanavra/civ7-sdk | `packages/sdk` | `kind:sdk` |
+| @swooper/mapgen-core | `packages/mapgen-core` | `kind:engine` |
+| @civ7/adapter | `packages/civ7-adapter` | `kind:adapter` |
+| @civ7/direct-control | `packages/civ7-direct-control` | `kind:control` |
+| @civ7/control-orpc | `packages/civ7-control-orpc` | `kind:control` |
+| @civ7/studio-server | `packages/studio-server` | `kind:control` |
+| @civ7/types | `packages/civ7-types` | `kind:foundation` |
+| @civ7/config | `packages/config` | `kind:foundation` |
+| @civ7/map-policy | `packages/civ7-map-policy` | `kind:foundation` |
+| @swooper/mapgen-viz | `packages/mapgen-viz` | `kind:foundation` |
+| @civ7/plugin-files | `packages/plugins/plugin-files` | `kind:plugin` |
+| @civ7/plugin-git | `packages/plugins/plugin-git` | `kind:plugin` |
+| @civ7/plugin-graph | `packages/plugins/plugin-graph` | `kind:plugin` |
+| @civ7/plugin-mods | `packages/plugins/plugin-mods` | `kind:plugin` |
+| mod-swooper-maps | `mods/mod-swooper-maps` | `kind:mod` |
+| mod-civ7-intelligence-bridge | `mods/mod-civ7-intelligence-bridge` | `kind:mod`, `kind:control` |
+| mod-swooper-civ-dacia | `mods/mod-swooper-civ-dacia` | `kind:mod` |
+| (new) @internal/habitat-harness | `tools/habitat-harness` | `kind:tooling` |
+
+## 3. Dependency constraints (project plane, initial rule set)
+
+Encodes current enforcement generalized to tags. Verified against actual
+`package.json` dependency edges at `main` — **no current violations** except
+the allowlisted adapter-boundary files (which are file-level, not project-level,
+and become the grit rule's baseline).
+
+| sourceTag | onlyDependOnLibsWithTags | Generalizes |
+|---|---|---|
+| `kind:foundation` | `kind:foundation` | leaf purity (types/config/policy/viz import nothing higher) |
+| `kind:adapter` | `kind:foundation` | adapter translates engine↔types; owns `/base-standard/` exclusively (`lint-adapter-boundary.sh`) |
+| `kind:engine` | `kind:adapter`, `kind:foundation` | core purity: mapgen-core sees adapter *types* only, never runtime values (`core-purity.test.ts`, G3 — runtime-value ban stays grit/test-owned) |
+| `kind:plugin` | `kind:plugin`, `kind:foundation` | plugins stay leaf-local (`cli/AGENTS.md`) |
+| `kind:sdk` | `kind:engine`, `kind:adapter`, `kind:foundation`, `kind:plugin` | SDK composes engine+adapter; mapgen subpath isolation (G11) stays grit-owned |
+| `kind:control` | `kind:control`, `kind:foundation`, `kind:adapter`, `kind:engine`, `kind:mod` ¹ | control service layering (`control-orpc` over `direct-control`); contract-ownership rules stay grit-owned |
+| `kind:mod` | `kind:sdk`, `kind:engine`, `kind:adapter`, `kind:foundation`, `kind:control` | mods consume SDK/engine/adapter/policy |
+| `kind:app` | everything except `kind:app` | apps are top of the graph; nothing imports apps |
+| `kind:tooling` | `kind:tooling`, `kind:foundation` | harness stays out of product graph |
+
+¹ `kind:control` → `kind:mod` exists only for the studio-server → mod-swooper-maps
+recipe-artifact edge; expect to narrow this when artifact packages split out.
+Recorded as a deliberate wide edge, revisit on ratchet review.
+
+Initial baseline expectation: **all constraints green at adoption** (the
+project-plane graph is already clean). The burn-down backlog lives in the
+intra-project plane (existing allowlists + new file-layer/grit rules).
+
+## 4. `scope:*` rule families (intra-project plane — grit/file-layer owned)
+
+Not Nx tags. These name rule families inside `mod-swooper-maps` (and
+mapgen-core) for provenance and grit-pattern grouping:
+
+| Family | Rules | Provenance |
+|---|---|---|
+| `scope:domain-surface` | recipes import domain only via `@mapgen/domain/<d>`, `/ops`, `/config.js`; step contracts only the entrypoint; no deep ops/rules/strategies imports; no domain-root `export *` facades | `lint-mapgen-recipe-imports.sh`, eslint blocks, `recipe-import-boundary.test.ts`, guardrails full profile |
+| `scope:runtime-purity` | steps/strategies: no TypeBox runtime (`Value.*`, `TypeCompiler`), no `runValidated`, no helper redeclarations, no config merges (`?? {}`, `Value.Default(`) | eslint blocks; guardrails full profile |
+| `scope:stage-isolation` | no sibling-stage step imports (G5); no milestone-prefixed recipe IDs (G1); stage-order doc sync (G6) | `lint-normalization-guardrails.mjs` |
+| `scope:rng-authority` | no engine RNG / official generators in authored generation | `rng-authority-boundary.test.ts` (stays a test) |
+| `scope:generated-zone` | generated paths are regenerate-only | root `AGENTS.md` promise (new enforcement, slice H5) |

--- a/docs/projects/habitat-harness/taxonomy.md
+++ b/docs/projects/habitat-harness/taxonomy.md
@@ -28,7 +28,7 @@ Two enforcement planes — do not conflate them:
 | `kind:mod` | Game-facing mod packages (recipes, domains, map configs, game runtime wrappers) | `mods/*`; `docs/system/ARCHITECTURE.md` |
 | `kind:tooling` | Repo-local dev tooling (the habitat harness itself) | new with this workstream |
 
-## 2. Per-project assignment (all 21 projects)
+## 2. Per-project assignment (all 21 existing projects + the new harness package)
 
 | Project | Path | Tags |
 |---|---|---|

--- a/docs/projects/habitat-harness/workstream-record.md
+++ b/docs/projects/habitat-harness/workstream-record.md
@@ -1,0 +1,86 @@
+# Habitat Harness — Workstream Record
+
+- **Workstream:** habitat-harness (enforcement/codemod harness over the whole repo)
+- **Owner:** workstream owner agent (single accountable synthesizer; agents assist)
+- **Method:** `civ7-systematic-workstream` (12 gates) composed with `civ7-open-spec-workstream` (per-slice phase loop)
+- **Controlling frame:** `docs/projects/habitat-harness/FRAME.md` (hard core, falsifier, settled decisions D1–D6)
+- **Branch:** `agent-F-habitat-harness-workstream` (worktree `wt-agent-F-habitat-harness-workstream`, parent `main`, Graphite-tracked)
+- **Status:** PREPARATION COMPLETE — execution not started (per Matei instruction 2026-06-12)
+
+## Gate state (systematic-workstream)
+
+| Gate | State | Evidence |
+|---|---|---|
+| 1 Frame | DONE | FRAME.md (standalone frame artifact) |
+| 2 Repo state | DONE | clean worktree off main; gt-tracked; deps installed |
+| 3 Diagnosis | DONE | FRAME §6 grounding insights; spec disposition §5 |
+| 4 Corpus | DONE | invariant-corpus.md (every existing check, owner, disposition) |
+| 5 Grouping | DONE | corpus §A–F families; taxonomy.md scope:* families |
+| 6 Expectations | DONE | per-slice verification gates; ratchet baselines predeclared (project plane green; adapter-boundary baseline = 6) |
+| 7 Architecture translation | DONE | taxonomy.md (tags/constraints); five-layer ownership in FRAME hard core #2 |
+| 8 Slices | DONE (defined, not executed) | OpenSpec train below; all strict-valid (146/146 repo-wide) |
+| 9 Local stats | NOT STARTED | begins with H1 execution |
+| 10 Runtime proof | N/A by design | harness touches structure only; byte-parity gates stand in (H1/H4) |
+| 11 Review | PENDING | pre-execution review lanes below |
+| 12 Closure | NOT STARTED | per-slice via closure checklists |
+
+## The change train (slices)
+
+| # | Change id | One-line scope | Requires | Parallel? |
+|---|---|---|---|---|
+| H1 | `habitat-nx-adoption` | Nx fully adopted via native Turbo migration; turbo retired; mise pin; tools/* workspace | — | train root |
+| H2 | `habitat-harness-scaffold` | tools/habitat-harness package: habitat CLI, rule pack, ratchet/baselines, Nx plugin; wrap ALL existing checks (zero new rules) | H1 | — |
+| H3 | `habitat-boundary-tags` | tags on all projects + enforce-module-boundaries (locked); ESLint quarantined to that one rule | H1, H2 | ∥ with H4 |
+| H4 | `habitat-biome-hygiene` | Biome owns hygiene; prettier retired; one blame-shielded reformat commit; ratcheted lint lane | H1, H2 | ∥ with H3 |
+| H5 | `habitat-grit-catalog` | Grit pattern catalog (ports 8 eslint families + 4 script families, fixtures, parity), first codemods, file-layer generated-zone protection | H2, H4 | — |
+| H6 | `habitat-enforcement-consolidation` | Retire superseded scripts/eslint/tests with parity evidence; habitat verify becomes the single path; CI re-pointed | H3, H5 | — |
+| H7 | `habitat-git-hooks` | Husky pre-commit (staged scope; restage ONLY formatter-touched files) + pre-push affected verify | H2, H4, H5 | ∥ with H8 prep |
+| H8 | `habitat-generators-migrations` | Project/pattern generators, harness migrations, habitat classify, agent operating procedure in AGENTS.md | H6 | train tail |
+
+Each slice = one OpenSpec change + one Graphite branch stacked on its
+prerequisites; phase continuity records go in
+`openspec/changes/<id>/workstream/` at execution time per
+`civ7-open-spec-workstream`.
+
+## Proof classes per slice (predeclared)
+
+- **OpenSpec validation:** every slice, `--strict` (already green for all 8 at definition).
+- **Local stats/parity:** H1 build-output byte parity; H4 reformat byte parity; H5 rule-parity tables (grit vs original finding sets); H6 retirement table.
+- **Probe gates:** synthetic violations per rule family (H2, H3, H5, H6, H7 probe matrices in tasks).
+- **Runtime proof:** not required (structure-only workstream); any slice claiming in-game behavior must escalate (it would violate FRAME exterior).
+- **Graphite/PR state:** labeled separately per closure-state matrix; never inferred from local green.
+
+## Review lanes (pre-execution, then per-slice)
+
+| Lane | Scope | When |
+|---|---|---|
+| Spec review | train coherence, shortcut language, task readiness | once before H1 starts (next action) |
+| Architecture review | taxonomy/constraints vs normalization-train ownership; no overlap with `normalize-import-boundaries` change (coordination note below) | before H3 |
+| Implementation review | per-slice diff + fixtures + baselines | each slice |
+| Evidence review | parity tables, probe matrices, byte-parity claims | H1, H4, H5, H6 |
+| Closure review | tasks/records/Graphite state agreement | each slice |
+
+**Coordination note:** the MapGen normalization train
+(`openspec/changes/README.md`) includes `normalize-import-boundaries` and
+`normalize-guardrails-promotion`, which touch overlapping enforcement surfaces
+(import policy, G-guards). The habitat train encodes guards AS THEY EXIST at
+adoption time (current implied architecture, D4). If a normalization slice
+lands mid-train and changes a guard, the habitat port re-baselines from the
+new state — recorded in the slice's downstream-realignment ledger. Neither
+train redefines the other's authority.
+
+## Standing rules during execution
+
+- Discrepancies found → append to `discrepancy-log.md`, do not resolve in-slice (D5).
+- Trade-offs taken → FRAME §3 table, visibly revisitable (D6).
+- New baseline entries only via the rule-introduction gate; baselines otherwise shrink-only.
+- habitat-native rule budget watched against the FRAME degeneration trigger (≥3 tool-assigned rules falling back to native ⇒ stop and re-evaluate).
+- Worktree/Graphite discipline per repo skills; one slice per branch; `gt restack --upstack` after mid-stack changes; `gt sync --no-restack` in shared environments.
+
+## Next exact action (when execution begins)
+
+1. Run the pre-execution spec-review lane over the 8 changes (fresh reviewer
+   agents; disposition ledger in this directory).
+2. Open H1: copy phase-record template into
+   `openspec/changes/habitat-nx-adoption/workstream/`, then execute tasks 1.1+
+   on a stacked branch off this one.

--- a/docs/projects/habitat-harness/workstream-record.md
+++ b/docs/projects/habitat-harness/workstream-record.md
@@ -21,7 +21,7 @@
 | 8 Slices | DONE (defined, not executed) | OpenSpec train below; all strict-valid (146/146 repo-wide) |
 | 9 Local stats | NOT STARTED | begins with H1 execution |
 | 10 Runtime proof | N/A by design | harness touches structure only; byte-parity gates stand in (H1/H4) |
-| 11 Review | PENDING | pre-execution review lanes below |
+| 11 Review | IN TRAIN | spec lane DONE (ledger); architecture lane before H3; impl/evidence/closure per slice |
 | 12 Closure | NOT STARTED | per-slice via closure checklists |
 
 ## The change train (slices)
@@ -30,12 +30,12 @@
 |---|---|---|---|---|
 | H1 | `habitat-nx-adoption` | Nx fully adopted via native Turbo migration; turbo retired; mise pin; tools/* workspace | — | train root |
 | H2 | `habitat-harness-scaffold` | tools/habitat-harness package: habitat CLI, rule pack, ratchet/baselines, Nx plugin; wrap ALL existing checks (zero new rules) | H1 | — |
-| H3 | `habitat-boundary-tags` | tags on all projects + enforce-module-boundaries (locked); ESLint quarantined to that one rule | H1, H2 | ∥ with H4 |
-| H4 | `habitat-biome-hygiene` | Biome owns hygiene; prettier retired; one blame-shielded reformat commit; ratcheted lint lane | H1, H2 | ∥ with H3 |
-| H5 | `habitat-grit-catalog` | Grit pattern catalog (ports 8 eslint families + 4 script families, fixtures, parity), first codemods, file-layer generated-zone protection | H2, H4 | — |
-| H6 | `habitat-enforcement-consolidation` | Retire superseded scripts/eslint/tests with parity evidence; habitat verify becomes the single path; CI re-pointed | H3, H5 | — |
-| H7 | `habitat-git-hooks` | Husky pre-commit (staged scope; restage ONLY formatter-touched files) + pre-push affected verify | H2, H4, H5 | ∥ with H8 prep |
-| H8 | `habitat-generators-migrations` | Project/pattern generators, harness migrations, habitat classify, agent operating procedure in AGENTS.md | H6 | train tail |
+| H3 | `habitat-boundary-tags` | tags on all projects + enforce-module-boundaries (locked at empty baseline); ESLint quarantined to that one rule | H1, H2 | — |
+| H4 | `habitat-biome-hygiene` | Biome owns hygiene; prettier retired; one blame-shielded reformat commit; ratcheted lint lane | H1, H2, H3 | — (serialized after H3: shared writes on `package.json` files, `ci.yml`, rule pack — reformat would conflict with tag edits; ledger F1) |
+| H5 | `habitat-grit-catalog` | Grit pattern catalog (ports 8 eslint families + script families incl. G8/G10/G11, fixtures, probe-confirmed parity), first codemods, file-layer generated-zone protection | H2, H4 | — |
+| H6 | `habitat-enforcement-consolidation` | Retire superseded scripts/eslint/tests with per-rule parity + probe evidence; habitat verify becomes the single path; CI re-pointed | H3, H5 | — |
+| H7 | `habitat-git-hooks` | Husky pre-commit (staged scope; restage ONLY formatter-touched files) + pre-push affected verify; dispositions legacy `scripts/git-hooks` | H2, H3, H4, H5 | — |
+| H8 | `habitat-generators-migrations` | Project/pattern generators, harness migrations, habitat classify, agent operating procedure in AGENTS.md | H6, H7 | train tail (strictly after H7; ledger F40) |
 
 Each slice = one OpenSpec change + one Graphite branch stacked on its
 prerequisites; phase continuity records go in
@@ -54,7 +54,7 @@ prerequisites; phase continuity records go in
 
 | Lane | Scope | When |
 |---|---|---|
-| Spec review | train coherence, shortcut language, task readiness | once before H1 starts (next action) |
+| Spec review | train coherence, shortcut language, task readiness | DONE 2026-06-12 — 4 reviewers, 4× READY-WITH-REPAIRS; all repairs applied (see `review-disposition-ledger.md`) |
 | Architecture review | taxonomy/constraints vs normalization-train ownership; no overlap with `normalize-import-boundaries` change (coordination note below) | before H3 |
 | Implementation review | per-slice diff + fixtures + baselines | each slice |
 | Evidence review | parity tables, probe matrices, byte-parity claims | H1, H4, H5, H6 |
@@ -77,10 +77,8 @@ train redefines the other's authority.
 - habitat-native rule budget watched against the FRAME degeneration trigger (≥3 tool-assigned rules falling back to native ⇒ stop and re-evaluate).
 - Worktree/Graphite discipline per repo skills; one slice per branch; `gt restack --upstack` after mid-stack changes; `gt sync --no-restack` in shared environments.
 
-## Next exact action (when execution begins)
+## Next exact action
 
-1. Run the pre-execution spec-review lane over the 8 changes (fresh reviewer
-   agents; disposition ledger in this directory).
-2. Open H1: copy phase-record template into
-   `openspec/changes/habitat-nx-adoption/workstream/`, then execute tasks 1.1+
-   on a stacked branch off this one.
+1. ~~Pre-execution spec-review lane~~ DONE (`review-disposition-ledger.md`, all repairs applied).
+2. Open H1: phase record into `openspec/changes/habitat-nx-adoption/workstream/`,
+   then execute tasks 1.1+ on a stacked branch off this one.

--- a/openspec/changes/habitat-biome-hygiene/proposal.md
+++ b/openspec/changes/habitat-biome-hygiene/proposal.md
@@ -1,0 +1,89 @@
+## Why
+
+The repo has a `.prettierrc` but zero formatting enforcement anywhere (CI or
+local) — formatting consistency is promised by convention only
+(discrepancy-log DL-12). The harness assigns the hygiene layer to Biome
+(format, ordinary lint hygiene, import organization). Matei D3: this gets done
+now, not deferred; trade-offs recorded. Biome 2.4.x verified working under Bun
+(`bunx --bun @biomejs/biome`).
+
+## Target Authority Refs
+
+- `docs/projects/habitat-harness/FRAME.md` (hard core #2; trade-offs table; D3)
+- `docs/projects/habitat-harness/habitat-harness-spec-draft-input.md` §5.3
+  (Biome ownership), §12.1 (ESLint must not duplicate hygiene)
+- `https://biomejs.dev/guides/getting-started/` (Bun commands)
+
+## What Changes
+
+- Add `@biomejs/biome` as exact-pinned devDependency; root `biome.json`
+  (formatter + linter + assist enabled; excludes: `node_modules`, `dist`,
+  `mod`, `.nx`, generated zones, `.civ7/outputs`, `docs/_archive`).
+- Translate `.prettierrc` settings (semi, double quotes, trailing comma es5,
+  printWidth 100) into Biome formatter config so the reformat diff is
+  minimal; then remove `.prettierrc` and any prettier devDependencies.
+- One dedicated repo-wide reformat commit
+  (`bunx --bun @biomejs/biome format --write .`), recorded in a new
+  `.git-blame-ignore-revs`.
+- Biome lint: start with `recommended` OFF except rules that are green or
+  trivially fixable; every enabled rule registers in the harness rule pack
+  with a ratchet baseline (red rules land baselined, burned down later).
+- Harness integration: `biome:format`, `biome:check`, `biome:ci` inferred
+  targets (never plain `lint`); `habitat fix` runs Biome format + safe
+  assists; `habitat check`/CI run `biome:ci`.
+
+## What Does Not Change
+
+- No code semantics; the reformat commit is format-only (verified by
+  build/test parity).
+- `eslint.config.js` untouched (retired later); ESLint gains no hygiene role.
+- No grit/file-layer rules.
+
+## Requires
+
+- `habitat-nx-adoption`, `habitat-harness-scaffold`
+
+## Enables Parallel Work
+
+- Runs parallel with `habitat-boundary-tags` (disjoint writes).
+- Required by `habitat-grit-catalog` (grit:apply must Biome-format rewrites)
+  and `habitat-git-hooks` (staged formatting).
+
+## Affected Owners
+
+- New `biome.json`, `.git-blame-ignore-revs`; removed `.prettierrc`
+- Repo-wide format-only diff (the reformat commit)
+- `tools/habitat-harness` rule pack + plugin targets; root scripts; CI
+
+## Forbidden Owners
+
+- No Biome rule that overlaps a boundary/syntax-layer concern (import
+  boundaries, domain surfaces) — those belong to Nx/Grit.
+- No formatting of generated zones, official resources, or archives.
+- No prettier left anywhere (config, deps, editor docs).
+
+## Stop Conditions
+
+- Biome cannot express a `.prettierrc` setting and the resulting diff is not
+  acceptable as a one-time cost — stop and record the delta before
+  reformatting.
+- The reformat commit changes any build output byte (should be impossible;
+  verify).
+
+## Consumer Impact
+
+One large format-only commit (blame-shielded). Thereafter formatting is
+automatic via `habitat fix`/hooks and enforced via `biome:ci`. Editor guidance
+documented in harness README.
+
+## Verification Gates
+
+- `bun run openspec -- validate habitat-biome-hygiene --strict`
+- `bunx --bun @biomejs/biome ci .` green post-reformat.
+- `bun run build && bun run test` green pre/post reformat with identical
+  `mod/**` build outputs (byte parity).
+- `.git-blame-ignore-revs` contains the reformat commit; `git blame` probe on
+  a touched file attributes pre-reformat authorship.
+- `bun run habitat check` includes biome rules with correct baseline counts;
+  `habitat fix --dry-run` reports format diffs without writing.
+- `git grep -i prettier` → no functional references remain.

--- a/openspec/changes/habitat-biome-hygiene/proposal.md
+++ b/openspec/changes/habitat-biome-hygiene/proposal.md
@@ -42,10 +42,12 @@ now, not deferred; trade-offs recorded. Biome 2.4.x verified working under Bun
 ## Requires
 
 - `habitat-nx-adoption`, `habitat-harness-scaffold`
+- `habitat-boundary-tags` — serialized after H3 (shared writes: package.json
+  files, ci.yml, rule pack; the repo-wide reformat would conflict with H3's
+  tag edits — ledger F1).
 
 ## Enables Parallel Work
 
-- Runs parallel with `habitat-boundary-tags` (disjoint writes).
 - Required by `habitat-grit-catalog` (grit:apply must Biome-format rewrites)
   and `habitat-git-hooks` (staged formatting).
 
@@ -67,8 +69,12 @@ now, not deferred; trade-offs recorded. Biome 2.4.x verified working under Bun
 - Biome cannot express a `.prettierrc` setting and the resulting diff is not
   acceptable as a one-time cost — stop and record the delta before
   reformatting.
-- The reformat commit changes any build output byte (should be impossible;
-  verify).
+- Build-output parity is asserted on formatting-independent artifacts
+  (`mod/**` XML/SQL/asset files byte-identical). If bundled JS output differs,
+  compare after a minify-normalization pass (e.g. `esbuild --minify` both
+  sides) — formatting-only differences there are accepted and recorded as a
+  trade-off in the phase record; any NON-formatting difference is the stop
+  condition.
 
 ## Consumer Impact
 
@@ -80,8 +86,9 @@ documented in harness README.
 
 - `bun run openspec -- validate habitat-biome-hygiene --strict`
 - `bunx --bun @biomejs/biome ci .` green post-reformat.
-- `bun run build && bun run test` green pre/post reformat with identical
-  `mod/**` build outputs (byte parity).
+- `bun run build && bun run test` green pre/post reformat with build-output
+  parity per the stop condition (formatting-independent `mod/**` artifacts
+  byte-identical; bundled JS minify-normalized if needed).
 - `.git-blame-ignore-revs` contains the reformat commit; `git blame` probe on
   a touched file attributes pre-reformat authorship.
 - `bun run habitat check` includes biome rules with correct baseline counts;

--- a/openspec/changes/habitat-biome-hygiene/specs/habitat-harness/spec.md
+++ b/openspec/changes/habitat-biome-hygiene/specs/habitat-harness/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Biome Owns The Hygiene Layer
+
+Formatting, ordinary lint hygiene, and import organization SHALL be owned by
+Biome, enforced through `biome:ci`, with no competing formatter or hygiene
+linter in the repository.
+
+#### Scenario: Unformatted code is rejected
+- **WHEN** a change includes files violating the Biome formatter config
+- **THEN** `biome:ci` (via `habitat check` and CI) fails and `habitat fix`
+  repairs it deterministically
+
+#### Scenario: Hygiene rules ratchet, not block
+- **WHEN** a Biome lint rule is enabled while existing violations remain
+- **THEN** existing violations are baselined under the harness ratchet and only
+  new violations fail
+
+### Requirement: Reformat History Is Blame-Shielded
+
+The one-time repo-wide reformat SHALL be a dedicated format-only commit listed
+in `.git-blame-ignore-revs`, with build outputs proven byte-identical across
+the reformat.
+
+#### Scenario: Investigating authorship after reformat
+- **WHEN** `git blame` runs with the ignore-revs file on a reformatted file
+- **THEN** authorship attributes to pre-reformat commits, not the reformat

--- a/openspec/changes/habitat-biome-hygiene/tasks.md
+++ b/openspec/changes/habitat-biome-hygiene/tasks.md
@@ -1,0 +1,36 @@
+## 1. Biome Setup
+
+- [ ] 1.1 `bun add -d -E @biomejs/biome`; `bunx --bun @biomejs/biome init`;
+  configure `biome.json` (formatter matching `.prettierrc` semantics; linter
+  scoped per proposal; excludes for generated zones, `mod/**`, `dist/**`,
+  `.nx`, `.civ7/outputs`, `docs/_archive`, vendor files).
+- [ ] 1.2 Dry-run `biome format` repo-wide; review diff size; adjust config
+  until the delta is the accepted one-time cost (record stats in phase
+  record).
+
+## 2. Reformat And Prettier Retirement
+
+- [ ] 2.1 Capture pre-reformat build-output hashes (`mod/**`).
+- [ ] 2.2 Dedicated format-only commit: `bunx --bun @biomejs/biome format
+  --write .`; add commit SHA to new `.git-blame-ignore-revs`.
+- [ ] 2.3 Remove `.prettierrc` and prettier references (deps, docs, editor
+  config); `bun install`.
+- [ ] 2.4 Verify build/test green and `mod/**` byte parity with 2.1 hashes.
+
+## 3. Lint Hygiene Lane
+
+- [ ] 3.1 Enable Biome linter with the minimal green rule set; for each
+  desired-but-red recommended rule, register a rule-pack entry with a ratchet
+  baseline instead of disabling silently (list in phase record).
+- [ ] 3.2 Wire harness: `biome:format|check|ci` inferred targets; `habitat
+  fix` runs format + safe assists; `habitat check` runs `biome:ci`; CI
+  affected targets include `biome:ci`.
+
+## 4. Verification And Closure
+
+- [ ] 4.1 All proposal verification gates pass (biome ci, parity, blame probe,
+  habitat integration, no prettier residue).
+- [ ] 4.2 Harness README documents editor setup and the never-`lint`-named
+  target convention.
+- [ ] 4.3 `bun run openspec -- validate habitat-biome-hygiene --strict`;
+  realign docs; close per workstream record.

--- a/openspec/changes/habitat-biome-hygiene/tasks.md
+++ b/openspec/changes/habitat-biome-hygiene/tasks.md
@@ -4,9 +4,11 @@
   configure `biome.json` (formatter matching `.prettierrc` semantics; linter
   scoped per proposal; excludes for generated zones, `mod/**`, `dist/**`,
   `.nx`, `.civ7/outputs`, `docs/_archive`, vendor files).
-- [ ] 1.2 Dry-run `biome format` repo-wide; review diff size; adjust config
-  until the delta is the accepted one-time cost (record stats in phase
-  record).
+- [ ] 1.2 Dry-run `biome format` repo-wide; review diff size; the reformat
+  delta is accepted only if confined to whitespace/quote-style/trailing-comma
+  classes — verified by `git diff -w` on the reformat commit being
+  empty-or-quotes/commas-only plus a sampled diff review recorded in the
+  phase record (with diff stats).
 
 ## 2. Reformat And Prettier Retirement
 
@@ -15,7 +17,10 @@
   --write .`; add commit SHA to new `.git-blame-ignore-revs`.
 - [ ] 2.3 Remove `.prettierrc` and prettier references (deps, docs, editor
   config); `bun install`.
-- [ ] 2.4 Verify build/test green and `mod/**` byte parity with 2.1 hashes.
+- [ ] 2.4 Verify build/test green and build-output parity with 2.1 hashes per
+  the proposal stop condition (formatting-independent `mod/**` artifacts
+  byte-identical; bundled JS minify-normalized if it differs, recorded as a
+  trade-off).
 
 ## 3. Lint Hygiene Lane
 

--- a/openspec/changes/habitat-boundary-tags/proposal.md
+++ b/openspec/changes/habitat-boundary-tags/proposal.md
@@ -51,7 +51,10 @@ slice locks immediately.
 
 ## Enables Parallel Work
 
-- `habitat-biome-hygiene` runs in parallel (disjoint write sets).
+- `habitat-biome-hygiene` (H4) is serialized AFTER this change — both touch
+  root `package.json`, `ci.yml`, and the harness rule pack, and H4's repo-wide
+  reformat rewrites the `package.json` files this change edits tags into
+  (ledger F1).
 - `habitat-enforcement-consolidation` (boundary-adjacent retirements).
 
 ## Affected Owners
@@ -87,10 +90,13 @@ means zero immediate disruption.
 ## Verification Gates
 
 - `bun run openspec -- validate habitat-boundary-tags --strict`
-- `bunx nx affected -t boundaries` (and run-many --all) green on the clean tree.
-- Probe: temporary import from `packages/config` (kind:foundation) into
-  `@civ7/adapter` consumer direction that violates a constraint → boundaries
-  target fails with the tag-rule message; probe removed.
+- `bunx nx run-many -t boundaries --all` green on the clean tree (the gate);
+  `bunx nx affected -t boundaries` runs as a smoke check only (affected on a
+  clean tree runs nothing and proves nothing).
+- Probe: add `import '@civ7/adapter'` (plus the dependency edge) in a scratch
+  file inside `packages/config/src/` — `kind:foundation` may depend only on
+  `kind:foundation`, so the `boundaries` target must fail naming the
+  `kind:foundation` constraint; probe then reverted.
 - `bunx nx show project <p>` displays expected tags for spot-checked projects.
 - `bun run habitat check` includes the locked `nx-boundaries` rule.
 - `bun run build && bun run check && bun run test` unchanged-green.

--- a/openspec/changes/habitat-boundary-tags/proposal.md
+++ b/openspec/changes/habitat-boundary-tags/proposal.md
@@ -1,0 +1,96 @@
+## Why
+
+The project-plane architecture (which workspace project may depend on which)
+is currently enforced only indirectly (scripts checking specific import
+strings) or not at all. With Nx adopted, the derived taxonomy
+(docs/projects/habitat-harness/taxonomy.md) can be locked as graph law:
+tags on every project, dependency constraints via
+`@nx/enforce-module-boundaries`, ESLint quarantined to exactly that one rule.
+The taxonomy encodes the current implied architecture (Matei D4) — it was
+verified against actual dependency edges and is green at adoption, so this
+slice locks immediately.
+
+## Target Authority Refs
+
+- `docs/projects/habitat-harness/taxonomy.md` (tags, assignments, constraints — the controlling table)
+- `docs/projects/habitat-harness/FRAME.md` (hard core #2, #4)
+- `docs/projects/habitat-harness/habitat-harness-spec-draft-input.md` §5.4 (ESLint quarantine), §12.1
+- `https://nx.dev/docs/technologies/eslint/eslint-plugin/guides/enforce-module-boundaries`
+
+## What Changes
+
+- Add `"nx": {"tags": ["kind:..."]}` to every workspace project's
+  `package.json` exactly per taxonomy.md §2 (including
+  `tools/habitat-harness` → `kind:tooling`).
+- Create `eslint.boundaries.config.mjs` whose only rule is
+  `@nx/enforce-module-boundaries` with the depConstraints from taxonomy.md §3
+  (including the recorded wide edge `kind:control` → `kind:mod`).
+- Add `@nx/eslint-plugin` devDependency; ESLint runs on Node via `bunx eslint`.
+- Register a `boundaries` inferred target in the harness plugin (target name
+  `boundaries`, never `lint`); add it to `habitat check`/`verify` composition
+  and CI affected targets.
+- Register the rule in the harness rule pack as `nx-boundaries` owner with an
+  empty baseline (locked at adoption — the project plane is verified green).
+- Document tag vocabulary and the revision protocol (taxonomy changes are
+  deliberate rule-pack edits with provenance) in the harness README.
+
+## What Does Not Change
+
+- The existing `eslint.config.js` and `bun run lint` stay untouched (their
+  rules are ported and retired in `habitat-grit-catalog` /
+  `habitat-enforcement-consolidation`).
+- No intra-project rules (grit/file-layer territory).
+- No package dependency edits — if a constraint is discovered red during
+  implementation, the constraint is NOT weakened: record the edge, baseline
+  it explicitly, and log the discovery in the discrepancy log.
+
+## Requires
+
+- `habitat-nx-adoption`
+- `habitat-harness-scaffold`
+
+## Enables Parallel Work
+
+- `habitat-biome-hygiene` runs in parallel (disjoint write sets).
+- `habitat-enforcement-consolidation` (boundary-adjacent retirements).
+
+## Affected Owners
+
+- Every workspace `package.json` (tags field only)
+- New `eslint.boundaries.config.mjs`; root `package.json` devDependencies
+- `tools/habitat-harness` rule pack + plugin target wiring
+- `.github/workflows/ci.yml` (add `boundaries` to affected targets)
+
+## Forbidden Owners
+
+- No rules other than `@nx/enforce-module-boundaries` in the boundaries
+  config; no style/hygiene rules through ESLint ever again.
+- No `project.json` files; tags live in package.json.
+- No source-code edits in product packages.
+- No tag taxonomy redesign beyond taxonomy.md (revisions are future deliberate
+  changes).
+
+## Stop Conditions
+
+- A constraint from taxonomy.md is red against the real graph (taxonomy
+  verification was wrong) — stop, baseline the specific edge, log in
+  discrepancy-log.md, continue; do not weaken the constraint silently.
+- The boundary rule cannot see a dependency edge that exists (graph inference
+  gap) — stop and record before papering over.
+
+## Consumer Impact
+
+Cross-project imports that violate the taxonomy now fail `habitat check` and
+CI with an agent-readable message naming the tag rule. Currently-green repo
+means zero immediate disruption.
+
+## Verification Gates
+
+- `bun run openspec -- validate habitat-boundary-tags --strict`
+- `bunx nx affected -t boundaries` (and run-many --all) green on the clean tree.
+- Probe: temporary import from `packages/config` (kind:foundation) into
+  `@civ7/adapter` consumer direction that violates a constraint → boundaries
+  target fails with the tag-rule message; probe removed.
+- `bunx nx show project <p>` displays expected tags for spot-checked projects.
+- `bun run habitat check` includes the locked `nx-boundaries` rule.
+- `bun run build && bun run check && bun run test` unchanged-green.

--- a/openspec/changes/habitat-boundary-tags/specs/habitat-harness/spec.md
+++ b/openspec/changes/habitat-boundary-tags/specs/habitat-harness/spec.md
@@ -4,7 +4,10 @@
 
 Every workspace project SHALL carry `kind:*` tags from the derived taxonomy in
 its `package.json`, and cross-project dependency constraints SHALL be enforced
-by `@nx/enforce-module-boundaries` as a locked harness rule.
+by `@nx/enforce-module-boundaries` as a harness rule that is locked when its
+baseline is empty (expected at adoption); any red edge discovered at adoption
+is explicitly baselined and logged in the discrepancy log, and the rule locks
+when that baseline empties.
 
 #### Scenario: Illegal cross-project dependency
 - **WHEN** a project imports from a project whose tags violate the

--- a/openspec/changes/habitat-boundary-tags/specs/habitat-harness/spec.md
+++ b/openspec/changes/habitat-boundary-tags/specs/habitat-harness/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Project-Plane Boundaries Are Graph Law
+
+Every workspace project SHALL carry `kind:*` tags from the derived taxonomy in
+its `package.json`, and cross-project dependency constraints SHALL be enforced
+by `@nx/enforce-module-boundaries` as a locked harness rule.
+
+#### Scenario: Illegal cross-project dependency
+- **WHEN** a project imports from a project whose tags violate the
+  depConstraints (e.g. `kind:foundation` importing `kind:engine`)
+- **THEN** the `boundaries` target fails with a message naming the source tag,
+  the constraint, and the taxonomy revision protocol
+
+#### Scenario: Taxonomy revision is deliberate
+- **WHEN** a tag or constraint must change
+- **THEN** the change edits taxonomy.md and the boundary config together with
+  recorded provenance, not ad-hoc rule weakening
+
+### Requirement: ESLint Is Quarantined To The Boundary Rule
+
+ESLint SHALL exist in the repository only as the runner for
+`@nx/enforce-module-boundaries` via a dedicated boundaries config, exposed as
+the `boundaries` target (never named `lint`).
+
+#### Scenario: Adding an ESLint rule
+- **WHEN** a contributor proposes adding any other rule to the boundaries
+  config
+- **THEN** the harness documentation directs the rule to its owning layer
+  (Biome for hygiene, GritQL for syntax shape, file layer for paths) and the
+  boundaries config stays single-rule

--- a/openspec/changes/habitat-boundary-tags/tasks.md
+++ b/openspec/changes/habitat-boundary-tags/tasks.md
@@ -1,14 +1,17 @@
 ## 1. Tags
 
-- [ ] 1.1 Add `"nx": {"tags": [...]}` to all 21 workspace package.json files
-  plus `tools/habitat-harness`, exactly per taxonomy.md §2.
+- [ ] 1.1 Add `"nx": {"tags": [...]}` to all 21 workspace package.json files,
+  exactly per taxonomy.md §2. `tools/habitat-harness/package.json` already
+  carries `kind:tooling` pre-seeded by H2 — verify it matches taxonomy.md,
+  don't re-add.
 - [ ] 1.2 `bunx nx show project` spot-checks (adapter, mapgen-core,
   mod-swooper-maps, studio-server) confirm tags in the graph.
 
 ## 2. Boundary Rule
 
-- [ ] 2.1 Add `@nx/eslint-plugin` (+ eslint if needed by H6 ordering)
-  devDependency; create `eslint.boundaries.config.mjs` containing only
+- [ ] 2.1 Add `@nx/eslint-plugin` and `eslint` devDependencies (the
+  `boundaries` target owns the ESLint invocation; H6 only re-points aggregate
+  entrypoints); create `eslint.boundaries.config.mjs` containing only
   `@nx/enforce-module-boundaries` with taxonomy.md §3 depConstraints,
   per-constraint agent-readable messages, `enforceBuildableLibDependency`
   evaluated and recorded (expected: false — no buildable-lib split here).

--- a/openspec/changes/habitat-boundary-tags/tasks.md
+++ b/openspec/changes/habitat-boundary-tags/tasks.md
@@ -1,0 +1,36 @@
+## 1. Tags
+
+- [ ] 1.1 Add `"nx": {"tags": [...]}` to all 21 workspace package.json files
+  plus `tools/habitat-harness`, exactly per taxonomy.md §2.
+- [ ] 1.2 `bunx nx show project` spot-checks (adapter, mapgen-core,
+  mod-swooper-maps, studio-server) confirm tags in the graph.
+
+## 2. Boundary Rule
+
+- [ ] 2.1 Add `@nx/eslint-plugin` (+ eslint if needed by H6 ordering)
+  devDependency; create `eslint.boundaries.config.mjs` containing only
+  `@nx/enforce-module-boundaries` with taxonomy.md §3 depConstraints,
+  per-constraint agent-readable messages, `enforceBuildableLibDependency`
+  evaluated and recorded (expected: false — no buildable-lib split here).
+- [ ] 2.2 Run the rule repo-wide; if any constraint is red, follow the stop
+  condition (baseline the edge explicitly, log in discrepancy-log.md) —
+  expected green per taxonomy verification.
+
+## 3. Harness Integration
+
+- [ ] 3.1 Register `boundaries` inferred target in the harness plugin; add to
+  `habitat check`/`verify` composition with JSON diagnostics.
+- [ ] 3.2 Add rule-pack entry (owner `nx-boundaries`, baseline empty, locked);
+  remediation message points at taxonomy.md and the revision protocol.
+- [ ] 3.3 Add `boundaries` to CI affected targets.
+
+## 4. Verification And Closure
+
+- [ ] 4.1 `bunx nx run-many -t boundaries --all` green; violation probe fails
+  with tag-rule message, then removed.
+- [ ] 4.2 Harness README documents tag vocabulary + taxonomy revision
+  protocol; taxonomy.md marked "locked at adoption" with date.
+- [ ] 4.3 `bun run build && bun run check && bun run test` unchanged-green;
+  `bun run openspec -- validate habitat-boundary-tags --strict`; downstream
+  realignment (AGENTS.md routers mention boundaries target) and closure per
+  workstream record.

--- a/openspec/changes/habitat-enforcement-consolidation/proposal.md
+++ b/openspec/changes/habitat-enforcement-consolidation/proposal.md
@@ -18,20 +18,30 @@ the harness the only enforcement path, and re-points `check`/CI at
 ## What Changes
 
 - Retire ported lint scripts: `lint-adapter-boundary.sh`,
-  `lint-mapgen-recipe-imports.sh`, the grit-ported guardrail families of
-  `lint-domain-refactor-guardrails.sh` and `lint-normalization-guardrails.mjs`
-  (G1/G2/G5/G9; G3/G10/G11 covered by boundaries+grit),
+  `lint-mapgen-recipe-imports.sh`, the grit-ported BOUNDARY-profile guardrail
+  families of `lint-domain-refactor-guardrails.sh`, and the grit-ported
+  guardrails of `lint-normalization-guardrails.mjs` — G1/G2/G5/G8/G9/G10/G11
+  and the G3 runtime-value ban retire only against their LOCKED grit
+  equivalents ported in H5 (H5 ports all of them); G3's project-edge context
+  is the nx `kind:engine` tag rule; G10/G11 are intra-project shapes — grit
+  owns them, and no retirement may cite nx-boundaries as covering them; G6/G7
+  move habitat-native. Also retire
   `lint-control-orpc-contract-ownership.mjs`. Habitat-native survivors
-  (workspace-entrypoints, G6/G7 doc-sync, doc lints) move INTO
+  (workspace-entrypoints, G6/G7 doc-sync, JS doc lints) move INTO
   `tools/habitat-harness/src/rules/` as native TS rules and their scripts are
-  deleted.
+  deleted; `lint-mapgen-docs.py` is NOT rewritten in TS — it relocates (or
+  stays in place) wrapped as-is per corpus disposition ("port py→TS only if
+  touched").
 - Replace `eslint.config.js` with nothing: the 8 rule families are
   grit/boundaries-owned; ESLint remains only via
   `eslint.boundaries.config.mjs` (single boundary rule, from H3); `bun run
-  lint` becomes an alias for `habitat check` (or is removed; decided in
-  design, recorded in tasks).
-- Architecture-test dedup per corpus §C: `recipe-import-boundary.test.ts` and
-  `ecology-step-import-guardrails.test.ts` retire (grit equivalents locked);
+  lint` becomes an alias for `habitat check` (or is removed; decided and
+  recorded in tasks (task 1.2)).
+- Architecture-test dedup per corpus §C: `recipe-import-boundary.test.ts`
+  retires (grit equivalent locked);
+  `ecology-step-import-guardrails.test.ts` slims — the deep-import assertions
+  retire (locked grit equivalent), the retired-stage-dirs-absent assertions
+  stay (no grit/file rule covers directory absence);
   `core-purity.test.ts` slims to runtime-value semantics not expressible as
   tags (the import-graph half retires); `rng-authority-boundary`,
   `m11-projection-boundary-band`, `map-bundle-runtime-imports` stay (runtime
@@ -55,8 +65,9 @@ the harness the only enforcement path, and re-points `check`/CI at
 
 ## Enables Parallel Work
 
-- `habitat-git-hooks` and `habitat-generators-migrations` (clean single-path
-  harness underneath).
+- `habitat-git-hooks` (clean single-path harness underneath);
+  `habitat-generators-migrations` follows strictly after hooks land (both
+  write root `AGENTS.md` and the harness README — no H7∥H8 parallelism).
 
 ## Affected Owners
 
@@ -79,9 +90,9 @@ the harness the only enforcement path, and re-points `check`/CI at
 - A parity gap is discovered during retirement (the legacy mechanism catches
   something the port does not on a probe) — stop, restore the legacy check,
   log, repair the port first.
-- `habitat verify` is slower than the retired aggregate beyond an acceptable
-  bound on CI (record threshold in phase record) — stop and fix caching before
-  retiring.
+- `habitat verify` exceeds 1.25× the retired aggregate's wall-clock on CI
+  (bound pre-stated here; both timings measured and recorded in the phase
+  record) — stop and fix caching before retiring.
 
 ## Consumer Impact
 
@@ -93,9 +104,13 @@ uniform JSON.
 
 - `bun run openspec -- validate habitat-enforcement-consolidation --strict`
 - Retirement table complete: every deleted mechanism row cites its parity
-  evidence or supersession record.
-- Synthetic-violation probes (one per retired family) fail through the harness
-  path post-retirement.
+  evidence in the H5 parity form (`empty/empty + probe-confirmed`, or
+  identical non-empty finding sets) or a supersession record.
+- Per-retired-rule probe matrix: every retirement-table row carries a probe
+  entry (probe file path, injected violation, expected harness rule id)
+  demonstrating the replacement rule catches what the retired mechanism
+  caught; probes fail through the harness path post-retirement; matrix
+  recorded in the phase record.
 - `bun run build && bun run check && bun run test` green; CI green with
   habitat-only enforcement; no references to deleted scripts remain
   (`git grep` sweep).

--- a/openspec/changes/habitat-enforcement-consolidation/proposal.md
+++ b/openspec/changes/habitat-enforcement-consolidation/proposal.md
@@ -1,0 +1,101 @@
+## Why
+
+After boundaries (H3) and the grit catalog (H5) are locked with recorded
+parity, the repo briefly enforces many rules twice: legacy scripts/ESLint
+blocks and their harness ports. Dual enforcement is transitional scaffolding,
+not an end state — it doubles maintenance, splits diagnostics, and reintroduces
+the pre-harness sprawl. This slice retires every superseded mechanism, makes
+the harness the only enforcement path, and re-points `check`/CI at
+`habitat verify`.
+
+## Target Authority Refs
+
+- `docs/projects/habitat-harness/FRAME.md` (hard core #2; degeneration trigger)
+- `docs/projects/habitat-harness/invariant-corpus.md` (retire dispositions §A–§D)
+- Parity evidence recorded in `habitat-grit-catalog` and
+  `habitat-boundary-tags` phase records (precondition)
+
+## What Changes
+
+- Retire ported lint scripts: `lint-adapter-boundary.sh`,
+  `lint-mapgen-recipe-imports.sh`, the grit-ported guardrail families of
+  `lint-domain-refactor-guardrails.sh` and `lint-normalization-guardrails.mjs`
+  (G1/G2/G5/G9; G3/G10/G11 covered by boundaries+grit),
+  `lint-control-orpc-contract-ownership.mjs`. Habitat-native survivors
+  (workspace-entrypoints, G6/G7 doc-sync, doc lints) move INTO
+  `tools/habitat-harness/src/rules/` as native TS rules and their scripts are
+  deleted.
+- Replace `eslint.config.js` with nothing: the 8 rule families are
+  grit/boundaries-owned; ESLint remains only via
+  `eslint.boundaries.config.mjs` (single boundary rule, from H3); `bun run
+  lint` becomes an alias for `habitat check` (or is removed; decided in
+  design, recorded in tasks).
+- Architecture-test dedup per corpus §C: `recipe-import-boundary.test.ts` and
+  `ecology-step-import-guardrails.test.ts` retire (grit equivalents locked);
+  `core-purity.test.ts` slims to runtime-value semantics not expressible as
+  tags (the import-graph half retires); `rng-authority-boundary`,
+  `m11-projection-boundary-band`, `map-bundle-runtime-imports` stay (runtime
+  semantics, not structure).
+- Root `check` script and `ci:architecture-strict-core` re-point to
+  `habitat verify` (nx affected composition); CI uploads habitat diagnostics
+  as the single evidence artifact.
+- Sweep docs/AGENTS routers that referenced retired scripts.
+
+## What Does Not Change
+
+- No rule semantics: every retirement requires recorded parity or explicit
+  supersession; the enforced invariant set is identical before/after.
+- No baselines reset; ratchet state carries over.
+- Kept tests keep running where they run today.
+
+## Requires
+
+- `habitat-boundary-tags`
+- `habitat-grit-catalog`
+
+## Enables Parallel Work
+
+- `habitat-git-hooks` and `habitat-generators-migrations` (clean single-path
+  harness underneath).
+
+## Affected Owners
+
+- `scripts/lint/**` (deletions/moves), `eslint.config.js` (deletion)
+- `tools/habitat-harness/src/rules/**` (native rule absorption)
+- Root `package.json` scripts, `.github/workflows/ci.yml`
+- Retired/slimmed test files in `packages/mapgen-core/test/architecture/`,
+  `mods/mod-swooper-maps/test/pipeline/`, `mods/mod-swooper-maps/test/ecology/`
+- Docs/AGENTS routers referencing retired mechanisms
+
+## Forbidden Owners
+
+- No retirement without parity evidence cited per mechanism (table in tasks).
+- No weakening: a legacy check may not be deleted if its harness port covers
+  less; the gap blocks until covered or explicitly dispositioned by Matei.
+- No new rules in this slice.
+
+## Stop Conditions
+
+- A parity gap is discovered during retirement (the legacy mechanism catches
+  something the port does not on a probe) — stop, restore the legacy check,
+  log, repair the port first.
+- `habitat verify` is slower than the retired aggregate beyond an acceptable
+  bound on CI (record threshold in phase record) — stop and fix caching before
+  retiring.
+
+## Consumer Impact
+
+One enforcement surface: `bun run habitat check|fix|verify` locally, habitat
+targets in CI. Contributors stop learning nine script idioms. Diagnostics are
+uniform JSON.
+
+## Verification Gates
+
+- `bun run openspec -- validate habitat-enforcement-consolidation --strict`
+- Retirement table complete: every deleted mechanism row cites its parity
+  evidence or supersession record.
+- Synthetic-violation probes (one per retired family) fail through the harness
+  path post-retirement.
+- `bun run build && bun run check && bun run test` green; CI green with
+  habitat-only enforcement; no references to deleted scripts remain
+  (`git grep` sweep).

--- a/openspec/changes/habitat-enforcement-consolidation/specs/habitat-harness/spec.md
+++ b/openspec/changes/habitat-enforcement-consolidation/specs/habitat-harness/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: The Harness Is The Only Enforcement Path
+
+After consolidation, structural enforcement SHALL exist only as harness rules
+(nx-boundaries, grit, biome, file-layer, habitat-native). Superseded scripts,
+the legacy ESLint config, and duplicated architecture tests SHALL be retired
+with parity evidence recorded per mechanism.
+
+#### Scenario: Retired mechanism's invariant still enforced
+- **WHEN** a violation that a retired script would have caught is introduced
+- **THEN** the corresponding harness rule fails `habitat check` and CI
+
+#### Scenario: Retirement without parity is rejected
+- **WHEN** a retirement lacks recorded parity or supersession evidence
+- **THEN** the consolidation change does not proceed for that mechanism
+
+### Requirement: CI Verifies Through The Harness
+
+Root verification scripts and CI jobs SHALL invoke harness targets
+(`habitat verify` / nx affected harness targets) and publish harness JSON
+diagnostics as the verification artifact.
+
+#### Scenario: CI failure evidence
+- **WHEN** a CI enforcement step fails
+- **THEN** the uploaded habitat diagnostics name the rule id, file, line,
+  message, and remediation — sufficient for an agent to repair without
+  reading raw logs

--- a/openspec/changes/habitat-enforcement-consolidation/tasks.md
+++ b/openspec/changes/habitat-enforcement-consolidation/tasks.md
@@ -2,27 +2,46 @@
 
 - [ ] 1.1 Build the retirement table: every mechanism slated for deletion ×
   its harness owner × parity evidence pointer (from H3/H5 phase records);
-  any row without evidence blocks.
+  each row MUST cite the H5 parity form (`empty/empty + probe-confirmed`, or
+  identical non-empty finding sets); any row without evidence blocks. Owners
+  per the corrected corpus: G1/G2/G5/G8/G9/G10/G11 and the G3 runtime-value
+  ban retire only against LOCKED grit equivalents (H5 ports all of them);
+  G3's project-edge context is the nx `kind:engine` tag rule; G6/G7 move
+  habitat-native; no row may cite nx-boundaries as covering G10/G11 (they
+  are intra-project; grit owns them).
 - [ ] 1.2 Decide and record: `bun run lint` becomes `habitat check` alias vs
   removed (default: alias, to keep muscle memory working).
 
 ## 2. Script And ESLint Retirement
 
 - [ ] 2.1 Move habitat-native survivors (workspace-entrypoints, G6/G7
-  doc-sync, adr-lint, doc-ambiguity, mapgen-docs) into
+  doc-sync, adr-lint, doc-ambiguity) into
   `tools/habitat-harness/src/rules/` as native TS rules; delete their
-  `scripts/lint/` originals.
+  `scripts/lint/` originals. `lint-mapgen-docs.py` is NOT rewritten in TS —
+  it relocates (or stays in place) wrapped as-is per corpus disposition
+  ("port py→TS only if touched").
 - [ ] 2.2 Delete ported scripts (adapter-boundary, mapgen-recipe-imports,
   control-orpc-contract-ownership) and the ported guardrail families from the
-  two big guardrail scripts; delete whole scripts when emptied.
+  two big guardrail scripts, consuming H5's explicit enumeration: only the
+  BOUNDARY-profile families of `lint-domain-refactor-guardrails.sh`
+  (ops-import bans, cross-domain deep imports, RNG/engine import bans) are
+  ported and retire here; the FULL-profile-only families (JSDoc presence,
+  schema descriptions, config-merge bans) stay wrapped and MUST NOT be
+  deleted; delete whole scripts only when fully emptied.
 - [ ] 2.3 Delete `eslint.config.js`; remove `@typescript-eslint/*` deps if now
   unused; confirm `eslint.boundaries.config.mjs` is the only ESLint surface.
+- [ ] 2.4 Disposition the orphan data file
+  `scripts/lint/no-legacy-m4-foundation-tokens.txt`: verify at execution time
+  with a `git grep` that no consumer exists anywhere in the repo, then delete
+  it in the sweep with that evidence recorded in the phase record.
 
 ## 3. Test Dedup
 
-- [ ] 3.1 Retire `recipe-import-boundary.test.ts` and
-  `ecology-step-import-guardrails.test.ts` citing locked grit rules; slim
-  `core-purity.test.ts` to runtime-value semantics.
+- [ ] 3.1 Retire `recipe-import-boundary.test.ts` citing its locked grit
+  rule; slim `ecology-step-import-guardrails.test.ts` — retire the
+  deep-import assertions (locked grit equivalent), KEEP the
+  retired-stage-dirs-absent assertions (no grit/file rule covers directory
+  absence); slim `core-purity.test.ts` to runtime-value semantics.
 - [ ] 3.2 Confirm kept tests (rng-authority, m11 band, bundle-runtime) still
   run in their suites.
 
@@ -30,13 +49,17 @@
 
 - [ ] 4.1 Re-point root `check` and `ci:architecture-strict-core` to
   `habitat verify`; CI uploads habitat JSON diagnostics; record CI timing vs
-  the retired aggregate (stop-condition threshold).
+  the retired aggregate (stop-condition bound: ≤ 1.25× the retired
+  aggregate's wall-clock on CI; both timings in the phase record).
 - [ ] 4.2 Docs/AGENTS sweep for retired-script references.
 
 ## 5. Verification And Closure
 
-- [ ] 5.1 Per-family synthetic-violation probes fail through the harness;
-  probes removed.
+- [ ] 5.1 Per-retired-RULE probe matrix: every retirement-table row gets a
+  probe entry (probe file path, injected violation, expected harness rule id)
+  demonstrating the replacement rule catches what the retired mechanism
+  caught; probes fail through the harness, matrix recorded in the phase
+  record, probes removed.
 - [ ] 5.2 `bun run build && bun run check && bun run test` green; CI green;
   `git grep` shows no stale references.
 - [ ] 5.3 `bun run openspec -- validate habitat-enforcement-consolidation

--- a/openspec/changes/habitat-enforcement-consolidation/tasks.md
+++ b/openspec/changes/habitat-enforcement-consolidation/tasks.md
@@ -1,0 +1,43 @@
+## 1. Retirement Preconditions
+
+- [ ] 1.1 Build the retirement table: every mechanism slated for deletion ×
+  its harness owner × parity evidence pointer (from H3/H5 phase records);
+  any row without evidence blocks.
+- [ ] 1.2 Decide and record: `bun run lint` becomes `habitat check` alias vs
+  removed (default: alias, to keep muscle memory working).
+
+## 2. Script And ESLint Retirement
+
+- [ ] 2.1 Move habitat-native survivors (workspace-entrypoints, G6/G7
+  doc-sync, adr-lint, doc-ambiguity, mapgen-docs) into
+  `tools/habitat-harness/src/rules/` as native TS rules; delete their
+  `scripts/lint/` originals.
+- [ ] 2.2 Delete ported scripts (adapter-boundary, mapgen-recipe-imports,
+  control-orpc-contract-ownership) and the ported guardrail families from the
+  two big guardrail scripts; delete whole scripts when emptied.
+- [ ] 2.3 Delete `eslint.config.js`; remove `@typescript-eslint/*` deps if now
+  unused; confirm `eslint.boundaries.config.mjs` is the only ESLint surface.
+
+## 3. Test Dedup
+
+- [ ] 3.1 Retire `recipe-import-boundary.test.ts` and
+  `ecology-step-import-guardrails.test.ts` citing locked grit rules; slim
+  `core-purity.test.ts` to runtime-value semantics.
+- [ ] 3.2 Confirm kept tests (rng-authority, m11 band, bundle-runtime) still
+  run in their suites.
+
+## 4. Single-Path Wiring
+
+- [ ] 4.1 Re-point root `check` and `ci:architecture-strict-core` to
+  `habitat verify`; CI uploads habitat JSON diagnostics; record CI timing vs
+  the retired aggregate (stop-condition threshold).
+- [ ] 4.2 Docs/AGENTS sweep for retired-script references.
+
+## 5. Verification And Closure
+
+- [ ] 5.1 Per-family synthetic-violation probes fail through the harness;
+  probes removed.
+- [ ] 5.2 `bun run build && bun run check && bun run test` green; CI green;
+  `git grep` shows no stale references.
+- [ ] 5.3 `bun run openspec -- validate habitat-enforcement-consolidation
+  --strict`; realignment + closure per workstream record.

--- a/openspec/changes/habitat-generators-migrations/proposal.md
+++ b/openspec/changes/habitat-generators-migrations/proposal.md
@@ -28,8 +28,13 @@ procedure wiring (AGENTS.md routing) that makes classify-first the default.
 - `@internal/habitat-harness:pattern` generator: scaffolds a grit pattern +
   fixtures + rule-pack entry + empty baseline (rule-introduction path with
   the `--expand-baseline` gate from H2).
-- Harness migrations wiring (`bunx nx migrate @internal/habitat-harness`):
-  versioned migration stubs so future harness convention changes propagate.
+- Harness migrations wiring: migrations ship in the plugin's
+  `migrations.json`; because `@internal/habitat-harness` is unpublished,
+  `bunx nx migrate @internal/habitat-harness` (npm-registry version
+  resolution) does not apply — migrations are executed via a hand-authored
+  `migrations.json` run file + `bunx nx migrate
+  --run-migrations=migrations.json` (no registry resolution); versioned
+  migration stubs so future harness convention changes propagate.
 - `habitat classify <path-or-diff>` completes: maps any path/diff to project,
   tags, owning rules, and required targets (the agent entry point).
 - Agent operating procedure: root `AGENTS.md` Tooling Defaults section gains
@@ -45,6 +50,8 @@ procedure wiring (AGENTS.md routing) that makes classify-first the default.
 ## Requires
 
 - `habitat-enforcement-consolidation`
+- `habitat-git-hooks` (strictly sequential — both slices write root
+  `AGENTS.md` and the harness README; no parallelism with H7)
 
 ## Enables Parallel Work
 
@@ -83,7 +90,16 @@ impossible for supported kinds.
   generated output → probes removed.
 - Probe: pattern generator output passes the fixture runner and registers in
   the rule pack.
-- `bunx nx migrate @internal/habitat-harness` executes the no-op baseline
-  migration.
-- `habitat classify` returns correct project/tags/rules for spot-checked
-  paths (adapter file, generated file, mod step file, harness file).
+- The no-op baseline migration executes successfully via a hand-authored
+  `migrations.json` run file + `bunx nx migrate
+  --run-migrations=migrations.json` (no registry resolution; the package is
+  unpublished).
+- `habitat classify` spot-check matrix — four probe paths with expected
+  outputs (per `docs/projects/habitat-harness/taxonomy.md`), each naming the
+  owning project, tags, in-scope rules, and required verification targets:
+  - `packages/civ7-adapter/src/<any>.ts` → project `@civ7/adapter`, tag
+    `kind:adapter` (adapter `/base-standard/` ownership rules in scope)
+  - `mods/mod-swooper-maps/src/recipes/<any>` → project `mod-swooper-maps`,
+    tag `kind:mod`, recipe-surface rules in scope
+  - `packages/config/<any>` → project `@civ7/config`, tag `kind:foundation`
+  - `apps/mapgen-studio/src/<any>` → project `mapgen-studio`, tag `kind:app`

--- a/openspec/changes/habitat-generators-migrations/proposal.md
+++ b/openspec/changes/habitat-generators-migrations/proposal.md
@@ -1,0 +1,89 @@
+## Why
+
+The harness end-state (spec draft §14) includes "new structure comes from
+generators" and "agents classify before they author." With enforcement
+consolidated, the remaining gap is generative: creating a new
+package/plugin/pattern by hand invites the exact drift the harness exists to
+prevent, and harness convention changes have no propagation mechanism. This
+slice adds Nx generators for the repo's real project kinds, a pattern
+generator for new grit rules, harness migrations, and the agent operating
+procedure wiring (AGENTS.md routing) that makes classify-first the default.
+
+## Target Authority Refs
+
+- `docs/projects/habitat-harness/FRAME.md` (north star; hard core #1)
+- `docs/projects/habitat-harness/habitat-harness-spec-draft-input.md` §10
+  (agent operating procedure), §11 Phase 6 (generators/migrations)
+- `docs/projects/habitat-harness/taxonomy.md` (kinds a generator may scaffold)
+- `https://nx.dev/docs/extending-nx/recipes/organization-specific-plugin`
+
+## What Changes
+
+- `@internal/habitat-harness:project` generator: scaffolds a workspace
+  project by kind (`kind:plugin`, `kind:foundation`, `kind:app` initially —
+  the kinds with uniform shape), emitting package.json (with tags), tsconfig,
+  src/index.ts, test stub, and rule-pack-conformant layout; refuses kinds
+  whose shape is not uniform yet (mod, engine, control) with a documented
+  rationale.
+- `@internal/habitat-harness:pattern` generator: scaffolds a grit pattern +
+  fixtures + rule-pack entry + empty baseline (rule-introduction path with
+  the `--expand-baseline` gate from H2).
+- Harness migrations wiring (`bunx nx migrate @internal/habitat-harness`):
+  versioned migration stubs so future harness convention changes propagate.
+- `habitat classify <path-or-diff>` completes: maps any path/diff to project,
+  tags, owning rules, and required targets (the agent entry point).
+- Agent operating procedure: root `AGENTS.md` Tooling Defaults section gains
+  the classify→generate→author→verify loop; harness README carries the full
+  procedure (spec draft §10 adapted).
+
+## What Does Not Change
+
+- No retroactive restructuring of existing projects to generator output.
+- No new enforcement rules; generators must produce rule-clean output (proof
+  gate), not new constraints.
+
+## Requires
+
+- `habitat-enforcement-consolidation`
+
+## Enables Parallel Work
+
+- Train complete; future rule-introduction changes use the pattern generator.
+
+## Affected Owners
+
+- `tools/habitat-harness/src/generators/**`, `src/migrations/**`, CLI
+  `classify`
+- Root `AGENTS.md` (Tooling Defaults), harness README
+
+## Forbidden Owners
+
+- Generators must not scaffold domain logic, recipes, stages, or steps —
+  MapGen authoring surfaces are owned by the normalization train and mod
+  tooling, not the harness.
+- No generator output that requires immediate baseline entries.
+
+## Stop Conditions
+
+- A generated project fails any harness rule out of the box.
+- The project generator needs kind-specific knowledge that belongs to product
+  owners (e.g. mod scaffolding) — refuse the kind rather than guess.
+
+## Consumer Impact
+
+Agents start work with `habitat classify`, scaffold with generators, and
+author only business logic. New-project drift becomes structurally
+impossible for supported kinds.
+
+## Verification Gates
+
+- `bun run openspec -- validate habitat-generators-migrations --strict`
+- Probe: generate one project per supported kind in a scratch branch →
+  `bun run habitat check` and `bunx nx run-many -t build,check,test` green on
+  generated output → probes removed.
+- Probe: pattern generator output passes the fixture runner and registers in
+  the rule pack.
+- `bunx nx migrate @internal/habitat-harness` executes the no-op baseline
+  migration.
+- `habitat classify` returns correct project/tags/rules for spot-checked
+  paths (adapter file, generated file, mod step file, harness file).

--- a/openspec/changes/habitat-generators-migrations/specs/habitat-harness/spec.md
+++ b/openspec/changes/habitat-generators-migrations/specs/habitat-harness/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Structure Comes From Generators
+
+For supported project kinds, new workspace structure SHALL be scaffolded by
+harness generators whose output passes every harness rule with zero baseline
+entries. Unsupported kinds SHALL be refused with a documented rationale rather
+than scaffolded by guess.
+
+#### Scenario: New plugin project
+- **WHEN** `bunx nx g @internal/habitat-harness:project my-lib --kind=plugin`
+  runs
+- **THEN** the generated project carries correct tags, layout, and config, and
+  `habitat check` plus build/check/test pass without modification
+
+### Requirement: Agents Classify Before They Author
+
+The harness SHALL provide `habitat classify <path-or-diff>` mapping any target
+to its project, tags, owning rules, and required verification targets, and the
+repository's agent routing docs SHALL prescribe the
+classify→generate→author→verify loop.
+
+#### Scenario: Agent orients on an unfamiliar file
+- **WHEN** an agent runs `habitat classify` on a path it is about to edit
+- **THEN** the output names the owning project, its tags, the rules in scope,
+  and the targets that must pass before handoff
+
+### Requirement: Harness Evolution Propagates Via Migrations
+
+Changes to harness conventions SHALL ship with Nx migrations so downstream
+configuration updates are generated, not hand-applied.
+
+#### Scenario: Harness convention change
+- **WHEN** a harness version changes a convention consumed by projects
+- **THEN** `bunx nx migrate @internal/habitat-harness` applies the update
+  mechanically

--- a/openspec/changes/habitat-generators-migrations/specs/habitat-harness/spec.md
+++ b/openspec/changes/habitat-generators-migrations/specs/habitat-harness/spec.md
@@ -32,5 +32,6 @@ configuration updates are generated, not hand-applied.
 
 #### Scenario: Harness convention change
 - **WHEN** a harness version changes a convention consumed by projects
-- **THEN** `bunx nx migrate @internal/habitat-harness` applies the update
-  mechanically
+- **THEN** running the migration via a hand-authored `migrations.json` run
+  file (`bunx nx migrate --run-migrations=migrations.json`; the package is
+  unpublished, so no registry resolution) applies the update mechanically

--- a/openspec/changes/habitat-generators-migrations/tasks.md
+++ b/openspec/changes/habitat-generators-migrations/tasks.md
@@ -1,0 +1,28 @@
+## 1. Generators
+
+- [ ] 1.1 Implement `project` generator for uniform kinds (plugin, foundation,
+  app): package.json with tags, tsconfig, src/test stubs, workspace
+  registration; refusal path with rationale for non-uniform kinds.
+- [ ] 1.2 Implement `pattern` generator: grit pattern + fixtures + rule-pack
+  entry + empty baseline via the rule-introduction gate.
+- [ ] 1.3 Probe: one generated project per supported kind passes
+  `habitat check` + build/check/test cold; remove probes.
+
+## 2. Migrations
+
+- [ ] 2.1 Wire `migrations.json` + a no-op baseline migration;
+  `bunx nx migrate @internal/habitat-harness` proof.
+
+## 3. Classify And Agent Procedure
+
+- [ ] 3.1 Complete `habitat classify <path-or-diff>`: project, tags, owning
+  rules, required targets; JSON output.
+- [ ] 3.2 Update root `AGENTS.md` Tooling Defaults with the
+  classify→generate→author→verify loop; full procedure in harness README.
+
+## 4. Verification And Closure
+
+- [ ] 4.1 All proposal gates pass; classify spot-checks recorded.
+- [ ] 4.2 `bun run openspec -- validate habitat-generators-migrations
+  --strict`; downstream realignment (AGENTS routers, process docs); train
+  closure review against FRAME end-state checklist (§14 of spec draft input).

--- a/openspec/changes/habitat-generators-migrations/tasks.md
+++ b/openspec/changes/habitat-generators-migrations/tasks.md
@@ -10,8 +10,12 @@
 
 ## 2. Migrations
 
-- [ ] 2.1 Wire `migrations.json` + a no-op baseline migration;
-  `bunx nx migrate @internal/habitat-harness` proof.
+- [ ] 2.1 Wire the plugin's `migrations.json` + a no-op baseline migration;
+  proof: hand-author a `migrations.json` run file and execute `bunx nx
+  migrate --run-migrations=migrations.json` (the package is unpublished, so
+  `bunx nx migrate @internal/habitat-harness` registry resolution does not
+  apply). Note: the migration requirement's demonstrable gate in this slice
+  is the no-op migration execution only.
 
 ## 3. Classify And Agent Procedure
 
@@ -22,7 +26,9 @@
 
 ## 4. Verification And Closure
 
-- [ ] 4.1 All proposal gates pass; classify spot-checks recorded.
+- [ ] 4.1 All proposal gates pass; classify spot-checks recorded against the
+  four-path expected-output matrix in the proposal (owning project, tags,
+  in-scope rules, required verification targets per path).
 - [ ] 4.2 `bun run openspec -- validate habitat-generators-migrations
   --strict`; downstream realignment (AGENTS routers, process docs); train
   closure review against FRAME end-state checklist (§14 of spec draft input).

--- a/openspec/changes/habitat-git-hooks/proposal.md
+++ b/openspec/changes/habitat-git-hooks/proposal.md
@@ -1,0 +1,93 @@
+## Why
+
+All enforcement is currently CI-or-manual; the cheapest mistakes (formatting,
+generated-zone edits, forbidden source shapes) surface minutes-to-hours late.
+Husky owns local Git moments in the harness model. Matei D3: hooks are
+in-scope and get done now; pre-commit auto-staging is allowed only for files
+the formatter itself touched. CI remains authoritative (FRAME hard core #5) —
+hooks are friction reduction, never verification truth.
+
+## Target Authority Refs
+
+- `docs/projects/habitat-harness/FRAME.md` (D3, hard core #5, trade-offs table)
+- `docs/projects/habitat-harness/habitat-harness-spec-draft-input.md` §5.6
+  (hook policy table), §12.3 (hooks are not CI)
+- `https://typicode.github.io/husky/get-started.html`
+
+## What Changes
+
+- Add `husky` devDependency; root `prepare` script installs hooks; thin
+  delegator hook files (`.husky/pre-commit`, `.husky/pre-push`) that only call
+  `bun run habitat hook <name>`.
+- Implement `habitat hook pre-commit`: Biome format/check on staged files
+  only; cheap grit checks on staged files; generated-zone staged guard.
+  Auto-restage policy (D3): the hook captures the exact file list it formats
+  and re-stages **only those paths** (`git add -- <formatted files>`); it
+  never stages other dirty or foreign files (multi-lane worktree safety —
+  see shared-worktree note in design of record: other lanes may have staged
+  work in the same tree).
+- Implement `habitat hook pre-push`: `bunx nx affected -t
+  biome:ci,boundaries,grit:check,habitat:check,test --base=<merge-base>`
+  bounded to a recorded time budget; instructions for `--no-verify` escape
+  recorded as policy (allowed; CI catches).
+- `commit-msg` evaluated and explicitly NOT installed (repo uses Graphite
+  conventions, no enforced message shape today) — recorded decision, easy to
+  add later.
+- Local bun-only guard (pnpm artifact check) in pre-commit (mirrors CI guard).
+- Hook behavior documented in harness README + root AGENTS touchpoint;
+  Graphite interaction verified (`gt create`/`gt modify` invoke git hooks).
+
+## What Does Not Change
+
+- CI gates unchanged and authoritative; hooks add no new rules — they run
+  existing harness rules earlier.
+- No `post-checkout`/`post-merge` hooks in this slice (optional per spec
+  draft; deferred deliberately, recorded).
+
+## Requires
+
+- `habitat-harness-scaffold`
+- `habitat-biome-hygiene`
+- `habitat-grit-catalog` (staged grit checks; generated-zone guard)
+
+## Enables Parallel Work
+
+- `habitat-generators-migrations`.
+
+## Affected Owners
+
+- New `.husky/**`; root `package.json` (`prepare`, husky dep)
+- `tools/habitat-harness` hook command implementations
+- Harness README, root `AGENTS.md` tooling note
+
+## Forbidden Owners
+
+- Hooks must not run repo-wide checks at pre-commit (staged scope only).
+- Hooks must not mutate anything beyond formatter output on staged files; no
+  `git add -A`, no stash juggling, no re-staging of files the hook did not
+  format.
+- No hook bypass treated as verification failure (CI is the gate).
+
+## Stop Conditions
+
+- Pre-commit exceeds the recorded time budget on a typical staged set — stop
+  and trim scope before shipping.
+- Hook interaction with Graphite (`gt create/modify/absorb`) produces
+  surprising staging behavior in testing — stop and record before enabling.
+- Restage scope cannot be proven limited to formatter-touched files.
+
+## Consumer Impact
+
+Contributors and agents get sub-second-to-seconds local feedback; foreign
+staged files in shared worktrees are never touched (restage is path-exact).
+`--no-verify` remains available; CI unchanged.
+
+## Verification Gates
+
+- `bun run openspec -- validate habitat-git-hooks --strict`
+- Probe matrix (executed and recorded): staged-only formatting (dirty
+  unstaged file untouched); foreign staged file untouched by restage;
+  generated-zone staged edit blocked; pre-push runs affected targets only;
+  `gt create` and `gt modify` trigger hooks correctly in a worktree.
+- Hook timing recorded against the budget.
+- Fresh-clone `bun install` installs hooks (prepare script proof).

--- a/openspec/changes/habitat-git-hooks/proposal.md
+++ b/openspec/changes/habitat-git-hooks/proposal.md
@@ -24,29 +24,54 @@ hooks are friction reduction, never verification truth.
   Auto-restage policy (D3): the hook captures the exact file list it formats
   and re-stages **only those paths** (`git add -- <formatted files>`); it
   never stages other dirty or foreign files (multi-lane worktree safety —
-  see shared-worktree note in design of record: other lanes may have staged
-  work in the same tree).
+  see the foreign-staged-file probe, task 3.2, and its probe-matrix entry in
+  the phase record: other lanes may have staged work in the same tree).
+- Disposition the EXISTING legacy hook mechanism: `scripts/git-hooks/pre-commit`
+  (runs `scripts/civ7-resources/publish-submodule.sh` on every commit),
+  installed via `git config core.hooksPath scripts/git-hooks` by
+  `scripts/git-hooks/setup.sh` (root script `setup:git-hooks`). Husky's
+  install repoints `core.hooksPath`, silently dropping that behavior — so:
+  fold the publish-submodule invocation into `habitat hook pre-commit`
+  (preserving current behavior; inspect the script at execution time — if it
+  requires opt-in state, preserve the opt-in semantics and record the
+  decision in the phase record), then retire `scripts/git-hooks/` and the
+  `setup:git-hooks` root script in the same slice so the two mechanisms
+  never coexist.
 - Implement `habitat hook pre-push`: `bunx nx affected -t
   biome:ci,boundaries,grit:check,habitat:check,test --base=<merge-base>`
-  bounded to a recorded time budget; instructions for `--no-verify` escape
-  recorded as policy (allowed; CI catches).
+  bounded to a pre-measured time budget. Budget derivation: BEFORE wiring
+  hooks, measure baseline wall-clock on two declared probe sets — (a) a
+  10-file staged set for pre-commit, (b) a one-package change for pre-push;
+  budget = 2× measured baseline, recorded in the phase record FIRST; the
+  timing gate then fails if the wired hooks exceed those budgets.
+  Instructions for `--no-verify` escape recorded as policy (allowed; CI
+  catches). "Cheap grit checks" is defined by a rule-pack attribute
+  `hookScope: 'pre-commit'`; the tasks enumerate which pattern families get
+  it (fast, path-scoped patterns only) when wiring.
 - `commit-msg` evaluated and explicitly NOT installed (repo uses Graphite
   conventions, no enforced message shape today) — recorded decision, easy to
   add later.
-- Local bun-only guard (pnpm artifact check) in pre-commit (mirrors CI guard).
+- Local bun-only guard (pnpm artifact check) in pre-commit (mirrors CI
+  guard). This is a NEW rule: it is registered in the harness rule pack as a
+  file-layer rule with an empty, locked baseline via the rule-introduction
+  gate — this slice is its rule-introduction change.
 - Hook behavior documented in harness README + root AGENTS touchpoint;
   Graphite interaction verified (`gt create`/`gt modify` invoke git hooks).
 
 ## What Does Not Change
 
-- CI gates unchanged and authoritative; hooks add no new rules — they run
-  existing harness rules earlier.
+- CI gates unchanged and authoritative; hooks add exactly one registered rule
+  (the bun-only file-layer guard, empty locked baseline, introduced via the
+  rule-introduction gate); all other hook checks run existing harness rules
+  earlier.
 - No `post-checkout`/`post-merge` hooks in this slice (optional per spec
   draft; deferred deliberately, recorded).
 
 ## Requires
 
 - `habitat-harness-scaffold`
+- `habitat-boundary-tags` (pre-push affected run invokes the `boundaries`
+  target, which exists only after H3)
 - `habitat-biome-hygiene`
 - `habitat-grit-catalog` (staged grit checks; generated-zone guard)
 
@@ -70,8 +95,9 @@ hooks are friction reduction, never verification truth.
 
 ## Stop Conditions
 
-- Pre-commit exceeds the recorded time budget on a typical staged set — stop
-  and trim scope before shipping.
+- Pre-commit exceeds its pre-measured budget (2× baseline on the declared
+  10-file staged probe set, recorded before wiring) — stop and trim scope
+  before shipping.
 - Hook interaction with Graphite (`gt create/modify/absorb`) produces
   surprising staging behavior in testing — stop and record before enabling.
 - Restage scope cannot be proven limited to formatter-touched files.
@@ -89,5 +115,10 @@ staged files in shared worktrees are never touched (restage is path-exact).
   unstaged file untouched); foreign staged file untouched by restage;
   generated-zone staged edit blocked; pre-push runs affected targets only;
   `gt create` and `gt modify` trigger hooks correctly in a worktree.
-- Hook timing recorded against the budget.
+- Hook timing gate: budgets (2× measured baseline on the two declared probe
+  sets) recorded in the phase record BEFORE wiring; wired hooks measured
+  against them — the gate fails if either budget is exceeded.
+- Legacy hook disposition complete: publish-submodule behavior preserved in
+  `habitat hook pre-commit`; `scripts/git-hooks/` and `setup:git-hooks`
+  retired in this slice.
 - Fresh-clone `bun install` installs hooks (prepare script proof).

--- a/openspec/changes/habitat-git-hooks/specs/habitat-harness/spec.md
+++ b/openspec/changes/habitat-git-hooks/specs/habitat-harness/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Hooks Run Harness Checks At Git Moments
+
+Local Git hooks SHALL be thin delegators to `habitat hook <name>`: pre-commit
+runs staged-scope hygiene, cheap structural checks, and the generated-zone
+guard; pre-push runs merge-base affected verification. CI SHALL remain the
+authoritative gate.
+
+#### Scenario: Cheap mistake caught locally
+- **WHEN** a commit stages an unformatted file or a generated-zone hand-edit
+- **THEN** pre-commit fails (or fixes formatting) before the commit lands
+
+#### Scenario: Hook bypass
+- **WHEN** a contributor commits with `--no-verify`
+- **THEN** the same rules still gate the change in CI
+
+### Requirement: Pre-Commit Restages Only Formatter-Touched Files
+
+The pre-commit hook SHALL re-stage exactly the files its formatter modified
+and SHALL NOT stage, modify, or unstage any other file, including foreign
+staged files present in shared worktrees.
+
+#### Scenario: Foreign staged work is preserved
+- **WHEN** the index contains staged files from another work lane and
+  pre-commit formats the current change's staged files
+- **THEN** only the formatter-touched paths are re-staged and the foreign
+  staged entries are byte-identical afterward

--- a/openspec/changes/habitat-git-hooks/tasks.md
+++ b/openspec/changes/habitat-git-hooks/tasks.md
@@ -1,0 +1,34 @@
+## 1. Husky Wiring
+
+- [ ] 1.1 `bun add -d husky`; `bunx husky init`; root `prepare` script; thin
+  `.husky/pre-commit` and `.husky/pre-push` delegators calling
+  `bun run habitat hook <name>`.
+- [ ] 1.2 Fresh-clone probe: `bun install` installs hooks.
+
+## 2. Hook Implementations
+
+- [ ] 2.1 `habitat hook pre-commit`: staged-file Biome format/check with
+  path-exact restage of formatter-touched files only; staged grit cheap
+  checks; generated-zone staged guard; pnpm-artifact guard.
+- [ ] 2.2 `habitat hook pre-push`: merge-base affected run
+  (`biome:ci,boundaries,grit:check,habitat:check,test`) with timing capture.
+- [ ] 2.3 Record the commit-msg non-installation decision and the deferred
+  optional hooks (post-checkout/post-merge) in the rule pack docs.
+
+## 3. Safety Probes
+
+- [ ] 3.1 Staged/unstaged isolation probe: unstaged dirty file untouched.
+- [ ] 3.2 Foreign-staged-file probe: a staged file the hook did not format is
+  not re-staged or modified (multi-lane worktree safety).
+- [ ] 3.3 Generated-zone probe: staged hand-edit blocked with regenerate
+  remediation.
+- [ ] 3.4 Graphite probe: `gt create` / `gt modify` fire hooks with correct
+  staged scope in a worktree.
+
+## 4. Verification And Closure
+
+- [ ] 4.1 Timing within recorded budget; probe matrix results in phase record.
+- [ ] 4.2 Harness README + AGENTS touchpoint document hook behavior and the
+  `--no-verify`/CI-authoritative policy.
+- [ ] 4.3 `bun run openspec -- validate habitat-git-hooks --strict`;
+  realignment + closure per workstream record.

--- a/openspec/changes/habitat-git-hooks/tasks.md
+++ b/openspec/changes/habitat-git-hooks/tasks.md
@@ -1,19 +1,38 @@
-## 1. Husky Wiring
+## 1. Budget Baseline And Husky Wiring
 
-- [ ] 1.1 `bun add -d husky`; `bunx husky init`; root `prepare` script; thin
+- [ ] 1.1 BEFORE wiring hooks: measure baseline wall-clock on two declared
+  probe sets — (a) a 10-file staged set for pre-commit, (b) a one-package
+  change for pre-push; set budget = 2× measured baseline per hook; record
+  both budgets in the phase record FIRST (the timing gate in 4.1 fails
+  against these).
+- [ ] 1.2 `bun add -d husky`; `bunx husky init`; root `prepare` script; thin
   `.husky/pre-commit` and `.husky/pre-push` delegators calling
   `bun run habitat hook <name>`.
-- [ ] 1.2 Fresh-clone probe: `bun install` installs hooks.
+- [ ] 1.3 Fresh-clone probe: `bun install` installs hooks.
 
 ## 2. Hook Implementations
 
 - [ ] 2.1 `habitat hook pre-commit`: staged-file Biome format/check with
   path-exact restage of formatter-touched files only; staged grit cheap
-  checks; generated-zone staged guard; pnpm-artifact guard.
+  checks — defined as rule-pack patterns carrying the `hookScope:
+  'pre-commit'` attribute; enumerate which pattern families get the
+  attribute (fast, path-scoped patterns only) when wiring; generated-zone
+  staged guard; pnpm-artifact guard (registered in the rule pack as a
+  file-layer rule with an empty, locked baseline via the rule-introduction
+  gate — this slice is its rule-introduction change).
 - [ ] 2.2 `habitat hook pre-push`: merge-base affected run
   (`biome:ci,boundaries,grit:check,habitat:check,test`) with timing capture.
 - [ ] 2.3 Record the commit-msg non-installation decision and the deferred
   optional hooks (post-checkout/post-merge) in the rule pack docs.
+- [ ] 2.4 Legacy hook disposition: fold the
+  `scripts/civ7-resources/publish-submodule.sh` invocation from
+  `scripts/git-hooks/pre-commit` (installed via `git config core.hooksPath
+  scripts/git-hooks` by `scripts/git-hooks/setup.sh`, root script
+  `setup:git-hooks`) into `habitat hook pre-commit`, preserving current
+  behavior — inspect the script at execution time; if it requires opt-in
+  state, preserve the opt-in semantics and record the decision in the phase
+  record; then retire `scripts/git-hooks/` and the `setup:git-hooks` root
+  script in the same slice so the two mechanisms never coexist.
 
 ## 3. Safety Probes
 
@@ -27,7 +46,9 @@
 
 ## 4. Verification And Closure
 
-- [ ] 4.1 Timing within recorded budget; probe matrix results in phase record.
+- [ ] 4.1 Timing gate: wired hooks measured against the pre-recorded 2×
+  budgets from task 1.1 (gate fails if either is exceeded); probe matrix
+  results in phase record.
 - [ ] 4.2 Harness README + AGENTS touchpoint document hook behavior and the
   `--no-verify`/CI-authoritative policy.
 - [ ] 4.3 `bun run openspec -- validate habitat-git-hooks --strict`;

--- a/openspec/changes/habitat-grit-catalog/design.md
+++ b/openspec/changes/habitat-grit-catalog/design.md
@@ -16,14 +16,18 @@ tools/habitat-harness/patterns/grit/
     no-helper-redeclaration.md
     no-empty-schema-default.md
     no-runtime-config-merge.md
+    no-civ7-runtime-import.md
   stage-isolation/
     no-sibling-stage-import.md
     no-milestone-recipe-id.md
     no-domain-root-catalog.md
     no-wrapper-only-stage-config.md
+    placement-outcome-contract-boundary.md
   ownership/
     adapter-base-standard-isolation.md
     control-orpc-contract-ownership.md
+    viz-contract-ownership.md
+    sdk-mapgen-entrypoint-isolation.md
   codemods/
     export-star-to-named.md
     deep-import-to-public-surface.md
@@ -49,8 +53,9 @@ Known granularity notes:
   redeclarations) map to grit code snippets — fixture both positive and
   negative cases (e.g. `runValidatedFoo` must NOT match).
 - `lint-normalization-guardrails.mjs` G6/G7 (doc/code sync) are NOT grit
-  rules; they stay habitat-native (semantic, cross-file). Only G1/G2/G5/G9
-  port here.
+  rules; they stay habitat-native (semantic, cross-file). G1/G2/G5/G8/G9
+  (stage-isolation/contract), G10/G11 (ownership), and the G3 runtime-value
+  ban (runtime-purity) port here per the corpus split.
 - Studio artifact rule: worker-file exemptions (`pipeline.worker.ts`,
   `recipeRuntime.ts`) become pattern path excludes, mirrored from the eslint
   block.
@@ -59,12 +64,16 @@ Known granularity notes:
 
 File-layer rules live in the rule pack (not grit): glob + allowedWriters +
 remediation. Enforcement points:
-- `habitat check --staged`: fails if staged paths intersect protected globs
-  (unless the regenerating command is what produced them — detected by
-  invoking the generator in `--check` mode where available, else by message
-  guidance only; record this trade-off).
-- CI: regenerate-and-diff for `gen:maps` outputs (generator runs, diff must be
+- `habitat check --staged`: always fails on any staged path inside a protected
+  zone, regardless of generator `--check` support; the failure message carries
+  the owning regenerate command. The false-positive cost (committing
+  regenerated output requires `--no-verify` or a harness-recognized regen
+  marker) is accepted and recorded as a trade-off.
+- CI: regenerate-and-diff for both repo-runnable generators — `gen:maps`
+  outputs and `civ7-map-policy:gen-tables` (generator runs, diff must be
   empty) — drift detection, not just edit detection.
+  `packages/civ7-types/generated/**` (external resources workflow) gets
+  write-protection only; the regeneration gap is recorded in the phase record.
 
 ## Codemod rules (spec draft §8 made operational)
 

--- a/openspec/changes/habitat-grit-catalog/design.md
+++ b/openspec/changes/habitat-grit-catalog/design.md
@@ -1,0 +1,75 @@
+# Design — Grit Catalog + File Layer
+
+## Pattern layout
+
+```text
+tools/habitat-harness/patterns/grit/
+  domain-surface/
+    no-deep-domain-import.md
+    step-contract-entrypoint-only.md
+    recipe-imports-ops-surface.md
+    studio-imports-artifacts-only.md
+    no-domain-root-export-star.md
+  runtime-purity/
+    no-typebox-runtime.md
+    no-run-validated.md
+    no-helper-redeclaration.md
+    no-empty-schema-default.md
+    no-runtime-config-merge.md
+  stage-isolation/
+    no-sibling-stage-import.md
+    no-milestone-recipe-id.md
+    no-domain-root-catalog.md
+    no-wrapper-only-stage-config.md
+  ownership/
+    adapter-base-standard-isolation.md
+    control-orpc-contract-ownership.md
+  codemods/
+    export-star-to-named.md
+    deep-import-to-public-surface.md
+  fixtures/<pattern-name>/{input,output|match,nomatch}.ts
+```
+
+Patterns are grit-CLI markdown patterns (frontmatter `level: error`, body =
+failure message). De-risk gotchas baked in: non-capturing regex groups
+`(?:...)` only; no `register_diagnostic` (Biome-only construct); wrapper
+parses `grit check --json` and fails on any `results[]` entry not in the
+rule's baseline (grit exit code is not trusted).
+
+## Parity discipline (the load-bearing verification)
+
+Each ported rule declares its `parityWith` source (eslint block id or script
+id from invariant-corpus.md). The harness runs both mechanisms during this
+slice and asserts identical finding sets on the current tree. Parity evidence
+is the precondition for retirement in `habitat-enforcement-consolidation` —
+not this slice.
+
+Known granularity notes:
+- eslint `no-restricted-syntax` AST selectors (runValidated calls, helper
+  redeclarations) map to grit code snippets — fixture both positive and
+  negative cases (e.g. `runValidatedFoo` must NOT match).
+- `lint-normalization-guardrails.mjs` G6/G7 (doc/code sync) are NOT grit
+  rules; they stay habitat-native (semantic, cross-file). Only G1/G2/G5/G9
+  port here.
+- Studio artifact rule: worker-file exemptions (`pipeline.worker.ts`,
+  `recipeRuntime.ts`) become pattern path excludes, mirrored from the eslint
+  block.
+
+## File layer
+
+File-layer rules live in the rule pack (not grit): glob + allowedWriters +
+remediation. Enforcement points:
+- `habitat check --staged`: fails if staged paths intersect protected globs
+  (unless the regenerating command is what produced them — detected by
+  invoking the generator in `--check` mode where available, else by message
+  guidance only; record this trade-off).
+- CI: regenerate-and-diff for `gen:maps` outputs (generator runs, diff must be
+  empty) — drift detection, not just edit detection.
+
+## Codemod rules (spec draft §8 made operational)
+
+A grit-apply pattern ships only with: input/output fixtures, deterministic
+rewrite, Biome format step after apply, and a rule-pack entry marking it
+`mode: apply`. `habitat fix` runs apply-mode patterns only; check-only
+patterns emit diagnostics with remediation text. Ambiguity = diagnostic, never
+rewrite.

--- a/openspec/changes/habitat-grit-catalog/proposal.md
+++ b/openspec/changes/habitat-grit-catalog/proposal.md
@@ -1,0 +1,119 @@
+## Why
+
+The intra-project plane — domain surfaces, runtime purity, stage isolation,
+contract shapes inside `mod-swooper-maps`, plus generated-zone protection —
+is where most existing enforcement lives (8 ESLint rule families, 4 grit-able
+lint-script families) and where codemod capability is entirely missing. This
+slice creates the GritQL pattern catalog (syntax layer) and the file layer
+(path/generated-zone rules), porting those rules to harness ownership with
+fixtures, and establishing `grit:apply` codemods as a first-class remediation
+path. GritQL under Bun was de-risked 2026-06-12 (FRAME §4): install, check,
+apply, and `--json` all proven; known gotchas recorded.
+
+## Target Authority Refs
+
+- `docs/projects/habitat-harness/FRAME.md` §4 (grit de-risk + gotchas), hard core #1–#3
+- `docs/projects/habitat-harness/invariant-corpus.md` (port dispositions: §A, §B, §E)
+- `docs/projects/habitat-harness/taxonomy.md` §4 (scope:* rule families)
+- `docs/projects/habitat-harness/habitat-harness-spec-draft-input.md` §5.5
+  (GritQL ownership), §7 (file layer), §8 (remediation rules)
+- `https://docs.grit.io/language/overview`
+
+## What Changes
+
+- Add `@getgrit/cli` devDependency; `.grit/grit.yaml` loading
+  `tools/habitat-harness/patterns/grit/`; `grit init` artifacts committed as
+  appropriate.
+- Port to grit-check patterns (each with input/output fixtures and a tested
+  failure message; ESLint/script originals stay active until
+  `habitat-enforcement-consolidation`):
+  - `scope:domain-surface` family: deep domain imports, step-contract
+    entrypoint-only imports, recipe.ts ops-surface imports, studio
+    recipe-artifact imports, domain-root `export *` facades.
+  - `scope:runtime-purity` family: TypeBox `Value.*`/`TypeCompiler` in runtime
+    layers, `runValidated` calls, canonical-helper redeclaration, empty schema
+    defaults, config-merge patterns (`?? {}`, `Value.Default(`).
+  - `scope:stage-isolation` family: sibling-stage step imports (G5),
+    milestone-prefixed recipe IDs (G1), domain-root catalogs (G2),
+    wrapper-only stage config (G9).
+  - adapter-boundary `/base-standard/` import detection (baseline = current
+    6-file allowlist) and control-orpc contract-ownership patterns.
+- First grit-apply codemods (fixture-gated; apply runs Biome format after):
+  `export *` → named exports in contract surfaces; deep-import → public-surface
+  rewrite where the mapping is mechanical.
+- File layer in the harness rule pack: generated zones
+  (`mods/mod-swooper-maps/src/maps/generated/**`, `packages/civ7-types/generated/**`,
+  `packages/civ7-map-policy/src/civ7-tables.gen.ts`) become write-protected
+  paths with "regenerate via <command>" remediation, enforced by
+  `habitat check --staged` (diff-aware) and CI diff checks.
+- Harness integration: `grit:check` inferred target; `habitat fix` runs
+  approved grit-apply patterns; every pattern registered in the rule pack with
+  ratchet baselines (expected mostly green; adapter-boundary starts at 6).
+- The harness grit wrapper derives pass/fail from `--json` results (grit
+  exits 0 on findings — de-risk gotcha #4).
+
+## What Does Not Change
+
+- ESLint blocks and lint scripts remain active (dual-running with identical
+  semantics) until consolidation retires them — parity is the point of this
+  slice's verification.
+- No new architectural rules beyond the promised-but-unenforced generated-zone
+  protection; no semantic rewrites of product code outside fixture-proven
+  codemods (none auto-applied in this slice).
+- Architecture tests untouched.
+
+## Requires
+
+- `habitat-harness-scaffold`
+- `habitat-biome-hygiene` (grit-apply must format rewrites with Biome)
+
+## Enables Parallel Work
+
+- `habitat-enforcement-consolidation` (retirements depend on parity evidence
+  from this slice).
+- `habitat-git-hooks` (cheap staged grit checks).
+
+## Affected Owners
+
+- New: `tools/habitat-harness/patterns/grit/**` (+ fixtures), `.grit/grit.yaml`
+- `tools/habitat-harness` rule pack, plugin targets, baselines
+- Root devDependencies; CI affected targets (`grit:check`)
+
+## Forbidden Owners
+
+- GritQL must not own project-graph law (no cross-project dependency
+  reasoning in patterns — that is `boundaries`).
+- No pattern without fixtures may run in apply mode (check-only until
+  fixtures exist).
+- No hand-edits to generated zones, including in fixtures.
+- No semantic/domain-behavior rewrites in codemods (fail-closed rule).
+
+## Stop Conditions
+
+- A ported rule cannot reach parity with its ESLint/script original (different
+  match set on the current tree) — stop, record the delta, keep the original
+  authoritative for that rule, and log it; do not ship a weaker port.
+- GritQL cannot express a rule family at all — record per FRAME degeneration
+  trigger accounting (habitat-native budget) before reassigning.
+- A grit-apply pattern produces any non-format diff on fixtures beyond the
+  declared rewrite.
+
+## Consumer Impact
+
+Agents gain `habitat fix`-able structural rules with precise diagnostics.
+Generated zones become actually write-protected (first new enforcement; AGENTS
+promise made real). No behavior change in product code.
+
+## Verification Gates
+
+- `bun run openspec -- validate habitat-grit-catalog --strict`
+- Pattern parity: for each ported rule, grit-check findings on the current
+  tree match the original mechanism's findings exactly (empty vs empty, or
+  identical file sets); parity table recorded in the phase record.
+- Fixture suite: every pattern has passing input/output (apply) or
+  match/no-match (check) fixtures run by a harness test.
+- `bunx nx affected -t grit:check` green; `habitat fix --dry-run` lists only
+  approved codemods.
+- Generated-zone probe: a staged hand-edit to a generated file fails
+  `habitat check --staged` with the regenerate remediation; probe removed.
+- `bun run build && bun run check && bun run test` unchanged-green.

--- a/openspec/changes/habitat-grit-catalog/proposal.md
+++ b/openspec/changes/habitat-grit-catalog/proposal.md
@@ -2,7 +2,7 @@
 
 The intra-project plane — domain surfaces, runtime purity, stage isolation,
 contract shapes inside `mod-swooper-maps`, plus generated-zone protection —
-is where most existing enforcement lives (8 ESLint rule families, 4 grit-able
+is where most existing enforcement lives (8 ESLint rule families, 5 grit-able
 lint-script families) and where codemod capability is entirely missing. This
 slice creates the GritQL pattern catalog (syntax layer) and the file layer
 (path/generated-zone rules), porting those rules to harness ownership with
@@ -22,8 +22,8 @@ apply, and `--json` all proven; known gotchas recorded.
 ## What Changes
 
 - Add `@getgrit/cli` devDependency; `.grit/grit.yaml` loading
-  `tools/habitat-harness/patterns/grit/`; `grit init` artifacts committed as
-  appropriate.
+  `tools/habitat-harness/patterns/grit/`; commit `.grit/grit.yaml`; gitignore
+  `.grit/.gritmodules` and cache artifacts.
 - Port to grit-check patterns (each with input/output fixtures and a tested
   failure message; ESLint/script originals stay active until
   `habitat-enforcement-consolidation`):
@@ -32,12 +32,18 @@ apply, and `--json` all proven; known gotchas recorded.
     recipe-artifact imports, domain-root `export *` facades.
   - `scope:runtime-purity` family: TypeBox `Value.*`/`TypeCompiler` in runtime
     layers, `runValidated` calls, canonical-helper redeclaration, empty schema
-    defaults, config-merge patterns (`?? {}`, `Value.Default(`).
+    defaults, config-merge patterns (`?? {}`, `Value.Default(`), and the G3
+    runtime-value ban (no Civ7 runtime imports in mapgen-core engine/core
+    paths).
   - `scope:stage-isolation` family: sibling-stage step imports (G5),
     milestone-prefixed recipe IDs (G1), domain-root catalogs (G2),
-    wrapper-only stage config (G9).
-  - adapter-boundary `/base-standard/` import detection (baseline = current
-    6-file allowlist) and control-orpc contract-ownership patterns.
+    wrapper-only stage config (G9), placement outcome contract boundary (G8).
+  - ownership family: adapter-boundary `/base-standard/` import detection
+    (baseline = current 6-file allowlist), control-orpc contract-ownership
+    patterns, viz contract ownership (G10: no shared `steps/viz.ts` hubs, no
+    cross-step private viz imports), and SDK mapgen entrypoint isolation
+    (G11: SDK root must not import `./mapgen`; `@civ7/adapter/civ7`
+    importable only under `src/mapgen/`).
 - First grit-apply codemods (fixture-gated; apply runs Biome format after):
   `export *` → named exports in contract surfaces; deep-import → public-surface
   rewrite where the mapping is mechanical.
@@ -108,8 +114,13 @@ promise made real). No behavior change in product code.
 
 - `bun run openspec -- validate habitat-grit-catalog --strict`
 - Pattern parity: for each ported rule, grit-check findings on the current
-  tree match the original mechanism's findings exactly (empty vs empty, or
-  identical file sets); parity table recorded in the phase record.
+  tree match the original mechanism's findings exactly. Identical non-empty
+  finding sets are one acceptable form; for every ported rule whose
+  current-tree finding set is empty, parity additionally requires an
+  injected-violation dual run — a synthetic violation file run through BOTH
+  the original mechanism and the grit port, asserting both flag it. Parity
+  table rows record `empty/empty + probe-confirmed`; table recorded in the
+  phase record.
 - Fixture suite: every pattern has passing input/output (apply) or
   match/no-match (check) fixtures run by a harness test.
 - `bunx nx affected -t grit:check` green; `habitat fix --dry-run` lists only

--- a/openspec/changes/habitat-grit-catalog/specs/habitat-harness/spec.md
+++ b/openspec/changes/habitat-grit-catalog/specs/habitat-harness/spec.md
@@ -38,12 +38,13 @@ fail closed on ambiguity.
 
 Generated paths SHALL be writable only by their owning generators; staged
 hand-edits SHALL fail `habitat check --staged`, and CI SHALL detect drift by
-regenerating and diffing.
+regenerating and diffing zones that have a repo-runnable generator.
 
 #### Scenario: Hand-edit of a generated file
 - **WHEN** a change stages an edit under a protected generated zone
 - **THEN** the check fails with the owning regenerate command as remediation
 
 #### Scenario: Generator drift
-- **WHEN** generated outputs no longer match their source declarations
+- **WHEN** outputs in a zone with a repo-runnable generator no longer match
+  their source declarations
 - **THEN** the CI regenerate-and-diff gate fails naming the stale zone

--- a/openspec/changes/habitat-grit-catalog/specs/habitat-harness/spec.md
+++ b/openspec/changes/habitat-grit-catalog/specs/habitat-harness/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: GritQL Owns The Syntax Layer
+
+Source-shape invariants SHALL be enforced by GritQL patterns in the harness
+catalog — import shapes, forbidden constructs, and contract file shapes — each
+with fixtures and an agent-readable failure message, surfaced through
+`grit:check`.
+
+#### Scenario: Forbidden source shape introduced
+- **WHEN** a change introduces a non-baselined match of a catalog pattern
+  (e.g. a deep `@mapgen/domain/*/ops/*` import)
+- **THEN** `grit:check` fails via the harness with the pattern's message and
+  remediation, derived from grit JSON results (not exit codes)
+
+#### Scenario: Pattern without fixtures
+- **WHEN** a pattern lacks fixtures
+- **THEN** it may run only in check mode and cannot be wired into
+  `habitat fix`
+
+### Requirement: Codemods Are Deterministic Fixture-Gated Remediation
+
+`habitat fix` SHALL apply only approved grit-apply patterns that are
+deterministic, repeatable, fixture-proven, Biome-formatted after rewrite, and
+fail closed on ambiguity.
+
+#### Scenario: Safe rewrite available
+- **WHEN** a violation has an approved apply-mode pattern
+- **THEN** `habitat fix` rewrites it, runs Biome format on touched files, and
+  re-check passes
+
+#### Scenario: Ambiguous intent
+- **WHEN** a rewrite cannot be proven safe from the source shape alone
+- **THEN** the harness emits a diagnostic naming the boundary decision needed
+  and performs no rewrite
+
+### Requirement: Generated Zones Are Write-Protected
+
+Generated paths SHALL be writable only by their owning generators; staged
+hand-edits SHALL fail `habitat check --staged`, and CI SHALL detect drift by
+regenerating and diffing.
+
+#### Scenario: Hand-edit of a generated file
+- **WHEN** a change stages an edit under a protected generated zone
+- **THEN** the check fails with the owning regenerate command as remediation
+
+#### Scenario: Generator drift
+- **WHEN** generated outputs no longer match their source declarations
+- **THEN** the CI regenerate-and-diff gate fails naming the stale zone

--- a/openspec/changes/habitat-grit-catalog/tasks.md
+++ b/openspec/changes/habitat-grit-catalog/tasks.md
@@ -1,7 +1,8 @@
 ## 1. Grit Infrastructure
 
 - [ ] 1.1 `bun add -d @getgrit/cli`; `bunx grit init`; `.grit/grit.yaml`
-  loading `tools/habitat-harness/patterns/grit/`; gitignore grit cache.
+  loading `tools/habitat-harness/patterns/grit/`; commit `.grit/grit.yaml`;
+  gitignore `.grit/.gritmodules` and cache artifacts.
 - [ ] 1.2 Harness grit wrapper: run `grit check --json`, derive pass/fail from
   results vs baseline (never exit code); fixture-runner test harness for
   patterns.
@@ -10,16 +11,33 @@
 
 - [ ] 2.1 Port `scope:domain-surface` family (5 patterns) with fixtures;
   declare `parityWith` eslint/script ids.
-- [ ] 2.2 Port `scope:runtime-purity` family (5 patterns) with
-  positive/negative fixtures (selector-derived patterns especially).
-- [ ] 2.3 Port `scope:stage-isolation` family (G1, G2, G5, G9 → 4 patterns);
-  G6/G7 explicitly remain habitat-native (record in rule pack).
-- [ ] 2.4 Port ownership family: adapter `/base-standard/` isolation (baseline
-  = current 6 allowlisted files, migrated from the script allowlist) and
-  control-orpc contract-ownership patterns.
-- [ ] 2.5 Parity run: dual-execute originals vs grit rules; record the parity
-  table (identical finding sets) in the phase record; any delta follows the
-  stop condition.
+- [ ] 2.2 Port `scope:runtime-purity` family (6 patterns, including the G3
+  runtime-value ban — no Civ7 runtime imports in mapgen-core engine/core
+  paths) with positive/negative fixtures (selector-derived patterns
+  especially).
+- [ ] 2.3 Port `scope:stage-isolation` family (G1, G2, G5, G8, G9 → 5
+  patterns, each with fixtures); G6/G7 explicitly remain habitat-native
+  (record in rule pack).
+- [ ] 2.4 Port ownership family (4 patterns, each with fixtures): adapter
+  `/base-standard/` isolation (baseline = current 6 allowlisted files,
+  migrated from the script allowlist), control-orpc contract-ownership,
+  viz contract ownership (G10: no shared `steps/viz.ts` hubs, no cross-step
+  private viz imports), and SDK mapgen entrypoint isolation (G11: SDK root
+  must not import `./mapgen`; `@civ7/adapter/civ7` importable only under
+  `src/mapgen/`).
+- [ ] 2.5 domain-refactor-guardrails port scope (H6 consumes this enumeration
+  for its retirement table): the BOUNDARY-profile families port to grit in
+  this slice — ops-import bans (adapter/context/map-projection/
+  domain-root-config), cross-domain deep imports, and RNG/engine import bans
+  outside runtime layers. The FULL-profile-only families (JSDoc presence,
+  schema descriptions, config-merge bans) REMAIN wrapped (habitat wrapped
+  rule — not ported, not retired).
+- [ ] 2.6 Parity run: dual-execute originals vs grit rules; record the parity
+  table (identical finding sets) in the phase record; for every ported rule
+  whose current-tree finding set is empty, run an injected-violation dual run
+  (synthetic violation file through BOTH the original mechanism and the grit
+  port; assert both flag it) and record the row as `empty/empty +
+  probe-confirmed`; any delta follows the stop condition.
 
 ## 3. Codemods (apply mode)
 
@@ -33,16 +51,21 @@
 - [ ] 4.1 Rule-pack file-layer rules for the three generated zones with
   regenerate remediation messages; `habitat check --staged` protected-glob
   enforcement.
-- [ ] 4.2 CI regenerate-and-diff gate for `gen:maps` outputs (drift
-  detection); record the staged-edit trade-off from design.md in the phase
-  record.
+- [ ] 4.2 CI regenerate-and-diff gates for BOTH repo-runnable generators:
+  `gen:maps` outputs AND `civ7-map-policy:gen-tables` (`civ7-tables.gen.ts`)
+  — drift detection. `packages/civ7-types/generated/**` is produced by the
+  external resources workflow and cannot regenerate in CI: it gets
+  write-protection only; record that gap explicitly in the phase record,
+  along with the staged-edit trade-off from design.md.
 
 ## 5. Verification And Closure
 
 - [ ] 5.1 All fixtures green; `bunx nx affected -t grit:check` green;
   generated-zone staged probe fails then removed.
-- [ ] 5.2 Ratchet entries for every pattern (locked where parity shows zero
-  findings; adapter-boundary at 6).
+- [ ] 5.2 Ratchet entries for every rule introduced in this slice — all grit
+  patterns AND the three file-layer generated-zone rules (empty baselines,
+  locked at adoption); grit patterns locked where parity shows zero findings;
+  adapter-boundary starts at 6.
 - [ ] 5.3 `bun run build && bun run check && bun run test` unchanged-green;
   `bun run openspec -- validate habitat-grit-catalog --strict`; realignment +
   closure per workstream record.

--- a/openspec/changes/habitat-grit-catalog/tasks.md
+++ b/openspec/changes/habitat-grit-catalog/tasks.md
@@ -1,0 +1,48 @@
+## 1. Grit Infrastructure
+
+- [ ] 1.1 `bun add -d @getgrit/cli`; `bunx grit init`; `.grit/grit.yaml`
+  loading `tools/habitat-harness/patterns/grit/`; gitignore grit cache.
+- [ ] 1.2 Harness grit wrapper: run `grit check --json`, derive pass/fail from
+  results vs baseline (never exit code); fixture-runner test harness for
+  patterns.
+
+## 2. Pattern Porting (check mode)
+
+- [ ] 2.1 Port `scope:domain-surface` family (5 patterns) with fixtures;
+  declare `parityWith` eslint/script ids.
+- [ ] 2.2 Port `scope:runtime-purity` family (5 patterns) with
+  positive/negative fixtures (selector-derived patterns especially).
+- [ ] 2.3 Port `scope:stage-isolation` family (G1, G2, G5, G9 → 4 patterns);
+  G6/G7 explicitly remain habitat-native (record in rule pack).
+- [ ] 2.4 Port ownership family: adapter `/base-standard/` isolation (baseline
+  = current 6 allowlisted files, migrated from the script allowlist) and
+  control-orpc contract-ownership patterns.
+- [ ] 2.5 Parity run: dual-execute originals vs grit rules; record the parity
+  table (identical finding sets) in the phase record; any delta follows the
+  stop condition.
+
+## 3. Codemods (apply mode)
+
+- [ ] 3.1 `export-star-to-named` codemod with input/output fixtures; wire into
+  `habitat fix`; apply runs Biome format after rewrite.
+- [ ] 3.2 `deep-import-to-public-surface` codemod for mechanical mappings
+  only; ambiguous cases emit diagnostics (fixture both).
+
+## 4. File Layer
+
+- [ ] 4.1 Rule-pack file-layer rules for the three generated zones with
+  regenerate remediation messages; `habitat check --staged` protected-glob
+  enforcement.
+- [ ] 4.2 CI regenerate-and-diff gate for `gen:maps` outputs (drift
+  detection); record the staged-edit trade-off from design.md in the phase
+  record.
+
+## 5. Verification And Closure
+
+- [ ] 5.1 All fixtures green; `bunx nx affected -t grit:check` green;
+  generated-zone staged probe fails then removed.
+- [ ] 5.2 Ratchet entries for every pattern (locked where parity shows zero
+  findings; adapter-boundary at 6).
+- [ ] 5.3 `bun run build && bun run check && bun run test` unchanged-green;
+  `bun run openspec -- validate habitat-grit-catalog --strict`; realignment +
+  closure per workstream record.

--- a/openspec/changes/habitat-harness-scaffold/design.md
+++ b/openspec/changes/habitat-harness-scaffold/design.md
@@ -33,15 +33,24 @@ later: `nx-boundaries` | `grit-check` | `grit-apply` | `biome` | `file-layer` |
   (`ruleId + path + fingerprint`), committed.
 - `habitat check`: violation not in baseline → FAIL (new debt). In baseline →
   reported as `baselined`, non-failing.
-- Baseline self-check rule: baseline files may only lose entries vs the
-  merge-base version (CI compares); adding requires an explicit
-  `--expand-baseline` flag reserved for rule-introduction slices, recorded in
-  the phase record.
+- Baseline self-check rule (CI-visible mechanism): baseline files live at
+  `tools/habitat-harness/baselines/<rule-id>.json`; the self-check compares
+  baselines against the merge-base version and REJECTS any added entry UNLESS
+  the same change also registers that entry's `ruleId` as a NEW rule in the
+  rule pack — i.e. the ruleId does not exist at merge-base, cross-referenced
+  from the rule-pack diff. The local `--expand-baseline` CLI flag remains as
+  the local authoring gate for rule-introduction slices (recorded in the phase
+  record), but CI enforcement derives from the rule-pack cross-reference,
+  never from the flag.
 - Locked rule: empty baseline → any violation fails; the rule pack marks
   `locked: true` so messaging changes from "burn down" to "violation".
 - Prior art honored: `docs/.doc-ambiguity-lint-baseline.json` (existing
   baseline mechanism) and `lint-adapter-boundary.sh`'s allowlist migrate into
-  this machinery in later slices, not here.
+  this machinery in later slices, not here. A wrapped rule may reference a
+  legacy allowlist file (e.g. adapter-boundary's 6-file allowlist) as its
+  transitional exception source until its porting slice migrates the allowlist
+  into a `baselines/<rule-id>.json`; the spec's baseline requirement is
+  satisfied by that referenced allowlist in the interim.
 
 ## Wrapping strategy (zero-semantics-change)
 
@@ -53,7 +62,10 @@ the rule is ported to its owning tool (later slices), never by editing the
 script.
 
 `habitat verify` = check + (post-H1) `bunx nx affected -t build,check,test` —
-composition defined in the rule pack, not hardcoded.
+composition defined in the rule pack, not hardcoded. `habitat fix` with zero
+fixable rules registered prints "no fixable rules registered" and exits 0.
+`habitat verify` defaults its affected base to the merge-base with `main`
+(overridable via `--base`).
 
 ## Nx plugin
 

--- a/openspec/changes/habitat-harness-scaffold/design.md
+++ b/openspec/changes/habitat-harness-scaffold/design.md
@@ -1,0 +1,62 @@
+# Design — Harness Scaffold
+
+## Package layout (spec draft §4.3, trimmed to this slice)
+
+```text
+tools/habitat-harness/
+  package.json            # @internal/habitat-harness, private, kind:tooling tag
+  src/
+    index.ts
+    plugin.ts             # Nx createNodesV2 target inference from rule pack
+    bin/habitat.ts        # Bun-run CLI entrypoint
+    rules/
+      architecture.ts     # rule pack: defineHarnessRules({...})
+      messages.ts         # agent-readable failure messages + remediation text
+    lib/
+      graph.ts paths.ts tags.ts spawn.ts diagnostics.ts git.ts baseline.ts
+    executors/            # added per-slice as tools land (empty dirs not committed)
+  baselines/<rule-id>.json
+```
+
+## Rule-pack record (invariant record from spec draft §7.2)
+
+Each rule in `architecture.ts` carries:
+`id`, `ownerTool` (`wrapped-script` | `wrapped-eslint` | `wrapped-test` |
+later: `nx-boundaries` | `grit-check` | `grit-apply` | `biome` | `file-layer` |
+`habitat-native`), `scope`, `forbids`, `why`, `detect` (command), `remediate`
+(command or null), `message` (agent-readable), `exceptionPath`
+(baseline ref or `none`).
+
+## Ratchet semantics
+
+- Baseline file: sorted JSON array of stable violation keys
+  (`ruleId + path + fingerprint`), committed.
+- `habitat check`: violation not in baseline → FAIL (new debt). In baseline →
+  reported as `baselined`, non-failing.
+- Baseline self-check rule: baseline files may only lose entries vs the
+  merge-base version (CI compares); adding requires an explicit
+  `--expand-baseline` flag reserved for rule-introduction slices, recorded in
+  the phase record.
+- Locked rule: empty baseline → any violation fails; the rule pack marks
+  `locked: true` so messaging changes from "burn down" to "violation".
+- Prior art honored: `docs/.doc-ambiguity-lint-baseline.json` (existing
+  baseline mechanism) and `lint-adapter-boundary.sh`'s allowlist migrate into
+  this machinery in later slices, not here.
+
+## Wrapping strategy (zero-semantics-change)
+
+Wrapped rules execute the existing implementation via `spawn` (argument
+arrays), parse its output (or exit code where output is unstructured), and
+re-emit normalized JSON diagnostics. Where a script reports only pass/fail,
+the wrapped rule emits a single coarse diagnostic — granularity improves when
+the rule is ported to its owning tool (later slices), never by editing the
+script.
+
+`habitat verify` = check + (post-H1) `bunx nx affected -t build,check,test` —
+composition defined in the rule pack, not hardcoded.
+
+## Nx plugin
+
+`createNodesV2` infers a `habitat:check` target for projects matched by rule
+scopes, options-driven (`{ checkTargetName }` per spec draft §5.2). No
+`createDependencies` in this slice (no edges Nx cannot already infer).

--- a/openspec/changes/habitat-harness-scaffold/proposal.md
+++ b/openspec/changes/habitat-harness-scaffold/proposal.md
@@ -1,0 +1,102 @@
+## Why
+
+The habitat harness needs a home before any rule migrates: a repo-local
+package (`tools/habitat-harness`) owning the `habitat` CLI, the rule-pack
+format, the ratchet/baseline machinery, and an Nx plugin for target inference.
+This slice creates that machinery and wraps ALL existing enforcement behind it
+with machine-readable output — adding zero new rules and changing zero rule
+semantics — so every later slice is a pure rule migration with a stable
+harness underneath (FRAME hard core #1, #3).
+
+## Target Authority Refs
+
+- `docs/projects/habitat-harness/FRAME.md` (hard core #1–#3; degeneration trigger)
+- `docs/projects/habitat-harness/invariant-corpus.md` (wrap dispositions)
+- `docs/projects/habitat-harness/habitat-harness-spec-draft-input.md` §4.3
+  (layout), §6 (command set), §7.1–7.2 (rule pack + invariant record), §9
+  (machine-readable output)
+- `https://nx.dev/docs/extending-nx/project-graph-plugins` (createNodesV2)
+
+## What Changes
+
+- Create workspace package `tools/habitat-harness`
+  (`@internal/habitat-harness`, `kind:tooling`): Bun-run TS CLI at
+  `src/bin/habitat.ts`, libs (`graph`, `paths`, `spawn` with argument-array
+  spawning, `diagnostics`, `git`, `baseline`), rule pack at
+  `src/rules/architecture.ts`, agent-readable messages in `src/rules/messages.ts`.
+- Implement the normative command set: `habitat graph`, `habitat classify
+  <path-or-diff>`, `habitat check [--staged]`, `habitat fix [--dry-run]`,
+  `habitat verify`, `habitat hook <name>` (hook bodies land in
+  `habitat-git-hooks`).
+- Implement the ratchet: every rule has an explicit baseline file under
+  `tools/habitat-harness/baselines/<rule-id>.json` (violation list, frozen);
+  `habitat check` fails on NEW violations only; baselines shrink-only
+  (a CI-checked invariant); a rule with an empty baseline is **locked** and
+  hard-fails on any violation.
+- Wrap every existing check from the invariant corpus as a harness rule with
+  unchanged semantics: the 9 `scripts/lint/*` scripts, ESLint (`bun run lint`),
+  and the architecture test suites, each emitting JSON diagnostics
+  (`{ruleId, path, line, message, severity, baselined}`).
+- Add root scripts `habitat`, `habitat:check`, `habitat:fix`,
+  `habitat:verify` per the spec draft.
+- Implement the Nx plugin (`src/plugin.ts`, `createNodesV2`) registering
+  inferred targets for harness rules (`habitat:check`, later `boundaries`,
+  `biome:ci`, `grit:check`, `verify`) driven by the rule pack; register in
+  `nx.json` plugins.
+
+## What Does Not Change
+
+- No rule semantics change; no rule is added, removed, or re-owned.
+- Existing scripts keep working standalone until
+  `habitat-enforcement-consolidation` retires them.
+- `bun run check` and CI continue to pass identically.
+
+## Requires
+
+- `habitat-nx-adoption`
+
+## Enables Parallel Work
+
+- `habitat-boundary-tags` and `habitat-biome-hygiene` (parallel after this).
+- `habitat-grit-catalog`, `habitat-git-hooks`, `habitat-generators-migrations`.
+
+## Affected Owners
+
+- New: `tools/habitat-harness/**`
+- Root `package.json` scripts; `nx.json` plugins entry
+- `.github/workflows/ci.yml` (artifact upload of habitat JSON diagnostics only)
+
+## Forbidden Owners
+
+- No edits to `scripts/lint/*` internals (wrap, don't rewrite).
+- No edits to product packages (`apps/**`, `packages/**` outside tools,
+  `mods/**`).
+- No new rules, no baseline entries beyond what existing checks report today.
+- No shell-string command concatenation in spawn paths.
+
+## Stop Conditions
+
+- A wrapped check cannot produce stable machine-readable output without
+  changing its semantics — stop, record, and wrap at a coarser granularity.
+- The ratchet design cannot express an existing allowlist (e.g.
+  adapter-boundary's 6 files) losslessly.
+- Harness code starts importing product packages.
+
+## Consumer Impact
+
+Agents and contributors gain one entrypoint (`bun run habitat check|fix|verify`)
+with JSON evidence; existing entrypoints unchanged. CI gains diagnostic
+artifacts.
+
+## Verification Gates
+
+- `bun run openspec -- validate habitat-harness-scaffold --strict`
+- `bun run habitat check` exits green on a clean tree and reports every
+  corpus-wrapped rule with status + baseline counts.
+- `bun run habitat check --json` validates against the diagnostic schema.
+- Probe: introduce a synthetic adapter-boundary violation in a scratch file →
+  `habitat check` fails naming the rule and remediation; baseline untouched.
+- Probe: shrink-only invariant — adding a baseline entry fails the baseline
+  self-check.
+- `bunx nx run-many -t habitat:check --all` runs via the plugin.
+- `bun run build && bun run check && bun run test` unchanged-green.

--- a/openspec/changes/habitat-harness-scaffold/specs/habitat-harness/spec.md
+++ b/openspec/changes/habitat-harness-scaffold/specs/habitat-harness/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: The Harness Is The Single Enforcement Entrypoint
+
+The repository SHALL provide a repo-local harness package
+(`tools/habitat-harness`) exposing `habitat graph`, `habitat classify`,
+`habitat check`, `habitat fix`, `habitat verify`, and `habitat hook` as the
+canonical enforcement surface, emitting machine-readable JSON diagnostics for
+every rule.
+
+#### Scenario: Agent verifies a change locally
+- **WHEN** an agent runs `bun run habitat check`
+- **THEN** every registered rule reports status with rule id, scope, severity,
+  message, and remediation in both human and `--json` form
+
+#### Scenario: A rule fails
+- **WHEN** a rule detects a non-baselined violation
+- **THEN** the failure message names the violated invariant, why it exists,
+  and the exact remediation command or boundary decision required
+
+### Requirement: Every Rule Carries A Shrink-Only Ratchet Baseline
+
+Every harness rule SHALL have an explicit committed baseline of known
+violations. `habitat check` SHALL fail only on violations not in the baseline.
+Baselines SHALL only shrink outside rule-introduction changes, and a rule with
+an empty baseline SHALL be locked (any violation fails).
+
+#### Scenario: New debt is rejected
+- **WHEN** a change introduces a violation not present in the rule's baseline
+- **THEN** `habitat check` fails even though older baselined violations exist
+
+#### Scenario: Baseline expansion is blocked
+- **WHEN** a change adds entries to a baseline file outside a
+  rule-introduction change using the explicit expansion gate
+- **THEN** the baseline self-check fails the build
+
+#### Scenario: Rule locks at zero
+- **WHEN** a rule's baseline becomes empty
+- **THEN** the rule is locked and any future violation hard-fails
+
+### Requirement: Existing Checks Are Wrapped Without Semantic Change
+
+All inventoried enforcement mechanisms SHALL be invocable through the harness
+with unchanged semantics (per
+`docs/projects/habitat-harness/invariant-corpus.md`) until a later change
+explicitly ports or retires them.
+
+#### Scenario: Wrapped script parity
+- **WHEN** `habitat check` runs a wrapped rule on a tree where the original
+  script passes (or fails)
+- **THEN** the wrapped rule passes (or fails) identically, adding only
+  normalized diagnostics

--- a/openspec/changes/habitat-harness-scaffold/specs/habitat-harness/spec.md
+++ b/openspec/changes/habitat-harness-scaffold/specs/habitat-harness/spec.md
@@ -29,10 +29,16 @@ an empty baseline SHALL be locked (any violation fails).
 - **WHEN** a change introduces a violation not present in the rule's baseline
 - **THEN** `habitat check` fails even though older baselined violations exist
 
-#### Scenario: Baseline expansion is blocked
-- **WHEN** a change adds entries to a baseline file outside a
-  rule-introduction change using the explicit expansion gate
+#### Scenario: Expansion of an existing rule's baseline is rejected
+- **WHEN** a change adds entries to the baseline of a rule that already exists
+  at the merge-base
 - **THEN** the baseline self-check fails the build
+
+#### Scenario: Rule introduction lands with its baseline
+- **WHEN** a change registers a new ruleId in the rule pack and commits that
+  rule's baseline in the same change
+- **THEN** the self-check accepts the new baseline and the shrink-only rule
+  applies from then on
 
 #### Scenario: Rule locks at zero
 - **WHEN** a rule's baseline becomes empty

--- a/openspec/changes/habitat-harness-scaffold/tasks.md
+++ b/openspec/changes/habitat-harness-scaffold/tasks.md
@@ -1,0 +1,46 @@
+## 1. Package And CLI Skeleton
+
+- [ ] 1.1 Create `tools/habitat-harness` package (private,
+  `@internal/habitat-harness`, bun-run TS, no build step) and register in the
+  workspace; `bun install`.
+- [ ] 1.2 Implement `src/bin/habitat.ts` command surface (`graph`, `classify`,
+  `check`, `fix --dry-run`, `verify`, `hook` stub) with `lib/spawn.ts`
+  argument-array spawning and `lib/diagnostics.ts` JSON schema.
+- [ ] 1.3 Implement `lib/baseline.ts`: load/compare/shrink-only check,
+  `--expand-baseline` gate, locked-rule semantics.
+
+## 2. Rule Pack And Wraps
+
+- [ ] 2.1 Implement `rules/architecture.ts` + `rules/messages.ts` with the
+  invariant-record fields from design.md.
+- [ ] 2.2 Wrap the five root-`check` lint scripts (workspace-entrypoints,
+  domain-refactor-guardrails, mapgen-recipe-imports, normalization-guardrails,
+  mapgen-docs) as rules with JSON diagnostics.
+- [ ] 2.3 Wrap adapter-boundary (allowlist surfaced as reported-baselined
+  diagnostics, allowlist file untouched), control-orpc-contract-ownership,
+  adr-lint, doc-ambiguity (advisory lane, reusing its existing baseline).
+- [ ] 2.4 Wrap `bun run lint` (ESLint) and the architecture test suites
+  (`test:architecture-cutover`) as coarse-grained rules.
+- [ ] 2.5 Add root scripts (`habitat`, `habitat:check`, `habitat:fix`,
+  `habitat:verify`); wire `habitat verify` to check + nx affected targets.
+
+## 3. Nx Plugin
+
+- [ ] 3.1 Implement `src/plugin.ts` `createNodesV2` inferring `habitat:check`
+  targets from rule scopes; register in `nx.json` with target-name options.
+- [ ] 3.2 `bunx nx run-many -t habitat:check --all` green; target caching
+  configured with rule-pack + baselines as inputs.
+
+## 4. Verification And Closure
+
+- [ ] 4.1 Clean-tree run: `bun run habitat check` green; `--json` output
+  validates against the diagnostic schema; every corpus-wrapped rule present.
+- [ ] 4.2 Synthetic-violation probe (scratch file breaking adapter boundary):
+  fails with rule id + remediation message; remove probe.
+- [ ] 4.3 Baseline shrink-only probe: hand-adding a baseline entry fails the
+  self-check.
+- [ ] 4.4 `bun run build && bun run check && bun run test` unchanged-green;
+  CI uploads habitat JSON diagnostics artifact.
+- [ ] 4.5 `bun run openspec -- validate habitat-harness-scaffold --strict`;
+  realign docs (FRAME §7 pointer already exists; add harness README); close
+  per workstream record.

--- a/openspec/changes/habitat-harness-scaffold/tasks.md
+++ b/openspec/changes/habitat-harness-scaffold/tasks.md
@@ -19,8 +19,18 @@
 - [ ] 2.3 Wrap adapter-boundary (allowlist surfaced as reported-baselined
   diagnostics, allowlist file untouched), control-orpc-contract-ownership,
   adr-lint, doc-ambiguity (advisory lane, reusing its existing baseline).
-- [ ] 2.4 Wrap `bun run lint` (ESLint) and the architecture test suites
-  (`test:architecture-cutover`) as coarse-grained rules.
+- [ ] 2.4 Wrap `bun run lint` (ESLint) as a coarse-grained rule. Wrap the
+  corpus §C six architecture tests with per-file invocations — each as
+  `bun test <explicit test file path>` (they are NOT covered by
+  `test:architecture-cutover`):
+  `packages/mapgen-core/test/architecture/core-purity.test.ts`,
+  `mods/mod-swooper-maps/test/pipeline/rng-authority-boundary.test.ts`,
+  `mods/mod-swooper-maps/test/pipeline/recipe-import-boundary.test.ts`,
+  `mods/mod-swooper-maps/test/ecology/ecology-step-import-guardrails.test.ts`,
+  `mods/mod-swooper-maps/test/foundation/m11-projection-boundary-band.test.ts`,
+  `mods/mod-swooper-maps/test/build/map-bundle-runtime-imports.test.ts`.
+  Separately wrap `test:architecture-cutover` (coarse, 4 cutover tests) as its
+  own wrapped rule.
 - [ ] 2.5 Add root scripts (`habitat`, `habitat:check`, `habitat:fix`,
   `habitat:verify`); wire `habitat verify` to check + nx affected targets.
 
@@ -35,10 +45,20 @@
 
 - [ ] 4.1 Clean-tree run: `bun run habitat check` green; `--json` output
   validates against the diagnostic schema; every corpus-wrapped rule present.
-- [ ] 4.2 Synthetic-violation probe (scratch file breaking adapter boundary):
-  fails with rule id + remediation message; remove probe.
+- [ ] 4.2 Synthetic-violation probe matrix — one injected violation per
+  wrapped family:
+  (a) script family: a `/base-standard/` import outside
+  `packages/civ7-adapter` → expect the wrapped adapter-boundary rule id fails;
+  (b) ESLint family: a deep `@mapgen/domain/*/ops/*` import → expect the
+  wrapped eslint lane fails;
+  (c) architecture-test family: a Civ7 runtime ref in mapgen-core prod code →
+  expect the wrapped core-purity suite fails.
+  Each row records probe file path, injected violation, and expected rule
+  id/failure text; matrix recorded in the phase record; probes reverted after
+  capture.
 - [ ] 4.3 Baseline shrink-only probe: hand-adding a baseline entry fails the
-  self-check.
+  self-check. CI-side probe: a commit adding an entry to an EXISTING rule's
+  baseline must fail the self-check as run in CI (not only via the local CLI).
 - [ ] 4.4 `bun run build && bun run check && bun run test` unchanged-green;
   CI uploads habitat JSON diagnostics artifact.
 - [ ] 4.5 `bun run openspec -- validate habitat-harness-scaffold --strict`;

--- a/openspec/changes/habitat-nx-adoption/design.md
+++ b/openspec/changes/habitat-nx-adoption/design.md
@@ -1,0 +1,50 @@
+# Design — Nx Adoption (Turbo Retirement)
+
+## Conversion map (turbo.json → nx.json)
+
+Current `turbo.json` tasks and their Nx equivalents:
+
+| turbo.json | nx.json |
+|---|---|
+| `build` (`dependsOn: ["^build"]`, outputs `dist/**`, `types/**`, `example-generated-mod/**`, `mod/**`) | targetDefault `build`: same `dependsOn`, same `outputs` with `{projectRoot}` interpolation, `cache: true` |
+| `check` (`dependsOn: ["^build", "^check"]`) | targetDefault `check`: same dependsOn, `cache: true`, no outputs |
+| `lint` (no cache) | targetDefault `lint`, `cache: true` only if inputs are declared correctly; otherwise leave uncached initially |
+| `test` (`dependsOn: ["^build"]`) | targetDefault `test`, `cache: true` with test inputs |
+| `test:architecture-cutover` | same pattern as `test` |
+| `mod-swooper-maps#build:studio-recipes` (outputs `src/maps/generated/**`) | project-level target override in `mods/mod-swooper-maps/package.json` `"nx"` field |
+| `mapgen-studio#dev` (depends on studio-recipes, `persistent: true`) | project-level override; `persistent` → `continuous: true` |
+
+Fields requiring manual decisions (converter does not map): any `env`/
+`globalEnv` usage → Nx `inputs` env entries; `globalDependencies` →
+`sharedGlobals` namedInput (include `civ.config.jsonc`, `tsconfig.base.json`,
+`bun.lock` if turbo listed them).
+
+## Posture rules
+
+- Nx runs on Node (`bunx nx`); never `bunx --bun nx`. Bun stays package
+  manager and script runner. Pin both in `mise.toml`
+  (node per `engines` ≥22.14, bun per `packageManager` field).
+- Projects remain package.json-based (Nx infers from workspaces). No
+  `project.json` files; per-project Nx config goes in the package.json `"nx"`
+  field when needed.
+- `.nx/cache` gitignored; no Nx Cloud (`useInferencePlugins`/cloud prompts
+  declined; `nx.json` carries no `nxCloudId`).
+- Version: latest 22.x at execution time (`bunx nx@latest init`); record exact
+  version in the phase record. `nx migrate` to 23 later is out of scope.
+
+## CI shape
+
+`ci` job: `bun install --frozen-lockfile` → `bunx nx run-many -t build check
+lint test --all` initially; switch to `nx affected` with
+`--base=$NX_BASE --head=$NX_HEAD` once `nrwl/nx-set-shas` (or manual
+merge-base) is wired. `architecture-strict-core` job keeps its current
+script-level steps (they are re-pointed to harness targets in later slices,
+not here).
+
+## Risk containment
+
+First task is the init + diff (the de-risked path): run `bunx nx@latest init`
+on the branch, diff generated `nx.json` against `turbo.json` semantics, and
+only then remove turbo. If conversion is lossy in a way that cannot be
+expressed (stop condition), record evidence in the phase record and surface
+to Matei — this is the FRAME falsifier for D1.

--- a/openspec/changes/habitat-nx-adoption/design.md
+++ b/openspec/changes/habitat-nx-adoption/design.md
@@ -14,6 +14,20 @@ Current `turbo.json` tasks and their Nx equivalents:
 | `mod-swooper-maps#build:studio-recipes` (outputs `src/maps/generated/**`) | project-level target override in `mods/mod-swooper-maps/package.json` `"nx"` field |
 | `mapgen-studio#dev` (depends on studio-recipes, `persistent: true`) | project-level override; `persistent` → `continuous: true` |
 
+**This table is ILLUSTRATIVE — it covers ~7 of the 18 task entries in
+`turbo.json`. The implementer MUST enumerate every task entry in `turbo.json`
+at execution time and convert each one.** Explicitly including:
+
+- `mod-swooper-maps#build` — carries `env: ["SWOOPER_STUDIO_RUN_ID"]`, which
+  becomes an Nx input (env entry) on that project's override.
+- The three `mapgen-studio#*` targets (`build`, `check`, `test`) that depend on
+  `mod-swooper-maps#build:studio-recipes` (plus `mapgen-studio#dev` above).
+- `deploy`, `deploy:studio`, `clean`, `dev`, and `@civ7/docs#dev`.
+- The root `deploy:mods` script's `--filter='./mods/*'` path-glob, which has no
+  direct Nx equivalent — map it to an explicit
+  `nx run-many --projects=<mod project names>` list or a tag-based selector,
+  and record the choice in the phase record.
+
 Fields requiring manual decisions (converter does not map): any `env`/
 `globalEnv` usage → Nx `inputs` env entries; `globalDependencies` →
 `sharedGlobals` namedInput (include `civ.config.jsonc`, `tsconfig.base.json`,

--- a/openspec/changes/habitat-nx-adoption/proposal.md
+++ b/openspec/changes/habitat-nx-adoption/proposal.md
@@ -97,11 +97,18 @@ scope. No package-level consumer impact.
 ## Verification Gates
 
 - `bun run openspec -- validate habitat-nx-adoption --strict`
-- `bunx nx graph --file=graph.json` succeeds; graph contains all 21 projects
-  with correct dependency edges (spot-check adapter/mapgen-core/mod edges).
+- `bunx nx graph --file=graph.json` succeeds; graph contains all 21 projects;
+  every workspace `dependencies`/`devDependencies` edge declared in the 22
+  package.json manifests appears as an edge in `nx graph --file=graph.json`
+  output (scripted set comparison recorded in the phase record); spot-check
+  adapter/mapgen-core/mod edges as a sanity layer.
 - `bun run build && bun run check && bun run test` green, byte-equivalent
   behavior to `main` for build outputs of `mod-swooper-maps` (mod/ output diff
   empty on same inputs).
+- Cache behavior: run `bunx nx run-many -t build --all` twice on an unchanged
+  tree — second run must report all tasks as cache hits; then touch one source
+  file in `packages/config` — only `@civ7/config` and its dependents may miss
+  cache.
 - `bunx nx affected -t check --base=main` runs and scopes correctly on a probe
   change.
 - CI workflow passes on the PR with Nx commands.

--- a/openspec/changes/habitat-nx-adoption/proposal.md
+++ b/openspec/changes/habitat-nx-adoption/proposal.md
@@ -1,0 +1,108 @@
+## Why
+
+The habitat harness (docs/projects/habitat-harness/FRAME.md) requires an
+authoritative repository graph: project identity, tags, dependency edges,
+affected-scope calculation, cacheable targets, local generators, and
+migrations. Turbo provides task orchestration only — no graph queries, no
+tags, no boundary enforcement, no generators. Matei's settled decision D1:
+adopt Nx fully and retire Turbo; no dual-orchestrator posture.
+
+Nx documents a native Turborepo migration (`nx init` detects `turbo.json` and
+converts tasks to `targetDefaults`) and officially supports Bun workspaces
+with Nx running on Node via `bunx nx`. Verified 2026-06-12; sources in
+FRAME.md §4.
+
+## Target Authority Refs
+
+- `docs/projects/habitat-harness/FRAME.md` (hard core #2, #5; decisions D1)
+- `docs/projects/habitat-harness/habitat-harness-spec-draft-input.md` §5.2 (Nx ownership), §2 (Bun posture)
+- Official Nx docs checked 2026-06-12:
+  - `https://nx.dev/docs/guides/adopting-nx/from-turborepo`
+  - `https://nx.dev/docs/guides/nx-cloud/use-bun`
+  - `https://nx.dev/docs/extending-nx/project-graph-plugins`
+- Root `AGENTS.md` Tooling Defaults (turbo-orchestrated root scripts — updated by this change)
+
+## What Changes
+
+- Run the documented Nx adoption (`bunx nx@latest init`, latest 22.x; never
+  21.5.0/21.6.0) and convert every `turbo.json` task to `nx.json`
+  `targetDefaults`/`namedInputs`, including the special
+  `mod-swooper-maps#build:studio-recipes` / `mapgen-studio#dev` dependency.
+- Manual conversion pass for fields the converter does not map: env-var
+  inputs, explicit `cache: true`, `persistent` → `continuous`.
+- Pin runtimes in a new root `mise.toml` (node + bun); Nx runs on Node via
+  `bunx nx`; Bun remains the only package manager.
+- Add `tools/*` to root `package.json` workspaces (empty until
+  `habitat-harness-scaffold`).
+- Re-point root scripts (`build`, `check`, `test`, `lint`, `test:ci`,
+  `ci:architecture-strict-core`, dev scripts) from `turbo run ...` to
+  `bunx nx run-many ...` / `bunx nx affected ...` equivalents.
+- Update `.github/workflows/ci.yml` to Nx commands with affected-scope
+  (`NX_BASE`/`NX_HEAD`) and keep the full-repo fallback.
+- Update `scripts/lint/lint-workspace-entrypoints.mjs` to forbid nested `nx`
+  orchestration in package-local scripts (replacing the nested-turbo rule).
+- Remove `turbo` devDependency, `turbo.json`, and `.turbo` cache references.
+- Update root `AGENTS.md` Tooling Defaults and any docs that name turbo as the
+  orchestrator.
+
+## What Does Not Change
+
+- No project tags, boundary rules, or new enforcement (those are
+  `habitat-boundary-tags` and later slices).
+- No package code, no build outputs, no test content.
+- Bun lockfile, workspace layout (other than adding `tools/*`), and package
+  scripts' semantics.
+
+## Requires
+
+- None (train root).
+
+## Enables Parallel Work
+
+- `habitat-harness-scaffold` (Nx plugin + target inference).
+- All later slices that use `nx affected` or Nx targets.
+
+## Affected Owners
+
+- Root config: `package.json`, `nx.json` (new), `turbo.json` (removed),
+  `mise.toml` (new), `.github/workflows/ci.yml`
+- `scripts/lint/lint-workspace-entrypoints.mjs`
+- Root `AGENTS.md`, `docs/PROCESS.md`-adjacent tooling docs that name turbo
+
+## Forbidden Owners
+
+- No `project.json` files in product packages (projects stay
+  package.json-based; harness-owned target inference comes later).
+- No Nx Cloud onboarding, no `nx-cloud` dependency, no distributed agents.
+- No turbo+nx coexistence after this change lands (no surviving `turbo.json`).
+- No running Nx under the Bun runtime (`bunx --bun nx` is forbidden); no `nx`
+  invocation from bun `postinstall`.
+
+## Stop Conditions
+
+- The converted graph cannot reproduce an existing pipeline behavior
+  (task ordering, caching correctness, or the studio-recipes special
+  dependency) — stop and record before forcing it.
+- `nx init` requires lockfile or workspace changes beyond adding nx
+  devDependencies — stop and verify against the Bun support docs.
+- Any check that is green on `main` becomes red under Nx orchestration for
+  orchestration reasons (not rule reasons).
+
+## Consumer Impact
+
+Contributors and agents switch from `turbo run` to `bun run <script>` (root
+scripts preserved) or `bunx nx ...`. CI runtime should improve via affected
+scope. No package-level consumer impact.
+
+## Verification Gates
+
+- `bun run openspec -- validate habitat-nx-adoption --strict`
+- `bunx nx graph --file=graph.json` succeeds; graph contains all 21 projects
+  with correct dependency edges (spot-check adapter/mapgen-core/mod edges).
+- `bun run build && bun run check && bun run test` green, byte-equivalent
+  behavior to `main` for build outputs of `mod-swooper-maps` (mod/ output diff
+  empty on same inputs).
+- `bunx nx affected -t check --base=main` runs and scopes correctly on a probe
+  change.
+- CI workflow passes on the PR with Nx commands.
+- `git grep -l "turbo"` returns only historical docs/changelog references.

--- a/openspec/changes/habitat-nx-adoption/specs/habitat-harness/spec.md
+++ b/openspec/changes/habitat-nx-adoption/specs/habitat-harness/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Nx Owns The Repository Graph
+
+The repository SHALL use Nx as the single task orchestrator and project-graph
+authority: project identity, dependency edges, affected-scope calculation,
+target wiring, and cache policy. Turbo SHALL NOT remain installed or
+configured after this change.
+
+#### Scenario: Orchestrating a cross-workspace task
+- **WHEN** a root workflow runs build/check/lint/test across workspaces
+- **THEN** it runs through Nx (`bunx nx run-many` / `bunx nx affected`)
+- **AND** no `turbo.json` or `turbo` dependency exists in the repository
+
+#### Scenario: Querying the project graph
+- **WHEN** an agent needs project identity or dependency edges
+- **THEN** `bunx nx graph` and `bunx nx show project <name>` answer from the
+  Nx graph covering every workspace project
+
+### Requirement: Bun Remains The Package Manager With Nx On Node
+
+Bun SHALL remain the only package manager and package-script runner. Nx SHALL
+run on the Node runtime invoked through `bunx nx`. Both runtimes SHALL be
+pinned in a committed `mise.toml`.
+
+#### Scenario: Installing and running
+- **WHEN** dependencies are installed or root scripts run
+- **THEN** `bun install` / `bun run <script>` are used, and Nx commands execute
+  via `bunx nx` on Node
+- **AND** no workflow invokes Nx under the Bun runtime or from a bun
+  `postinstall` hook
+
+#### Scenario: CI reproducibility
+- **WHEN** CI installs dependencies
+- **THEN** it uses `bun install --frozen-lockfile` against the committed text
+  `bun.lock`
+
+### Requirement: Pipeline Parity Through Conversion
+
+The Nx task configuration SHALL reproduce the retired turbo pipeline's
+semantics: task dependency ordering, cacheability, declared outputs, and the
+studio-recipes special dependency.
+
+#### Scenario: Build output parity
+- **WHEN** `bun run build` runs on an unchanged source tree before and after
+  this change
+- **THEN** `mods/mod-swooper-maps/mod/**` build outputs are byte-identical
+
+#### Scenario: Studio dev dependency preserved
+- **WHEN** `mapgen-studio` dev starts
+- **THEN** Nx first ensures `mod-swooper-maps` studio recipes are built, as the
+  turbo pipeline did

--- a/openspec/changes/habitat-nx-adoption/tasks.md
+++ b/openspec/changes/habitat-nx-adoption/tasks.md
@@ -1,0 +1,49 @@
+## 1. Init And Conversion
+
+- [ ] 1.1 Record current `main` baselines: `bun run build && bun run check &&
+  bun run test` green; hash `mods/mod-swooper-maps/mod/**` build output for
+  later byte-parity comparison.
+- [ ] 1.2 Run `bunx nx@latest init` (latest 22.x; abort if resolver selects
+  21.5.0/21.6.0); decline Nx Cloud; record exact version in the phase record.
+- [ ] 1.3 Diff generated `nx.json` against `turbo.json` semantics; apply the
+  manual conversion pass from design.md (env inputs, `cache: true`,
+  `persistent` → `continuous`, `sharedGlobals`).
+- [ ] 1.4 Move `mod-swooper-maps#build:studio-recipes` and `mapgen-studio#dev`
+  overrides into the respective package.json `"nx"` fields.
+- [ ] 1.5 Add `tools/*` to root workspaces; add root `mise.toml` pinning node
+  and bun; gitignore `.nx/cache` and `.nx/workspace-data`.
+
+## 2. Script And CI Re-Pointing
+
+- [ ] 2.1 Re-point root package scripts from `turbo run ...` to
+  `bunx nx run-many ...` (and `nx affected` where scoped), preserving script
+  names and semantics.
+- [ ] 2.2 Update `.github/workflows/ci.yml` to Nx commands; keep frozen-lockfile
+  install and the pnpm guard; keep `architecture-strict-core` job steps
+  otherwise unchanged.
+- [ ] 2.3 Update `scripts/lint/lint-workspace-entrypoints.mjs`: forbid nested
+  `nx` orchestration in package-local scripts (replace nested-turbo rule);
+  keep all other rules.
+
+## 3. Turbo Retirement
+
+- [ ] 3.1 Remove `turbo` devDependency and `turbo.json`; remove `.turbo` from
+  gitignore/caches; `bun install` to update lockfile.
+- [ ] 3.2 Sweep docs: update root `AGENTS.md` Tooling Defaults and any doc
+  that names turbo as orchestrator (`git grep -il turbo docs/ AGENTS.md`);
+  leave historical project docs untouched.
+
+## 4. Verification And Closure
+
+- [ ] 4.1 `bunx nx graph --file=graph.json`: all 21 projects present;
+  spot-check edges (mapgen-core→adapter types, mod-swooper-maps→sdk/engine,
+  studio-server edges).
+- [ ] 4.2 `bun run build && bun run check && bun run test` green;
+  `mods/mod-swooper-maps/mod/**` output byte-identical to the 1.1 baseline.
+- [ ] 4.3 Probe `bunx nx affected -t check --base=main` with a one-package
+  change; confirm correct scoping.
+- [ ] 4.4 `git grep -l turbo` limited to historical references; record
+  residuals in the phase record.
+- [ ] 4.5 `bun run openspec -- validate habitat-nx-adoption --strict`; update
+  downstream realignment (AGENTS.md, process docs) and close per workstream
+  record.

--- a/openspec/changes/habitat-nx-adoption/tasks.md
+++ b/openspec/changes/habitat-nx-adoption/tasks.md
@@ -8,8 +8,11 @@
 - [ ] 1.3 Diff generated `nx.json` against `turbo.json` semantics; apply the
   manual conversion pass from design.md (env inputs, `cache: true`,
   `persistent` → `continuous`, `sharedGlobals`).
-- [ ] 1.4 Move `mod-swooper-maps#build:studio-recipes` and `mapgen-studio#dev`
-  overrides into the respective package.json `"nx"` fields.
+- [ ] 1.4 Move all project-scoped turbo.json overrides (7 at time of writing:
+  `mod-swooper-maps#build`, `mod-swooper-maps#check`, `@civ7/docs#dev`,
+  `mapgen-studio#dev`/`#build`/`#check`/`#test`) plus the
+  `build:studio-recipes` target into the respective package.json `"nx"`
+  fields.
 - [ ] 1.5 Add `tools/*` to root workspaces; add root `mise.toml` pinning node
   and bun; gitignore `.nx/cache` and `.nx/workspace-data`.
 
@@ -23,7 +26,9 @@
   otherwise unchanged.
 - [ ] 2.3 Update `scripts/lint/lint-workspace-entrypoints.mjs`: forbid nested
   `nx` orchestration in package-local scripts (replace nested-turbo rule);
-  keep all other rules.
+  keep all other rules. Expected green at landing (no current violations);
+  record in the phase record that this rule-semantics edit precedes the
+  ratchet machinery (H2) deliberately.
 
 ## 3. Turbo Retirement
 
@@ -40,10 +45,17 @@
   studio-server edges).
 - [ ] 4.2 `bun run build && bun run check && bun run test` green;
   `mods/mod-swooper-maps/mod/**` output byte-identical to the 1.1 baseline.
-- [ ] 4.3 Probe `bunx nx affected -t check --base=main` with a one-package
-  change; confirm correct scoping.
-- [ ] 4.4 `git grep -l turbo` limited to historical references; record
+- [ ] 4.3 Affected probe: touch one source file in `packages/config`, run
+  `bunx nx affected -t check --base=main`; expected affected set =
+  `@civ7/config` plus its dependents as listed in graph.json (record the
+  expected set in the phase record before running); confirm the actual
+  affected set matches.
+- [ ] 4.4 Cache-behavior gate: run `bunx nx run-many -t build --all` twice on
+  an unchanged tree — second run must report all tasks as cache hits; then
+  touch one source file in `packages/config` — only `@civ7/config` and its
+  dependents may miss cache.
+- [ ] 4.5 `git grep -l turbo` limited to historical references; record
   residuals in the phase record.
-- [ ] 4.5 `bun run openspec -- validate habitat-nx-adoption --strict`; update
+- [ ] 4.6 `bun run openspec -- validate habitat-nx-adoption --strict`; update
   downstream realignment (AGENTS.md, process docs) and close per workstream
   record.


### PR DESCRIPTION
This PR establishes the complete preparation baseline for the habitat-harness workstream — a repository-local enforcement toolkit (`tools/habitat-harness`) that makes the repo's existing architecture executable and ratchetable rather than prose-documented.

The workstream frame (`FRAME.md`) defines the scope: re-home all existing structural enforcement (9 lint scripts, 6 architecture tests, 8 ESLint rule families, CI jobs, and unenforced AGENTS.md promises) into a five-layer harness with one owning tool per concern — Nx for the project graph and module boundaries, GritQL for syntax-shape rules and codemods, Biome for hygiene, a file layer for generated-zone protection, and a small set of habitat-native checks for doc/manifest rules. A shrink-only ratchet lets new rules land red and burn down to green without blocking unrelated work.

Settled decisions recorded: Nx fully adopted retiring Turbo (D1), GritQL stays (D2), Husky and Biome are in-scope now with pre-commit restaging limited to formatter-touched files only (D3), the tag taxonomy is derived from current enforcement state and locked on the ratchet (D4), doc-vs-code discrepancies are logged not resolved during this workstream (D5).

The companion artifacts added alongside the frame are:

- **`taxonomy.md`** — derived `kind:*` tag assignments for all 21 existing projects plus the new harness package, dependency constraints verified green against actual edges, and `scope:*` intra-project rule families for GritQL grouping
- **`invariant-corpus.md`** — complete migration map of every existing check to its harness owner and disposition (port, wrap-then-port, keep-as-test, keep)
- **`discrepancy-log.md`** — 14 doc-vs-code discrepancies found during derivation, all in the favorable direction (enforcement ahead of docs, no code violating docs)
- **`workstream-record.md`** — systematic-workstream gate state and the 8-slice change train with dependency ordering

The OpenSpec change train defines 8 slices in dependency order: H1 Nx adoption (Turbo retirement via native converter), H2 harness scaffold (CLI, rule pack, ratchet, wrapping all existing checks with zero semantic change), H3 boundary tags (project tags + `enforce-module-boundaries` locked at empty baseline), H4 Biome hygiene (Prettier retired, one blame-shielded reformat commit), H5 GritQL catalog (20+ patterns porting the ESLint and script families, file-layer generated-zone protection, first codemods), H6 enforcement consolidation (retire superseded mechanisms with per-rule parity evidence), H7 Husky hooks (staged-scope pre-commit, affected pre-push, legacy hook disposition), H8 generators and migrations (project/pattern generators, `habitat classify`, agent operating procedure).

A pre-execution spec review by four agents (train coherence, shortcut language, cold executability, FRAME conformance) produced 40 findings — all accepted, two amended — covering gaps such as G8/G10/G11 ownership, the existing `scripts/git-hooks/pre-commit` publish-submodule behavior that Husky would silently drop, vacuous parity gates, and the baseline self-check CI mechanism. All repairs are applied; the review lane is closed and recorded in `review-disposition-ledger.md`.

Preparation is complete. Execution begins with H1.