### PR TITLE
`docs(habitat-harness): add Effect and GritQL official-docs evidence packs for Grit adapter DRA`

### DIFF
--- a/docs/projects/habitat-harness/research/effect-grit-adapter/effect-official-docs.md
+++ b/docs/projects/habitat-harness/research/effect-grit-adapter/effect-official-docs.md
@@ -1,0 +1,175 @@
+# Effect Official Docs Evidence Pack For Habitat Grit Adapter
+
+Retrieval date: 2026-06-14.
+
+## Objective
+
+Decide, from verified or corroborated official-source evidence, whether Effect can simplify and strengthen the Habitat Harness command/Grit proof substrate without weakening the product outcome.
+
+This is not a generic library endorsement. The question is whether Effect's documented capabilities should become an implementation dependency, design constraint, or non-blocking compatibility point for Habitat's Grit adapter and command runner.
+
+## Frame
+
+- **In scope:** Effect capabilities relevant to typed command execution, structured error/provenance capture, parser/schema discipline, resource boundaries around Grit apply/check, command proof records, service injection, cancellation/interruption, and tests.
+- **Foreground:** official Effect documentation, exact source URLs, and how each documented capability maps to Habitat's current substrate needs.
+- **Exterior:** Effect marketing, blogs, unofficial examples, package popularity, non-Effect alternatives, product/runtime Civ7 semantics, and claims that Effect itself proves Grit/Biome/Nx correctness.
+- **Hard core:** Habitat remains a repo-local executable structural operating system for agents. Its product outcome is stable command behavior, truthful proof records, ratcheted structural enforcement, and safe remediation. Effect is acceptable only if it strengthens those properties without replacing Habitat's oclif command surface or weakening current parity gates.
+- **Falsifier:** if adopting Effect changes Habitat command names/flags/exit codes/stdout/stderr/JSON shape before parity proof, hides Grit/Biome/Nx evidence behind opaque failures, or becomes Promise wrapping without typed errors/services/scopes, then Effect is not strengthening this substrate.
+
+## Source Map
+
+Official Effect documentation used:
+
+- The Effect Type: https://effect.website/docs/getting-started/the-effect-type/
+- Creating Effects: https://effect.website/docs/getting-started/creating-effects/
+- Using Generators: https://effect.website/docs/getting-started/using-generators/
+- Expected Errors: https://effect.website/docs/error-management/expected-errors/
+- Error Channel Operations: https://effect.website/docs/error-management/error-channel-operations/
+- Data: https://effect.website/docs/data-types/data/
+- Runtime: https://effect.website/docs/runtime/
+- Managing Layers: https://effect.website/docs/requirements-management/layers/
+- Resource Management Introduction: https://effect.website/docs/resource-management/introduction/
+- Scope: https://effect.website/docs/resource-management/scope/
+- Effect Platform Introduction: https://effect.website/docs/platform/introduction/
+- Command: https://effect.website/docs/platform/command/
+- Schema Introduction: https://effect.website/docs/schema/introduction/
+- Schema Getting Started: https://effect.website/docs/schema/getting-started/
+- Configuration: https://effect.website/docs/configuration/
+- Basic Concurrency: https://effect.website/docs/concurrency/basic-concurrency/
+- Fibers: https://effect.website/docs/concurrency/fibers/
+- TestClock: https://effect.website/docs/testing/testclock/
+
+Local Habitat context read as repository evidence, not Effect authority:
+
+- `agent-F-habitat-effect-core:docs/projects/habitat-harness/FRAME.md`
+- `agent-F-habitat-effect-core:openspec/changes/habitat-effect-native-core/design.md`
+- `agent-F-habitat-effect-core:openspec/changes/habitat-effect-native-core/workstream/frame.md`
+- `agent-F-habitat-effect-core:openspec/changes/habitat-effect-native-core/specs/habitat-effect-runtime-substrate/spec.md`
+- `agent-F-habitat-effect-core:openspec/changes/habitat-effect-native-core/specs/habitat-effect-command-programs/spec.md`
+- `agent-F-habitat-effect-core:openspec/changes/habitat-grit-catalog/design.md`
+- `agent-F-habitat-effect-core:tools/habitat-harness/src/lib/{grit,spawn,command-engine,baseline,hooks,generated-zones,diagnostics}.ts`
+
+## Findings With Provenance
+
+- **Verified: Effect values carry success, error, and requirement types.** The official `Effect<Success, Error, Requirements>` type captures successful result, expected error, and contextual dependency requirements, and Effect values model synchronous, asynchronous, concurrent, and resourceful computations. (source: https://effect.website/docs/getting-started/the-effect-type/, retrieved 2026-06-14)
+
+- **Verified: Effect execution belongs at runtime/program edges.** Runtime docs describe Effect programs as descriptions that require a runtime to execute; `Runtime.runPromise` is explicitly effectful and "should only be used at the edges of your program." (source: https://effect.website/docs/runtime/, retrieved 2026-06-14)
+
+- **Verified: expected errors are tracked in the error channel.** The Expected Errors docs show `Effect.fail` and state that Effect keeps possible errors as a union in the program type. The Data docs document `Data.TaggedError`, which adds `_tag` fields for structured handling with `catchTag`/`catchTags`. (sources: https://effect.website/docs/error-management/expected-errors/, https://effect.website/docs/data-types/data/, https://effect.website/docs/error-management/error-channel-operations/, retrieved 2026-06-14)
+
+- **Verified: `Effect.gen` is official workflow composition, not just syntax sugar.** The docs say `Effect.gen` lets code look synchronous while handling asynchronous tasks, errors, and complex control flow with explicit `yield*` over effects. (source: https://effect.website/docs/getting-started/using-generators/, retrieved 2026-06-14)
+
+- **Verified: Effect distinguishes non-failing synchronous work from fallible work.** `Effect.sync` is for operations you are sure will not fail; thrown errors become defects. The Creating Effects docs also separate fallible constructors such as `try`/`tryPromise`. (source: https://effect.website/docs/getting-started/creating-effects/, retrieved 2026-06-14)
+
+- **Verified: resource finalization is first-class and interruption-aware.** Resource docs state `Effect.ensuring` runs a finalizer on success, failure, or interruption. Scope docs document scopes/finalizers and `acquireRelease` patterns for scoped resource lifetimes. (sources: https://effect.website/docs/resource-management/introduction/, https://effect.website/docs/resource-management/scope/, retrieved 2026-06-14)
+
+- **Verified: `@effect/platform` officially documents command execution primitives.** Platform introduction says `@effect/platform` provides platform-independent abstractions for Node.js, Deno, Bun, and browsers, and lists `Command`, `FileSystem`, `Path`, `Runtime`, and `Terminal` as stable modules. Command docs show `Command.make`, command output as strings or exit codes, custom environment variables, inherited stdout, and Node/Bun/Deno platform layers. (sources: https://effect.website/docs/platform/introduction/, https://effect.website/docs/platform/command/, retrieved 2026-06-14)
+
+- **Verified: Schema is an official parse/validation layer.** Schema docs describe `effect/Schema` as defining schemas that validate and transform data in TypeScript, including decoding, encoding, asserting, JSON Schema generation, and `ParseError` returns for decode/encode failures. (sources: https://effect.website/docs/schema/introduction/, https://effect.website/docs/schema/getting-started/, retrieved 2026-06-14)
+
+- **Verified: Config/Context/Layers are official dependency and configuration primitives.** The Effect type's `Requirements` are stored in `Context`; Layer docs show service tags, `Layer.succeed`, `Effect.Service`, `Effect.provideService`, and service construction with declared dependencies. Configuration docs show typed config composition, defaults/fallbacks, sensitive values, and test config providers. (sources: https://effect.website/docs/getting-started/the-effect-type/, https://effect.website/docs/requirements-management/layers/, https://effect.website/docs/configuration/, retrieved 2026-06-14)
+
+- **Verified: cancellation/interruption and child-fiber lifetime are documented.** Runtime docs state default runtime flags include interruption. Basic Concurrency and Fibers docs describe `interrupt`, `onInterrupt`, interruption of concurrent effects, and auto-supervision where child fibers attached to the parent scope terminate with the parent. (sources: https://effect.website/docs/runtime/, https://effect.website/docs/concurrency/basic-concurrency/, https://effect.website/docs/concurrency/fibers/, retrieved 2026-06-14)
+
+- **Verified: testing support includes controllable time and injectable services.** TestClock docs state tests can control time with `TestClock.adjust`/`setTime` so scheduled effects run without waiting for real time. Layer docs show replacing service implementations with `provideService` or test layers. (sources: https://effect.website/docs/testing/testclock/, https://effect.website/docs/requirements-management/layers/, retrieved 2026-06-14)
+
+## Plausible Application To Habitat
+
+These are applications inferred from official capabilities plus local Habitat design/code. They are not official Effect claims.
+
+- **Typed errors:** Habitat can model command-infrastructure failures as tagged errors: `ToolUnavailable`, `ToolJsonParseFailed`, `BaselineMalformed`, `UnsafePartialStaging`, `GritApplyFailed`, `GeneratedZoneRestoreFailed`, and `InternalReportSchemaViolation`. Rule violations should remain report data, not fatal Effect errors, unless the command cannot produce a valid report.
+
+- **`Effect.gen`:** Habitat's `check`, `fix`, `graph`, hook, and generated-zone flows have multi-step orchestration with fallible tool calls, parse boundaries, temp dirs, and output rendering. `Effect.gen` can make those workflows linear while preserving typed errors and service requirements.
+
+- **Scope/resource safety:** Habitat's current branch code has manual cleanup paths for graph temp directories, Grit cache dirs, formatter restaging, generated-zone snapshots, and hook subprocesses. Effect scopes/finalizers fit the requirement that cleanup complete even on failure/interruption. This is especially relevant before expanding Grit apply or introducing async subprocess handling.
+
+- **Process/command execution:** `@effect/platform/Command` can represent `grit`, `biome`, `nx`, `git`, and `bun` invocations as command values with explicit process name, args, environment, output, and exit data. That directly supports truthful command proof records. Habitat still has to own cwd policy, parse Grit JSON, and derive failure from findings because local Grit evidence says raw `grit check` can exit 0 with findings.
+
+- **Schema:** Grit JSON, Habitat `CheckReport`, classify diff results, baseline files, and generated-zone definitions are parsing boundaries. Effect Schema can replace ad hoc JSON parse/shape checks where the boundary is reused or safety-critical. It is not necessary for pure internal TypeScript types that already have stable tests.
+
+- **Config/Context/Layers:** Habitat service interfaces map cleanly to layers: workspace paths, process runner, Git, Grit, Biome, Nx, baseline store, rule registry, hook runner, generated-zone verifier, and clock. This improves unit tests by substituting fake services without touching the real repo, Git index, or subprocesses.
+
+- **Cancellation/interruption:** If command execution becomes asynchronous, cancellation has product value only if it also preserves proof truth: child processes/fibers must be parent-scoped, finalizers must run, and command output must not claim success after an interrupted or partially applied operation.
+
+- **Testing:** Fake layers and `TestClock` can remove sleeps and real subprocess dependence from unit tests for retry/backoff/debounce/timeouts. Native Grit pattern tests and end-to-end command parity tests should remain as integration proof.
+
+## Risks And Costs
+
+- **Added abstraction:** Effect adds a runtime, fiber, scope, service/layer, and typed-error model. If used only to wrap existing Promises or `spawnSync`, it increases complexity without improving proof quality.
+
+- **Dependency footprint:** A real adoption likely adds at least `effect`, `@effect/platform`, and a platform package such as `@effect/platform-node` or `@effect/platform-bun`. Official docs show platform support, but exact package versions, peer resolution, and repo Bun/Node behavior still need in-repo proof.
+
+- **Learning curve:** `Effect.gen`, error channels, scoped resources, and Layer wiring require team/agent discipline. The risk is scattering `Effect.run*` or losing the oclif adapter boundary.
+
+- **CLI mismatch risk:** Habitat's command contract depends on deterministic stdout/stderr placement, JSON shape, and exit codes. Effect runtime helpers or platform command streaming can accidentally move output timing or failure representation unless the oclif adapter remains responsible for final rendering.
+
+- **Grit support gap:** Official Effect docs do not provide a Grit adapter, Grit JSON schema, codemod transaction semantics, or proof that Grit apply is safe. Those remain Habitat-specific invariants and tests.
+
+- **Process concurrency risk:** Effect makes concurrency easier, but Habitat's Grit/Biome/Nx/Git surfaces are not automatically safe for fan-out. Bounded concurrency must be an explicit design choice after parity, not a default refactor side effect.
+
+- **Schema normalization risk:** Effect Schema parse errors are useful, but Habitat's external JSON/proof records must stay stable and user-facing. Raw `ParseError` output should be normalized into Habitat diagnostics or typed command failures.
+
+- **Platform documentation nuance:** The docs navigation groups platform pages under "Platform Unstable", while the Platform Introduction page lists Command/FileSystem/Path/Runtime/Terminal as stable modules. Treat Command as officially documented and stable-listed, but verify package release notes and exact versions before making it critical infrastructure.
+
+## Constraints / Invariants To Encode
+
+- Do not make Effect a product acceptance gate. Habitat's product outcome is command/proof correctness; Effect is a substrate mechanism that must prove parity.
+
+- Keep oclif as the command shell. Effect programs live below command adapters; adapters own flag parsing, final stdout/stderr, `--output`, and exit-code mapping.
+
+- Keep `Effect.run*` at host boundaries: oclif command classes, hook entrypoints, Nx generator/migration factories, or one small Habitat runtime bridge. Core libraries return `Effect` values or pure results.
+
+- Separate rule findings from infrastructure failures. Findings are `CheckReport` data; infrastructure failures are typed Effect errors.
+
+- Use argument-array command execution only. No shell interpolation. Preserve argv, cwd, env, stdout, stderr, exit code, and parse/projection provenance in proof records.
+
+- Use scopes/finalizers for temp dirs, cache locks, generated-zone snapshots/restores, async child processes, background fibers, and any Grit apply transaction boundary.
+
+- Preserve existing Grit adapter semantics: one native JSON scan per check process, `--level error`, cache/env policy, JSON parse from stdout or stderr, projection by `local_name` or `check_id`, and derived pass/fail from findings rather than raw exit code.
+
+- Adopt Schema only at real external boundaries, not as a blanket rewrite of plain internal types.
+
+- Unit-test service logic with fake layers; retain native Grit pattern tests and command parity integration tests.
+
+## Open Questions / Uncertainties
+
+- **Exact dependency set:** official docs prove capabilities, not the exact package versions to use in this repo. Fast verification: in the Habitat worktree, add candidate versions with Bun, inspect peer output, and prove dev plus built oclif commands execute.
+
+- **Platform package choice:** docs support Node/Deno/Bun platform layers. Habitat's built oclif runner is Node-oriented while local scripts run through Bun. Fast verification: run the same minimal command/file/path program under Bun dev and built Node invocation.
+
+- **Command parity:** official docs do not prove stdout/stderr/exit-code parity against current `spawnSync`. Fast verification: golden parity tests for `check --json`, `fix --dry-run`, `graph --json`, hook pre-commit/pre-push, and Grit parse-failure cases.
+
+- **Grit apply transactionality:** Effect Scope can clean up resources, but Grit itself is not documented by Effect. Fast verification: local transactional wrapper tests with dry-run, successful apply+format, apply failure, format failure, and restore/dirty-worktree proof.
+
+- **Schema ergonomics:** Effect Schema can parse, but raw parse errors may not match Habitat's JSON contract. Fast verification: convert one Grit report parser behind a compatibility adapter and compare diagnostics.
+
+## Decision Table
+
+| Capability | Confirmed official capability | Habitat decision | Rationale |
+|---|---|---|---|
+| Typed errors / tagged failures | `Effect` has an expected error channel; docs show unions of expected errors; `Data.TaggedError` supports tagged structured errors and `catchTag` handling. | **Adopt in this workstream** | Directly strengthens command failures, provenance, and adapter-level exit-code mapping. Keep rule violations as data. |
+| `Effect.gen` workflow composition | Official docs describe generator-based composition for async tasks, errors, and control flow. | **Adopt in this workstream** | Fits multi-step command/Grit orchestration while preserving typed failures and service dependencies. Avoid in tiny pure functions. |
+| Scope / resource safety | Docs support finalizers on success/failure/interruption and scoped acquire/release. | **Adopt in this workstream** | Load-bearing for temp dirs, Grit apply boundaries, generated-zone restore, cache locks, child processes, and hook cleanup. |
+| Process / command execution | `@effect/platform` officially documents stable `Command` and platform layers for Node/Deno/Bun/browser environments. | **Adopt in this workstream, behind `HabitatProcess`, after parity proof** | Strong fit for truthful argv/env/stdout/stderr/exit records. Habitat must preserve cwd policy and CLI output behavior. |
+| Schema parsing / validation | `effect/Schema` supports decoding, encoding, asserting, JSON Schema, and `ParseError` boundaries. | **Design-compatible but not required** | Useful for Grit JSON/report/baseline boundaries, but not necessary for first adoption if manual validators are stable. Adopt boundary-by-boundary. |
+| Context / Layers / service injection | Docs show Context requirements, service tags, `Layer.succeed`, `Effect.Service`, `provideService`, and layer-managed dependencies. | **Adopt in this workstream** | Matches Habitat's need for fakeable Git/FS/process/Grit/Biome/Nx/baseline services and runtime-bound infrastructure. |
+| Config | Docs support typed config composition, defaults, fallback, sensitive values, and mocked providers. | **Design-compatible but not required** | Habitat has limited config needs today. Use when env/tool policy becomes shared service config; do not force it into static rule data. |
+| Cancellation / interruption | Runtime and concurrency docs cover interruption, `onInterrupt`, and auto-supervised child fibers. | **Adopt in this workstream as a quality gate for async/scoped work** | Needed if command runner introduces async processes/fibers. Not a product feature unless cleanup/proof semantics are preserved. |
+| Testing: fake layers | Layer docs show service substitution with `provideService` and test implementations. | **Adopt in this workstream** | Directly improves command runner/Grit adapter tests without real Git/process/filesystem side effects. |
+| Testing: `TestClock` | TestClock docs allow manual time control for sleeps/timeouts/schedules. | **Design-compatible but not required** | Adopt only where retries, polling, debounce, timeout, or backoff is introduced. |
+
+## Synthesis
+
+Official Effect documentation confirms native support for the substrate problems Habitat is trying to repair: typed error channels, effectful workflow composition, scoped resources/finalizers, services/layers, platform command execution, schema parsing, cancellation/interruption, and test seams.
+
+The evidence supports **narrow adoption for the Habitat command runner and Grit adapter substrate**, especially for typed errors, service/layer boundaries, scoped resources, and command execution provenance. It does **not** support treating Effect as a product-outcome blocker: official docs do not prove Grit safety, Habitat command parity, baseline shrink-only behavior, or codemod transactionality. Those remain local Habitat invariants requiring parity tests and proof records.
+
+Recommended decision: adopt Effect as an implementation dependency for the Effect-native Habitat core workstream only if the first slice proves dependency installation, dev/built command execution, and no behavior change. Do not block Habitat's product outcome on Effect; block only on the substrate parity gates the workstream declares.
+
+## Suggested Next Edits
+
+- file: `openspec/changes/habitat-effect-native-core/workstream/phase-record.md` -> change: add this note as the official-doc evidence input for Effect capability claims.
+- file: `openspec/changes/habitat-effect-native-core/specs/habitat-effect-runtime-substrate/spec.md` -> change: require the runtime bridge to keep `Effect.run*` at adapter boundaries and dispose scoped resources before command completion.
+- file: `openspec/changes/habitat-effect-native-core/specs/habitat-effect-process-baselines/spec.md` -> change: require command proof records to preserve argv/env/cwd/stdout/stderr/exit code plus parse/projection provenance.
+- file: `openspec/changes/habitat-effect-native-core/specs/habitat-effect-check-orchestration/spec.md` -> change: require Grit JSON parser parity before replacing the existing parser with Effect Schema or typed parser effects.
+- file: `tools/habitat-harness/test/**` -> change: add fake-layer parity tests before migrating live command paths.

--- a/docs/projects/habitat-harness/research/effect-grit-adapter/gritql-official-docs.md
+++ b/docs/projects/habitat-harness/research/effect-grit-adapter/gritql-official-docs.md
@@ -1,0 +1,409 @@
+# GritQL / Grit CLI Official Evidence Pack For Habitat Harness
+
+Retrieval date: 2026-06-14.
+
+Official repo snapshot used for source corroboration: `biomejs/gritql`
+commit `c80b3026471b229f41b279c3eb0c162dcdacfdb1`.
+
+## Objective
+
+Produce verified or corroborated official-source evidence for the GritQL and
+Grit CLI semantics that matter to Habitat Harness proof design before broad
+pattern backfill. The next DRA packet needs to decide whether a typed
+Effect-backed Grit adapter is warranted and, if so, which guarantees it must
+own for 22 check patterns and one apply codemod.
+
+## Frame
+
+- In: official `docs.grit.io` documentation, official `biomejs/gritql`
+  repository docs/source/tests, and only the semantics needed for Habitat
+  proof: scan scope, fixtures, baseline behavior, injected violations,
+  JSON/provenance, and safe apply.
+- Foreground: what can be relied on as public Grit behavior versus what Habitat
+  must wrap, pin, or empirically probe.
+- Exterior: blogs, model memory, Biome's separate GritQL plugin behavior, and
+  local Habitat pattern implementation details not yet present in this repo.
+- Structural alternative considered: a public-docs-only adapter contract. That
+  fails because the public docs do not define JSON schema, local baseline
+  semantics, or exit behavior with enough precision for audit-grade proof.
+- Falsifier: if a pinned `grit version --jsonl`/`grit help`/empirical probe on
+  Habitat's chosen CLI version contradicts the source-derived observations
+  below, the adapter contract must prefer the pinned CLI behavior and record
+  the public-doc gap explicitly.
+
+## Source Map
+
+Public docs, all retrieved 2026-06-14:
+
+- CLI reference: https://docs.grit.io/cli/reference
+- CLI quickstart: https://docs.grit.io/cli/quickstart
+- Configuration: https://docs.grit.io/guides/config
+- Pattern libraries: https://docs.grit.io/guides/patterns
+- Testing GritQL: https://docs.grit.io/guides/testing
+- Continuous Integration: https://docs.grit.io/guides/ci
+- Syntax reference: https://docs.grit.io/language/syntax
+- Patterns: https://docs.grit.io/language/patterns
+- Conditions: https://docs.grit.io/language/conditions
+- Pattern modifiers: https://docs.grit.io/language/modifiers
+- Variable scoping / bubble: https://docs.grit.io/language/bubble
+- Common idioms: https://docs.grit.io/language/idioms
+- Target languages: https://docs.grit.io/language/target-languages
+- Functions: https://docs.grit.io/language/functions
+
+Official repo docs/source URLs, all retrieved 2026-06-14:
+
+- CLI docs source:
+  https://github.com/biomejs/gritql/blob/c80b3026471b229f41b279c3eb0c162dcdacfdb1/docs/src/pages/cli/reference.mdoc
+- Config docs source:
+  https://github.com/biomejs/gritql/blob/c80b3026471b229f41b279c3eb0c162dcdacfdb1/docs/src/pages/guides/config.mdoc
+- Pattern libraries docs source:
+  https://github.com/biomejs/gritql/blob/c80b3026471b229f41b279c3eb0c162dcdacfdb1/docs/src/pages/guides/patterns.mdoc
+- Testing docs source:
+  https://github.com/biomejs/gritql/blob/c80b3026471b229f41b279c3eb0c162dcdacfdb1/docs/src/pages/guides/testing.mdoc
+- CI docs source:
+  https://github.com/biomejs/gritql/blob/c80b3026471b229f41b279c3eb0c162dcdacfdb1/docs/src/pages/guides/ci.mdoc
+- Syntax/pattern docs:
+  https://github.com/biomejs/gritql/tree/c80b3026471b229f41b279c3eb0c162dcdacfdb1/docs/src/pages/language
+- CLI output flags:
+  https://github.com/biomejs/gritql/blob/c80b3026471b229f41b279c3eb0c162dcdacfdb1/crates/cli/src/flags.rs
+- JSONL messenger:
+  https://github.com/biomejs/gritql/blob/c80b3026471b229f41b279c3eb0c162dcdacfdb1/crates/cli/src/jsonl.rs
+- Check command implementation:
+  https://github.com/biomejs/gritql/blob/c80b3026471b229f41b279c3eb0c162dcdacfdb1/crates/cli/src/commands/check.rs
+- Apply command implementation:
+  https://github.com/biomejs/gritql/blob/c80b3026471b229f41b279c3eb0c162dcdacfdb1/crates/cli/src/commands/apply_pattern.rs
+- Scan JSON implementation:
+  https://github.com/biomejs/gritql/blob/c80b3026471b229f41b279c3eb0c162dcdacfdb1/crates/cli/src/scan.rs
+- MatchResult API:
+  https://github.com/biomejs/gritql/blob/c80b3026471b229f41b279c3eb0c162dcdacfdb1/crates/core/src/api.rs
+- Compact JSONL API:
+  https://github.com/biomejs/gritql/blob/c80b3026471b229f41b279c3eb0c162dcdacfdb1/crates/core/src/compact_api.rs
+- Path expansion:
+  https://github.com/biomejs/gritql/blob/c80b3026471b229f41b279c3eb0c162dcdacfdb1/crates/language/src/target_language.rs
+- CLI tests:
+  https://github.com/biomejs/gritql/tree/c80b3026471b229f41b279c3eb0c162dcdacfdb1/crates/cli_bin/tests
+
+## Findings With Provenance
+
+### Pattern Syntax And Matching
+
+- Confirmed public behavior: a Grit query root is a pattern; patterns can be
+  code snippets, metavariable-bearing snippets, AST node patterns, rewrites,
+  regexes, compound patterns, modifiers, or `where`-restricted patterns.
+  (sources: https://docs.grit.io/language/syntax; repo lines:
+  `docs/src/pages/language/syntax.mdoc` lines 14-84, 92-132, 142-166)
+- Confirmed public behavior: snippets can use metavariables; `$filename`,
+  `$new_files`, `$program`, and `$grit_*` names are reserved; `$program` means
+  the current program, `$filename` the current relative file path, and
+  `$new_files` a list of new files. (source: https://docs.grit.io/language/patterns;
+  repo lines: `patterns.mdoc` lines 73-96 and 158-164)
+- Confirmed public behavior: Grit supports language declarations and currently
+  supports JavaScript/TypeScript, Python, JSON, CSS, Rust, Ruby, PHP, and
+  alpha/beta languages listed in target-language docs. If no language is
+  specified, Grit defaults to JavaScript, but docs warn that may change and
+  recommend explicit language declarations. (source:
+  https://docs.grit.io/language/target-languages; repo lines:
+  `target-languages.mdoc` lines 5-20 and 24-56)
+- Confirmed public behavior: `where` can contain one condition or a comma
+  separated list, and multiple conditions must all be true. The `<:` operator
+  matches a metavariable on the left against a pattern on the right. (source:
+  https://docs.grit.io/language/conditions; repo lines:
+  `conditions.mdoc` lines 26-35)
+- Confirmed public behavior: rewrites are `pattern => pattern`, can include
+  metavariables, are themselves patterns, and their right side must be a code
+  snippet or a metavariable bound to one. Dot (`.`) on the right side deletes
+  matched code. (source: https://docs.grit.io/language/patterns; repo lines:
+  `patterns.mdoc` lines 166-216 and 571-573)
+- Confirmed public behavior: rewrites can be used in conditions only when the
+  left side is a metavariable; the condition matches only if the rewrite
+  succeeds for all referenced locations. (source:
+  https://docs.grit.io/language/conditions; repo lines:
+  `conditions.mdoc` lines 151-157)
+- Confirmed public behavior: `bubble` creates a new scope so metavariables
+  inside do not stay bound to the same value across all matches in the file.
+  Without `bubble`, repeated matches can fail because an existing binding is
+  reused. (source: https://docs.grit.io/language/bubble; repo lines:
+  `bubble.mdoc` lines 17-52)
+
+### Replacement Limitations And Risk Surface
+
+- Confirmed public behavior: `raw` output bypasses Grit's built-in attempts to
+  ensure output code is valid; it should be used only when the emitted text is
+  intentionally as-is. (source: https://docs.grit.io/language/patterns; repo
+  lines: `patterns.mdoc` lines 50-53)
+- Confirmed public behavior: broad rewrites can lose syntactic/semantic details
+  such as `async` and argument comments; docs recommend matching a larger
+  pattern and rewriting only specific metavariables. (source:
+  https://docs.grit.io/language/idioms; repo lines: `idioms.mdoc` lines
+  128-181)
+- Confirmed public behavior: `$new_files` can create files as a side effect but
+  does not consider existing files and can overwrite them. (source:
+  https://docs.grit.io/language/idioms; repo lines: `idioms.mdoc` lines 50-82)
+- Confirmed public behavior: `sequential` is supported only at the top level of
+  a Grit program, and its steps are not auto-wrapped. (source:
+  https://docs.grit.io/language/patterns; repo lines: `patterns.mdoc` lines
+  434-445)
+- Confirmed public behavior: custom JavaScript functions must return a
+  stringable value, run in a WebAssembly sandbox, cannot access filesystem or
+  network, erroring functions make the pattern fail to match, and foreign
+  functions cannot bind new variables. (source:
+  https://docs.grit.io/language/functions; repo lines: `functions.mdoc` lines
+  113-119)
+- Habitat inference: any apply codemod that uses `raw`, `$new_files`, broad
+  whole-node rewrites, `todo`, custom JS functions, `sequential`, or
+  `multifile` needs an explicit allowlist and additional proof. Public docs
+  expose these as powerful features, not safety guarantees.
+
+### Pattern Definitions And Fixtures
+
+- Confirmed public behavior: `.grit/grit.yaml` config can define inline
+  patterns with `name`, `tags`, `level`, `body`, `description`, and `samples`.
+  `level: none` disables a pattern in the example. (source:
+  https://docs.grit.io/guides/config; repo lines: `config.mdoc` lines 21-67)
+- Confirmed public behavior: all patterns from `.grit/patterns` are imported by
+  default; markdown patterns can live under `.grit/patterns` including
+  subdirectories. (sources: https://docs.grit.io/guides/config and
+  https://docs.grit.io/guides/patterns; repo lines: `config.mdoc` lines
+  153-155)
+- Confirmed public behavior: markdown pattern files derive pattern name from
+  filename, title from first heading unless front matter overrides it,
+  description from first non-heading paragraph, body from first fenced code
+  block, metadata from YAML front matter, and test cases from subheadings.
+  One code block means a positive match; two code blocks mean input/expected
+  output; two identical blocks mean a negative case; `// @filename: example.js`
+  can group multiple input/output files. (source:
+  https://docs.grit.io/guides/testing; repo lines:
+  `docs/src/markdoc/partials/markdown_rules.md` lines 1-11)
+- Confirmed public behavior: YAML `samples` under `.grit/grit.yaml` require
+  both `input` and `output`. (source: https://docs.grit.io/guides/testing;
+  repo lines: `testing.mdoc` lines 27-54)
+- Confirmed public behavior: `grit patterns test` runs all defined patterns;
+  `--filter` runs a subset. CLI reference also documents `--exclude`,
+  `--verbose`, `--update`, and `--watch`. (sources:
+  https://docs.grit.io/guides/testing and https://docs.grit.io/cli/reference;
+  repo lines: `testing.mdoc` lines 5-10 and `reference.mdoc` lines 453-473)
+- Habitat inference: `grit patterns test` is necessary but insufficient for
+  injected-violation proof because pattern fixtures prove sample behavior, not
+  current-tree scan scope, baseline deltas, ignored-path behavior, or
+  production command JSON/provenance.
+
+### Check, Apply, And Baseline Semantics
+
+- Confirmed public behavior: `grit check [PATHS]...` checks pattern violations
+  on target paths, defaulting `PATHS` to `.`. Options include `--fix`,
+  `--level`, `--no-cache`, `--refresh-cache`, `--github-actions`, and
+  `--only-in-json`. (source: https://docs.grit.io/cli/reference; repo lines:
+  `reference.mdoc` lines 74-109)
+- Confirmed public behavior: `grit apply <PATTERN_OR_WORKFLOW> [PATHS]...`
+  accepts a pattern name, pattern body, pattern call, pattern file path, or
+  workflow name; target paths default to `.`. Options include `--output`,
+  `--limit`, `--dry-run`, `--force`, `--interactive`, `--output-file`,
+  `--stdin`, `--cache`, `--refresh-cache`, `--language`, and `--only-in-json`.
+  (source: https://docs.grit.io/cli/reference; repo lines: `reference.mdoc`
+  lines 147-225)
+- Confirmed public behavior: `--dry-run` is documented as showing the changes
+  that would be applied; `--force` is documented as force-apply even if there
+  are uncommitted changes. (source: https://docs.grit.io/cli/reference; repo
+  lines: `reference.mdoc` lines 181-192)
+- Confirmed public CI behavior: hosted CI checks run on all files in a commit
+  not excluded by `.gritignore`, report `warn` or higher, and fail when an
+  `error` level pattern appears that did not previously trigger on the last
+  default-branch commit. The GitHub Action does not include a cache of previous
+  results and annotates all `warn` or higher results. (source:
+  https://docs.grit.io/guides/ci; repo lines: `ci.mdoc` lines 17-34)
+- Source-derived behavior: local `grit check` filters enforced patterns at
+  `--level` or, by default, `warn`, and skips universal patterns. It exits with
+  a `GoodError` when files have rewrites and `--fix` was not used. (sources:
+  `check.rs` lines 111-116 and 404-418;
+  `error.rs` lines 1-3; tests `check.rs` lines 47-60)
+- Source-derived behavior: `grit check --fix` applies rewrite results and then
+  returns success with a fixed-file count. (source: `check.rs` lines 404-407)
+- Habitat inference: local `grit check` is current-tree oriented, not
+  trend-baselined. Hosted CI has baseline/trend semantics, but Habitat should
+  not import that baseline model into local proof unless it intentionally wraps
+  it. For DRA proof, baseline must be Habitat-owned: clean-tree zero or
+  expected-count snapshot, then injected violation delta.
+
+### Scan Roots And Path Filtering
+
+- Confirmed public behavior: check/apply `PATHS` default to `.` and
+  `--only-in-json` restricts analysis to ranges in an ESLint-style JSON array
+  of filePath/message ranges. (source: https://docs.grit.io/cli/reference;
+  repo lines: `reference.mdoc` lines 82-109 and 155-225)
+- Confirmed public behavior: Grit ignores `.gitignore` files and any files in a
+  `.grit` directory by default. Additional `.gritignore` files are cascading
+  glob files. (source: https://docs.grit.io/guides/config; repo lines:
+  `config.mdoc` lines 179-186)
+- Source-derived behavior: path expansion selects file types by target language,
+  adds `.gritignore` as a custom ignore file, explicitly excludes `**/.grit/**`,
+  uses standard filters, and accepts multiple start paths. With no target
+  language, implementation selects TypeScript and JavaScript file types.
+  (source: `target_language.rs` lines 436-480)
+- Habitat inference: current-tree scan proof must run in a controlled fixture
+  root with explicit paths, explicit language declarations, known `.gitignore`
+  and `.gritignore` contents, and no range filter unless the proof is
+  specifically for range-restricted scans.
+
+### JSON, JSONL, And Provenance
+
+- Confirmed public behavior: global `--json` and `--jsonl` exist, but docs only
+  say they are supported on some commands; no public schema is documented.
+  (source: https://docs.grit.io/cli/reference; repo lines: `reference.mdoc`
+  lines 61-67)
+- Source-derived behavior: `--json` and `--jsonl` conflict with each other and
+  are mapped to output formats. For some error paths, JSON/JSONL output formats
+  are treated as "always OK" by implementation, meaning the adapter cannot rely
+  solely on process exit status. (sources: `flags.rs` lines 1-8 and 66-74;
+  `apply_pattern.rs` lines 495-524 and 576-583)
+- Source-derived behavior: `grit apply --json` is rejected by the local
+  emitter with "JSON output is not supported for apply_pattern"; `--jsonl`
+  uses `JSONLineMessenger`. (source: `messenger_variant.rs` lines 276-296)
+- Source-derived behavior: `JSONLineMessenger` serializes each `MatchResult` as
+  a JSON object per line in standard mode or a compact representation in
+  compact mode. (source: `jsonl.rs` lines 57-70)
+- Source-derived behavior: `MatchResult` JSONL variants include `PatternInfo`,
+  `AllDone`, `Match`, `InputFile`, `Rewrite`, `CreateFile`, `RemoveFile`,
+  `DoneFile`, and `AnalysisLog`; rewrites carry original/rewritten file data
+  plus optional `reason`; `AllDone` carries `processed`, `found`, and a reason;
+  `AnalysisLog` carries level, message, position, file, engine id, optional
+  range, syntax tree, and source. (source: `api.rs` lines 17-35, 489-558,
+  735-763)
+- Source-derived behavior: compact JSONL removes file contents from matches and
+  rewrites, preserving source file, ranges, and optional reason. (source:
+  `compact_api.rs` lines 13-92)
+- Source-derived behavior: `grit check --json` logs a Semgrep-like object with
+  `paths` and `results`; each result includes `check_id`, `local_name`,
+  `start`, `end`, `path`, and `extra` containing message and severity. This is
+  implementation, not public schema. (sources: `scan.rs` lines 7-78 and tests
+  `check.rs` lines 70-76)
+- Source-derived behavior: plumbing check rewrites can attach a reason with
+  source `Gritql`, pattern title/name/level, and no metadata/explanation.
+  Normal `check --json` uses the Semgrep-like path instead. (source: `check.rs`
+  lines 286-302)
+- Habitat inference: Habitat needs its own typed output contract that consumes
+  Grit output and emits stable records. The adapter should treat raw Grit JSON
+  as an input format, not as Habitat's durable proof artifact.
+
+### Safe Apply Behavior
+
+- Confirmed public behavior: `--dry-run`, `--interactive`, `--force`, and
+  `--output-file` are part of apply's documented surface. (source:
+  https://docs.grit.io/cli/reference; repo lines: `reference.mdoc` lines
+  181-200)
+- Source-derived behavior: `--dry-run` conflicts with hidden `--format` and
+  `--interactive`; normal result handling applies rewrites only when
+  `dry_run` is false. (sources: `apply_pattern.rs` lines 109-132 and
+  `emit.rs` lines 148-150)
+- Source-derived behavior: if a rewrite would be applied in a dirty git working
+  tree and neither `--dry-run` nor `--force` is set, Grit blocks in non-TTY
+  environments and prompts in TTY environments. The dirty check includes
+  modified, new, and deleted working-tree files including untracked files.
+  (sources: `apply_pattern.rs` lines 534-548 and `utils.rs` lines 17-40)
+- Source-derived behavior corroborated by official tests: non-TTY apply in a
+  dirty git repo fails, reports "Untracked changes detected" and `--force`,
+  leaves the target file unmodified, and succeeds when rerun with `--force`.
+  (source: `crates/cli_bin/tests/apply.rs` lines 2667-2694)
+- Habitat inference: safe apply proof must not depend on Grit's prompt behavior
+  because Habitat runs non-interactively. The adapter should enforce its own
+  clean temporary worktree, run dry-run first, then apply only after expected
+  file/hunk validation.
+
+## Constraints / Invariants To Encode
+
+- Public docs are enough to justify using Grit for structural check/apply, but
+  not enough to make raw CLI output an audit-grade contract.
+- Habitat must pin and record the exact Grit CLI version or binary hash for all
+  proof runs; source-derived behavior is not a stable public guarantee.
+- Pattern files for Habitat should declare language explicitly; default
+  JavaScript behavior is documented as subject to change.
+- Every one of the 22 checks must have at least one positive fixture, one
+  negative fixture, and one injected-violation proof against the current tree or
+  a controlled fixture tree.
+- Fixture tests (`grit patterns test`) and scan tests (`grit check`) are
+  separate gates. Passing samples does not prove scan scope or baseline.
+- Baseline semantics are Habitat-owned for local proof. Do not rely on hosted
+  CI trend semantics unless the DRA explicitly chooses that system boundary.
+- Grit output parsing must validate both process exit and record contents.
+  `AnalysisLog` at error severity, malformed JSON/JSONL, missing `AllDone`, or
+  unexpected file/range provenance must fail the proof.
+- `--no-cache` or `--refresh-cache` should be used in proof runs unless the
+  proof explicitly covers cache behavior.
+- Safe apply requires dry-run, explicit file allowlist, clean temporary
+  worktree, expected-diff assertion, apply, post-apply diff assertion, and
+  idempotence or follow-up `check` proof.
+
+## Open Questions / Uncertainties
+
+- Public docs do not specify stable JSON/JSONL schemas. Fastest verification:
+  pin the Habitat-selected `grit` version, run small probes for `check --json`,
+  `apply --jsonl --output compact`, compile error, match-only pattern, rewrite
+  pattern, and empty input, then snapshot the accepted adapter input schema.
+- Public docs do not specify all exit-code behavior. Fastest verification:
+  probe clean no-match, match, rewrite, compile error, parse error, dirty apply,
+  and JSONL error modes; encode the wrapper's normalized status contract.
+- Public docs do not define local baseline semantics for `grit check`; only
+  hosted CI trend baseline is documented. Fastest verification: treat local
+  baseline as Habitat-owned and avoid inferring official baseline behavior.
+- Public docs do not say whether `grit patterns test --update` has any
+  safeguards against accidental fixture rewrites. Fastest verification: do not
+  allow `--update` in proof mode; reserve it for authoring mode.
+- Public docs do not specify path normalization stability across output modes.
+  Fastest verification: probe relative/absolute paths from repo root and
+  subdirectories; normalize in the adapter and record the original raw path.
+- Public docs do not specify how cache affects JSON/proof determinism. Fastest
+  verification: use `--no-cache` in check proof and `--refresh-cache` in any
+  cache-specific test.
+
+## Required Habitat Adapter Obligations
+
+For the 22 check patterns:
+
+- Discover exactly 22 intended check patterns from Habitat's configured pattern
+  source and fail if the count, names, or levels drift unexpectedly.
+- Require each check pattern to be configured at `warn`/`error`, or run
+  `grit check --level info` intentionally and record that choice.
+- Run `grit patterns test --filter <pattern>` for each pattern's authored
+  fixtures, with `--update` disabled in proof mode.
+- Run a current-tree or controlled-fixture `grit check` with explicit path
+  roots, `--no-cache`, no range filter, and known ignore files.
+- For each check, inject a violation into a disposable fixture/current-tree
+  copy and prove the adapter observes exactly the expected pattern identity,
+  file, range, and severity.
+- Prove negative fixtures remain clean and ignored-path fixtures remain ignored.
+- Normalize raw output to a Habitat record:
+  `patternName`, `level`, `file`, `range`, `command`, `cwd`, `paths`,
+  `gritVersion`, `patternDigest`, `fixtureDigest`, `rawOutputDigest`.
+- Fail on `AnalysisLog` error records, missing/invalid JSON, missing expected
+  `AllDone`/summary, unexpected files, unexpected pattern names, or nonzero
+  process exit unless the specific probe declares that nonzero as expected.
+
+For the one apply codemod:
+
+- Run in an isolated clean git worktree or temp copy; never apply directly to a
+  dirty developer tree.
+- First execute `grit apply <codemod> <paths> --dry-run --jsonl --output compact`
+  or an empirically selected equivalent. If the selected Grit version cannot
+  provide usable dry-run JSONL, capture standard output plus a filesystem diff
+  after a temp apply.
+- Validate the candidate rewrite set before applying: expected files only,
+  expected count/ranges, no `AnalysisLog` error, no unapproved `CreateFile`,
+  `RemoveFile`, `raw`, `todo`, `$new_files`, or broad whole-node rewrite risk.
+- Apply only after dry-run validation, then assert the resulting diff matches
+  the expected allowlist and re-run the relevant check set.
+- Prove idempotence: a second dry-run/apply pass should produce zero rewrites
+  or an explicitly accepted stable residual.
+- Record full provenance for the codemod: raw Grit output digest, before/after
+  file digests, normalized rewrite records, command/cwd/env, Grit version, and
+  adapter version.
+
+## Suggested Next Edits
+
+- file: `docs/projects/habitat-harness/research/effect-grit-adapter/gritql-official-docs.md`
+  -> change: keep as the official-source evidence anchor for the DRA packet.
+- file: future Habitat adapter spec
+  -> change: encode the wrapper contract above instead of exposing raw Grit CLI
+  JSON as the durable proof schema.
+- file: future Habitat probe suite
+  -> change: add empirical probes for JSON schema, exit codes, path
+  normalization, cache behavior, dirty apply, and baseline/injected-violation
+  behavior on the pinned Grit version.


### PR DESCRIPTION
Two research evidence packs have been added under `docs/projects/habitat-harness/research/effect-grit-adapter/` to support the decision on whether and how to adopt Effect and formalize the Grit adapter contract for the Habitat Harness.

**Effect evidence pack** (`effect-official-docs.md`) documents verified capabilities from official Effect documentation — typed error channels, `Effect.gen` workflow composition, scoped resource finalization, `@effect/platform` command execution, Schema parsing, Context/Layer service injection, cancellation/interruption, and test seams — and maps each to Habitat's specific substrate needs. It includes a decision table distinguishing capabilities to adopt in this workstream (typed errors, `Effect.gen`, scopes, process execution, layers, testing with fake services) from those that are design-compatible but not yet required (Schema, Config, TestClock). It also records risks: abstraction overhead, dependency footprint, CLI output timing, and the hard constraint that Effect must never become a product acceptance gate or replace oclif as the command shell.

**GritQL evidence pack** (`gritql-official-docs.md`) documents verified and source-derived behavior from official `docs.grit.io` documentation and the `biomejs/gritql` repository at a pinned commit. Key findings include: `grit check` can exit 0 with findings, requiring Habitat to derive pass/fail from record contents rather than exit code; `grit apply --json` is rejected by the local emitter; local `grit check` has no trend-baseline semantics (only hosted CI does), so baseline must be Habitat-owned; dirty-worktree apply blocks non-interactively without `--force`; and no stable public JSON/JSONL schema is documented. The pack encodes required adapter obligations for all 22 check patterns and the one apply codemod, covering fixture proof, injected-violation proof, dry-run validation, provenance normalization, and idempotence.

Both packs include open questions with fast-verification paths and suggested follow-on edits to downstream specs and probe suites.