### PR TITLE
`fix(sdk): synchronize XmlFile and ImportFile writes so Mod.build completes before returning`

### DIFF
--- a/openspec/changes/civ7-sdk-mod-build-sync-writes/proposal.md
+++ b/openspec/changes/civ7-sdk-mod-build-sync-writes/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+`Mod.build()` returns before concrete SDK file writes finish because
+`XmlFile.write()` and `ImportFile.write()` queue asynchronous `fs.mkdir`
+callbacks and then perform synchronous writes inside those callbacks. Vitest
+teardown can remove the temp output directory before the late callback runs,
+surfacing as unhandled `ENOENT` exceptions after all SDK tests have otherwise
+passed.
+
+This is a correctness bug in the SDK build contract, not a test timing issue.
+Callers should be able to read generated files or tear down temporary output
+immediately after `Mod.build()` returns.
+
+## What Changes
+
+- Make concrete SDK file writes complete before `write()` returns.
+- Remove the sleep workaround in the mod build test so the test asserts the
+  synchronous completion contract directly.
+- Move the existing mapgen `createMap` test's heavy module import out of the
+  timed test body so the SDK package test command can complete in this
+  environment; this does not change SDK runtime behavior.
+- Keep the public `Mod.build()` API synchronous; no async migration or caller
+  compatibility layer is introduced.
+
+## What Does Not Change
+
+- No change to generated XML structure or `.modinfo` contents.
+- No change to builder APIs, action-group handling, or output paths.
+- No broad SDK refactor.
+
+## Affected Owners
+
+- `packages/sdk/src/files/XmlFile.ts`
+- `packages/sdk/src/files/ImportFile.ts`
+- `packages/sdk/test/mod-build.test.ts`
+- `packages/sdk/test/mapgen-create-map.test.ts`
+- Adjacent docs/tests only if verification exposes stale guidance.
+
+## Verification Gates
+
+- `cd packages/sdk && bun run test`
+- `cd packages/sdk && bun run check`
+- `cd packages/plugins/plugin-files && bun run test`
+- `bun run openspec -- validate civ7-sdk-mod-build-sync-writes --strict`
+
+## Stop Conditions
+
+- The fix requires changing `Mod.build()` to async.
+- Generated XML or `.modinfo` content changes beyond write timing.
+- Package-local test commands still surface unhandled async filesystem errors.

--- a/openspec/changes/civ7-sdk-mod-build-sync-writes/specs/civ7-sdk/spec.md
+++ b/openspec/changes/civ7-sdk-mod-build-sync-writes/specs/civ7-sdk/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Mod Build Writes Complete Before Return
+
+The SDK `Mod.build()` workflow SHALL complete all generated file writes before
+returning to the caller.
+
+#### Scenario: Caller reads generated files immediately
+- **WHEN** a caller invokes `Mod.build(<temp-dir>)`
+- **THEN** the generated `.modinfo` and builder/import files are readable as
+  soon as the call returns
+
+#### Scenario: Test teardown removes the output directory immediately
+- **WHEN** a test removes the output directory immediately after `Mod.build()`
+  returns
+- **THEN** no pending SDK filesystem callback attempts to write into the
+  removed directory

