### PR TITLE
`docs(studio): add post-#1748 reconciliation notes to component audit and runtime refactor frame`

### DIFF
--- a/docs/projects/mapgen-studio-redesign/audit/03-component-architecture.md
+++ b/docs/projects/mapgen-studio-redesign/audit/03-component-architecture.md
@@ -5,6 +5,15 @@
 **Date:** 2026-06-08
 **Lens applied:** `dev:vercel-composition-patterns`, `dev:vercel-react-best-practices`, `dev:frontend-design`
 
+> **Current-status note (2026-06-16):** this audit predates the Studio runtime
+> Effect refactor stack that landed on `origin/main` through PR `#1748`. Its
+> polling, watchdog, browser-recovery, and TanStack status-query recommendations
+> are historical decomposition evidence, not current runtime authority. Current
+> runtime ownership is daemon/EventHub/Effect-owned; see
+> `docs/projects/studio-runtime-simplification/OPENSPEC-PACKET-TRAIN.md` and the
+> `mapgen-studio-game-door-invariant` D12 proof ledgers before using this audit
+> for runtime behavior.
+
 > **Behavior-parity constraint (non-negotiable):** map-gen pipeline, Deck.gl rendering, recipe semantics, and the live-game runtime loop must be preserved bit-for-bit. Sections flag every piece of **load-bearing live-control state** so decomposition does not break the live loop.
 
 ---

--- a/docs/projects/studio-runtime-simplification/RUNTIME-EFFECT-REFACTOR-FRAME.md
+++ b/docs/projects/studio-runtime-simplification/RUNTIME-EFFECT-REFACTOR-FRAME.md
@@ -4,6 +4,14 @@ Status: normative spike frame
 Date: 2026-06-14
 Scope: Mapgen Studio runtime simplification closeout and Effect-based mutation runtime refactor
 
+Current-main reconciliation, 2026-06-16: the D0-D12 runtime stack has landed on
+`origin/main` through PR `#1748`. The domino descriptions below remain the
+normative frame and historical proof plan for the stack, but the "Immediate Next
+Work" section is superseded by current OpenSpec workstream records. Current
+known open runtime-record work is D10's narrowed live-game watcher-specific
+Civ7 proof gap plus any later docs/OpenSpec realignment slice, not reopening D2
+or D3.
+
 ## Purpose
 
 The product outcome is a strong, reliable Mapgen Studio core: the daemon owns ephemeral runtime truth, game-facing mutations are orchestrated through typed Effect services, public contracts are TypeBox-owned, and the local development loop is boring enough that Play and Save/Deploy do not destabilize the server that is reporting their state.
@@ -697,6 +705,11 @@ Live slices:
 - Arc is not part of this refactor's implementation plan; it is not a task runner, build tool, process manager, or reactive state library: <https://arc.tsdk.dev/>.
 
 ## Immediate Next Work
+
+This section is historical. It described the next work as of 2026-06-14 before
+the runtime stack landed on `origin/main` through `#1748`. Use the current
+OpenSpec workstream records and packet train status instead of reopening these
+early dominoes by default.
 
 1. Confirm the active runtime stack base and whether the tactical `dev-watch-deploy-isolation`/dev-host cleanup branches are merged, pending, or dirty.
 2. Open D2 (`mapgen-studio-engine-effect-corpus`) if the corpus is not already represented in a live OpenSpec change.


### PR DESCRIPTION
Adds historical-status notices to two runtime documentation files clarifying that the D0–D12 runtime stack landed on `origin/main` via PR `#1748`. The component architecture audit now warns readers that its polling, watchdog, browser-recovery, and TanStack recommendations predate the Effect refactor and that current runtime ownership belongs to the daemon/EventHub/Effect layer. The runtime Effect refactor frame marks its "Immediate Next Work" section as historical, directing readers to current OpenSpec workstream records and packet train status rather than reopening D2 or D3, while noting that the only known open gap is D10's Civ7 watcher-specific proof.