### PR TITLE
`chore(docs): replace mint binary references with mintlify`

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "dev": "bun run scripts/dev-staged.ts",
-    "start": "mint dev -p 6660 --no-open",
+    "start": "mintlify dev -p 6660 --no-open",
     "normalize": "bun run scripts/update-code-blocks.ts",
     "check": "tsc -p tsconfig.json --noEmit",
     "check:ts": "tsc -p tsconfig.json --noEmit",

--- a/apps/docs/scripts/broken-links-pages-only.ts
+++ b/apps/docs/scripts/broken-links-pages-only.ts
@@ -50,9 +50,9 @@ async function run(): Promise<void> {
       });
     }
 
-    // Use local mint binary from original project node_modules
-    const mintBin = resolve(projectRoot, "node_modules/.bin/mint");
-    const result = spawnSync(mintBin, ["broken-links"], {
+    // Use the docs app's installed Mintlify CLI so builds do not depend on global binaries.
+    const mintlifyBin = resolve(projectRoot, "node_modules/.bin/mintlify");
+    const result = spawnSync(mintlifyBin, ["broken-links"], {
       cwd: tmpRoot,
       stdio: "inherit",
       env: process.env,

--- a/apps/docs/scripts/dev-staged.ts
+++ b/apps/docs/scripts/dev-staged.ts
@@ -81,9 +81,8 @@ async function main(): Promise<void> {
     console.warn("⚠️  Failed to start watcher (continuing):", e);
   }
 
-  const mintBin = resolve(process.cwd(), "node_modules/.bin/mint");
-  const command = existsSync(mintBin) ? mintBin : "mint";
-  await runCommand(command, ["dev", "-p", "4000", "--no-open"]);
+  const mintlifyBin = resolve(process.cwd(), "node_modules/.bin/mintlify");
+  await runCommand(mintlifyBin, ["dev", "-p", "4000", "--no-open"]);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
Updates the Mintlify CLI binary references from the deprecated `mint` command to `mintlify` across the docs scripts and start command. This ensures the local `node_modules/.bin/mintlify` binary is used directly, removing the fallback to a global binary.