### PR TITLE
`fix(openspec): reconcile D10/D11 live-proof handoffs against D12 state-machine consumption`

### DIFF
--- a/openspec/changes/mapgen-studio-live-game-watch/tasks.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/tasks.md
@@ -67,7 +67,20 @@
 - [ ] 5.8 Live Civ7 proof with branch, commit, command/API path, timestamps,
       relevant logs, and parsed payload shape.
 - [x] 5.9 If Civ7 is unavailable, write `workstream/next-packet.md` and leave
-      D10 not-green for live behavior.
+      D10 not-green for live-game watcher behavior.
+
+Live-proof reconciliation note, 2026-06-16:
+
+- D12 later ran live Run in Game and Save&Deploy state-machine proof through
+  Nx Studio, `studio.events.watch`, keyed status, and
+  `studio.operations.current({})`.
+- That proof consumes the broad operation/product handoff from D10/D11, but it
+  does not explicitly prove D10's live-game watcher-specific subclaims: first
+  retained `live-game`, reconnect replay, unchanged-key quiet behavior, and
+  changed live-game state publication against a real Civ7 session.
+- Task 5.8 therefore remains open as a narrowed live-game watcher proof gap,
+  not as a blocker for D12 drain or Run in Game / Save&Deploy state-machine
+  closure.
 
 ## 6. Closure
 

--- a/openspec/changes/mapgen-studio-live-game-watch/workstream/next-packet.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/workstream/next-packet.md
@@ -1,16 +1,20 @@
-# D10 Next Packet - Live Civ7 Proof Handoff
+# D10 Next Packet - Narrow Live-Game Watcher Proof
 
-Status: D10 implementation is not green for live Civ7 product behavior until this proof is run.
-Owner: D12 game-door invariant lane unless a live-Civ7 D10 proof lane is opened first.
-Date: 2026-06-15
+Status: narrowed live-game watcher proof gap; operation live proof consumed by D12
+Date opened: 2026-06-15
+Date narrowed: 2026-06-16
 
 ## Missing Proof Class
 
 D10 unit, source, OpenSpec, and Nx gates prove the daemon/runtime watcher shape,
 browser live-status cadence deletion, event-hub replay, and client stale-result
-guards. They do not prove live FireTuner/game behavior.
+guards. D12 later ran live Run in Game and Save&Deploy state-machine proof
+through Nx Studio, `studio.events.watch`, keyed status, and
+`studio.operations.current({})`. That D12 proof consumes the broad operation
+handoff, but it does not explicitly prove every D10 live-game watcher-specific
+subclaim.
 
-The missing proof is live Civ7 runtime evidence that:
+The remaining missing proof is live Civ7 runtime evidence that:
 
 - daemon startup activates `StudioLiveGameWatcher` through the package
   `ManagedRuntime`;
@@ -80,7 +84,9 @@ Record the actual paths used by the dev runner. Expected places to inspect:
 ## Closure Rule
 
 Do not edit D10 retroactively to claim green live behavior without appending the
-live proof evidence to the D10/D12 workstream records. If the environment is
-unavailable again, keep this handoff open and preserve the D10 claim as:
+live-game watcher proof evidence to the D10/D12 workstream records. If the
+environment is unavailable again, keep this narrowed handoff open and preserve
+the D10 claim as:
 
-> implementation/static gates green; live Civ7 product proof not run or claimed.
+> implementation/static gates green; D12 consumed operation state-machine live
+> proof; live-game watcher-specific Civ7 proof not run or claimed.

--- a/openspec/changes/mapgen-studio-live-game-watch/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/workstream/phase-record.md
@@ -7,7 +7,9 @@
 - OpenSpec change: `mapgen-studio-live-game-watch`
 - Owner: Codex implementation DRA lane
 - Branch/Graphite stack: `codex/runtime-effect-live-game-watch`
-- Status: implementation committed at current branch tip; live Civ7 proof not run or claimed
+- Status: implementation committed at current branch tip; operation
+  state-machine live proof consumed by D12; live-game watcher-specific Civ7
+  proof remains narrowed in `next-packet.md`
 
 ## Objective
 
@@ -19,9 +21,10 @@
   runner cleanup, final public/manual status endpoint closeout.
 - Done condition for this slice: code/tests/docs prove package-owned watcher
   mechanics, daemon/runtime composition, client pushed-state application,
