### PR TITLE
`docs(studio): add R4 runtime effect recovery closeout audit and update design handoff records`

### DIFF
--- a/docs/projects/studio-runtime-simplification/workstream/runtime-effect-recovery-closeout/FINAL-AUDIT.md
+++ b/docs/projects/studio-runtime-simplification/workstream/runtime-effect-recovery-closeout/FINAL-AUDIT.md
@@ -1,0 +1,77 @@
+# Runtime Effect Recovery Closeout Audit
+
+Status: R4 closeout audit validated for the recovery branch stack.
+Date: 2026-06-16.
+
+## Scope
+
+This audit closes the docs/OpenSpec recovery realignment stack that followed the
+runtime Effect recovery prework. It does not close the broader runtime-proof
+goal, rerun live Civ7, edit runtime TypeScript, submit Graphite branches, or
+claim product behavior beyond the existing D12 proof ledgers.
+
+## Exterior
+
+- Runtime code and public contract changes.
+- Live Civ7 verification.
+- Generated artifacts and lockfiles.
+- Graphite submit, PR creation, merge, or broad restack of unrelated branches.
+- Closing D10 watcher-specific live proof without a fresh proof owner.
+
+## Implemented Stack
+
+| Slice | Branch | Commit | Result |
+| --- | --- | --- | --- |
+| Prework | `codex/runtime-effect-prework-frame` | `dad1c74e9` | Framing, investigation, packet corpus, problem classification, review disposition, and next objective package committed. |
+| Design | `codex/runtime-effect-recovery-design` | `f10de82d4` | R0-R4 sequence reviewed and approved for docs/OpenSpec realignment. |
+| R0 | `codex/runtime-effect-d12-drain-reconcile` | `315efbbf1` | D12 final-drain records now match current `origin/main` evidence through `#1748`. |
+| R1 | `codex/runtime-effect-live-proof-realign` | `7d98eaaa0` | D11 and D5 consumed handoffs point to D12 proof; D10 remains narrowed to watcher-specific live-game proof. |
+| R2 | `codex/runtime-effect-packet-accounting-realign` | `04cc86f83` | Historical packet accounting no longer keeps completed runtime packets active by stale rows. |
+| R3 | `codex/runtime-effect-active-doc-drift` | `bc31bf51a` | Active project docs now warn that old browser polling/recovery and early-packet next-work text is historical. |
+| R4 | `codex/runtime-effect-recovery-closeout` | current slice | This audit records final agreement and the retained proof gap. |
+
+## Current Packet State
+
+`openspec list` reports every runtime Effect packet complete except
+`mapgen-studio-live-game-watch`, which remains `36/37 tasks`. That incomplete
+state is intentional after R1/R2: D10 still owns a narrowed live-game
+watcher-specific proof gap for first retained state, reconnect replay, quiet
+unchanged state, and changed-state observation against a real Civ7 process.
+
+## Closeout Decision
+
+The docs/OpenSpec realignment workstream is internally consistent after R0-R3:
+D12 drain state, consumed handoff records, historical packet accounting, and
+active project doc authority now agree with current main evidence.
+
+The broader runtime-proof objective must remain open because D10's retained
+watcher-specific live proof is not complete. The correct next action is a D10
+proof slice that captures live Civ7 evidence first. Runtime implementation
+belongs in that slice only if the proof exposes a current defect.
+
+## Validation Boundary
+
+R4 validation proves documentation integrity only:
+
+| Command | Result | Boundary |
+| --- | --- | --- |
+| `git status --short --branch` | R4 branch had only the intended docs edits and new closeout directory before commit. | Worktree scope. |
+| `gt log --no-interactive --stack` | Stack shows prework, design, R0, R1, R2, R3, and current R4 branch above `main` at `654f58d8f`. | Graphite stack shape only; no submit/drain. |
+| `bun run openspec:validate` | Passed: 186 items passed, 0 failed. | OpenSpec tree shape only. |
+| `bun run openspec -- list` | All runtime Effect packets complete except `mapgen-studio-live-game-watch` at `36/37 tasks`. | Packet-accounting state. |
+| `bun run habitat classify docs/projects/studio-runtime-simplification/workstream/runtime-effect-recovery-design` | Passed; workspace-level path; returned `bun run lint`. | Required target discovery. |
+| `bun run habitat classify docs/projects/studio-runtime-simplification/workstream/runtime-effect-recovery-closeout` | Passed; workspace-level path; returned `bun run lint`. | Required target discovery. |
+| `git diff --check` | Passed before commit. | Diff whitespace hygiene only. |
+| `bun run lint` | Non-green on unrelated `mod-swooper-maps:habitat:check` rules listed below; `@internal/habitat-harness:habitat:check` passed with advisory `doc-ambiguity`. | Root graph hygiene; not green, not caused by this docs-only write set. |
+
+Root `bun run lint` is expected to remain non-green on unrelated
+`mod-swooper-maps:habitat:check` rules:
+`arch-test-m11-projection-band`, `arch-test-map-bundle-runtime-imports`, and
+`arch-test-cutover`. That is not caused by this docs-only recovery stack and is
+not repaired here.
+
+## Review Disposition
+
+There are no accepted unresolved P1/P2 findings against the docs/OpenSpec
+realignment stack. The retained D10 proof gap is an explicit out-of-scope
+runtime-product proof obligation, not a docs-realignment defect.

