### PR TITLE
`docs(habitat): add Effect-native core parent design workstream`

### DIFF
--- a/openspec/changes/habitat-effect-native-core/design.md
+++ b/openspec/changes/habitat-effect-native-core/design.md
@@ -1,0 +1,281 @@
+# Design — Effect-Native Habitat Core
+
+## Resolved Target Shape
+
+```text
+oclif command class
+  -> Habitat runtime bridge
+    -> Effect program
+      -> Habitat services/layers
+        -> platform command/filesystem/path/terminal
+        -> Git, Nx, Grit, Biome, baseline, hook, generated-zone services
+
+Nx generator or migration factory
+  -> Habitat Nx adapter bridge
+    -> Effect program or pure generator helper
+      -> Habitat services/layers
+        -> Nx Tree-backed generator workspace
+        -> rule-pack, baseline, taxonomy, and migration helpers
+```
+
+The command shell stays oclif. Oclif classes parse flags/args, run exactly one
+Habitat Effect program, render/write the returned result, and dispose the
+runtime before `Command.run()` resolves. Core modules return `Effect` values and
+structured results; they do not call `Effect.runPromise` or exit the process.
+
+The H8 generator and migration shell stays Nx. Generator and migration factory
+functions remain the metadata-declared Nx entrypoints. If they call reusable
+Effect logic, the factory is the host adapter boundary and must close any
+runtime, fibers, child processes, or scoped resources before returning or
+rejecting to Nx.
+
+The live layer is Node-oriented because the built oclif runner is
+`#!/usr/bin/env node` and the repo declares Node engine support. Root Bun
+scripts remain the normal invocation route for local development. A temp
+dependency probe on 2026-06-14 installed the Node platform packages under Bun
+without peer warnings and successfully ran a minimal `NodeContext.layer` program
+under Bun. The first implementation child repeats that proof in-repo before
+editing the harness manifest. Service interfaces stay platform-neutral.
+
+## Package Decision
+
+Add these dependencies to `@internal/habitat-harness` during implementation:
+
+- `effect@3.21.3`
+- `@effect/platform@0.96.1`
+- `@effect/platform-node@0.107.0`
+
+Registry peer evidence on 2026-06-14 shows the platform packages accept
+`effect@^3.21.2`. Registry metadata for `@effect/platform-node` also declares
+peers on `@effect/rpc`, `@effect/sql`, and `@effect/cluster`; Bun accepted the
+install without peer warnings in a temp probe. The first implementation task
+must repeat the install in-repo, inspect peer output, and prove both
+`bun tools/habitat-harness/bin/dev.ts ...` and the built `bin/run.js` path still
+execute. Required peer warnings or runtime failure stop the child change before
+core code migration.
+
+Do not add `effect-orpc`. Habitat is a local CLI harness in this change, not an
+RPC service.
+
+## Runtime Bridge
+
+Introduce a small adapter-level API, for example:
+
+```ts
+runHabitatCommand(program, options): Promise<A>
+```
+
+Responsibilities:
+
+- assemble `HabitatRuntimeLive`;
+- run the provided Effect program;
+- map expected Habitat errors into command-facing failure records;
+- dispose the runtime in `finally`;
+- ensure all scoped resources, fibers, child processes, and finalizers finish
+  before returning to oclif.
+
+`HabitatCommand` may expose a protected helper that calls this bridge. Command
+classes still own oclif parsing and final stdout/stderr writes so machine JSON
+stays deterministic.
+
+Pure report stringification, schema validation, and human rendering stay plain.
+Command adapters own stdout/stderr emission and `--output` writes, or delegate
+only the file write to a narrowly scoped adapter output capability.
+
+## Service Boundaries
+
+| Service | Owns | Backing Layer |
+|---|---|---|
+| `HabitatWorkspace` | repo root, harness root, baselines dir, repo-relative paths, package discovery | platform path/filesystem |
+| `HabitatProcess` | argument-array execution, cwd/env/PATH policy, stdout/stderr capture, exit code, subprocess lifecycle | platform Command |
+| `HabitatGit` | merge-base, git show, staged paths, unstaged paths, Graphite parent, exact `git add` | `HabitatProcess` |
+| `BaselineStore` | load/write baselines, shrink-only integrity, violation-key application | workspace + fs + Git |
+| `RuleRegistry` | rule-pack loading, rule lookup, selection | workspace + fs |
+| `RuleRunner` | dispatch to Grit/file-layer/native/process-backed rules | registry + tool services |
+| `GritService` | one JSON scan per check process, apply-mode patterns, cache dir policy, JSON parsing handoff | process + workspace |
+| `BiomeService` | format/check/fix command construction and execution | process |
+| `NxService` | affected verification, graph generation | process + scoped temp |
+| `HookRunner` | pre-commit/pre-push orchestration and staged-index mutation policy | Git + tool services |
+| `GeneratedZoneVerifier` | snapshot, regenerate, diff, restore, delete untracked generated artifacts | fs + Git + process |
+| `NxGeneratorTree` | generator-owned `exists`, `children`, `read`, `write`, JSON writes, and dry-run/in-memory tree semantics | Nx `Tree` |
+| Effect `Clock` / `TestClock` | duration measurement, schedules, deterministic timing tests | Effect built-ins |
+
+Keep these plain:
+
+- diagnostic/report TypeScript types;
+- report rendering functions;
+- Grit JSON parser and adapter-boundary parser;
+- git name-status parser;
+- generated-zone path matching;
+- rule status calculation after diagnostics are available;
+- Nx `createNodesV2` plugin JS.
+
+## Error Model
+
+Separate domain findings from infrastructure failures.
+
+- Rule violations are data in `CheckReport`; they do not fail the Effect program
+  unless command execution itself cannot produce a report.
+- Non-zero tool exits that currently become diagnostics remain diagnostics.
+- Process launch failures, unreadable malformed baseline files, invalid
+  generated-zone definitions, and unparseable mandatory tool JSON become tagged
+  Habitat errors.
+- Command adapters map tagged errors to stderr and exit code 1 or 2 according to
+  the existing command class semantics.
+
+Use `Data.TaggedError` for expected internal errors where the caller needs
+structured fields. Internal report-schema failures remain defects: the adapter
+surfaces them as internal errors rather than treating an impossible report shape
+as an expected user/tool failure.
+
+## Resource And Concurrency Policy
+
+Use `Scope` for:
+
+- temp directories created by graph generation or probes;
+- child-process lifetimes where streaming execution is introduced;
+- generated-zone file snapshots and restore finalizers;
+- lock files or cache guards;
+- queue drains and background fibers.
+
+Rule execution should be sequential until parity tests prove bounded fan-out.
+After parity is pinned, `Effect.all` concurrency must be a declared number based
+on tool/process safety. Grit keeps one scan per check process; rule projection
+can consume the shared result.
+
+Generator-owned files are not platform-filesystem writes. The generator child
+uses an Nx `Tree`-backed service so dry-run behavior, in-memory generator
+tests, and Nx transaction semantics remain intact. Platform filesystem access
+from generator logic is allowed only for explicitly documented read-only
+evidence outside the generator tree.
+
+Grit parity includes the exact current audit roots, `--level error`,
+`GRIT_CACHE_DIR`, `GRIT_TELEMETRY_DISABLED`, parser attempts against stdout and
+stderr, and projection by `local_name` or `check_id`. The hook staged-file Grit
+scan is a separate parity surface because it scans staged TS/JS paths rather
+than the full audit roots.
+
+Use `Queue` for staged-file or probe drains only when there is a real producer
+and consumer boundary. Use `Semaphore` around Git index mutation, generated-zone
+snapshot/restore, and shared cache access when those paths can be invoked in the
+same runtime. Use `Schedule` for retry/debounce policies such as transient tool
+execution, polling, and hook debounce; do not encode reusable timing policy with
+ad hoc timers.
+
+## Migration Phases
+
+### Phase 1: Runtime And Service Skeleton
+
+Add the dependencies, runtime bridge, service tags, live layers, and fake test
+layers. Keep existing command behavior by adapting current synchronous helpers
+behind the new services.
+
+### Phase 2: Process, Workspace, Git, Baseline
+
+Move PATH injection, command execution, repo path logic, merge-base/git-show,
+staged path parsing, and baseline integrity into services. Add parity tests for
+stdout/stderr/exit code, no-merge-base behavior, malformed baseline behavior,
+Git index path parsing, and `--expand-baseline` authoring behavior. Baseline
+authoring parity includes selected-rule writes, stable sort/newline formatting,
+no check report emission during expansion, and the rule-introduction exception
+used by shrink-only integrity.
+
+### Phase 3: Check Orchestration
+
+Move `createCheckReport`, baseline application, rule dispatch, Grit shared-scan
+projection, file-layer checks, and report emission into Effect programs. Keep
+the `CheckReport` schema and human rendering stable.
+
+### Phase 4: Remaining Oclif Commands
+
+Move `fix`, `verify`, `graph`, and `classify` onto Effect-backed command
+programs. `graph` uses scoped temp directories. `verify` keeps output
+forwarding and affected target semantics. H8 classify parity includes
+repo-relative and absolute paths, workspace-level paths, literal diffs,
+`.diff`/`.patch` files, and the four-path matrix recorded by H8.
+
+### Phase 5: Nx Generators And Migrations
+
+Move reusable H8 generator/migration logic behind Nx-native adapters. The
+project generator keeps schema acceptance for all taxonomy spellings while
+runtime-refusing non-uniform kinds; it keeps default roots/package names,
+non-empty root refusal, package scripts, ESM exports, Node engine, tsconfig,
+source/test stubs, and README output. The pattern generator keeps native Grit
+pattern creation, empty baseline creation, duplicate artifact refusal, and
+rule-pack append semantics. Migrations remain Nx migration factories and local
+run-file driven because the package is unpublished.
+
+Before implementation chooses module boundaries, it must pin one bridge for the
+current ESM package plus source CJS factory metadata while preserving the H8
+metadata paths: CJS factories dynamically import implementation code, or a
+deliberately small CJS-compatible pure core remains for generator/migration
+factories.
+
+### Phase 6: Hooks
+
+Move pre-commit and pre-push orchestration after fake Git/FS/process tests pin:
+resource publish invocation, staged file-layer check, partially staged refusal,
+formatter-touched restage, Biome check, Grit staged scan, Graphite parent base,
+and pre-push affected target set.
+
+The migrated pre-commit path calls internal Habitat check/rule programs for the
+staged file-layer check instead of spawning `bun tools/habitat-harness/bin/dev.ts
+check` recursively. The preserved H7 resource-publish behavior remains the one
+non-formatter mutation carve-out and is limited to the resources submodule
+gitlink behavior already accepted by H7.
+
+### Phase 7: Generated-Zone Verifier
+
+Move `verify-generated-zones.mjs` after snapshot/restore/delete parity is
+covered by tests. The scoped snapshot finalizer restores tracked map artifact
+files even when regeneration or diff checks fail, then removes untracked map
+artifacts created by the verification run. The policy-table path remains a
+check-only gate unless a later source-backed child change changes that behavior;
+the verifier still proves the final worktree is clean across all generated
+target inputs.
+
+## Test Strategy
+
+- Adapter tests keep mocking at the command boundary to prove oclif flag/arg
+  parsing and stdout/stderr writes.
+- Service tests use fake layers for process, Git, filesystem, workspace, and
+  clock.
+- Generator tests use an Nx `Tree`-backed fake/live service so dry-run,
+  in-memory tree behavior, and duplicate write protection remain under Nx
+  control.
+- Parity tests compare pre-refactor and Effect-backed command outputs for
+  representative `check`, `fix --dry-run`, `verify --base`, `graph --json`,
+  `classify`, `hook pre-commit`, `hook pre-push`, and generated-zone checks.
+- Command parity includes `check --output`, filtered checks, staged file-layer
+  checks, unknown hook exit 2, and verify check-fail ordering before Nx runs.
+- Native Grit pattern tests remain native Grit tests.
+- Runtime lifecycle tests assert scoped finalizers run before command helpers
+  resolve.
+- TestClock covers schedule/backoff/debounce policies introduced by the slice.
+
+## Review Lanes Before Implementation
+
+- OpenSpec lane: sequencing after H8, artifact shape, stop conditions, and no
+  historical rewrite of H1-H8.
+- Effect lane: service/layer design, runtime placement, scope closure, tagged
+  errors, platform dependency choice, concurrency policy.
+- Harness parity lane: command contracts, JSON, baselines, Grit, hooks,
+  classify, generators, generated-zone verification.
+- Testing lane: fake layers, deterministic clock, lifecycle tests, native tool
+  probes.
+- Workflow lane: Graphite cleanliness, generated artifact discipline, validation
+  gates, and documentation touchpoints.
+
+## Parent Spec Split
+
+This parent change uses one spec directory per major child workstream:
+
+| Child change | Parent spec delta |
+|---|---|
+| `habitat-effect-runtime-substrate` | `specs/habitat-effect-runtime-substrate/spec.md` |
+| `habitat-effect-process-baselines` | `specs/habitat-effect-process-baselines/spec.md` |
+| `habitat-effect-check-orchestration` | `specs/habitat-effect-check-orchestration/spec.md` |
+| `habitat-effect-command-programs` | `specs/habitat-effect-command-programs/spec.md` |
+| `habitat-effect-nx-generators-migrations` | `specs/habitat-effect-nx-generators-migrations/spec.md` |
+| `habitat-effect-hooks` | `specs/habitat-effect-hooks/spec.md` |
+| `habitat-effect-generated-verifier` | `specs/habitat-effect-generated-verifier/spec.md` |