-  browser cadence deletion, and either live Civ7 proof or a not-green live-proof
-  handoff. Live Civ7 proof is not available in this implementation pass, so
-  `workstream/next-packet.md` carries the remaining product-runtime proof.
+  browser cadence deletion, and either live-game watcher proof or a not-green
+  live-proof handoff. D12 later consumed Run in Game and Save&Deploy operation
+  live proof, while `workstream/next-packet.md` carries the remaining
+  live-game watcher-specific proof.
 
 ## Gate 1 - Frame
 
@@ -137,7 +140,9 @@ schema/residue closeout.
   watcher bypass.
 - App tests prove live-runtime model keying and event adoption paths.
 - Negative searches prove browser live-status cadence deletion.
-- `next-packet.md` records the missing live Civ7 proof; no live product proof is claimed.
+- D12 records live Run in Game and Save&Deploy operation state-machine proof.
+- `next-packet.md` records the remaining live-game watcher-specific proof; D10
+  does not claim that proof from D12.
 
 ## Gate 11 - Review
 
@@ -155,5 +160,6 @@ Implementation commit closure requires:
 - fresh implementation review has no unresolved P1/P2;
 - OpenSpec, package/app checks, focused tests, Nx checks, negative searches, and
   `git diff --check` are recorded;
-- `workstream/next-packet.md` records the unrun live Civ7 proof;
+- `workstream/next-packet.md` records the narrowed unrun live-game watcher
+  proof;
 - explicit paths are staged and Graphite commit leaves the worktree clean.

--- a/openspec/changes/mapgen-studio-nx-dev-runner/tasks.md
+++ b/openspec/changes/mapgen-studio-nx-dev-runner/tasks.md
@@ -42,16 +42,16 @@
       one backend, one frontend, no `devLive.ts`, no daemon `bun --watch`.
 - [x] 4.6 Negative search for active Turbo dev routes, app-local supervisor
       routes, and daemon Bun watcher routes.
-- [ ] 4.7 Play live proof under Nx dev with accepted/deploy-entered/
+- [x] 4.7 Play live proof under Nx dev with accepted/deploy-entered/
       deploy-exited/terminal samples, stable `serverInstanceId`, operation id,
       branch, commit, command/API path, timestamps, and log pointers.
-- [ ] 4.8 Save&Deploy live proof under Nx dev with accepted/deploy-entered/
+- [x] 4.8 Save&Deploy live proof under Nx dev with accepted/deploy-entered/
       deploy-exited/terminal samples, stable `serverInstanceId`, operation id,
       branch, commit, command/API path, timestamps, log pointers, and D1
       deploy/write isolation still true.
 - [x] 4.9 If live Civ7 is unavailable, write `workstream/next-packet.md` and
       leave D11 not-green for live operation behavior.
-- [ ] 4.10 Package/app gates reported by Habitat classify.
+- [x] 4.10 Package/app gates reported by Habitat classify.
 - [x] 4.11 `git diff --check`, `git status --short --branch`, `gt status`, and
       `gt log --no-interactive`.
 
@@ -65,3 +65,15 @@
 - [x] 5.4 Graphite branch is committed cleanly without unrelated staged files;
       closure records refer to the current branch tip so later message-only
       amends do not stale the packet evidence.
+
+Live-proof reconciliation note, 2026-06-16:
+
+- D12 later ran the live state-machine pass through the D11 Nx Studio runner.
+  The D12 testing and final-proof ledgers record the Nx Studio frontend/daemon
+  ports, stable daemon identity, invalid Run in Game rejection before
+  operation admission, disposable Run in Game terminal `complete` through
+  `studio.events.watch`, keyed status, and current projection, plus
+  Save&Deploy terminal `complete` through the same event/status/current shape.
+- D12 also recorded root graph gates selected by Habitat classify. This closes
+  D11's live operation proof and Habitat-classify handoff as a downstream
+  proof-consumption record, without claiming new D11 runtime behavior.

