### PR TITLE
`fix(cli): add project-scoped 30s testTimeout for CLI Vitest project under Nx root-load execution`

### DIFF
--- a/docs/projects/habitat-harness/workstream-record.md
+++ b/docs/projects/habitat-harness/workstream-record.md
@@ -5,8 +5,8 @@
 - **Method:** `civ7-systematic-workstream` (12 gates) composed with `civ7-open-spec-workstream` (per-slice phase loop)
 - **Controlling frame:** `docs/projects/habitat-harness/FRAME.md` (hard core, falsifier, settled decisions D1–D6)
 - **Stack root:** `agent-F-habitat-harness-workstream` (worktree `wt-agent-F-habitat-harness-workstream`, parent `main`, Graphite-tracked)
-- **Current execution branch:** `agent-F-mapgen-studio-test-timeouts` stacked above the promoted H4 proof repairs
-- **Status:** IN EXECUTION — H1/H2/H3 closed locally; H4 Biome setup/lint/integration is complete and DL-15/DL-16 promoted repairs are verified; the `mapgen-studio:test` timeout class is locally repaired with direct and representative Nx-load proof, but H4 2.4 and closure still require a final full root-test proof. H4.5 oclif CLI slice is implemented and verified before downstream CLI surface hardening.
+- **Current execution branch:** `agent-F-cli-root-load-test-timeouts` stacked above the promoted H4 proof repairs
+- **Status:** IN EXECUTION — H1/H2/H3 closed locally; H4 Biome setup/lint/integration is complete and DL-15/DL-16 promoted repairs are verified; the first `mapgen-studio:test` timeout class and the CLI root-load timeout class are locally repaired, but H4 2.4 and closure remain blocked by a second `mapgen-studio:test` root-load class. H4.5 oclif CLI slice is implemented and verified before downstream CLI surface hardening.
 
 ## Gate state (systematic-workstream)
 
@@ -20,7 +20,7 @@
 | 6 Expectations | DONE | per-slice verification gates; ratchet baselines predeclared (project plane green; adapter-boundary baseline = 6) |
 | 7 Architecture translation | DONE | taxonomy.md (tags/constraints); five-layer ownership in FRAME hard core #2 |
 | 8 Slices | IN TRAIN | OpenSpec train below; H1/H2/H3 closed locally; H4 active with Biome integration complete; H4.5 oclif CLI migration implemented locally; promoted proof repairs are stacked above H4 |
-| 9 Local stats | IN TRAIN | H1 build-output byte parity complete; H4 tracked post-format hashes match pre-format hashes; post-repair root build has no generated drift; `mapgen-studio` timeouts have local repair proof; final root test still pending |
+| 9 Local stats | IN TRAIN | H1 build-output byte parity complete; H4 tracked post-format hashes match pre-format hashes; post-repair root build has no generated drift; first `mapgen-studio` and CLI timeout classes have local repair proof; final root test still red on second mapgen class |
 | 10 Runtime proof | N/A by design | harness touches structure only; byte-parity gates stand in (H1/H4) |
 | 11 Review | IN TRAIN | spec lane DONE (ledger); architecture lane before H3; impl/evidence/closure per slice |
 | 12 Closure | IN TRAIN | H1/H2/H3 have local phase closure records; H4 open on root-test proof; H4.5 and promoted proof repairs are implemented/verified locally above H4 |
@@ -55,9 +55,12 @@ machine-output semantics before H5-H8 add more command surface. The promoted
 proof repairs for DL-16 (`intelligence-bridge-ui-bundle`), SDK async teardown
 (`civ7-sdk-mod-build-sync-writes`), adapter-boundary river metadata, and
 DL-15 plugin Vitest project scoping are stacked above H4. H4 task 2.4 remains
