### PR TITLE
`fix(mapgen-studio): project-scoped 180s testTimeout, compact browser-runner fixture to clear H4 root-test timeout blocker`

### DIFF
--- a/apps/mapgen-studio/test/browserRunner/standardLayerVisibility.test.ts
+++ b/apps/mapgen-studio/test/browserRunner/standardLayerVisibility.test.ts
@@ -42,7 +42,7 @@ async function runStandardRecipeInWorker(): Promise<BrowserRunEvent[]> {
       recipeId: "mod-swooper-maps/standard",
       seed: 1780185340,
       mapSizeId: "MAPSIZE_TINY",
-      dimensions: { width: 60, height: 38 },
+      dimensions: { width: 32, height: 20 },
       latitudeBounds: { topLatitude: 70, bottomLatitude: -70 },
       playerCount: 4,
       resourcesMode: "balanced",
@@ -50,7 +50,7 @@ async function runStandardRecipeInWorker(): Promise<BrowserRunEvent[]> {
     },
   });
 
-  const deadline = Date.now() + 30_000;
+  const deadline = Date.now() + 120_000;
   while (Date.now() < deadline) {
     const terminal = harness.events.find(
       (event) =>
@@ -111,5 +111,5 @@ describe("standard browser runner layer visibility", () => {
     );
     expect(rawWorldMotionLayers.length).toBeGreaterThan(0);
     expect(rawWorldMotionLayers.every((event) => visibilityOf(event.layer) === "debug")).toBe(true);
-  }, 35_000);
+  }, 240_000);
 });

--- a/docs/projects/habitat-harness/workstream-record.md
+++ b/docs/projects/habitat-harness/workstream-record.md
@@ -5,8 +5,8 @@
 - **Method:** `civ7-systematic-workstream` (12 gates) composed with `civ7-open-spec-workstream` (per-slice phase loop)
 - **Controlling frame:** `docs/projects/habitat-harness/FRAME.md` (hard core, falsifier, settled decisions D1–D6)
 - **Stack root:** `agent-F-habitat-harness-workstream` (worktree `wt-agent-F-habitat-harness-workstream`, parent `main`, Graphite-tracked)
-- **Current execution branch:** `agent-F-plugin-vitest-project-scope` stacked above the promoted H4 proof repairs
-- **Status:** IN EXECUTION — H1/H2/H3 closed locally; H4 Biome setup/lint/integration is complete and DL-15/DL-16 promoted repairs are verified, but H4 2.4 evidence pass and closure remain blocked by repo-wide `mapgen-studio:test` timeouts under the root test run; H4.5 oclif CLI slice is implemented and verified before downstream CLI surface hardening
+- **Current execution branch:** `agent-F-mapgen-studio-test-timeouts` stacked above the promoted H4 proof repairs
+- **Status:** IN EXECUTION — H1/H2/H3 closed locally; H4 Biome setup/lint/integration is complete and DL-15/DL-16 promoted repairs are verified; the `mapgen-studio:test` timeout class is locally repaired with direct and representative Nx-load proof, but H4 2.4 and closure still require a final full root-test proof. H4.5 oclif CLI slice is implemented and verified before downstream CLI surface hardening.
 
 ## Gate state (systematic-workstream)
 
@@ -20,7 +20,7 @@
 | 6 Expectations | DONE | per-slice verification gates; ratchet baselines predeclared (project plane green; adapter-boundary baseline = 6) |
 | 7 Architecture translation | DONE | taxonomy.md (tags/constraints); five-layer ownership in FRAME hard core #2 |
 | 8 Slices | IN TRAIN | OpenSpec train below; H1/H2/H3 closed locally; H4 active with Biome integration complete; H4.5 oclif CLI migration implemented locally; promoted proof repairs are stacked above H4 |