--- a/openspec/changes/civ7-sdk-mod-build-sync-writes/tasks.md
+++ b/openspec/changes/civ7-sdk-mod-build-sync-writes/tasks.md
@@ -1,0 +1,30 @@
+## 1. Phase Opening
+
+- [x] 1.1 Open `workstream/phase-record.md` before implementation and record
+  the suspected async write race.
+- [x] 1.2 Reproduce or inspect the race in `XmlFile.write`,
+  `ImportFile.write`, and SDK mod tests.
+
+## 2. Implementation
+
+- [x] 2.1 Make `XmlFile.write()` complete directory creation and file writing
+  before returning.
+- [x] 2.2 Make `ImportFile.write()` complete directory creation and copy
+  before returning.
+- [x] 2.3 Remove sleep-based test compensation and assert generated files are
+  readable immediately after `Mod.build()`.
+- [x] 2.4 Stabilize the existing SDK mapgen `createMap` test timeout discovered
+  while running the package-level verification gate by moving heavy import setup
+  out of the timed body.
+
+## 3. Verification
+
+- [x] 3.1 Run `cd packages/sdk && bun run test`.
+- [x] 3.2 Run `cd packages/sdk && bun run check`.
+- [x] 3.3 Run `cd packages/plugins/plugin-files && bun run test`.
+  Disposition: exact command ran and no SDK ENOENT surfaced, but it still exits
+  1 because bare `vitest run` ascends into unrelated mapgen-studio root
+  projects with missing `mod-swooper-maps/recipes/standard-artifacts` imports
+  and existing timeouts. Scoped `bun vitest run --project plugin-files` passes.
+- [x] 3.4 Run `bun run openspec -- validate civ7-sdk-mod-build-sync-writes
+  --strict`.

--- a/openspec/changes/civ7-sdk-mod-build-sync-writes/workstream/phase-record.md
+++ b/openspec/changes/civ7-sdk-mod-build-sync-writes/workstream/phase-record.md
@@ -1,0 +1,95 @@
+# Phase Record
+
+## Phase
+
+- Project: Habitat Harness / SDK repair
+- Phase: `civ7-sdk-mod-build-sync-writes`
+- Owner: Codex
+- Branch/Graphite stack: `agent-F-sdk-mod-test-teardown` above `agent-F-habitat-oclif-cli`
+- Started: 2026-06-13
+- Status: Implemented and verified with residual unrelated umbrella-test red; ready for commit
+
+## Objective
+
+- Target movement: repair the SDK mod build write contract so `Mod.build()`
+  leaves no asynchronous file callbacks running after it returns.
+- Non-goals: async API migration, generated XML/content changes, broad SDK
+  builder refactor, Habitat rule changes.
+- Done condition: concrete file writes are synchronous/complete, tests remove
+  sleep compensation, SDK tests pass without unhandled ENOENT, plugin-files
+  scoped tests pass, exact plugin-files package command is dispositioned if
+  still blocked by unrelated root-project failures, OpenSpec validates, and
+  branch commits cleanly.
+
+## Authority
+
+- Root/subtree `AGENTS.md`: root `AGENTS.md`; `packages/sdk/AGENTS.md`.
+- Project refs: user/Fable suggested task "Fix async-write race in SDK mod
+  tests (ENOENT teardown)"; Habitat H4 DL-15 root/package test blocker.
+- Code refs: `packages/sdk/src/files/XmlFile.ts`,
+  `packages/sdk/src/files/ImportFile.ts`, `packages/sdk/src/core/Mod.ts`,
+  `packages/sdk/test/mod.test.ts`, `packages/sdk/test/mod-build.test.ts`,
+  `packages/sdk/test/mapgen-create-map.test.ts`.
+
+## Current State
+
+- Repo/Graphite state: clean branch created above H4.5.
+- Dirty files and owner: only this OpenSpec repair record at phase open.
+- Current code evidence: `XmlFile.write()` and `ImportFile.write()` call async
+  `fs.mkdir(..., callback)` and perform synchronous write/copy inside the
+  callback. `Mod.build()` returns immediately after invoking `file.write()`.
+- Tests/guards affected: SDK Vitest project, plugin-files package-local test
+  command that ascends to the root Vitest config, SDK typecheck.
+
+## Scope
+
+- Write set: `packages/sdk/src/files/XmlFile.ts`,
+  `packages/sdk/src/files/ImportFile.ts`, `packages/sdk/test/mod-build.test.ts`,
+  `packages/sdk/test/mapgen-create-map.test.ts`, this OpenSpec change.
+- Protected files: generated outputs, unrelated SDK builders, root Vitest
+  project scoping.
+- Consumer impact: `Mod.build()` remains synchronous but becomes stronger:
+  files are durable when the method returns.
+
+## Implementation
+
+- Completed tasks: all tasks in `tasks.md` completed with 3.3 residual red
+  disposition.
+- Remaining tasks: commit.
+- Stop conditions triggered: none.
+
+## Verification
+
+- Commands run:
+  - `cd packages/sdk && bun run test`
+  - `cd packages/sdk && bun run check`
+  - `cd packages/sdk && bun vitest run --project sdk test/mapgen-create-map.test.ts --testTimeout 20000`
+  - `cd packages/plugins/plugin-files && bun run test`
+  - `cd packages/plugins/plugin-files && bun vitest run --project plugin-files`
+  - `bun run openspec -- validate civ7-sdk-mod-build-sync-writes --strict`
+  - `git diff --check`
+- Results:
+  - SDK test passes: 6 files, 10 tests.
+  - SDK check passes.
+  - Single mapgen timeout probe passes with larger timeout, proving the prior
+    red was import/setup budget rather than assertion failure; final fix moves
+    import out of the timed body and full SDK test passes with default timeout.
+  - Exact plugin-files package command no longer reports SDK ENOENT and shows
+    SDK/plugin-files tests passing, but exits 1 due unrelated mapgen-studio
+    root-project failures: missing
+    `mod-swooper-maps/recipes/standard-artifacts` and existing mapgen-studio
+    timeouts.
+  - Scoped plugin-files project passes: 1 file, 6 tests.
+  - OpenSpec and diff checks pass.
+- Skipped gates and rationale: no generated XML byte-parity fixture was added
+  because existing `mod-build.test.ts` reads generated `.modinfo` and builder
+  XML immediately after `Mod.build()` and asserts content markers.
+- Evidence boundary: this repair closes the late SDK filesystem callback; it
+  does not solve root Vitest project scoping or unrelated mapgen-studio missing
+  artifact/timeouts.
+
+## Next Action
+
+- Exact next step: final status/diff check, stage, and commit via Graphite.
+- First files to inspect: `git diff --stat`, `git status --short --branch`.
+- Stop condition: dirty files outside the SDK repair write set.