--- a/docs/projects/studio-runtime-simplification/workstream/runtime-effect-recovery-design/NEXT-PACKET.md
+++ b/docs/projects/studio-runtime-simplification/workstream/runtime-effect-recovery-design/NEXT-PACKET.md
@@ -1,19 +1,36 @@
-# Next Packet - Runtime Effect Recovery Design
+# Next Packet - Runtime Effect Recovery Closeout
 
-Status: reviewed design handoff.
+Status: R4 closeout handoff.
 
 ## Next Action
 
-Open implementation slice R0, `D12 Drain Reconciliation`, as a new Graphite
-branch stacked above the design commit. Do not edit runtime source. Begin with
-the write set and stop conditions in `CHANGESET-DESIGN.md`.
+Do not reopen R0-R3. They have been implemented as a docs/OpenSpec Graphite
+stack above the prework and design commits:
 
-R0 must complete before R1/R2/R3 starts because the current D12 closure state is
-the authority for later consumed-proof and packet-accounting realignment.
+- R0 `315efbbf1` reconciled D12 final drain.
+- R1 `7d98eaaa0` realigned consumed live-proof handoffs and retained only D10's
+  narrowed watcher-specific live-game proof gap.
+- R2 `04cc86f83` realigned stale historical packet accounting.
+- R3 `bc31bf51a` bannered active project doc drift.
 
-## If Review Finds Code Residue
+The next substantive packet, if the broader runtime-proof goal continues, is a
+D10 live-game watcher proof slice. Its owner is
+`openspec/changes/mapgen-studio-live-game-watch`, and its initial posture should
+be proof execution and evidence capture, not code implementation. Runtime code
+changes become in scope only if that live proof finds a current product defect.
 
-Stop docs-only implementation. Add a new R0 blocker slice ahead of drain
-realignment that names the exact production residue, owner, forbidden owners,
-write set, tests, and proof classes. Do not claim D12 closure until the residue
-slice is designed, reviewed, implemented, and verified.
+## Retained Proof Gap
+
+`openspec list` intentionally still reports
+`mapgen-studio-live-game-watch` as `36/37 tasks`. That remaining row is the
+watcher-specific live Civ7 proof subclaim that D12 did not independently close:
+first retained live-game state, reconnect replay, quiet unchanged state, and
+changed-state observation against a real Civ7 process.
+
+## Stop Conditions
+
+- Do not mark the broader runtime-proof goal complete while the D10 proof gap is
+  still open.
+- Do not claim a fresh live Civ7 pass from the docs-only R0-R4 recovery stack.
+- Do not edit runtime source in the D10 proof slice unless the proof run exposes
+  a current defect with exact reproduction evidence.