--- a/openspec/changes/habitat-effect-native-core/proposal.md
+++ b/openspec/changes/habitat-effect-native-core/proposal.md
@@ -1,0 +1,212 @@
+# Change: Effect-Native Habitat Core
+
+## Summary
+
+Create the parent design workstream for making Habitat's reusable core
+Effect-native now that the H8 Habitat train tail is locally closed. Oclif
+remains the command adapter for Habitat commands; Nx remains the host adapter
+for Habitat generators and migrations. Reusable Habitat logic moves into
+Effect programs composed from services/layers for workspace access, process
+execution, Git, baselines, rule orchestration, Grit, Biome, Nx, hooks,
+classify, generated-zone verification, and Nx generator tree operations.
+
+This parent change records architecture, sequencing, stop conditions, review
+findings, and child workstream boundaries. Implementation is split into child
+OpenSpec changes after this parent. The intended refactor preserves command
+names, flags, JSON contracts, exit semantics, ratchet behavior, hook policy,
+resource-publish behavior, classify output, Nx generator/migration surface, and
+enforcement ownership.
+
+## Why
+
+The current harness is deliberately migration-first and enforcement-first. That
+served H1-H8: Nx, Biome, Grit, file-layer checks, baselines, hooks, generators,
+and classify needed to land without inventing a product architecture. The result
+is now a real orchestration toolkit whose core still relies on synchronous
+Node/Bun filesystem and process calls.
+
+Effect is the right substrate for the next stage because the harness now needs
+typed services, scoped resources, bounded concurrency, queues, retry/debounce
+policy, deterministic testing, and adapter-owned lifecycle closure. Official
+Effect docs make those first-class concepts: services/context and layers,
+resource management with Scope/finalizers, ManagedRuntime, platform Command and
+FileSystem services, Queue/PubSub/Semaphore, Schedule, Schema, Config, logging,
+and TestClock.
+
+Local precedent already exists in `@civ7/studio-server`: a `ManagedRuntime`
+is built at the host boundary, services are supplied through layers, a scoped
+resource is acquired with `Effect.acquireRelease`, and runtime disposal closes
+the owned resource.
+
+## Target Authority Refs
+
+- `docs/projects/habitat-harness/FRAME.md` hard core, D7, and trade-off note
+  that future Effect internals run from the CLI adapter and close scopes before
+  command completion.
+- `docs/projects/habitat-harness/workstream-record.md` H1-H8 train order.
+- `docs/projects/habitat-harness/review-disposition-ledger.md` F40 H8-after-H7
+  sequencing decision.
+- `openspec/changes/habitat-oclif-cli/specs/habitat-harness/spec.md`
+  lifecycle-boundary requirement.
+- `openspec/changes/habitat-git-hooks/workstream/phase-record.md` current H7
+  status.
+- `openspec/changes/habitat-generators-migrations/proposal.md`,
+  `openspec/changes/habitat-generators-migrations/specs/habitat-harness/spec.md`,
+  `openspec/changes/habitat-generators-migrations/tasks.md`, and
+  `openspec/changes/habitat-generators-migrations/workstream/phase-record.md`
+  as the H8 parity target.
+- Official Effect docs for services/context, layers, resource management,
+  runtime, platform command/filesystem/path/terminal, concurrency primitives,
+  scheduling, schema/config/logging, and testing.
+- Local Effect precedent in `packages/studio-server/src/runtime.ts`,
+  `packages/studio-server/src/services/Civ7TunerSession.ts`,
+  `packages/studio-server/src/handler.ts`, and
+  `packages/civ7-control-orpc/src/procedure.ts`.
+
+## What Changes
+
+- Add a parent OpenSpec workstream, `habitat-effect-native-core`, that defines
+  the Effect-native Habitat core architecture and child implementation gates
+  with one spec delta per major child change.
+- Split implementation into child changes:
+  `habitat-effect-runtime-substrate`,
+  `habitat-effect-process-baselines`,
+  `habitat-effect-check-orchestration`,
+  `habitat-effect-command-programs`,
+  `habitat-effect-nx-generators-migrations`,
+  `habitat-effect-hooks`, and
+  `habitat-effect-generated-verifier`.
+- Make oclif commands adapter-only: parse flags/args, run one Habitat Effect
+  program, render/write the returned result, and dispose the runtime before
+  command completion.
+- Make Nx generators and migrations adapter-owned: Nx factory functions remain
+  native generator/migration entrypoints, use an Nx `Tree`-backed service for
+  tree-owned reads/writes, and close generator/migration-scoped resources before
+  returning to Nx.
+- Introduce Effect services/layers for Habitat workspace, process execution,
+  Git, baselines, rule registry, rule runner, Grit, Biome, Nx, hooks,
+  generated-zone verification, reporting, Nx generator tree access, and clock
+  access.
+- Add dependency and runtime guidance for Effect and a Node-oriented live
+  platform layer, with in-repo proof required before manifest changes.
+- Add parity gates for command contracts, JSON output, baselines, Grit scan
+  semantics, hooks, classify, generators, migrations, and generated-zone drift.
+- Add review lanes and stop conditions before implementation begins.
+
+## What Does Not Change
+
+- No command name, flag, JSON schema, stdout/stderr placement, exit-code,
+  ratchet, hook, classify, generator, migration, or generated-zone behavior
+  changes as part of the substrate refactor.
+- No Nx generator schema, `generators.json`, `migrations.json`, factory module
+  loading, dry-run tree behavior, or local migration run-file contract changes.
+- No product/runtime Civ7 control, MapGen/Swooper, SDK, Studio, or mod behavior
+  is redesigned.
+- No `effect-orpc` dependency is added to Habitat in this CLI-core slice.
+- No historical H1-H8 proposal/task/spec record is rewritten.
+
+## Requires For Implementation
+
+- H7 `habitat-git-hooks` closed and committed.
+- H8 `habitat-generators-migrations` closed and committed.
+- The Habitat command, hook, classify, generator, and migration surfaces after
+  H8 treated as the parity target.
+- Verified package versions for `effect`, `@effect/platform`, and the live
+  platform layer. Temp-install evidence on 2026-06-14 supports
+  `effect@3.21.3`, `@effect/platform@0.96.1`, and
+  `@effect/platform-node@0.107.0`; the first implementation child must repeat
+  this proof in-repo.
+
+## Enables Parallel Work
+
+- Future Habitat command implementations can use typed services without
+  touching oclif command parsing.
+- Rule and tool orchestration can gain bounded parallelism and deterministic
+  test layers.
+- Hook, generator, migration, baseline, probe, queue, and schedule work can
+  share one resource/lifecycle model while preserving their host-specific
+  adapter boundaries.
+- Later service/API exposure can be evaluated from a typed core. This change
+  does not introduce `effect-orpc`.
+
+## Affected Owners
+
+- `tools/habitat-harness/**`
+- `openspec/changes/habitat-effect-native-core/**`
+- Adjacent Habitat docs under `docs/projects/habitat-harness/**` only when
+  stable authority must be updated after implementation evidence exists.
+- Root scripts, Nx inferred targets, and Husky hook delegators only where
+  command invocation must remain wired to the same Habitat surface.
+
+## Forbidden Owners
+
+- Product/runtime Civ7 control surfaces.
+- MapGen/Swooper product, domain, recipe, projection, adapter, SDK, and Studio
+  behavior.
+- Historical H1-H8 proposals/tasks/specs. Downstream realignment is recorded
+  under this parent change or its child changes, not by rewriting H1-H8
+  historical records.
+- Generated `dist/**`, `mod/**`, `oclif.manifest.json`, and lockfiles outside
+  package-manager or build commands.
+
+## Write Set
+
+Implementation work should add an Effect core under `tools/habitat-harness/src`
+and migrate existing `lib/**`/command internals into that core in phases. The
+OpenSpec artifacts for this change are the authority for the phased write set.
+
+## Stop Conditions
+
+- A child implementation change starts before H7 and H8 are closed.
+- A parity probe changes JSON shape, stdout/stderr placement, exit code,
+  ratchet semantics, hook mutation behavior, classify output, Nx generator
+  behavior, or Nx migration behavior.
+- An Effect runtime or scoped resource can outlive `Command.run()`.
+- A generator/migration-scoped Effect runtime, fiber, process, or resource can
+  outlive the Nx generator or migration factory promise/callback.
+- Hook migration restages any path beyond formatter-touched files except the
+  preserved resource-publish submodule gitlink behavior from H7.
+- Grit check execution stops being one native JSON scan per check process.
+- Generated-zone verification cannot prove snapshot/restore/delete parity.
+- Dependency installation changes peer resolution in a way build/check cannot
+  prove.
+
+## Consumer Impact
+
+Contributors and agents should observe the same Habitat commands and outputs.
+The intended impact is internal: stronger lifecycle ownership, service-level
+tests, bounded orchestration, and a core that future Habitat commands can reuse
+without duplicating process, Git, filesystem, baseline, or scheduling code.
+
+## Parent Closure Gates
+
+OpenSpec validation proves artifact shape only for this parent design. It does
+not prove implementation behavior, generated output behavior, hook behavior, or
+runtime lifecycle behavior.
+
+- `bun run openspec -- validate habitat-effect-native-core --strict`
+- `bun run openspec:validate`
+- `git diff --check`
+- `git status --short --branch`
+- `gt status` and `gt info`
+
+## Future Child Implementation Gates
+
+- `bun install`
+- `bun run build`
+- `bun run --cwd tools/habitat-harness check`
+- `bun run --cwd tools/habitat-harness test`
+- `bun run habitat:check -- --json`
+- `bun run habitat:verify -- --base <Graphite parent or explicit test ref>`
+- Hook parity probes from H7: staged/unstaged isolation, partially staged
+  format-eligible file, foreign staged file, generated-zone block, Graphite base.
+- H8 classify probes for path, workspace path, literal diff, `.diff`/`.patch`
+  file, and the four-path matrix.
+- H8 project-generator probes for supported kind output, `kind:*` spelling,
+  non-empty root refusal, unsupported-kind refusal, and zero new baseline
+  entries.
+- H8 pattern-generator probe for native Grit pattern, empty baseline,
+  rule-pack entry, duplicate artifact refusal, and native Grit fixture proof.
+- H8 local migration probe via package `./tools/habitat-harness` and
+  `bun run nx migrate --run-migrations=<run-file>.json --skip-install`.
+- Generated-zone drift check.

