### PR TITLE
`fix(adapter-boundary): allowlist river-type-metadata.source.ts as map-policy provenance exception`

### DIFF
--- a/openspec/changes/adapter-boundary-river-metadata-provenance/proposal.md
+++ b/openspec/changes/adapter-boundary-river-metadata-provenance/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+`bun run lint:adapter-boundary` is red because
+`packages/civ7-map-policy/src/river-type-metadata.source.ts` contains
+`/base-standard/` path strings used as provenance metadata for Civ7 river type
+enum values. The adapter-boundary script correctly bans runtime
+`/base-standard/` ownership outside `@civ7/adapter`, but map-policy already has
+an explicit provenance-string exception class for generated/static Civ7 policy
+sources.
+
+This file belongs to that existing exception class. Leaving it unallowlisted
+makes the strict architecture gate fail on a non-runtime string and blocks the
+Habitat workstream's baseline burn-down path.
+
+## What Changes
+
+- Add `packages/civ7-map-policy/src/river-type-metadata.source.ts` to the
+  adapter-boundary allowlist under the existing map-policy provenance rationale.
+- Record the provenance-string interpretation and verification evidence in this
+  OpenSpec slice.
+
+## What Does Not Change
+
+- No adapter-boundary weakening: runtime `/base-standard/` imports remain owned
+  by `packages/civ7-adapter`.
+- No generated table edits and no map-policy behavior change.
+- No Habitat ratchet-baseline edit in this slice; the existing
+  `tools/habitat-harness/baselines/adapter-boundary.json` entry becomes
+  prunable by the later shrink-only ratchet path.
+
+## Affected Owners
+
+- `scripts/lint/lint-adapter-boundary.sh`
+- `packages/civ7-map-policy/src/river-type-metadata.source.ts` as evidence only
+- Habitat workstream baseline records as downstream context only
+
+## Verification Gates
+
+- `bun run lint:adapter-boundary`
+- `bun run openspec -- validate adapter-boundary-river-metadata-provenance --strict`
+- `git diff --check`
+
+## Stop Conditions
+
+- The path strings are used as runtime imports or direct engine access rather
+  than provenance metadata.
+- The fix requires changing the adapter-boundary scanner semantics.

--- a/openspec/changes/adapter-boundary-river-metadata-provenance/specs/habitat-harness/spec.md
+++ b/openspec/changes/adapter-boundary-river-metadata-provenance/specs/habitat-harness/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Adapter Boundary Provenance Exceptions Stay Explicit
+
+The adapter-boundary gate SHALL allow map-policy files to contain
+`/base-standard/` strings only when those strings are documented provenance
+metadata rather than runtime imports or direct engine access.
+
+#### Scenario: River metadata records Civ7 source paths
+- **WHEN** `packages/civ7-map-policy/src/river-type-metadata.source.ts`
+  records Civ7 source files for hand-reviewed river type enum values
+- **THEN** `bun run lint:adapter-boundary` treats those paths as a tracked
+  map-policy provenance exception
+
+#### Scenario: Non-provenance file references base-standard
+- **WHEN** a non-allowlisted package file references `/base-standard/`
+- **THEN** `bun run lint:adapter-boundary` fails and prints the offending file

--- a/openspec/changes/adapter-boundary-river-metadata-provenance/tasks.md
+++ b/openspec/changes/adapter-boundary-river-metadata-provenance/tasks.md
@@ -1,0 +1,20 @@
+## 1. Phase Opening
+
+- [x] 1.1 Reproduce the adapter-boundary failure and capture the exact
+  unapproved file.
+- [x] 1.2 Inspect `river-type-metadata.source.ts` and confirm its
+  `/base-standard/` strings are provenance metadata, not runtime imports.
+
+## 2. Implementation
+
+- [x] 2.1 Add `river-type-metadata.source.ts` to the existing map-policy
+  provenance allowlist in `lint-adapter-boundary.sh`.
+- [x] 2.2 Leave Habitat adapter-boundary ratchet baseline unchanged for the
+  later shrink-only prune path.
+
+## 3. Verification
+
+- [x] 3.1 Run `bun run lint:adapter-boundary`.
+- [x] 3.2 Run `bun run openspec -- validate
+  adapter-boundary-river-metadata-provenance --strict`.
+- [x] 3.3 Run `git diff --check`.