--- a/docs/projects/studio-runtime-simplification/workstream/runtime-effect-recovery-design/PACKET-REALIGNMENT-LEDGER.md
+++ b/docs/projects/studio-runtime-simplification/workstream/runtime-effect-recovery-design/PACKET-REALIGNMENT-LEDGER.md
@@ -1,6 +1,11 @@
 # Packet Realignment Ledger
 
-Status: design draft pending sidecar review.
+Status: design reviewed and executed through R0-R3; R4 closeout audit pending.
+
+R4 closeout note: the ledger's design dispositions have been applied as
+docs/OpenSpec realignment slices. The only retained open packet state is D10's
+narrowed watcher-specific live-game proof gap, which remains outside the
+docs-only realignment closure claim.
 
 ## Current Main Evidence
 

--- a/docs/projects/studio-runtime-simplification/workstream/runtime-effect-recovery-design/PHASE-RECORD.md
+++ b/docs/projects/studio-runtime-simplification/workstream/runtime-effect-recovery-design/PHASE-RECORD.md
@@ -6,8 +6,8 @@
 - Phase id: `runtime-effect-recovery-design`.
 - Branch: `codex/runtime-effect-recovery-design`.
 - Parent slice: `codex/runtime-effect-prework-frame`.
-- Status: design reviewed and approved for sequential docs/OpenSpec realignment;
-  no runtime implementation edits.
+- Status: design reviewed, approved, and executed through R0-R3 docs/OpenSpec
+  realignment; R4 closeout audit in progress; no runtime implementation edits.
 - Started: 2026-06-16.
 
 ## Objective
@@ -133,6 +133,22 @@ The approved implementation sequence is in `CHANGESET-DESIGN.md`. No slice is
 approved for implementation until `REVIEW-DISPOSITION.md` records no accepted
 unresolved P1/P2 finding against this design.
 
+## Gate 8A - Implementation Record
+
+| Slice | Branch | Commit | Disposition |
+| --- | --- | --- | --- |
+| Prework | `codex/runtime-effect-prework-frame` | `dad1c74e9` | Framing, investigation, packet corpus, classification, review disposition, and next objective package committed. |
+| Design | `codex/runtime-effect-recovery-design` | `f10de82d4` | Full R0-R4 docs/OpenSpec realignment design reviewed and approved. |
+| R0 | `codex/runtime-effect-d12-drain-reconcile` | `315efbbf1` | D12 final-drain records reconciled to current `origin/main` evidence through `#1748`. |
+| R1 | `codex/runtime-effect-live-proof-realign` | `7d98eaaa0` | D11 and D5 consumed-proof handoffs closed with D12 pointers; D10 narrowed to watcher-specific live-game proof only. |
+| R2 | `codex/runtime-effect-packet-accounting-realign` | `04cc86f83` | Historical packet accounting ledgers realigned; completed packets no longer appear open by stale row state. |
+| R3 | `codex/runtime-effect-active-doc-drift` | `bc31bf51a` | Active project docs bannered so historical browser/polling and early-packet text is not current runtime authority. |
+| R4 | `codex/runtime-effect-recovery-closeout` | current slice | Final audit records agreement, validation boundaries, and retained D10 proof gap. |
+
+The remaining open runtime-record item after R0-R3 is the deliberately retained
+D10 live-game watcher-specific proof row. It is not a docs/OpenSpec realignment
+defect and it is not closed by this recovery audit.
+
 ## Gates 9-10 - Proof Labels
 
 | Proof class | Design phase claim |
