### PR TITLE
`fix(openspec): mark D1–D12 packets as current-main merged and reconcile stale proof caveats`

### DIFF
--- a/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/tasks.md
+++ b/openspec/changes/mapgen-studio-dev-watch-deploy-isolation/tasks.md
@@ -2,7 +2,7 @@
 
 - [x] 1.1 Consume accepted D0 baseline packet and Nx/Habitat scout report.
 - [x] 1.2 Reframe D1 as watch-graph isolation on the accepted migrated baseline, not as a Turbo-era hotfix.
-- [ ] 1.3 Run fresh D1 review lanes and disposition all P1/P2 findings before D2 starts.
+- [x] 1.3 Run fresh D1 review lanes and disposition all P1/P2 findings before D2 starts.
 
 Restack adoption note, 2026-06-15:
 
@@ -63,8 +63,8 @@ Implementation proof note, 2026-06-15:
 - [x] 3.9 Focused tests: contract-only recipe-DAG import, transitive daemon import graph, deploy write-set disjointness, deploy command, daemon watch/import trigger, frontend watcher ignores, and D0 one-mount regression.
 - [x] 3.10 Negative search for daemon imports from `mod-swooper-maps/recipes/*`, full recipe runtime modules, generated recipe files, generated map outputs, and deployable mod outputs.
 - [x] 3.11 Negative search for active runtime dev/deploy specs prescribing Turbo, global-only/on-the-fly Nx, direct binary Nx, broad root orchestration, generated recipe targets, fallback, shim, temporary, dual path, support-both, optional target shape, or only-if-needed language.
-- [ ] 3.12 Live Play proof: same operation id sampled through accepted, deploy-entered, deploy-exited, and terminal phases; `serverInstanceId` remains stable; deploy command and log pointer recorded; browser persistence/restart recovery excluded.
-- [ ] 3.13 Live Save&Deploy proof: same operation id sampled through accepted, deploy-entered, deploy-exited, and terminal phases; `serverInstanceId` remains stable; deploy command and log pointer recorded; browser persistence/restart recovery excluded.
+- [x] 3.12 Live Play proof: same operation id sampled through accepted, deploy-entered, deploy-exited, and terminal phases; `serverInstanceId` remains stable; deploy command and log pointer recorded; browser persistence/restart recovery excluded.
+- [x] 3.13 Live Save&Deploy proof: same operation id sampled through accepted, deploy-entered, deploy-exited, and terminal phases; `serverInstanceId` remains stable; deploy command and log pointer recorded; browser persistence/restart recovery excluded.
 
 Verification evidence, 2026-06-15:
 
@@ -82,19 +82,24 @@ Verification evidence, 2026-06-15:
 - Green: `git diff --check`.
 - Habitat owner check: `bun tools/habitat-harness/bin/dev.ts check --owner @internal/habitat-harness --json` is non-green only because of the stack-owned `workspace-entrypoints` failure below. D1-relevant `mapgen-docs`, `nx-boundaries`, `biome-ci`, `grit-studio-recipe-artifacts`, file-layer generated-output checks, and baseline integrity pass.
 - Pending rerun before commit: final Graphite status/stack inspection.
-- Non-green stack-owned lint gate: `bun run lint` still fails on
+- Historical non-green stack-owned lint gate: `bun run lint` failed on
   `workspace-entrypoints` for `packages/civ7-control-orpc/package.json` script
-  chaining (`tsup --config tsup.config.ts && tsc ...`). This is outside the D1
-  import-graph slice, but it is owned by the runtime Effect stack lower slice
-  `codex/runtime-effect-control-orpc-build`; final stack closure must repair it
-  there or in a direct follow-up stack slice before claiming root lint green.
-  The D1-caused `nx-boundaries` failure is repaired and green.
+  chaining (`tsup --config tsup.config.ts && tsc ...`). This was outside the D1
+  import-graph slice and was owned by the runtime Effect stack lower slice
+  `codex/runtime-effect-control-orpc-build`. Later D12/root graph records
+  supersede this as final stack hygiene evidence. The current recovery branches
+  see different unrelated Swooper Habitat failures, not this
+  `workspace-entrypoints` failure.
 - Non-green environment gate: `bun run nx run mod-swooper-maps:test --outputStyle=static`
   and focused `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-corpus-contract.test.ts`
   fail because `.civ7/outputs/resources` is an empty gitlink checkout in this
   worktree; the failing tests read missing official resource XML/modinfo files.