-| 9 Local stats | IN TRAIN | H1 build-output byte parity complete; H4 tracked post-format hashes match pre-format hashes; post-repair root build has no generated drift; root test remains red through `mapgen-studio` timeouts |
+| 9 Local stats | IN TRAIN | H1 build-output byte parity complete; H4 tracked post-format hashes match pre-format hashes; post-repair root build has no generated drift; `mapgen-studio` timeouts have local repair proof; final root test still pending |
 | 10 Runtime proof | N/A by design | harness touches structure only; byte-parity gates stand in (H1/H4) |
 | 11 Review | IN TRAIN | spec lane DONE (ledger); architecture lane before H3; impl/evidence/closure per slice |
 | 12 Closure | IN TRAIN | H1/H2/H3 have local phase closure records; H4 open on root-test proof; H4.5 and promoted proof repairs are implemented/verified locally above H4 |
@@ -55,8 +55,9 @@ machine-output semantics before H5-H8 add more command surface. The promoted
 proof repairs for DL-16 (`intelligence-bridge-ui-bundle`), SDK async teardown
 (`civ7-sdk-mod-build-sync-writes`), adapter-boundary river metadata, and
 DL-15 plugin Vitest project scoping are stacked above H4. H4 task 2.4 remains
-open because the post-repair root test still fails in `mapgen-studio:test`
-with timeout failures under repo-wide execution; root build/parity is green.
+open because the full root test has not yet been rerun green after the
+`mapgen-studio-test-timeouts` repair; root build/parity is green, and direct
+plus representative Nx-load `mapgen-studio:test` proof is green.
 
 ## Proof classes per slice (predeclared)
 
@@ -100,6 +101,5 @@ train redefines the other's authority.
    `workstream/phase-record.md`).
 3. ~~H4.5 oclif CLI migration and promoted DL-16 / SDK teardown /
    adapter-boundary repairs~~ DONE locally on the stack.
-4. Commit/restack `plugin-vitest-project-scope`, then isolate and repair the
-   repo-wide `mapgen-studio:test` timeout class before claiming H4 task 2.4 or
-   moving into H5.
+4. Validate and commit `mapgen-studio-test-timeouts`, then rerun the full root
+   test before claiming H4 task 2.4 or moving into H5.

--- a/openspec/changes/habitat-biome-hygiene/workstream/phase-record.md
+++ b/openspec/changes/habitat-biome-hygiene/workstream/phase-record.md
@@ -7,7 +7,7 @@
 - Owner: workstream owner agent (Codex continuation)
 - Branch/Graphite stack: `agent-F-habitat-biome-hygiene` -> `agent-F-habitat-boundary-tags` -> `agent-F-habitat-harness-scaffold` -> `agent-F-habitat-nx-adoption` -> `agent-F-habitat-harness-workstream` -> `main`
 - Started: 2026-06-13
-- Status: OPEN — Biome setup, format commit, blame shield, Prettier retirement, lint lane, and harness/Nx/CI integration complete; DL-15/DL-16 promoted repairs are verified, but task 2.4 and closure remain blocked by repo-wide `mapgen-studio:test` timeouts under the root test run.
+- Status: OPEN — Biome setup, format commit, blame shield, Prettier retirement, lint lane, and harness/Nx/CI integration complete; DL-15/DL-16 promoted repairs are verified, and the repo-wide `mapgen-studio:test` timeout class has a local repair slice. Task 2.4 and closure still require a final root-test proof before a green H4 claim.
 
 ## Objective
 
@@ -60,10 +60,10 @@
 ## Implementation
 
 - Completed tasks: 1.1, 1.2, 2.1, 2.2, 2.3, 3.1, 3.2, 4.2.
-- Remaining tasks: 2.4, 4.1, 4.3. Task 2.4 has partial evidence: root build green; tracked pre/post format hashes match; fresh root build has no generated drift after DL-16 repair; plugin package tests and SDK package tests are green after DL-15 repairs. Root test remains red through `mapgen-studio:test` timeout failures under full repo-wide execution, so 2.4 is not marked complete.
+- Remaining tasks: 2.4, 4.1, 4.3. Task 2.4 has partial evidence: root build green; tracked pre/post format hashes match; fresh root build has no generated drift after DL-16 repair; plugin package tests and SDK package tests are green after DL-15 repairs. The `mapgen-studio:test` timeout class has been repaired in `mapgen-studio-test-timeouts`, with direct project proof and a representative Nx load proof, but full root test has not been rerun green, so 2.4 is not marked complete.
 - Biome lint lane: minimal green bug-risk rule set is enabled in `biome.json` with `recommended: false`; no desired red Biome rule was silently disabled after selection. The red assist class (`organizeImports`) was repaired mechanically by applying the safe assist and committing it separately; no ratchet baseline is required for `biome-ci` because the rule is locked with zero diagnostics.
 - Harness integration: `@internal/habitat-harness` now infers `biome:format`, `biome:check`, and `biome:ci`; `habitat fix` runs `biome check --write .` and `--dry-run` runs non-writing `biome check .`; `habitat check` includes locked `biome-ci`; `habitat verify` composes `build,check,test,boundaries,biome:ci`; CI runs `bunx nx run-many -t biome:ci`; README documents editor setup and the never-plain-`lint` target convention.