--- a/openspec/changes/habitat-effect-native-core/specs/habitat-effect-check-orchestration/spec.md
+++ b/openspec/changes/habitat-effect-native-core/specs/habitat-effect-check-orchestration/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Check Orchestration Runs Through Effect Services
+
+`habitat check` SHALL build its report through Effect-backed rule registry,
+rule selection, baseline application, rule execution, and reporting programs
+while preserving the established `CheckReport` schema and human report text.
+
+#### Scenario: JSON report contract is preserved
+- **WHEN** an agent runs `bun run habitat:check -- --json`
+- **THEN** the emitted report validates against the established `CheckReport`
+  schema
+- **AND** rule violations remain report data rather than infrastructure errors
+- **AND** logs, lifecycle messages, and tool progress do not pollute JSON
+  stdout
+
+#### Scenario: Filtered checks preserve selection semantics
+- **WHEN** an agent runs `habitat check` with `--rule`, `--owner`, `--tool`, or
+  `--staged`
+- **THEN** the Effect-backed rule selection and execution surface matches the
+  current selected rule set, staged scope, diagnostics, and exit behavior
+
+### Requirement: Grit Checks Preserve The Native Shared-Scan Model
+
+Grit-backed full checks SHALL preserve one native Grit JSON scan per check
+process, then project the shared Grit report into selected Habitat rules.
+
+#### Scenario: Multiple Grit rules share one scan
+- **WHEN** `habitat check` evaluates multiple Grit-backed rules
+- **THEN** Habitat runs one native Grit JSON scan for that check process
+- **AND** projects the shared report into matching rule-pack entries by the
+  established `local_name` or `check_id` mapping
+- **AND** applies each selected rule's baseline independently
+
+#### Scenario: Grit invocation parity is pinned
+- **WHEN** the Grit service performs the full-check scan
+- **THEN** it preserves the current audit roots, `--level error`,
+  `GRIT_CACHE_DIR`, `GRIT_TELEMETRY_DISABLED`, and stdout/stderr JSON parser
+  attempts
+
+### Requirement: Report Rendering And Output Boundaries Remain Deterministic
+
+Habitat SHALL keep report stringification, schema validation, and human
+rendering pure and deterministic across the Effect migration. Command adapters
+or a narrowly scoped output-file capability SHALL own stdout/stderr and
+`--output` writes.
+
+#### Scenario: Output file and stdout behavior stay stable
+- **WHEN** an agent runs `habitat check --json --output <path>`
+- **THEN** the JSON report written to `<path>` and the command stdout behavior
+  match the established command contract
+- **AND** reusable check orchestration does not own stdout/stderr emission
+- **AND** internal report-schema failures remain defects surfaced by the
+  adapter rather than expected user or tool errors

--- a/openspec/changes/habitat-effect-native-core/specs/habitat-effect-command-programs/spec.md
+++ b/openspec/changes/habitat-effect-native-core/specs/habitat-effect-command-programs/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Non-Check Command Programs Preserve Existing Contracts
+
+`fix`, `verify`, `graph`, and `classify` SHALL move reusable command logic into
+Effect programs without changing command names, flags, stdout/stderr placement,
+exit semantics, or JSON shapes.
+
+#### Scenario: Fix dry-run preserves external tool output
+- **WHEN** an agent runs `habitat fix --dry-run`
+- **THEN** Habitat runs the established dry-run Grit apply path and Biome check
+  path
+- **AND** stdout, stderr, and exit code match the pre-refactor behavior
+
+#### Scenario: Verify stops before Nx when check fails
+- **WHEN** `habitat verify` cannot produce a passing Habitat check report
+- **THEN** it preserves the established check-fail ordering before Nx affected
+  verification
+- **AND** it does not hide check failure behind later affected-target output
+
+#### Scenario: Graph command cleans scoped temp output
+- **WHEN** an agent runs `habitat graph --json`
+- **THEN** Habitat generates the Nx graph through a scoped temp directory
+- **AND** returns compact JSON when requested
+- **AND** removes the temp directory before command completion
+
+### Requirement: Classify Preserves H8 Path And Diff Semantics
+
+`habitat classify <path-or-diff>` SHALL preserve the H8 classification
+contract for repo paths, absolute paths, literal diffs, `.diff` files, and
+`.patch` files.
+
+#### Scenario: Path classification returns ownership and verification targets
+- **WHEN** an agent classifies a path under a workspace project
+- **THEN** the output includes `path`, `project`, `projectRoot`, `tags`,
+  `rulesInScope`, and `requiredTargets`
+- **AND** required project targets use the established `bun run nx run
+  <project>:check` and `bun run nx run <project>:test` command strings
+- **AND** workspace-level Habitat targets are included
+
+#### Scenario: H8 classify matrix stays stable
+- **WHEN** agents classify the H8 matrix paths for adapter, mod, foundation,
+  and app projects
+- **THEN** `packages/civ7-adapter/src/index.ts` resolves to project
+  `@civ7/adapter`, tag `kind:adapter`, and the adapter boundary rule in scope
+- **AND** `mods/mod-swooper-maps/src/recipes/standard/recipe.ts` resolves to
+  project `mod-swooper-maps`, tag `kind:mod`, and recipe-surface rules in
+  scope
+- **AND** `packages/config/src/index.ts` resolves to project `@civ7/config`,
+  tag `kind:foundation`, and internal harness rules in scope
+- **AND** `apps/mapgen-studio/src/main.tsx` resolves to project
+  `mapgen-studio`, tag `kind:app`, and Studio recipe-artifact rules in scope
+
+#### Scenario: Diff classification returns changed path classifications
+- **WHEN** an agent classifies a literal Git diff or a `.diff`/`.patch` file
+- **THEN** the output has schema version `1`, input kind `diff`, and a sorted
+  path classification for each path collected from H8's `diff --git ... b/<path>`
+  and `+++ b/<path>` parser
+- **AND** the literal `/dev/null` marker is ignored rather than emitted as a
+  target path
+
+#### Scenario: Patch-file classification reads only diff-like patch files
+- **WHEN** the classify target is an existing `.diff` or `.patch` file
+- **THEN** Habitat treats the file as a diff only when it contains a Git diff
+  header or `+++ b/` changed-file marker
+- **AND** otherwise classifies the file path itself as a normal path target
+
+#### Scenario: Workspace-level classification stays explicit
+- **WHEN** a classified path does not belong to any discovered workspace
+  project
+- **THEN** the output reports `project: null`, a workspace-level note, and the
+  established workspace required targets

--- a/openspec/changes/habitat-effect-native-core/specs/habitat-effect-generated-verifier/spec.md
+++ b/openspec/changes/habitat-effect-native-core/specs/habitat-effect-generated-verifier/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Generated-Zone Verification Uses Scoped Restoration
+
+Generated-zone verification SHALL use scoped services for snapshotting,
+regeneration, diff checks, restoration, and cleanup while preserving the
+current drift diagnostics and final worktree cleanliness behavior.
+
+#### Scenario: Map artifact verification restores tracked files
+- **WHEN** generated-zone verification regenerates map artifacts
+- **THEN** tracked map artifact contents are restored before command
+  completion even when regeneration or diff checks fail
+- **AND** untracked map artifacts created by the verification run are removed
+- **AND** drift diagnostics continue to identify changed generated artifacts
+
+#### Scenario: Policy-table verification remains check-only
+- **WHEN** generated-zone verification checks Civ7 map-policy tables
+- **THEN** Habitat runs the established check-only policy-table gate
+- **AND** the command leaves the worktree clean across all generated target
+  inputs
+
+### Requirement: Generated-Zone Staged Guards Remain Enforcement Data
+
+Generated-zone staged hand-edit detection SHALL remain a Habitat rule/check
+surface, not an unscoped side effect of the verifier migration.
+
+#### Scenario: Staged hand-edit still fails check
+- **WHEN** a staged change edits a protected generated zone by hand
+- **THEN** `habitat check --staged` fails with the owning regenerate command as
+  remediation
+- **AND** the Effect migration does not add baseline entries or mutate the
+  staged file to hide the finding