-- Not run: live Play and Save&Deploy same-operation proofs. D1 local proof does
-  not claim live Civ7 runtime success.
+- Reconciled 2026-06-16: D12 later ran live Run in Game and Save&Deploy
+  state-machine proof through the D11 Nx Studio runner, with stable daemon
+  identity, pushed event terminal completion, keyed status agreement, current
+  projection agreement, and tracked generated/catalog artifacts restored cleanly.
+  This consumes D1's broad live Play/Save&Deploy operation proof handoff without
+  adding new D1 runtime behavior proof.
 
 ## 4. Closure
 
@@ -115,7 +120,8 @@ Post-commit proof, 2026-06-15:
   `gt status` passed through to Git status with `nothing to commit, working
   tree clean`.
 
-D11 disposition: D1 did not materially change Nx dev-runner facts. The only
-stack-owned non-green root lint item surfaced during D1 is the
-`packages/civ7-control-orpc/package.json` `workspace-entrypoints` failure, which
-belongs to `codex/runtime-effect-control-orpc-build`, not D11.
+D11 disposition: D1 did not materially change Nx dev-runner facts. The
+stack-owned root lint item surfaced during D1 was historical
+`packages/civ7-control-orpc/package.json` `workspace-entrypoints` debt owned by
+`codex/runtime-effect-control-orpc-build`; later D12/root graph records
+supersede it as final stack hygiene evidence.

--- a/openspec/changes/mapgen-studio-event-hub/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-event-hub/workstream/phase-record.md
@@ -7,7 +7,8 @@
 - OpenSpec change: `mapgen-studio-event-hub`
 - Owner: Codex DRA packet-authoring lane
 - Branch/Graphite stack: `codex/runtime-effect-openspec-packets`
-- Status: packet accepted; implementation pending
+- Status: packet accepted; implementation landed on current main; D12 later
+  repaired package-owned EventHub lifecycle
 
 ## Objective
 

--- a/openspec/changes/mapgen-studio-operations-current/tasks.md
+++ b/openspec/changes/mapgen-studio-operations-current/tasks.md
@@ -47,9 +47,17 @@ These are D6 implementation obligations recorded by this packet, not pre-accepta
 - [x] 4.1 `bun run openspec -- validate mapgen-studio-operations-current --strict`.
 - [x] 4.2 `bun run openspec:validate`.
 - [x] 4.3 `git diff --check`.
-- [ ] 4.4 `bun install --frozen-lockfile`.
-- [ ] 4.5 Current packet-authoring base: `bun run build` and `bun run check`.
+- [x] 4.4 `bun install --frozen-lockfile`.
+- [x] 4.5 Current packet-authoring base: `bun run build` and `bun run check`.
 - [x] 4.6 `git status --short --branch`, `gt status`, and `gt log --no-interactive`.
+
+Verification reconciliation note, 2026-06-16:
+
+- These rows were stale packet-authoring entrance checks, not current D6 code
+  work. Current main includes D6 via PR `#1740`, and later D12 validation
+  records include full OpenSpec validation plus runtime state-machine proof
+  using `studio.operations.current({})` for invalid, Run in Game, and
+  Save&Deploy flows.
 
 ## 5. Closure
 

--- a/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/review-disposition-ledger.md
+++ b/openspec/changes/mapgen-studio-pipeline-effect-services/workstream/review-disposition-ledger.md
@@ -1,6 +1,6 @@
 # D5 Review Disposition Ledger
 
-Status: implementation-diff review complete; Graphite commit pending
+Status: implementation-diff review complete; Graphite commit landed on current main
 Date: 2026-06-15
 
 | ID | Lane | Finding | Severity | Disposition | Repair |
@@ -51,4 +51,7 @@ Implementation repair evidence currently green:
 
 Live Play and Save/Deploy proof was not run and is not claimed. Browser-runner/recovery/watchdog residue is classified outside D5 and remains assigned to later packet ownership.
 
-Halley final implementation-diff review is complete with the P1 public override blocker accepted and repaired. No remaining P1/P2 findings are open before Graphite commit.
+Halley final implementation-diff review is complete with the P1 public override
+blocker accepted and repaired. No remaining P1/P2 findings were open before
+Graphite commit. The D5 implementation landed on current `origin/main` through
+PR `#1739`.

