### PR TITLE
`fix(mod-swooper-maps): make catalog ownership proof order-insensitive; advance H4 blocker to recipe artifact race`

### DIFF
--- a/docs/projects/habitat-harness/workstream-record.md
+++ b/docs/projects/habitat-harness/workstream-record.md
@@ -5,8 +5,8 @@
 - **Method:** `civ7-systematic-workstream` (12 gates) composed with `civ7-open-spec-workstream` (per-slice phase loop)
 - **Controlling frame:** `docs/projects/habitat-harness/FRAME.md` (hard core, falsifier, settled decisions D1–D6)
 - **Stack root:** `agent-F-habitat-harness-workstream` (worktree `wt-agent-F-habitat-harness-workstream`, parent `main`, Graphite-tracked)
-- **Current execution branch:** `agent-F-mapgen-studio-root-load-followup` stacked above the promoted H4 proof repairs
-- **Status:** IN EXECUTION — H1/H2/H3 closed locally; H4 Biome setup/lint/integration is complete and DL-15/DL-16 promoted repairs are verified; the first `mapgen-studio:test` timeout class, the CLI root-load timeout class, and the second `mapgen-studio:test` root-load class are locally repaired. A fresh full root-test rerun passed `mapgen-studio:test` but exposed a separate deterministic `mod-swooper-maps:test` catalog facade order proof. H4 2.4 and closure remain open until that blocker is repaired and full root-test proof is green. H4.5 oclif CLI slice is implemented and verified before downstream CLI surface hardening.
+- **Current execution branch:** `agent-F-mod-swooper-catalog-order-proof` stacked above the promoted H4 proof repairs
+- **Status:** IN EXECUTION — H1/H2/H3 closed locally; H4 Biome setup/lint/integration is complete and DL-15/DL-16 promoted repairs are verified; the first `mapgen-studio:test` timeout class, the CLI root-load timeout class, the second `mapgen-studio:test` root-load class, and the `mod-swooper-maps:test` catalog facade order proof are locally repaired. A fresh full root-test rerun now fails in a separate `mod-swooper-maps:test` generated recipe artifact race: the test can import `dist/recipes/standard-artifacts.js` while another root task is cleaning/rebuilding `build:studio-recipes`. H4 2.4 and closure remain open until that blocker is repaired and full root-test proof is green. H4.5 oclif CLI slice is implemented and verified before downstream CLI surface hardening.
 
 ## Gate state (systematic-workstream)
 
@@ -20,7 +20,7 @@
 | 6 Expectations | DONE | per-slice verification gates; ratchet baselines predeclared (project plane green; adapter-boundary baseline = 6) |
 | 7 Architecture translation | DONE | taxonomy.md (tags/constraints); five-layer ownership in FRAME hard core #2 |
 | 8 Slices | IN TRAIN | OpenSpec train below; H1/H2/H3 closed locally; H4 active with Biome integration complete; H4.5 oclif CLI migration implemented locally; promoted proof repairs are stacked above H4 |
-| 9 Local stats | IN TRAIN | H1 build-output byte parity complete; H4 tracked post-format hashes match pre-format hashes; post-repair root build has no generated drift; first `mapgen-studio`, CLI, and second `mapgen-studio` root-load classes have local repair proof; fresh full root now fails in `mod-swooper-maps:test` catalog-order proof |
+| 9 Local stats | IN TRAIN | H1 build-output byte parity complete; H4 tracked post-format hashes match pre-format hashes; post-repair root build has no generated drift; first `mapgen-studio`, CLI, second `mapgen-studio`, and `mod-swooper` catalog-order classes have local repair proof; fresh full root now fails in `mod-swooper-maps:test` recipe artifact race |
 | 10 Runtime proof | N/A by design | harness touches structure only; byte-parity gates stand in (H1/H4) |
 | 11 Review | IN TRAIN | spec lane DONE (ledger); architecture lane before H3; impl/evidence/closure per slice |
 | 12 Closure | IN TRAIN | H1/H2/H3 have local phase closure records; H4 open on root-test proof; H4.5 and promoted proof repairs are implemented/verified locally above H4 |