--- a/openspec/changes/mapgen-studio-nx-dev-runner/workstream/next-packet.md
+++ b/openspec/changes/mapgen-studio-nx-dev-runner/workstream/next-packet.md
@@ -1,58 +1,38 @@
-# D11 Next Packet - Live Nx Dev Operation Proof
+# D11 Next Packet - Closed Live Nx Dev Operation Proof
 
-Status: not-green live product proof handoff
-Date: 2026-06-15
-Branch: `codex/runtime-effect-nx-dev-runner`
+Status: closed by D12 live state-machine proof
+Date opened: 2026-06-15
+Date reconciled: 2026-06-16
+Branch originally recorded: `codex/runtime-effect-nx-dev-runner`
 
-## Missing Proof
+## Why This Exists
 
-D11 has executable proof for Nx-owned dev orchestration, process topology, and
-deletion of the app-local supervisor. It does not have live Civ7 Play or
-Save&Deploy phase-sampled `serverInstanceId` proof.
+D11 originally handed off live Civ7 Play and Save&Deploy proof under the
+Nx-owned Studio dev runner. D12 consumed that gap with a live state-machine pass
+recorded in:
 
-The missing proof is:
+- `openspec/changes/mapgen-studio-game-door-invariant/workstream/testing-ledger.md`
+- `openspec/changes/mapgen-studio-game-door-invariant/workstream/final-proof-ledger.md`
 
-- Run in Game / Play while `bun run nx run mapgen-studio:dev --outputStyle=stream`
-  is active.
-- Save&Deploy while the same Nx dev target is active.
-- For each operation, sample accepted, deploy-entered, deploy-exited, and
-  terminal phases from daemon APIs/events.
-- Record one stable `serverInstanceId` for all samples in the same operation.
-- Record branch, commit, operation id, API path or UI command, timestamps, and
-  relevant daemon/game log paths.
-- Prove operation completion is not explained by daemon restart recovery,
-  browser reload, or operation adoption after a new daemon starts.
+The D12 proof records:
 
-## Re-Entry Prerequisites
+- Nx Studio frontend on `localhost:5173` and daemon RPC on
+  `127.0.0.1:5174`;
+- stable daemon identity across the live pass;
+- invalid Run in Game rejection before operation admission;
+- disposable Run in Game terminal `complete` through `studio.events.watch`,
+  keyed status, and `studio.operations.current({})`;
+- Save&Deploy terminal `complete` through `studio.events.watch`, keyed status,
+  and `studio.operations.current({})`;
+- transient `studio-current` outputs ignored and tracked generated/catalog
+  artifacts restored cleanly.
 
-- Civ7 running and reachable through the normal Studio direct-control/FireTuner
-  path.
-- Studio dev runner started with:
+This closes the D11 live operation handoff as downstream proof consumption. It
+does not add new live proof beyond D12, and it does not prove D10's narrower
+live-game watcher replay/quiet/change subclaims.
 
-```bash
-bun run nx run mapgen-studio:dev --outputStyle=stream
-```
+## Reopening Rule
 
-- Backend health visible at `http://127.0.0.1:5174/healthz`.
-- Frontend visible at `http://localhost:5173/`.
-- No active process command containing `devLive.ts` or `bun --watch`.
-
-## Process Proof Already Captured
-
-Current D11 proof captured on 2026-06-15:
-
-- `bun run nx run mapgen-studio:dev --outputStyle=stream` started
-  `mapgen-studio:serve-daemon` and `mapgen-studio:dev`.
-- Process sample showed one Nx runner, two Nx executor children, one Vite
-  frontend process, and one `bun src/server/daemon/daemon.ts` backend process.
-- Process sample showed no `devLive.ts` and no `bun --watch`.
-- `curl http://127.0.0.1:5174/healthz` returned `ok: true`,
-  `runtimeMode: "studio-daemon-effect-orpc"`, and daemon identity
-  `studio-server-mqfnojkq-1gwf-1`.
-- `curl -I http://localhost:5173/` returned HTTP 200 from Vite.
-
-## Blocked Closure Claim
-
-Until the live operation proof above is run, D11 must not be described as live
-Play/SaveDeploy product-green. D12 must consume this as a live-proof gap rather
-than silently treating D10/D11 unit or process proof as end-to-end game proof.
+Do not use this file as an active next packet. Reopen only if a future change
+modifies Nx dev topology, Play/SaveDeploy runtime behavior under Nx dev, or the
+D12 live proof records are invalidated by stronger evidence.