--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -144,4 +144,4 @@ See `apps/playground/src/examples/` for working examples
 - Game schema: Extract with `bun run refresh:data` at workspace root
 
 ### Testing Notes
-- `XmlFile.write` uses an asynchronous `fs.mkdir` callback; wait briefly after `Mod.build` in tests before reading generated files.
+- `Mod.build` completes SDK file writes before returning; tests may read generated files or remove temporary output directories immediately after the call.

--- a/packages/sdk/src/files/ImportFile.ts
+++ b/packages/sdk/src/files/ImportFile.ts
@@ -16,13 +16,8 @@ export class ImportFile extends BaseFile<ImportFile> implements TXmlFile {
   }
 
   write(dist: string) {
-    try {
-      console.log(`${dist}${this.path}${this.name}`);
-      fs.mkdir(`${dist}${this.path}`, { recursive: true }, (err) => {
-        fs.cpSync(this.content, `${dist}${this.path}${this.name}`);
-      });
-    } catch (err) {
-      console.error(err);
-    }
+    console.log(`${dist}${this.path}${this.name}`);
+    fs.mkdirSync(`${dist}${this.path}`, { recursive: true });
+    fs.cpSync(this.content, `${dist}${this.path}${this.name}`);
   }
 }

--- a/packages/sdk/src/files/XmlFile.ts
+++ b/packages/sdk/src/files/XmlFile.ts
@@ -16,20 +16,15 @@ export class XmlFile extends BaseFile<XmlFile> implements TXmlFile {
   }
 
   write(dist: string) {
-    try {
-      const data = toXML(this.content || undefined, {
-        header: true,
-        indent: "    ",
-      });
-      console.log(`${dist}${this.path}${this.name}`);
-      fs.mkdir(`${dist}${this.path}`, { recursive: true }, (err) => {
-        fs.writeFileSync(
-          `${dist}${this.path}${this.name}`,
-          data + `\n<!-- generated with https://github.com/izica/civ7-modding-tools -->`
-        );
-      });
-    } catch (err) {
-      console.error(err);
-    }
+    const data = toXML(this.content || undefined, {
+      header: true,
+      indent: "    ",
+    });
+    console.log(`${dist}${this.path}${this.name}`);
+    fs.mkdirSync(`${dist}${this.path}`, { recursive: true });
+    fs.writeFileSync(
+      `${dist}${this.path}${this.name}`,
+      data + `\n<!-- generated with https://github.com/izica/civ7-modding-tools -->`
+    );
   }
 }