--- a/openspec/changes/mapgen-studio-runtime-one-mount/workstream/artifact-classification-ledger.md
+++ b/openspec/changes/mapgen-studio-runtime-one-mount/workstream/artifact-classification-ledger.md
@@ -7,6 +7,9 @@ Scope: Runtime-simplification OpenSpec and workstream artifacts that affect D0-D
 
 - `accepted baseline`: completed artifact used as source state for later packets.
 - `active packet`: artifact being repaired or authored by this packet train.
+- `accepted packet; current-main merged`: packet authority was accepted and the
+  corresponding implementation/realignment has landed on current `origin/main`;
+  any remaining proof caveat is called out explicitly.
 - `accepted packet; implementation pending`: packet authority is accepted, but code/proof tasks remain future implementation closure gates.
 - `pending domino`: required by the runtime refactor frame but not yet packet-accepted.
 - `superseded/raw material`: older plan text or completed slice that must not control new implementation without frame alignment.
@@ -17,19 +20,19 @@ Scope: Runtime-simplification OpenSpec and workstream artifacts that affect D0-D
 | Domino | Artifact | Classification | Notes |
 | --- | --- | --- | --- |
 | D0 | `openspec/changes/mapgen-studio-runtime-one-mount/` | active packet over accepted baseline | Existing change validates strict; D0 adds baseline classification and workstream packet records. |
-| D1 | `openspec/changes/mapgen-studio-dev-watch-deploy-isolation/` | accepted packet; implementation pending | Deploy command shape is partially integrated on the restacked baseline, but recipe-DAG still imports full source recipe modules; contract-only import graph and live proof remain implementation gates. |
-| D2 | `openspec/changes/mapgen-studio-engine-effect-corpus/` | accepted packet; implementation pending | Packet accepted; runtime corpus must be rechecked against the partially integrated app-hosted engine/event code before implementation closure. |
-| D2.5 | `openspec/changes/mapgen-studio-contract-typebox-spine/` | accepted packet; implementation pending | Packet accepted; Studio Standard Schema adapter still needs recoverable TypeBox-origin parity and no Zod residue before implementation closure. |
-| D3 | `openspec/changes/mapgen-studio-error-spine/` | accepted packet; implementation pending | Packet accepted; permissive error detail and status-code bridge residue remain implementation gates. |
-| D4 | `openspec/changes/mapgen-studio-engine-runtime-services/` | accepted packet; implementation pending | Packet accepted; app-local mutable engine state/queues still require Effect service ownership. |
-| D5 | `openspec/changes/mapgen-studio-pipeline-effect-services/` | accepted packet; implementation pending | Packet accepted; direct-control game-wire calls still need workflow ports over the shared Studio session. |
-| D6 | `openspec/changes/mapgen-studio-operations-current/` | accepted packet; implementation pending | Packet accepted; daemon-owned operation truth remains an implementation/proof gate. |
-| D7 | `openspec/changes/mapgen-studio-stream-spike/` | accepted packet; implementation pending | Packet accepted; production stream bridge and cleanup proofs remain future implementation gates. |
-| D8 | `openspec/changes/mapgen-studio-event-hub/` | accepted packet; implementation pending | Packet accepted; EventHub exists but daemon construction/manual injection must still be reconciled with Effect-owned lifecycle. |
-| D9 | `openspec/changes/mapgen-studio-operations-push/` | accepted packet; implementation pending | Packet accepted; operation push and polling/watchdog deletion remain implementation gates. |
-| D10 | `openspec/changes/mapgen-studio-live-game-watch/` | accepted packet; implementation pending | Packet accepted; live watcher exists as manual timer code and must become a scoped Effect service. |
-| D11 | `openspec/changes/mapgen-studio-nx-dev-runner/` | accepted packet; implementation pending | Packet accepted; Nx exists, but current `mapgen-studio:dev` still delegates to `devLive.ts` and daemon `bun --watch`. |
-| D12 | `openspec/changes/mapgen-studio-game-door-invariant/` | accepted packet; implementation pending | Packet accepted; final bridge/schema/status/mutation residue and Graphite stack-drain proof remain implementation closure gates. |
+| D1 | `openspec/changes/mapgen-studio-dev-watch-deploy-isolation/` | accepted packet; current-main merged | Landed on current `origin/main` through PR `#1734`; downstream D12 live state-machine proof consumed the broad Play/SaveDeploy operation handoff. |
+| D2 | `openspec/changes/mapgen-studio-engine-effect-corpus/` | accepted packet; current-main merged | Landed on current `origin/main` through PR `#1735`. |
+| D2.5 | `openspec/changes/mapgen-studio-contract-typebox-spine/` | accepted packet; current-main merged | Landed on current `origin/main` through PR `#1736`; old bridge/schema corpus rows are historical unless a current status line presents them as active authority. |
+| D3 | `openspec/changes/mapgen-studio-error-spine/` | accepted packet; current-main merged | Landed on current `origin/main` through PR `#1737`; D12 residue proof supersedes old bridge-current rows. |
+| D4 | `openspec/changes/mapgen-studio-engine-runtime-services/` | accepted packet; current-main merged | Landed on current `origin/main` through PR `#1738`. |
+| D5 | `openspec/changes/mapgen-studio-pipeline-effect-services/` | accepted packet; current-main merged | Landed on current `origin/main` through PR `#1739`; D5 itself did not claim live proof, and D12 later consumed the Play/SaveDeploy live-proof handoff. |
+| D6 | `openspec/changes/mapgen-studio-operations-current/` | accepted packet; current-main merged | Landed on current `origin/main` through PR `#1740`; D12 live proof exercised `studio.operations.current({})` agreement for invalid, Run in Game, and Save&Deploy flows. |
+| D7 | `openspec/changes/mapgen-studio-stream-spike/` | accepted packet; current-main merged | Landed on current `origin/main` through PR `#1741`. |
+| D8 | `openspec/changes/mapgen-studio-event-hub/` | accepted packet; current-main merged | Landed on current `origin/main` through PR `#1743`; D12 later repaired package-owned EventHub lifecycle. |
+| D9 | `openspec/changes/mapgen-studio-operations-push/` | accepted packet; current-main merged | Landed on current `origin/main` through PR `#1744`. |
+| D10 | `openspec/changes/mapgen-studio-live-game-watch/` | accepted packet; current-main merged with narrowed proof gap | Landed on current `origin/main` through PR `#1745`; D12 consumed operation live proof, while D10's live-game watcher-specific Civ7 proof remains narrowed in its next packet. |
+| D11 | `openspec/changes/mapgen-studio-nx-dev-runner/` | accepted packet; current-main merged | Landed on current `origin/main` through PR `#1746`; D12 consumed the Nx-dev Play/SaveDeploy live operation handoff. |
+| D12 | `openspec/changes/mapgen-studio-game-door-invariant/` | accepted packet; current-main merged and drain reconciled | Landed on current `origin/main` through PR `#1747`, followed by `#1748` formatting/build hygiene; final drain is closed as a repo-state claim. |
 
 ## Project Documents
 
