### PR TITLE
`refactor(mod-swooper-maps): consolidate domain imports to index entries`

### DIFF
--- a/apps/mapgen-studio/test/devServer/daemonDeployIsolation.test.ts
+++ b/apps/mapgen-studio/test/devServer/daemonDeployIsolation.test.ts
@@ -35,7 +35,11 @@ function resolveLocalImport(fromFile: string, specifier: string): string | null 
   }
   if (specifier.startsWith("@mapgen/domain/")) {
     const suffix = specifier.slice("@mapgen/domain/".length).replace(/\.(m?js)$/, "");
-    return resolve(repoRoot, "mods/mod-swooper-maps/src/domain", `${suffix}.ts`);
+    const base = resolve(repoRoot, "mods/mod-swooper-maps/src/domain", suffix);
+    for (const candidate of [`${base}.ts`, `${base}/index.ts`]) {
+      if (existsSync(candidate)) return candidate;
+    }
+    return `${base}.ts`;
   }
   if (!specifier.startsWith(".")) return null;
   const base = resolve(dirname(fromFile), specifier);
@@ -127,11 +131,8 @@ describe("daemon deploy isolation", () => {
       });
       expect({ file: rel(file), source }).not.toMatchObject({
         source: expect.stringMatching(
-          /from\s+["'](?:mod-swooper-maps\/recipes\/(?:standard|standard-artifacts|standard-map-configs|browser-test)|@mapgen\/domain\/[^"']+\/ops["'])/
+          /from\s+["'](?:mod-swooper-maps\/recipes\/(?:standard|standard-artifacts|standard-map-configs|browser-test)|@mapgen\/domain\/[^"']+\/(?:contract|ops)["'])/
         ),