-- Stop conditions triggered: task 2.4 cannot close as green yet. The earlier DL-15 package-local Vitest fan-out / SDK teardown defects and DL-16 intelligence-bridge bundle drift are repaired, but the root test still exposes `mapgen-studio:test` timeouts under repo-wide load. That timeout class must be isolated or repaired before H4 can make the proposal's strict build/test green claim.
+- Stop conditions triggered: task 2.4 cannot close as green yet. The earlier DL-15 package-local Vitest fan-out / SDK teardown defects and DL-16 intelligence-bridge bundle drift are repaired. The root-test `mapgen-studio:test` timeout class is now isolated and locally repaired, but H4 still needs a final root-test proof before the proposal's strict build/test green claim.
 
 ## Verification
 
@@ -200,8 +200,20 @@
   root-test claim is made from that run.
 - Skipped gates and rationale: task 2.4 is not marked complete because the
   proposal asks for build/test green plus build-output parity. Root build and
-  build-output parity are green after promoted repairs, but root test remains
-  red through the `mapgen-studio` timeout class.
+  build-output parity are green after promoted repairs. The last full root
+  test result was red through the `mapgen-studio` timeout class; that class has
+  local repair proof now, but full root test has not been rerun green.
+- Mapgen timeout repair evidence: `mapgen-studio-test-timeouts` gives only the
+  root `mapgen-studio` Vitest project a 180s timeout budget and reduces the
+  `standardLayerVisibility` browser-worker fixture to a compact `32x20`
+  standard-recipe run without changing assertions. Direct
+  `bunx vitest run --config vitest.config.ts --project mapgen-studio` passes
+  47 files / 233 tests in 148.72s. A representative Nx load probe including
+  `mapgen-studio`, `@civ7/studio-server`, `@internal/habitat-harness`,
+  `@civ7/docs`, `@civ7/playground`, and
+  `mod-civ7-intelligence-bridge` passes with `mapgen-studio:test` at 47 files /
+  233 tests in 381.19s. A full root test rerun is still required before H4 task
+  2.4 can be marked complete.
 - Minimal Biome rule promotion result: selected green correctness/suspicious
   bug-risk rules pass under `biome ci`; nested `**/_archive/**` is excluded so
   live code can keep `noGlobalIsFinite` without historical archive churn.
@@ -235,16 +247,16 @@
 
 - Downstream docs/specs/issues updated: top-level workstream record reconciled from stale pre-execution state to H4-active state; H4 tasks updated for 3.1/3.2/4.2; DL-12 updated from pending to enforced Biome hygiene reality; DL-15/DL-16 moved to resolved-by-promoted-repair after the SDK/plugin/intelligence slices.
 - Tests/guards updated: Swooper Maps import guard now parses imports structurally; Habitat rule pack now includes locked `biome-ci`; CI includes `biome:ci`.
-- Deferrals/triage updated: the user/Fable suggested DL-15 SDK teardown, DL-16 intelligence bundle, and adapter-boundary river metadata repairs were promoted into separate Graphite/OpenSpec slices. A new H4 proof blocker remains: repo-wide `mapgen-studio:test` timeouts under full Nx test load.
+- Deferrals/triage updated: the user/Fable suggested DL-15 SDK teardown, DL-16 intelligence bundle, and adapter-boundary river metadata repairs were promoted into separate Graphite/OpenSpec slices. The H4 `mapgen-studio:test` timeout blocker is promoted into and locally repaired by the `mapgen-studio-test-timeouts` slice; full root-test closure remains pending.
 - Downstream realignment ledger: N/A at phase open.
 
 ## Next Action
 