@@ -61,10 +61,14 @@ open because the full root test is not yet green after the
 CLI root-load timeout class is repaired, and direct plus representative
 Nx-load `mapgen-studio:test` proof is green for both known mapgen classes. A
 fresh full root-test rerun passed `mapgen-studio:test` but failed in
-`mod-swooper-maps:test`: the morphology catalog ownership proof expects the
-domain config facade exports in pre-Biome order while the source now exports
-the same two recipe-facing modules in Biome-organized order. No H4 green claim
-is made until that separate proof is repaired and full root test passes.
+`mod-swooper-maps:test`: first on a morphology catalog ownership proof whose
+allowed exports were in Biome-organized order, then after that local repair on
+an unhandled ENOENT reading
+`mods/mod-swooper-maps/dist/recipes/standard-artifacts.js`. The latter appears
+to be an Nx target dependency/output race between package tests that import
+generated recipe exports and root tasks that clean/rebuild `build:studio-recipes`.
+No H4 green claim is made until that separate proof is repaired and full root
+test passes.
 
 ## Proof classes per slice (predeclared)
 
@@ -99,6 +103,12 @@ train redefines the other's authority.
 - Trade-offs taken → FRAME §3 table, visibly revisitable (D6).
 - New baseline entries only via the rule-introduction gate; baselines otherwise shrink-only.
 - habitat-native rule budget watched against the FRAME degeneration trigger (≥3 tool-assigned rules falling back to native ⇒ stop and re-evaluate).
+- Structural/boundary/lint-style checks found in normal test suites are
+  temporary compatibility gates only. H5/H6 must migrate them into the Habitat
+  harness owner that fits (Nx/Biome/Grit/file-layer/native), prove parity, and
+  retire the normal-test copy. Current H4 root-proof examples:
+  `mods/mod-swooper-maps/test/morphology/catalog-ownership.test.ts` and
+  `mods/mod-swooper-maps/test/config/standard-recipe-artifact-guards.test.ts`.
 - Worktree/Graphite discipline per repo skills; one slice per branch; `gt restack --upstack` after mid-stack changes; `gt sync --no-restack` in shared environments.
 
 ## Next exact action
@@ -108,6 +118,6 @@ train redefines the other's authority.
    `workstream/phase-record.md`).
 3. ~~H4.5 oclif CLI migration and promoted DL-16 / SDK teardown /
    adapter-boundary repairs~~ DONE locally on the stack.
-4. Validate and commit `mapgen-studio-root-load-followup`, then promote the
-   `mod-swooper-maps:test` morphology catalog-order proof into the next
+4. Validate and commit `mod-swooper-catalog-order-proof`, then promote the
+   `mod-swooper-maps:test` generated recipe artifact race into the next
    root-test repair slice before claiming H4 task 2.4 or moving into H5.