--- a/openspec/changes/habitat-effect-native-core/specs/habitat-effect-hooks/spec.md
+++ b/openspec/changes/habitat-effect-native-core/specs/habitat-effect-hooks/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Hooks Preserve H7 Git-Moment Policy
+
+Hook execution SHALL use Effect services for Git index inspection, mutation,
+process execution, staged-file checks, formatting, and affected verification
+while preserving the H7 local-hook policy. Husky hooks remain thin delegators
+to `habitat hook <name>`.
+
+#### Scenario: Pre-commit restages only formatter-touched files
+- **WHEN** `habitat hook pre-commit` formats staged Biome-supported files
+- **THEN** Habitat restages only files whose content changed due to the
+  formatter
+- **AND** it fails before formatting a format-eligible file with both staged
+  and unstaged hunks
+
+#### Scenario: Resource publish behavior remains the only non-formatter carve-out
+- **WHEN** `habitat hook pre-commit` preserves the H7 resource-publish behavior
+- **THEN** any Git index mutation outside formatter-touched files is limited to
+  the accepted resources submodule gitlink behavior
+- **AND** the hook does not stage unrelated worktree paths
+
+#### Scenario: Hook orchestration does not invoke Habitat recursively
+- **WHEN** `habitat hook pre-commit` runs staged file-layer checks
+- **THEN** the hook calls the internal Habitat check or rule program through
+  the same command-scoped runtime
+- **AND** it does not spawn another `habitat` CLI process for that check
+
+### Requirement: Pre-Push Keeps Committed-Range Verification
+
+`habitat hook pre-push` SHALL preserve the H7 committed-range affected
+verification semantics and Graphite base handling.
+
+#### Scenario: Graphite parent base drives affected verification
+- **WHEN** pre-push runs in a Graphite stack branch
+- **THEN** Habitat uses the established Graphite parent or explicit base
+  behavior for affected target selection
+- **AND** it runs the same affected build, check, test, boundaries, Biome,
+  Grit, and generated-zone target set as before the Effect migration
+
+#### Scenario: Unknown hook names remain rejected
+- **WHEN** an agent runs `habitat hook <unknown>`
+- **THEN** the command exits with the established unknown-hook exit behavior
+- **AND** the error is emitted outside machine JSON output

--- a/openspec/changes/habitat-effect-native-core/specs/habitat-effect-nx-generators-migrations/spec.md
+++ b/openspec/changes/habitat-effect-native-core/specs/habitat-effect-nx-generators-migrations/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: Nx Generators Remain Nx Plugin Surfaces
+
+The Habitat project and pattern generators SHALL remain Nx plugin generator
+surfaces declared from `@internal/habitat-harness` metadata. If reusable
+generator logic uses Effect services, the Nx generator function SHALL be the
+host adapter boundary and SHALL NOT require oclif command execution.
+
+#### Scenario: Generator writes use the Nx virtual tree
+- **WHEN** generator logic reads or writes generator-owned files
+- **THEN** it uses an Nx `Tree`-backed workspace service for `exists`,
+  `children`, `read`, `write`, and JSON writes
+- **AND** generator dry-runs, in-memory tree tests, and Nx transaction behavior
+  remain authoritative
+- **AND** neither Effect-backed code nor pure helper code writes through the
+  platform filesystem for tree-owned files
+
+#### Scenario: Supported project kinds generate clean structure
+- **WHEN** `bun run nx g @internal/habitat-harness:project <name>
+  --kind=<foundation|plugin|app>` runs
+- **THEN** the generated project carries the correct default package name and
+  root for its kind: `packages/<name>` for foundation,
+  `packages/plugins/plugin-<name>` for plugin, and `apps/<name>` for app
+- **AND** generated `package.json` includes the `kind:*` tag, `build`,
+  `check`, `test`, and `clean` scripts, ESM exports, `files: ["dist"]`, and
+  Node engine constraint
+- **AND** generated `tsconfig.json`, `src/index.ts`, Bun test stub, and README
+  match the H8 scaffold contract
+- **AND** generated output passes Habitat rules with zero new baseline entries
+  before probe cleanup
+
+#### Scenario: Project generator accepts taxonomy spellings
+- **WHEN** the project generator schema accepts a taxonomy kind
+- **THEN** both bare kind values and `kind:*` spellings remain accepted at the
+  schema boundary
+- **AND** supported kinds normalize to the same generated output regardless of
+  spelling
+
+#### Scenario: Non-uniform project kinds are refused
+- **WHEN** an agent asks the project generator for `mod`, `engine`, `control`,
+  `adapter`, `sdk`, or `tooling`
+- **THEN** the generator refuses the request with the documented domain-owner
+  rationale
+- **AND** no guessed project shape is written
+
+#### Scenario: Non-empty project roots are protected
+- **WHEN** the normalized generator root already exists and contains files
+- **THEN** the project generator fails before writing scaffold output
+- **AND** existing project files remain untouched
+
+### Requirement: Pattern Generator Preserves Rule-Pack And Baseline Coupling
+
+The Habitat pattern generator SHALL keep native Grit pattern creation, empty
+locked baseline creation, and Habitat rule-pack registration as one Nx
+generator operation.
+
+#### Scenario: New Grit-backed rule scaffold is atomic
+- **WHEN** `bun run nx g @internal/habitat-harness:pattern <rule-id>` runs
+- **THEN** Habitat writes `.grit/patterns/habitat/checks/<pattern>.md`
+- **AND** writes `tools/habitat-harness/baselines/<rule-id>.json` as an empty
+  locked baseline
+- **AND** appends a `grit-check` rule-pack entry with the established owner,
+  lane, detect, message, `exceptionPath: "none"`, `gritPattern`, and
+  `hookScope: "pre-commit"`
+- **AND** native Grit pattern fixture proof remains the pattern acceptance gate
+
+#### Scenario: Existing pattern, baseline, or rule id is protected
+- **WHEN** the requested pattern path, baseline path, or Habitat rule id
+  already exists
+- **THEN** the generator fails before overwriting any existing rule artifact
+
+### Requirement: Nx Generator Module Boundaries Are Explicit
+
+The Effect migration SHALL preserve the current Nx factory metadata contract:
+`generators.json` and `migrations.json` expose factory entries that Nx can load
+from the repo-local harness package.
+
+#### Scenario: CommonJS factory entries bridge intentionally
+- **WHEN** Effect-backed TypeScript or ESM code is shared by generator or
+  migration factories
+- **THEN** the child implementation preserves the current source CJS factory
+  metadata entries and chooses one bridge: CJS factories dynamically import
+  implementation code, or a deliberately small CJS-compatible pure core remains
+  for that factory
+- **AND** Nx generator and migration invocation works through the declared
+  metadata paths after `bun run --cwd tools/habitat-harness build`
+
+### Requirement: Harness Migrations Remain Local Nx Migrations
+
+Harness convention changes SHALL ship as Nx migrations declared in
+`migrations.json`. Because `@internal/habitat-harness` is unpublished,
+migration proof SHALL use a hand-authored run file whose package points at
+`./tools/habitat-harness` and SHALL NOT rely on npm-registry version
+resolution.
+
+#### Scenario: Migration factories keep Nx lifecycle semantics
+- **WHEN** a migration uses Effect-backed reusable logic
+- **THEN** the migration factory remains an Nx migration adapter
+- **AND** it returns the expected Nx callback or task shape
+- **AND** expected migration failures surface to Nx by throwing or rejecting
+- **AND** any migration-scoped Effect runtime, fiber, process, or resource is
+  closed before the migration promise resolves
+
+#### Scenario: Local migration run file executes
+- **WHEN** a harness migration is proved locally
+- **THEN** the proof runs `bun run nx migrate --run-migrations=<run-file>.json
+  --skip-install`
+- **AND** the run file uses package `./tools/habitat-harness`
+- **AND** migration behavior is recorded without changing generator or command
+  contracts

--- a/openspec/changes/habitat-effect-native-core/specs/habitat-effect-process-baselines/spec.md
+++ b/openspec/changes/habitat-effect-native-core/specs/habitat-effect-process-baselines/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Resourceful Habitat Capabilities Are Layered Services
+
+Habitat SHALL provide resourceful tooling capabilities through injectable
+Effect contexts and layers. Service interfaces SHALL expose Habitat concepts
+rather than oclif, Node, Bun, or shell-specific details.
+
+#### Scenario: Service-level tests replace live tool boundaries
+- **WHEN** Habitat core tests exercise workspace, process, Git, baseline,
+  external tool, hook, or generated-zone logic
+- **THEN** tests can provide fake service layers for process, filesystem, Git,
+  workspace, and clock behavior
+- **AND** command adapter tests can remain focused on host parsing and output
+  writing
+
+#### Scenario: Process execution remains argument-array based
+- **WHEN** Habitat invokes Git, Nx, Grit, Biome, Bun, or repo scripts through
+  its core services
+- **THEN** execution uses structured command arguments, explicit cwd/env/PATH
+  policy, and normalized stdout/stderr/exit-code results
+- **AND** shell-string interpolation is not introduced
+
+### Requirement: Workspace And Git State Are Explicit Service Inputs
+
+Habitat SHALL move workspace path resolution, package discovery, Git merge-base
+discovery, staged path discovery, unstaged path checks, and exact `git add`
+operations behind services with fakeable behavior and preserved current parsing
+semantics.
+
+#### Scenario: Workspace package discovery remains classification-compatible
+- **WHEN** Habitat discovers project roots for command, classify, generator,
+  or rule ownership logic
+- **THEN** it scans the established `apps`, `packages`, `packages/plugins`,
+  `mods`, and `tools` roots
+- **AND** it preserves longest-root ownership selection for nested roots such
+  as `packages/plugins/*`
+
+#### Scenario: Git mutation is explicit
+- **WHEN** Habitat must mutate the Git index
+- **THEN** the mutation goes through a Git service operation naming the exact
+  paths being staged
+- **AND** the service can be faked in tests to prove no unrelated path is
+  staged, unstaged, or rewritten
+
+### Requirement: Baseline Store Preserves Ratchet Semantics
+
+Habitat SHALL move baseline loading, writing, violation-key application, and
+shrink-only integrity checks behind Effect services without changing ratchet
+behavior.
+
+#### Scenario: Ratchet semantics survive service migration
+- **WHEN** a baseline file grows for an existing rule relative to the merge-base
+- **THEN** `habitat check` reports the baseline-integrity violation and fails
+- **AND** normal check, verify, hook, classify, generator, migration, and
+  generated-zone execution do not write baseline entries
+
+#### Scenario: Baseline authoring remains explicit
+- **WHEN** an author runs `habitat check --expand-baseline --rule <id>`
+- **THEN** Habitat writes only the selected rule's current unbaselined error
+  keys to that rule's baseline
+- **AND** the written baseline remains sorted JSON with the established
+  trailing newline format
+- **AND** the command emits authoring messages rather than a `CheckReport`