-- Exact next step: commit the `plugin-vitest-project-scope` repair slice, then
-  isolate the repo-wide `mapgen-studio:test` timeout class and repair or
-  scope it before claiming H4 task 2.4 or closure.
-- First files to inspect for closure blockers:
-  `apps/mapgen-studio/vitest.config.ts`, root `vitest.config.ts`,
-  mapgen-studio timeout-heavy suites under `apps/mapgen-studio/test/server`,
-  `test/viz`, `test/ui`, and `test/runInGame`, plus Nx test parallelism.
+- Exact next step: validate and commit the `mapgen-studio-test-timeouts`
+  repair slice, then rerun the full root test before claiming H4 task 2.4 or
+  closure.
+- First files to inspect for closure blockers if root test remains red:
+  the new root-test log, `mods/mod-swooper-maps` long-running test behavior,
+  and any remaining non-mapgen timeout or assertion class surfaced by the full
+  run.
 - Stop condition: Biome config would format generated/protected zones, create non-format semantic diff, or require hygiene ownership that overlaps Nx/Grit.

--- a/openspec/changes/mapgen-studio-test-timeouts/proposal.md
+++ b/openspec/changes/mapgen-studio-test-timeouts/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+After the promoted H4 proof repairs, the repo-wide root test no longer fails
+through DL-15 package-local Vitest fan-out or DL-16 intelligence-bridge bundle
+drift. The remaining H4 root-test blocker is `mapgen-studio:test`: under the
+full Nx run it inherits Vitest's default 5s per-test timeout and times out
+integration-heavy server, Effect-scoped tuner session, UI render, and real
+Studio-emission tests.
+
+The Habitat H4 proof gate needs root test evidence to fail on real behavior,
+not on a project timeout budget that is too small for the app's known
+integration surface under repo-wide load.
+
+## What Changes
+
+- Give the `mapgen-studio` Vitest project an explicit timeout budget in the
+  root workspace config.
+- Reduce the `standardLayerVisibility` browser-runner fixture to the compact
+  standard-recipe scale while preserving its layer visibility assertions.
+- Keep the change project-scoped so other package/app tests retain their
+  current default timeout behavior.
+- Record the remaining H4 proof evidence and rerun focused/representative
+  gates.
+
+## What Does Not Change
+
+- No app runtime, server, Effect Layer/Scope, or product behavior changes.
+- No assertions are weakened or skipped.
+- No global Vitest timeout increase for unrelated projects.
+
+## Affected Owners
+
+- `vitest.config.ts`
+- `apps/mapgen-studio/test/browserRunner/standardLayerVisibility.test.ts`
+- Habitat H4 proof records
+
+## Verification Gates
+
+- `bunx vitest run --config vitest.config.ts --project mapgen-studio`
+- Representative repo-wide load probe including `mapgen-studio:test`
+- `bun run openspec -- validate mapgen-studio-test-timeouts --strict`
+- `git diff --check`
+
+## Stop Conditions
+
+- A timeout increase hides a real deterministic failing assertion.
+- The fix must be global instead of project-scoped.
+- `mapgen-studio` still times out under a representative root-load probe.

--- a/openspec/changes/mapgen-studio-test-timeouts/specs/habitat-harness/spec.md
+++ b/openspec/changes/mapgen-studio-test-timeouts/specs/habitat-harness/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Root Test Proof Uses Project-Appropriate Timeout Budgets
+
+Repo-wide Habitat proof runs SHALL allow integration-heavy Vitest projects to
+declare project-scoped timeout budgets without changing unrelated projects.
+
+#### Scenario: Mapgen Studio runs under root Nx test load
+- **WHEN** Nx runs `mapgen-studio:test` as part of a repo-wide or
+  representative root test run
+- **THEN** the project uses its explicit `mapgen-studio` timeout budget
+- **AND** tests fail only on assertion/runtime failures, not the default
+  workspace 5s timeout being too small under full-load execution
+- **AND** unrelated projects keep their existing timeout behavior
+
+#### Scenario: Browser-runner visibility proof uses compact fixture scale
+- **WHEN** `standardLayerVisibility` runs the standard recipe in the browser
+  worker harness
+- **THEN** the test may use a compact standard-recipe map size that keeps the
+  worker runtime inside the project timeout budget
+- **AND** it still asserts the terminal `run.finished` event, default-visible
+  core balance layers, vector/arrow tile movement layers, and debug-only raw
+  world motion layers