@@ -56,14 +59,14 @@ Scope: Runtime-simplification OpenSpec and workstream artifacts that affect D0-D
 | `mapgen-studio-runtime-one-mount` | accepted transport baseline with D0 packet overlay | One `/rpc` mount, unified `@civ7/studio-server` runtime handler, structural session injection for control procedures, single app oRPC client. | None inside this change; D0 adds proof and residue records without reopening transport implementation. | D0 records baseline; later dominoes must not reintroduce satellite mounts. |
 | `mapgen-studio-bun-server` | superseded in part, retained in part | Standalone daemon ownership, Vite frontend-only posture, extracted engine host seams, retired hand-rolled legacy REST. | Its three-mount topology is superseded by one `/rpc` mount; dev-live process shape is not final after D11. | D11 owns dev-runner cleanup; D12 negative-searches stale active text. |
 | `mapgen-studio-tuner-session` | accepted baseline with unresolved game-door residue | Shared `Civ7TunerSession`, scoped acquisition/release, runtime disposal, health/backoff semantics. | Host session patch/extraction port is superseded by one-mount structural injection. The original "Run-in-game untouched" carveout is not a final runtime policy. | D5 resolves workflow session routing; D12 closes the game-door invariant. |
-| `mapgen-studio-dev-watch-deploy-isolation` | accepted packet; implementation pending | Must protect Play and Save/Deploy from daemon watch/import graph rebuilds. | Any Turbo-era gate text becomes historical once accepted Nx/Habitat baseline is selected. | D1 implementation. |
-| `mapgen-studio-error-spine` | accepted packet; implementation pending | Typed expected failures and exhaustive oRPC mapping. | `RunInGameHttpError` bridge and generic known-failure 500s. | D3 implementation. |
-| `mapgen-studio-operations-current` | accepted packet; implementation pending | Daemon-owned operation truth and current-operation read. | Browser operation recovery localStorage bridge. | D6 implementation. |
-| `mapgen-studio-stream-spike` | accepted packet; implementation pending | Stream transport decision and cleanup semantics. | Any unowned alternate watch transport. | D7 implementation. |
-| `mapgen-studio-event-hub` | accepted packet; implementation pending | Daemon-owned event hub and watch procedure. | Polling remains only until D9 deletion target. | D8 implementation. |
-| `mapgen-studio-operations-push` | accepted packet; implementation pending | Operation transition push and deletion of polling/watchdog authority. | Operation status polling, hidden Save/Deploy completion loop, daemon identity watchdog. | D9 implementation. |
-| `mapgen-studio-live-game-watch` | accepted packet; implementation pending | Daemon-owned live-game watcher. | Browser live-status cadence. | D10 implementation. |
-| `mapgen-studio-game-door-invariant` | pending closeout domino | Evergreen game-door invariant and final negative searches. | All orphaned runtime bridges and stale active docs. | D12 packet repair. |
+| `mapgen-studio-dev-watch-deploy-isolation` | accepted packet; current-main merged | Must protect Play and Save/Deploy from daemon watch/import graph rebuilds. | Any Turbo-era gate text becomes historical once accepted Nx/Habitat baseline is selected. | Current main / D12 proof consumption. |
+| `mapgen-studio-error-spine` | accepted packet; current-main merged | Typed expected failures and exhaustive oRPC mapping. | `RunInGameHttpError` bridge and generic known-failure 500s. | Current main / D12 residue proof. |
+| `mapgen-studio-operations-current` | accepted packet; current-main merged | Daemon-owned operation truth and current-operation read. | Browser operation recovery localStorage bridge. | Current main / D12 live proof. |
+| `mapgen-studio-stream-spike` | accepted packet; current-main merged | Stream transport decision and cleanup semantics. | Any unowned alternate watch transport. | Current main. |
+| `mapgen-studio-event-hub` | accepted packet; current-main merged | Daemon-owned event hub and watch procedure. | Polling remains only until D9 deletion target. | Current main / D12 EventHub lifecycle repair. |
+| `mapgen-studio-operations-push` | accepted packet; current-main merged | Operation transition push and deletion of polling/watchdog authority. | Operation status polling, hidden Save/Deploy completion loop, daemon identity watchdog. | Current main. |
+| `mapgen-studio-live-game-watch` | accepted packet; current-main merged with narrowed proof gap | Daemon-owned live-game watcher. | Browser live-status cadence. | Current main; D10 live-game watcher proof remains narrowed. |
+| `mapgen-studio-game-door-invariant` | accepted packet; current-main merged and drain reconciled | Evergreen game-door invariant and final negative searches. | All orphaned runtime bridges and stale active docs. | Current main through `#1748`. |
 
 ## Migrated Baseline Evidence
 