-open because the full root test has not yet been rerun green after the
-`mapgen-studio-test-timeouts` repair; root build/parity is green, and direct
-plus representative Nx-load `mapgen-studio:test` proof is green.
+open because the full root test is not yet green after the
+`mapgen-studio-test-timeouts` and `cli-root-load-test-timeouts` repairs. Root
+build/parity is green, the CLI root-load timeout class is repaired, and direct
+plus representative Nx-load `mapgen-studio:test` proof is green for the first
+mapgen class; the latest full root proof now fails in a second mapgen
+root-load class.
 
 ## Proof classes per slice (predeclared)
 
@@ -101,5 +104,6 @@ train redefines the other's authority.
    `workstream/phase-record.md`).
 3. ~~H4.5 oclif CLI migration and promoted DL-16 / SDK teardown /
    adapter-boundary repairs~~ DONE locally on the stack.
-4. Validate and commit `mapgen-studio-test-timeouts`, then rerun the full root
-   test before claiming H4 task 2.4 or moving into H5.
+4. Validate and commit `cli-root-load-test-timeouts`, then isolate the remaining
+   `mapgen-studio:test` root-load failures before claiming H4 task 2.4 or
+   moving into H5.

--- a/openspec/changes/cli-root-load-test-timeouts/proposal.md
+++ b/openspec/changes/cli-root-load-test-timeouts/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+After `mapgen-studio:test` was stabilized, the H4 root test proof advanced to
+the CLI project and exposed a second root-load timeout class. Direct CLI Vitest
+passed, but Nx execution of `@mateicanavra/civ7-cli:test` failed several
+integration-heavy game command tests at Vitest's 5s default timeout. Timed-out
+tests left async command/server work in flight, which contaminated later
+assertions in the same files.
+
+The Habitat proof gate needs CLI failures to represent command behavior, not a
+test timeout budget that is too small under Nx/root-load execution.
+
+## What Changes
+
+- Give only the `cli` Vitest project an explicit timeout budget in the root
+  workspace config.
+- Record the focused direct and Nx evidence that distinguishes deterministic
+  CLI behavior from root-load timing.
+
+## What Does Not Change
+
+- No CLI command, oclif, direct-control, Effect, or product/runtime behavior
+  changes.
+- No assertions are weakened or skipped.
+- No global Vitest timeout increase for unrelated projects.
+
+## Affected Owners
+
+- `vitest.config.ts`
+- Habitat H4 proof records
+
+## Verification Gates
+
+- `bunx vitest run --config vitest.config.ts --project cli`
+- `bunx nx run @mateicanavra/civ7-cli:test --outputStyle=static`
+- Representative root-load test probe that includes `@mateicanavra/civ7-cli:test`
+- `bun run openspec -- validate cli-root-load-test-timeouts --strict`
+- `git diff --check`
+
+## Stop Conditions
+
+- A timeout increase hides a deterministic assertion failure.
+- The fix must be global instead of project-scoped.
+- CLI tests still fail under focused Nx execution after the timeout budget is
+  applied.

--- a/openspec/changes/cli-root-load-test-timeouts/specs/habitat-harness/spec.md
+++ b/openspec/changes/cli-root-load-test-timeouts/specs/habitat-harness/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: CLI Root-Load Tests Use Project-Appropriate Timeout Budgets
+
+Repo-wide Habitat proof runs SHALL allow the oclif CLI Vitest project to
+declare a project-scoped timeout budget without changing unrelated projects.
+
+#### Scenario: CLI tests run under Nx/root-load execution
+- **WHEN** Nx runs `@mateicanavra/civ7-cli:test` as part of a focused or
+  repo-wide root test run
+- **THEN** the project uses its explicit `cli` timeout budget
+- **AND** tests fail only on assertion/runtime failures, not the default
+  workspace 5s timeout being too small under Nx/root-load execution
+- **AND** unrelated projects keep their existing timeout behavior

