### PR TITLE
`fix(mapgen-studio): reduce standardLayerVisibility fixture and stabilize tuner FIN proof under root-load`

### DIFF
--- a/apps/mapgen-studio/test/browserRunner/standardLayerVisibility.test.ts
+++ b/apps/mapgen-studio/test/browserRunner/standardLayerVisibility.test.ts
@@ -42,15 +42,15 @@ async function runStandardRecipeInWorker(): Promise<BrowserRunEvent[]> {
       recipeId: "mod-swooper-maps/standard",
       seed: 1780185340,
       mapSizeId: "MAPSIZE_TINY",
-      dimensions: { width: 32, height: 20 },
+      dimensions: { width: 8, height: 6 },
       latitudeBounds: { topLatitude: 70, bottomLatitude: -70 },
-      playerCount: 4,
+      playerCount: 2,
       resourcesMode: "balanced",
       configOverrides: {},
     },
   });
 
-  const deadline = Date.now() + 120_000;
+  const deadline = Date.now() + 180_000;
   while (Date.now() < deadline) {
     const terminal = harness.events.find(
       (event) =>

--- a/apps/mapgen-studio/test/server/tunerSession.test.ts
+++ b/apps/mapgen-studio/test/server/tunerSession.test.ts
@@ -34,24 +34,26 @@ describe("Civ7TunerSession (Effect scoped shared session)", () => {
     const tuner = await startFakeTuner();
     const { runtime, service } = await makeRuntime(tuner.port);
 
-    const first = await runtime.runPromise(
-      service.use((o) =>
-        executeCiv7Command({ port: tuner.port, command: "first", timeoutMs: 1_000, ...o })
-      )
-    );
-    const second = await runtime.runPromise(
-      service.use((o) =>
-        executeCiv7Command({ port: tuner.port, command: "second", timeoutMs: 1_000, ...o })
-      )
-    );
+    try {
+      const first = await runtime.runPromise(
+        service.use((o) =>
+          executeCiv7Command({ port: tuner.port, command: "first", timeoutMs: 5_000, ...o })
+        )
+      );
+      const second = await runtime.runPromise(
+        service.use((o) =>
+          executeCiv7Command({ port: tuner.port, command: "second", timeoutMs: 5_000, ...o })
+        )
+      );
 
-    expect(first.output).toEqual(["null"]);
-    expect(second.output).toEqual(["null"]);
-    expect(tuner.connections()).toBe(1);
+      expect(first.output).toEqual(["null"]);
+      expect(second.output).toEqual(["null"]);
+      expect(tuner.connections()).toBe(1);
+    } finally {
+      await runtime.dispose();
+    }
 
-    await runtime.dispose();
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(tuner.finReceived()).toBe(true);
+    expect(await waitForFin(tuner)).toBe(true);
   });
 
   test("gate: fails fast after the threshold, half-opens after cooldown, resets on success", async () => {
@@ -193,6 +195,15 @@ async function startFakeTuner(): Promise<FakeTuner> {
     },
     close,
   };
+}
+
+async function waitForFin(tuner: FakeTuner): Promise<boolean> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (tuner.finReceived()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return tuner.finReceived();
 }
 
 function encodeResponse(listenerId: number, parts: readonly string[]): Buffer {

--- a/docs/projects/habitat-harness/workstream-record.md
+++ b/docs/projects/habitat-harness/workstream-record.md
@@ -5,8 +5,8 @@
 - **Method:** `civ7-systematic-workstream` (12 gates) composed with `civ7-open-spec-workstream` (per-slice phase loop)
 - **Controlling frame:** `docs/projects/habitat-harness/FRAME.md` (hard core, falsifier, settled decisions D1–D6)
 - **Stack root:** `agent-F-habitat-harness-workstream` (worktree `wt-agent-F-habitat-harness-workstream`, parent `main`, Graphite-tracked)
-- **Current execution branch:** `agent-F-cli-root-load-test-timeouts` stacked above the promoted H4 proof repairs
-- **Status:** IN EXECUTION — H1/H2/H3 closed locally; H4 Biome setup/lint/integration is complete and DL-15/DL-16 promoted repairs are verified; the first `mapgen-studio:test` timeout class and the CLI root-load timeout class are locally repaired, but H4 2.4 and closure remain blocked by a second `mapgen-studio:test` root-load class. H4.5 oclif CLI slice is implemented and verified before downstream CLI surface hardening.
+- **Current execution branch:** `agent-F-mapgen-studio-root-load-followup` stacked above the promoted H4 proof repairs
+- **Status:** IN EXECUTION — H1/H2/H3 closed locally; H4 Biome setup/lint/integration is complete and DL-15/DL-16 promoted repairs are verified; the first `mapgen-studio:test` timeout class, the CLI root-load timeout class, and the second `mapgen-studio:test` root-load class are locally repaired. A fresh full root-test rerun passed `mapgen-studio:test` but exposed a separate deterministic `mod-swooper-maps:test` catalog facade order proof. H4 2.4 and closure remain open until that blocker is repaired and full root-test proof is green. H4.5 oclif CLI slice is implemented and verified before downstream CLI surface hardening.
 
 ## Gate state (systematic-workstream)
 
@@ -20,7 +20,7 @@
 | 6 Expectations | DONE | per-slice verification gates; ratchet baselines predeclared (project plane green; adapter-boundary baseline = 6) |
 | 7 Architecture translation | DONE | taxonomy.md (tags/constraints); five-layer ownership in FRAME hard core #2 |
 | 8 Slices | IN TRAIN | OpenSpec train below; H1/H2/H3 closed locally; H4 active with Biome integration complete; H4.5 oclif CLI migration implemented locally; promoted proof repairs are stacked above H4 |
-| 9 Local stats | IN TRAIN | H1 build-output byte parity complete; H4 tracked post-format hashes match pre-format hashes; post-repair root build has no generated drift; first `mapgen-studio` and CLI timeout classes have local repair proof; final root test still red on second mapgen class |
+| 9 Local stats | IN TRAIN | H1 build-output byte parity complete; H4 tracked post-format hashes match pre-format hashes; post-repair root build has no generated drift; first `mapgen-studio`, CLI, and second `mapgen-studio` root-load classes have local repair proof; fresh full root now fails in `mod-swooper-maps:test` catalog-order proof |
 | 10 Runtime proof | N/A by design | harness touches structure only; byte-parity gates stand in (H1/H4) |
 | 11 Review | IN TRAIN | spec lane DONE (ledger); architecture lane before H3; impl/evidence/closure per slice |
 | 12 Closure | IN TRAIN | H1/H2/H3 have local phase closure records; H4 open on root-test proof; H4.5 and promoted proof repairs are implemented/verified locally above H4 |
@@ -56,11 +56,15 @@ proof repairs for DL-16 (`intelligence-bridge-ui-bundle`), SDK async teardown
 (`civ7-sdk-mod-build-sync-writes`), adapter-boundary river metadata, and
 DL-15 plugin Vitest project scoping are stacked above H4. H4 task 2.4 remains
 open because the full root test is not yet green after the
-`mapgen-studio-test-timeouts` and `cli-root-load-test-timeouts` repairs. Root
-build/parity is green, the CLI root-load timeout class is repaired, and direct
-plus representative Nx-load `mapgen-studio:test` proof is green for the first
-mapgen class; the latest full root proof now fails in a second mapgen
-root-load class.
+`mapgen-studio-test-timeouts`, `cli-root-load-test-timeouts`, and
+`mapgen-studio-root-load-followup` repairs. Root build/parity is green, the
+CLI root-load timeout class is repaired, and direct plus representative
+Nx-load `mapgen-studio:test` proof is green for both known mapgen classes. A
+fresh full root-test rerun passed `mapgen-studio:test` but failed in
+`mod-swooper-maps:test`: the morphology catalog ownership proof expects the
+domain config facade exports in pre-Biome order while the source now exports
+the same two recipe-facing modules in Biome-organized order. No H4 green claim
+is made until that separate proof is repaired and full root test passes.
 
 ## Proof classes per slice (predeclared)
 
@@ -104,6 +108,6 @@ train redefines the other's authority.
    `workstream/phase-record.md`).
 3. ~~H4.5 oclif CLI migration and promoted DL-16 / SDK teardown /
    adapter-boundary repairs~~ DONE locally on the stack.
-4. Validate and commit `cli-root-load-test-timeouts`, then isolate the remaining
-   `mapgen-studio:test` root-load failures before claiming H4 task 2.4 or
-   moving into H5.
+4. Validate and commit `mapgen-studio-root-load-followup`, then promote the
+   `mod-swooper-maps:test` morphology catalog-order proof into the next
+   root-test repair slice before claiming H4 task 2.4 or moving into H5.

--- a/openspec/changes/habitat-biome-hygiene/workstream/phase-record.md
+++ b/openspec/changes/habitat-biome-hygiene/workstream/phase-record.md
@@ -7,7 +7,7 @@
 - Owner: workstream owner agent (Codex continuation)
 - Branch/Graphite stack: `agent-F-habitat-biome-hygiene` -> `agent-F-habitat-boundary-tags` -> `agent-F-habitat-harness-scaffold` -> `agent-F-habitat-nx-adoption` -> `agent-F-habitat-harness-workstream` -> `main`
 - Started: 2026-06-13
-- Status: OPEN — Biome setup, format commit, blame shield, Prettier retirement, lint lane, and harness/Nx/CI integration complete; DL-15/DL-16 promoted repairs are verified; the first mapgen timeout class and CLI timeout class have local repair slices. Task 2.4 and closure remain blocked by a second `mapgen-studio:test` root-load class.
+- Status: OPEN — Biome setup, format commit, blame shield, Prettier retirement, lint lane, and harness/Nx/CI integration complete; DL-15/DL-16 promoted repairs are verified; the first mapgen timeout class, CLI timeout class, and second mapgen root-load class have local repair slices. A fresh full root-test rerun passed `mapgen-studio:test` and now fails in a separate deterministic `mod-swooper-maps:test` catalog facade order proof; task 2.4 and closure remain open.
 
 ## Objective
 
@@ -60,10 +60,10 @@
 ## Implementation
 
 - Completed tasks: 1.1, 1.2, 2.1, 2.2, 2.3, 3.1, 3.2, 4.2.
-- Remaining tasks: 2.4, 4.1, 4.3. Task 2.4 has partial evidence: root build green; tracked pre/post format hashes match; fresh root build has no generated drift after DL-16 repair; plugin package tests and SDK package tests are green after DL-15 repairs. The first `mapgen-studio:test` timeout class has been repaired in `mapgen-studio-test-timeouts`; the CLI root-load timeout class has been repaired in `cli-root-load-test-timeouts`; full root test now fails in a second mapgen root-load class, so 2.4 is not marked complete.
+- Remaining tasks: 2.4, 4.1, 4.3. Task 2.4 has partial evidence: root build green; tracked pre/post format hashes match; fresh root build has no generated drift after DL-16 repair; plugin package tests and SDK package tests are green after DL-15 repairs. The first `mapgen-studio:test` timeout class has been repaired in `mapgen-studio-test-timeouts`; the CLI root-load timeout class has been repaired in `cli-root-load-test-timeouts`; the second mapgen root-load class has focused/direct/representative proof in `mapgen-studio-root-load-followup`, and the next full root-test rerun passed `mapgen-studio:test`. That full root proof now fails in `mod-swooper-maps:test`, so task 2.4 is not marked complete.
 - Biome lint lane: minimal green bug-risk rule set is enabled in `biome.json` with `recommended: false`; no desired red Biome rule was silently disabled after selection. The red assist class (`organizeImports`) was repaired mechanically by applying the safe assist and committing it separately; no ratchet baseline is required for `biome-ci` because the rule is locked with zero diagnostics.
 - Harness integration: `@internal/habitat-harness` now infers `biome:format`, `biome:check`, and `biome:ci`; `habitat fix` runs `biome check --write .` and `--dry-run` runs non-writing `biome check .`; `habitat check` includes locked `biome-ci`; `habitat verify` composes `build,check,test,boundaries,biome:ci`; CI runs `bunx nx run-many -t biome:ci`; README documents editor setup and the never-plain-`lint` target convention.
-- Stop conditions triggered: task 2.4 cannot close as green yet. The earlier DL-15 package-local Vitest fan-out / SDK teardown defects and DL-16 intelligence-bridge bundle drift are repaired. The first root-test `mapgen-studio:test` timeout class and CLI timeout class are locally repaired, but a second mapgen root-load class remains: `standardLayerVisibility` can still exceed 240s under full/root-load execution, and `Civ7TunerSession` can fail its first shared-session test under that same load.
+- Stop conditions triggered: task 2.4 cannot close as green yet. The earlier DL-15 package-local Vitest fan-out / SDK teardown defects and DL-16 intelligence-bridge bundle drift are repaired. The first root-test `mapgen-studio:test` timeout class, CLI timeout class, and second mapgen root-load class are locally repaired. The current stop condition is a separate deterministic `mod-swooper-maps:test` morphology catalog ownership proof: the domain config facade exports the same allowed recipe-facing modules, but in Biome-organized order.
 
 ## Verification
 
@@ -222,11 +222,36 @@
   CLI passed 53 files / 234 tests in 445.71s while `mapgen-studio:test` failed
   separately.
 - Root test after CLI timeout repair: `NX_DAEMON=false bunx nx run-many -t
-  test --outputStyle=static` no longer exposes the CLI timeout class. It fails
+  test --outputStyle=static` no longer exposes the CLI timeout class. It failed
   in `mapgen-studio:test` with `standardLayerVisibility` timing out at 240s and
   `Civ7TunerSession` failing the first shared-session test. The wrapper was
   interrupted only after the root proof was already red and another child had
   continued running.
+- Mapgen root-load follow-up evidence: `mapgen-studio-root-load-followup`
+  reduces the `standardLayerVisibility` fixture to the same standard recipe at
+  `8x6` with two players while preserving the existing terminal/layer
+  assertions, and stabilizes the first `Civ7TunerSession` proof with a
+  test-local 5s fake-tuner command timeout, `finally` disposal, and bounded FIN
+  polling. Focused browser proof passed (1 test, 35.788s body). Focused tuner
+  proof passed (3 tests, 1.28s body after the final browser reduction). Direct
+  `mapgen-studio` project proof passed 47 files / 233 tests in 131.53s.
+  Representative uncached Nx load proof with `--excludeTaskDependencies`
+  passed for `mapgen-studio`, `@mateicanavra/civ7-cli`,
+  `@internal/habitat-harness`, and `mod-civ7-intelligence-bridge`; the final
+  `8x6` run exited 0 for all four targets and `standardLayerVisibility` passed
+  in 11.150s.
+- Root test after mapgen root-load follow-up:
+  `NX_DAEMON=false bunx nx run-many -t test --outputStyle=static` failed with
+  exit 1, but no longer through `mapgen-studio:test` (`mapgen-studio` passed
+  47 files / 233 tests). The failed task is `mod-swooper-maps:test`, and a
+  focused reproduction with `NX_DAEMON=false bunx nx run
+  mod-swooper-maps:test --skip-nx-cache --outputStyle=static` fails only
+  `test/morphology/catalog-ownership.test.ts` (`morphology catalog ownership >
+  keeps the domain config facade limited to recipe-facing knobs`). The expected
+  and received files contain the same two exports
+  (`./shared/knobs.js` and `./shared/knob-multipliers.js`) in different order.
+  This is the next promoted H4 proof repair; no H4 task 2.4 green claim is
+  made from this root run.
 - Minimal Biome rule promotion result: selected green correctness/suspicious
   bug-risk rules pass under `biome ci`; nested `**/_archive/**` is excluded so
   live code can keep `noGlobalIsFinite` without historical archive churn.
@@ -260,17 +285,18 @@
 
 - Downstream docs/specs/issues updated: top-level workstream record reconciled from stale pre-execution state to H4-active state; H4 tasks updated for 3.1/3.2/4.2; DL-12 updated from pending to enforced Biome hygiene reality; DL-15/DL-16 moved to resolved-by-promoted-repair after the SDK/plugin/intelligence slices.
 - Tests/guards updated: Swooper Maps import guard now parses imports structurally; Habitat rule pack now includes locked `biome-ci`; CI includes `biome:ci`.
-- Deferrals/triage updated: the user/Fable suggested DL-15 SDK teardown, DL-16 intelligence bundle, and adapter-boundary river metadata repairs were promoted into separate Graphite/OpenSpec slices. The first H4 `mapgen-studio:test` timeout blocker and the CLI root-load timeout blocker are promoted into local repair slices; a second mapgen root-load blocker remains and should be isolated in the next slice.
+- Deferrals/triage updated: the user/Fable suggested DL-15 SDK teardown, DL-16 intelligence bundle, and adapter-boundary river metadata repairs were promoted into separate Graphite/OpenSpec slices. The first H4 `mapgen-studio:test` timeout blocker, the CLI root-load timeout blocker, and the second mapgen root-load blocker are promoted into local repair slices. The remaining root-test blocker is `mod-swooper-maps:test` morphology catalog facade order proof and should be isolated in the next slice.
 - Downstream realignment ledger: N/A at phase open.
 
 ## Next Action
 
-- Exact next step: validate and commit the `cli-root-load-test-timeouts`
-  repair slice, then isolate the remaining `mapgen-studio:test` root-load
-  failures before claiming H4 task 2.4 or closure.
-- First files to inspect for the remaining mapgen blocker:
-  `apps/mapgen-studio/test/browserRunner/standardLayerVisibility.test.ts`,
-  `apps/mapgen-studio/test/server/tunerSession.test.ts`, and the new root-test
-  logs under `/tmp/habitat-root-test-after-cli-timeout-budget.log` and
-  `/tmp/cli-mapgen-root-load-after-timeout-budget-skip-cache.log`.
+- Exact next step: validate and commit the `mapgen-studio-root-load-followup`
+  repair slice, then promote the current `mod-swooper-maps:test` morphology
+  catalog facade order proof into its own root-test repair slice before
+  claiming H4 task 2.4 or closure.
+- First files to inspect for the remaining Swooper Maps blocker:
+  `mods/mod-swooper-maps/AGENTS.md`,
+  `mods/mod-swooper-maps/test/morphology/catalog-ownership.test.ts`,
+  `mods/mod-swooper-maps/src/domain/morphology/config.ts`, and the focused
+  reproduction log at `/tmp/mod-swooper-maps-test-after-mapgen-followup.log`.
 - Stop condition: Biome config would format generated/protected zones, create non-format semantic diff, or require hygiene ownership that overlaps Nx/Grit.

--- a/openspec/changes/mapgen-studio-root-load-followup/proposal.md
+++ b/openspec/changes/mapgen-studio-root-load-followup/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+After the first `mapgen-studio` timeout slice and the CLI timeout repair, the
+H4 root-test proof no longer fails on inherited 5s project budgets or CLI
+root-load timing. The remaining blocker is a second `mapgen-studio:test`
+root-load class:
+
+- `standardLayerVisibility` can still exceed its own explicit 240s budget under
+  saturated root Nx load.
+- `Civ7TunerSession` can fail its first shared-session test under the same
+  load with an `Effect.tryPromise` timeout/error while preserving the direct
+  project green path.
+
+H4 needs root-test evidence that proves the Biome reformat did not change
+behavior. These failures are proof-harness brittleness under full repo load,
+not changes to Studio behavior or Habitat architecture.
+
+## What Changes
+
+- Further reduce the `standardLayerVisibility` browser-worker fixture workload
+  while keeping the same standard recipe and the same layer visibility
+  assertions.
+- Make the first `Civ7TunerSession` test dispose the Effect runtime in a
+  `finally` path and wait for the peer-observed FIN with a bounded poll instead
+  of a fixed sleep.
+- Keep the proof repair test-local and semantics-preserving.
+- Update H4 records with the new evidence boundary.
+
+## What Does Not Change
+
+- No Studio runtime, recipe, worker, Effect Layer/Scope, or direct-control
+  production behavior changes.
+- No assertion is skipped or weakened: the browser test still requires
+  `run.finished` and the expected visible/debug layers, and the tuner test
+  still requires one shared connection plus graceful FIN on runtime dispose.
+- No global Vitest timeout increase for unrelated projects.
+
+## Affected Owners
+
+- `apps/mapgen-studio/test/browserRunner/standardLayerVisibility.test.ts`
+- `apps/mapgen-studio/test/server/tunerSession.test.ts`
+- Habitat H4 proof records
+
+## Verification Gates
+
+- Focused browser-worker test.
+- Focused `Civ7TunerSession` test.
+- Direct `mapgen-studio` Vitest project.
+- Representative uncached Nx load probe that includes `mapgen-studio:test`.
+- `bun run openspec -- validate mapgen-studio-root-load-followup --strict`
+- H4 cross-validation.
+- `git diff --check`
+
+## Stop Conditions
+
+- A test becomes green only by removing the production path being asserted.
+- The one-connection or FIN invariant is weakened.
+- A root-load probe still fails in the same mapgen class after this repair.

--- a/openspec/changes/mapgen-studio-root-load-followup/specs/habitat-harness/spec.md
+++ b/openspec/changes/mapgen-studio-root-load-followup/specs/habitat-harness/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Mapgen Studio Root-Load Proofs Are Assertion-Preserving
+
+Habitat H4 root-test proof repairs SHALL keep existing mapgen-studio
+behavioral assertions intact while making the proof resilient under repo-wide
+Nx load.
+
+#### Scenario: Browser visibility proof uses a compact standard recipe fixture
+- **WHEN** `standardLayerVisibility` runs in the browser-worker harness
+- **THEN** it still executes the standard recipe
+- **AND** it still requires `run.finished`, default-visible core balance
+  layers, default-visible tile movement vector/arrow layers, and debug-only raw
+  world motion layers
+- **AND** the fixture scale is compact enough to run inside the explicit
+  project/root-load timeout budget
+
+#### Scenario: Effect-scoped tuner session closes gracefully under load
+- **WHEN** the shared `Civ7TunerSession` proof runs under saturated root-load
+  execution
+- **THEN** the test still proves two uses share exactly one connection
+- **AND** disposing the `ManagedRuntime` still emits a peer-observed FIN
+- **AND** cleanup runs even if a command assertion fails before disposal

--- a/openspec/changes/mapgen-studio-root-load-followup/tasks.md
+++ b/openspec/changes/mapgen-studio-root-load-followup/tasks.md
@@ -1,0 +1,24 @@
+## 1. Phase Opening
+
+- [x] 1.1 Create the phase record before implementation.
+- [x] 1.2 Preserve the inherited H4/root-load failure evidence.
+
+## 2. Implementation
+
+- [x] 2.1 Reduce the `standardLayerVisibility` fixture workload without
+  changing the standard recipe or assertions.
+- [x] 2.2 Stabilize the first `Civ7TunerSession` proof with deterministic
+  cleanup and bounded FIN waiting.
+- [x] 2.3 Confirm no production app/runtime code or unrelated project timeout
+  budgets change.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused browser-worker test.
+- [x] 3.2 Run the focused `Civ7TunerSession` test.
+- [x] 3.3 Run the direct `mapgen-studio` Vitest project.
+- [x] 3.4 Run a representative uncached Nx load probe including
+  `mapgen-studio:test`.
+- [x] 3.5 Run OpenSpec validation for this change and H4.
+- [x] 3.6 Run `git diff --check`.
+- [x] 3.7 Update H4/workstream records with the result.

--- a/openspec/changes/mapgen-studio-root-load-followup/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-root-load-followup/workstream/phase-record.md
@@ -1,0 +1,135 @@
+# Mapgen Studio Root-Load Follow-up Phase Record
+
+## State
+
+- Branch/Graphite stack: `agent-F-mapgen-studio-root-load-followup` above
+  `agent-F-cli-root-load-test-timeouts`.
+- Change id: `mapgen-studio-root-load-followup`.
+- Objective: remove the remaining H4 root-test proof blocker by stabilizing
+  the second `mapgen-studio:test` root-load class without weakening existing
+  assertions.
+- Status: IMPLEMENTED AND LOCALLY VERIFIED; full H4 root-test proof was rerun
+  after this repair and passed `mapgen-studio:test`, then failed in a separate
+  `mod-swooper-maps:test` catalog-order proof. H4 task 2.4 remains open.
+
+## Authority And Inputs
+
+- Root `AGENTS.md`: keep generated outputs read-only, update adjacent records,
+  and leave the worktree clean.
+- H4 phase record: H4 task 2.4 remains open because full/root-load test proof
+  fails only in `mapgen-studio:test` after the earlier DL-15/DL-16, first
+  mapgen, and CLI repairs.
+- `mapgen-studio-test-timeouts`: previous slice gave the project a scoped
+  timeout and reduced the browser fixture to `32x20`, but heavy root load can
+  still exceed the browser test's explicit 240s budget.
+- `cli-root-load-test-timeouts`: CLI root-load timeouts are repaired; the
+  remaining red class is independent.
+
+## Opening Evidence
+
+- Representative uncached root-load probe after the CLI timeout repair:
+  `NX_DAEMON=false bunx nx run-many -t test
+  --projects=@mateicanavra/civ7-cli,mapgen-studio,@internal/habitat-harness,mod-civ7-intelligence-bridge
+  --parallel=4 --skip-nx-cache --outputStyle=static` failed in
+  `mapgen-studio:test`, while CLI passed 53 files / 234 tests in 445.71s.
+- The failing mapgen classes were:
+  - `test/browserRunner/standardLayerVisibility.test.ts`: explicit 240s
+    timeout at 241.738s.
+  - `test/server/tunerSession.test.ts`: first shared-session FIN test failed
+    with `(FiberFailure) UnknownException: An unknown error occurred in
+    Effect.tryPromise`.
+- A later full root probe replayed the same mapgen class; no H4 task 2.4 green
+  claim has been made.
+
+## Implementation Plan
+
+1. Keep `standardLayerVisibility` on the standard recipe and preserve every
+   asserted layer/invariant, but shrink the map dimensions further so the proof
+   covers layer wiring rather than large-map runtime.
+2. Keep the tuner test's one-connection and FIN assertions, but make cleanup
+   deterministic with `finally` and replace the fixed 50ms FIN sleep with a
+   bounded poll.
+3. Verify focused tests first, then direct project, then representative
+   uncached Nx load using `--excludeTaskDependencies` to avoid unrelated
+   dependency rebuild churn.
+
+## Verification
+
+- Focused browser-worker probes:
+  - `bunx vitest run --config vitest.config.ts --project mapgen-studio
+    test/browserRunner/standardLayerVisibility.test.ts` passed with the
+    intermediate `24x16` fixture, but the test body still took 204.70s under
+    concurrent focused load, which was too close to the 240s cap.
+  - The same focused command passed with `16x12` in 120.28s.
+  - The same focused command passed with `12x8`/2 players in 37.83s, proving
+    the same assertions still held at the smaller standard-recipe scale.
+  - Final focused proof with `8x6`/2 players passed with exit 0 (1 file / 1
+    test, 39.41s duration, test body 35.788s). The emitted logs showed
+    `plotCount: 48`, placement surface output, resource placement output, and
+    the unchanged layer assertions passed.
+- Focused tuner proof:
+  `bunx vitest run --config vitest.config.ts --project mapgen-studio
+  test/server/tunerSession.test.ts` passed twice after the final tuner change:
+  first in 180.98s total / 6.02s test time while the browser focused run was
+  concurrent, then in 34.44s total / 1.28s test time after the final browser
+  reduction.
+- Direct project proof:
+  - With the intermediate `12x8` fixture, `bunx vitest run --config
+    vitest.config.ts --project mapgen-studio` passed 47 files / 233 tests in
+    171.33s.
+  - With the final `8x6` fixture, the same direct project command passed 47
+    files / 233 tests in 131.53s. `standardLayerVisibility` passed inside that
+    run with a 116.811s test body; `tunerSession` passed with the first
+    shared-session FIN proof at 931ms.
+- Representative load proof:
+  - An intermediate `12x8` run passed:
+    `NX_DAEMON=false bunx nx run-many -t test
+    --projects=mapgen-studio,@mateicanavra/civ7-cli,@internal/habitat-harness,mod-civ7-intelligence-bridge
+    --parallel=4 --skip-nx-cache --excludeTaskDependencies --outputStyle=static`.
+    `mapgen-studio:test` passed 47 files / 233 tests in 350.45s; the browser
+    proof passed in 190.111s and the tuner proof passed in 3.201s.
+  - Final `8x6` representative proof used the same command and passed with
+    exit 0 for all four targets. `mapgen-studio:test` passed 47 files / 233
+    tests; `standardLayerVisibility` passed in 11.150s and the CLI target
+    passed 53 files / 234 tests. Nx still reported `@mateicanavra/civ7-cli:test`
+    as flaky because of prior failed history, but the command exited 0.
+- OpenSpec validation:
+  `bun run openspec -- validate mapgen-studio-root-load-followup --strict`
+  passed.
+- H4 cross-validation:
+  `bun run openspec -- validate habitat-biome-hygiene --strict` passed.
+- Full root-test proof after this repair:
+  `NX_DAEMON=false bunx nx run-many -t test --outputStyle=static` failed with
+  exit 1, but the repaired class stayed green: `mapgen-studio:test` passed 47
+  files / 233 tests. The failed task is now `mod-swooper-maps:test`. A focused
+  reproduction with `NX_DAEMON=false bunx nx run mod-swooper-maps:test
+  --skip-nx-cache --outputStyle=static` fails only the morphology catalog
+  ownership proof, where the domain config facade contains the same two
+  allowed exports in Biome-organized order. This confirms the mapgen-studio
+  slice's repair boundary and promotes the next root-test blocker into its own
+  slice.
+- Diff hygiene:
+  `git diff --check` passed.
+- Generated/protected drift check:
+  `git diff --name-only | rg '(^|/)dist/|(^|/)types/|(^|/)mod/|^\.civ7/outputs/|src/maps/generated|packages/civ7-types/generated|civ7-tables\.gen\.ts|example-generated-mod|packages/cli/out\.svg' || true`
+  returned no tracked generated/protected paths.
+
+## Agent Review Notes
+
+- Lagrange (`019ec1fa-0148-78c2-a2a4-5460544956e8`) independently confirmed
+  the tuner-session shape: increase only the fake-tuner command timeout in the
+  first proof, dispose the Effect runtime in `finally`, and poll for FIN
+  without weakening the one-connection or FIN assertions.
+- Peirce (`019ec1f9-5e87-7901-8427-94bf587e3d20`) independently confirmed the
+  browser-runner shape: keep `mod-swooper-maps/standard`, not
+  `browser-test`, because the lightweight recipe cannot preserve the ecology
+  score-layer or placement land-mask assertions; shrink the fixture instead.
+
+## H4 Carry-forward
+
+- This slice clears the known second `mapgen-studio:test` root-load class under
+  focused, direct project, and representative uncached Nx load evidence.
+- A full root-test rerun after this slice passed `mapgen-studio:test` and
+  exposed a separate `mod-swooper-maps:test` catalog-order proof failure. No
+  full-root green claim is made from this slice alone; H4 task 2.4 remains open
+  until the next blocker is repaired and root test passes.


### PR DESCRIPTION
This repair slice addresses the second `mapgen-studio:test` root-load failure class that remained after the earlier timeout and CLI fixes.

**`standardLayerVisibility`** had its browser-worker fixture reduced from `32×20` with 4 players to `8×6` with 2 players. The standard recipe, terminal assertions, and all layer visibility checks are preserved — the fixture is smaller to ensure the test completes within its explicit budget under saturated root Nx load. The deadline is extended to 180s to match the now-smaller but still real workload.

**`Civ7TunerSession`** first shared-session test is stabilized by wrapping the two command executions and assertions in a `try/finally` block so the Effect `ManagedRuntime` is always disposed even if an assertion fails before reaching it. The fixed 50ms FIN sleep is replaced with a bounded poll (`waitForFin`) that checks every 20ms for up to 2 seconds, eliminating the race between disposal and peer-observed FIN detection. The fake-tuner command timeout is raised from 1s to 5s to absorb scheduling jitter under concurrent load.

No production runtime, recipe, worker, or Effect Layer/Scope behavior changes. No assertions are removed or weakened: the browser test still requires `run.finished` and the expected visible/debug layers; the tuner test still requires exactly one shared connection and a graceful FIN on runtime dispose.

A full root-test rerun after this repair passed `mapgen-studio:test` (47 files / 233 tests) but exposed a separate deterministic failure in `mod-swooper-maps:test`, where the morphology catalog ownership proof expects domain config facade exports in pre-Biome order. That failure is unrelated to this slice and will be promoted into its own repair. H4 task 2.4 remains open until that proof is fixed and the full root test passes.