### PR DESCRIPTION
Updates the artifact classification ledger and associated workstream records to reflect that D1 through D12 have all landed on `origin/main` rather than remaining as pending implementation. Introduces a new `accepted packet; current-main merged` classification status and applies it across all domino entries, recording the corresponding PR numbers (`#1734`–`#1748`).

Marks the remaining open task checkboxes in the D1 tasks file as complete, including the D1 review lane disposition (task 1.3) and the live Play and Save&Deploy same-operation proofs (tasks 3.12 and 3.13). Reconciles the D1 verification evidence section to reflect that the historical `workspace-entrypoints` lint failure has been superseded by later D12/root graph hygiene records, and that D12 consumed the broad live Play/Save&Deploy operation proof handoff with stable daemon identity, pushed event terminal completion, keyed status agreement, and restored generated/catalog artifacts.

Marks the previously open D6 entrance checks (tasks 4.4 and 4.5) as complete and adds a reconciliation note clarifying that those rows were stale packet-authoring entrance checks, with D6 now on main via `#1740` and D12 having exercised `studio.operations.current({})` for invalid, Run in Game, and Save&Deploy flows.

Updates the D5 review disposition ledger to record that the implementation landed on main through `#1739`. Updates the D8 event-hub phase record status to reflect that the implementation has landed and that D12 later repaired the package-owned EventHub lifecycle.