--- a/openspec/changes/cli-root-load-test-timeouts/tasks.md
+++ b/openspec/changes/cli-root-load-test-timeouts/tasks.md
@@ -1,0 +1,21 @@
+## 1. Phase Opening
+
+- [x] 1.1 Create phase record before implementation.
+- [x] 1.2 Preserve direct and Nx CLI failure/pass evidence.
+
+## 2. Implementation
+
+- [x] 2.1 Add a project-scoped timeout budget for `cli` in root Vitest project
+  config.
+- [x] 2.2 Confirm no CLI assertions, command semantics, suites, or unrelated
+  projects are changed.
+
+## 3. Verification
+
+- [x] 3.1 Run `bunx nx run @mateicanavra/civ7-cli:test --outputStyle=static`.
+- [x] 3.2 Run representative/root-load probes that include
+  `@mateicanavra/civ7-cli:test`, and record any non-CLI blocker separately.
+- [x] 3.3 Run `bun run openspec -- validate cli-root-load-test-timeouts
+  --strict`.
+- [x] 3.4 Run `git diff --check`.
+- [x] 3.5 Update H4 records with the result.

--- a/openspec/changes/cli-root-load-test-timeouts/workstream/phase-record.md
+++ b/openspec/changes/cli-root-load-test-timeouts/workstream/phase-record.md
@@ -1,0 +1,84 @@
+# CLI Root-Load Test Timeouts Phase Record
+
+## State
+
+- Branch/Graphite stack: `agent-F-cli-root-load-test-timeouts` above
+  `agent-F-mapgen-studio-test-timeouts`.
+- Change id: `cli-root-load-test-timeouts`.
+- Objective: remove the next H4 root-test proof blocker by giving the
+  integration-heavy oclif CLI Vitest project an explicit project-scoped
+  timeout budget.
+- Status: implemented and locally verified; ready to commit.
+
+## Authority And Inputs
+
+- Root `AGENTS.md`: update adjacent docs/tests when behavior or public
+  contracts change; keep generated artifacts read-only.
+- `packages/cli/AGENTS.md`: CLI uses oclif, direct-control for game commands,
+  and `bun run test:cli`/Nx-backed test paths for package validation.
+- H4 phase record: root build/parity is green, but H4 task 2.4 needs a full
+  root test proof.
+- `vitest.config.ts`: root Vitest project matrix previously gave `cli` only
+  `test.name` plus `NODE_ENV`, inheriting the default 5s timeout.
+
+## Opening Evidence
+
+- Full root test after the mapgen timeout repair:
+  `NX_DAEMON=false bunx nx run-many -t test --outputStyle=static` advanced
+  past `mapgen-studio:test` (47 files / 233 tests passed in 381.19s) and then
+  failed in the `cli` project. The wrapper was interrupted only after CLI was
+  already red and another child target had continued running silently.
+- Direct CLI proof:
+  `bunx vitest run --config vitest.config.ts --project cli` passed with exit 0
+  (53 files / 234 tests, 278.03s).
+- Focused Nx CLI reproduction:
+  `bunx nx run @mateicanavra/civ7-cli:test --outputStyle=static` failed with
+  exit 1. The first failures were 5s timeouts in integration-heavy game command
+  files; later assertion mismatches appeared in the same files after earlier
+  timeouts left command/server work in flight.
+
+## Implementation
+
+- `vitest.config.ts` now gives only the `cli` project an explicit
+  `testTimeout: 30_000`; unrelated projects keep their existing timeout
+  behavior.
+- No CLI command code, oclif metadata, direct-control behavior, assertions, or
+  suites are changed.
+
+## Verification
+
+- Focused Nx CLI proof after the timeout budget:
+  `bunx nx run @mateicanavra/civ7-cli:test --outputStyle=static` passed with
+  exit 0. Nx ran the CLI test target and 8 dependency tasks; CLI passed 53
+  files / 234 tests in 309.74s.
+- Representative cache-backed root-load probe after the timeout budget:
+  `NX_DAEMON=false bunx nx run-many -t test
+  --projects=@mateicanavra/civ7-cli,mapgen-studio,@civ7/studio-server,@internal/habitat-harness,@civ7/docs,@civ7/playground,mod-civ7-intelligence-bridge
+  --parallel=6 --outputStyle=static` passed with exit 0, but most task output
+  was cache-backed, so it is secondary evidence only.
+- Representative uncached load probe:
+  `NX_DAEMON=false bunx nx run-many -t test
+  --projects=@mateicanavra/civ7-cli,mapgen-studio,@internal/habitat-harness,mod-civ7-intelligence-bridge
+  --parallel=4 --skip-nx-cache --outputStyle=static` failed with exit 1 in
+  `mapgen-studio:test`, not CLI. In that same uncached run, CLI passed 53
+  files / 234 tests in 445.71s. The remaining mapgen failures were
+  `standardLayerVisibility` timing out at 240s and
+  `Civ7TunerSession` failing its first shared-session test.
+- Full root proof after the timeout budget:
+  `NX_DAEMON=false bunx nx run-many -t test --outputStyle=static` again failed
+  in `mapgen-studio:test` with the same two-mapgen-test class. The wrapper was
+  interrupted only after the root proof was already red.
+- Evidence boundary: this slice clears the CLI root-load timeout class. H4
+  task 2.4 remains open because a separate mapgen root-load class is now the
+  root-test blocker.
+- OpenSpec validation:
+  `bun run openspec -- validate cli-root-load-test-timeouts --strict` passed
+  with `Change 'cli-root-load-test-timeouts' is valid`.
+- H4 cross-validation:
+  `bun run openspec -- validate habitat-biome-hygiene --strict` passed with
+  `Change 'habitat-biome-hygiene' is valid`.
+- Diff hygiene:
+  `git diff --check` passed with no output.
+- Generated/protected drift check:
+  `git diff --name-only | rg '(^|/)dist/|(^|/)types/|(^|/)mod/|^\.civ7/outputs/|src/maps/generated|packages/civ7-types/generated|civ7-tables\.gen\.ts|example-generated-mod' || true`
+  returned no tracked generated/protected paths.