--- a/openspec/changes/mapgen-studio-test-timeouts/tasks.md
+++ b/openspec/changes/mapgen-studio-test-timeouts/tasks.md
@@ -1,0 +1,22 @@
+## 1. Phase Opening
+
+- [x] 1.1 Create phase record before implementation.
+- [x] 1.2 Reproduce or preserve the H4 root-test timeout evidence.
+
+## 2. Implementation
+
+- [x] 2.1 Add a project-scoped timeout budget for `mapgen-studio` in root
+  Vitest project config.
+- [x] 2.2 Confirm no assertions, suites, or unrelated projects are skipped or
+  weakened.
+
+## 3. Verification
+
+- [x] 3.1 Run `bunx vitest run --config vitest.config.ts --project
+  mapgen-studio`.
+- [x] 3.2 Run a representative root-load test probe that includes
+  `mapgen-studio:test`.
+- [x] 3.3 Run `bun run openspec -- validate mapgen-studio-test-timeouts
+  --strict`.
+- [x] 3.4 Run `git diff --check`.
+- [x] 3.5 Update H4 records with the result.

--- a/openspec/changes/mapgen-studio-test-timeouts/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-test-timeouts/workstream/phase-record.md
@@ -1,0 +1,96 @@
+# Mapgen Studio Test Timeouts Phase Record
+
+## State
+
+- Branch/Graphite stack: `agent-F-mapgen-studio-test-timeouts` above
+  `agent-F-plugin-vitest-project-scope`.
+- Change id: `mapgen-studio-test-timeouts`.
+- Objective: remove the remaining H4 root-test proof blocker by giving the
+  integration-heavy `mapgen-studio` Vitest project an explicit project-scoped
+  timeout budget and keeping its browser-worker fixture inside that budget
+  without dropping assertions.
+- Status: implemented and locally verified; ready to commit.
+
+## Authority And Inputs
+
+- Root `AGENTS.md`: update adjacent docs/tests when behavior or public
+  contracts change; keep generated artifacts read-only.
+- H4 phase record: after DL-15/DL-16 repairs, root test remains red through
+  `mapgen-studio:test` timing out under full Nx test load.
+- `vitest.config.ts`: root Vitest project matrix gave `mapgen-studio` only
+  `test: { name: "mapgen-studio" }`, inheriting the default 5s timeout before
+  this slice.
+
+## Opening Evidence
+
+- Root probe:
+  `NX_DAEMON=false bunx nx run-many -t test --outputStyle=static` progressed
+  past DL-15/DL-16 classes but `mapgen-studio:test` failed with 13 failed
+  files / 16 timed-out tests after 601.30s.
+- Timed-out classes include server one-mount, Effect-scoped tuner session,
+  UI render, run-in-game console, and real Studio-emission visualization
+  assertions.
+- Remaining `mod-swooper-maps:test` child was interrupted only after the root
+  probe was already red and had continued CPU-bound for more than 25 minutes.
+
+## Implementation Plan
+
+1. Add a `testTimeout` only to the `mapgen-studio` root Vitest project.
+2. Keep all tests and assertions intact.
+3. If the browser-worker fixture exceeds its own deadline, reduce fixture size
+   instead of weakening the layer visibility assertions.
+4. Verify direct `mapgen-studio` project execution, then run a representative
+   load probe.
+5. Update H4 records and close this slice only if the timeout class is gone.
+
+## Implementation
+
+- `vitest.config.ts` now gives only the `mapgen-studio` project an explicit
+  `testTimeout: 180_000`; unrelated projects keep their existing timeout
+  behavior.
+- `standardLayerVisibility` keeps the same standard recipe, seed, layer
+  assertions, terminal `run.finished` expectation, default-visible balance
+  layer checks, tile-movement vector/arrow checks, and debug-only raw world
+  motion checks.
+- The browser-worker fixture uses compact `32x20` dimensions, a 120s internal
+  worker deadline, and a 240s per-test budget. This removes the remaining
+  deterministic timeout symptom without skipping suites or assertions.
+
+## Verification
+
+- `NX_DAEMON=false bunx nx run mapgen-studio:test --skip-nx-cache` was
+  attempted first and interrupted after more than 25 minutes in dependency
+  generation before reaching the Vitest project. No green claim is made from
+  that probe.
+- Direct pre-fix focused evidence:
+  `bunx vitest run --config vitest.config.ts --project mapgen-studio` failed
+  with `standardLayerVisibility` hitting its 35s explicit timeout and several
+  other suites hitting the inherited 5s default timeout class.
+- After adding the project timeout, the inherited-5s class was gone: 46/47
+  files passed, including formerly slow standard-emission and one-mount
+  suites. The remaining failure was `standardLayerVisibility`, where the
+  worker did not finish before its own 30s internal deadline.
+- Focused browser-worker proof after fixture reduction:
+  `bunx vitest run --config vitest.config.ts --project mapgen-studio
+  test/browserRunner/standardLayerVisibility.test.ts` passed with exit 0
+  (1 test, 52.02s).
+- Full direct project proof after fixture reduction:
+  `bunx vitest run --config vitest.config.ts --project mapgen-studio` passed
+  with exit 0 (47 files, 233 tests, 148.72s).
+- Representative Nx load proof:
+  `NX_DAEMON=false bunx nx run-many -t test
+  --projects=mapgen-studio,@civ7/studio-server,@internal/habitat-harness,@civ7/docs,@civ7/playground,mod-civ7-intelligence-bridge
+  --parallel=6 --outputStyle=static` passed with exit 0. Nx reported all six
+  requested projects and 14 dependency tasks successful; `mapgen-studio:test`
+  passed 47 files / 233 tests in 381.19s under the representative load.
+- OpenSpec validation:
+  `bun run openspec -- validate mapgen-studio-test-timeouts --strict` passed
+  with `Change 'mapgen-studio-test-timeouts' is valid`.
+- H4 cross-validation:
+  `bun run openspec -- validate habitat-biome-hygiene --strict` passed with
+  `Change 'habitat-biome-hygiene' is valid`.
+- Diff hygiene:
+  `git diff --check` passed with no output.
+- Generated/protected drift check:
+  `git diff --name-only | rg '(^|/)dist/|(^|/)types/|(^|/)mod/|^\.civ7/outputs/|src/maps/generated|packages/civ7-types/generated|civ7-tables\.gen\.ts|example-generated-mod' || true`
+  returned no tracked generated/protected paths.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -75,7 +75,10 @@ export default defineConfig({
             },
           ],
         },