--- a/openspec/changes/habitat-effect-native-core/specs/habitat-effect-runtime-substrate/spec.md
+++ b/openspec/changes/habitat-effect-native-core/specs/habitat-effect-runtime-substrate/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Oclif Adapters Bridge Into A Managed Effect Runtime
+
+Each Habitat oclif command SHALL remain a command adapter. The adapter SHALL
+parse flags and arguments, run one Habitat Effect program through a command
+scoped runtime bridge, render or write the returned result, and dispose the
+runtime before `Command.run()` resolves.
+
+#### Scenario: Check command uses the runtime bridge
+- **WHEN** an agent runs `bun run habitat:check -- --json`
+- **THEN** the oclif adapter runs the Effect-backed check program through the
+  Habitat runtime bridge
+- **AND** the adapter remains responsible for deterministic JSON stdout
+  emission
+- **AND** the command exits non-zero when enforced Habitat rules fail or when
+  the command cannot produce a valid report
+- **AND** infrastructure failures are reported outside JSON stdout
+
+#### Scenario: Scoped resources close before command completion
+- **WHEN** a Habitat command creates temp directories, child processes, queues,
+  file snapshots, cache locks, or background fibers through Effect services
+- **THEN** all command-scoped finalizers finish before the oclif command
+  resolves
+- **AND** no command-owned child process, fiber, or runtime scope remains active
+  after command completion
+
+### Requirement: Habitat Core Programs Are Effect Values
+
+Reusable Habitat core modules SHALL expose `Effect` programs and structured
+results. Core modules SHALL NOT call `Effect.runPromise`, `process.exit`, or
+oclif APIs from below the adapter boundary.
+
+#### Scenario: Core logic is reused outside oclif commands
+- **WHEN** check, classify, hook, generator, migration, or generated-zone logic
+  needs reusable orchestration
+- **THEN** the reusable logic is expressed as Effect programs or pure functions
+  below the relevant host adapter
+- **AND** the host adapter owns runtime execution and disposal
+
+### Requirement: Runtime Dependencies Are Proved By Repo Gates
+
+The Habitat Effect implementation SHALL prove selected Effect runtime and
+platform packages through the repo's Bun, built oclif, Nx, Habitat, and
+OpenSpec gates before migrating command behavior onto those dependencies.
+
+#### Scenario: Platform dependency versions are accepted by the workspace
+- **WHEN** the Effect implementation adds selected Effect runtime and platform
+  packages to `@internal/habitat-harness`
+- **THEN** `bun install` completes with peer-resolution evidence recorded in
+  the phase record
+- **AND** root Bun Habitat scripts and the built oclif runner both execute the
+  Habitat command surface
+
+#### Scenario: RPC libraries remain outside the CLI core
+- **WHEN** the Habitat core becomes Effect-native
+- **THEN** `effect-orpc` is not added to `@internal/habitat-harness`
+- **AND** RPC exposure is handled only by a separate service/API change with
+  its own proposal and spec delta

--- a/openspec/changes/habitat-effect-native-core/tasks.md
+++ b/openspec/changes/habitat-effect-native-core/tasks.md
@@ -1,0 +1,52 @@
+## 0. Parent Design Preconditions
+
+- [x] 0.1 Confirm this parent change remains design-only and is stacked after
+  closed H7 `habitat-git-hooks` and H8 `habitat-generators-migrations`.
+- [x] 0.2 Record branch/stack state, protected owners, and current stop-condition
+  status in the phase record.
+- [x] 0.3 Run OpenSpec, Effect-idiom, and Habitat-parity review lanes and record
+  finding dispositions before committing this design slice.
+- [x] 0.4 Re-investigate completed H8 from branch diff, OpenSpec records, phase
+  record, generator/migration metadata, classify implementation, generator
+  source, migration source, tests, README, and AGENTS updates.
+
+## 1. Parent Spec Split
+
+- [x] 1.1 Replace the singular `habitat-harness` spec delta with child-aligned
+  parent deltas for runtime substrate, process/baselines, check orchestration,
+  command programs, Nx generators/migrations, hooks, and generated verifier.
+- [x] 1.2 Add H8 reassessment evidence covering classify, project generator,
+  pattern generator, migration metadata, tests, README, and AGENTS changes.
+- [x] 1.3 Update proposal, design, frame, phase record, and review disposition
+  so oclif command programs and Nx generator/migration factories have separate
+  host-adapter boundaries.
+- [x] 1.4 Run formal review lanes for authority/H8 parity, OpenSpec shape,
+  Effect architecture, Nx generator/migration boundary, proof/closure, and
+  future-DRA information design.
+- [x] 1.5 Repair accepted review findings in the parent artifacts.
+
+## 2. Next Child Changes
+
+The parent is complete when this checklist closes. Future implementation work
+starts new OpenSpec child changes:
+
+- `habitat-effect-runtime-substrate`
+- `habitat-effect-process-baselines`
+- `habitat-effect-check-orchestration`
+- `habitat-effect-command-programs`
+- `habitat-effect-nx-generators-migrations`
+- `habitat-effect-hooks`
+- `habitat-effect-generated-verifier`
+
+## 3. Parent Verification
+
+- [x] 3.1 Run `bun run openspec -- validate habitat-effect-native-core --strict`.
+- [x] 3.2 Run `bun run openspec:validate`.
+- [x] 3.3 Run `git diff --check`.
+- [x] 3.4 Run `git status --short --branch`.
+- [x] 3.5 Run `gt status` and `gt info`.
+- [x] 3.6 Commit the initial parent design slice via Graphite without editing
+  H1-H8 historical records.
+- [x] 3.7 Validate and commit the H8 reassessment plus split-spec revision via
+  Graphite without editing H1-H8
+  historical records.

