### PR TITLE
`feat(mapgen-studio): move Run in Game and Save/Deploy orchestration into package-owned Effect workflow services`

### DIFF
--- a/apps/mapgen-studio/src/server/runInGame/requestValidation.ts
+++ b/apps/mapgen-studio/src/server/runInGame/requestValidation.ts
@@ -18,7 +18,11 @@ export function assertNoRawControlFields(value: unknown): void {
       ? next.map((child, index) => [String(index), child] as const)
       : Object.entries(next);
     for (const [key, child] of entries) {
-      if (/^(?:command|script|javascript|rawJs|rawCommand|session|stateName)$/i.test(key)) {
+      if (
+        /^(?:args|command|context|operationType|script|javascript|rawJs|rawCommand|session|stateName)$/i.test(
+          key
+        )
+      ) {
         throw new Error("Run in Game request must not include raw control commands");
       }
       if (child && typeof child === "object") stack.push(child);

--- a/apps/mapgen-studio/src/server/studio/engines.ts
+++ b/apps/mapgen-studio/src/server/studio/engines.ts
@@ -6,15 +6,8 @@ import { promisify } from "node:util";
 import {
   Civ7DirectControlError,
   DEFAULT_CIV7_SCRIPTING_LOG,
-  DEFAULT_CIV7_TUNER_TIMEOUT_MS,
-  ensureCiv7SetupMapRowVisible,
-  getCiv7PlayableStatus,
-  getCiv7SetupSnapshot,
   logTextFromSnapshot,
-  runCiv7SinglePlayerFromSetup,
   snapshotFile,
-  startCiv7Autoplay,
-  stopCiv7Autoplay,
   waitForFreshLogMarkers,
 } from "@civ7/direct-control";
 import { deployMod, resolveModsDir } from "@civ7/plugin-mods";
@@ -25,14 +18,10 @@ import type {
   StudioRuntimeFailure,
 } from "@civ7/studio-server";
 import {
-  autoplayStartStopFailed,
-  autoplayVerificationFailed,
   dependencyUnavailable,
-  deployFailed,
   invalidRequest,
   isStudioRuntimeFailure,
   materializationFailed,
-  operationBlocked,
   proofFailed,
 } from "@civ7/studio-server";
 import { buildLiveRuntimeStatusState } from "../../features/liveRuntime/model";
@@ -53,6 +42,7 @@ import {
   runInGameMaterializationScriptUnresolvedLinks,
   runInGameRequiredMaterializationMarkers,
 } from "../runInGame/proofIdentity";
+import type { RunInGameDetailedProofLog } from "../runInGame/proofTypes";
 import { parseRunInGameSetupRequest } from "../runInGame/requestValidation";
 
 // ============================================================================
@@ -76,7 +66,6 @@ const CIV7_PROCESS_PATTERN = "CivilizationVII.app/Contents/MacOS/CivilizationVII
 const CIV7_PROCESS_GRACEFUL_QUIT_TIMEOUT_MS = 45_000;
 const CIV7_PROCESS_FORCE_QUIT_TIMEOUT_MS = 30_000;
 const CIV7_PROCESS_FORCE_KILL_TIMEOUT_MS = 15_000;
-const CIV7_PROCESS_RESTART_WAIT_TIMEOUT_MS = 180_000;
 const CIV7_PROCESS_RESTART_POLL_INTERVAL_MS = 2_000;
 const CIV7_PROCESS_EXIT_STABLE_POLLS = 2;
 const CIV7_PROCESS_LAUNCH_COMMAND_TIMEOUT_MS = 10_000;
@@ -221,31 +210,6 @@ async function restartCiv7ProcessViaSteam(): Promise<{
     );
   }
 
-  const startedAt = Date.now();
-  let setupPhase: string | undefined;
-  while (Date.now() - startedAt <= CIV7_PROCESS_RESTART_WAIT_TIMEOUT_MS) {
-    try {
-      const snapshot = await getCiv7SetupSnapshot({ timeoutMs: DEFAULT_CIV7_TUNER_TIMEOUT_MS });
-      setupPhase = snapshot.snapshot.phase;
-      if (setupPhase === "shell") break;
-    } catch {
-      // Civ is still starting.
-    }
-    await sleep(CIV7_PROCESS_RESTART_POLL_INTERVAL_MS);
-  }
-
-  if (setupPhase !== "shell") {
-    throw unavailableEngineDependency(
-      `Civ7 process restarted but setup shell was not ready within ${CIV7_PROCESS_RESTART_WAIT_TIMEOUT_MS}ms`,
-      "civ7-setup-shell-timeout",
-      undefined,
-      {
-        setupPhase,
-        timeoutMs: CIV7_PROCESS_RESTART_WAIT_TIMEOUT_MS,
-      }
-    );
-  }
-
   return {
     command: `${shutdown.quit.command} && ${steamLaunch.command}`,
     quit: shutdown.quit,
@@ -254,7 +218,6 @@ async function restartCiv7ProcessViaSteam(): Promise<{
     shutdown,
     launch,
     launchAttempts: steamLaunch.attempts,
-    setupPhase,
   };
 }
 
@@ -533,44 +496,6 @@ function failureDiagnostics(err: unknown): StudioBoundedDiagnostics | undefined 
   return isStudioRuntimeFailure(err) ? err.diagnostics : undefined;
 }
 
-function saveDeployFailureForOperation(
-  err: unknown,
-  phase: "saving" | "deploying",
-  details: Readonly<{
-    path: string;
-    sourcePath?: string;
-    rollbackFailure?: unknown;
-  }>
-): StudioRuntimeFailure {
-  if (isStudioRuntimeFailure(err) && details.rollbackFailure === undefined) {
-    return err;
-  }
-  const reason =
-    details.rollbackFailure !== undefined ? "rollback-failed" : phase === "saving" ? "save-failed" : "deploy-failed";
-  const originalFailure = isStudioRuntimeFailure(err) ? err : undefined;
-  return deployFailed({
-    message: originalFailure?.message ?? (err instanceof Error ? err.message : "Deploy failed"),
-    reason,
-    diagnostics: boundedDiagnostics({
-      ...failureDiagnostics(err),
-      code: `save-deploy-${reason}`,
-      path: details.path,
-      sourcePath: details.sourcePath,
-      failedAtPhase: phase,
-      originalFailureTag: originalFailure?.tag,
-      originalFailureReason: originalFailure?.reason,
-      cause: originalFailure === undefined ? err : undefined,
-      rollbackFailure: details.rollbackFailure,
-    }),
-    recoveryActions: [
-      "copy-diagnostics",
-      "retry-status",
-      "retry-save-deploy",
-      ...(phase === "deploying" ? ["inspect-deploy-output" as const] : []),
-    ],
-  });
-}
-
 async function restoreRepoConfig(target: string, previous: string | null): Promise<void> {
   if (previous === null) {
     await rm(target, { force: true });
@@ -582,7 +507,7 @@ async function restoreRepoConfig(target: string, previous: string | null): Promi
 type RunInGameInput = Parameters<StudioOperationRuntimePorts["materializeRunInGame"]>[0]["input"];
 type RunInGameMaterialized = Awaited<ReturnType<StudioOperationRuntimePorts["materializeRunInGame"]>>;
 type RunInGameDeployment = Awaited<ReturnType<StudioOperationRuntimePorts["deployRunInGame"]>>;
-type RunInGameStarted = Awaited<ReturnType<StudioOperationRuntimePorts["startGameForRunInGame"]>>;
+type RunInGameStarted = Readonly<{ start?: unknown }>;
 type SaveDeployPrepared = Awaited<ReturnType<StudioOperationRuntimePorts["prepareSaveDeployStart"]>>;
 
 type RunInGameLeafContext = Readonly<{
@@ -743,119 +668,7 @@ export function createStudioOperationRuntimePorts(
       return context.deployment;
     },
     restartCivForRunInGame: async () => ({ processRestart: await restartCiv7ProcessViaSteam() }),
-    checkCiv7ForRunInGame: async ({ requestId }) => {
-      const context = requireRunContext(runContexts, requestId);
-      await getCiv7PlayableStatus({ timeoutMs: DEFAULT_CIV7_TUNER_TIMEOUT_MS }).catch((err) => {
-        throw unavailableEngineDependency(
-          "Civ7 direct-control status is unavailable",
-          "direct-control-status-unavailable",
-          err,
-          { materialization: context.materialization }
-        );
-      });
-    },
-    prepareSetupForRunInGame: async ({ requestId }) => {
-      const context = requireRunContext(runContexts, requestId);
-      const materialization = requireMaterialization(context, requestId);
-      const launchMapScript = requireContextValue(
-        context.launchMapScript ?? materialization.mapScript,
-        "Run in Game map script",
-        requestId
-      );
-      const rowVisibility = await ensureCiv7SetupMapRowVisible(
-        {
-          file: launchMapScript,
-          limit: 20,
-          reloadIfMissing: context.requestedMode === "disposable" ? "exit-to-shell" : "none",
-          waitTimeoutMs: SCRIPTING_LOG_WAIT_TIMEOUT_MS,
-          pollIntervalMs: 1_000,
-        },
-        { timeoutMs: DEFAULT_CIV7_TUNER_TIMEOUT_MS }
-      );
-      const rowProof = rowVisibility.final;
-      if (rowProof.rows.length === 0) {
-        throw operationBlocked({
-          message: `Civ7 setup cannot see ${launchMapScript}`,
-          diagnostics: boundedDiagnostics({
-            code: "setup-map-row-not-visible",
-            reloadRequired: true,
-            reloadBoundary:
-              context.requestedMode === "disposable" ? "process-restart-required" : "setup-row-missing",
-            reloadAttempted: rowVisibility.refreshed,
-            mapScript: launchMapScript,
-            materialization: { mode: context.requestedMode, path: materialization.path },
-          }),
-        });
-      }
-      context.rowProof = rowProof;
-      context.rowVisibility = rowVisibility;
-      return { rowProof, rowVisibility, reloadRequired: rowVisibility.refreshed };
-    },
-    startGameForRunInGame: async ({ requestId }) => {
-      const context = requireRunContext(runContexts, requestId);
-      const materialization = requireMaterialization(context, requestId);
-      const scriptingLogPath = requireContextValue(
-        context.scriptingLogPath,
-        "Run in Game scripting log path",
-        requestId
-      );
-      const scriptingSnapshot = requireContextValue(
-        context.scriptingSnapshot,
-        "Run in Game scripting log snapshot",
-        requestId
-      );
-      const launchMapScript = requireContextValue(
-        context.launchMapScript ?? materialization.mapScript,
-        "Run in Game map script",
-        requestId
-      );
-      const start = await runCiv7SinglePlayerFromSetup(
-        {
-          mapScript: launchMapScript,
-          mapSize: context.mapSize,
-          seed: context.seed,
-          gameSeed: context.seed,
-          ...(context.playerCount === undefined ? {} : { playerCount: context.playerCount }),
-          ...(context.setupConfig.savedConfig === undefined
-            ? {}
-            : { savedConfig: context.setupConfig.savedConfig }),
-          options: context.setupConfig.gameOptions,
-          playerOptions: context.setupConfig.playerOptions,
-          fromRunningGame: "exit-to-shell",
-          waitForTuner: true,
-          waitTimeoutMs: SCRIPTING_LOG_WAIT_TIMEOUT_MS,
-        },
-        { timeoutMs: DEFAULT_CIV7_TUNER_TIMEOUT_MS }
-      ).catch(async (err: unknown) => {
-        const mapgenFailure = await waitForCiv7MapgenLogFailure({
-          readFreshLogText: () => readFreshLogText(scriptingLogPath, scriptingSnapshot),
-          sleep,
-          timeoutMs: SCRIPTING_LOG_FAILURE_GRACE_MS,
-          pollIntervalMs: SCRIPTING_LOG_FAILURE_POLL_INTERVAL_MS,
-          mapScript: launchMapScript,
-        });
-        if (mapgenFailure) {
-          throw proofFailed({
-            message: mapgenFailure.message,
-            reason: "start-game-failed",
-            diagnostics: boundedDiagnostics({
-              ...mapgenFailure,
-              materialization,
-              cause: cloneForJson(err instanceof Civ7DirectControlError ? err.details : err),
-            }),
-          });
-        }
-        throw unavailableEngineDependency(
-          "Civ7 direct-control start is unavailable",
-          "direct-control-start-unavailable",
-          err,
-          { materialization }
-        );
-      });
-      context.started = { start };
-      return context.started;
-    },
-    waitForRunInGameProof: async ({ requestId }) => {
+    waitForRunInGameLogProof: async ({ requestId, setup, started }) => {
       const context = requireRunContext(runContexts, requestId);
       const materialization = requireMaterialization(context, requestId);
       const scriptingLogPath = requireContextValue(
@@ -926,14 +739,42 @@ export function createStudioOperationRuntimePorts(
           }),
         });
       }
-      const started = context.started?.start as Awaited<ReturnType<typeof runCiv7SinglePlayerFromSetup>> | undefined;
-      const liveRuntimeStatus = started?.start.mapSummary
+      context.rowProof = setup.rowProof;
+      context.rowVisibility = setup.rowVisibility;
+      context.started = started;
+      return {
+        result: {
+          ok: true,
+          requestId,
+          materialization,
+          deploy: context.deployment?.deploy,
+          rowProof: setup.rowProof,
+          rowVisibility: setup.rowVisibility,
+          start: started.start,
+          logMarkerProof,
+          logProof,
+        },
+        materialization,
+        logMarkerProof,
+        logProof,
+      };
+    },
+    buildRunInGameProof: async ({ requestId, setup, started, log }) => {
+      const context = requireRunContext(runContexts, requestId);
+      const materialization = requireMaterialization(context, requestId);
+      const startedResult = started.start as
+        | {
+            prepare?: { after?: { snapshot?: unknown } };
+            start?: { mapSummary?: unknown };
+          }
+        | undefined;
+      const liveRuntimeStatus = startedResult?.start?.mapSummary
         ? buildLiveRuntimeStatusState({
             body: {
               ok: true,
               observedAt: new Date().toISOString(),
               status: { readiness: "running-game" },
-              mapSummary: started.start.mapSummary,
+              mapSummary: startedResult.start.mapSummary,
             },
             observedAtFallback: new Date().toISOString(),
           })
@@ -947,10 +788,10 @@ export function createStudioOperationRuntimePorts(
         generatedSourceScript: materialization.generatedSourceScript,
         localModScript: materialization.localModScript,
         deployedModScript: materialization.deployedModScript,
-        rowProof: context.rowProof,
-        setupSnapshot: started?.prepare.after.snapshot,
-        startMapSummary: started?.start.mapSummary,
-        logProof,
+        rowProof: setup.rowProof,
+        setupSnapshot: startedResult?.prepare?.after?.snapshot,
+        startMapSummary: startedResult?.start?.mapSummary,
+        logProof: log.logProof as RunInGameDetailedProofLog | undefined,
         ...(liveRuntimeStatus
           ? {
               liveRuntimeSnapshot: {
@@ -968,11 +809,11 @@ export function createStudioOperationRuntimePorts(
           requestId,
           materialization,
           deploy: context.deployment?.deploy,
-          rowProof: context.rowProof,
-          rowVisibility: context.rowVisibility,
-          start: started,
-          logMarkerProof,
-          logProof,
+          rowProof: setup.rowProof,
+          rowVisibility: setup.rowVisibility,
+          start: started.start,
+          logMarkerProof: log.logMarkerProof,
+          logProof: log.logProof,
           exactAuthorshipProof,
         },
         materialization,
@@ -1020,33 +861,17 @@ export function createStudioOperationRuntimePorts(
     },
     deploySavedMapConfig: async ({ requestId }) => {
       const context = requireSaveContext(saveContexts, requestId);
-      try {
-        const deploy = await deploySwooperMaps(repoRoot);
-        saveContexts.delete(requestId);
-        return { path: context.path, saved: true, deployed: true, deploy };
-      } catch (err) {
-        let rollbackFailure: unknown;
-        try {
-          await restoreRepoConfig(context.target, context.previous);
-        } catch (restoreErr) {
-          rollbackFailure = restoreErr;
-        } finally {
-          saveContexts.delete(requestId);
-        }
-        throw saveDeployFailureForOperation(err, "deploying", {
-          path: context.path ?? "",
-          sourcePath: context.parsedRequest.sourcePath,
-          rollbackFailure,
-        });
-      }
+      const deploy = await deploySwooperMaps(repoRoot);
+      return { path: context.path, saved: true, deployed: true, deploy };
     },
-    runAutoplay: async (input) => runAutoplayLeaf(input.action),
-    normalizeSaveDeployFailure: ({ err, phase }) =>
-      isStudioRuntimeFailure(err)
-        ? err
-        : saveDeployFailureForOperation(err, phase, {
-            path: "",
-          }),
+    rollbackSaveDeploy: async ({ requestId }) => {
+      const context = requireSaveContext(saveContexts, requestId);
+      await restoreRepoConfig(context.target, context.previous);
+      return {
+        path: context.path,
+        ...(context.previous === null ? { deleted: true } : { restored: true }),
+      };
+    },
     failureDiagnostics,
   };
 
@@ -1121,48 +946,6 @@ export function createStudioOperationRuntimePorts(
       requestStatus,
     };
   }
-}
-
-async function runAutoplayLeaf(action: "start" | "stop") {
-  const opts = {
-    timeoutMs: DEFAULT_CIV7_TUNER_TIMEOUT_MS,
-    waitTimeoutMs: SCRIPTING_LOG_WAIT_TIMEOUT_MS,
-    pollIntervalMs: 1_000,
-  };
-  const result = await (action === "start" ? startCiv7Autoplay(opts) : stopCiv7Autoplay(opts)).catch(
-    (err: unknown) => {
-      throw autoplayStartStopFailed({
-        message: `Civ7 autoplay ${action} failed`,
-        reason: action === "start" ? "start-failed" : "stop-failed",
-        diagnostics: boundedDiagnostics({
-          code: `civ7-autoplay-${action}-failed`,
-          action,
-          ...failureDiagnostics(err),
-          cause: err,
-        }),
-      });
-    }
-  );
-  if (!result.verified) {
-    throw autoplayVerificationFailed({
-      message: `Civ7 autoplay ${action} verification failed`,
-      diagnostics: boundedDiagnostics({
-        code: "civ7-autoplay-verification-failed",
-        action,
-        autoplay: result.after.autoplay,
-        game: result.after.game,
-        gameContext: result.after.gameContext,
-      }),
-    });
-  }
-  return {
-    ok: true,
-    action,
-    autoplay: result.after.autoplay,
-    game: result.after.game,
-    gameContext: result.after.gameContext,
-    result,
-  };
 }
 
 function parseSaveDeployInput(

--- a/apps/mapgen-studio/test/runInGame/requestValidation.test.ts
+++ b/apps/mapgen-studio/test/runInGame/requestValidation.test.ts
@@ -8,12 +8,15 @@ import {
 } from "../../src/server/runInGame/requestValidation";
 
 describe("Run in Game request validation", () => {
-  it("pairs the open public start schema with host-side raw-control rejection", () => {
+  it("rejects raw-control top-level tunnel fields in TypeBox and nested fields in host validation", () => {
     const startInputSchema = typeboxInputSchemaFromContractProcedure(runInGame.start);
     const rawKeys = [
+      "args",
       "command",
+      "context",
       "script",
       "javascript",
+      "operationType",
       "rawCommand",
       "rawJs",
       "session",
@@ -22,7 +25,7 @@ describe("Run in Game request validation", () => {
 
     for (const key of rawKeys) {
       const topLevelPayload = validRunInGameRequest({ [key]: "raw-control" });
-      expect(Value.Check(startInputSchema, topLevelPayload)).toBe(true);
+      expect(Value.Check(startInputSchema, topLevelPayload)).toBe(false);
       expect(() => parseRunInGameSetupRequest(topLevelPayload)).toThrow("raw control commands");
 
       const nestedPayload = validRunInGameRequest({

--- a/apps/mapgen-studio/test/server/oneMount.test.ts
+++ b/apps/mapgen-studio/test/server/oneMount.test.ts
@@ -256,21 +256,12 @@ function makeOperationRuntimePorts(): StudioOperationRuntimePorts {
     },
     materializeRunInGame: async () => ({}),
     deployRunInGame: async () => ({}),
-    checkCiv7ForRunInGame: async () => undefined,
-    prepareSetupForRunInGame: async () => ({}),
-    startGameForRunInGame: async () => ({}),
-    waitForRunInGameProof: async () => ({ result: { ok: true } }),
+    waitForRunInGameLogProof: async () => ({ result: { ok: true } }),
+    buildRunInGameProof: async () => ({ result: { ok: true } }),
     prepareSaveDeployStart: async () => ({}),
     saveMapConfig: async () => ({ saved: true }),
     deploySavedMapConfig: async () => ({ deployed: true }),
-    runAutoplay: async (input) => ({
-      ok: true,
-      action: input.action,
-      autoplay: {},
-      game: {},
-      gameContext: {},
-      result: {},
-    }),
+    rollbackSaveDeploy: async () => ({ restored: true }),
   };
 }
 

--- a/openspec/changes/mapgen-studio-pipeline-effect-services/tasks.md
+++ b/openspec/changes/mapgen-studio-pipeline-effect-services/tasks.md
@@ -41,15 +41,16 @@
 
 These are D5 implementation obligations recorded by this packet, not pre-acceptance authoring tasks.
 
-- [ ] 3A.1 Implement package-owned workflow services and port service tags/layers.
-- [ ] 3A.2 Move Run in Game orchestration out of app engines into `RunInGameWorkflow`.
-- [ ] 3A.3 Move Save/Deploy orchestration out of app engines into `SaveDeployWorkflow`.
-- [ ] 3A.4 Move Autoplay command orchestration into `AutoplayWorkflow`.
-- [ ] 3A.5 Route all workflow transitions through `StudioOperationRuntime`.
-- [ ] 3A.6 Route game-wire calls through the shared `Civ7TunerSession` backed workflow control service.
-- [ ] 3A.7 Replace app mutation lifecycle context callbacks with package services and bounded ports.
-- [ ] 3A.8 Delete or reduce `createStudioEngines` to composition-only with negative proof.
-- [ ] 3A.9 Run package/app/scenario tests, negative searches, and live Play/SaveDeploy proof.
+- [x] 3A.1 Implement package-owned workflow services and port service tags/layers.
+- [x] 3A.2 Move Run in Game orchestration out of app engines into `RunInGameWorkflow`.
+- [x] 3A.3 Move Save/Deploy orchestration out of app engines into `SaveDeployWorkflow`.
+- [x] 3A.4 Move Autoplay command orchestration into `AutoplayWorkflow`.
+- [x] 3A.5 Route all workflow transitions through `StudioOperationRuntime`.
+- [x] 3A.6 Route game-wire calls through the shared `Civ7TunerSession` backed workflow control service.
+- [x] 3A.7 Replace app mutation lifecycle context callbacks with package services and bounded ports.
+- [x] 3A.8 Delete or reduce `createStudioEngines` to composition-only with negative proof.
+- [x] 3A.9 Run package/app/scenario tests and negative searches.
+- [ ] 3A.10 Live Play/SaveDeploy proof is not claimed in D5; D12 retains the game-door live-proof handoff.
 
 ## 4. Verification
 
@@ -65,3 +66,14 @@ These are D5 implementation obligations recorded by this packet, not pre-accepta
 - [x] 5.1 Record review acceptance in `review-disposition-ledger.md`.
 - [x] 5.2 Mark D5 accepted in `OPENSPEC-PACKET-TRAIN.md`.
 - [x] 5.3 Commit accepted D5 packet through Graphite with clean/quarantined worktree state.
+
+## 6. Implementation Closure
+
+- [x] 6.1 Package-owned workflows, ports, and runtime integration implemented on `codex/runtime-effect-pipeline-effect-services`.
+- [x] 6.2 Focused package runtime/session/handler proof passed: `bun run --cwd packages/studio-server test -- test/workflowSessionGraph.test.ts test/operationRuntime.test.ts test/handler.test.ts`.
+- [x] 6.3 Package/app type and build gates passed: `bun run --cwd packages/studio-server check`, `bun run --cwd packages/studio-server build`, `bun run --cwd apps/mapgen-studio check`, and `bun run --cwd apps/mapgen-studio build`.
+- [x] 6.4 App focused proof passed: `bun run --cwd apps/mapgen-studio test -- runInGame/requestValidation.test.ts server/oneMount.test.ts server/engineEffectCorpus.test.ts`.
+- [x] 6.5 OpenSpec/diff hygiene passed: `bun run openspec -- validate mapgen-studio-pipeline-effect-services --strict` and `git diff --check`.
+- [x] 6.6 Negative searches classified package game-call ownership, no app lifecycle engine production surface, no status-code bridge residue, and no old `waitForRunInGameProof` seam.
+- [x] 6.7 Fresh implementation-diff review disposition recorded after final dirty diff review.
+- [x] 6.8 Commit implementation slice through Graphite with clean/quarantined worktree state: D5 implementation is committed at the current `codex/runtime-effect-pipeline-effect-services` branch tip; post-commit `git status --short --branch` showed a clean worktree.

--- a/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/closure-checklist.md
+++ b/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/closure-checklist.md
@@ -1,7 +1,7 @@
 # D5 Packet Closure Checklist
 
-Status: accepted
-Date: 2026-06-14
+Status: implementation committed
+Date: 2026-06-15
 
 ## Packet Shape
 
@@ -44,21 +44,38 @@ Date: 2026-06-14
 - `bun run openspec -- validate mapgen-studio-pipeline-effect-services --strict` passed.
 - `bun run openspec:validate` passed: 151 passed, 0 failed.
 - `git diff --check` passed.
-- `git status --short --branch`, `gt status`, and `gt log --no-interactive` were checked on `codex/runtime-effect-openspec-packets`; only the D5 packet files are pending before commit.
+- Historical packet-authoring status proof was checked on `codex/runtime-effect-openspec-packets` before the D5 packet commit. Current D5 implementation work is on `codex/runtime-effect-pipeline-effect-services`; the implementation commit exists at the current branch tip and post-commit `git status --short --branch` was clean.
 
 ## Future Implementation Closure Gates
 
-- [ ] `RunInGameWorkflow`, `SaveDeployWorkflow`, and `AutoplayWorkflow` are package-owned Effect services.
-- [ ] workflow services enter through D4 `StudioOperationRuntime`.
-- [ ] D3 typed failures are the only expected workflow failure model.
-- [ ] Run in Game materialization/proof/start/log/exact-authorship semantics remain green.
-- [ ] Save/Deploy save/deploy/rollback semantics remain green.
-- [ ] Save/Deploy same-request idempotency remains green.
-- [ ] Autoplay conflict/unavailable/start/stop/verification failures are typed.
-- [ ] Studio workflow game calls use shared `Civ7TunerSession`.
-- [ ] no app-local workflow authority remains in `createStudioEngines`, app helpers, or package context.
-- [ ] no unsanctioned session constructor or `withCiv7DirectControlSession` use exists in Studio workflow/app/router code.
-- [ ] public raw-control input guardrails remain green.
-- [ ] control-oRPC/direct-control package gates or untouched dispositions are recorded.
-- [ ] D12 game-door handoff evidence is recorded.
+- [x] `RunInGameWorkflow`, `SaveDeployWorkflow`, and `AutoplayWorkflow` are package-owned Effect services.
+- [x] workflow services enter through D4 `StudioOperationRuntime`.
+- [x] D3 typed failures are the only expected workflow failure model.
+- [x] Run in Game materialization/proof/start/log/exact-authorship semantics remain green.
+- [x] Save/Deploy save/deploy/rollback semantics remain green.
+- [x] Save/Deploy same-request idempotency remains green.
+- [x] Autoplay conflict/unavailable/start/stop/verification failures are typed.
+- [x] Studio workflow game calls use shared `Civ7TunerSession`.
+- [x] no app-local workflow authority remains in `createStudioEngines`, app helpers, or package context.
+- [x] no unsanctioned session constructor or `withCiv7DirectControlSession` use exists in Studio workflow/app/router code.
+- [x] public raw-control input guardrails remain green.
+- [x] control-oRPC/direct-control package disposition is recorded: D5 touched neither package; package game-call routing is through `@civ7/studio-server` services.
+- [x] D12 game-door handoff evidence is recorded.
 - [ ] live Play and Save/Deploy proof is recorded.
+- [x] fresh implementation-diff review disposition is recorded.
+- [x] Graphite implementation commit exists and post-commit `git status --short --branch` is clean.
+
+## Implementation Evidence
+
+- `bun run --cwd packages/studio-server check` passed.
+- `bun run --cwd packages/studio-server build` passed; no tracked `dist` artifact diff is pending.
+- `bun run --cwd packages/studio-server test -- test/workflowSessionGraph.test.ts test/operationRuntime.test.ts test/handler.test.ts` passed. `workflowSessionGraph.test.ts` now includes both source-shape guards and a dynamic Layer proof that `Civ7WorkflowControlLive` consumes an externally supplied `Civ7TunerSession`.
+- `bun run --cwd apps/mapgen-studio check` passed after the package declaration rebuild.
+- `bun run --cwd apps/mapgen-studio build` passed.
+- `bun run --cwd apps/mapgen-studio test -- runInGame/requestValidation.test.ts server/oneMount.test.ts server/engineEffectCorpus.test.ts` passed.
+- `bun run openspec -- validate mapgen-studio-pipeline-effect-services --strict` passed.
+- `git diff --check` passed.
+- Negative scans show direct-control game-call imports only in package `Civ7TunerClient` read services and package `Civ7WorkflowControl` workflow actions; lifecycle/error seam scan has no production hits, with remaining `createStudioEngines`/engine token hits only in `engineEffectCorpus.test.ts` as deletion/negative-proof fixtures.
+- Final implementation-diff review found a public `StudioServerContext.civ7WorkflowControl` override. The override was removed from the public context and production runtime path, and the root `Civ7WorkflowControl*` export was removed. Package declarations were rebuilt; public DTS no longer exposes the override or workflow-control layer, and the remaining fake workflow-control seam is package-internal to `makeStudioOperationRuntimeLayer` tests.
+
+Live Play and Save/Deploy were not run for D5 and are not claimed green. D12 retains the final game-door live-proof handoff.

--- a/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/game-wire-ledger.md
+++ b/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/game-wire-ledger.md
@@ -1,7 +1,7 @@
 # D5 Game-Wire Ledger
 
-Status: draft
-Date: 2026-06-14
+Status: implementation candidate
+Date: 2026-06-15
 
 ## Decision
 
@@ -48,3 +48,18 @@ D5 implementation must hand D12:
 - public-route raw-field search classification;
 - control-oRPC/direct-control metadata proof;
 - live Play and Save/Deploy proof pointers.
+
+## Implementation Disposition
+
+D5 implemented `packages/studio-server/src/ports/Civ7WorkflowControl.ts` as the workflow game-call facade. It depends on `Civ7TunerSession` and calls direct-control atoms through `tuner.use(...)`; it does not import or provide `Civ7TunerSessionLive`, call `makeCiv7TunerSessionLayer`, or construct `Civ7DirectControlSession`.
+
+`packages/studio-server/src/runtime.ts` is the visible owner/composition point for `Civ7TunerSessionLive`: it names `const civ7TunerSessionLayer = Civ7TunerSessionLive`, merges that layer into the Studio runtime graph, and provides that named layer to the operation runtime graph when no test/runtime override is supplied.
+
+Proof:
+
+- `bun run --cwd packages/studio-server test -- test/workflowSessionGraph.test.ts test/operationRuntime.test.ts test/handler.test.ts` passed.
+- `test/workflowSessionGraph.test.ts` includes a static source-shape guard for the production graph and a dynamic Layer proof that `Civ7WorkflowControlLive` consumes an externally supplied `Civ7TunerSession` service. The dynamic proof does not claim `Civ7TunerClient` and `Civ7WorkflowControlLive` share one live FireTuner socket by running against Civ7; it proves workflow-control has no independent session owner.
+- The game-call scan hits only package-owned `Civ7TunerClient` read services and package-owned `Civ7WorkflowControl` workflow actions; app production code has no direct setup/start/autoplay game-call imports.
+- The session-owner scan hits only `packages/studio-server/src/runtime.ts` for the accepted top-level `Civ7TunerSessionLive` composition.
+
+Live Play and Save/Deploy proof was not run in D5. D12 retains the final live game-door proof pointer requirement.

--- a/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/phase-record.md
@@ -1,10 +1,11 @@
 # D5 Packet Phase Record - Pipeline Effect Services
 
-Status: accepted
-Date: 2026-06-14
+Status: implementation committed
+Date: 2026-06-15
 Domino: D5
 OpenSpec change: `mapgen-studio-pipeline-effect-services`
-Graphite packet branch: `codex/runtime-effect-openspec-packets`
+Graphite implementation branch: `codex/runtime-effect-pipeline-effect-services`
+Graphite implementation commit: current `codex/runtime-effect-pipeline-effect-services` branch tip
 
 ## Frame
 
@@ -59,7 +60,7 @@ The D5 implementation slice cannot close if:
 - Autoplay conflict/unavailable/start/stop/verification failures are not typed;
 - Studio workflow/app/router code constructs `Civ7DirectControlSession` or calls `withCiv7DirectControlSession`;
 - public Studio/control-oRPC mutation inputs in the D5 corpus accept executable raw command/session/script fields without explicit disposition;
-- live Play and Save/Deploy proof is absent after implementation changes successful execution paths.
+- it claims live Play or Save/Deploy proof without a real live run.
 
 ## Packet Acceptance Evidence
 
@@ -72,3 +73,26 @@ The D5 implementation slice cannot close if:
 - `bun run openspec:validate` passed.
 - `git diff --check` passed.
 - `git status --short --branch`, `gt status`, and `gt log --no-interactive` were checked before closure.
+
+## Implementation Evidence
+
+D5 implementation moved workflow phase programs into package-owned services while preserving D4 runtime ownership of admission, registry, fibers, events, current/status projection, TTL, and disposal:
+
+- `RunInGameWorkflow`, `SaveDeployWorkflow`, and `AutoplayWorkflow` own ordered phase programs.
+- App code supplies bounded leaf atoms for filesystem/materialization/deploy/log/proof/process work.
+- `Civ7WorkflowControlLive` depends on externally supplied `Civ7TunerSession`; `makeStudioRuntime` owns the visible `Civ7TunerSessionLive` composition.
+- Save/Deploy deploy failure, rollback failure, and cleanup failure each produce one terminal projection.
+- Run in Game exact-authorship proof is built before cleanup and terminal completion; source-snapshot identity remains stable through accepted/status/current/event/final proof projections.
+
+Implementation gates passed:
+
+- `bun run --cwd packages/studio-server check`
+- `bun run --cwd packages/studio-server build`
+- `bun run --cwd packages/studio-server test -- test/workflowSessionGraph.test.ts test/operationRuntime.test.ts test/handler.test.ts`
+- `bun run --cwd apps/mapgen-studio check`
+- `bun run --cwd apps/mapgen-studio build`
+- `bun run --cwd apps/mapgen-studio test -- runInGame/requestValidation.test.ts server/oneMount.test.ts server/engineEffectCorpus.test.ts`
+- `bun run openspec -- validate mapgen-studio-pipeline-effect-services --strict`
+- `git diff --check`
+
+Live Play and Save/Deploy proof was not run in D5 and is not claimed. D12 retains final live game-door proof closure.

--- a/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/review-disposition-ledger.md
+++ b/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/review-disposition-ledger.md
@@ -1,7 +1,7 @@
 # D5 Review Disposition Ledger
 
-Status: accepted
-Date: 2026-06-14
+Status: implementation-diff review complete; Graphite commit pending
+Date: 2026-06-15
 
 | ID | Lane | Finding | Severity | Disposition | Repair |
 | --- | --- | --- | --- | --- | --- |
@@ -18,6 +18,12 @@ Date: 2026-06-14
 | D5-R11 | Game-wire/TypeScript | OpenSpec raw-tunnel scenario omitted `command` and `rawJs`. | P2 | accepted | Repaired in OpenSpec scenario to include `command` and `rawJs`. |
 | D5-R12 | Workflow/lifecycle repair review | Run in Game ordered program still emitted terminal D4 completion before cleanup finalizers. | P1 | accepted | Repaired in `design.md`: runtime/exact-authorship proof is non-terminal, cleanup/regeneration runs before terminal complete, and cleanup failure projects typed/contained failure instead of success. |
 | D5-R13 | Game-wire/black-ice repair review | Raw-field guard scope still depended on an unenumerated D5 corpus, and negative-search gates omitted literal `command`/`rawJs` coverage. | P2 | accepted | Repaired in `workflow-corpus-ledger.md` with explicit Studio mutation and control-oRPC `risk: "mutation"` corpus; repaired proposal/testing/game-wire negative gates to include `command` and `rawJs` coverage. |
+| D5-I1 | Supervisor implementation review | `Civ7WorkflowControlLive` self-provided `Civ7TunerSessionLive`, hiding a possible second session owner while `makeStudioRuntime` also provided the session. | P1 | accepted | Repaired: `Civ7WorkflowControlLive` depends on `Civ7TunerSession`; `makeStudioRuntime` names/provides `civ7TunerSessionLayer`. `workflowSessionGraph.test.ts` adds source guard plus dynamic external-session Layer proof. |
+| D5-I2 | Supervisor implementation review | Save/Deploy cleanup/rollback ordering could publish multiple terminal failures or retry cleanup after cleanup failure. | P1 | accepted | Repaired in `SaveDeployWorkflow`: package-owned `rollbackSaveDeploy` atom, single `finalizeFailure`, cleanup-attempt guard, and tests for deploy failure, rollback failure, cleanup failure, terminal event count, and active gate release. |
+| D5-I3 | Fresh implementation review | Run in Game completion was still at risk of occurring before cleanup, and proof construction remained too app-monolithic. | P1 | accepted | Repaired: workflow waits log evidence, builds exact-authorship proof, runs cleanup, then completes; app leaf split into `waitForRunInGameLogProof` and `buildRunInGameProof`. |
+| D5-I4 | Fresh implementation review | Public raw-control guard proof needed top-level TypeBox rejection and nested open-input rejection. | P2 | accepted | Repaired in `contract/runInGame.ts`, `requestValidation.ts`, and `requestValidation.test.ts`; top-level forbidden fields fail schema and nested executable fields fail host parser. |
+| D5-I5 | Implementation proof correction | Static source guard alone did not prove `Civ7WorkflowControlLive` consumes an externally supplied session. | P2 | accepted | Repaired with dynamic Layer proof using fake `Civ7TunerSession`; docs distinguish this from unclaimed live shared-socket proof. |
+| D5-I6 | Final implementation-diff review | Halley found `StudioServerContext.civ7WorkflowControl` exposed a public workflow-control override that could bypass the shared-session graph. | P1 | accepted | Repaired by deleting the public context override, production runtime branch, and root `Civ7WorkflowControl*` export. `makeStudioRuntime` always composes `Civ7WorkflowControlLive` through the named top-level session layer; fake workflow-control remains only as package-internal `makeStudioOperationRuntimeLayer` test seam. Rebuilt package declarations and verified no `civ7WorkflowControl`/`Civ7WorkflowControl` appears in public DTS. |
 
 ## Repair Review Closure
 
@@ -29,3 +35,20 @@ Accepted repair-review agents:
 - Lifecycle: accepted proof-before-cleanup-before-terminal-complete ordering.
 - Game-wire/TypeScript: accepted explicit mutation guard corpus and full raw-field search coverage.
 - Hardening/black-ice: accepted D5-R2 through D5-R10 after repair; follow-up D5-R13 was accepted by the narrow corpus re-check.
+
+## Implementation Review Closure
+
+Implementation repair evidence currently green:
+
+- `bun run --cwd packages/studio-server check`
+- `bun run --cwd packages/studio-server build`
+- `bun run --cwd packages/studio-server test -- test/workflowSessionGraph.test.ts test/operationRuntime.test.ts test/handler.test.ts`
+- `bun run --cwd apps/mapgen-studio check`
+- `bun run --cwd apps/mapgen-studio build`
+- `bun run --cwd apps/mapgen-studio test -- runInGame/requestValidation.test.ts server/oneMount.test.ts server/engineEffectCorpus.test.ts`
+- `bun run openspec -- validate mapgen-studio-pipeline-effect-services --strict`
+- `git diff --check`
+
+Live Play and Save/Deploy proof was not run and is not claimed. Browser-runner/recovery/watchdog residue is classified outside D5 and remains assigned to later packet ownership.
+
+Halley final implementation-diff review is complete with the P1 public override blocker accepted and repaired. No remaining P1/P2 findings are open before Graphite commit.

--- a/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/testing-ledger.md
+++ b/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/testing-ledger.md
@@ -1,7 +1,7 @@
 # D5 Testing Ledger
 
-Status: draft
-Date: 2026-06-14
+Status: implementation candidate
+Date: 2026-06-15
 
 | Layer | Required proof | Adequacy criterion |
 | --- | --- | --- |
@@ -98,3 +98,44 @@ rg -n "turbo run|bun x turbo|mod-swooper-maps#build|buildSwooperMapsStudioDeploy
 ```
 
 Hits are not automatically failures. D5 implementation must classify them as sanctioned package owner, bounded port adapter, non-executable status/proof evidence, test fixture, historical evidence, or blocker.
+
+## Implementation Results
+
+Commands run on `codex/runtime-effect-pipeline-effect-services`:
+
+```bash
+bun run --cwd packages/studio-server check
+bun run --cwd packages/studio-server build
+bun run --cwd packages/studio-server test -- test/workflowSessionGraph.test.ts test/operationRuntime.test.ts test/handler.test.ts
+bun run --cwd apps/mapgen-studio check
+bun run --cwd apps/mapgen-studio build
+bun run --cwd apps/mapgen-studio test -- runInGame/requestValidation.test.ts server/oneMount.test.ts server/engineEffectCorpus.test.ts
+bun run openspec -- validate mapgen-studio-pipeline-effect-services --strict
+git diff --check
+```
+
+All commands passed. The Studio app build emitted the existing Vite large-chunk warning only.
+
+Focused D5 proof now covers:
+
+- `RunInGameWorkflow`, `SaveDeployWorkflow`, and `AutoplayWorkflow` entering through the real D4 `StudioOperationRuntime` with fake leaf ports.
+- Save/Deploy deploy failure, rollback failure, and cleanup failure producing one terminal projection and releasing the active gate.
+- Run in Game proof split into `waitForRunInGameLogProof` and `buildRunInGameProof`, with source-snapshot identity preserved from accepted/status/current/event projection through final exact-authorship proof.
+- Raw-control guard rejection for top-level TypeBox-forbidden fields and nested host-validator raw fields.
+- `workflowSessionGraph.test.ts` source guard that `Civ7WorkflowControlLive` does not self-provide or construct `Civ7TunerSessionLive`, plus dynamic Layer proof that `Civ7WorkflowControlLive` consumes an externally supplied `Civ7TunerSession` service.
+
+Negative searches run:
+
+```bash
+rg -n "Civ7WorkflowControlLive.*Layer\\.provide|Layer\\.provide\\(Civ7TunerSessionLive\\)|new\\s+Civ7DirectControlSession|makeCiv7TunerSessionLayer|Civ7TunerSessionLive" packages/studio-server/src/ports/Civ7WorkflowControl.ts packages/studio-server/src/runtime.ts packages/studio-server/src/operationRuntime/StudioOperationRuntime.ts
+rg -n "ensureCiv7SetupMapRowVisible|getCiv7PlayableStatus|getCiv7SetupSnapshot|runCiv7SinglePlayerFromSetup|startCiv7Autoplay|stopCiv7Autoplay|withCiv7DirectControlSession" apps/mapgen-studio/src packages/studio-server/src -g '*.ts'
+rg -n "normalizeSaveDeployFailure|saveDeployFailureForOperation|RunInGameHttpError|StudioEngineError|createStudioEngines|runRunInGameStartEngine|runSaveDeployEngine|runAutoplayEngine|createRunInGameOperationStore|createMapConfigSaveDeployOperationStore|waitForRunInGameProof" apps/mapgen-studio/src packages/studio-server/src packages/studio-server/test apps/mapgen-studio/test -g '*.ts' -g '*.tsx'
+```
+
+Disposition:
+
+- The session-owner scan hits only `packages/studio-server/src/runtime.ts`, where `Civ7TunerSessionLive` is imported, named as `civ7TunerSessionLayer`, merged, and provided to the operation runtime graph. `Civ7WorkflowControl.ts` has no self-provider or constructor hit.
+- The game-call scan hits package-owned `Civ7TunerClient` read services and package-owned `Civ7WorkflowControl` workflow actions. There are no app production game-call imports.
+- The lifecycle/error seam scan has no production hits. Remaining `createStudioEngines`/engine-token hits are in `apps/mapgen-studio/test/server/engineEffectCorpus.test.ts` as negative/deletion proof fixtures.
+
+Live Play and Save/Deploy proof was not run in D5 and is not claimed green.

--- a/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/workflow-corpus-ledger.md
+++ b/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/workflow-corpus-ledger.md
@@ -1,7 +1,7 @@
 # D5 Workflow Corpus Ledger
 
-Status: draft corpus
-Date: 2026-06-14
+Status: implementation candidate
+Date: 2026-06-15
 
 | Surface | Current evidence | D5 target | Risk if omitted | Oracle |
 | --- | --- | --- | --- | --- |
@@ -57,3 +57,24 @@ rg -n "\\bcommand\\b|operationType|rawCommand|script|javascript|session|stateNam
 ```
 
 Every hit is classified as executable public input, non-executable status/proof evidence, direct-control package internals, test/historical evidence, or blocker.
+
+## Implementation Disposition
+
+D5 implementation moved the phase programs into package workflow modules and left the app host as bounded leaf-port implementation:
+
+- `packages/studio-server/src/workflows/RunInGameWorkflow.ts`
+- `packages/studio-server/src/workflows/SaveDeployWorkflow.ts`
+- `packages/studio-server/src/workflows/AutoplayWorkflow.ts`
+- `packages/studio-server/src/workflows/workflowTransitions.ts`
+- `packages/studio-server/src/ports/*`
+
+`apps/mapgen-studio/src/server/studio/engines.ts` now provides leaf atoms for filesystem/materialization/deploy/proof/log/process work. It does not own operation ids, admission, active/current projections, events, phase transitions, typed workflow failure classification, or background workers.
+
+Review-driven repairs included:
+
+- Save/Deploy rollback moved into the package workflow through a `rollbackSaveDeploy` leaf atom; deploy failure, rollback failure, and cleanup failure each produce one terminal projection.
+- Run in Game proof waiting was split into `waitForRunInGameLogProof` and `buildRunInGameProof`, so the package workflow owns ordering while the app leaf owns log parsing and exact-authorship construction details.
+- Shared-session ownership was repaired so `Civ7WorkflowControlLive` depends on externally provided `Civ7TunerSession`; `makeStudioRuntime` owns the visible `Civ7TunerSessionLive` layer composition.
+- Raw-control guards reject top-level TypeBox-forbidden fields and nested host-validator fields for `runInGame.start`.
+
+Residual browser-runner/recovery/watchdog cleanup is not claimed by D5. It remains assigned to later D6/D9/D10/D12 packet ownership.

--- a/packages/studio-server/src/contract/runInGame.ts
+++ b/packages/studio-server/src/contract/runInGame.ts
@@ -308,12 +308,11 @@ export const status = oc
 // data (sealed code/materialization/recovery diagnostics) - declared as the defined
 // RUN_IN_GAME_BLOCKED/INVALID/FAILED/UNAVAILABLE codes (./errors.ts).
 //
-// SECURITY BOUNDARY (target-arch section 1): the handler runs `assertNoRawControlFields`
-// - a deep scan rejecting `command|script|javascript|rawJs|rawCommand|session|stateName` keys. The
-// input is therefore intentionally permissive at the contract layer (the deep scan
-// + recipe pinning + kebab-case id + seed/mapSize/playerCount validation live in
-// `parseRunInGameSetupRequest`, ported in A2/A3). Known top-level fields are typed;
-// the body is otherwise passed through for the validator to reject raw-control keys.
+// SECURITY BOUNDARY (target-arch section 1): the TypeBox contract rejects known
+// raw-control top-level tunnel keys, while the host validator deep-scans opaque
+// config/setup/source payloads for the same vocabulary before any workflow port
+// runs. Recipe pinning + kebab-case id + seed/mapSize/playerCount validation
+// live in `parseRunInGameSetupRequest`, ported in A2/A3.
 export const start = oc
   .errors(runInGameErrors)
   .input(
@@ -325,6 +324,16 @@ export const start = oc
           mapSize: Type.Optional(Type.String()),
           playerCount: Type.Optional(Type.Integer()),
           resources: Type.Optional(Type.String()),
+          args: Type.Optional(Type.Never()),
+          command: Type.Optional(Type.Never()),
+          context: Type.Optional(Type.Never()),
+          javascript: Type.Optional(Type.Never()),
+          operationType: Type.Optional(Type.Never()),
+          rawCommand: Type.Optional(Type.Never()),
+          rawJs: Type.Optional(Type.Never()),
+          script: Type.Optional(Type.Never()),
+          session: Type.Optional(Type.Never()),
+          stateName: Type.Optional(Type.Never()),
           materialization: Type.Optional(
             Type.Object(
               {

--- a/packages/studio-server/src/operationRuntime/StudioOperationRuntime.ts
+++ b/packages/studio-server/src/operationRuntime/StudioOperationRuntime.ts
@@ -5,22 +5,26 @@ import type { StudioInputs, StudioOutputs } from "../context.js";
 import type { RunInGameRequestStatus } from "../contract/runInGame.js";
 import type { StudioOperationsCurrent } from "../contract/studio.js";
 import {
-  invalidRequest,
-  isStudioRuntimeFailure,
   runtimeDisposed,
   type StudioRuntimeFailure,
 } from "../errors/index.js";
+import type { Civ7TunerSession } from "../services/Civ7TunerSession.js";
 import type { StudioEventHubApi } from "../services/StudioEventHub.js";
 import type {
-  RunInGameDeployment,
   RunInGamePreparedRequest,
-  RunInGameRestartResult,
-  RunInGameSetupPrepared,
-  SaveDeployPreparedRequest,
-  RunInGameStarted,
   StudioDaemonIdentity,
   StudioOperationRuntimePorts,
 } from "./ports.js";
+import {
+  AutoplayWorkflow,
+  type Civ7WorkflowControl,
+  Civ7WorkflowControlLive,
+  makeAutoplayWorkflowLayer,
+  makeRunInGameWorkflowLayer,
+  makeSaveDeployWorkflowLayer,
+  RunInGameWorkflow,
+  SaveDeployWorkflow,
+} from "../workflows/index.js";
 import { operationEvent, projectCurrent } from "./projection.js";
 import {
   admitRunInGame,
@@ -35,7 +39,6 @@ import {
   markDisposed,
   transitionRunInGame,
   transitionSaveDeploy,
-  type RunInGameFailurePhase,
   type RunInGameTransition,
   type SaveDeployTransition,
 } from "./registry.js";
@@ -66,19 +69,45 @@ export class StudioOperationRuntime extends Context.Tag(
   "@civ7/studio-server/StudioOperationRuntime"
 )<StudioOperationRuntime, StudioOperationRuntimeApi>() {}
 
-export function makeStudioOperationRuntimeLayer(args: Readonly<{
+type StudioOperationRuntimeLayerBaseArgs = Readonly<{
   ports: StudioOperationRuntimePorts;
   eventHub: StudioEventHubApi;
   ttlMs?: number;
-}>): Layer.Layer<StudioOperationRuntime> {
-  return Layer.scoped(StudioOperationRuntime, makeStudioOperationRuntime(args));
+}>;
+
+export function makeStudioOperationRuntimeLayer(
+  args: StudioOperationRuntimeLayerBaseArgs & Readonly<{
+    civ7WorkflowControl: Layer.Layer<Civ7WorkflowControl>;
+  }>
+): Layer.Layer<StudioOperationRuntime>;
+export function makeStudioOperationRuntimeLayer(
+  args: StudioOperationRuntimeLayerBaseArgs & Readonly<{
+    civ7WorkflowControl?: undefined;
+  }>
+): Layer.Layer<StudioOperationRuntime, never, Civ7TunerSession>;
+export function makeStudioOperationRuntimeLayer(args: StudioOperationRuntimeLayerBaseArgs & Readonly<{
+  civ7WorkflowControl?: Layer.Layer<Civ7WorkflowControl>;
+}>): Layer.Layer<StudioOperationRuntime, never, Civ7TunerSession> {
+  const workflowLayer = Layer.mergeAll(
+    makeRunInGameWorkflowLayer({ ports: args.ports }),
+    makeSaveDeployWorkflowLayer({ ports: args.ports }),
+    makeAutoplayWorkflowLayer()
+  ).pipe(Layer.provide(args.civ7WorkflowControl ?? Civ7WorkflowControlLive));
+  return Layer.provide(
+    Layer.scoped(StudioOperationRuntime, makeStudioOperationRuntime(args)),
+    workflowLayer
+  );
 }
 
 function makeStudioOperationRuntime(args: Readonly<{
   ports: StudioOperationRuntimePorts;
   eventHub: StudioEventHubApi;
   ttlMs?: number;
-}>): Effect.Effect<StudioOperationRuntimeApi, never, Scope.Scope> {
+}>): Effect.Effect<
+  StudioOperationRuntimeApi,
+  never,
+  Scope.Scope | RunInGameWorkflow | SaveDeployWorkflow | AutoplayWorkflow
+> {
   return Effect.gen(function* () {
     const now = () => args.ports.clock?.now() ?? new Date();
     const nowIso = () => now().toISOString();
@@ -93,6 +122,9 @@ function makeStudioOperationRuntime(args: Readonly<{
     const registry = yield* makeRegistry(identity);
     const admissionGate = yield* Effect.makeSemaphore(1);
     const fibers = yield* FiberSet.make<void, never>();
+    const runInGameWorkflow = yield* RunInGameWorkflow;
+    const saveDeployWorkflow = yield* SaveDeployWorkflow;
+    const autoplayWorkflow = yield* AutoplayWorkflow;
 
     const publish = (operation: Parameters<typeof operationEvent>[0]) =>
       Effect.tryPromise({
@@ -126,155 +158,42 @@ function makeStudioOperationRuntime(args: Readonly<{
       input: StudioInputs["runInGame"]["start"],
       prepared: RunInGamePreparedRequest
     ) =>
-      Effect.gen(function* () {
-        let phase: RunInGameFailurePhase = "materializing";
-        let materialized: Awaited<ReturnType<StudioOperationRuntimePorts["materializeRunInGame"]>> = {};
-        const work = Effect.gen(function* () {
-          yield* transitionRun(requestId, { phase });
-          materialized = yield* tryPromise(() =>
-            args.ports.materializeRunInGame({ requestId, input, prepared })
-          );
-          if (materialized.materialization) {
-            yield* transitionRun(requestId, {
-              phase,
-              materialization: materialized.materialization,
-            });
-          }
-
-          phase = "deploying";
-          yield* transitionRun(requestId, { phase, materialization: materialized.materialization });
-          const deployment = yield* tryPromise(() =>
-            args.ports.deployRunInGame({ requestId, prepared, materialized })
-          );
-          yield* transitionRun(requestId, {
-            phase,
-            materialization: deployment.materialization ?? materialized.materialization,
-          });
-
-          const restart = yield* maybeRestart(requestId, prepared, deployment);
-          phase = "checking-civ7";
-          yield* transitionRun(requestId, {
-            phase,
-            materialization: deployment.materialization ?? materialized.materialization,
-            ...(restart.processRestart === undefined
-              ? {}
-              : { processRestart: restart.processRestart }),
-          });
-          yield* tryPromise(() =>
-            args.ports.checkCiv7ForRunInGame({ requestId, prepared, deployment })
-          );
-
-          phase = "preparing-setup";
-          yield* transitionRun(requestId, { phase });
-          const setup = yield* tryPromise(() =>
-            args.ports.prepareSetupForRunInGame({ requestId, prepared, deployment })
-          );
-          if (setup.reloadRequired) {
-            phase = "reload-needed";
-            yield* transitionRun(requestId, { phase });
-          }
-
-          phase = "starting-game";
-          yield* transitionRun(requestId, { phase });
-          const started = yield* tryPromise(() =>
-            args.ports.startGameForRunInGame({ requestId, prepared, deployment, setup })
-          );
-
-          phase = "waiting-for-proof";
-          yield* transitionRun(requestId, { phase });
-          const proof = yield* tryPromise(() =>
-            args.ports.waitForRunInGameProof({
-              requestId,
-              prepared,
-              deployment,
-              setup,
-              started,
-            })
-          );
-          yield* transitionRun(requestId, {
-            phase: "complete",
-            result: proof.result ?? { ok: true },
-            materialization:
-              proof.materialization ?? deployment.materialization ?? materialized.materialization,
-            ...(proof.exactAuthorshipProof === undefined
-              ? {}
-              : { exactAuthorshipProof: proof.exactAuthorshipProof }),
-          });
-        });
-        yield* work.pipe(
-          Effect.catchAll((err) =>
+      runInGameWorkflow.start({
+        requestId,
+        input,
+        prepared,
+        transitions: {
+          transition: (transition) => transitionRun(requestId, transition).pipe(Effect.asVoid),
+          fail: ({ phase, err }) =>
             failRunInGame({
               registry,
               requestId,
               nowIso: nowIso(),
               phase,
               err,
-            }).pipe(Effect.flatMap(publish))
-          ),
-          Effect.ensuring(
-            Effect.promise(() => materialized?.cleanup?.() ?? Promise.resolve()).pipe(
-              Effect.catchAll(() => Effect.void)
-            )
-          )
-        );
-      }).pipe(Effect.catchAll(() => Effect.void));
+            }).pipe(Effect.flatMap(publish), Effect.asVoid),
+        },
+      });
 
     const saveDeployWorker = (
       requestId: string,
       input: StudioInputs["mapConfigs"]["saveDeploy"]
     ) =>
-      Effect.gen(function* () {
-        let phase: "saving" | "deploying" = "saving";
-        let prepared: SaveDeployPreparedRequest = {};
-        const work = Effect.gen(function* () {
-          prepared = sanitizeSaveDeployPrepared(yield* tryPromise(() =>
-            args.ports.prepareSaveDeployStart({
-              requestId,
-              input,
-            })
-          ));
-          yield* transitionSave(requestId, {
-            phase,
-            ...(prepared.path === undefined ? {} : { path: prepared.path }),
-          });
-          const saved = yield* tryPromise(() =>
-            args.ports.saveMapConfig({ requestId, input, prepared })
-          );
-          phase = "deploying";
-          yield* transitionSave(requestId, {
-            phase,
-            path: saved.path ?? prepared.path,
-            saved: saved.saved ?? true,
-          });
-          const deployed = yield* tryPromise(() =>
-            args.ports.deploySavedMapConfig({ requestId, input, prepared, saved })
-          );
-          yield* transitionSave(requestId, {
-            phase: "complete",
-            path: deployed.path ?? saved.path ?? prepared.path,
-            saved: deployed.saved ?? saved.saved ?? true,
-            deployed: deployed.deployed ?? true,
-            deploy: deployed.deploy,
-          });
-        });
-        yield* work.pipe(
-          Effect.catchAll((err) =>
+      saveDeployWorkflow.start({
+        requestId,
+        input,
+        transitions: {
+          transition: (transition) => transitionSave(requestId, transition).pipe(Effect.asVoid),
+          fail: ({ phase, err }) =>
             failSaveDeploy({
               registry,
               requestId,
               nowIso: nowIso(),
               phase,
               err,
-              normalize: args.ports.normalizeSaveDeployFailure,
-            }).pipe(Effect.flatMap(publish))
-          ),
-          Effect.ensuring(
-            Effect.promise(() => prepared.cleanup?.() ?? Promise.resolve()).pipe(
-              Effect.catchAll(() => Effect.void)
-            )
-          )
-        );
-      }).pipe(Effect.catchAll(() => Effect.void));
+            }).pipe(Effect.flatMap(publish), Effect.asVoid),
+        },
+      });
 
     const transitionRun = (
       requestId: string,
@@ -291,23 +210,6 @@ function makeStudioOperationRuntime(args: Readonly<{
       transitionSaveDeploy({ registry, requestId, nowIso: nowIso(), transition }).pipe(
         Effect.flatMap(publish)
       );
-
-    const maybeRestart = (
-      requestId: string,
-      prepared: RunInGamePreparedRequest,
-      deployment: RunInGameDeployment
-    ): Effect.Effect<RunInGameRestartResult, StudioRuntimeFailure> => {
-      if (!prepared.request.restartCivProcess || !args.ports.restartCivForRunInGame) {
-        return Effect.succeed({});
-      }
-      return Effect.gen(function* () {
-        yield* transitionRun(requestId, { phase: "restarting-civ" });
-        return yield* tryPromise(() =>
-          args.ports.restartCivForRunInGame?.({ requestId, prepared, deployment }) ??
-          Promise.resolve({})
-        );
-      });
-    };
 
     const api: StudioOperationRuntimeApi = {
       identity,
@@ -374,7 +276,7 @@ function makeStudioOperationRuntime(args: Readonly<{
               nowIso: nowIso(),
               ttlMs: args.ttlMs,
             });
-            return yield* tryPromise(() => args.ports.runAutoplay(input));
+            return yield* autoplayWorkflow.run(input);
           })
         ),
       operationsCurrent: Effect.gen(function* () {
@@ -384,13 +286,6 @@ function makeStudioOperationRuntime(args: Readonly<{
     };
 
     return yield* Effect.acquireRelease(Effect.succeed(api), () => dispose);
-  });
-}
-
-function tryPromise<A>(try_: () => Promise<A>): Effect.Effect<A, StudioRuntimeFailure> {
-  return Effect.tryPromise({
-    try: try_,
-    catch: toRuntimeFailure,
   });
 }
 
@@ -438,13 +333,6 @@ function prepareRunInGameRequest(
   };
 }
 
-function sanitizeSaveDeployPrepared(prepared: SaveDeployPreparedRequest): SaveDeployPreparedRequest {
-  return {
-    ...(prepared.path === undefined ? {} : { path: prepared.path }),
-    ...(prepared.cleanup === undefined ? {} : { cleanup: prepared.cleanup }),
-  };
-}
-
 function stableHash(value: unknown): string {
   return createHash("sha256").update(JSON.stringify(canonicalize(value))).digest("hex");
 }
@@ -459,15 +347,4 @@ function canonicalize(value: unknown): unknown {
     return out;
   }
   return value;
-}
-
-function toRuntimeFailure(err: unknown): StudioRuntimeFailure {
-  if (isStudioRuntimeFailure(err)) return err;
-  return invalidRequest({
-    message: err instanceof Error && err.message ? err.message : "Studio operation failed",
-    diagnostics: {
-      code: "studio-operation-port-failed",
-      cause: err instanceof Error && err.message ? err.message : String(err),
-    },
-  });
 }

--- a/packages/studio-server/src/operationRuntime/ports.ts
+++ b/packages/studio-server/src/operationRuntime/ports.ts
@@ -1,136 +1,17 @@
-import type { StudioInputs, StudioOutputs } from "../context.js";
-import type { MapConfigSaveDeployStatus } from "../contract/mapConfigs.js";
-import type {
-  RunInGameExactAuthorshipProof,
-  RunInGameMaterializationStatus,
-  RunInGameProcessRestartStatus,
-  RunInGameRequestStatus,
-} from "../contract/runInGame.js";
-import type { StudioBoundedDiagnostics, StudioRuntimeFailure } from "../errors/index.js";
-
-export type StudioDaemonIdentity = Readonly<{
-  serverInstanceId: string;
-  serverStartedAt: string;
-}>;
-
-export type StudioClock = Readonly<{
-  now(): Date;
-}>;
-
-export type RunInGamePreparedRequest = Readonly<{
-  fingerprint: string;
-  request: RunInGameRequestStatus;
-}>;
-
-export type RunInGameMaterialized = Readonly<{
-  materialization?: RunInGameMaterializationStatus;
-  cleanup?(): Promise<void>;
-}>;
-
-export type RunInGameDeployment = Readonly<{
-  materialization?: RunInGameMaterializationStatus;
-  deploy?: unknown;
-}>;
-
-export type RunInGameRestartResult = Readonly<{
-  processRestart?: RunInGameProcessRestartStatus;
-}>;
-
-export type RunInGameSetupPrepared = Readonly<{
-  rowProof?: unknown;
-  rowVisibility?: unknown;
-  reloadRequired?: boolean;
-}>;
-
-export type RunInGameStarted = Readonly<{
-  start?: unknown;
-}>;
-
-export type RunInGameProof = Readonly<{
-  result?: unknown;
-  exactAuthorshipProof?: RunInGameExactAuthorshipProof;
-  materialization?: RunInGameMaterializationStatus;
-}>;
-
-export type SaveDeployPreparedRequest = Readonly<{
-  path?: string;
-  cleanup?(): Promise<void>;
-}>;
-
-export type SaveDeploySaved = Readonly<{
-  path?: string;
-  saved?: boolean;
-}>;
-
-export type SaveDeployDeployed = Readonly<{
-  path?: string;
-  saved?: boolean;
-  deployed?: boolean;
-  deploy?: MapConfigSaveDeployStatus["deploy"];
-}>;
-
-export type StudioOperationRuntimePorts = Readonly<{
-  clock?: StudioClock;
-
-  materializeRunInGame(args: Readonly<{
-    requestId: string;
-    input: StudioInputs["runInGame"]["start"];
-    prepared: RunInGamePreparedRequest;
-  }>): Promise<RunInGameMaterialized>;
-  deployRunInGame(args: Readonly<{
-    requestId: string;
-    prepared: RunInGamePreparedRequest;
-    materialized: RunInGameMaterialized;
-  }>): Promise<RunInGameDeployment>;
-  restartCivForRunInGame?(args: Readonly<{
-    requestId: string;
-    prepared: RunInGamePreparedRequest;
-    deployment: RunInGameDeployment;
-  }>): Promise<RunInGameRestartResult>;
-  checkCiv7ForRunInGame(args: Readonly<{
-    requestId: string;
-    prepared: RunInGamePreparedRequest;
-    deployment: RunInGameDeployment;
-  }>): Promise<void>;
-  prepareSetupForRunInGame(args: Readonly<{
-    requestId: string;
-    prepared: RunInGamePreparedRequest;
-    deployment: RunInGameDeployment;
-  }>): Promise<RunInGameSetupPrepared>;
-  startGameForRunInGame(args: Readonly<{
-    requestId: string;
-    prepared: RunInGamePreparedRequest;
-    deployment: RunInGameDeployment;
-    setup: RunInGameSetupPrepared;
-  }>): Promise<RunInGameStarted>;
-  waitForRunInGameProof(args: Readonly<{
-    requestId: string;
-    prepared: RunInGamePreparedRequest;
-    deployment: RunInGameDeployment;
-    setup: RunInGameSetupPrepared;
-    started: RunInGameStarted;
-  }>): Promise<RunInGameProof>;
-
-  prepareSaveDeployStart(args: Readonly<{
-    requestId: string;
-    input: StudioInputs["mapConfigs"]["saveDeploy"];
-  }>): Promise<SaveDeployPreparedRequest>;
-  saveMapConfig(args: Readonly<{
-    requestId: string;
-    input: StudioInputs["mapConfigs"]["saveDeploy"];
-    prepared: SaveDeployPreparedRequest;
-  }>): Promise<SaveDeploySaved>;
-  deploySavedMapConfig(args: Readonly<{
-    requestId: string;
-    input: StudioInputs["mapConfigs"]["saveDeploy"];
-    prepared: SaveDeployPreparedRequest;
-    saved: SaveDeploySaved;
-  }>): Promise<SaveDeployDeployed>;
-
-  runAutoplay(input: StudioInputs["civ7"]["autoplay"]): Promise<StudioOutputs["civ7"]["autoplay"]>;
-  normalizeSaveDeployFailure?(args: Readonly<{
-    err: unknown;
-    phase: "saving" | "deploying";
-  }>): StudioRuntimeFailure | undefined;
-  failureDiagnostics?(err: unknown): StudioBoundedDiagnostics | undefined;
-}>;
+export type {
+  RunInGameDeployment,
+  RunInGameLogEvidence,
+  RunInGameMaterialized,
+  RunInGamePreparedRequest,
+  RunInGameProof,
+  RunInGameRestartResult,
+  RunInGameSetupPrepared,
+  RunInGameStarted,
+  SaveDeployDeployed,
+  SaveDeployPreparedRequest,
+  SaveDeployRollback,
+  SaveDeploySaved,
+  StudioClock,
+  StudioDaemonIdentity,
+} from "../ports/index.js";
+export type { StudioWorkflowPorts as StudioOperationRuntimePorts } from "../ports/index.js";

--- a/packages/studio-server/src/operationRuntime/registry.ts
+++ b/packages/studio-server/src/operationRuntime/registry.ts
@@ -412,7 +412,6 @@ export function failSaveDeploy(args: Readonly<{
   nowIso: string;
   phase: "saving" | "deploying";
   err: unknown;
-  normalize?: (args: Readonly<{ err: unknown; phase: "saving" | "deploying" }>) => StudioRuntimeFailure | undefined;
 }>): Effect.Effect<SaveDeployInternalOperation> {
   return SynchronizedRef.modify(args.registry, (state) => {
     const current = state.saveDeploy[args.requestId];
@@ -431,9 +430,7 @@ export function failSaveDeploy(args: Readonly<{
         state,
       ] as const;
     }
-    const failure =
-      args.normalize?.({ err: args.err, phase: args.phase }) ??
-      toRuntimeFailure(args.err, "Save failed");
+    const failure = toRuntimeFailure(args.err, "Save failed");
     const operation = failSaveOperation(current, args.nowIso, failure, args.phase);
     return [
       operation,

--- a/packages/studio-server/src/ports/Civ7ProcessControl.ts
+++ b/packages/studio-server/src/ports/Civ7ProcessControl.ts
@@ -1,0 +1,13 @@
+import type {
+  RunInGameDeployment,
+  RunInGamePreparedRequest,
+  RunInGameRestartResult,
+} from "./workflowTypes.js";
+
+export type Civ7ProcessControl = Readonly<{
+  restartCivForRunInGame?(args: Readonly<{
+    requestId: string;
+    prepared: RunInGamePreparedRequest;
+    deployment: RunInGameDeployment;
+  }>): Promise<RunInGameRestartResult>;
+}>;

--- a/packages/studio-server/src/ports/Civ7WorkflowControl.ts
+++ b/packages/studio-server/src/ports/Civ7WorkflowControl.ts
@@ -1,0 +1,351 @@
+import {
+  type Civ7DirectControlSession,
+  type Civ7PlayerSetupOptions,
+  type Civ7SavedGameConfigurationRef,
+  type Civ7SetupOptionValue,
+  DEFAULT_CIV7_TUNER_TIMEOUT_MS,
+  ensureCiv7SetupMapRowVisible,
+  getCiv7PlayableStatus,
+  runCiv7SinglePlayerFromSetup,
+  startCiv7Autoplay,
+  stopCiv7Autoplay,
+} from "@civ7/direct-control";
+import { Context, Effect, Layer } from "effect";
+
+import type { StudioInputs, StudioOutputs } from "../context.js";
+import {
+  autoplayStartStopFailed,
+  autoplayVerificationFailed,
+  dependencyUnavailable,
+  operationBlocked,
+  type StudioBoundedDiagnostics,
+  type StudioBoundedDiagnosticValue,
+  type StudioRuntimeFailure,
+} from "../errors/index.js";
+import { Civ7TunerSession } from "../services/Civ7TunerSession.js";
+import type {
+  RunInGameDeployment,
+  RunInGamePreparedRequest,
+  RunInGameSetupPrepared,
+  RunInGameStarted,
+} from "./workflowTypes.js";
+
+const SCRIPTING_LOG_WAIT_TIMEOUT_MS = 90_000;
+
+export interface Civ7WorkflowControlApi {
+  readonly checkPlayable: (args: Readonly<{
+    requestId: string;
+    prepared: RunInGamePreparedRequest;
+    deployment: RunInGameDeployment;
+  }>) => Effect.Effect<void, StudioRuntimeFailure>;
+  readonly prepareSetup: (args: Readonly<{
+    requestId: string;
+    prepared: RunInGamePreparedRequest;
+    deployment: RunInGameDeployment;
+  }>) => Effect.Effect<RunInGameSetupPrepared, StudioRuntimeFailure>;
+  readonly startGame: (args: Readonly<{
+    requestId: string;
+    prepared: RunInGamePreparedRequest;
+    deployment: RunInGameDeployment;
+    setup: RunInGameSetupPrepared;
+  }>) => Effect.Effect<RunInGameStarted, StudioRuntimeFailure>;
+  readonly runAutoplay: (
+    input: StudioInputs["civ7"]["autoplay"]
+  ) => Effect.Effect<StudioOutputs["civ7"]["autoplay"], StudioRuntimeFailure>;
+}
+
+export class Civ7WorkflowControl extends Context.Tag(
+  "@civ7/studio-server/Civ7WorkflowControl"
+)<Civ7WorkflowControl, Civ7WorkflowControlApi>() {}
+
+export const Civ7WorkflowControlLive: Layer.Layer<
+  Civ7WorkflowControl,
+  never,
+  Civ7TunerSession
+> = Layer.effect(
+  Civ7WorkflowControl,
+  Effect.gen(function* () {
+    const tuner = yield* Civ7TunerSession;
+    const runTuner = <A>(
+      action: (options: { readonly session: Civ7DirectControlSession }) => Promise<A>,
+      toFailure: (err: unknown) => StudioRuntimeFailure
+    ) =>
+      tuner.use((options) => action(options)).pipe(
+        Effect.mapError((err) => toFailure(err))
+      );
+
+    const directControlUnavailable = (
+      message: string,
+      code: string,
+      err: unknown,
+      details: Record<string, unknown> = {}
+    ) =>
+      dependencyUnavailable({
+        message,
+        dependency: "direct-control",
+        causeSummary: diagnosticString(err),
+        diagnostics: boundedDiagnostics({
+          code,
+          ...details,
+          cause: diagnosticString(err),
+        }),
+        recoveryActions: ["copy-diagnostics", "retry-status", "retry-run"],
+      });
+
+    return {
+      checkPlayable: (args) =>
+        runTuner(
+          (options) =>
+            getCiv7PlayableStatus({
+              timeoutMs: DEFAULT_CIV7_TUNER_TIMEOUT_MS,
+              ...options,
+            }),
+          (err) =>
+            directControlUnavailable(
+              "Civ7 direct-control status is unavailable",
+              "direct-control-status-unavailable",
+              err,
+              { materialization: args.deployment.materialization }
+            )
+        ).pipe(Effect.asVoid),
+
+      prepareSetup: (args) => {
+        const materialization = args.deployment.materialization;
+        const launchMapScript = materialization?.mapScript;
+        if (!launchMapScript) {
+          return Effect.fail(
+            operationBlocked({
+              message: "Run in Game map script is missing before setup preparation",
+              diagnostics: boundedDiagnostics({
+                code: "run-in-game-map-script-missing",
+                requestId: args.requestId,
+                materialization,
+              }),
+            })
+          );
+        }
+        return runTuner(
+          (options) =>
+            ensureCiv7SetupMapRowVisible(
+              {
+                file: launchMapScript,
+                limit: 20,
+                reloadIfMissing:
+                  args.prepared.request.materializationMode === "disposable"
+                    ? "exit-to-shell"
+                    : "none",
+                waitTimeoutMs: SCRIPTING_LOG_WAIT_TIMEOUT_MS,
+                pollIntervalMs: 1_000,
+              },
+              { timeoutMs: DEFAULT_CIV7_TUNER_TIMEOUT_MS, ...options }
+            ),
+          (err) =>
+            directControlUnavailable(
+              "Civ7 setup row visibility check is unavailable",
+              "direct-control-setup-row-unavailable",
+              err,
+              { materialization }
+            )
+        ).pipe(
+          Effect.flatMap((rowVisibility) => {
+            const rowProof = rowVisibility.final;
+            if (rowProof.rows.length === 0) {
+              return Effect.fail(
+                operationBlocked({
+                  message: `Civ7 setup cannot see ${launchMapScript}`,
+                  diagnostics: boundedDiagnostics({
+                    code: "setup-map-row-not-visible",
+                    reloadRequired: true,
+                    reloadBoundary:
+                      args.prepared.request.materializationMode === "disposable"
+                        ? "process-restart-required"
+                        : "setup-row-missing",
+                    reloadAttempted: rowVisibility.refreshed,
+                    mapScript: launchMapScript,
+                    materialization,
+                  }),
+                })
+              );
+            }
+            return Effect.succeed({
+              rowProof,
+              rowVisibility,
+              reloadRequired: rowVisibility.refreshed,
+            });
+          })
+        );
+      },
+
+      startGame: (args) => {
+        const materialization = args.deployment.materialization;
+        const launchMapScript = materialization?.mapScript;
+        const request = args.prepared.request;
+        const mapSize = request.mapSize;
+        const seed = request.seed;
+        if (!launchMapScript || !mapSize || seed === undefined) {
+          return Effect.fail(
+            operationBlocked({
+              message: "Run in Game start is missing map script, map size, or seed",
+              diagnostics: boundedDiagnostics({
+                code: "run-in-game-start-input-missing",
+                requestId: args.requestId,
+                materialization,
+                mapSize,
+                seed,
+              }),
+            })
+          );
+        }
+        return runTuner(
+          (options) =>
+            runCiv7SinglePlayerFromSetup(
+              {
+                mapScript: launchMapScript,
+                mapSize,
+                seed,
+                gameSeed: seed,
+                ...(request.playerCount === undefined ? {} : { playerCount: request.playerCount }),
+                ...(readSavedConfig(request.setupConfig) === undefined
+                  ? {}
+                  : { savedConfig: readSavedConfig(request.setupConfig) }),
+                options: readGameOptions(request.setupConfig),
+                playerOptions: readPlayerOptions(request.setupConfig),
+                fromRunningGame: "exit-to-shell",
+                waitForTuner: true,
+                waitTimeoutMs: SCRIPTING_LOG_WAIT_TIMEOUT_MS,
+              },
+              { timeoutMs: DEFAULT_CIV7_TUNER_TIMEOUT_MS, ...options }
+            ),
+          (err) =>
+            directControlUnavailable(
+              "Civ7 direct-control start is unavailable",
+              "direct-control-start-unavailable",
+              err,
+              { materialization }
+            )
+        ).pipe(Effect.map((start) => ({ start })));
+      },
+
+      runAutoplay: (input) => {
+        const opts = {
+          timeoutMs: DEFAULT_CIV7_TUNER_TIMEOUT_MS,
+          waitTimeoutMs: SCRIPTING_LOG_WAIT_TIMEOUT_MS,
+          pollIntervalMs: 1_000,
+        };
+        return runTuner(
+          (options) =>
+            input.action === "start"
+              ? startCiv7Autoplay({ ...opts, ...options })
+              : stopCiv7Autoplay({ ...opts, ...options }),
+          (err) =>
+            autoplayStartStopFailed({
+              message: `Civ7 autoplay ${input.action} failed`,
+              reason: input.action === "start" ? "start-failed" : "stop-failed",
+              diagnostics: boundedDiagnostics({
+                code: `civ7-autoplay-${input.action}-failed`,
+                action: input.action,
+                cause: diagnosticString(err),
+              }),
+            })
+        ).pipe(
+          Effect.flatMap((result) => {
+            if (result.verified) {
+              return Effect.succeed({
+                ok: true,
+                action: input.action,
+                autoplay: result.after.autoplay,
+                game: result.after.game,
+                gameContext: result.after.gameContext,
+                result,
+              });
+            }
+            return Effect.fail(
+              autoplayVerificationFailed({
+                message: `Civ7 autoplay ${input.action} verification failed`,
+                diagnostics: boundedDiagnostics({
+                  code: "civ7-autoplay-verification-failed",
+                  action: input.action,
+                  autoplay: result.after.autoplay,
+                  game: result.after.game,
+                  gameContext: result.after.gameContext,
+                }),
+              })
+            );
+          })
+        );
+      },
+    } satisfies Civ7WorkflowControlApi;
+  })
+);
+
+function readSetupConfigValue(value: unknown, key: string): unknown {
+  if (!value || typeof value !== "object") return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+function readSavedConfig(value: unknown): Civ7SavedGameConfigurationRef | undefined {
+  const savedConfig = readSetupConfigValue(value, "savedConfig");
+  if (!savedConfig || typeof savedConfig !== "object") return undefined;
+  const record = savedConfig as Record<string, unknown>;
+  if (
+    typeof record.id !== "string" ||
+    typeof record.displayName !== "string" ||
+    typeof record.fileName !== "string" ||
+    typeof record.path !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    id: record.id,
+    displayName: record.displayName,
+    fileName: record.fileName,
+    path: record.path,
+  };
+}
+
+function readGameOptions(value: unknown): Readonly<Record<string, Civ7SetupOptionValue>> | undefined {
+  const gameOptions = readSetupConfigValue(value, "gameOptions");
+  return gameOptions && typeof gameOptions === "object"
+    ? (gameOptions as Readonly<Record<string, Civ7SetupOptionValue>>)
+    : undefined;
+}
+
+function readPlayerOptions(value: unknown): ReadonlyArray<Civ7PlayerSetupOptions> | undefined {
+  const playerOptions = readSetupConfigValue(value, "playerOptions");
+  return Array.isArray(playerOptions)
+    ? (playerOptions as ReadonlyArray<Civ7PlayerSetupOptions>)
+    : undefined;
+}
+
+function boundedDiagnostics(value: Record<string, unknown>): StudioBoundedDiagnostics {
+  const out: Record<string, StudioBoundedDiagnosticValue> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    out[key] = boundedDiagnosticValue(entry);
+  }
+  return out;
+}
+
+function boundedDiagnosticValue(value: unknown): StudioBoundedDiagnosticValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => diagnosticString(entry) ?? "");
+  }
+  return diagnosticString(value) ?? "";
+}
+
+function diagnosticString(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (value instanceof Error && value.message) return value.message;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/studio-server/src/ports/DeployRunner.ts
+++ b/packages/studio-server/src/ports/DeployRunner.ts
@@ -1,0 +1,23 @@
+import type { StudioInputs } from "../context.js";
+import type {
+  RunInGameDeployment,
+  RunInGameMaterialized,
+  RunInGamePreparedRequest,
+  SaveDeployDeployed,
+  SaveDeployPreparedRequest,
+  SaveDeploySaved,
+} from "./workflowTypes.js";
+
+export type DeployRunner = Readonly<{
+  deployRunInGame(args: Readonly<{
+    requestId: string;
+    prepared: RunInGamePreparedRequest;
+    materialized: RunInGameMaterialized;
+  }>): Promise<RunInGameDeployment>;
+  deploySavedMapConfig(args: Readonly<{
+    requestId: string;
+    input: StudioInputs["mapConfigs"]["saveDeploy"];
+    prepared: SaveDeployPreparedRequest;
+    saved: SaveDeploySaved;
+  }>): Promise<SaveDeployDeployed>;
+}>;

--- a/packages/studio-server/src/ports/MapConfigStore.ts
+++ b/packages/studio-server/src/ports/MapConfigStore.ts
@@ -1,0 +1,27 @@
+import type { StudioInputs } from "../context.js";
+import type {
+  SaveDeployPreparedRequest,
+  SaveDeployRollback,
+  SaveDeploySaved,
+  WorkflowFailureDiagnosticsPort,
+} from "./workflowTypes.js";
+
+export type MapConfigStore = WorkflowFailureDiagnosticsPort & Readonly<{
+  prepareSaveDeployStart(args: Readonly<{
+    requestId: string;
+    input: StudioInputs["mapConfigs"]["saveDeploy"];
+  }>): Promise<SaveDeployPreparedRequest>;
+  saveMapConfig(args: Readonly<{
+    requestId: string;
+    input: StudioInputs["mapConfigs"]["saveDeploy"];
+    prepared: SaveDeployPreparedRequest;
+  }>): Promise<SaveDeploySaved>;
+  rollbackSaveDeploy(args: Readonly<{
+    requestId: string;
+    input: StudioInputs["mapConfigs"]["saveDeploy"];
+    prepared: SaveDeployPreparedRequest;
+    saved?: SaveDeploySaved;
+    failedAtPhase: "saving" | "deploying";
+    cause: unknown;
+  }>): Promise<SaveDeployRollback>;
+}>;

--- a/packages/studio-server/src/ports/ProofBuilder.ts
+++ b/packages/studio-server/src/ports/ProofBuilder.ts
@@ -1,0 +1,26 @@
+import type { StudioInputs } from "../context.js";
+import type {
+  RunInGameDeployment,
+  RunInGameLogEvidence,
+  RunInGameMaterialized,
+  RunInGamePreparedRequest,
+  RunInGameProof,
+  RunInGameSetupPrepared,
+  RunInGameStarted,
+} from "./workflowTypes.js";
+
+export type ProofBuilder = Readonly<{
+  materializeRunInGame(args: Readonly<{
+    requestId: string;
+    input: StudioInputs["runInGame"]["start"];
+    prepared: RunInGamePreparedRequest;
+  }>): Promise<RunInGameMaterialized>;
+  buildRunInGameProof(args: Readonly<{
+    requestId: string;
+    prepared: RunInGamePreparedRequest;
+    deployment: RunInGameDeployment;
+    setup: RunInGameSetupPrepared;
+    started: RunInGameStarted;
+    log: RunInGameLogEvidence;
+  }>): Promise<RunInGameProof>;
+}>;

--- a/packages/studio-server/src/ports/ScriptingLog.ts
+++ b/packages/studio-server/src/ports/ScriptingLog.ts
@@ -1,0 +1,17 @@
+import type {
+  RunInGameDeployment,
+  RunInGameLogEvidence,
+  RunInGamePreparedRequest,
+  RunInGameSetupPrepared,
+  RunInGameStarted,
+} from "./workflowTypes.js";
+
+export type ScriptingLog = Readonly<{
+  waitForRunInGameLogProof(args: Readonly<{
+    requestId: string;
+    prepared: RunInGamePreparedRequest;
+    deployment: RunInGameDeployment;
+    setup: RunInGameSetupPrepared;
+    started: RunInGameStarted;
+  }>): Promise<RunInGameLogEvidence>;
+}>;

--- a/packages/studio-server/src/ports/index.ts
+++ b/packages/studio-server/src/ports/index.ts
@@ -1,0 +1,45 @@
+export type { Civ7ProcessControl } from "./Civ7ProcessControl.js";
+export {
+  Civ7WorkflowControl,
+  Civ7WorkflowControlLive,
+  type Civ7WorkflowControlApi,
+} from "./Civ7WorkflowControl.js";
+export type { DeployRunner } from "./DeployRunner.js";
+export type { MapConfigStore } from "./MapConfigStore.js";
+export type { ProofBuilder } from "./ProofBuilder.js";
+export type { ScriptingLog } from "./ScriptingLog.js";
+export type {
+  RunInGameDeployment,
+  RunInGameLogEvidence,
+  RunInGameMaterialized,
+  RunInGamePreparedRequest,
+  RunInGameProof,
+  RunInGameRestartResult,
+  RunInGameSetupPrepared,
+  RunInGameStarted,
+  SaveDeployDeployed,
+  SaveDeployPreparedRequest,
+  SaveDeployRollback,
+  SaveDeploySaved,
+  StudioClock,
+  StudioDaemonIdentity,
+  WorkflowFailureDiagnosticsPort,
+  WorkflowInput,
+  WorkflowOutput,
+} from "./workflowTypes.js";
+
+import type { Civ7ProcessControl } from "./Civ7ProcessControl.js";
+import type { DeployRunner } from "./DeployRunner.js";
+import type { MapConfigStore } from "./MapConfigStore.js";
+import type { ProofBuilder } from "./ProofBuilder.js";
+import type { ScriptingLog } from "./ScriptingLog.js";
+import type { StudioClock } from "./workflowTypes.js";
+
+export type StudioWorkflowPorts = Readonly<{
+  clock?: StudioClock;
+}> &
+  ProofBuilder &
+  DeployRunner &
+  Civ7ProcessControl &
+  ScriptingLog &
+  MapConfigStore;

--- a/packages/studio-server/src/ports/workflowTypes.ts
+++ b/packages/studio-server/src/ports/workflowTypes.ts
@@ -1,0 +1,90 @@
+import type { StudioInputs, StudioOutputs } from "../context.js";
+import type { MapConfigSaveDeployStatus } from "../contract/mapConfigs.js";
+import type {
+  RunInGameExactAuthorshipProof,
+  RunInGameMaterializationStatus,
+  RunInGameProcessRestartStatus,
+  RunInGameRequestStatus,
+} from "../contract/runInGame.js";
+import type { StudioBoundedDiagnostics } from "../errors/index.js";
+
+export type StudioDaemonIdentity = Readonly<{
+  serverInstanceId: string;
+  serverStartedAt: string;
+}>;
+
+export type StudioClock = Readonly<{
+  now(): Date;
+}>;
+
+export type RunInGamePreparedRequest = Readonly<{
+  fingerprint: string;
+  request: RunInGameRequestStatus;
+}>;
+
+export type RunInGameMaterialized = Readonly<{
+  materialization?: RunInGameMaterializationStatus;
+  cleanup?(): Promise<void>;
+}>;
+
+export type RunInGameDeployment = Readonly<{
+  materialization?: RunInGameMaterializationStatus;
+  deploy?: unknown;
+}>;
+
+export type RunInGameRestartResult = Readonly<{
+  processRestart?: RunInGameProcessRestartStatus;
+}>;
+
+export type RunInGameSetupPrepared = Readonly<{
+  rowProof?: unknown;
+  rowVisibility?: unknown;
+  reloadRequired?: boolean;
+}>;
+
+export type RunInGameStarted = Readonly<{
+  start?: unknown;
+}>;
+
+export type RunInGameLogEvidence = Readonly<{
+  result?: unknown;
+  materialization?: RunInGameMaterializationStatus;
+  logMarkerProof?: unknown;
+  logProof?: unknown;
+}>;
+
+export type RunInGameProof = Readonly<{
+  result?: unknown;
+  exactAuthorshipProof?: RunInGameExactAuthorshipProof;
+  materialization?: RunInGameMaterializationStatus;
+}>;
+
+export type SaveDeployPreparedRequest = Readonly<{
+  path?: string;
+  cleanup?(): Promise<void>;
+}>;
+
+export type SaveDeploySaved = Readonly<{
+  path?: string;
+  saved?: boolean;
+}>;
+
+export type SaveDeployRollback = Readonly<{
+  path?: string;
+  restored?: boolean;
+  deleted?: boolean;
+}>;
+
+export type SaveDeployDeployed = Readonly<{
+  path?: string;
+  saved?: boolean;
+  deployed?: boolean;
+  deploy?: MapConfigSaveDeployStatus["deploy"];
+}>;
+
+export type WorkflowFailureDiagnosticsPort = Readonly<{
+  failureDiagnostics?(err: unknown): StudioBoundedDiagnostics | undefined;
+}>;
+
+export type WorkflowInput = StudioInputs;
+export type WorkflowOutput = StudioOutputs;

--- a/packages/studio-server/src/runtime.ts
+++ b/packages/studio-server/src/runtime.ts
@@ -10,10 +10,12 @@ import { StudioEventHub } from "./services/StudioEventHub.js";
 /**
  * Builds the `ManagedRuntime` backing the effect-orpc router for one host.
  *
- * `Civ7TunerSession` is the scoped owner of the ONE shared FireTuner
- * connection; `Civ7TunerClient` consumes it, and layer memoization guarantees
- * both graphs see the same instance (the SAME `Civ7TunerSessionLive`
- * reference appears in the merge and in the client's dependencies).
+ * `Civ7TunerSession` is the scoped owner of the daemon FireTuner connection.
+ * D5 keeps ownership visible: this runtime names one top-level
+ * `Civ7TunerSessionLive` layer and provides that same layer reference into the
+ * operation runtime graph, while `Civ7WorkflowControlLive` depends on
+ * `Civ7TunerSession` instead of constructing or self-providing a session.
+ * Live shared-socket proof remains a D12 game-door closure item.
  * The operation runtime is a scoped package service owning daemon identity,
  * operation admission, registries, TTL/tombstones, background workers, events,
  * and disposal. `StudioConfig` carries only the remaining host seams.
@@ -33,15 +35,17 @@ type StudioRuntimeEnv =
 export type StudioRuntime = ManagedRuntime.ManagedRuntime<unknown, never>;
 
 export function makeStudioRuntime(context: StudioServerContext): StudioRuntime {
+  const civ7TunerSessionLayer = Civ7TunerSessionLive;
+  const operationRuntimeLayer = makeStudioOperationRuntimeLayer({
+    ports: context.operationRuntime,
+    eventHub: context.eventHub,
+  }).pipe(Layer.provide(civ7TunerSessionLayer));
   const layer = Layer.mergeAll(
-    Civ7TunerSessionLive,
+    civ7TunerSessionLayer,
     Civ7TunerClient.Default,
     Layer.succeed(StudioConfig, context),
     Layer.succeed(StudioEventHub, context.eventHub),
-    makeStudioOperationRuntimeLayer({
-      ports: context.operationRuntime,
-      eventHub: context.eventHub,
-    })
+    operationRuntimeLayer
   );
   return ManagedRuntime.make(layer) as unknown as StudioRuntime;
 }

--- a/packages/studio-server/src/workflows/AutoplayWorkflow.ts
+++ b/packages/studio-server/src/workflows/AutoplayWorkflow.ts
@@ -1,0 +1,24 @@
+import { Context, Effect, Layer } from "effect";
+
+import type { StudioInputs, StudioOutputs } from "../context.js";
+import type { StudioRuntimeFailure } from "../errors/index.js";
+import { Civ7WorkflowControl } from "../ports/index.js";
+
+export interface AutoplayWorkflowApi {
+  readonly run: (
+    input: StudioInputs["civ7"]["autoplay"]
+  ) => Effect.Effect<StudioOutputs["civ7"]["autoplay"], StudioRuntimeFailure>;
+}
+
+export class AutoplayWorkflow extends Context.Tag(
+  "@civ7/studio-server/AutoplayWorkflow"
+)<AutoplayWorkflow, AutoplayWorkflowApi>() {}
+
+export function makeAutoplayWorkflowLayer(): Layer.Layer<AutoplayWorkflow, never, Civ7WorkflowControl> {
+  return Layer.effect(
+    AutoplayWorkflow,
+    Effect.map(Civ7WorkflowControl, (civ7) => ({
+      run: (input) => civ7.runAutoplay(input),
+    }))
+  );
+}

--- a/packages/studio-server/src/workflows/RunInGameWorkflow.ts
+++ b/packages/studio-server/src/workflows/RunInGameWorkflow.ts
@@ -1,0 +1,262 @@
+import { Context, Effect, Layer } from "effect";
+
+import type { StudioInputs } from "../context.js";
+import {
+  materializationFailed,
+  type StudioBoundedDiagnostics,
+  type StudioBoundedDiagnosticValue,
+} from "../errors/index.js";
+import type {
+  RunInGameDeployment,
+  RunInGameMaterialized,
+  RunInGamePreparedRequest,
+  RunInGameRestartResult,
+  StudioWorkflowPorts,
+} from "../ports/index.js";
+import { Civ7WorkflowControl, type Civ7WorkflowControlApi } from "../ports/index.js";
+import type { RunInGameFailurePhase } from "../operationRuntime/registry.js";
+import type { RunInGameWorkflowTransitions } from "./workflowTransitions.js";
+
+export type RunInGameWorkflowStart = Readonly<{
+  requestId: string;
+  input: StudioInputs["runInGame"]["start"];
+  prepared: RunInGamePreparedRequest;
+  transitions: RunInGameWorkflowTransitions;
+}>;
+
+export interface RunInGameWorkflowApi {
+  readonly start: (args: RunInGameWorkflowStart) => Effect.Effect<void, never>;
+}
+
+export class RunInGameWorkflow extends Context.Tag(
+  "@civ7/studio-server/RunInGameWorkflow"
+)<RunInGameWorkflow, RunInGameWorkflowApi>() {}
+
+export function makeRunInGameWorkflowLayer(args: Readonly<{
+  ports: StudioWorkflowPorts;
+}>): Layer.Layer<RunInGameWorkflow, never, Civ7WorkflowControl> {
+  return Layer.effect(
+    RunInGameWorkflow,
+    Effect.map(Civ7WorkflowControl, (civ7) => makeRunInGameWorkflow({ ...args, civ7 }))
+  );
+}
+
+function makeRunInGameWorkflow(args: Readonly<{
+  ports: StudioWorkflowPorts;
+  civ7: Civ7WorkflowControlApi;
+}>): RunInGameWorkflowApi {
+  const tryPromise = <A>(try_: () => Promise<A>) =>
+    Effect.tryPromise({
+      try: try_,
+      catch: (err) => err,
+    });
+
+  const maybeRestart = (
+    workflow: RunInGameWorkflowStart,
+    deployment: RunInGameDeployment
+  ): Effect.Effect<RunInGameRestartResult, unknown> => {
+    if (!workflow.prepared.request.restartCivProcess || !args.ports.restartCivForRunInGame) {
+      return Effect.succeed({});
+    }
+    return Effect.gen(function* () {
+      yield* workflow.transitions.transition({ phase: "restarting-civ" });
+      return yield* tryPromise(() =>
+        args.ports.restartCivForRunInGame?.({
+          requestId: workflow.requestId,
+          prepared: workflow.prepared,
+          deployment,
+        }) ?? Promise.resolve({})
+      );
+    });
+  };
+
+  return {
+    start: (workflow) =>
+      Effect.gen(function* () {
+        let phase: RunInGameFailurePhase = "materializing";
+        let materialized: RunInGameMaterialized = {};
+        let cleanupAttempted = false;
+        const cleanupMaterialized = (failure?: unknown) => {
+          if (cleanupAttempted || materialized.cleanup === undefined) return Effect.void;
+          return Effect.sync(() => {
+            cleanupAttempted = true;
+          }).pipe(
+            Effect.flatMap(() => tryPromise(() => materialized.cleanup?.() ?? Promise.resolve())),
+            Effect.mapError((err) =>
+              runInGameCleanupFailure({
+                err,
+                phase,
+                original: failure,
+              })
+            )
+          );
+        };
+        const work = Effect.gen(function* () {
+          yield* workflow.transitions.transition({ phase });
+          materialized = yield* tryPromise(() =>
+            args.ports.materializeRunInGame({
+              requestId: workflow.requestId,
+              input: workflow.input,
+              prepared: workflow.prepared,
+            })
+          );
+          if (materialized.materialization) {
+            yield* workflow.transitions.transition({
+              phase,
+              materialization: materialized.materialization,
+            });
+          }
+
+          phase = "deploying";
+          yield* workflow.transitions.transition({
+            phase,
+            materialization: materialized.materialization,
+          });
+          const deployment = yield* tryPromise(() =>
+            args.ports.deployRunInGame({
+              requestId: workflow.requestId,
+              prepared: workflow.prepared,
+              materialized,
+            })
+          );
+          yield* workflow.transitions.transition({
+            phase,
+            materialization: deployment.materialization ?? materialized.materialization,
+          });
+
+          const restart = yield* maybeRestart(workflow, deployment);
+          phase = "checking-civ7";
+          yield* workflow.transitions.transition({
+            phase,
+            materialization: deployment.materialization ?? materialized.materialization,
+            ...(restart.processRestart === undefined
+              ? {}
+              : { processRestart: restart.processRestart }),
+          });
+          yield* args.civ7.checkPlayable({
+            requestId: workflow.requestId,
+            prepared: workflow.prepared,
+            deployment,
+          });
+
+          phase = "preparing-setup";
+          yield* workflow.transitions.transition({ phase });
+          const setup = yield* args.civ7.prepareSetup({
+            requestId: workflow.requestId,
+            prepared: workflow.prepared,
+            deployment,
+          });
+          if (setup.reloadRequired) {
+            phase = "reload-needed";
+            yield* workflow.transitions.transition({ phase });
+          }
+
+          phase = "starting-game";
+          yield* workflow.transitions.transition({ phase });
+          const started = yield* args.civ7.startGame({
+            requestId: workflow.requestId,
+            prepared: workflow.prepared,
+            deployment,
+            setup,
+          });
+
+          phase = "waiting-for-proof";
+          yield* workflow.transitions.transition({ phase });
+          const log = yield* tryPromise(() =>
+            args.ports.waitForRunInGameLogProof({
+              requestId: workflow.requestId,
+              prepared: workflow.prepared,
+              deployment,
+              setup,
+              started,
+            })
+          );
+          const proof = yield* tryPromise(() =>
+            args.ports.buildRunInGameProof({
+              requestId: workflow.requestId,
+              prepared: workflow.prepared,
+              deployment,
+              setup,
+              started,
+              log,
+            })
+          );
+          yield* cleanupMaterialized();
+          yield* workflow.transitions.transition({
+            phase: "complete",
+            result: proof.result ?? { ok: true },
+            materialization:
+              proof.materialization ?? deployment.materialization ?? materialized.materialization,
+            ...(proof.exactAuthorshipProof === undefined
+              ? {}
+              : { exactAuthorshipProof: proof.exactAuthorshipProof }),
+          });
+        });
+
+        yield* work.pipe(
+          Effect.catchAll((err) =>
+            cleanupMaterialized(err).pipe(
+              Effect.flatMap(() => workflow.transitions.fail({ phase, err })),
+              Effect.catchAll((cleanupErr) =>
+                workflow.transitions.fail({ phase, err: cleanupErr })
+              )
+            )
+          ),
+          Effect.ensuring(
+            cleanupMaterialized().pipe(
+              Effect.catchAll(() => Effect.void)
+            )
+          )
+        );
+      }).pipe(Effect.catchAll(() => Effect.void)),
+  };
+}
+
+function runInGameCleanupFailure(args: Readonly<{
+  err: unknown;
+  phase: RunInGameFailurePhase;
+  original?: unknown;
+}>) {
+  return materializationFailed({
+    message: "Run in Game materialization cleanup failed",
+    diagnostics: boundedDiagnostics({
+      code: "run-in-game-cleanup-failed",
+      failedAtPhase: args.phase,
+      cause: diagnosticString(args.err),
+      originalFailure: args.original === undefined ? undefined : diagnosticString(args.original),
+    }),
+  });
+}
+
+function boundedDiagnostics(value: Record<string, unknown>): StudioBoundedDiagnostics {
+  const out: Record<string, StudioBoundedDiagnosticValue> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry !== undefined) out[key] = boundedDiagnosticValue(entry);
+  }
+  return out;
+}
+
+function boundedDiagnosticValue(value: unknown): StudioBoundedDiagnosticValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => diagnosticString(entry) ?? "");
+  }
+  return diagnosticString(value) ?? "";
+}
+
+function diagnosticString(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (value instanceof Error && value.message) return value.message;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/studio-server/src/workflows/SaveDeployWorkflow.ts
+++ b/packages/studio-server/src/workflows/SaveDeployWorkflow.ts
@@ -1,0 +1,302 @@
+import { Context, Effect, Layer } from "effect";
+
+import type { StudioInputs } from "../context.js";
+import {
+  deployFailed,
+  isStudioRuntimeFailure,
+  type StudioBoundedDiagnostics,
+  type StudioBoundedDiagnosticValue,
+} from "../errors/index.js";
+import type {
+  SaveDeployPreparedRequest,
+  SaveDeployRollback,
+  StudioWorkflowPorts,
+} from "../ports/index.js";
+import type { SaveDeployWorkflowTransitions } from "./workflowTransitions.js";
+
+export type SaveDeployWorkflowStart = Readonly<{
+  requestId: string;
+  input: StudioInputs["mapConfigs"]["saveDeploy"];
+  transitions: SaveDeployWorkflowTransitions;
+}>;
+
+export interface SaveDeployWorkflowApi {
+  readonly start: (args: SaveDeployWorkflowStart) => Effect.Effect<void, never>;
+}
+
+export class SaveDeployWorkflow extends Context.Tag(
+  "@civ7/studio-server/SaveDeployWorkflow"
+)<SaveDeployWorkflow, SaveDeployWorkflowApi>() {}
+
+export function makeSaveDeployWorkflowLayer(args: Readonly<{
+  ports: StudioWorkflowPorts;
+}>): Layer.Layer<SaveDeployWorkflow> {
+  return Layer.succeed(SaveDeployWorkflow, makeSaveDeployWorkflow(args));
+}
+
+function makeSaveDeployWorkflow(args: Readonly<{
+  ports: StudioWorkflowPorts;
+}>): SaveDeployWorkflowApi {
+  const tryPromise = <A>(try_: () => Promise<A>) =>
+    Effect.tryPromise({
+      try: try_,
+      catch: (err) => err,
+    });
+
+  return {
+    start: (workflow) =>
+      Effect.gen(function* () {
+        let phase: "saving" | "deploying" = "saving";
+        let prepared: SaveDeployPreparedRequest = {};
+        let saved: Awaited<ReturnType<StudioWorkflowPorts["saveMapConfig"]>> | undefined;
+        let cleanupAttempted = false;
+        const cleanupPrepared = (failure?: unknown) => {
+          if (cleanupAttempted || prepared.cleanup === undefined) return Effect.void;
+          return Effect.sync(() => {
+            cleanupAttempted = true;
+          }).pipe(
+            Effect.flatMap(() => tryPromise(() => prepared.cleanup?.() ?? Promise.resolve())),
+            Effect.mapError((err) =>
+              saveDeployCleanupFailure({
+                err,
+                phase,
+                original: failure,
+                path: prepared.path,
+                diagnostics: args.ports.failureDiagnostics?.(err),
+              })
+            )
+          );
+        };
+        const rollback = (cause: unknown) => {
+          if (prepared.path === undefined) return Effect.succeed<SaveDeployRollback>({});
+          return tryPromise(() =>
+            args.ports.rollbackSaveDeploy({
+              requestId: workflow.requestId,
+              input: workflow.input,
+              prepared,
+              saved,
+              failedAtPhase: phase,
+              cause,
+            })
+          );
+        };
+        const work = Effect.gen(function* () {
+          prepared = sanitizeSaveDeployPrepared(yield* tryPromise(() =>
+            args.ports.prepareSaveDeployStart({
+              requestId: workflow.requestId,
+              input: workflow.input,
+            })
+          ));
+          yield* workflow.transitions.transition({
+            phase,
+            ...(prepared.path === undefined ? {} : { path: prepared.path }),
+          });
+          const savedResult = yield* tryPromise(() =>
+            args.ports.saveMapConfig({
+              requestId: workflow.requestId,
+              input: workflow.input,
+              prepared,
+            })
+          );
+          saved = savedResult;
+          phase = "deploying";
+          yield* workflow.transitions.transition({
+            phase,
+            path: savedResult.path ?? prepared.path,
+            saved: savedResult.saved ?? true,
+          });
+          const deployed = yield* tryPromise(() =>
+            args.ports.deploySavedMapConfig({
+              requestId: workflow.requestId,
+              input: workflow.input,
+              prepared,
+              saved: savedResult,
+            })
+          );
+          yield* cleanupPrepared();
+          yield* workflow.transitions.transition({
+            phase: "complete",
+            path: deployed.path ?? savedResult.path ?? prepared.path,
+            saved: deployed.saved ?? savedResult.saved ?? true,
+            deployed: deployed.deployed ?? true,
+            deploy: deployed.deploy,
+          });
+        });
+
+        yield* work.pipe(
+          Effect.catchAll((err) => finalizeFailure(err)),
+          Effect.ensuring(
+            cleanupPrepared().pipe(
+              Effect.catchAll(() => Effect.void)
+            )
+          )
+        );
+
+        function finalizeFailure(err: unknown) {
+          return Effect.gen(function* () {
+            let rollbackResult: SaveDeployRollback = {};
+            let rollbackErr: unknown;
+            if (!isSaveDeployCleanupFailure(err)) {
+              const rollbackEither = yield* Effect.either(rollback(err));
+              if (rollbackEither._tag === "Left") {
+                rollbackErr = rollbackEither.left;
+              } else {
+                rollbackResult = rollbackEither.right;
+              }
+            }
+            const cleanupEither = yield* Effect.either(cleanupPrepared(err));
+            if (cleanupEither._tag === "Left") {
+              yield* workflow.transitions.fail({ phase, err: cleanupEither.left });
+              return;
+            }
+            if (rollbackErr !== undefined) {
+              yield* workflow.transitions.fail({
+                phase,
+                err: saveDeployRollbackFailure({
+                  err,
+                  rollbackErr,
+                  phase,
+                  path: prepared.path,
+                  diagnostics: args.ports.failureDiagnostics?.(err),
+                }),
+              });
+              return;
+            }
+            yield* workflow.transitions.fail({
+              phase,
+              err: saveDeployWorkflowFailure({
+                err,
+                phase,
+                path: prepared.path,
+                rollback: rollbackResult,
+                diagnostics: args.ports.failureDiagnostics?.(err),
+              }),
+            });
+          });
+        }
+      }).pipe(Effect.catchAll(() => Effect.void)),
+  };
+}
+
+function sanitizeSaveDeployPrepared(prepared: SaveDeployPreparedRequest): SaveDeployPreparedRequest {
+  return {
+    ...(prepared.path === undefined ? {} : { path: prepared.path }),
+    ...(prepared.cleanup === undefined ? {} : { cleanup: prepared.cleanup }),
+  };
+}
+
+function saveDeployWorkflowFailure(args: Readonly<{
+  err: unknown;
+  phase: "saving" | "deploying";
+  path?: string;
+  rollback: SaveDeployRollback;
+  diagnostics?: StudioBoundedDiagnostics;
+}>) {
+  if (isStudioRuntimeFailure(args.err)) return args.err;
+  const reason = args.phase === "saving" ? "save-failed" : "deploy-failed";
+  return deployFailed({
+    message: args.err instanceof Error && args.err.message ? args.err.message : "Save/Deploy failed",
+    reason,
+    diagnostics: boundedDiagnostics({
+      ...args.diagnostics,
+      code: `save-deploy-${reason}`,
+      failedAtPhase: args.phase,
+      path: args.path,
+      cause: diagnosticString(args.err),
+      rollbackPath: args.rollback.path,
+      rollbackRestored: args.rollback.restored,
+      rollbackDeleted: args.rollback.deleted,
+    }),
+    recoveryActions: [
+      "copy-diagnostics",
+      "retry-status",
+      "retry-save-deploy",
+      ...(args.phase === "deploying" ? ["inspect-deploy-output" as const] : []),
+    ],
+  });
+}
+
+function saveDeployRollbackFailure(args: Readonly<{
+  err: unknown;
+  rollbackErr: unknown;
+  phase: "saving" | "deploying";
+  path?: string;
+  diagnostics?: StudioBoundedDiagnostics;
+}>) {
+  return deployFailed({
+    message: "Save/Deploy rollback failed after workflow failure",
+    reason: "rollback-failed",
+    diagnostics: boundedDiagnostics({
+      ...args.diagnostics,
+      code: "save-deploy-rollback-failed",
+      failedAtPhase: args.phase,
+      path: args.path,
+      cause: diagnosticString(args.err),
+      rollbackFailure: diagnosticString(args.rollbackErr),
+    }),
+    recoveryActions: ["copy-diagnostics", "retry-status", "retry-save-deploy", "inspect-deploy-output"],
+  });
+}
+
+function saveDeployCleanupFailure(args: Readonly<{
+  err: unknown;
+  phase: "saving" | "deploying";
+  original?: unknown;
+  path?: string;
+  diagnostics?: StudioBoundedDiagnostics;
+}>) {
+  return deployFailed({
+    message: "Save/Deploy cleanup failed",
+    reason: args.phase === "saving" ? "save-failed" : "deploy-failed",
+    diagnostics: boundedDiagnostics({
+      ...args.diagnostics,
+      code: "save-deploy-cleanup-failed",
+      failedAtPhase: args.phase,
+      path: args.path,
+      cause: diagnosticString(args.err),
+      originalFailure: args.original === undefined ? undefined : diagnosticString(args.original),
+    }),
+    recoveryActions: ["copy-diagnostics", "retry-status", "retry-save-deploy"],
+  });
+}
+
+function isSaveDeployCleanupFailure(value: unknown): boolean {
+  return (
+    isStudioRuntimeFailure(value) &&
+    value.tag === "DeployFailed" &&
+    value.diagnostics?.code === "save-deploy-cleanup-failed"
+  );
+}
+
+function boundedDiagnostics(value: Record<string, unknown>): StudioBoundedDiagnostics {
+  const out: Record<string, StudioBoundedDiagnosticValue> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry !== undefined) out[key] = boundedDiagnosticValue(entry);
+  }
+  return out;
+}
+
+function boundedDiagnosticValue(value: unknown): StudioBoundedDiagnosticValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => diagnosticString(entry) ?? "");
+  }
+  return diagnosticString(value) ?? "";
+}
+
+function diagnosticString(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (value instanceof Error && value.message) return value.message;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/studio-server/src/workflows/index.ts
+++ b/packages/studio-server/src/workflows/index.ts
@@ -1,0 +1,26 @@
+export {
+  AutoplayWorkflow,
+  makeAutoplayWorkflowLayer,
+  type AutoplayWorkflowApi,
+} from "./AutoplayWorkflow.js";
+export {
+  Civ7WorkflowControl,
+  Civ7WorkflowControlLive,
+  type Civ7WorkflowControlApi,
+} from "../ports/index.js";
+export {
+  RunInGameWorkflow,
+  makeRunInGameWorkflowLayer,
+  type RunInGameWorkflowApi,
+  type RunInGameWorkflowStart,
+} from "./RunInGameWorkflow.js";
+export {
+  SaveDeployWorkflow,
+  makeSaveDeployWorkflowLayer,
+  type SaveDeployWorkflowApi,
+  type SaveDeployWorkflowStart,
+} from "./SaveDeployWorkflow.js";
+export type {
+  RunInGameWorkflowTransitions,
+  SaveDeployWorkflowTransitions,
+} from "./workflowTransitions.js";

--- a/packages/studio-server/src/workflows/workflowTransitions.ts
+++ b/packages/studio-server/src/workflows/workflowTransitions.ts
@@ -1,0 +1,24 @@
+import type { Effect } from "effect";
+
+import type { StudioRuntimeFailure } from "../errors/index.js";
+import type {
+  RunInGameFailurePhase,
+  RunInGameTransition,
+  SaveDeployTransition,
+} from "../operationRuntime/registry.js";
+
+export type RunInGameWorkflowTransitions = Readonly<{
+  transition(transition: RunInGameTransition): Effect.Effect<void, StudioRuntimeFailure>;
+  fail(args: Readonly<{
+    phase: RunInGameFailurePhase;
+    err: unknown;
+  }>): Effect.Effect<void, never>;
+}>;
+
+export type SaveDeployWorkflowTransitions = Readonly<{
+  transition(transition: SaveDeployTransition): Effect.Effect<void, StudioRuntimeFailure>;
+  fail(args: Readonly<{
+    phase: "saving" | "deploying";
+    err: unknown;
+  }>): Effect.Effect<void, never>;
+}>;

--- a/packages/studio-server/test/handler.test.ts
+++ b/packages/studio-server/test/handler.test.ts
@@ -7,8 +7,6 @@ import { afterEach, describe, expect, test } from "vitest";
 import {
   createStudioEventHub,
   createStudioRpcHandler,
-  invalidRequest,
-  operationBlocked,
   type StudioEventHubApi,
   type StudioOperationRuntimePorts,
   type StudioRouter,
@@ -171,39 +169,6 @@ describe("studio-server RPC handler", () => {
       serverInstanceId: expect.stringMatching(/^studio-server-/),
       serverStartedAt: "2026-06-10T00:00:00.000Z",
       diagnostics: { code: "save-deploy-request-not-found" },
-    });
-  });
-
-  test("maps typed runtime leaf failures through the package error spine", async () => {
-    const context = makeContext({
-      operationRuntime: makeOperationRuntimePorts({
-        runAutoplay: async () => {
-          throw operationBlocked({
-            message: "Autoplay blocked by test",
-            activeRequestId: "run-1",
-            activePhase: "deploying",
-            diagnostics: { code: "autoplay-test-blocked" },
-          });
-        },
-      }),
-    });
-    const client = await listenWithClient(context);
-
-    const { error } = await safe(client.civ7.autoplay({ action: "start" }));
-
-    expect(error).toBeInstanceOf(ORPCError);
-    if (!(error instanceof ORPCError)) throw new Error("expected an ORPCError");
-    expect(isDefinedError(error)).toBe(true);
-    expect(error.code).toBe("AUTOPLAY_BLOCKED");
-    expect(error.status).toBe(409);
-    expect(error.data).toMatchObject({
-      tag: "OperationBlocked",
-      namespace: "autoplay",
-      reason: "active-operation-conflict",
-      message: "Autoplay blocked by test",
-      activeRequestId: "run-1",
-      activePhase: "deploying",
-      diagnostics: { code: "autoplay-test-blocked" },
     });
   });
 
@@ -372,26 +337,12 @@ function makeOperationRuntimePorts(
     },
     materializeRunInGame: async () => ({}),
     deployRunInGame: async () => ({}),
-    checkCiv7ForRunInGame: async () => undefined,
-    prepareSetupForRunInGame: async () => ({}),
-    startGameForRunInGame: async () => ({}),
-    waitForRunInGameProof: async () => ({ result: { ok: true } }),
+    waitForRunInGameLogProof: async () => ({ result: { ok: true } }),
+    buildRunInGameProof: async () => ({ result: { ok: true } }),
     prepareSaveDeployStart: async () => ({}),
     saveMapConfig: async () => ({ saved: true }),
     deploySavedMapConfig: async () => ({ deployed: true }),
-    runAutoplay: async (input) => ({
-      ok: true,
-      action: input.action,
-      autoplay: {},
-      game: {},
-      gameContext: {},
-      result: {},
-    }),
-    normalizeSaveDeployFailure: ({ err }) =>
-      invalidRequest({
-        message: err instanceof Error ? err.message : "Save failed",
-        diagnostics: { code: "save-deploy-test-failed" },
-      }),
+    rollbackSaveDeploy: async () => ({ restored: true }),
     ...overrides,
   };
 }

--- a/packages/studio-server/test/operationRuntime.test.ts
+++ b/packages/studio-server/test/operationRuntime.test.ts
@@ -1,4 +1,4 @@
-import { Effect, ManagedRuntime } from "effect";
+import { Effect, Layer, ManagedRuntime } from "effect";
 import { afterEach, describe, expect, test } from "vitest";
 
 import { createStudioEventHub, type StudioEventHubApi } from "../src/services/StudioEventHub";
@@ -8,6 +8,7 @@ import {
   type StudioOperationRuntimePorts,
 } from "../src/operationRuntime";
 import type { StudioEvent } from "../src/contract/studio";
+import { Civ7WorkflowControl, type Civ7WorkflowControlApi } from "../src/ports";
 
 const openRuntimes: ManagedRuntime.ManagedRuntime<StudioOperationRuntime, never>[] = [];
 const openEventHubs: StudioEventHubApi[] = [];
@@ -85,7 +86,7 @@ describe("StudioOperationRuntime", () => {
     const runtime = ManagedRuntime.make(
       makeStudioOperationRuntimeLayer({
         ports: makePorts({
-          waitForRunInGameProof: async ({ requestId, prepared, deployment }) => ({
+          buildRunInGameProof: async ({ requestId, prepared, deployment }) => ({
             result: { ok: true },
             exactAuthorshipProof: {
               status: "complete",
@@ -106,6 +107,7 @@ describe("StudioOperationRuntime", () => {
           }),
         }),
         eventHub: recordingEventHub,
+        civ7WorkflowControl: makeCiv7WorkflowControlLayer(),
       })
     );
     openRuntimes.push(runtime);
@@ -290,17 +292,20 @@ describe("StudioOperationRuntime", () => {
           savePrepareCalls += 1;
           return {};
         },
-        runAutoplay: async (input) => {
-          autoplayCalls += 1;
-          return {
-            ok: true,
-            action: input.action,
-            autoplay: {},
-            game: {},
-            gameContext: {},
-            result: {},
-          };
-        },
+      },
+      civ7: {
+        runAutoplay: (input) =>
+          Effect.sync(() => {
+            autoplayCalls += 1;
+            return {
+              ok: true,
+              action: input.action,
+              autoplay: {},
+              game: {},
+              gameContext: {},
+              result: {},
+            };
+          }),
       },
     });
     const service = await runtime.runPromise(StudioOperationRuntime);
@@ -365,10 +370,27 @@ describe("StudioOperationRuntime", () => {
   });
 
   test("Save/Deploy leaf failure projects terminal state and releases the mutation gate", async () => {
+    const events: StudioEvent[] = [];
+    let rollbackCalls = 0;
+    let cleanupCalls = 0;
     const { runtime } = makeRuntime({
+      eventSink: events,
       ports: {
+        prepareSaveDeployStart: async () => ({
+          path: "mods/mod-swooper-maps/src/maps/configs/test.config.json",
+          cleanup: async () => {
+            cleanupCalls += 1;
+          },
+        }),
         deploySavedMapConfig: async () => {
           throw new Error("deploy failed");
+        },
+        rollbackSaveDeploy: async () => {
+          rollbackCalls += 1;
+          return {
+            path: "mods/mod-swooper-maps/src/maps/configs/test.config.json",
+            restored: true,
+          };
         },
       },
     });
@@ -397,8 +419,146 @@ describe("StudioOperationRuntime", () => {
       error: "deploy failed",
       details: {
         failedAtPhase: "deploying",
+        reason: "deploy-failed",
+        code: "save-deploy-deploy-failed",
+        rollbackRestored: true,
       },
     });
+    expect(rollbackCalls).toBe(1);
+    expect(cleanupCalls).toBe(1);
+    expect(terminalSaveDeployEvents(events, accepted.requestId)).toHaveLength(1);
+
+    await expect(
+      runtime.runPromise(service.runInGameStart({ recipeId: "mod-swooper-maps/standard" }))
+    ).resolves.toMatchObject({
+      ok: true,
+      status: "running",
+    });
+  });
+
+  test("Save/Deploy rollback failure projects one rollback terminal state", async () => {
+    const events: StudioEvent[] = [];
+    let rollbackCalls = 0;
+    let cleanupCalls = 0;
+    const { runtime } = makeRuntime({
+      eventSink: events,
+      ports: {
+        prepareSaveDeployStart: async () => ({
+          path: "mods/mod-swooper-maps/src/maps/configs/test.config.json",
+          cleanup: async () => {
+            cleanupCalls += 1;
+          },
+        }),
+        deploySavedMapConfig: async () => {
+          throw new Error("deploy failed");
+        },
+        rollbackSaveDeploy: async () => {
+          rollbackCalls += 1;
+          throw new Error("restore failed");
+        },
+      },
+    });
+    const service = await runtime.runPromise(StudioOperationRuntime);
+
+    const accepted = await runtime.runPromise(
+      service.saveDeployStart({ requestId: "save-rollback-fail", id: "test-config", envelope: {} })
+    );
+    await expect
+      .poll(async () => {
+        const status = await runtime.runPromise(
+          service.saveDeployStatus({ requestId: accepted.requestId })
+        );
+        return status.status;
+      })
+      .toBe("failed");
+
+    const failed = await runtime.runPromise(
+      service.saveDeployStatus({ requestId: accepted.requestId })
+    );
+    expect(failed).toMatchObject({
+      ok: false,
+      requestId: "save-rollback-fail",
+      phase: "failed",
+      status: "failed",
+      error: "Save/Deploy rollback failed after workflow failure",
+      details: {
+        failedAtPhase: "deploying",
+        reason: "rollback-failed",
+        code: "save-deploy-rollback-failed",
+        rollbackFailure: "restore failed",
+      },
+    });
+    expect(rollbackCalls).toBe(1);
+    expect(cleanupCalls).toBe(1);
+    expect(terminalSaveDeployEvents(events, accepted.requestId)).toHaveLength(1);
+
+    await expect(
+      runtime.runPromise(service.runInGameStart({ recipeId: "mod-swooper-maps/standard" }))
+    ).resolves.toMatchObject({
+      ok: true,
+      status: "running",
+    });
+  });
+
+  test("Save/Deploy cleanup failure projects one cleanup terminal state without retry", async () => {
+    const events: StudioEvent[] = [];
+    let rollbackCalls = 0;
+    let cleanupCalls = 0;
+    const { runtime } = makeRuntime({
+      eventSink: events,
+      ports: {
+        prepareSaveDeployStart: async () => ({
+          path: "mods/mod-swooper-maps/src/maps/configs/test.config.json",
+          cleanup: async () => {
+            cleanupCalls += 1;
+            throw new Error("cleanup failed");
+          },
+        }),
+        deploySavedMapConfig: async () => {
+          throw new Error("deploy failed");
+        },
+        rollbackSaveDeploy: async () => {
+          rollbackCalls += 1;
+          return {
+            path: "mods/mod-swooper-maps/src/maps/configs/test.config.json",
+            restored: true,
+          };
+        },
+      },
+    });
+    const service = await runtime.runPromise(StudioOperationRuntime);
+
+    const accepted = await runtime.runPromise(
+      service.saveDeployStart({ requestId: "save-cleanup-fail", id: "test-config", envelope: {} })
+    );
+    await expect
+      .poll(async () => {
+        const status = await runtime.runPromise(
+          service.saveDeployStatus({ requestId: accepted.requestId })
+        );
+        return status.status;
+      })
+      .toBe("failed");
+
+    const failed = await runtime.runPromise(
+      service.saveDeployStatus({ requestId: accepted.requestId })
+    );
+    expect(failed).toMatchObject({
+      ok: false,
+      requestId: "save-cleanup-fail",
+      phase: "failed",
+      status: "failed",
+      error: "Save/Deploy cleanup failed",
+      details: {
+        failedAtPhase: "deploying",
+        reason: "deploy-failed",
+        code: "save-deploy-cleanup-failed",
+        cause: "cleanup failed",
+      },
+    });
+    expect(rollbackCalls).toBe(1);
+    expect(cleanupCalls).toBe(1);
+    expect(terminalSaveDeployEvents(events, accepted.requestId)).toHaveLength(1);
 
     await expect(
       runtime.runPromise(service.runInGameStart({ recipeId: "mod-swooper-maps/standard" }))
@@ -427,7 +587,7 @@ describe("StudioOperationRuntime", () => {
     const blocker = deferred<void>();
     const { runtime } = makeRuntime({
       ports: {
-        waitForRunInGameProof: async () => {
+        buildRunInGameProof: async () => {
           await blocker.promise;
           return { result: { ok: true } };
         },
@@ -477,17 +637,20 @@ describe("StudioOperationRuntime", () => {
           savePrepareCalls += 1;
           return {};
         },
-        runAutoplay: async (input) => {
-          autoplayCalls += 1;
-          return {
-            ok: true,
-            action: input.action,
-            autoplay: {},
-            game: {},
-            gameContext: {},
-            result: {},
-          };
-        },
+      },
+      civ7: {
+        runAutoplay: (input) =>
+          Effect.sync(() => {
+            autoplayCalls += 1;
+            return {
+              ok: true,
+              action: input.action,
+              autoplay: {},
+              game: {},
+              gameContext: {},
+              result: {},
+            };
+          }),
       },
     });
     const service = await runtime.runPromise(StudioOperationRuntime);
@@ -563,6 +726,7 @@ describe("StudioOperationRuntime", () => {
       makeStudioOperationRuntimeLayer({
         ports: makePorts(),
         eventHub: failingEventHub,
+        civ7WorkflowControl: makeCiv7WorkflowControlLayer(),
       })
     );
     openRuntimes.push(runtime);
@@ -596,6 +760,7 @@ describe("StudioOperationRuntime", () => {
       makeStudioOperationRuntimeLayer({
         ports: makePorts(),
         eventHub: recordingEventHub,
+        civ7WorkflowControl: makeCiv7WorkflowControlLayer(),
       })
     );
     openRuntimes.push(runtime);
@@ -647,6 +812,7 @@ describe("StudioOperationRuntime", () => {
           },
         }),
         eventHub: recordingEventHub,
+        civ7WorkflowControl: makeCiv7WorkflowControlLayer(),
       })
     );
     openRuntimes.push(runtime);
@@ -685,10 +851,22 @@ describe("StudioOperationRuntime", () => {
 
 function makeRuntime(overrides: {
   ports?: Partial<StudioOperationRuntimePorts>;
+  civ7?: Partial<Civ7WorkflowControlApi>;
   ttlMs?: number;
+  eventSink?: StudioEvent[];
 } = {}) {
   const eventHub = createStudioEventHub();
   openEventHubs.push(eventHub);
+  const runtimeEventHub: StudioEventHubApi =
+    overrides.eventSink === undefined
+      ? eventHub
+      : {
+          ...eventHub,
+          publish: async (event) => {
+            overrides.eventSink?.push(event);
+            await eventHub.publish(event);
+          },
+        };
   const ports: StudioOperationRuntimePorts = {
     ...makePorts(),
     ...overrides.ports,
@@ -696,7 +874,8 @@ function makeRuntime(overrides: {
   const runtime = ManagedRuntime.make(
     makeStudioOperationRuntimeLayer({
       ports,
-      eventHub,
+      eventHub: runtimeEventHub,
+      civ7WorkflowControl: makeCiv7WorkflowControlLayer(overrides.civ7),
       ttlMs: overrides.ttlMs,
     })
   );
@@ -711,26 +890,41 @@ function makePorts(overrides: Partial<StudioOperationRuntimePorts> = {}): Studio
     },
     materializeRunInGame: async () => ({}),
     deployRunInGame: async () => ({}),
-    checkCiv7ForRunInGame: async () => undefined,
-    prepareSetupForRunInGame: async () => ({}),
-    startGameForRunInGame: async () => ({}),
-    waitForRunInGameProof: async () => ({ result: { ok: true } }),
+    waitForRunInGameLogProof: async () => ({ result: { ok: true } }),
+    buildRunInGameProof: async () => ({ result: { ok: true } }),
     prepareSaveDeployStart: async () => ({}),
     saveMapConfig: async () => ({
       path: "mods/mod-swooper-maps/src/maps/configs/test.config.json",
       saved: true,
     }),
     deploySavedMapConfig: async () => ({ deployed: true }),
-    runAutoplay: async (input) => ({
-      ok: true,
-      action: input.action,
-      autoplay: {},
-      game: {},
-      gameContext: {},
-      result: {},
+    rollbackSaveDeploy: async () => ({
+      path: "mods/mod-swooper-maps/src/maps/configs/test.config.json",
+      restored: true,
     }),
     ...overrides,
   };
+}
+
+function makeCiv7WorkflowControlLayer(
+  overrides: Partial<Civ7WorkflowControlApi> = {}
+): Layer.Layer<Civ7WorkflowControl> {
+  const service: Civ7WorkflowControlApi = {
+    checkPlayable: () => Effect.void,
+    prepareSetup: () => Effect.succeed({}),
+    startGame: () => Effect.succeed({}),
+    runAutoplay: (input) =>
+      Effect.succeed({
+        ok: true,
+        action: input.action,
+        autoplay: {},
+        game: {},
+        gameContext: {},
+        result: {},
+      }),
+    ...overrides,
+  };
+  return Layer.succeed(Civ7WorkflowControl, service);
 }
 
 async function expectFailure<A, E>(
@@ -760,4 +954,17 @@ function deferred<T>() {
     reject = rejectPromise;
   });
   return { promise, resolve, reject };
+}
+
+function terminalSaveDeployEvents(
+  events: readonly StudioEvent[],
+  requestId: string
+): StudioEvent[] {
+  return events.filter(
+    (event) =>
+      event.type === "operation" &&
+      event.kind === "save-deploy" &&
+      event.status.requestId === requestId &&
+      event.status.status !== "running"
+  );
 }

--- a/packages/studio-server/test/workflowSessionGraph.test.ts
+++ b/packages/studio-server/test/workflowSessionGraph.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Effect, Layer } from "effect";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7WorkflowControl,
+  Civ7WorkflowControlLive,
+  type RunInGameDeployment,
+  type RunInGamePreparedRequest,
+} from "../src/ports";
+import {
+  Civ7TunerSession,
+  type Civ7TunerSessionApi,
+} from "../src/services/Civ7TunerSession";
+
+describe("Studio workflow session graph", () => {
+  test("workflow control depends on the runtime-owned Civ7TunerSession layer", () => {
+    const root = dirname(dirname(fileURLToPath(import.meta.url)));
+    const workflowControl = readFileSync(
+      join(root, "src/ports/Civ7WorkflowControl.ts"),
+      "utf8"
+    );
+    const operationRuntime = readFileSync(
+      join(root, "src/operationRuntime/StudioOperationRuntime.ts"),
+      "utf8"
+    );
+    const runtime = readFileSync(join(root, "src/runtime.ts"), "utf8");
+
+    expect(workflowControl).toContain("yield* Civ7TunerSession");
+    expect(workflowControl).not.toContain("Civ7TunerSessionLive");
+    expect(workflowControl).not.toContain("makeCiv7TunerSessionLayer");
+    expect(workflowControl).not.toMatch(/\bnew\s+Civ7DirectControlSession\s*\(/);
+    expect(workflowControl).not.toMatch(/Civ7WorkflowControlLive[\s\S]*Layer\.provide/);
+
+    expect(operationRuntime).toContain("Civ7WorkflowControlLive");
+    expect(operationRuntime).toContain("Civ7TunerSession");
+    expect(runtime).toContain("const civ7TunerSessionLayer = Civ7TunerSessionLive");
+    expect(runtime).toContain(".pipe(Layer.provide(civ7TunerSessionLayer))");
+  });
+
+  test("workflow control consumes an externally supplied tuner session service", async () => {
+    let useCalls = 0;
+    const fakeSession: Civ7TunerSessionApi = {
+      session: {} as Civ7TunerSessionApi["session"],
+      use: () =>
+        Effect.sync(() => {
+          useCalls += 1;
+          return { ok: true };
+        }),
+      health: Effect.succeed({
+        consecutiveResponseTimeouts: 0,
+        gateOpenUntil: null,
+        wedgeSuspected: false,
+      }),
+    };
+    const layer = Civ7WorkflowControlLive.pipe(
+      Layer.provide(Layer.succeed(Civ7TunerSession, fakeSession))
+    );
+    const prepared: RunInGamePreparedRequest = {
+      fingerprint: "fingerprint-1",
+      request: {
+        recipeId: "mod-swooper-maps/standard",
+        fingerprint: "fingerprint-1",
+      },
+    };
+    const deployment: RunInGameDeployment = {};
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const workflowControl = yield* Civ7WorkflowControl;
+        yield* workflowControl.checkPlayable({
+          requestId: "run-1",
+          prepared,
+          deployment,
+        });
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(useCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
Workflow orchestration for Run in Game, Save/Deploy, and Autoplay has been moved out of the app-level engine and into package-owned Effect services (`RunInGameWorkflow`, `SaveDeployWorkflow`, `AutoplayWorkflow`). The app host now supplies bounded leaf-port atoms for filesystem, materialization, deploy, log, and proof work, while the package owns phase ordering, typed failure classification, admission, registries, TTL, background workers, events, and disposal.

**Run in Game**

The monolithic `waitForRunInGameProof` leaf is split into `waitForRunInGameLogProof` (log parsing and marker evidence) and `buildRunInGameProof` (exact-authorship proof construction). The workflow waits for log evidence, builds the proof, runs cleanup, and only then emits the terminal completion transition. The app-side `checkCiv7ForRunInGame`, `prepareSetupForRunInGame`, and `startGameForRunInGame` leaves are removed; those calls now go through `Civ7WorkflowControlLive` (`checkPlayable`, `prepareSetup`, `startGame`).

**Save/Deploy**

Rollback is now a dedicated `rollbackSaveDeploy` leaf atom owned by the package workflow. Deploy failure, rollback failure, and cleanup failure each produce exactly one terminal projection and release the active gate. The inline `saveDeployFailureForOperation` helper and the `normalizeSaveDeployFailure` port are removed.

**Autoplay**

Autoplay orchestration moves into `AutoplayWorkflow`, which delegates to `Civ7WorkflowControlLive.runAutoplay`. The app-level `runAutoplay` port and `runAutoplayLeaf` helper are removed.

**Session ownership**

`Civ7WorkflowControlLive` depends on an externally supplied `Civ7TunerSession` rather than constructing or self-providing one. `makeStudioRuntime` names a single top-level `civ7TunerSessionLayer = Civ7TunerSessionLive` and provides that same reference into the operation runtime graph. A new `workflowSessionGraph.test.ts` adds a static source guard confirming `Civ7WorkflowControl.ts` does not import `Civ7TunerSessionLive` or construct a session, plus a dynamic Layer proof that `Civ7WorkflowControlLive` consumes an externally supplied `Civ7TunerSession`.

**Raw-control guardrails**

The `runInGame.start` TypeBox contract now marks known raw-control tunnel keys (`args`, `command`, `context`, `javascript`, `operationType`, `rawCommand`, `rawJs`, `script`, `session`, `stateName`) as `Type.Never()` so top-level payloads fail schema validation. The host-side `assertNoRawControlFields` deep scan is extended to cover the same vocabulary for nested opaque config/setup/source payloads. Tests are updated to assert top-level rejection at the schema layer and nested rejection at the host validator.

**Tests**

New `operationRuntime.test.ts` cases cover Save/Deploy deploy failure with rollback, rollback failure producing one terminal event, and cleanup failure producing one terminal event without retry. The `makeRuntime` helper accepts a `civ7` override for `Civ7WorkflowControlApi` and an `eventSink` for terminal event counting. The `runAutoplay` port override is replaced with a `Civ7WorkflowControl` layer override.