@@ -177,4 +193,6 @@ This design phase closes when:
 | `bun run openspec:validate` | Passed: 186 items passed, 0 failed. | OpenSpec tree shape only. |
 | `bun run habitat classify docs/projects/studio-runtime-simplification/workstream/runtime-effect-recovery-design` | Passed; workspace-level path; returned `bun run lint`. | Required target discovery for this docs-only path. |
 | `bun run lint` | Non-green on `mod-swooper-maps:habitat:check`: `arch-test-m11-projection-band`, `arch-test-map-bundle-runtime-imports`, `arch-test-cutover`. `@internal/habitat-harness:habitat:check` passed with advisory `doc-ambiguity`. | Root graph hygiene is not green. The failures are outside this docs-only design write set and are not repaired here. |
-| `git diff --check` | Passed before review integration; rerun required before commit. | Diff whitespace hygiene only. |
+| `git diff --check` | Passed for design and R4 closeout edits before commit. | Diff whitespace hygiene only. |
+| R4 `bun run openspec -- list` packet scan | All runtime Effect packets complete except `mapgen-studio-live-game-watch` at `36/37 tasks`. | Confirms the retained D10 proof gap remains explicit. |
+| R4 habitat classify | `runtime-effect-recovery-design` and `runtime-effect-recovery-closeout` both classify as workspace-level docs paths requiring `bun run lint`. | Required target discovery for the closeout write set. |

--- a/docs/projects/studio-runtime-simplification/workstream/runtime-effect-recovery-design/REVIEW-DISPOSITION.md
+++ b/docs/projects/studio-runtime-simplification/workstream/runtime-effect-recovery-design/REVIEW-DISPOSITION.md
@@ -1,7 +1,7 @@
 # Review Disposition - Runtime Effect Recovery Design
 
-Status: review wave complete; design approved for sequential docs/OpenSpec
-realignment.
+Status: review wave complete; design approved and executed through R0-R3
+docs/OpenSpec realignment; R4 closeout audit pending.
 
 Accepted P1/P2 findings block design approval until repaired, rejected with
 evidence, or moved outside the design closure claim.
@@ -31,7 +31,10 @@ evidence, or moved outside the design closure claim.
 
 ## Design Approval State
 
-Design is approved for implementation of R0-R4 in the order defined by
-`CHANGESET-DESIGN.md`. There are no accepted unresolved P1/P2 findings against
-the design. R0 remains the first implementation slice and must complete before
-any later realignment slice starts.
+Design was approved for implementation of R0-R4 in the order defined by
+`CHANGESET-DESIGN.md`. R0-R3 have been implemented, and there are no accepted
+unresolved P1/P2 findings against the docs/OpenSpec realignment design.
+
+The remaining D10 watcher-specific live-game proof row is not a rejected review
+finding and is not closed by this docs-only recovery stack. It is retained as
+the next proof owner if the broader runtime-proof objective continues.


### PR DESCRIPTION
This PR closes out the R4 slice of the runtime Effect recovery docs/OpenSpec realignment stack.

The closeout audit (`FINAL-AUDIT.md`) records that R0–R3 have been implemented and are internally consistent: D12 drain state, consumed handoff records, historical packet accounting, and active project doc authority all agree with current main evidence. The audit explicitly bounds what R4 validates—documentation integrity only—and does not claim a live Civ7 pass, runtime code correctness, or completion of the broader runtime-proof goal.

The one intentionally retained open item is the `mapgen-studio-live-game-watch` packet at `36/37 tasks`. D10's watcher-specific live-game proof subclaim (first retained state, reconnect replay, quiet unchanged state, changed-state observation against a real Civ7 process) was never in scope for the docs-only recovery stack and remains the correct entry point for any continuation of the runtime-proof objective.

Supporting design documents are updated to reflect that R0–R3 are complete, the `NEXT-PACKET.md` handoff now points forward to a D10 live-game proof slice rather than back to R0 implementation instructions, and the `PHASE-RECORD.md` Gate 8A implementation table records each branch, commit, and disposition for the full prework-through-R4 stack.