--- a/openspec/changes/habitat-effect-native-core/workstream/frame.md
+++ b/openspec/changes/habitat-effect-native-core/workstream/frame.md
@@ -1,0 +1,240 @@
+# Frame — Effect-Native Habitat Core
+
+## Objective
+
+Design the post-H8 Habitat refactor that makes the toolkit core idiomatic
+Effect while preserving the existing Habitat command surface. This change is
+the parent/design workstream; implementation is split into child OpenSpec
+changes that execute only after H8 closes. The command shell remains oclif;
+reusable Habitat logic becomes Effect programs composed from services and
+layers.
+
+This frame is the grounding artifact for the change. Proposal, design, tasks,
+and spec deltas must stay inside this frame unless a later review record amends
+it with source-backed evidence.
+
+## Authority Stack
+
+1. Current user direction: create a stacked OpenSpec slice after the current
+   Habitat workstream changesets, with deep Effect grounding and adversarial
+   review.
+2. Repo process: Graphite stacked work, clean worktrees, OpenSpec artifact
+   rules, Bun/Nx tooling, and Habitat project documents.
+3. Habitat project authority:
+   `docs/projects/habitat-harness/FRAME.md`,
+   `docs/projects/habitat-harness/workstream-record.md`,
+   `docs/projects/habitat-harness/invariant-corpus.md`,
+   `docs/projects/habitat-harness/taxonomy.md`, and
+   `docs/projects/habitat-harness/review-disposition-ledger.md`.
+4. Active Habitat OpenSpec train:
+   H1 `habitat-nx-adoption`, H2 `habitat-harness-scaffold`,
+   H3 `habitat-boundary-tags`, H4 `habitat-biome-hygiene`,
+   H4.5 `habitat-oclif-cli`, H5 `habitat-grit-catalog`,
+   H6 `habitat-enforcement-consolidation`, H7 `habitat-git-hooks`,
+   H8 `habitat-generators-migrations`.
+5. Official Effect documentation and the repo's existing Effect usage in
+   `@civ7/studio-server` and `@civ7/control-orpc`.
+6. Current `tools/habitat-harness` source and tests as implementation evidence.
+
+## Timing
+
+This design slice was grounded while H7/H8 were still in motion. The current
+stack now records H7 and H8 complete, and the effect branch is stacked on the H8
+tail branch. The Effect implementation children still start after this parent
+design because H8 defines the final command, hook, generator, classify, README,
+and agent procedure surface that the Effect core must preserve.
+
+The branch `agent-F-habitat-effect-core` is Graphite-parented to
+`agent-F-habitat-generators-migrations`. The branch now has the initial parent
+design commit and is being revised to split the parent spec into one spec delta
+per major child workstream after re-reading completed H8.
+
+## Current Habitat Shape
+
+The existing harness has a sound outer split but a synchronous core:
+
+- oclif command classes under `tools/habitat-harness/src/commands/**` parse
+  flags and delegate to `lib/command-engine.ts` or hook helpers.
+- `command-engine.ts` runs rule selection, baseline application, Grit/Biome/Nx
+  process calls, graph temp-dir management, report rendering, and classify
+  package scans.
+- `spawn.ts` centralizes argument-array `spawnSync` with repo-local PATH
+  injection.
+- `baseline.ts`, `generated-zones.ts`, `grit.ts`, and `hooks.ts` use direct
+  Node filesystem, Git, hashing, temp, and process APIs.
+- Existing command tests mostly mock `command-engine` at the adapter boundary;
+  deeper service behavior needs fake-service coverage as the core becomes
+  Effect-native.
+- H8 added Nx plugin surfaces in addition to the CLI surface:
+  `generators.json`, `migrations.json`, CJS project/pattern generator
+  factories, a no-op migration factory, and local migration proof through a
+  hand-authored run file whose package is `./tools/habitat-harness`.
+- H8 completed `classify <path-or-diff>` as an agent-facing orientation
+  command for paths, literal diffs, and `.diff`/`.patch` files.
+
+This confirms the refactor target: keep command adapters thin, move the
+resourceful and orchestrating core below them into Effect services, and treat
+Nx generators/migrations as their own host-adapter surface rather than oclif
+commands.
+
+## Effect Doctrine For This Slice
+
+Official Effect docs establish these design obligations:
+
+- Effects are executable program descriptions run by a runtime with a context;
+  the core should return `Effect<A, E, R>` rather than running itself.
+- Services and layers model capabilities and dependency graphs. Service
+  interfaces must expose Habitat concepts, while layer construction owns
+  implementation dependencies.
+- `Scope`, finalizers, and acquire/release patterns own resources such as temp
+  directories, subprocess lifetimes, locks, generated-artifact snapshots, and
+  queues.
+- `ManagedRuntime` belongs at adapter or host boundaries. The oclif command
+  adapter creates/runs/disposes the Habitat runtime for command execution.
+- Concurrency is explicit. Bounded concurrency is the default for rule and
+  process fan-out; tiny fixed fan-outs may state their bound directly.
+- Queues, semaphores, and schedules are used where Habitat has real queued work,
+  shared mutation surfaces, retry, polling, or debounce policy.
+- Platform process/filesystem/path/terminal abstractions are the preferred
+  direction for new resourceful core code. Registry and temp-install evidence
+  on 2026-06-14 shows `effect@3.21.3`, `@effect/platform@0.96.1`, and
+  `@effect/platform-node@0.107.0` install cleanly under Bun, and a minimal
+  `NodeContext.layer` import/run succeeds under Bun. The live Habitat layer
+  should be Node-oriented because the built oclif bin is Node-executed; the
+  first implementation child must repeat the proof in-repo for both Bun dev and
+  built Node invocation.
+- Schema/config/logging may be Effect-native internally, but command JSON output
+  remains deterministic and adapter-controlled.
+- Generator-owned files stay under Nx `Tree` control. Effect-backed generator
+  logic must use a Tree-backed service for tree writes so dry-runs, in-memory
+  tests, and Nx transaction behavior remain authoritative.
+
+Local Effect precedent strengthens the same shape:
+
+- `packages/studio-server/src/runtime.ts` builds a `ManagedRuntime` from layers.
+- `packages/studio-server/src/services/Civ7TunerSession.ts` uses
+  `Layer.scoped` and `Effect.acquireRelease` to own a shared resource and close
+  it through runtime disposal.
+- `packages/studio-server/src/handler.ts` bridges Effect to a host API and
+  exposes an explicit `dispose()` obligation.
+- `packages/civ7-control-orpc/src/procedure.ts` uses Effect at the service/API
+  surface, while `effect-orpc` is reserved for RPC contracts. Habitat CLI does
+  not get `effect-orpc` in this slice.
+
+## Core Service Map
+
+The first implementation phase should introduce services at the Habitat
+concept boundary:
+
+- `HabitatWorkspace`: repo root, harness root, baseline paths, repo-relative
+  normalization, package/project discovery.
+- `HabitatProcess`: argument-array process execution, cwd/env/PATH policy,
+  stdout/stderr capture, exit-code normalization, child lifecycle.
+- `HabitatGit`: merge-base, git show, staged paths, unstaged detection,
+  Graphite parent detection, exact `git add` for owned hook restaging.
+- `BaselineStore`: baseline load/write, violation keys, shrink-only integrity
+  check using `HabitatGit`.
+- `RuleRegistry`: rule-pack data and selection.
+- `RuleRunner`: dispatch to Grit, file-layer, native, and process-backed rule
+  runners.
+- `GritService`, `BiomeService`, `NxService`: external tool command builders
+  and execution policy.
+- `HookRunner`: pre-commit/pre-push orchestration over explicit services,
+  keeping Git index mutation isolated.
+- `GeneratedZoneVerifier`: snapshot/regenerate/diff/restore/delete semantics
+  for generated-zone drift checks.
+- `NxGeneratorTree`: Nx `Tree`-backed generator workspace operations used by
+  project and pattern generators.
+- Effect `Clock`/`TestClock`: duration measurement, schedules, deterministic
+  timing tests. Do not wrap it in a Habitat-specific clock service unless a
+  later child change proves Habitat-specific semantics.
+
+Plain data and pure functions should stay plain: diagnostic/report types,
+report formatting, parser functions, rule selection predicates, path matching,
+status calculation, and the Nx `createNodesV2` plugin.
+
+Runtime bridge and layer assembly are adapter concerns, not core services
+available to reusable Habitat programs. Command output is also adapter-owned:
+pure report rendering stays plain, while stdout/stderr and `--output` writes
+remain at the host boundary or a narrow output-file capability.
+
+## Non-Negotiables
+
+- No command behavior change is accepted as part of the substrate refactor:
+  command names, flags, exit codes, stdout/stderr shape, JSON schema, ratchet
+  semantics, hook policy, and generator/classify behavior remain stable.
+- The core must not call `process.exit`, mutate global process state beyond an
+  explicit adapter boundary, or run Effect programs from deep library modules.
+- Every acquired command resource must be scoped to command execution or to a
+  named service lifetime that the adapter closes before `Command.run()`
+  resolves. Every acquired generator/migration resource must close before the
+  Nx factory promise/callback returns to Nx.
+- Hook mutation remains exact: pre-commit may restage only formatter-touched
+  files and must preserve partially staged protections.
+- Baselines remain shrink-only. No rule/baseline expansion is hidden inside
+  the Effect refactor.
+- Grit remains one native JSON scan per check process until a later source-backed
+  change proves another execution model.
+- `effect-orpc` is out of scope for local CLI harness internals.
+- Generated artifacts, lockfiles, and dist output are changed only through the
+  repo's scripts and package-manager commands.
+
+## Risk Surfaces
+
+- Async process execution can reorder output, alter buffering, or return before
+  child cleanup. `HabitatProcess` parity tests must pin stdout/stderr/exit
+  behavior before command migration.
+- Grit report caching is process-global today. The Effect service must preserve
+  one scan per check invocation without leaking cached findings across tests or
+  commands.
+- Baseline integrity has a documented no-merge-base behavior. That behavior must
+  stay explicit in service tests.
+- Hook pre-commit combines resource publishing, file-layer check, formatting,
+  restaging, Biome check, and Grit staged scan. It needs isolated fake Git/FS
+  tests before live-hook migration.
+- Nx generator/migration factories currently live as CJS metadata targets in
+  an ESM package. The generator/migration child must choose an explicit CJS to
+  ESM bridge or intentionally keep a small CJS-compatible core.
+- Generated-zone verification snapshots tracked files, restores them, and
+  removes untracked generated files. Convert this surface after core process,
+  Git, and filesystem services are already proven.
+- Adding `@effect/platform` packages changes dependency policy. Implementation
+  must add the verified versions through Bun, inspect peer resolution, and prove
+  both root Bun scripts and the built Node oclif runner still execute.
+
+## Review Lanes
+
+Before implementation begins, run adversarial review over:
+
+- OpenSpec sequencing and artifact fit: after H8, no H1-H8 historical rewrite,
+  specs keep behavior/process requirements rather than implementation detail.
+- Effect idiom: service/layer boundaries, runtime placement, scope closure,
+  error modeling, platform dependency decision, and concurrency policy.
+- Harness behavior parity: commands, JSON, baselines, Grit, hooks, classify,
+  generators, generated-zone drift checks.
+- Testability: fake service layers, deterministic clocks, process parity probes,
+  live Grit integration retention.
+- Repo workflow: Graphite stack cleanliness, generated artifact hygiene,
+  validation gates, documentation touchpoints.
+
+## First Workstream Shape
+
+Use `habitat-effect-native-core` as the parent/design change, then execute child
+implementation changes after H8 closure:
+
+1. `habitat-effect-runtime-substrate`: dependencies, runtime bridge, service
+   tags, live/fake layers.
+2. `habitat-effect-process-baselines`: workspace, process, Git, and baseline
+   services.
+3. `habitat-effect-check-orchestration`: rule registry, Grit/file-layer/native
+   rule runner, check/report Effect program.
+4. `habitat-effect-command-programs`: fix, verify, graph, and classify.
+5. `habitat-effect-nx-generators-migrations`: Nx project/pattern generators,
+   Tree-backed writes, factory bridge, and local migrations.
+6. `habitat-effect-hooks`: hook orchestration, resource-publish carve-out, and
+   staged-index safety.
+7. `habitat-effect-generated-verifier`: generated-zone drift verifier.
+
+Each child change gets its own proposal/design/tasks/spec delta and closure
+gates. The parent change records architecture, sequencing, stop conditions,
+review findings, and child boundaries; it does not implement the refactor.