--- a/openspec/changes/mapgen-studio-nx-dev-runner/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-nx-dev-runner/workstream/phase-record.md
@@ -8,7 +8,7 @@
 - Owner: Codex DRA implementation lane
 - Branch/Graphite stack: `codex/runtime-effect-nx-dev-runner`
 - Status: implementation committed at current branch tip; live Civ7
-  Play/SaveDeploy proof is not-green and handed off in `next-packet.md`
+  Play/SaveDeploy proof consumed by D12 live state-machine pass
 
 ## Objective
 
@@ -19,8 +19,8 @@
   changes.
 - Done condition: D11 implementation lands as its own Graphite slice with Nx
   target topology, process deletion targets, proof gates, live operation
-  stability handoff, baseline stop conditions, and downstream D12 residue
-  realignment recorded truthfully.
+  stability handoff or downstream proof consumption, baseline stop conditions,
+  and downstream D12 residue realignment recorded truthfully.
 
 ## Gate 1 - Frame
 
@@ -147,13 +147,13 @@ D11 implementation closure requires:
 - shortcut scan has no active fallback/dual-path/Turbo/app-supervisor target.
 - running process proof shows Nx-owned daemon/frontend, no `devLive.ts`, and
   no daemon `bun --watch`.
-- live Play/SaveDeploy proof is either run or carried as an explicit not-green
-  next packet; current D11 does not claim live product proof.
+- live Play/SaveDeploy proof is either run or consumed by a downstream proof
+  record; D12 consumed this with a live state-machine pass through the D11 Nx
+  Studio runner.
 - Graphite/worktree state is clean after commit.
 
 ## Next Action
 
-After the closure-record/message amend, verify `git status --short --branch`
-is clean on D11 before moving to D12. D12 consumes D11's process-proof,
-live-proof gap, lint disposition, and EventHub/runtime-residue outputs for
-final closeout.
+D11's live operation proof handoff is closed by D12 proof consumption. Future
+work should not reopen D11 unless Nx dev topology or Play/SaveDeploy behavior
+changes.

--- a/openspec/changes/mapgen-studio-pipeline-effect-services/tasks.md
+++ b/openspec/changes/mapgen-studio-pipeline-effect-services/tasks.md
@@ -50,7 +50,8 @@ These are D5 implementation obligations recorded by this packet, not pre-accepta
 - [x] 3A.7 Replace app mutation lifecycle context callbacks with package services and bounded ports.
 - [x] 3A.8 Delete or reduce `createStudioEngines` to composition-only with negative proof.
 - [x] 3A.9 Run package/app/scenario tests and negative searches.
-- [ ] 3A.10 Live Play/SaveDeploy proof is not claimed in D5; D12 retains the game-door live-proof handoff.
+- [x] 3A.10 Live Play/SaveDeploy proof is not claimed in D5; D12 consumed the
+      game-door live-proof handoff with the later live state-machine pass.
 
 ## 4. Verification
 


### PR DESCRIPTION
This PR reconciles the live proof status across the D10, D11, and D5 workstream records following D12's live state-machine pass through Nx Studio.

D12 ran live Run in Game and Save&Deploy proofs through `studio.events.watch`, keyed status, and `studio.operations.current({})`, recording stable daemon identity, invalid Run in Game rejection before operation admission, and terminal `complete` for both operation types. This closes the D11 live operation handoff and the D5 game-door live-proof handoff as downstream proof consumption.

D10's live-game watcher proof gap is narrowed rather than closed. The D12 proof covers the broad operation/product handoff but does not prove D10's watcher-specific subclaims: first retained `live-game`, reconnect replay, unchanged-key quiet behavior, and changed live-game state publication against a real Civ7 session. Task 5.8 remains open as a narrowed gap and is not a blocker for D12 drain or Run in Game / Save&Deploy state-machine closure.

The D11 `next-packet.md` is updated from an active handoff to a closed record, with a reopening rule restricting future use to cases where Nx dev topology or Play/SaveDeploy runtime behavior changes. The D10 `next-packet.md` and `phase-record.md` are updated to reflect that the operation state-machine live proof was consumed by D12 while the live-game watcher-specific proof remains outstanding.