### PR TITLE
`fix(studio): harden event stream cleanup and proof boundaries`

### DIFF
--- a/apps/mapgen-studio/src/app/hooks/useStudioEvents.ts
+++ b/apps/mapgen-studio/src/app/hooks/useStudioEvents.ts
@@ -18,8 +18,14 @@ export function studioEventsWatchClientContext() {
   };
 }
 
+type StudioEventsWatchProcedure = Pick<typeof orpc.studio.events.watch, "experimental_liveOptions">;
+
 export function studioEventsWatchLiveOptions() {
-  return orpc.studio.events.watch.experimental_liveOptions({
+  return studioEventsWatchLiveOptionsFor(orpc.studio.events.watch);
+}
+
+export function studioEventsWatchLiveOptionsFor(watch: StudioEventsWatchProcedure) {
+  return watch.experimental_liveOptions({
     input: {},
     context: studioEventsWatchClientContext(),
     retry: false,

--- a/apps/mapgen-studio/test/devServer/viteProxyStream.test.ts
+++ b/apps/mapgen-studio/test/devServer/viteProxyStream.test.ts
@@ -54,13 +54,19 @@ describe("Vite /rpc dev proxy streaming", () => {
     expect(response.body).not.toBeNull();
 
     const reader = response.body!.getReader();
-    const firstRead = await withTimeout(reader.read(), 1_000, "first proxied SSE chunk");
-    const firstText = new TextDecoder().decode(firstRead.value);
-    expect(firstText).toContain("data: first");
+    try {
+      const firstText = await readUntil(reader, "data: first");
+      expect(firstText).toContain("data: first");
 
-    await expect(secondChunkWritten.promise).resolves.toBeUndefined();
-    releaseUpstream.resolve();
-    await reader.cancel();
+      await expect(secondChunkWritten.promise).resolves.toBeUndefined();
+      const fullText = firstText.includes("data: second")
+        ? firstText
+        : `${firstText}${await readUntil(reader, "data: second")}`;
+      expect(fullText.indexOf("data: first")).toBeLessThan(fullText.indexOf("data: second"));
+    } finally {
+      releaseUpstream.resolve();
+      await reader.cancel();
+    }
   });
 });
 
@@ -126,4 +132,19 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: str
   } finally {
     if (timeout !== undefined) clearTimeout(timeout);
   }
+}
+
+async function readUntil(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  needle: string
+): Promise<string> {
+  const decoder = new TextDecoder();
+  let text = "";
+  while (!text.includes(needle)) {
+    const chunk = await withTimeout(reader.read(), 1_000, `proxied SSE chunk containing ${needle}`);
+    if (chunk.done) break;
+    text += decoder.decode(chunk.value, { stream: true });
+  }
+  text += decoder.decode();
+  return text;
 }

--- a/apps/mapgen-studio/test/studioEvents/operationAdoption.test.ts
+++ b/apps/mapgen-studio/test/studioEvents/operationAdoption.test.ts
@@ -8,12 +8,14 @@ import type {
   StudioOperationEvent,
   StudioOperationsCurrent,
 } from "@civ7/studio-server";
+import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { describe, expect, test } from "vitest";
 
 import {
   STUDIO_EVENT_STREAM_RETRY_ATTEMPTS,
   studioEventsWatchClientContext,
   studioEventsWatchLiveOptions,
+  studioEventsWatchLiveOptionsFor,
 } from "../../src/app/hooks/useStudioEvents";
 import {
   adoptStudioOperationsCurrent,
@@ -319,6 +321,46 @@ describe("Studio event operation adoption", () => {
     expect(JSON.stringify(options.queryKey)).toContain('"watch"');
     expect(typeof options.queryFn).toBe("function");
   });
+
+  test("live event query function invokes watch with scoped stream retry context", async () => {
+    const calls: Array<{ input: unknown; options: { signal?: AbortSignal; context?: unknown } }> = [];
+    const fakeClient = {
+      studio: {
+        events: {
+          watch: async (input: unknown, options: { signal?: AbortSignal; context?: unknown } = {}) => {
+            calls.push({ input, options });
+            return oneEventIterator({
+              type: "hello",
+              serverInstanceId: "studio-test",
+              serverStartedAt: "2026-06-13T00:00:00.000Z",
+              observedAt: "2026-06-13T00:00:01.000Z",
+            });
+          },
+        },
+      },
+    };
+    const fakeOrpc = createTanstackQueryUtils(fakeClient);
+    const options = studioEventsWatchLiveOptionsFor(fakeOrpc.studio.events.watch);
+    if (typeof options.queryFn !== "function") {
+      throw new Error("expected a live query function");
+    }
+
+    await options.queryFn({
+      signal: new AbortController().signal,
+      queryKey: options.queryKey,
+      client: {
+        setQueryData() {
+          return undefined;
+        },
+      },
+    } as Parameters<typeof options.queryFn>[0]);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.input).toEqual({});
+    expect(calls[0]?.options.context).toMatchObject({
+      retry: STUDIO_EVENT_STREAM_RETRY_ATTEMPTS,
+    });
+  });
 });
 
 function adoptionState(initial?: {
@@ -360,6 +402,15 @@ function liveGameEvent(state: StudioLiveGameEvent["state"]): StudioLiveGameEvent
     observedAt: "2026-06-13T00:00:02.000Z",
     state,
   };
+}
+
+type TestStudioEvent =
+  | StudioLiveGameEvent
+  | StudioOperationEvent
+  | { type: "hello"; serverInstanceId: string; serverStartedAt: string; observedAt: string };
+
+async function* oneEventIterator(event: TestStudioEvent) {
+  yield event;
 }
 
 function currentOperations(overrides?: Partial<StudioOperationsCurrent>): StudioOperationsCurrent {

--- a/openspec/changes/mapgen-studio-stream-spike/tasks.md
+++ b/openspec/changes/mapgen-studio-stream-spike/tasks.md
@@ -31,12 +31,19 @@
 
 These are D7 implementation obligations recorded by this packet, not pre-acceptance authoring tasks.
 
-- [ ] 3A.1 Implement or preserve `studio.events.watch` with `.effect()` and `eventIterator(...)`.
-- [ ] 3A.2 Prove TypeBox event schema origin and Standard Schema adapter use.
-- [ ] 3A.3 Prove iterator close, abort/disconnect, interruption, and repeated subscribe/close cleanup as separate cases.
-- [ ] 3A.4 Prove one `/rpc` stream passthrough through Vite with at least two ordered chunks before upstream close.
-- [ ] 3A.5 Prove `experimental_liveOptions` plus nonzero retry on the actual watch path.
-- [ ] 3A.6 Promote or delete every D7 spike fixture when D8/D9 production tests cover the same guarantee.
+- [x] 3A.1 Implement or preserve `studio.events.watch` with `.effect()` and `eventIterator(...)`.
+- [x] 3A.2 Prove TypeBox event schema origin and Standard Schema adapter use.
+- [x] 3A.3 Prove iterator close, abort/disconnect, interruption, and repeated subscribe/close cleanup as separate cases.
+- [x] 3A.4 Prove one `/rpc` stream passthrough through Vite with at least two ordered chunks before upstream close.
+- [x] 3A.5 Prove `experimental_liveOptions` plus nonzero retry on the actual watch path.
+- [x] 3A.6 Promote or delete every D7 spike fixture when D8/D9 production tests cover the same guarantee.
+
+Implementation evidence:
+
+- `packages/studio-server/src/router/index.ts` still implements `studio.events.watch` through `oe.studio.events.watch.effect(...)`, and `packages/studio-server/src/contract/studio.ts` still owns the TypeBox event union through the Standard Schema `eventIterator(...)` adapter.
+- `bun run --cwd packages/studio-server test -- test/handler.test.ts test/contractTypeboxSpine.test.ts` passed with package proofs for iterator `return()`, response-body cancel/disconnect cleanup, hub shutdown/interruption cleanup, repeated subscribe/close, event delivery, and TypeBox/Standard Schema contract origin.
+- `bun run --cwd apps/mapgen-studio test -- test/devServer/viteProxyStream.test.ts test/studioEvents/operationAdoption.test.ts` passed with Vite `/rpc` two-ordered-chunk passthrough and actual watch-path `experimental_liveOptions` query-function nonzero retry proof.
+- D7 introduces no new spike-only fixture. Historical S3/D8 references remain classified downstream in the D8/D9 packet records, not as D7 production paths.
 
 ## 4. Verification
 
@@ -51,3 +58,10 @@ These are D7 implementation obligations recorded by this packet, not pre-accepta
 - [x] 5.1 Record review acceptance in `review-disposition-ledger.md`.
 - [x] 5.2 Mark D7 accepted in `OPENSPEC-PACKET-TRAIN.md`.
 - [x] 5.3 Commit accepted D7 packet through Graphite with clean/quarantined worktree state.
+- [x] 5.4 Record fresh implementation-diff review disposition with no unresolved P1/P2.
+- [x] 5.5 Commit D7 implementation changes through Graphite with clean/quarantined worktree state.
+
+Post-commit disposition:
+
+- D7 implementation is committed at the current `codex/runtime-effect-stream-spike` branch tip (`fix(studio): harden event stream cleanup`).
+- Post-amend `git status --short --branch` is clean.

--- a/openspec/changes/mapgen-studio-stream-spike/workstream/closure-checklist.md
+++ b/openspec/changes/mapgen-studio-stream-spike/workstream/closure-checklist.md
@@ -1,6 +1,6 @@
 # D7 Packet Closure Checklist
 
-Status: accepted
+Status: packet accepted; implementation committed at current branch tip
 Date: 2026-06-14
 
 ## Packet Shape
@@ -35,12 +35,22 @@ Date: 2026-06-14
 
 ## Future Implementation Closure Gates
 
-- [ ] `studio.events.watch` uses `.effect()` and `eventIterator(...)`.
-- [ ] event schema origin is TypeBox/Standard Schema.
-- [ ] iterator close cleanup is tested.
-- [ ] abort/disconnect cleanup is tested as its own case.
-- [ ] interruption cleanup is tested as its own case.
-- [ ] repeated subscribe/close leak proof is tested.
-- [ ] Vite `/rpc` stream passthrough is tested with at least two ordered chunks before upstream close.
-- [ ] `experimental_liveOptions` and nonzero retry are tested on the actual watch path.
-- [ ] spike fixture promotion/deletion is recorded.
+- [x] `studio.events.watch` uses `.effect()` and `eventIterator(...)`.
+- [x] event schema origin is TypeBox/Standard Schema.
+- [x] iterator close cleanup is tested.
+- [x] abort/disconnect cleanup is tested as its own case.
+- [x] interruption cleanup is tested as its own case.
+- [x] repeated subscribe/close leak proof is tested.
+- [x] Vite `/rpc` stream passthrough is tested with at least two ordered chunks before upstream close.
+- [x] `experimental_liveOptions` and nonzero retry are tested on the actual watch path.
+- [x] spike fixture promotion/deletion is recorded.
+
+## Implementation Closure Gates
+
+- [x] Package handler/contract tests passed.
+- [x] App Vite stream/adoption tests passed.
+- [x] Package and app TypeScript checks passed.
+- [x] Negative transport/retry/spike scans run and classified.
+- [x] Fresh implementation-diff review disposition recorded with no unresolved P1/P2.
+- [x] Graphite implementation commit exists at the current `codex/runtime-effect-stream-spike` branch tip (`fix(studio): harden event stream cleanup`).
+- [x] Post-amend `git status --short --branch` is clean.

--- a/openspec/changes/mapgen-studio-stream-spike/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-stream-spike/workstream/phase-record.md
@@ -1,10 +1,11 @@
 # D7 Packet Phase Record - Stream Transport Decision
 
-Status: accepted
+Status: packet accepted; implementation committed at current branch tip
 Date: 2026-06-14
 Domino: D7
 OpenSpec change: `mapgen-studio-stream-spike`
 Graphite packet branch: `codex/runtime-effect-openspec-packets`
+Graphite implementation branch: `codex/runtime-effect-stream-spike`
 
 ## Frame
 
@@ -52,18 +53,21 @@ D7 must be reframed if `effect-orpc` `.effect()` cannot return an event iterator
 
 ## Repo State / Baseline
 
-- Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-runtime-effect-refactor-frame`.
-- Branch: `codex/runtime-effect-openspec-packets`.
-- Stack position: packet branch above accepted D0-D6 packet commits.
-- Dirty-file owner during packet drafting: D7 packet docs under `openspec/changes/mapgen-studio-stream-spike/**`.
-- Selected authoring baseline: current packet branch after D6 commit `82fe38319`.
-- Dependency/build entrance evidence for this branch was refreshed at D6 acceptance: `bun install --frozen-lockfile`, `bun run build`, and `bun run check` passed on 2026-06-14. D7 acceptance requires OpenSpec/Graphite/status gates because D7 is docs-only and does not change package code.
+- Packet-authoring worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-runtime-effect-refactor-frame`.
+- Packet-authoring branch: `codex/runtime-effect-openspec-packets`.
+- Implementation worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-S-studio-runtime-effect-refactor`.
+- Implementation branch: `codex/runtime-effect-stream-spike`, stacked above D6 current-operations commit `f6df0bea1`.
+- Implementation write set changes `StudioEventHub` cleanup behavior plus package/app stream tests and D7 workstream docs. D7 is no longer a docs-only slice during implementation.
+- Dirty-file owner during implementation: D7 stream transport files and D7 packet/workstream docs only.
 
 ## Write Set / Protected Paths
 
 Write set:
 
 - `openspec/changes/mapgen-studio-stream-spike/**`
+- `packages/studio-server/src/services/StudioEventHub.ts`
+- `packages/studio-server/test/handler.test.ts`
+- `apps/mapgen-studio/test/devServer/viteProxyStream.test.ts`
 - `docs/projects/studio-runtime-simplification/OPENSPEC-PACKET-TRAIN.md` when marking acceptance
 
 Protected paths:

--- a/openspec/changes/mapgen-studio-stream-spike/workstream/review-disposition-ledger.md
+++ b/openspec/changes/mapgen-studio-stream-spike/workstream/review-disposition-ledger.md
@@ -1,12 +1,15 @@
 # D7 Review Disposition Ledger
 
-Status: accepted
+Status: packet accepted; implementation-diff review findings repaired and committed at current branch tip
 Date: 2026-06-14
 
 | ID | Lane | Finding | Severity | Disposition | Repair |
 | --- | --- | --- | --- | --- | --- |
 | D7-R1 | Testing/proof adequacy | Cleanup scenario combined client abort/disconnect and watch-fiber interruption, allowing one proof path to satisfy both. | P2 | accepted | Spec/tasks/testing now split client abort/disconnect and runtime/fiber interruption into separate cleanup proof cases with observable baseline-return criteria. |
 | D7-R2 | Testing/proof adequacy | Vite `/rpc` passthrough criterion only required first chunk before upstream close and did not falsify later-event drop. | P2 | accepted | Spec/design/proposal/tasks/testing now require at least two ordered chunks before upstream close; findings record the current first-chunk guard as needing strengthening or equal successor proof. |
+| D7-R3 | Implementation proof review (Sartre) | Interruption cleanup was initially claimed from EventHub shutdown subscriber-count cleanup only, without proving a pending watch read settled. | P2 | accepted/repaired | `packages/studio-server/test/handler.test.ts` now opens a subscription, consumes `hello`, starts a pending `iterator.next()`, calls `eventHub.shutdown()`, asserts the pending read settles as an interruption/fiber-shutdown rejection, and then proves subscriber count returns to baseline. |
+| D7-R4 | Implementation proof review (Sartre) | Actual watch-path retry proof only checked helper configuration/query key shape, not that the live query function invoked `studio.events.watch` with the nonzero retry context. | P2 | accepted/repaired | `apps/mapgen-studio/src/app/hooks/useStudioEvents.ts` exposes `studioEventsWatchLiveOptionsFor(...)` for injection, and `apps/mapgen-studio/test/studioEvents/operationAdoption.test.ts` uses real `createTanstackQueryUtils` live options against a fake watch client to assert `queryFn` calls watch with `{ retry: Number.POSITIVE_INFINITY }`. |
+| D7-R5 | Implementation proof review (Sartre) | Vite two-chunk test could wait for a second read if the first read already contained both chunks, and failure paths could leave the upstream response unreleased. | P3 | accepted/repaired | `apps/mapgen-studio/test/devServer/viteProxyStream.test.ts` now accumulates/coalesces stream text safely and releases upstream plus cancels the reader in `finally`. |
 
 ## Required Fresh Reviews
 
@@ -25,3 +28,9 @@ Date: 2026-06-14
 | Transport/API and client retry | Curie | accepted | Selected `.effect()` + `eventIterator(...)`, TypeBox/Standard Schema, one `/rpc`, `experimental_liveOptions`, and actual watch-path nonzero retry have no remaining P1/P2. |
 | Effect cleanup and testing proof | Nietzsche | accepted after repair | Separate abort/disconnect and interruption proof cases plus two-ordered-chunk Vite passthrough oracle repaired prior P2 findings. |
 | Hardening/black-ice/downstream | Darwin | accepted | Gate 1/2 frame, prework/testing/downstream ledgers, fixture disposition, and downstream stale-vocabulary repair scope have no remaining P1/P2. |
+
+## Implementation Review Acceptance - 2026-06-15
+
+| Lane | Reviewer | Result | Evidence |
+| --- | --- | --- | --- |
+| D7 implementation-diff proof boundary | Sartre | accepted after repair | Initial P2 findings for pending-read interruption proof and live query retry invocation proof were repaired; P3 Vite coalesced-read/finally cleanup was repaired. No unresolved P1/P2 remain before Graphite commit. |

--- a/openspec/changes/mapgen-studio-stream-spike/workstream/testing-ledger.md
+++ b/openspec/changes/mapgen-studio-stream-spike/workstream/testing-ledger.md
@@ -1,6 +1,6 @@
 # D7 Testing Ledger - Stream Transport Decision
 
-Status: packet proof contract accepted; implementation evidence pending
+Status: implementation evidence committed at current branch tip; live Civ7 proof is not run or claimed
 Date: 2026-06-14; accounting update 2026-06-15
 
 | Layer | Required proof | Adequacy criterion |
@@ -25,6 +25,31 @@ bun run --cwd apps/mapgen-studio test -- test/devServer/viteProxyStream.test.ts 
 bun run --cwd apps/mapgen-studio check
 ```
 
+## Implementation Evidence - 2026-06-15
+
+Commands run:
+
+```bash
+bun run --cwd packages/studio-server test -- test/handler.test.ts test/contractTypeboxSpine.test.ts
+bun run --cwd apps/mapgen-studio test -- test/devServer/viteProxyStream.test.ts test/studioEvents/operationAdoption.test.ts
+bun run --cwd packages/studio-server check
+bun run --cwd apps/mapgen-studio check
+```
+
+Results:
+
+- Package tests passed: `test/handler.test.ts` and `test/contractTypeboxSpine.test.ts` passed 13 tests.
+- App tests passed: `test/devServer/viteProxyStream.test.ts` and `test/studioEvents/operationAdoption.test.ts` passed 12 tests.
+- Package and app TypeScript checks passed.
+
+Proof disposition:
+
+- `test/contractTypeboxSpine.test.ts` proves the public event iterator is TypeBox-origin through the owned Standard Schema adapter.
+- `test/handler.test.ts` proves `studio.events.watch` delivery over the native effect-oRPC handler, iterator `return()` cleanup, response-body cancel/disconnect cleanup, pending-read interruption on EventHub shutdown, and repeated subscribe/close returning subscriber count to baseline.
+- `test/devServer/viteProxyStream.test.ts` proves Vite `/rpc` forwards at least two ordered event-stream chunks before upstream close without assuming one read equals one chunk.
+- `test/studioEvents/operationAdoption.test.ts` proves the actual watch hook uses `experimental_liveOptions` and that the generated live query function invokes `studio.events.watch` with nonzero retry context.
+- No live Civ7 Play/SaveDeploy proof was run or claimed; D7 is transport/lifecycle proof only.
+
 ## Negative Search Gates
 
 ```bash
@@ -33,6 +58,12 @@ rg -n "streamedOptions|experimental_streamedOptions" apps/mapgen-studio/src pack
 rg -n "retry: 0|default retry|ClientRetryPlugin\\(\\).*reconnect" apps/mapgen-studio/src packages/studio-server/src openspec/changes/mapgen-studio-stream-spike -g "*.{ts,tsx,md}"
 rg -n "streamSpike|spike-only|proof-only" packages/studio-server/test apps/mapgen-studio/test openspec/changes/mapgen-studio-event-hub openspec/changes/mapgen-studio-operations-push -g "*.{ts,tsx,md}"
 ```
+
+Negative scan disposition from implementation pass:
+
+- Alternate transport/stale streamed helper scans produced no production source hits.
+- Retry scan hit `apps/mapgen-studio/src/lib/query.ts:30` (`retry: 0`) for the generic QueryClient default, plus D7 docs that intentionally forbid default-only retry claims. The actual watch path proof remains `apps/mapgen-studio/src/app/hooks/useStudioEvents.ts` / `test/studioEvents/operationAdoption.test.ts`, where watch context supplies nonzero retry.
+- Spike scan hit downstream D8/D9 packet text that explicitly records promotion/deletion obligations. No D7 production code or D7 test fixture introduces a hidden spike-only runtime path.
 
 ## Proof Labels
 

--- a/packages/studio-server/src/services/StudioEventHub.ts
+++ b/packages/studio-server/src/services/StudioEventHub.ts
@@ -19,6 +19,7 @@ export class StudioEventHub extends Context.Tag("@civ7/studio-server/StudioEvent
 
 export function createStudioEventHub(): StudioEventHubApi {
   let activeSubscribers = 0;
+  const activeReleases = new Set<() => Promise<void>>();
   const pubsubPromise = Effect.runPromise(PubSub.unbounded<StudioEvent>());
 
   return {
@@ -35,14 +36,23 @@ export function createStudioEventHub(): StudioEventHubApi {
       const subscription = pubsubPromise.then(async (pubsub) => {
         const scope = await Effect.runPromise(Scope.make());
         const queue = await Effect.runPromise(PubSub.subscribe(pubsub).pipe(Scope.extend(scope)));
+        let released = false;
+        const release = async () => {
+          if (released) return;
+          released = true;
+          activeReleases.delete(release);
+          await Effect.runPromise(Scope.close(scope, Exit.void));
+          activeSubscribers -= 1;
+        };
 
         if (closed) {
           await Effect.runPromise(Scope.close(scope, Exit.void));
-          return { queue, scope, counted: false };
+          return { queue, release: undefined };
         }
 
         activeSubscribers += 1;
-        return { queue, scope, counted: true };
+        activeReleases.add(release);
+        return { queue, release };
       });
 
       return new AsyncIteratorClass<StudioEvent>(
@@ -62,9 +72,8 @@ export function createStudioEventHub(): StudioEventHubApi {
           if (closed) return;
           closed = true;
 
-          const { scope, counted } = await subscription;
-          await Effect.runPromise(Scope.close(scope, Exit.void));
-          if (counted) activeSubscribers -= 1;
+          const { release } = await subscription;
+          await release?.();
         }
       );
     },
@@ -74,6 +83,7 @@ export function createStudioEventHub(): StudioEventHubApi {
     },
 
     async shutdown() {
+      await Promise.all([...activeReleases].map((release) => release()));
       const pubsub = await pubsubPromise;
       await Effect.runPromise(PubSub.shutdown(pubsub));
     },

--- a/packages/studio-server/test/handler.test.ts
+++ b/packages/studio-server/test/handler.test.ts
@@ -202,6 +202,79 @@ describe("studio-server RPC handler", () => {
     await iterator.return?.();
     await expect.poll(() => eventHub.activeSubscriberCount(), { timeout: 1_000 }).toBe(0);
   }, 10_000);
+
+  test("repeated studio.events.watch subscribe and close returns subscriber count to baseline", async () => {
+    const eventHub = trackEventHub(createStudioEventHub());
+    const handler = trackHandle(createStudioRpcHandler(makeContext({ eventHub })));
+    const client = directClient(handler);
+
+    for (let index = 0; index < 3; index += 1) {
+      const iterator = await client.studio.events.watch({});
+      await expect(iterator.next()).resolves.toMatchObject({
+        done: false,
+        value: { type: "hello" },
+      });
+      expect(eventHub.activeSubscriberCount()).toBe(1);
+      await iterator.return?.();
+      await expect.poll(() => eventHub.activeSubscriberCount(), { timeout: 1_000 }).toBe(0);
+    }
+  }, 10_000);
+
+  test("cancelling the watch response body releases the subscription", async () => {
+    const eventHub = trackEventHub(createStudioEventHub());
+    const handler = trackHandle(createStudioRpcHandler(makeContext({ eventHub })));
+    const result = await handler.handle(
+      new Request("http://studio.test/rpc/studio/events/watch", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: {} }),
+      }),
+      { prefix: "/rpc" }
+    );
+
+    expect(result.matched).toBe(true);
+    expect(result.response?.status).toBe(200);
+    expect(result.response?.headers.get("content-type")).toContain("text/event-stream");
+    expect(result.response?.body).not.toBeNull();
+
+    const reader = result.response!.body!.getReader();
+    const text = await readUntil(reader, "hello");
+    expect(text).toContain("hello");
+    expect(eventHub.activeSubscriberCount()).toBe(1);
+
+    await reader.cancel();
+    await expect.poll(() => eventHub.activeSubscriberCount(), { timeout: 1_000 }).toBe(0);
+  }, 10_000);
+
+  test("event hub shutdown interrupts open watch subscriptions and releases scopes", async () => {
+    const eventHub = trackEventHub(createStudioEventHub());
+    const iterator = eventHub.subscribe({
+      initialEvents: [
+        {
+          type: "hello",
+          serverInstanceId: "studio-server-test",
+          serverStartedAt: "2026-06-10T00:00:00.000Z",
+          observedAt: "2026-06-10T00:00:00.000Z",
+        },
+      ],
+    });
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { type: "hello" },
+    });
+    expect(eventHub.activeSubscriberCount()).toBe(1);
+
+    const pendingNext = settle(iterator.next());
+    await eventHub.shutdown();
+    const pendingOutcome = await withTimeout(pendingNext, 1_000, "pending event iterator read to settle");
+    expect(pendingOutcome.status).toBe("rejected");
+    if (pendingOutcome.status === "rejected") {
+      expect(String(pendingOutcome.reason)).toMatch(/interrupted|FiberFailure|shutdown/i);
+    }
+    await expect.poll(() => eventHub.activeSubscriberCount(), { timeout: 1_000 }).toBe(0);
+    await iterator.return?.();
+  });
 });
 
 function trackHandle(handle: StudioRpcHandle): StudioRpcHandle {
@@ -355,4 +428,43 @@ function deferred<T>() {
     reject = rejectPromise;
   });
   return { promise, resolve, reject };
+}
+
+async function readUntil(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  needle: string
+): Promise<string> {
+  const decoder = new TextDecoder();
+  let text = "";
+  while (!text.includes(needle)) {
+    const chunk = await withTimeout(reader.read(), 1_000, `event stream chunk containing ${needle}`);
+    if (chunk.done) break;
+    text += decoder.decode(chunk.value, { stream: true });
+  }
+  text += decoder.decode();
+  return text;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+async function settle<T>(
+  promise: Promise<T>
+): Promise<{ status: "fulfilled"; value: T } | { status: "rejected"; reason: unknown }> {
+  try {
+    return { status: "fulfilled", value: await promise };
+  } catch (reason) {
+    return { status: "rejected", reason };
+  }
 }


### PR DESCRIPTION
This PR closes out the D7 stream transport implementation by hardening `StudioEventHub` cleanup and filling the remaining proof gaps identified during implementation review.

**`StudioEventHub` cleanup hardening**

The hub now tracks all active release callbacks in a `Set`. Each subscriber gets a single idempotent `release()` function that closes its Effect scope, decrements the subscriber count, and removes itself from the set. `shutdown()` drains the set before shutting down the PubSub, so any open subscription scopes are closed before the underlying channel goes away. This eliminates the previous race where a pending `iterator.next()` could be left dangling after hub shutdown.

**Interruption proof for pending reads**

A new handler test opens a subscription, consumes the `hello` event, starts a pending `iterator.next()`, calls `eventHub.shutdown()`, and asserts the pending read settles as a rejected interruption/fiber-shutdown error. It then confirms the subscriber count returns to zero. This closes the P2 finding that interruption cleanup was only claimed from subscriber-count evidence without proving the pending read actually settled.

**Live query retry invocation proof**

`studioEventsWatchLiveOptionsFor` is extracted from `studioEventsWatchLiveOptions` to accept an injected watch procedure. A new adoption test uses real `createTanstackQueryUtils` against a fake watch client, invokes the live `queryFn` directly, and asserts that `studio.events.watch` was called with `{ retry: STUDIO_EVENT_STREAM_RETRY_ATTEMPTS }` in the context. This closes the P2 finding that the retry proof only checked query key shape rather than actual invocation behavior.

**Vite two-chunk test robustness**

The Vite proxy stream test now uses a `readUntil` helper that accumulates chunks until the needle string appears, rather than assuming one read equals one chunk. Both the upstream release and reader cancel are moved into a `finally` block so the upstream response is never left unreleased on failure. The same `readUntil` pattern is added to the handler tests.