### PR TITLE
`feat(mapgen-studio): add env-configurable dev ports and close D10 live-game watcher proof`

### DIFF
--- a/apps/mapgen-studio/src/server/daemon/daemon.ts
+++ b/apps/mapgen-studio/src/server/daemon/daemon.ts
@@ -58,8 +58,9 @@ const mimeTypes: Record<string, string> = {
 
 export function parseStudioDaemonArgs(
   argv: readonly string[],
-  defaults: Readonly<{ repoRoot: string }>
+  defaults: Readonly<{ repoRoot: string; env?: Readonly<Record<string, string | undefined>> }>
 ): StudioDaemonArgs {
+  const env = defaults.env ?? process.env;
   const options = new Map<string, string>();
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -71,12 +72,22 @@ export function parseStudioDaemonArgs(
     index += 1;
   }
   const assetsRoot = options.get("assets-root");
+  const portValue = options.get("port") ?? env.STUDIO_DAEMON_PORT;
   return {
     host: options.get("host") ?? "127.0.0.1",
-    port: Number(options.get("port") ?? STUDIO_DAEMON_DEFAULT_PORT),
+    port: parsePort(portValue, STUDIO_DAEMON_DEFAULT_PORT, "Studio daemon port"),
     repoRoot: resolve(options.get("repo-root") ?? defaults.repoRoot),
     ...(assetsRoot ? { assetsRoot: resolve(assetsRoot) } : {}),
   };
+}
+
+function parsePort(value: string | undefined, fallback: number, label: string): number {
+  if (value === undefined) return fallback;
+  const port = Number(value);
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    throw new Error(`${label} must be an integer from 1 to 65535: ${value}`);
+  }
+  return port;
 }
 
 /**

--- a/apps/mapgen-studio/test/server/daemonFetch.test.ts
+++ b/apps/mapgen-studio/test/server/daemonFetch.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 
-import { createStudioDaemonFetch, type StudioDaemonDeps } from "../../src/server/daemon/daemon";
+import {
+  createStudioDaemonFetch,
+  parseStudioDaemonArgs,
+  type StudioDaemonDeps,
+} from "../../src/server/daemon/daemon";
 
 function makeDeps(overrides: Partial<StudioDaemonDeps> = {}): {
   deps: StudioDaemonDeps;
@@ -21,6 +25,28 @@ function makeDeps(overrides: Partial<StudioDaemonDeps> = {}): {
 }
 
 describe("studio daemon fetch router", () => {
+  test("daemon args accept an env override for isolated dev ports", () => {
+    expect(
+      parseStudioDaemonArgs([], {
+        repoRoot: "/repo",
+        env: { STUDIO_DAEMON_PORT: "5274" },
+      })
+    ).toMatchObject({
+      host: "127.0.0.1",
+      port: 5274,
+      repoRoot: "/repo",
+    });
+  });
+
+  test("explicit daemon port args override the env port", () => {
+    expect(
+      parseStudioDaemonArgs(["--port", "5374"], {
+        repoRoot: "/repo",
+        env: { STUDIO_DAEMON_PORT: "5274" },
+      }).port
+    ).toBe(5374);
+  });
+
   test("serves /healthz from the health probe", async () => {
     const { deps } = makeDeps();
     const fetchHandler = createStudioDaemonFetch(deps);

--- a/apps/mapgen-studio/test/server/nxDevRunner.test.ts
+++ b/apps/mapgen-studio/test/server/nxDevRunner.test.ts
@@ -63,4 +63,13 @@ describe("Nx dev runner topology", () => {
     expect(JSON.stringify(appPackage.scripts)).not.toContain("bun --watch");
     expect(existsSync(join(appRoot, "src/server/daemon/devLive.ts"))).toBe(false);
   });
+
+  test("dev server ports can be isolated by environment", () => {
+    const daemonSource = readFileSync(join(appRoot, "src/server/daemon/daemon.ts"), "utf8");
+    const viteSource = readFileSync(join(appRoot, "vite.config.ts"), "utf8");
+
+    expect(daemonSource).toContain("STUDIO_DAEMON_PORT");
+    expect(viteSource).toContain("STUDIO_DEV_PORT");
+    expect(viteSource).toContain("STUDIO_DEV_RPC_TARGET");
+  });
 });

--- a/apps/mapgen-studio/vite.config.ts
+++ b/apps/mapgen-studio/vite.config.ts
@@ -20,7 +20,17 @@ import { defineConfig } from "vite";
 // daemon runs under Bun, which loads TS natively).
 // ===========================================================================
 
+const STUDIO_DEV_PORT = parsePort(process.env.STUDIO_DEV_PORT, 5173, "STUDIO_DEV_PORT");
 const STUDIO_DEV_RPC_TARGET = process.env.STUDIO_DEV_RPC_TARGET ?? "http://127.0.0.1:5174";
+
+function parsePort(value: string | undefined, fallback: number, label: string): number {
+  if (value === undefined) return fallback;
+  const port = Number(value);
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    throw new Error(`${label} must be an integer from 1 to 65535: ${value}`);
+  }
+  return port;
+}
 
 export default defineConfig(({ command }) => ({
   plugins: [react(), tailwindcss()],
@@ -46,7 +56,7 @@ export default defineConfig(({ command }) => ({
     sourcemap: true,
   },
   server: {
-    port: 5173,
+    port: STUDIO_DEV_PORT,
     strictPort: true,
     proxy: {
       "/rpc": { target: STUDIO_DEV_RPC_TARGET },

--- a/openspec/changes/mapgen-studio-live-game-watch/tasks.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/tasks.md
@@ -64,12 +64,13 @@
 - [x] 5.6 Package/app check gates selected by the implementation write set.
 - [x] 5.7 Negative searches for deleted browser cadence symbols and alternate
       watcher/session/event paths.
-- [ ] 5.8 Live Civ7 proof with branch, commit, command/API path, timestamps,
+- [x] 5.8 Live Civ7 proof with branch, commit, command/API path, timestamps,
       relevant logs, and parsed payload shape.
 - [x] 5.9 If Civ7 is unavailable, write `workstream/next-packet.md` and leave
       D10 not-green for live-game watcher behavior.
 
-Live-proof reconciliation note, 2026-06-16:
+Historical live-proof reconciliation note, 2026-06-16, superseded by the
+completion note below:
 
 - D12 later ran live Run in Game and Save&Deploy state-machine proof through
   Nx Studio, `studio.events.watch`, keyed status, and
@@ -78,9 +79,23 @@ Live-proof reconciliation note, 2026-06-16:
   does not explicitly prove D10's live-game watcher-specific subclaims: first
   retained `live-game`, reconnect replay, unchanged-key quiet behavior, and
   changed live-game state publication against a real Civ7 session.
-- Task 5.8 therefore remains open as a narrowed live-game watcher proof gap,
+- At that time, task 5.8 remained open as a narrowed live-game watcher proof gap,
   not as a blocker for D12 drain or Run in Game / Save&Deploy state-machine
   closure.
+
+Live-proof completion note, 2026-06-16:
+
+- Branch `codex/studio-dev-port-env` at `aa8325a83` ran the D10 narrowed
+  watcher proof against a local tuner-ready Civ7 session through full Studio
+  dev surfaces: daemon `127.0.0.1:5274`, frontend `http://localhost:5273`.
+- Raw captures are recorded in `workstream/testing-ledger.md`: preflight JSON,
+  first stream, reconnect stream, quiet-window streams, changed-turn stream,
+  parsed summaries, listener/daemon-health captures, and browser/network proof.
+- The accepted live claim is watcher-specific: `hello`, first retained
+  `live-game`, reconnect replay, unchanged-key quiet window, changed
+  `live-game` state after a real autoplay trigger including `turn: 34 -> 35`,
+  source-composition proof, and browser event-stream consumption without
+  background live-status/readiness cadence.
 
 ## 6. Closure
 

--- a/openspec/changes/mapgen-studio-live-game-watch/workstream/closure-checklist.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/workstream/closure-checklist.md
@@ -1,7 +1,7 @@
 # D10 Closure Checklist - Studio Live Game Watch
 
-Status: implementation committed at current branch tip; live Civ7 product proof not run or claimed.
-Date: 2026-06-15
+Status: implementation committed; D10 watcher-specific live Civ7 proof passed.
+Date: 2026-06-15; live proof updated 2026-06-16.
 
 - [x] Proposal, design, tasks, and spec delta agree on D10 ownership.
 - [x] D10 packet uses the runtime Effect refactor frame and packet train as
@@ -24,21 +24,23 @@ Date: 2026-06-15
       search with retained non-D10 hits classified.
 - [x] Snapshot/setup request-response follow-up rules are protected by model
       tests and `StudioShell` source guard.
-- [x] `workstream/next-packet.md` records the missing live Civ7 proof, re-entry
-      commands, prerequisites, log paths, owner, and not-green claim.
+- [x] `workstream/next-packet.md` records the original missing live Civ7 proof,
+      re-entry commands, prerequisites, log paths, owner, and later closure
+      append.
 - [x] `bun run openspec -- validate mapgen-studio-live-game-watch --strict`
       passed.
 - [x] `bun run openspec:validate` passed.
 - [x] Focused package/app tests and checks passed.
 - [x] Nx-owned `@civ7/studio-server:check` and `mapgen-studio:check` passed.
-- [ ] Live Civ7 proof with real game/FireTuner evidence passed.
+- [x] Live Civ7 proof with real game/FireTuner evidence passed for D10
+      watcher-specific task 5.8; raw captures and parsed browser/network proof
+      are recorded in `workstream/testing-ledger.md`.
 - [x] Graphite implementation commit exists for D10 at the current branch tip.
-- [x] Post-commit `git status --short --branch` was clean before closure-doc
-      amendment; this checklist is amended into that commit so the final
-      post-amend status must also be clean.
+- [x] Post-proof record commit must leave `git status --short --branch` clean
+      before D10 live-proof closeout is claimed.
 
 Residual implementation risk:
 
-- Live Civ7 behavior is not green until `workstream/next-packet.md` is executed
-  and recorded. D10 may commit static/runtime implementation evidence, but must
-  not claim product-runtime green for live game behavior.
+- This checklist does not claim Graphite submit/PR/drain.
+- This checklist does not claim live shared-socket instrumentation beyond
+  source-composition proof plus live stream output.

--- a/openspec/changes/mapgen-studio-live-game-watch/workstream/live-proof-plan.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/workstream/live-proof-plan.md
@@ -97,6 +97,16 @@ Start the repo-native full Studio dev target when browser/UI proof is in scope:
 bun run nx run mapgen-studio:dev --outputStyle=static
 ```
 
+If the default Studio ports are occupied, isolate this proof worktree with
+explicit environment ports:
+
+```bash
+STUDIO_DAEMON_PORT=5274 \
+STUDIO_DEV_PORT=5273 \
+STUDIO_DEV_RPC_TARGET=http://127.0.0.1:5274 \
+bun run nx run mapgen-studio:dev --outputStyle=static
+```
+
 Expected local surfaces:
 
 - frontend: `http://127.0.0.1:5173` or the port printed by Vite;
@@ -118,6 +128,9 @@ timeout 12s curl -sN \
   http://127.0.0.1:5174/rpc/studio/events/watch \
   | tee /tmp/d10-live-watch-1.sse
 ```
+
+When isolated ports are used, replace `5174` with the recorded
+`STUDIO_DAEMON_PORT`.
 
 Use the same command for reconnect replay with a new output file after the first
 `live-game` event has been captured.

--- a/openspec/changes/mapgen-studio-live-game-watch/workstream/live-proof-plan.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/workstream/live-proof-plan.md
@@ -1,6 +1,7 @@
 # D10 Live-Game Watcher Proof Plan
 
-Status: proof-slice design repaired after fresh review; proof execution pending.
+Status: proof-slice design repaired after fresh review; proof executed for D10
+task 5.8 on 2026-06-16.
 Date: 2026-06-16.
 Branch: `codex/runtime-effect-d10-live-proof`.
 
@@ -212,3 +213,36 @@ rejected with source evidence, or explicitly moved outside the closure claim.
 | D10-LIVE-REV-05 | P2 | proof/environment reviewers | L4 quiet proof was underbounded and the `curl` stream was indefinite/unparsed. | accepted-repaired: capture is bounded, two watcher intervals plus margin are required, and parsed event rows must record stable keys and timestamps. |
 | D10-LIVE-REV-06 | P2 | proof/environment reviewers | L7 allowed static negative search to replace live browser consumption. | accepted-repaired: same-run browser/network capture is required; source proof may only support absence/classification. |
 | D10-LIVE-REV-07 | P3 | environment reviewer | Environment prerequisites were not executable. | accepted-repaired: `civ7 game status --json` and `civ7 game health --tuner --json` preflights are now required. |
+
+## Execution Append - 2026-06-16
+
+Executed on branch `codex/studio-dev-port-env` at `aa8325a83` with isolated
+ports:
+
+```bash
+STUDIO_DAEMON_PORT=5274 \
+STUDIO_DEV_PORT=5273 \
+STUDIO_DEV_RPC_TARGET=http://127.0.0.1:5274 \
+bun run nx run mapgen-studio:dev --outputStyle=static
+```
+
+Accepted raw artifacts:
+
+- `/tmp/d10-live-watch-1.sse`;
+- `/tmp/d10-live-watch-2.sse`;
+- `/tmp/d10-live-watch-changed.sse`;
+- `/tmp/d10-live-proof-summary.json`;
+- `/tmp/d10-live-watch-current.sse`;
+- `/tmp/d10-live-watch-turn-change.sse`;
+- `/tmp/d10-live-turn-change-summary.json`;
+- `/tmp/d10-game-status.json`;
+- `/tmp/d10-game-health.json`;
+- `/tmp/d10-daemon-health.json`;
+- `/tmp/d10-vite-listener.txt`;
+- `/tmp/d10-daemon-listener.txt`;
+- `/tmp/d10-browser-network-proof.json`;
+- `/tmp/d10-browser-network-proof.png`.
+
+The detailed evidence ledger is `workstream/testing-ledger.md`. No runtime
+source edits were made for proof convenience; the only implementation slice
+needed before proof was isolated Studio dev ports.

--- a/openspec/changes/mapgen-studio-live-game-watch/workstream/next-packet.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/workstream/next-packet.md
@@ -1,10 +1,10 @@
 # D10 Next Packet - Narrow Live-Game Watcher Proof
 
-Status: narrowed live-game watcher proof gap; operation live proof consumed by D12
+Status: closed by 2026-06-16 D10 watcher-specific live proof
 Date opened: 2026-06-15
 Date narrowed: 2026-06-16
 
-## Missing Proof Class
+## Original Missing Proof Class
 
 D10 unit, source, OpenSpec, and Nx gates prove the daemon/runtime watcher shape,
 browser live-status cadence deletion, event-hub replay, and client stale-result
@@ -12,9 +12,10 @@ guards. D12 later ran live Run in Game and Save&Deploy state-machine proof
 through Nx Studio, `studio.events.watch`, keyed status, and
 `studio.operations.current({})`. That D12 proof consumes the broad operation
 handoff, but it does not explicitly prove every D10 live-game watcher-specific
-subclaim.
+subclaim. This section records the original gap that the closure append below
+supersedes.
 
-The remaining missing proof is live Civ7 runtime evidence that:
+The then-missing proof was live Civ7 runtime evidence that:
 
 - the daemon package `ManagedRuntime` activates `StudioLiveGameWatcher` before
   serving `/rpc` requests that depend on runtime identity or event streaming;
@@ -90,3 +91,25 @@ the D10 claim as:
 
 > implementation/static gates green; D12 consumed operation state-machine live
 > proof; live-game watcher-specific Civ7 proof not run or claimed.
+
+## Closure Append - 2026-06-16
+
+This packet was executed on branch `codex/studio-dev-port-env` at `aa8325a83`.
+The accepted evidence is recorded in `workstream/testing-ledger.md` under
+`Live Proof Append - 2026-06-16`.
+
+Closed observations:
+
+- `hello` and first retained `live-game` from `/tmp/d10-live-watch-1.sse`;
+- reconnect replay from `/tmp/d10-live-watch-2.sse`;
+- unchanged-key quiet behavior across bounded streams;
+- changed live-game state after autoplay trigger, including `turn: 34 -> 35`,
+  from `/tmp/d10-live-turn-change-summary.json` and
+  `/tmp/d10-live-watch-turn-change.sse`;
+- browser/network event-stream consumption without background live-status or
+  readiness cadence from `/tmp/d10-browser-network-proof.json`;
+- source-composition proof from daemon host, handler, runtime, and watcher
+  source pointers named in `workstream/testing-ledger.md`.
+
+Residual exterior: Graphite submit/drain and broad product state-machine proof
+remain outside this D10 next-packet closure.

--- a/openspec/changes/mapgen-studio-live-game-watch/workstream/phase-record.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/workstream/phase-record.md
@@ -7,9 +7,9 @@
 - OpenSpec change: `mapgen-studio-live-game-watch`
 - Owner: Codex implementation DRA lane
 - Branch/Graphite stack: `codex/runtime-effect-live-game-watch`
-- Status: implementation committed at current branch tip; operation
-  state-machine live proof consumed by D12; live-game watcher-specific Civ7
-  proof remains narrowed in `next-packet.md`
+- Status: implementation committed; operation state-machine live proof consumed
+  by D12; D10 live-game watcher-specific Civ7 proof passed in the 2026-06-16
+  re-entry.
 
 ## Objective
 
@@ -87,7 +87,7 @@ The implementation repairs the ownership split:
 | snapshot follow-up | request/response `civ7.live.snapshot` | live preview state | request-key/stale-commit tests retained |
 | setup follow-up | request/response setup reads | setup suggestions/visibility | setup request-key stale/newer-event model test |
 | browser cadence deletion | app source/tests | live status freshness | negative searches |
-| live proof | local Civ7 runtime | product confidence | not run; `workstream/next-packet.md` records re-entry |
+| live proof | local Civ7 runtime | product confidence | D10 watcher-specific proof passed 2026-06-16; `workstream/testing-ledger.md` records raw and parsed captures |
 
 ## Gate 5 - Grouping
 
@@ -107,7 +107,8 @@ The implementation repairs the ownership split:
 - Client state updates from pushed events.
 - Snapshot/setup reads are request/response follow-ups triggered by pushed state, with request keys and stale/newer-event protection.
 - Browser live status freshness has no remaining scheduler or readiness cadence seam.
-- D10 is not green for live Civ7 product behavior until the next-packet proof is run.
+- D10 watcher-specific live proof is green as of the 2026-06-16 re-entry. Broad
+  product/state-machine proof remains owned by the downstream D12 records.
 
 ## Gate 7 - Architecture Translation
 
@@ -141,8 +142,8 @@ schema/residue closeout.
 - App tests prove live-runtime model keying and event adoption paths.
 - Negative searches prove browser live-status cadence deletion.
 - D12 records live Run in Game and Save&Deploy operation state-machine proof.
-- `next-packet.md` records the remaining live-game watcher-specific proof; D10
-  does not claim that proof from D12.
+- `testing-ledger.md` records the live-game watcher-specific proof; D10 does not
+  claim that proof from D12.
 
 ## Gate 11 - Review
 
@@ -153,14 +154,14 @@ schema/residue closeout.
   live-game replay, non-throwing failure counts, proof wording, native Effect
   tick path, private fake-read seam, and workstream proof truthfulness.
 
-## Gate 12 - Closure
+## Gate 12 - Historical Implementation Closure
 
-Implementation commit closure requires:
+The original implementation commit closure required:
 
 - fresh implementation review has no unresolved P1/P2;
 - OpenSpec, package/app checks, focused tests, Nx checks, negative searches, and
   `git diff --check` are recorded;
-- `workstream/next-packet.md` records the narrowed unrun live-game watcher
+- `workstream/next-packet.md` records the then-narrowed unrun live-game watcher
   proof;
 - explicit paths are staged and Graphite commit leaves the worktree clean.
 
@@ -170,14 +171,36 @@ Implementation commit closure requires:
 - Re-entry reason: the recovery closeout stack preserved D10 task 5.8 as the
   only open runtime Effect packet row after D12 drain and stale accounting were
   reconciled.
-- Current status: proof-slice design draft in `workstream/live-proof-plan.md`;
+- Entry status: proof-slice design draft in `workstream/live-proof-plan.md`;
   fresh review found one P1 and multiple P2 plan issues, all repaired in the
-  plan before proof execution; no live Civ7 proof has been rerun or claimed in
-  this branch.
+  plan before proof execution; live Civ7 proof was not yet claimed at this
+  re-entry checkpoint.
 - Owner: D10 live-game watcher proof records and task 5.8 only.
 - Exterior: runtime code, public contracts, generated outputs, success-only
   proof logging, Graphite submit, and broad product/state-machine closure
   outside the watcher-specific claim.
-- Gate position: systematic gates 1-8 have been reopened and repaired for the
-  retained live proof only; gates 9-12 remain blocked until the static gates,
-  environment preflight, event-stream proof, and browser/network proof exist.
+- Gate position at entry: systematic gates 1-8 had been reopened and repaired
+  for the retained live proof only; gates 9-12 remained blocked until the
+  static gates, environment preflight, event-stream proof, and browser/network
+  proof existed.
+
+## D10 Live-Proof Execution - 2026-06-16
+
+- Branch and commit: `codex/studio-dev-port-env` at `aa8325a83`.
+- Proof target: D10 task 5.8 only.
+- Dev surfaces: daemon `127.0.0.1:5274`, frontend `http://localhost:5273`.
+- Static gates: `git diff --check`, focused app port tests,
+  `mapgen-studio:check`, `mapgen-studio:test`, D10 strict OpenSpec validation,
+  full OpenSpec validation, and `bun run lint` passed; lint retained only the
+  existing `doc-ambiguity` advisory.
+- Live gates: `/tmp/d10-game-status.json` and `/tmp/d10-game-health.json`
+  returned `ok: true` and `readiness: "tuner-ready"`;
+  `/tmp/d10-live-watch-1.sse` proved first `hello` and `live-game`;
+  `/tmp/d10-live-watch-2.sse` proved reconnect replay; the bounded streams
+  proved quiet unchanged-key behavior; `/tmp/d10-live-turn-change-summary.json`
+  and `/tmp/d10-live-watch-turn-change.sse` proved changed state after an
+  autoplay trigger with `turn: 34 -> 35`;
+  `/tmp/d10-browser-network-proof.json` proved browser event-stream consumption
+  without background live-status or readiness cadence.
+- Gate position: D10 task 5.8 is closed by this proof record; proof-audit
+  findings are accepted/repaired in `workstream/testing-ledger.md`.

--- a/openspec/changes/mapgen-studio-live-game-watch/workstream/testing-ledger.md
+++ b/openspec/changes/mapgen-studio-live-game-watch/workstream/testing-ledger.md
@@ -1,7 +1,7 @@
 # D10 Testing Ledger - Studio Live Game Watch
 
-Status: implementation evidence recorded before Graphite commit; live Civ7 Play/SaveDeploy proof is not run or claimed.
-Date: 2026-06-15
+Status: implementation evidence plus narrowed live-game watcher proof recorded.
+Date: 2026-06-15; live proof appended 2026-06-16.
 
 ## Proof Matrix
 
@@ -16,7 +16,7 @@ Date: 2026-06-15
 | Nx package check | `bun run nx run @civ7/studio-server:check --outputStyle=static` | passed; graph-owned Habitat/Grit dependencies green |
 | Nx app check | `bun run nx run mapgen-studio:check --outputStyle=static` | passed; rebuilt `@civ7/studio-server` outputs through Nx dependency graph |
 | Negative search | cadence/status/session scans below | passed with classified non-D10 hits only |
-| Live Civ7 proof | local game/FireTuner proof | not run; see `workstream/next-packet.md` |
+| Live Civ7 proof | local game/FireTuner proof | passed for D10 watcher-specific task 5.8 on 2026-06-16; see live proof append below |
 
 ## Focused Behavior Evidence
 
@@ -86,7 +86,7 @@ Result classification:
   and `orpc.ts` route taxonomy comment;
 - `StudioShell` uses `liveControlPort.display.explore.request` only.
 
-## Live Proof Boundary
+## Original Live Proof Boundary
 
 No live Civ7/FireTuner product proof was run in this D10 implementation pass.
 D10 therefore does not claim live game green. `workstream/next-packet.md`
@@ -94,10 +94,109 @@ records the missing proof class, environment prerequisites, re-entry commands,
 log paths, and closure rule for the D12 game-door invariant lane or an earlier
 live-proof lane.
 
+## Live Proof Append - 2026-06-16
+
+Proof class: D10 live-game watcher-specific proof for task 5.8. This is not a
+Graphite submit/drain claim and not a broad product proof beyond the watcher
+surface named here.
+
+Execution state:
+
+- branch and commit: `codex/studio-dev-port-env` at `aa8325a83`;
+- worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-runtime-effect-prework`;
+- proof-run identity: `git rev-parse --abbrev-ref HEAD` returned
+  `codex/studio-dev-port-env`, `git rev-parse --short=9 HEAD` returned
+  `aa8325a83`, and `git status --short --branch` returned a clean branch before
+  proof-record edits;
+- game preflight: `/tmp/d10-game-status.json` records
+  `node packages/cli/bin/run.js game status --json` returning `ok: true`,
+  `playable: true`, `readiness: "tuner-ready"`;
+- tuner preflight: `/tmp/d10-game-health.json` records
+  `node packages/cli/bin/run.js game health --tuner --json` returning
+  `ok: true`, host `127.0.0.1`, port `4318`, turn `25`, map `74x46`,
+  `autoplayActive: false`;
+- Studio command:
+  `STUDIO_DAEMON_PORT=5274 STUDIO_DEV_PORT=5273 STUDIO_DEV_RPC_TARGET=http://127.0.0.1:5274 bun run nx run mapgen-studio:dev --outputStyle=static`;
+- daemon health: `/tmp/d10-daemon-health.json` records
+  `http://127.0.0.1:5274/healthz` returning
+  `runtimeMode: "studio-daemon-effect-orpc"`, repo root equal to this worktree,
+  and `serverInstanceId: "studio-server-mqg5sfqo-agj-1"`;
+- listener proof: `/tmp/d10-daemon-listener.txt` records Bun listening on
+  `127.0.0.1:5274`; `/tmp/d10-vite-listener.txt` records Vite listening on
+  `[::1]:5273`;
+- frontend: `http://localhost:5273/` returned `200 OK` before browser proof;
+- cleanup: after the autoplay trigger, `node packages/cli/bin/run.js game
+  autoplay --action configure --observe-as-player 0 --return-as-player 0
+  --no-pause --json` returned `ok: true`; final recorded autoplay state remained
+  `isActive: false` and `isPaused: false`.
+
+Raw and parsed artifacts:
+
+- `/tmp/d10-live-watch-1.sse` - first bounded stream, 596 bytes, mtime
+  `2026-06-16T00:46:09-0400`;
+- `/tmp/d10-live-watch-2.sse` - reconnect stream, 596 bytes, mtime
+  `2026-06-16T00:46:27-0400`;
+- `/tmp/d10-live-watch-changed.sse` - changed-state stream, 988 bytes, mtime
+  `2026-06-16T00:47:46-0400`;
+- `/tmp/d10-live-proof-summary.json` - parsed changed-state evidence, 5834
+  bytes, mtime `2026-06-16T00:47:58-0400`;
+- `/tmp/d10-live-watch-current.sse` - later live stream with explicit turn
+  progression, 1396 bytes, mtime `2026-06-16T00:53:03-0400`;
+- `/tmp/d10-live-watch-turn-change.sse` - changed-turn stream after recorded
+  autoplay trigger, 1012 bytes, mtime `2026-06-16T00:54:21-0400`;
+- `/tmp/d10-live-turn-change-summary.json` - parsed turn-change evidence, 6748
+  bytes, mtime `2026-06-16T00:54:43-0400`;
+- `/tmp/d10-browser-network-proof.json` - same-run browser/network summary,
+  4122 bytes, mtime `2026-06-16T00:49:25-0400`;
+- `/tmp/d10-browser-network-proof.png` - browser screenshot from the same run,
+  389355 bytes, mtime `2026-06-16T00:49:25-0400`.
+- `/tmp/d10-game-status.json`, `/tmp/d10-game-health.json`,
+  `/tmp/d10-daemon-health.json`, `/tmp/d10-vite-listener.txt`, and
+  `/tmp/d10-daemon-listener.txt` - preflight/surface proof artifacts, mtimes
+  `2026-06-16T00:52:56-0400` through `2026-06-16T00:52:59-0400`.
+
+Accepted L1-L7 observations:
+
+| ID | Result | Evidence |
+| --- | --- | --- |
+| L1 initial subscribe | passed | `/tmp/d10-live-watch-1.sse` contains `hello` with `serverInstanceId: "studio-server-mqg5sfqo-agj-1"`, `serverStartedAt: "2026-06-16T04:45:34.512Z"`, `observedAt: "2026-06-16T04:45:59.116Z"`. |
+| L2 first live-game | passed | Same stream contains `live-game` with `status: "ok"`, `turn: 1`, `seed: -928103809`, `snapshotId: "status:1:ab1139ae"`, `bindingStatus: "unbound-runtime"`, `failureCount: 0`. |
+| L3 reconnect replay | passed | `/tmp/d10-live-watch-2.sse` opened after L2 and contains `hello` at `2026-06-16T04:46:17.186Z` followed by the retained `live-game` with `snapshotId: "status:1:ab1139ae"` and observedAt `2026-06-16T04:45:42.519Z`. |
+| L4 quiet unchanged key | passed | `/tmp/d10-live-watch-1.sse` emitted one replayed `live-game` with stable key `ok:status:1:ab1139ae`; from `hello.observedAt` `2026-06-16T04:45:59.116Z` until bounded stream close at file mtime `2026-06-16T00:46:09-0400`, no duplicate unchanged-key `live-game` appeared. `/tmp/d10-live-watch-2.sse` repeated the same retained key from `hello.observedAt` `2026-06-16T04:46:17.186Z` until stream close at `2026-06-16T00:46:27-0400`. Each window exceeds two 3000ms watcher intervals plus margin. |
+| L5 changed state | passed | `/tmp/d10-live-turn-change-summary.json` records trigger `node packages/cli/bin/run.js game autoplay --action start --turns 1 --json --wait-timeout-ms 30000`, exit `0`, started `2026-06-16T04:53:56.176Z`, completed `2026-06-16T04:54:10.638Z`; `/tmp/d10-live-watch-turn-change.sse` changed from `turn: 34`, `snapshotId: "status:34:443ccd4c"`, `autoplayActive: false` to `turn: 35`, `snapshotId: "status:35:f6bb1f45"`, `autoplayActive: true` at `2026-06-16T04:54:21.182Z`. `/tmp/d10-live-watch-current.sse` separately shows live runtime progression `turn: 24 -> 25 -> 26`. |
+| L6 runtime/source path | passed | Live stream was produced by daemon `runtimeMode: "studio-daemon-effect-orpc"`; source composition shows `apps/mapgen-studio/src/server/daemon/daemon.ts` calls `createStudioRpcHandler(context, { liveGameWatch: {} })`, `packages/studio-server/src/handler.ts` ensures `StudioLiveGameWatcher` before handling `/rpc`, `packages/studio-server/src/runtime.ts` composes `StudioLiveGameWatcher` with `Civ7TunerClient`, `Civ7TunerSessionLive`, and `StudioEventHubLive`, and `packages/studio-server/src/liveGame/watcher.ts` publishes only when `liveGameStateKey` changes. |
+| L7 browser no-background-cadence | passed | `/tmp/d10-browser-network-proof.json` records title `MapGen Studio`, body text `Ready. Live Civ7 turn 2 seed -928103809`, one `/rpc/studio/events/watch` request/response with `text/event-stream`, one allowed `/rpc/civ7/live/snapshot`, one allowed `/rpc/civ7/setupConfig`, no request failures, and no `civ7.live.status` or `readiness.current` requests during the 15-second capture. |
+
+Static gates rerun on this stack before closure:
+
+- `git diff --check` passed;
+- `bun run --cwd apps/mapgen-studio test -- test/server/daemonFetch.test.ts test/server/nxDevRunner.test.ts` passed, 13 tests;
+- `bun run nx run mapgen-studio:check --outputStyle=static` passed;
+- `bun run openspec -- validate mapgen-studio-live-game-watch --strict` passed;
+- `bun run openspec:validate` passed, 186 items;
+- `bun run habitat classify apps/mapgen-studio` required
+  `nx run mapgen-studio:check`, `nx run mapgen-studio:test`, and
+  `bun run lint`;
+- `bun run habitat classify openspec/changes/mapgen-studio-live-game-watch/workstream` required `bun run lint`;
+- `bun run nx run mapgen-studio:test --outputStyle=static` passed, 50 files
+  and 247 tests;
+- `bun run lint` passed with the existing `doc-ambiguity` advisory only.
+
+Proof-audit disposition:
+
+| Finding | Severity | Disposition |
+| --- | --- | --- |
+| Authoritative records still showed task 5.8 and live proof open. | P1 | accepted-repaired: `tasks.md`, `testing-ledger.md`, `closure-checklist.md`, `phase-record.md`, `next-packet.md`, and `live-proof-plan.md` now promote the accepted proof and preserve proof boundaries. |
+| Quiet-window timestamps and stable key were not explicit enough. | P2 | accepted-repaired: L4 now names the stable key, stream start markers, close mtimes, and the no-duplicate condition across two bounded windows. |
+| L5 changed-state criterion was ambiguous when only autoplay/snapshot state changed. | P2 | accepted-repaired: a second turn-change capture proves `turn: 34 -> 35` after the recorded autoplay trigger. |
+| Preflight, run identity, static gates, and daemon/run surfaces needed artifact pointers. | P2 | accepted-repaired: the ledger now names branch/commit/status, `/tmp/d10-game-status.json`, `/tmp/d10-game-health.json`, `/tmp/d10-daemon-health.json`, listener captures, exact dev command, and current static gates. |
+| Browser proof needed concise L7 summary. | P3 | accepted-repaired: L7 names the browser/network JSON and screenshot evidence. |
+
 ## Notes
 
 - The production watcher source-composition test is intentionally source-shape
   proof, not live shared-socket proof. It proves no direct-control bypass or
   internal session owner exists in `liveGame/watcher.ts`, and that runtime
   composition uses the named `Civ7TunerClient`/`Civ7TunerSession` layers.
-- Live shared-socket behavior remains a D12 live game-door proof item.
+- Live shared-socket instrumentation is not claimed here. L6 pairs live stream
+  output with source-composition proof for the current daemon/runtime path.


### PR DESCRIPTION
Adds environment variable overrides for Studio dev server ports (`STUDIO_DAEMON_PORT`, `STUDIO_DEV_PORT`, `STUDIO_DEV_RPC_TARGET`) so that parallel worktrees or CI environments can run isolated Studio instances without port conflicts. The daemon's `parseStudioDaemonArgs` now reads `STUDIO_DAEMON_PORT` from the environment when no `--port` flag is supplied, and `vite.config.ts` reads `STUDIO_DEV_PORT` for the Vite dev server port. Both sites share the same integer validation logic (1–65535) and throw a descriptive error on invalid input. CLI `--port` flags continue to take precedence over the environment variable.

Tests cover the new env-override path and confirm that an explicit `--port` argument wins over `STUDIO_DAEMON_PORT`. A source-shape test asserts that both `STUDIO_DAEMON_PORT` and `STUDIO_DEV_PORT`/`STUDIO_DEV_RPC_TARGET` are present in their respective source files.

The D10 live-game watcher proof (task 5.8) was executed on this branch using isolated ports (`STUDIO_DAEMON_PORT=5274`, `STUDIO_DEV_PORT=5273`) against a tuner-ready local Civ7 session. The proof confirmed `hello` and first retained `live-game` events, reconnect replay, unchanged-key quiet behavior, and a changed live-game state after an autoplay trigger advancing turn 34 → 35, along with browser event-stream consumption free of background live-status or readiness cadence. Workstream documents (`tasks.md`, `closure-checklist.md`, `phase-record.md`, `next-packet.md`, `live-proof-plan.md`, `testing-ledger.md`) are updated to record the accepted evidence and close task 5.8.