### PR TITLE
`fix(cli): add ^build dependency to build:tsc target`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,8 @@
     "targets": {
       "build:tsc": {
         "dependsOn": [
-          "clean:dist"
+          "clean:dist",
+          "^build"
         ],
         "cache": true,
         "outputs": [


### PR DESCRIPTION
Ensures the CLI package's TypeScript build depends on upstream packages being built first (`^build`), preventing build failures caused by missing or stale dependencies from workspace packages.