--- a/mods/mod-swooper-maps/test/morphology/catalog-ownership.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/catalog-ownership.test.ts
@@ -25,13 +25,17 @@ function collectTsFiles(dir: string): string[] {
 
 describe("morphology catalog ownership", () => {
   it("keeps the domain config facade limited to recipe-facing knobs", () => {
-    const configText = readFileSync(join(MORPHOLOGY_ROOT, "config.ts"), "utf8").trim();
+    const configExports = readFileSync(join(MORPHOLOGY_ROOT, "config.ts"), "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .sort();
+    const expectedConfigExports = [
+      'export * from "./shared/knob-multipliers.js";',
+      'export * from "./shared/knobs.js";',
+    ].sort();
 
-    expect(configText).toBe(
-      ['export * from "./shared/knobs.js";', 'export * from "./shared/knob-multipliers.js";'].join(
-        "\n"
-      )
-    );
+    expect(configExports).toEqual(expectedConfigExports);
   });
 
   it("keeps op strategy schemas out of domain config facades", () => {

--- a/openspec/changes/habitat-biome-hygiene/workstream/phase-record.md
+++ b/openspec/changes/habitat-biome-hygiene/workstream/phase-record.md
@@ -7,7 +7,7 @@
 - Owner: workstream owner agent (Codex continuation)
 - Branch/Graphite stack: `agent-F-habitat-biome-hygiene` -> `agent-F-habitat-boundary-tags` -> `agent-F-habitat-harness-scaffold` -> `agent-F-habitat-nx-adoption` -> `agent-F-habitat-harness-workstream` -> `main`
 - Started: 2026-06-13
-- Status: OPEN — Biome setup, format commit, blame shield, Prettier retirement, lint lane, and harness/Nx/CI integration complete; DL-15/DL-16 promoted repairs are verified; the first mapgen timeout class, CLI timeout class, and second mapgen root-load class have local repair slices. A fresh full root-test rerun passed `mapgen-studio:test` and now fails in a separate deterministic `mod-swooper-maps:test` catalog facade order proof; task 2.4 and closure remain open.
+- Status: OPEN — Biome setup, format commit, blame shield, Prettier retirement, lint lane, and harness/Nx/CI integration complete; DL-15/DL-16 promoted repairs are verified; the first mapgen timeout class, CLI timeout class, second mapgen root-load class, and Swooper Maps catalog-order proof have local repair slices. A fresh full root-test rerun now fails in a separate `mod-swooper-maps:test` generated recipe artifact race; task 2.4 and closure remain open.
 
 ## Objective
 
@@ -60,10 +60,10 @@
 ## Implementation
 
 - Completed tasks: 1.1, 1.2, 2.1, 2.2, 2.3, 3.1, 3.2, 4.2.
-- Remaining tasks: 2.4, 4.1, 4.3. Task 2.4 has partial evidence: root build green; tracked pre/post format hashes match; fresh root build has no generated drift after DL-16 repair; plugin package tests and SDK package tests are green after DL-15 repairs. The first `mapgen-studio:test` timeout class has been repaired in `mapgen-studio-test-timeouts`; the CLI root-load timeout class has been repaired in `cli-root-load-test-timeouts`; the second mapgen root-load class has focused/direct/representative proof in `mapgen-studio-root-load-followup`, and the next full root-test rerun passed `mapgen-studio:test`. That full root proof now fails in `mod-swooper-maps:test`, so task 2.4 is not marked complete.
+- Remaining tasks: 2.4, 4.1, 4.3. Task 2.4 has partial evidence: root build green; tracked pre/post format hashes match; fresh root build has no generated drift after DL-16 repair; plugin package tests and SDK package tests are green after DL-15 repairs. The first `mapgen-studio:test` timeout class has been repaired in `mapgen-studio-test-timeouts`; the CLI root-load timeout class has been repaired in `cli-root-load-test-timeouts`; the second mapgen root-load class has focused/direct/representative proof in `mapgen-studio-root-load-followup`, and the next full root-test rerun passed `mapgen-studio:test`. The Swooper Maps catalog-order proof has focused and Nx project proof in `mod-swooper-catalog-order-proof`. The full root proof now fails in a separate `mod-swooper-maps:test` generated recipe artifact race, so task 2.4 is not marked complete.
 - Biome lint lane: minimal green bug-risk rule set is enabled in `biome.json` with `recommended: false`; no desired red Biome rule was silently disabled after selection. The red assist class (`organizeImports`) was repaired mechanically by applying the safe assist and committing it separately; no ratchet baseline is required for `biome-ci` because the rule is locked with zero diagnostics.
 - Harness integration: `@internal/habitat-harness` now infers `biome:format`, `biome:check`, and `biome:ci`; `habitat fix` runs `biome check --write .` and `--dry-run` runs non-writing `biome check .`; `habitat check` includes locked `biome-ci`; `habitat verify` composes `build,check,test,boundaries,biome:ci`; CI runs `bunx nx run-many -t biome:ci`; README documents editor setup and the never-plain-`lint` target convention.
-- Stop conditions triggered: task 2.4 cannot close as green yet. The earlier DL-15 package-local Vitest fan-out / SDK teardown defects and DL-16 intelligence-bridge bundle drift are repaired. The first root-test `mapgen-studio:test` timeout class, CLI timeout class, and second mapgen root-load class are locally repaired. The current stop condition is a separate deterministic `mod-swooper-maps:test` morphology catalog ownership proof: the domain config facade exports the same allowed recipe-facing modules, but in Biome-organized order.
+- Stop conditions triggered: task 2.4 cannot close as green yet. The earlier DL-15 package-local Vitest fan-out / SDK teardown defects and DL-16 intelligence-bridge bundle drift are repaired. The first root-test `mapgen-studio:test` timeout class, CLI timeout class, second mapgen root-load class, and Swooper Maps catalog-order proof are locally repaired. The current stop condition is a separate `mod-swooper-maps:test` generated recipe artifact race: under full root execution, the package test can import `dist/recipes/standard-artifacts.js` while another target is cleaning/rebuilding `build:studio-recipes`.
 
 ## Verification
 
@@ -252,6 +252,24 @@
   (`./shared/knobs.js` and `./shared/knob-multipliers.js`) in different order.
   This is the next promoted H4 proof repair; no H4 task 2.4 green claim is
   made from this root run.
+- Swooper Maps catalog-order proof evidence: `mod-swooper-catalog-order-proof`
+  keeps the morphology config facade source unchanged and changes the
+  ownership proof to compare the exact set of non-empty export lines. Focused
+  `bun test test/morphology/catalog-ownership.test.ts` passed 3 tests / 6
+  expects. `NX_DAEMON=false bunx nx run mod-swooper-maps:test --skip-nx-cache
+  --outputStyle=static` passed 567 tests, 2 skipped, 0 failed across 145 files
+  with 31,867 expects. No generated/protected tracked drift was present after
+  the Nx project proof.
+- Root test after Swooper Maps catalog-order proof:
+  `NX_DAEMON=false bunx nx run-many -t test --outputStyle=static` failed with
+  exit 1. `mapgen-studio:test` still passed 47 files / 233 tests. The failed
+  task remained `mod-swooper-maps:test`, but the catalog-order proof no longer
+  failed; the new failure was an unhandled ENOENT reading
+  `mods/mod-swooper-maps/dist/recipes/standard-artifacts.js` during
+  `test/config/standard-recipe-artifact-guards.test.ts`. The file exists after
+  the run completes, pointing to a root-load target/output race around
+  `build:studio-recipes`, not catalog facade ownership. This is the next
+  promoted H4 proof repair.
 - Minimal Biome rule promotion result: selected green correctness/suspicious
   bug-risk rules pass under `biome ci`; nested `**/_archive/**` is excluded so
   live code can keep `noGlobalIsFinite` without historical archive churn.
@@ -285,18 +303,25 @@
 
 - Downstream docs/specs/issues updated: top-level workstream record reconciled from stale pre-execution state to H4-active state; H4 tasks updated for 3.1/3.2/4.2; DL-12 updated from pending to enforced Biome hygiene reality; DL-15/DL-16 moved to resolved-by-promoted-repair after the SDK/plugin/intelligence slices.
 - Tests/guards updated: Swooper Maps import guard now parses imports structurally; Habitat rule pack now includes locked `biome-ci`; CI includes `biome:ci`.
-- Deferrals/triage updated: the user/Fable suggested DL-15 SDK teardown, DL-16 intelligence bundle, and adapter-boundary river metadata repairs were promoted into separate Graphite/OpenSpec slices. The first H4 `mapgen-studio:test` timeout blocker, the CLI root-load timeout blocker, and the second mapgen root-load blocker are promoted into local repair slices. The remaining root-test blocker is `mod-swooper-maps:test` morphology catalog facade order proof and should be isolated in the next slice.
+- Deferrals/triage updated: the user/Fable suggested DL-15 SDK teardown, DL-16 intelligence bundle, and adapter-boundary river metadata repairs were promoted into separate Graphite/OpenSpec slices. The first H4 `mapgen-studio:test` timeout blocker, the CLI root-load timeout blocker, the second mapgen root-load blocker, and the Swooper Maps catalog-order proof are promoted into local repair slices. The remaining root-test blocker is `mod-swooper-maps:test` generated recipe artifact race and should be isolated in the next slice.
+- Structural-test migration note: the catalog ownership proof and standard
+  recipe artifact guard are not intended to remain ordinary tests at workstream
+  end. H4 may repair them only as inherited root-proof blockers; H5/H6 should
+  port them to the harness owner that fits, prove parity, and retire the
+  normal-test copy.
 - Downstream realignment ledger: N/A at phase open.
 
 ## Next Action
 
-- Exact next step: validate and commit the `mapgen-studio-root-load-followup`
-  repair slice, then promote the current `mod-swooper-maps:test` morphology
-  catalog facade order proof into its own root-test repair slice before
-  claiming H4 task 2.4 or closure.
-- First files to inspect for the remaining Swooper Maps blocker:
-  `mods/mod-swooper-maps/AGENTS.md`,
-  `mods/mod-swooper-maps/test/morphology/catalog-ownership.test.ts`,
-  `mods/mod-swooper-maps/src/domain/morphology/config.ts`, and the focused
-  reproduction log at `/tmp/mod-swooper-maps-test-after-mapgen-followup.log`.
+- Exact next step: validate and commit the `mod-swooper-catalog-order-proof`
+  repair slice, then promote the current `mod-swooper-maps:test` generated
+  recipe artifact race into its own root-test repair slice before claiming H4
+  task 2.4 or closure.
+- First files to inspect for the remaining Swooper Maps artifact-race blocker:
+  `mods/mod-swooper-maps/package.json`,
+  `mods/mod-swooper-maps/tsup.studio-recipes.config.ts`,
+  `mods/mod-swooper-maps/scripts/generate-studio-recipe-types.ts`,
+  `mods/mod-swooper-maps/test/config/standard-recipe-artifact-guards.test.ts`,
+  `apps/mapgen-studio/package.json`, `nx.json`, and the full root log at
+  `/tmp/h4-root-test-after-swooper-catalog-proof.log`.
 - Stop condition: Biome config would format generated/protected zones, create non-format semantic diff, or require hygiene ownership that overlaps Nx/Grit.

--- a/openspec/changes/mod-swooper-catalog-order-proof/proposal.md
+++ b/openspec/changes/mod-swooper-catalog-order-proof/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+After `mapgen-studio-root-load-followup`, the H4 full root-test proof no
+longer fails through `mapgen-studio:test`. The next deterministic blocker is
+`mod-swooper-maps:test`:
+
+- `test/morphology/catalog-ownership.test.ts` checks that the morphology domain
+  config facade stays limited to recipe-facing knob exports.
+- The source facade still exports exactly the allowed modules, but Biome import
+  organization sorted them in the opposite order from the test's literal
+  string.
+
+The ownership invariant is correct; the order-sensitive assertion is not. H4
+needs the proof to enforce facade membership exactly without fighting the
+formatter.
+
+## What Changes
+
+- Make the morphology catalog ownership proof parse/export the facade as a set
+  of export lines.
+- Keep the allowed export set exact: no strategy schemas, ops, or extra domain
+  modules may enter the domain config facade.
+- Record the full-root blocker and verification boundary in the H4 workstream
+  evidence.
+
+## What Does Not Change
+
+- No Swooper Maps runtime behavior, recipes, morphology implementation, or
+  generated `mod/` output changes.
+- No weakening of the facade ownership invariant: the test still fails for any
+  missing or extra export.
+- No Biome/taxonomy/Habitat rule weakening.
+
+## Affected Owners
+
+- `mods/mod-swooper-maps/test/morphology/catalog-ownership.test.ts`
+- Habitat H4 proof records
+
+## Verification Gates
+
+- Focused morphology catalog ownership test from the package.
+- Direct `mod-swooper-maps` project test through Nx.
+- OpenSpec validation for this change and H4.
+- `git diff --check`
+- Generated/protected drift grep.
+
+## Stop Conditions
+
+- The facade ownership assertion stops rejecting extra exports.
+- Source/runtime files must change to satisfy formatter-controlled ordering.
+- `mod-swooper-maps:test` remains red in the same catalog ownership class.

--- a/openspec/changes/mod-swooper-catalog-order-proof/specs/habitat-harness/spec.md
+++ b/openspec/changes/mod-swooper-catalog-order-proof/specs/habitat-harness/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Formatter-Stable Catalog Ownership Proofs
+
+Habitat H4 proof repairs SHALL preserve exact architectural ownership checks
+while avoiding assertions whose only failure mode is formatter-controlled
+ordering.
+
+#### Scenario: Domain config facade exports are checked as an exact set
+- **WHEN** the Swooper Maps morphology catalog ownership proof reads the domain
+  config facade
+- **THEN** it accepts the allowed recipe-facing knob exports in any
+  formatter-produced order
+- **AND** it still fails for any missing export
+- **AND** it still fails for any extra export from op strategy schemas,
+  implementation modules, or unrelated domain surfaces

--- a/openspec/changes/mod-swooper-catalog-order-proof/tasks.md
+++ b/openspec/changes/mod-swooper-catalog-order-proof/tasks.md
@@ -1,0 +1,19 @@
+## 1. Phase Opening
+
+- [x] 1.1 Create the phase record before implementation.
+- [x] 1.2 Preserve the full-root and focused reproduction evidence.
+
+## 2. Implementation
+
+- [x] 2.1 Make the morphology config facade proof exact but order-insensitive.
+- [x] 2.2 Confirm no source/runtime or generated output changes are needed.
+- [x] 2.3 Update H4/workstream records with the repaired proof boundary.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused morphology catalog ownership test.
+- [x] 3.2 Run `mod-swooper-maps:test` through Nx.
+- [ ] 3.3 Run OpenSpec validation for this change and H4.
+- [ ] 3.4 Run `git diff --check`.
+- [x] 3.5 Check for generated/protected drift.
+- [x] 3.6 Rerun the full root test before claiming H4 task 2.4.

--- a/openspec/changes/mod-swooper-catalog-order-proof/workstream/phase-record.md
+++ b/openspec/changes/mod-swooper-catalog-order-proof/workstream/phase-record.md
@@ -1,0 +1,81 @@
+# Mod Swooper Catalog Order Proof Phase Record
+
+## State
+
+- Branch/Graphite stack: `agent-F-mod-swooper-catalog-order-proof` above
+  `agent-F-mapgen-studio-root-load-followup`.
+- Change id: `mod-swooper-catalog-order-proof`.
+- Objective: remove the current H4 full-root proof blocker by making the
+  Swooper Maps morphology catalog ownership test exact about facade membership
+  but independent of Biome-controlled export order.
+- Status: IMPLEMENTED AND LOCALLY VERIFIED; full H4 root-test proof was rerun
+  after this repair and failed in a separate generated recipe artifact race.
+
+## Authority And Inputs
+
+- Root `AGENTS.md`: keep generated outputs read-only, update adjacent records,
+  and leave the worktree clean.
+- `mods/mod-swooper-maps/AGENTS.md`: `mod/` is generated build output and must
+  stay read-only; use package/root test commands for verification.
+- `mods/mod-swooper-maps/src/AGENTS.md`: source entrypoints stay small and
+  declarative; avoid source changes for a test-order issue.
+- H4 phase record: H4 task 2.4 remains open because the full root-test proof
+  now fails in `mod-swooper-maps:test` after the mapgen-studio root-load
+  classes are repaired.
+
+## Opening Evidence
+
+- Full root proof after `mapgen-studio-root-load-followup`:
+  `NX_DAEMON=false bunx nx run-many -t test --outputStyle=static` failed with
+  exit 1. `mapgen-studio:test` passed 47 files / 233 tests. The failed task is
+  `mod-swooper-maps:test`.
+- Focused reproduction:
+  `NX_DAEMON=false bunx nx run mod-swooper-maps:test --skip-nx-cache
+  --outputStyle=static` failed only
+  `test/morphology/catalog-ownership.test.ts` (`morphology catalog ownership >
+  keeps the domain config facade limited to recipe-facing knobs`).
+- The expected and received facade contents have the same two allowed export
+  lines, `./shared/knobs.js` and `./shared/knob-multipliers.js`, in different
+  order.
+
+## Implementation Plan
+
+1. Keep the source facade unchanged unless investigation finds real ownership
+   drift.
+2. Replace the literal file-string assertion with an exact set assertion over
+   non-empty export lines.
+3. Verify the focused proof first, then the direct Nx project, then update H4
+   records before the next full root-test proof.
+
+## Verification
+
+- Focused proof:
+  `bun test test/morphology/catalog-ownership.test.ts` from
+  `mods/mod-swooper-maps` passed 3 tests / 6 expects.
+- Direct Nx project proof:
+  `NX_DAEMON=false bunx nx run mod-swooper-maps:test --skip-nx-cache
+  --outputStyle=static` passed twice after the repair. The logged run at
+  `/tmp/mod-swooper-maps-test-after-catalog-order-proof.log` passed 567 tests,
+  2 skipped, 0 failed across 145 files with 31,867 expects.
+- Generated/protected drift check after the Nx project proof returned no
+  tracked generated/protected paths.
+- Full root proof after this repair:
+  `NX_DAEMON=false bunx nx run-many -t test --outputStyle=static` failed with
+  exit 1. `mapgen-studio:test` passed 47 files / 233 tests, and the
+  catalog-order proof no longer failed. The failed task remained
+  `mod-swooper-maps:test` because `test/config/standard-recipe-artifact-guards.test.ts`
+  saw an unhandled ENOENT reading
+  `mods/mod-swooper-maps/dist/recipes/standard-artifacts.js` while root-load
+  execution was also rebuilding `build:studio-recipes`. This is a separate
+  generated recipe artifact race and the next H4 proof repair.
+
+## H4 Carry-forward
+
+- This slice clears the catalog facade order proof under focused and direct Nx
+  project evidence.
+- This is a temporary H4 root-proof repair, not the final home for the guard.
+  The catalog ownership proof is a structural boundary check and should be
+  migrated into Habitat-owned enforcement during H5/H6, then retired from the
+  normal test suite after parity proof.
+- No H4 task 2.4 green claim is made until the generated recipe artifact race
+  is repaired and full root test passes.


### PR DESCRIPTION
The `mod-swooper-maps:test` morphology catalog ownership proof was failing under full root execution because Biome's import organizer reordered the two allowed facade exports (`./shared/knobs.js` and `./shared/knob-multipliers.js`) relative to the test's literal string expectation. The source facade was correct; only the assertion was order-sensitive.

The fix replaces the exact file-string comparison in `catalog-ownership.test.ts` with a set-based comparison over non-empty export lines, so the proof enforces facade membership exactly without being sensitive to formatter-controlled ordering. The allowed export set is unchanged — any missing or extra export still fails the test.

Focused proof (`bun test test/morphology/catalog-ownership.test.ts`) passed 3 tests / 6 expects. Direct Nx project proof (`mod-swooper-maps:test`) passed 567 tests across 145 files with 31,867 expects and no generated drift.

A subsequent full root-test rerun confirmed the catalog-order failure is cleared. The run now fails on a separate blocker: `test/config/standard-recipe-artifact-guards.test.ts` hits an ENOENT reading `dist/recipes/standard-artifacts.js` while another root task is concurrently cleaning and rebuilding `build:studio-recipes`. That generated recipe artifact race is the next promoted H4 proof repair; no H4 task 2.4 green claim is made from this slice.

Workstream and phase records are updated to reflect the new stop condition, the carry-forward note that both the catalog ownership proof and the recipe artifact guard are temporary H4 root-proof repairs to be migrated into Habitat-owned enforcement during H5/H6, and the next exact action targeting the artifact race.