--- a/openspec/changes/habitat-effect-native-core/workstream/h8-reassessment.md
+++ b/openspec/changes/habitat-effect-native-core/workstream/h8-reassessment.md
@@ -1,0 +1,69 @@
+# H8 Reassessment — Effect-Native Habitat Core
+
+## Evidence Read
+
+- H8 branch diff: `agent-F-habitat-git-hooks..agent-F-habitat-generators-migrations`.
+- H8 records:
+  `openspec/changes/habitat-generators-migrations/proposal.md`,
+  `openspec/changes/habitat-generators-migrations/specs/habitat-harness/spec.md`,
+  `openspec/changes/habitat-generators-migrations/tasks.md`, and
+  `openspec/changes/habitat-generators-migrations/workstream/phase-record.md`.
+- H8 implementation:
+  `tools/habitat-harness/generators.json`,
+  `tools/habitat-harness/migrations.json`,
+  `tools/habitat-harness/package.json`,
+  `tools/habitat-harness/src/commands/classify.ts`,
+  `tools/habitat-harness/src/lib/command-engine.ts`,
+  `tools/habitat-harness/src/generators/project/generator.cjs`,
+  `tools/habitat-harness/src/generators/pattern/generator.cjs`,
+  `tools/habitat-harness/src/migrations/baseline-metadata-noop.cjs`,
+  `tools/habitat-harness/test/commands/habitat-commands.test.ts`, and
+  `tools/habitat-harness/test/lib/classify.test.ts`.
+- H8 operating-loop docs:
+  root `AGENTS.md`, `tools/habitat-harness/README.md`, and
+  `docs/projects/habitat-harness/workstream-record.md`.
+
+## H8 Surfaces That Affect The Effect Design
+
+- H8 made Habitat a repo-local Nx plugin surface as well as an oclif CLI:
+  `generators.json` declares `project` and `pattern`; `migrations.json`
+  declares a local migration; `package.json` exposes generator and migration
+  metadata.
+- `classify <path-or-diff>` now handles repo-relative paths, absolute paths,
+  literal diffs, and `.diff`/`.patch` files. Diff classification returns
+  schema version `1`, input kind `diff`, and sorted path classifications for
+  changed `b/` paths.
+- Project classification discovers owners across `apps`, `packages`,
+  `packages/plugins`, `mods`, and `tools`, chooses the longest matching root,
+  and emits `path`, `project`, `projectRoot`, `tags`, `rulesInScope`, and
+  `requiredTargets`. Workspace paths emit `project: null`, the
+  workspace-level note, and workspace targets.
+- The project generator supports only uniform `foundation`, `plugin`, and
+  `app` kinds at runtime, while its schema accepts taxonomy kinds and `kind:*`
+  spellings. Unsupported kinds are refused with a domain-owner rationale.
+- Project generator output includes kind-specific default roots/package names,
+  `package.json` tags/scripts/exports/files/engine, `tsconfig.json`,
+  `src/index.ts`, a Bun test stub, and README. Non-empty roots are refused.
+- The pattern generator writes a native Grit pattern, an empty locked baseline,
+  and a `grit-check` rule-pack entry in one generator operation, and refuses
+  duplicate pattern paths, baseline paths, or rule ids.
+- Migration proof is local because `@internal/habitat-harness` is unpublished:
+  a hand-authored run file points at package `./tools/habitat-harness`, then
+  `bun run nx migrate --run-migrations=<run-file>.json --skip-install` runs.
+
+## Design Consequences
+
+- The parent spec cannot stay singular; H8 adds enough distinct behavior
+  surfaces that one broad `habitat-harness` spec would hide important host
+  boundaries.
+- Nx generators and migrations are not oclif command programs. They require a
+  distinct child change and spec delta:
+  `habitat-effect-nx-generators-migrations`.
+- Generator-owned writes must stay Nx `Tree` writes. Effect-backed generator
+  logic needs a Tree-backed service rather than direct platform filesystem
+  writes for generator output.
+- Generator and migration runtime lifecycle is bounded by Nx factory promise
+  completion, not `Command.run()` completion.
+- The ESM package plus CJS factory metadata requires an explicit implementation
+  bridge before Effect TypeScript is shared with generator or migration
+  factories.