-        test: { name: "mapgen-studio" },
+        test: {
+          name: "mapgen-studio",
+          testTimeout: 180_000,
+        },
       },
       {
         extends: true,


### PR DESCRIPTION
The `mapgen-studio` Vitest project was inheriting Vitest's default 5s per-test timeout, causing integration-heavy suites (server one-mount, Effect-scoped tuner sessions, UI render, run-in-game console, and Studio-emission visualization tests) to time out under full Nx repo-wide test load. This was the last remaining blocker for the H4 root-test proof gate after the DL-15/DL-16 repairs.

This change gives only the `mapgen-studio` Vitest project an explicit `testTimeout: 180_000` in the root workspace config, leaving all other projects at their existing defaults. The `standardLayerVisibility` browser-worker fixture is reduced to a compact `32x20` map size with a 120s internal worker deadline and a 240s per-test budget, keeping all layer visibility assertions intact — terminal `run.finished`, default-visible balance layers, vector/arrow tile movement layers, and debug-only raw world motion layers are all still verified.

Direct project proof: `bunx vitest run --config vitest.config.ts --project mapgen-studio` passes 47 files / 233 tests in 148.72s. A representative Nx load probe across `mapgen-studio`, `@civ7/studio-server`, `@internal/habitat-harness`, `@civ7/docs`, `@civ7/playground`, and `mod-civ7-intelligence-bridge` passes with `mapgen-studio:test` completing 47 files / 233 tests in 381.19s. A full root test rerun is still required before H4 task 2.4 can be marked complete.