--- a/openspec/changes/habitat-biome-hygiene/workstream/phase-record.md
+++ b/openspec/changes/habitat-biome-hygiene/workstream/phase-record.md
@@ -7,7 +7,7 @@
 - Owner: workstream owner agent (Codex continuation)
 - Branch/Graphite stack: `agent-F-habitat-biome-hygiene` -> `agent-F-habitat-boundary-tags` -> `agent-F-habitat-harness-scaffold` -> `agent-F-habitat-nx-adoption` -> `agent-F-habitat-harness-workstream` -> `main`
 - Started: 2026-06-13
-- Status: OPEN — Biome setup, format commit, blame shield, Prettier retirement, lint lane, and harness/Nx/CI integration complete; DL-15/DL-16 promoted repairs are verified, and the repo-wide `mapgen-studio:test` timeout class has a local repair slice. Task 2.4 and closure still require a final root-test proof before a green H4 claim.
+- Status: OPEN — Biome setup, format commit, blame shield, Prettier retirement, lint lane, and harness/Nx/CI integration complete; DL-15/DL-16 promoted repairs are verified; the first mapgen timeout class and CLI timeout class have local repair slices. Task 2.4 and closure remain blocked by a second `mapgen-studio:test` root-load class.
 
 ## Objective
 
@@ -60,10 +60,10 @@
 ## Implementation
 
 - Completed tasks: 1.1, 1.2, 2.1, 2.2, 2.3, 3.1, 3.2, 4.2.