--- a/openspec/changes/adapter-boundary-river-metadata-provenance/workstream/phase-record.md
+++ b/openspec/changes/adapter-boundary-river-metadata-provenance/workstream/phase-record.md
@@ -1,0 +1,68 @@
+# Adapter Boundary River Metadata Provenance Phase Record
+
+## State
+
+- Branch/Graphite stack:
+  `agent-F-adapter-boundary-river-metadata` above
+  `agent-F-sdk-mod-test-teardown`.
+- Change id: `adapter-boundary-river-metadata-provenance`.
+- Objective: restore the strict adapter-boundary gate by classifying
+  `river-type-metadata.source.ts` as the same map-policy provenance-string
+  exception class already used by generated/static policy sources.
+- Status: implemented and verified.
+
+## Authority And Inputs
+
+- Direct user suggested task: fix red adapter-boundary lint on main by
+  confirming river metadata references are provenance strings and adding the
+  file to the script allowlist.
+- Root `AGENTS.md`: update adjacent docs/tests when behavior or public
+  contracts change; keep repo clean; use Graphite.
+- `docs/projects/habitat-harness/invariant-corpus.md`: adapter-boundary is a
+  wrapped rule with an allowlist/ratchet baseline.
+- `scripts/lint/lint-adapter-boundary.sh`: map-policy generated/static Civ7
+  policy provenance strings are not runtime imports or direct engine access.
+
+## Findings
+
+- `bun run lint:adapter-boundary` failed with one unapproved file:
+  `packages/civ7-map-policy/src/river-type-metadata.source.ts`.
+- The offending strings are array values under
+  `CIV7_RIVER_TYPE_METADATA_SOURCE.source`, alongside a file header that says
+  the file is hand-reviewed input for generated Civ7 browser tables.
+- Existing allowlisted map-policy files contain the same source-path class,
+  including `civ7-tables.gen.ts`, `river-constants.ts`, and
+  `resource-constants.ts`.
+- `tools/habitat-harness/baselines/adapter-boundary.json` currently contains
+  the same file as a Habitat baseline entry. This slice intentionally does not
+  edit that baseline; it becomes prunable through the later shrink-only ratchet
+  flow after the legacy lint gate is green.
+
+## Implementation Plan
+
+1. Add `packages/civ7-map-policy/src/river-type-metadata.source.ts` to the
+   existing map-policy provenance allowlist in
+   `scripts/lint/lint-adapter-boundary.sh`.
+2. Validate adapter-boundary, OpenSpec, and diff whitespace.
+3. Commit as a narrow Graphite slice.
+
+## Verification
+
+- PASS: `bun run lint:adapter-boundary`
+  - Result: `Adapter boundary check passed.`
+  - Output now lists 7 allowlisted files, including
+    `packages/civ7-map-policy/src/river-type-metadata.source.ts`.
+- PASS: `bun run openspec -- validate
+  adapter-boundary-river-metadata-provenance --strict`
+  - Result: `Change 'adapter-boundary-river-metadata-provenance' is valid`.
+- PASS: `git diff --check`
+
+## Downstream Realignment
+
+- Habitat baseline shrink: no patch in this slice. The baseline entry in
+  `tools/habitat-harness/baselines/adapter-boundary.json` should be removed by
+  the later ratchet/prune mechanism once that slice evaluates current
+  findings.
+- Taxonomy: no change. `kind:adapter` remains the only owner of runtime
+  `/base-standard/` imports; map-policy provenance strings remain file-level
+  exceptions.

--- a/scripts/lint/lint-adapter-boundary.sh
+++ b/scripts/lint/lint-adapter-boundary.sh
@@ -33,6 +33,7 @@ ALLOWLIST=(
   "packages/civ7-map-policy/src/coast-classification.ts"
   "packages/civ7-map-policy/src/resource-constants.ts"
   "packages/civ7-map-policy/src/river-constants.ts"
+  "packages/civ7-map-policy/src/river-type-metadata.source.ts"
   "packages/civ7-map-policy/test/map-policy.test.ts"
 )
 


### PR DESCRIPTION
`packages/civ7-map-policy/src/river-type-metadata.source.ts` contains `/base-standard/` path strings used as provenance metadata for Civ7 river type enum values, which caused `bun run lint:adapter-boundary` to fail. These strings are not runtime imports or direct engine access — they are hand-reviewed source references in the same class as other already-allowlisted map-policy files such as `civ7-tables.gen.ts`, `river-constants.ts`, and `resource-constants.ts`.

This adds `river-type-metadata.source.ts` to the existing map-policy provenance allowlist in `lint-adapter-boundary.sh`, restoring the strict adapter-boundary gate without weakening it. Runtime `/base-standard/` imports remain exclusively owned by `packages/civ7-adapter`. The Habitat ratchet baseline in `tools/habitat-harness/baselines/adapter-boundary.json` is left untouched and becomes prunable through the later shrink-only ratchet path.