### PR TITLE
`fix(studio-server): serialize tuner session use calls with semaphore and improve error cause diagnostics`

### DIFF
--- a/apps/mapgen-studio/test/server/tunerSession.test.ts
+++ b/apps/mapgen-studio/test/server/tunerSession.test.ts
@@ -56,6 +56,29 @@ describe("Civ7TunerSession (Effect scoped shared session)", () => {
     expect(await waitForFin(tuner)).toBe(true);
   });
 
+  test("serializes use calls over the shared session", async () => {
+    const tuner = await startFakeTuner();
+    const { runtime, service } = await makeRuntime(tuner.port);
+    cleanups.push(() => runtime.dispose());
+
+    let active = 0;
+    let maxActive = 0;
+    const run = () =>
+      runtime.runPromise(
+        service.use(async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          active -= 1;
+          return true;
+        })
+      );
+
+    await Promise.all([run(), run(), run()]);
+
+    expect(maxActive).toBe(1);
+  });
+
   test("gate: fails fast after the threshold, half-opens after cooldown, resets on success", async () => {
     const tuner = await startFakeTuner();
     const { runtime, service } = await makeRuntime(tuner.port, {

--- a/packages/studio-server/src/ports/Civ7WorkflowControl.ts
+++ b/packages/studio-server/src/ports/Civ7WorkflowControl.ts
@@ -350,10 +350,21 @@ function boundedDiagnosticValue(value: unknown): StudioBoundedDiagnosticValue {
 
 function diagnosticString(value: unknown): string | undefined {
   if (value === undefined) return undefined;
-  if (value instanceof Error && value.message) return value.message;
+  if (value instanceof Error && value.message) {
+    const cause = errorCause(value);
+    const causeMessage = cause === undefined ? undefined : diagnosticString(cause);
+    if (!causeMessage) return value.message;
+    return value.message === "An unknown error occurred in Effect.tryPromise"
+      ? causeMessage
+      : `${value.message}: ${causeMessage}`;
+  }
   try {
     return JSON.stringify(value);
   } catch {
     return String(value);
   }
+}
+
+function errorCause(value: Error): unknown {
+  return (value as Error & { cause?: unknown }).cause;
 }

--- a/packages/studio-server/src/runtime.ts
+++ b/packages/studio-server/src/runtime.ts
@@ -59,7 +59,7 @@ export function makeStudioRuntime(
   const eventHubLayer = StudioEventHubLive;
   const operationRuntimeLayer = makeStudioOperationRuntimeLayer({
     ports: context.operationRuntime,
-  }).pipe(Layer.provide(civ7TunerSessionLayer));
+  });
   const liveGameWatcherLayer =
     options.liveGameWatch === undefined
       ? Layer.empty
@@ -73,11 +73,9 @@ export function makeStudioRuntime(
     Layer.mergeAll(liveGameWatcherLayer, operationRuntimeLayer),
     eventHubLayer
   );
-  const layer = Layer.mergeAll(
-    civ7TunerSessionLayer,
-    civ7TunerClientLayer,
-    Layer.succeed(StudioConfig, context),
-    eventHubOwnedLayer
+  const layer = Layer.provideMerge(
+    Layer.mergeAll(civ7TunerClientLayer, Layer.succeed(StudioConfig, context), eventHubOwnedLayer),
+    civ7TunerSessionLayer
   );
   return ManagedRuntime.make(layer) as unknown as StudioRuntime;
 }

--- a/packages/studio-server/src/services/Civ7TunerSession.ts
+++ b/packages/studio-server/src/services/Civ7TunerSession.ts
@@ -92,30 +92,33 @@ const make = (
       (s) => Effect.promise(() => s.close())
     );
     const gateOpenUntil = yield* Ref.make(0);
+    const useGate = yield* Effect.makeSemaphore(1);
 
     const use = <A>(run: (o: { readonly session: Civ7DirectControlSession }) => Promise<A>) =>
-      Effect.gen(function* () {
-        const now = yield* Clock.currentTimeMillis;
-        const openUntil = yield* Ref.get(gateOpenUntil);
-        if (now < openUntil) {
-          return yield* new Civ7TunerBackoffError({
-            consecutiveResponseTimeouts: session.stats.consecutiveResponseTimeouts,
-            retryAtMs: openUntil,
-          });
-        }
-        return yield* Effect.tryPromise(() => run({ session })).pipe(
-          Effect.tapError(() =>
-            // The session's counter only moves on response-timeouts (the
-            // wedge/busy signature) — connection-refused (game not running)
-            // stays un-gated so readiness keeps reporting fast.
-            session.stats.consecutiveResponseTimeouts >= threshold
-              ? Effect.flatMap(Clock.currentTimeMillis, (at) =>
-                  Ref.set(gateOpenUntil, at + cooldownMs)
-                )
-              : Effect.void
-          )
-        );
-      });
+      useGate.withPermits(1)(
+        Effect.gen(function* () {
+          const now = yield* Clock.currentTimeMillis;
+          const openUntil = yield* Ref.get(gateOpenUntil);
+          if (now < openUntil) {
+            return yield* new Civ7TunerBackoffError({
+              consecutiveResponseTimeouts: session.stats.consecutiveResponseTimeouts,
+              retryAtMs: openUntil,
+            });
+          }
+          return yield* Effect.tryPromise(() => run({ session })).pipe(
+            Effect.tapError(() =>
+              // The session's counter only moves on response-timeouts (the
+              // wedge/busy signature) — connection-refused (game not running)
+              // stays un-gated so readiness keeps reporting fast.
+              session.stats.consecutiveResponseTimeouts >= threshold
+                ? Effect.flatMap(Clock.currentTimeMillis, (at) =>
+                    Ref.set(gateOpenUntil, at + cooldownMs)
+                  )
+                : Effect.void
+            )
+          );
+        })
+      );
 
     const health = Effect.gen(function* () {
       const openUntil = yield* Ref.get(gateOpenUntil);

--- a/packages/studio-server/test/handler.test.ts
+++ b/packages/studio-server/test/handler.test.ts
@@ -111,7 +111,12 @@ describe("studio-server RPC handler", () => {
       }),
     });
     const client = await listenWithClient(context);
-    const run = await client.runInGame.start({ recipeId: "mod-swooper-maps/standard" });
+    const run = await client.runInGame.start({
+      recipeId: "mod-swooper-maps/standard",
+      seed: 43,
+      mapSize: "MAPSIZE_STANDARD",
+      config: {},
+    });
 
     const { error } = await safe(
       client.mapConfigs.saveDeploy({ requestId: "save-1", id: "test-config", envelope: {} })
@@ -244,7 +249,12 @@ describe("studio-server RPC handler", () => {
       .poll(async () => (await client.mapConfigs.status({ requestId: save.requestId })).phase)
       .toBe("complete");
 
-    const run = await client.runInGame.start({ recipeId: "mod-swooper-maps/standard" });
+    const run = await client.runInGame.start({
+      recipeId: "mod-swooper-maps/standard",
+      seed: 43,
+      mapSize: "MAPSIZE_STANDARD",
+      config: {},
+    });
     const runEvent = await readOperationEvent(
       iterator,
       (event) => event.kind === "run-in-game" && event.status.requestId === run.requestId

--- a/packages/studio-server/test/workflowSessionGraph.test.ts
+++ b/packages/studio-server/test/workflowSessionGraph.test.ts
@@ -31,7 +31,7 @@ describe("Studio workflow session graph", () => {
     expect(operationRuntime).toContain("Civ7WorkflowControlLive");
     expect(operationRuntime).toContain("Civ7TunerSession");
     expect(runtime).toContain("const civ7TunerSessionLayer = Civ7TunerSessionLive");
-    expect(runtime).toContain(".pipe(Layer.provide(civ7TunerSessionLayer))");
+    expect(runtime).not.toContain(".pipe(Layer.provide(civ7TunerSessionLayer))");
   });
 
   test("workflow control consumes an externally supplied tuner session service", async () => {


### PR DESCRIPTION
Wraps all `Civ7TunerSession.use` calls in a semaphore so that concurrent callers are serialized rather than allowed to overlap on the shared session. A test is added to verify that the maximum concurrency observed across parallel `use` calls is exactly 1.

The `civ7TunerSessionLayer` dependency wiring is updated to use `Layer.provideMerge` so the session layer is correctly shared as a single instance across all consumers, rather than being duplicated by `Layer.mergeAll`. The `operationRuntimeLayer` no longer explicitly provides `civ7TunerSessionLayer` since it is now inherited through the merged layer graph.

Error cause chaining is improved in `diagnosticString`: when an `Error` has a `.cause`, the cause's message is appended to the diagnostic output. The generic `"An unknown error occurred in Effect.tryPromise"` wrapper message is suppressed in favor of the underlying cause message directly.