-- Remaining tasks: 2.4, 4.1, 4.3. Task 2.4 has partial evidence: root build green; tracked pre/post format hashes match; fresh root build has no generated drift after DL-16 repair; plugin package tests and SDK package tests are green after DL-15 repairs. The `mapgen-studio:test` timeout class has been repaired in `mapgen-studio-test-timeouts`, with direct project proof and a representative Nx load proof, but full root test has not been rerun green, so 2.4 is not marked complete.
+- Remaining tasks: 2.4, 4.1, 4.3. Task 2.4 has partial evidence: root build green; tracked pre/post format hashes match; fresh root build has no generated drift after DL-16 repair; plugin package tests and SDK package tests are green after DL-15 repairs. The first `mapgen-studio:test` timeout class has been repaired in `mapgen-studio-test-timeouts`; the CLI root-load timeout class has been repaired in `cli-root-load-test-timeouts`; full root test now fails in a second mapgen root-load class, so 2.4 is not marked complete.
 - Biome lint lane: minimal green bug-risk rule set is enabled in `biome.json` with `recommended: false`; no desired red Biome rule was silently disabled after selection. The red assist class (`organizeImports`) was repaired mechanically by applying the safe assist and committing it separately; no ratchet baseline is required for `biome-ci` because the rule is locked with zero diagnostics.
 - Harness integration: `@internal/habitat-harness` now infers `biome:format`, `biome:check`, and `biome:ci`; `habitat fix` runs `biome check --write .` and `--dry-run` runs non-writing `biome check .`; `habitat check` includes locked `biome-ci`; `habitat verify` composes `build,check,test,boundaries,biome:ci`; CI runs `bunx nx run-many -t biome:ci`; README documents editor setup and the never-plain-`lint` target convention.
-- Stop conditions triggered: task 2.4 cannot close as green yet. The earlier DL-15 package-local Vitest fan-out / SDK teardown defects and DL-16 intelligence-bridge bundle drift are repaired. The root-test `mapgen-studio:test` timeout class is now isolated and locally repaired, but H4 still needs a final root-test proof before the proposal's strict build/test green claim.
+- Stop conditions triggered: task 2.4 cannot close as green yet. The earlier DL-15 package-local Vitest fan-out / SDK teardown defects and DL-16 intelligence-bridge bundle drift are repaired. The first root-test `mapgen-studio:test` timeout class and CLI timeout class are locally repaired, but a second mapgen root-load class remains: `standardLayerVisibility` can still exceed 240s under full/root-load execution, and `Civ7TunerSession` can fail its first shared-session test under that same load.
 
 ## Verification
 
@@ -214,6 +214,19 @@
   `mod-civ7-intelligence-bridge` passes with `mapgen-studio:test` at 47 files /
   233 tests in 381.19s. A full root test rerun is still required before H4 task
   2.4 can be marked complete.
+- CLI timeout repair evidence: `cli-root-load-test-timeouts` gives only the
+  root `cli` Vitest project a 30s timeout budget. Direct CLI proof passed 53
+  files / 234 tests in 278.03s before the change; focused Nx CLI reproduced
+  5s timeout failures before the change; after the change, focused Nx CLI
+  passed 53 files / 234 tests in 309.74s. Under a heavier uncached load probe,
+  CLI passed 53 files / 234 tests in 445.71s while `mapgen-studio:test` failed
+  separately.
+- Root test after CLI timeout repair: `NX_DAEMON=false bunx nx run-many -t
+  test --outputStyle=static` no longer exposes the CLI timeout class. It fails
+  in `mapgen-studio:test` with `standardLayerVisibility` timing out at 240s and
+  `Civ7TunerSession` failing the first shared-session test. The wrapper was
+  interrupted only after the root proof was already red and another child had
+  continued running.
 - Minimal Biome rule promotion result: selected green correctness/suspicious
   bug-risk rules pass under `biome ci`; nested `**/_archive/**` is excluded so
   live code can keep `noGlobalIsFinite` without historical archive churn.