-      });
-      expect({ file: graphPath, source }).not.toMatchObject({
-        source: expect.stringMatching(/from\s+["']@mapgen\/domain\/[^/"']+["']/),
       });
       if (!graphPath.startsWith("mods/mod-swooper-maps/src/recipes/")) continue;
       expect({ file: rel(file), source }).not.toMatchObject({

--- a/mods/mod-swooper-maps/src/domain/ecology/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/index.ts
@@ -1,4 +1,4 @@
-import { defineDomain } from "@swooper/mapgen-core/authoring";
+import { defineDomain } from "@swooper/mapgen-core/authoring/contracts";
 
 import ops from "./ops/contracts.js";
 

--- a/mods/mod-swooper-maps/src/domain/foundation/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/index.ts
@@ -1,4 +1,4 @@
-import { defineDomain } from "@swooper/mapgen-core/authoring";
+import { defineDomain } from "@swooper/mapgen-core/authoring/contracts";
 
 import ops from "./ops/contracts.js";
 

--- a/mods/mod-swooper-maps/src/domain/hydrology/index.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/index.ts
@@ -1,4 +1,4 @@
-import { defineDomain } from "@swooper/mapgen-core/authoring";
+import { defineDomain } from "@swooper/mapgen-core/authoring/contracts";
 
 import ops from "./ops/contracts.js";
 

--- a/mods/mod-swooper-maps/src/domain/morphology/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/index.ts
@@ -1,4 +1,4 @@
-import { defineDomain } from "@swooper/mapgen-core/authoring";
+import { defineDomain } from "@swooper/mapgen-core/authoring/contracts";
 
 import ops from "./ops/contracts.js";
 

--- a/mods/mod-swooper-maps/src/domain/narrative/index.ts
+++ b/mods/mod-swooper-maps/src/domain/narrative/index.ts
@@ -1,4 +1,4 @@
-import { defineDomain } from "@swooper/mapgen-core/authoring";
+import { defineDomain } from "@swooper/mapgen-core/authoring/contracts";
 
 import ops from "./ops/contracts.js";
 

--- a/mods/mod-swooper-maps/src/domain/placement/index.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/index.ts
@@ -1,4 +1,4 @@
-import { defineDomain } from "@swooper/mapgen-core/authoring";
+import { defineDomain } from "@swooper/mapgen-core/authoring/contracts";
 
 import ops from "./ops/contracts.js";
 

--- a/mods/mod-swooper-maps/src/domain/resources/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/index.ts
@@ -1,4 +1,4 @@
-import { defineDomain } from "@swooper/mapgen-core/authoring";
+import { defineDomain } from "@swooper/mapgen-core/authoring/contracts";
 
 import ops from "./ops/contracts.js";
 
@@ -9,6 +9,3 @@ export default domain;
 export * from "./lib/corpus/index.js";
 export * from "./lib/corpus/runtime-ids.js";
 export * from "./lib/earthlike-expectations/index.js";
-export * from "./policy/habitat-eligibility.js";
-export * from "./policy/initial-map-authoring.js";
-export * from "./policy/resource-legality.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-biomes/steps/biomes/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-biomes/steps/biomes/contract.ts
@@ -1,4 +1,4 @@
-import ecology from "@mapgen/domain/ecology/contract";
+import ecology from "@mapgen/domain/ecology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { ecologyArtifacts } from "../../../ecology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-floodplains/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-floodplains/contract.ts
@@ -1,4 +1,4 @@
-import ecology from "@mapgen/domain/ecology/contract";
+import ecology from "@mapgen/domain/ecology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { ecologyArtifacts } from "../../../ecology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-ice/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-ice/contract.ts
@@ -1,4 +1,4 @@
-import ecology from "@mapgen/domain/ecology/contract";
+import ecology from "@mapgen/domain/ecology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { ecologyArtifacts } from "../../../ecology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-plot-effects/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-plot-effects/contract.ts
@@ -1,4 +1,4 @@
-import ecology from "@mapgen/domain/ecology/contract";
+import ecology from "@mapgen/domain/ecology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { ecologyArtifacts } from "../../../ecology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-reefs/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-reefs/contract.ts
@@ -1,4 +1,4 @@
-import ecology from "@mapgen/domain/ecology/contract";
+import ecology from "@mapgen/domain/ecology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { ecologyArtifacts } from "../../../ecology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-vegetation/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-vegetation/contract.ts
@@ -1,4 +1,4 @@
-import ecology from "@mapgen/domain/ecology/contract";
+import ecology from "@mapgen/domain/ecology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { ecologyArtifacts } from "../../../ecology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-wetlands/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-wetlands/contract.ts
@@ -1,4 +1,4 @@
-import ecology from "@mapgen/domain/ecology/contract";
+import ecology from "@mapgen/domain/ecology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { ecologyArtifacts } from "../../../ecology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/contract.ts
@@ -1,4 +1,4 @@
-import ecology from "@mapgen/domain/ecology/contract";
+import ecology from "@mapgen/domain/ecology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { ecologyArtifacts } from "../../../ecology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-pedology/steps/pedology/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-pedology/steps/pedology/contract.ts
@@ -1,4 +1,4 @@
-import ecology from "@mapgen/domain/ecology/contract";
+import ecology from "@mapgen/domain/ecology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import { ecologyArtifacts } from "../../../ecology/artifacts.js";
 import { hydrologyClimateBaselineArtifacts } from "../../../hydrology-climate-baseline/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-pedology/steps/resource-basins/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-pedology/steps/resource-basins/contract.ts
@@ -1,4 +1,4 @@
-import ecology from "@mapgen/domain/ecology/contract";
+import ecology from "@mapgen/domain/ecology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import { ecologyArtifacts } from "../../../ecology/artifacts.js";
 import { hydrologyClimateBaselineArtifacts } from "../../../hydrology-climate-baseline/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts.ts
@@ -1,4 +1,4 @@
-import { FEATURE_PLACEMENT_KEYS, type PlotEffectKey } from "@mapgen/domain/ecology/contract";
+import { FEATURE_PLACEMENT_KEYS, type PlotEffectKey } from "@mapgen/domain/ecology";
 import {
   defineArtifact,
   type Static,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crust.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crust.contract.ts
@@ -1,4 +1,4 @@
-import foundation from "@mapgen/domain/foundation/contract";
+import foundation from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { foundationArtifacts } from "../artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crustEvolution.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crustEvolution.contract.ts
@@ -1,4 +1,4 @@
-import foundation from "@mapgen/domain/foundation/contract";
+import foundation from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { foundationArtifacts } from "../artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mantleForcing.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mantleForcing.contract.ts
@@ -1,4 +1,4 @@
-import foundation from "@mapgen/domain/foundation/contract";
+import foundation from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { foundationArtifacts } from "../artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mantlePotential.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mantlePotential.contract.ts
@@ -1,4 +1,4 @@
-import foundation from "@mapgen/domain/foundation/contract";
+import foundation from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { foundationArtifacts } from "../artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.contract.ts
@@ -1,4 +1,4 @@
-import foundation from "@mapgen/domain/foundation/contract";
+import foundation from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { foundationArtifacts } from "../artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.contract.ts
@@ -1,4 +1,4 @@
-import foundation from "@mapgen/domain/foundation/contract";
+import foundation from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { foundationArtifacts } from "../artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateMotion.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateMotion.contract.ts
@@ -1,4 +1,4 @@
-import foundation from "@mapgen/domain/foundation/contract";
+import foundation from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { foundationArtifacts } from "../artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts
@@ -1,4 +1,4 @@
-import foundation from "@mapgen/domain/foundation/contract";
+import foundation from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import { mapArtifacts } from "../../../map-artifacts.js";
 import { foundationArtifacts } from "../artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts
@@ -1,4 +1,4 @@
-import foundation from "@mapgen/domain/foundation/contract";
+import foundation from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { foundationArtifacts } from "../artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/artifacts.ts
@@ -1,4 +1,4 @@
-import { HydrologyWindFieldSchema } from "@mapgen/domain/hydrology/contract";
+import { HydrologyWindFieldSchema } from "@mapgen/domain/hydrology";
 import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 
 /**

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.contract.ts
@@ -1,4 +1,4 @@
-import hydrology from "@mapgen/domain/hydrology/contract";
+import hydrology from "@mapgen/domain/hydrology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import { morphologyArtifacts } from "../../morphology/artifacts.js";
 import { hydrologyClimateBaselineArtifacts } from "../artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/steps/climateRefine.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/steps/climateRefine.contract.ts
@@ -1,4 +1,4 @@
-import hydrology from "@mapgen/domain/hydrology/contract";
+import hydrology from "@mapgen/domain/hydrology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import { hydrologyClimateBaselineArtifacts } from "../../hydrology-climate-baseline/artifacts.js";
 import { hydrologyHydrographyArtifacts } from "../../hydrology-hydrography/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/lakes.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/lakes.contract.ts
@@ -1,4 +1,4 @@
-import hydrology from "@mapgen/domain/hydrology/contract";
+import hydrology from "@mapgen/domain/hydrology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import { morphologyArtifacts } from "../../morphology/artifacts.js";
 import { hydrologyHydrographyArtifacts } from "../artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/rivers.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/rivers.contract.ts
@@ -1,4 +1,4 @@
-import hydrology from "@mapgen/domain/hydrology/contract";
+import hydrology from "@mapgen/domain/hydrology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import { hydrologyClimateBaselineArtifacts } from "../../hydrology-climate-baseline/artifacts.js";
 import { morphologyArtifacts } from "../../morphology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/contract.ts
@@ -1,4 +1,4 @@
-import ecology from "@mapgen/domain/ecology/contract";
+import ecology from "@mapgen/domain/ecology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import {
   FIELD_DEPENDENCY_TAGS,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plotBiomes.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plotBiomes.contract.ts
@@ -1,4 +1,4 @@
-import { BiomeEngineBindingsSchema } from "@mapgen/domain/ecology/contract";
+import { BiomeEngineBindingsSchema } from "@mapgen/domain/ecology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.contract.ts
@@ -1,4 +1,4 @@
-import hydrology from "@mapgen/domain/hydrology/contract";
+import hydrology from "@mapgen/domain/hydrology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { MAP_PROJECTION_EFFECT_TAGS } from "../../../tag-contracts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.contract.ts
@@ -1,4 +1,4 @@
-import morphology from "@mapgen/domain/morphology/contract";
+import morphology from "@mapgen/domain/morphology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { mapArtifacts } from "../../../map-artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.contract.ts
@@ -1,4 +1,4 @@
-import morphology from "@mapgen/domain/morphology/contract";
+import morphology from "@mapgen/domain/morphology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { morphologyArtifacts } from "../../morphology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/steps/geomorphology.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/steps/geomorphology.contract.ts
@@ -1,4 +1,4 @@
-import morphology from "@mapgen/domain/morphology/contract";
+import morphology from "@mapgen/domain/morphology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { morphologyArtifacts } from "../../morphology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/islands.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/islands.contract.ts
@@ -1,4 +1,4 @@
-import morphology from "@mapgen/domain/morphology/contract";
+import morphology from "@mapgen/domain/morphology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { mapArtifacts } from "../../../map-artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/landmasses.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/landmasses.contract.ts
@@ -1,4 +1,4 @@
-import morphology from "@mapgen/domain/morphology/contract";
+import morphology from "@mapgen/domain/morphology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { morphologyArtifacts } from "../../morphology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/mountains.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/mountains.contract.ts
@@ -1,4 +1,4 @@
-import morphology from "@mapgen/domain/morphology/contract";
+import morphology from "@mapgen/domain/morphology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { morphologyArtifacts } from "../../morphology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/volcanoes.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/volcanoes.contract.ts
@@ -1,4 +1,4 @@
-import morphology from "@mapgen/domain/morphology/contract";
+import morphology from "@mapgen/domain/morphology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { mapArtifacts } from "../../../map-artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-routing/steps/routing.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-routing/steps/routing.contract.ts
@@ -1,4 +1,4 @@
-import morphology from "@mapgen/domain/morphology/contract";
+import morphology from "@mapgen/domain/morphology";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { morphologyArtifacts } from "../../morphology/artifacts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/contract/discovery-plan.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/contract/discovery-plan.contract.ts
@@ -1,4 +1,4 @@
-import placement from "@mapgen/domain/placement/contract";
+import placement from "@mapgen/domain/placement";
 import { defineArtifact } from "@swooper/mapgen-core/authoring/contracts";
 
 /** Discovery plan (`artifact:placement.discoveryPlan`). One artifact per file by repo convention. */

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/contract/natural-wonder-plan.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/contract/natural-wonder-plan.contract.ts
@@ -1,4 +1,4 @@
-import placement from "@mapgen/domain/placement/contract";
+import placement from "@mapgen/domain/placement";
 import { defineArtifact } from "@swooper/mapgen-core/authoring/contracts";
 
 /** Natural-wonder plan (`artifact:placement.naturalWonderPlan`). One artifact per file by repo convention. */

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/contract/resource-demand-plan.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/contract/resource-demand-plan.contract.ts
@@ -1,4 +1,4 @@
-import resources from "@mapgen/domain/resources/contract";
+import resources from "@mapgen/domain/resources";
 import { defineArtifact, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 /** Resource demand plan (`artifact:placement.resourceDemandPlan`). One artifact per file by repo convention. */

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/contract/resource-plan-adjusted.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/contract/resource-plan-adjusted.contract.ts
@@ -1,4 +1,4 @@
-import resources from "@mapgen/domain/resources/contract";
+import resources from "@mapgen/domain/resources";
 import { defineArtifact } from "@swooper/mapgen-core/authoring/contracts";
 
 /** Support-adjusted resource plan (`artifact:placement.resourcePlanAdjusted`). One artifact per file by repo convention. */

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/contract/resource-plan.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/contract/resource-plan.contract.ts
@@ -1,4 +1,4 @@
-import resources from "@mapgen/domain/resources/contract";
+import resources from "@mapgen/domain/resources";
 import { defineArtifact } from "@swooper/mapgen-core/authoring/contracts";
 
 /** Site-selection resource plan (`artifact:placement.resourcePlan`). One artifact per file by repo convention. */

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/contract/start-assignment.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/contract/start-assignment.contract.ts
@@ -1,4 +1,4 @@
-import placement from "@mapgen/domain/placement/contract";
+import placement from "@mapgen/domain/placement";
 import { defineArtifact, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 /** Verified start assignment (`artifact:placement.startAssignment`). One artifact per file by repo convention. */

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/placement-inputs.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/placement-inputs.ts
@@ -1,4 +1,4 @@
-import placement from "@mapgen/domain/placement/contract";
+import placement from "@mapgen/domain/placement";
 import { type Static, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 export const PlacementInputsConfigSchema = Type.Object(

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/adjust-resources/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/adjust-resources/contract.ts
@@ -1,4 +1,4 @@
-import resources from "@mapgen/domain/resources/contract";
+import resources from "@mapgen/domain/resources";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import { mapArtifacts } from "../../../../map-artifacts.js";
 import { PLACEMENT_PRODUCT_EFFECT_TAGS } from "../../../../tag-contracts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/contract.ts
@@ -1,4 +1,4 @@
-import placement from "@mapgen/domain/placement/contract";
+import placement from "@mapgen/domain/placement";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import { mapArtifacts } from "../../../../map-artifacts.js";
 import { PLACEMENT_PRODUCT_EFFECT_TAGS } from "../../../../tag-contracts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/contract.ts
@@ -1,4 +1,4 @@
-import placement from "@mapgen/domain/placement/contract";
+import placement from "@mapgen/domain/placement";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/contract.ts
@@ -1,4 +1,4 @@
-import resources from "@mapgen/domain/resources/contract";
+import resources from "@mapgen/domain/resources";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import { mapArtifacts } from "../../../../map-artifacts.js";
 import { PLACEMENT_PRODUCT_EFFECT_TAGS } from "../../../../tag-contracts.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/planning.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/planning.ts
@@ -4,17 +4,23 @@ import resources from "@mapgen/domain/resources";
 import type { ExtendedMapContext } from "@swooper/mapgen-core";
 import type { Static } from "@swooper/mapgen-core/authoring";
 import {
-  buildHabitatEligibility,
-  buildResourceLegalityMask,
   EARTHLIKE_RESOURCE_EXPECTATIONS,
-  getInitialMapResourcePolicyForType,
-  RESOURCE_HABITAT_SIGNALS,
-  type ResourceFamilyId,
-  type ResourceLegalitySurface,
-  resolveActiveResourceAge,
   resolveResourceRuntimeIds,
 } from "../../../../../../domain/resources/index.js";
 import type { OfficialResourceType } from "../../../../../../domain/resources/lib/corpus/types.js";
+import {
+  buildHabitatEligibility,
+  RESOURCE_HABITAT_SIGNALS,
+  type ResourceFamilyId,
+} from "../../../../../../domain/resources/policy/habitat-eligibility.js";
+import {
+  getInitialMapResourcePolicyForType,
+  resolveActiveResourceAge,
+} from "../../../../../../domain/resources/policy/initial-map-authoring.js";
+import {
+  buildResourceLegalityMask,
+  type ResourceLegalitySurface,
+} from "../../../../../../domain/resources/policy/resource-legality.js";
 
 type HabitatFields = Static<(typeof resources.ops.deriveHabitatFields)["output"]>;
 type SelectSitesInput = Static<(typeof resources.ops.selectResourceSites)["input"]>;


### PR DESCRIPTION
Domain index files now serve as the canonical entry point for `@mapgen/domain/*` imports, replacing the previous `@mapgen/domain/*/contract` sub-path. Each domain's `index.ts` re-exports its contract definitions via `defineDomain`, sourcing `defineDomain` from `@swooper/mapgen-core/authoring/contracts` instead of `@swooper/mapgen-core/authoring`.

The three resource policy modules (`habitat-eligibility`, `initial-map-authoring`, `resource-legality`) are no longer re-exported from the `resources` domain index and must now be imported directly from their respective policy files. Callers in `planning.ts` have been updated accordingly.

The import resolver in the daemon deploy isolation test now supports `index.ts` barrel files when resolving `@mapgen/domain/*` specifiers, and the isolation boundary check has been extended to also flag imports of `@mapgen/domain/*/contract` sub-paths alongside `ops`.