--- a/packages/sdk/test/mapgen-create-map.test.ts
+++ b/packages/sdk/test/mapgen-create-map.test.ts
@@ -20,6 +20,8 @@ vi.mock("@civ7/adapter/civ7", async () => {
   };
 });
 
+import { createMap } from "../src/mapgen/createMap";
+
 describe("createMap", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -27,7 +29,7 @@ describe("createMap", () => {
     delete (globalThis as any).GameplayMap;
   });
 
-  test("emits exact-authorship proof and completion markers around a successful recipe run", async () => {
+  test("emits exact-authorship proof and completion markers around a successful recipe run", () => {
     const handlers = new Map<string, (...args: unknown[]) => void>();
     const engineCalls: Array<{ method: string; args: unknown[] }> = [];
     (globalThis as any).engine = {
@@ -50,7 +52,6 @@ describe("createMap", () => {
     };
 
     try {
-      const { createMap } = await import("../src/mapgen/createMap");
       const recipeRun = vi.fn(() => {
         logs.push("recipe-run");
       });

--- a/packages/sdk/test/mod-build.test.ts
+++ b/packages/sdk/test/mod-build.test.ts
@@ -18,13 +18,12 @@ class FileBuilder extends BaseBuilder {
   }
 }
 
-test("Mod.build writes modinfo referencing builder files", async () => {
+test("Mod.build writes modinfo referencing builder files", () => {
   const mod = new Mod({ id: "my-mod" });
   mod.add(new FileBuilder());
   const tmp = fs.mkdtempSync(join(os.tmpdir(), "mod-build-"));
   try {
     mod.build(tmp);
-    await new Promise((r) => setTimeout(r, 50));
     const modinfoPath = join(tmp, "my-mod.modinfo");
     const xml = fs.readFileSync(modinfoPath, "utf-8");
     expect(xml).toContain("<UpdateDatabase>");


### PR DESCRIPTION
Fix async write race in `XmlFile.write` and `ImportFile.write` that caused `ENOENT` errors during test teardown

Both `XmlFile.write()` and `ImportFile.write()` were queuing asynchronous `fs.mkdir` callbacks and performing their actual file writes inside those callbacks. Because `Mod.build()` returned immediately after invoking `file.write()`, Vitest teardown could remove the temporary output directory before the late callbacks fired, producing unhandled `ENOENT` exceptions after tests had otherwise passed.

The fix replaces the async `fs.mkdir` + callback pattern with synchronous `fs.mkdirSync` in both file classes, so directory creation and file writing complete before `write()` returns. `Mod.build()` remains synchronous and its public API is unchanged; it now simply provides a stronger guarantee that all generated files are durable when the call returns.

The sleep workaround (`await new Promise((r) => setTimeout(r, 50))`) in `mod-build.test.ts` is removed, and the test is converted back to a synchronous function that reads generated files immediately after `Mod.build()`, directly asserting the corrected contract.

The `mapgen-create-map.test.ts` test had a separate issue where the heavy `createMap` module import was happening inside the timed test body, causing intermittent timeouts. The import is moved to module scope so it no longer consumes test budget.

The SDK `AGENTS.md` testing note is updated to reflect that the async write workaround is no longer needed.