@@ -247,16 +260,17 @@
 
 - Downstream docs/specs/issues updated: top-level workstream record reconciled from stale pre-execution state to H4-active state; H4 tasks updated for 3.1/3.2/4.2; DL-12 updated from pending to enforced Biome hygiene reality; DL-15/DL-16 moved to resolved-by-promoted-repair after the SDK/plugin/intelligence slices.
 - Tests/guards updated: Swooper Maps import guard now parses imports structurally; Habitat rule pack now includes locked `biome-ci`; CI includes `biome:ci`.
-- Deferrals/triage updated: the user/Fable suggested DL-15 SDK teardown, DL-16 intelligence bundle, and adapter-boundary river metadata repairs were promoted into separate Graphite/OpenSpec slices. The H4 `mapgen-studio:test` timeout blocker is promoted into and locally repaired by the `mapgen-studio-test-timeouts` slice; full root-test closure remains pending.
+- Deferrals/triage updated: the user/Fable suggested DL-15 SDK teardown, DL-16 intelligence bundle, and adapter-boundary river metadata repairs were promoted into separate Graphite/OpenSpec slices. The first H4 `mapgen-studio:test` timeout blocker and the CLI root-load timeout blocker are promoted into local repair slices; a second mapgen root-load blocker remains and should be isolated in the next slice.
 - Downstream realignment ledger: N/A at phase open.
 
 ## Next Action
 
-- Exact next step: validate and commit the `mapgen-studio-test-timeouts`
-  repair slice, then rerun the full root test before claiming H4 task 2.4 or
-  closure.
-- First files to inspect for closure blockers if root test remains red:
-  the new root-test log, `mods/mod-swooper-maps` long-running test behavior,
-  and any remaining non-mapgen timeout or assertion class surfaced by the full
-  run.
+- Exact next step: validate and commit the `cli-root-load-test-timeouts`
+  repair slice, then isolate the remaining `mapgen-studio:test` root-load
+  failures before claiming H4 task 2.4 or closure.
+- First files to inspect for the remaining mapgen blocker:
+  `apps/mapgen-studio/test/browserRunner/standardLayerVisibility.test.ts`,
+  `apps/mapgen-studio/test/server/tunerSession.test.ts`, and the new root-test
+  logs under `/tmp/habitat-root-test-after-cli-timeout-budget.log` and
+  `/tmp/cli-mapgen-root-load-after-timeout-budget-skip-cache.log`.
 - Stop condition: Biome config would format generated/protected zones, create non-format semantic diff, or require hygiene ownership that overlaps Nx/Grit.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
         root: r("packages/cli"),
         test: {
           name: "cli",
+          testTimeout: 30_000,
           env: {
             // Ensure oclif does not attempt to load dev plugins (like @oclif/plugin-plugins)
             // during tests; treat tests as production to suppress noisy warnings.


### PR DESCRIPTION
Adds a project-scoped `testTimeout: 30_000` to the `cli` Vitest project in the root workspace config, fixing a second root-load timeout class that surfaced after the `mapgen-studio:test` timeout repair advanced the H4 root proof into the CLI project.

Under direct execution (`bunx vitest run --config vitest.config.ts --project cli`), all 53 CLI files / 234 tests passed within the default 5s budget. Under focused Nx execution (`bunx nx run @mateicanavra/civ7-cli:test`), integration-heavy game command tests hit the 5s default, leaving async command/server work in flight and contaminating later assertions in the same files. The project-scoped budget resolves those failures without touching unrelated projects or weakening any assertions.

After the fix, focused Nx CLI passes 53 files / 234 tests in 309.74s, and an uncached multi-project load probe confirms CLI passes (445.71s) while the remaining root-test blocker is isolated to a second `mapgen-studio:test` root-load class (`standardLayerVisibility` exceeding 240s and `Civ7TunerSession` failing its first shared-session test). H4 task 2.4 remains open pending resolution of that mapgen class.

The `cli-root-load-test-timeouts` OpenSpec slice is introduced with proposal, spec, tasks, and phase record. The workstream record and `habitat-biome-hygiene` phase record are updated to reflect the new blocker boundary.