--- a/openspec/changes/habitat-effect-native-core/workstream/phase-record.md
+++ b/openspec/changes/habitat-effect-native-core/workstream/phase-record.md
@@ -1,0 +1,166 @@
+# Phase Record — Effect-Native Habitat Core
+
+## Status
+
+CLOSED LOCALLY / DESIGN-ONLY — stacked after closed H7 and H8; implementation
+belongs in child changes after this parent design slice. This revision records
+the H8 reassessment and multi-spec split requested after the initial parent
+commit.
+
+## Branch And Stack State
+
+- Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-F-habitat-effect-core`
+- Branch: `agent-F-habitat-effect-core`
+- Graphite parent: `agent-F-habitat-generators-migrations`
+- Current branch state: `agent-F-habitat-effect-core` is stacked on H8 branch
+  `agent-F-habitat-generators-migrations`; the branch's unique design commit
+  owns this parent OpenSpec change.
+- Dirty ownership before commit: only
+  `openspec/changes/habitat-effect-native-core/**` is owned by this split
+  revision.
+
+## Protected / Forbidden Write Set
+
+- Do not edit H1-H8 historical OpenSpec records from this parent change.
+- Do not edit product/runtime Civ7 control, MapGen/Swooper, SDK, Studio, mods,
+  generated output, or lockfiles from this parent design slice.
+- Downstream realignment belongs under this change or child changes, not in
+  historical records.
+
+## Grounding
+
+- Frame: `openspec/changes/habitat-effect-native-core/workstream/frame.md`
+- Proposal: `openspec/changes/habitat-effect-native-core/proposal.md`
+- Design: `openspec/changes/habitat-effect-native-core/design.md`
+- Tasks: `openspec/changes/habitat-effect-native-core/tasks.md`
+- Spec deltas:
+  - `openspec/changes/habitat-effect-native-core/specs/habitat-effect-runtime-substrate/spec.md`
+  - `openspec/changes/habitat-effect-native-core/specs/habitat-effect-process-baselines/spec.md`
+  - `openspec/changes/habitat-effect-native-core/specs/habitat-effect-check-orchestration/spec.md`
+  - `openspec/changes/habitat-effect-native-core/specs/habitat-effect-command-programs/spec.md`
+  - `openspec/changes/habitat-effect-native-core/specs/habitat-effect-nx-generators-migrations/spec.md`
+  - `openspec/changes/habitat-effect-native-core/specs/habitat-effect-hooks/spec.md`
+  - `openspec/changes/habitat-effect-native-core/specs/habitat-effect-generated-verifier/spec.md`
+- H8 reassessment:
+  `openspec/changes/habitat-effect-native-core/workstream/h8-reassessment.md`
+- Review disposition:
+  `openspec/changes/habitat-effect-native-core/workstream/review-disposition.md`
+
+## Evidence Read
+
+- Habitat project docs: FRAME, workstream record, invariant corpus, taxonomy,
+  discrepancy log, review disposition ledger.
+- Habitat OpenSpec train: H1, H2, H3, H4, H4.5, H5, H6, H7, H8. The split
+  revision re-read H8 records and branch diff in full.
+- Current harness code: oclif commands, command engine, baselines, Grit, hooks,
+  generated zones, process runner, diagnostics, tests, README, root AGENTS,
+  H8 classify, H8 generators, and H8 migration metadata.
+- Local Effect precedent: `@civ7/studio-server` runtime/services/handler/tests
+  and `@civ7/control-orpc` procedure surface.
+- Official Effect docs: services/context, layers, resource management, Scope,
+  runtime/ManagedRuntime, platform command/filesystem/path/terminal,
+  concurrency primitives, scheduling, schema/config/logging, expected/tagged
+  errors, and testing/TestClock.
+
+## Agent Review Inputs
+
+- Sequencing/workstream review: parent design is acceptable; implementation
+  must wait until H8 closes and split into child changes.
+- Harness parity review: tighten check exit semantics, resource-publish carve
+  out, Grit details, baseline authoring, generated-zone policy table behavior,
+  H8 parity gates, and stdout/stderr probes.
+- H8 reassessment review: separate Nx generator/migration surfaces from oclif
+  command programs; pin classify payload shape; pin generator, pattern, and
+  migration parity.
+- OpenSpec split review: replace singular broad spec with multiple
+  capability-level spec deltas and update phase metadata.
+- Effect-idiom review: repeat platform dependency proof in-repo, reconcile Bun
+  dev path with Node live layer, keep internal report-schema failure as a
+  defect, remove custom clock abstraction, and forbid nested Habitat CLI
+  invocation inside migrated hooks.
+- Formal workstream review wave: authority/H8 parity, OpenSpec shape/task
+  readiness, Effect architecture/lifecycle, Nx generator/migration boundary,
+  proof/closure, and information-design/future-DRA clarity.
+
+## Current Decisions
+
+- `habitat-effect-native-core` is a parent/design OpenSpec change.
+- Child implementation changes:
+  `habitat-effect-runtime-substrate`,
+  `habitat-effect-process-baselines`,
+  `habitat-effect-check-orchestration`,
+  `habitat-effect-command-programs`,
+  `habitat-effect-nx-generators-migrations`,
+  `habitat-effect-hooks`,
+  `habitat-effect-generated-verifier`.
+- Oclif remains the command adapter.
+- Nx generators and migrations remain Nx host adapters with an Nx `Tree` backed
+  generator workspace service.
+- Core modules return Effect programs and structured results.
+- Live platform direction is Node-oriented, with in-repo proof required for both
+  Bun dev invocation and built Node oclif invocation before manifest edits.
+- Keep pure data/parsers/renderers plain.
+- Move hooks and generated-zone verification after process/Git/FS/baseline
+  services are proven.
+
+## Stop-Condition Status
+
+- H7/H8 not closed: clear in the current stack (`openspec list` reports both
+  complete); child implementation still waits for this parent design commit.
+- Command parity changed: no implementation in this slice.
+- Runtime/resource outlives command: no implementation in this slice.
+- Hook restage policy unproven: deferred to `habitat-effect-hooks`.
+- Grit scan model unproven: deferred to `habitat-effect-check-orchestration`.
+- Generated-zone snapshot/restore unproven: deferred to
+  `habitat-effect-generated-verifier`.
+- Dependency peer/runtime proof incomplete in-repo: deferred to
+  `habitat-effect-runtime-substrate`.
+- Nx generator Tree/runtime/module bridge unproven: deferred to
+  `habitat-effect-nx-generators-migrations`.
+
+## Validation Log
+
+- 2026-06-14: `bun install` completed before design drafting.
+- 2026-06-14: `bun run build` passed before design drafting.
+- 2026-06-14: `bun run openspec -- list` completed after install.
+- 2026-06-14: Temp dependency probe installed `effect@3.21.3`,
+  `@effect/platform@0.96.1`, and `@effect/platform-node@0.107.0` under Bun
+  without peer warnings.
+- 2026-06-14: Temp runtime probe imported `NodeContext.layer` and ran a minimal
+  Effect program under Bun.
+- 2026-06-14: `bun run openspec -- validate habitat-effect-native-core
+  --strict` passed after adversarial-review revisions.
+- 2026-06-14: `bun run openspec:validate` passed: 158 OpenSpec records valid.
+- 2026-06-14: `git diff --check` passed.
+- 2026-06-14: banned-language scan for this change returned no hits.
+- 2026-06-14: `gt info agent-F-habitat-effect-core` reported parent
+  `agent-F-habitat-generators-migrations`.
+- 2026-06-14: H8 branch diff and implementation files re-read; parent spec
+  split revised from one `habitat-harness` spec delta to seven child-aligned
+  spec deltas.
+- 2026-06-14: `bun run openspec -- validate habitat-effect-native-core
+  --strict` initially found missing parsed requirement keywords after the split;
+  requirement bodies were repaired.
+- 2026-06-14: `bun run openspec -- validate habitat-effect-native-core
+  --strict` passed after split repairs.
+- 2026-06-14: `bun run openspec:validate` passed: 158 OpenSpec records valid.
+- 2026-06-14: `git diff --check` passed after split repairs.
+- 2026-06-14: Formal review wave completed; accepted findings repaired for
+  classify deletion-diff parity, task scoping, Nx factory lifecycle stop
+  conditions, reporter/runtime boundaries, source CJS factory metadata parity,
+  Tree-write coverage, and parent-vs-child verification gates.
+- 2026-06-14: `bun run openspec -- list` reported
+  `habitat-effect-native-core` complete after task-scope repair.
+- 2026-06-14: `bun run openspec -- validate habitat-effect-native-core
+  --strict` passed after formal review repairs.
+- 2026-06-14: `bun run openspec:validate` passed after formal review repairs:
+  158 OpenSpec records valid.
+- 2026-06-14: `git diff --check` passed after formal review repairs.
+- 2026-06-14: shortcut-language scan returned no hits after formal review
+  repairs.
+
+## Next Exact Action
+
+Next implementation action is to draft `habitat-effect-runtime-substrate` as a
+child change. Keep this parent design read-only except for review-driven
+corrections.

--- a/openspec/changes/habitat-effect-native-core/workstream/review-disposition.md
+++ b/openspec/changes/habitat-effect-native-core/workstream/review-disposition.md
@@ -1,0 +1,188 @@
+# Review Disposition — Effect-Native Habitat Core
+
+## Source Reviews
+
+- Sequencing/workstream review agent: accepted.
+- Habitat parity review agent: accepted.
+- Effect-idiom review agent: accepted.
+- H8 parity reassessment agent: accepted.
+- Effect/Nx generator boundary review agent: accepted.
+- OpenSpec split/granularity review agent: accepted where consistent with H8
+  host-boundary evidence; superseded where it recommended merging Nx
+  generators/migrations back into command programs.
+- Formal authority/H8 parity lane: accepted.
+- Formal OpenSpec shape/task readiness lane: accepted.
+- Formal Effect architecture/lifecycle lane: accepted.
+- Formal Nx generator/migration boundary lane: accepted.
+- Formal proof/closure lane: accepted.
+- Formal information-design/future-DRA lane: accepted.
+
+## Dispositions
+
+### Parent vs Implementation Scope
+
+Accepted. `habitat-effect-native-core` is now the parent/design change. The full
+implementation is split into named child changes, each with its own future
+OpenSpec artifacts and closure gates.
+
+### H7/H8 Closure
+
+Accepted. Implementation was blocked until H7 and H8 closed. Both are now
+closed locally, and this parent design still does not mutate H1-H8
+implementation state.
+
+### Phase Record Shape
+
+Accepted. The phase record now records branch/stack state, dirty ownership,
+protected writes, evidence, decisions, stop-condition status, validation, and
+next action.
+
+### Spec Detail Level
+
+Accepted. Exact service inventory and package versions remain in design/tasks.
+The split spec deltas state behavior/process requirements: adapter lifecycle,
+injectable Effect capability boundaries, contract parity, hook/generated-zone
+mutation policy, Nx generator/migration host boundaries, and runtime proof
+obligations.
+
+### Check Exit Semantics
+
+Accepted. The spec now allows non-zero exit when enforced rules fail or when no
+valid report can be produced, while preserving JSON stdout isolation.
+
+### Resource Publish Carve-Out
+
+Accepted. H7's resource-publish gitlink behavior is now the explicit
+non-formatter carve-out for hook mutation policy.
+
+### Grit Parity
+
+Accepted. The design now pins full-check scan roots/options/env/parser/projection
+and distinguishes the staged hook scan.
+
+### Baseline Authoring
+
+Accepted. The spec and design now include `--expand-baseline` selected-rule
+writes, sorted/newline formatting, no report emission, no-merge-base behavior,
+and rule-introduction integrity semantics.
+
+### Generated-Zone Policy Path
+
+Accepted. The generated-zone design distinguishes map artifact snapshot/restore
+from the policy-table check-only gate and requires final worktree cleanliness.
+
+### H8 Parity
+
+Accepted. The command-program child scope now owns `classify` path and diff
+semantics only. Unsupported-kind refusal, pattern generator baseline/rule-pack
+entry, generated project probes, and migration run-file semantics are owned by
+`habitat-effect-nx-generators-migrations`.
+
+### Stdout/Stderr Matrix
+
+Accepted. The test strategy now names `fix --dry-run`, `graph --json`,
+`check --output`, filtered checks, staged checks, unknown hook exit 2, and
+verify check-fail ordering.
+
+### Platform Dependency Peers And Bun Dev Path
+
+Accepted with additional evidence. A temp Bun install of the proposed packages
+completed without peer warnings, and a minimal `NodeContext.layer` run succeeded
+under Bun. The first implementation child must repeat this proof in-repo before
+manifest edits.
+
+### Error Model
+
+Accepted. Expected external/tool/input failures use tagged errors; internal
+report-schema failures remain defects surfaced by the adapter.
+
+### Nested Habitat CLI In Hooks
+
+Accepted. The design now requires migrated hooks to call internal check/rule
+programs rather than spawning another Habitat CLI process.
+
+### Clock Abstraction
+
+Accepted. The design uses Effect `Clock`/`TestClock` directly and avoids a
+Habitat-specific clock wrapper unless a later child proves added semantics.
+
+### H8 Generator And Migration Boundary
+
+Accepted. H8 generators and migrations are not oclif command programs. The
+parent split now includes `habitat-effect-nx-generators-migrations`, and the
+design/specs require Nx factory adapters, Nx `Tree` backed writes, local
+migration run-file semantics, and explicit CJS/ESM bridge selection.
+
+### H8 Classify Contract
+
+Accepted. The command-program spec now pins H8 path, workspace path, literal
+diff, `.diff`/`.patch` file, and four-path matrix behavior, including
+`requiredTargets`, `rulesInScope`, and diff schema version `1`.
+
+### H8 Project Generator Parity
+
+Accepted. The Nx generator spec now pins supported kind output, taxonomy
+spelling normalization, unsupported-kind refusal, non-empty root refusal,
+package scripts/exports/files/engine, tsconfig, source/test stubs, README, and
+zero-new-baseline proof.
+
+### H8 Pattern Generator And Migration Proof
+
+Accepted. The Nx generator/migration spec now pins native Grit pattern output,
+empty locked baseline, `grit-check` rule-pack entry, duplicate artifact
+refusal, native Grit fixture proof, local run-file package
+`./tools/habitat-harness`, and `--skip-install` migration execution.
+
+### Multi-Spec Split
+
+Accepted. The deleted singular `habitat-harness` delta is replaced by seven
+child-aligned spec directories: runtime substrate, process/baselines,
+check orchestration, command programs, Nx generators/migrations, hooks, and
+generated verifier.
+
+### OpenSpec Validation Shape
+
+Accepted. The split must validate with `bun run openspec -- validate
+habitat-effect-native-core --strict` and `bun run openspec:validate`; any
+missing requirement keyword or stale spec pointer blocks closure.
+
+### Formal Review: Closure Overclaim And Future Child Tasks
+
+Accepted. The task ledger now separates completed parent split work from future
+child changes, removing unchecked future child drafting tasks from the parent
+completion count. The parent can close only after the split revision is
+committed via Graphite and the worktree is clean.
+
+### Formal Review: Nx Factory Lifecycle Stop Condition
+
+Accepted. The proposal now stops on generator/migration-scoped runtime, fiber,
+process, or resource leakage beyond the Nx factory promise/callback, not only
+leakage beyond oclif `Command.run()`.
+
+### Formal Review: Classify Deletion Diff Parity
+
+Accepted. The command-program spec now matches H8 parser behavior: literal
+`/dev/null` markers are ignored, but paths collected from `diff --git ... b/*`
+remain classified, including deletion diffs.
+
+### Formal Review: Reporter And Runtime Boundaries
+
+Accepted. Pure report stringification, schema validation, and human rendering
+remain plain. Command adapters own stdout/stderr and `--output` writes, or
+delegate only the file write to a narrow output-file capability. Runtime bridge
+and layer assembly are adapter concerns, not core services available to
+reusable Habitat programs.
+
+### Formal Review: CJS Factory Metadata Parity
+
+Accepted. The Nx generator/migration spec and design now preserve current
+source CJS factory metadata paths. The child implementation may use CJS
+factories that import implementation code or a deliberately small
+CJS-compatible pure core, but it may not move metadata to built factory files
+under this parent contract.
+
+### Formal Review: Verification Gate Taxonomy
+
+Accepted. The proposal now separates parent closure gates from future child
+implementation gates and states that OpenSpec validation proves artifact shape
+only for this parent.


### PR DESCRIPTION
This PR establishes the `habitat-effect-native-core` parent design workstream, which defines the architecture and sequencing for migrating Habitat's reusable core to idiomatic Effect. It is stacked after the closed H7 (`habitat-git-hooks`) and H8 (`habitat-generators-migrations`) changes and contains no implementation — only design artifacts, specs, and review records.

**What this introduces:**

- A frame, proposal, design, tasks, phase record, H8 reassessment, and review disposition for the parent workstream
- Seven child-aligned spec deltas replacing a prior singular spec, one per major implementation workstream: runtime substrate, process/baselines, check orchestration, command programs, Nx generators/migrations, hooks, and generated-zone verifier
- Architecture decisions covering the oclif-to-Effect runtime bridge, service/layer boundaries (`HabitatWorkspace`, `HabitatProcess`, `HabitatGit`, `BaselineStore`, `RuleRegistry`, `RuleRunner`, `GritService`, `BiomeService`, `NxService`, `HookRunner`, `GeneratedZoneVerifier`, `NxGeneratorTree`), error model using `Data.TaggedError`, resource/concurrency policy using `Scope`/`Queue`/`Semaphore`/`Schedule`, and a Node-oriented live platform layer with in-repo proof required before manifest changes
- Explicit treatment of Nx generators and migrations as a distinct host-adapter surface separate from oclif commands, requiring an Nx `Tree`-backed service for generator writes and an explicit CJS/ESM bridge for factory metadata
- Stop conditions covering runtime/resource lifecycle, hook mutation policy, Grit scan model, baseline ratchet semantics, generated-zone snapshot/restore, dependency peer resolution, and Nx factory promise closure
- A validated phase record confirming `bun run openspec -- validate habitat-effect-native-core --strict` and `bun run openspec:validate` pass, with all formal review findings accepted and repaired

No command behavior, JSON contracts, exit codes, hook policy, generator schemas, migration metadata, or H1–H8 historical records are changed.