### PR TITLE
`fix(mod-swooper-maps): restore projected coast terrain after adapter maintenance and track source coast mask separately from policy additions`

### DIFF
--- a/docs/system/libs/mapgen/reference/domains/MORPHOLOGY.md
+++ b/docs/system/libs/mapgen/reference/domains/MORPHOLOGY.md
@@ -66,7 +66,7 @@ MORPHOLOGY is **tile-first**: its canonical “truth” products are tile-indexe
 **Ground truth anchors**
 
 - `mods/mod-swooper-maps/src/recipes/standard/projection-policies/noWaterDrift.ts` (`assertNoWaterDrift`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.ts` (stamps `TERRAIN_COAST` from `coastlineMetrics.coastalWater || coastlineMetrics.shelfMask`, guarded by `assertNoWaterDrift`)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.ts` (seeds source coast from `coastlineMetrics.coastalWater || coastlineMetrics.shelfMask`, applies the Civ7 compatibility coast policy, then guards with `assertNoWaterDrift`)
 - `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotContinents.ts` (`context.adapter.stampContinents`, `assertNoWaterDrift`)
 - `mods/mod-swooper-maps/src/recipes/standard/stages/map-elevation/steps/buildElevation.ts` (`context.adapter.buildElevation`, `assertNoWaterDrift`)
 
@@ -222,7 +222,8 @@ Fields:
 
 - `mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts.ts` (`MorphologyCoastlineMetricsArtifactSchema`)
 - `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.ts` (`computeDistanceToCoast`, publishing `coastlineMetrics`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.ts` (projection uses `coastlineMetrics` derived from Morphology truth; no Civ `expandCoasts`)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.ts` (projection uses `coastlineMetrics` derived from Morphology truth, then records the Civ7 compatibility coast-band additions separately)
+- `mods/mod-swooper-maps/src/recipes/standard/projection-policies/coastProjectionParity.ts` (re-applies the declared coast/ocean water class after adapter maintenance can rewrite terrain)
 
 ### `artifact:morphology.volcanoes` (truth-only intent; tile space; immutable-at-F2)
 
@@ -558,10 +559,32 @@ Applies Morphology truth into the engine adapter (terrain/features), and emits e
 
 - `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/index.ts` (`steps` ordering)
 - `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.contract.ts` (`PlotCoastsStepContract.provides`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotContinents.contract.ts` (`PlotContinentsStepContract.requires/provides`)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotContinents.contract.ts` (`PlotContinentsStepContract.requires/provides`; requires `artifact:map.morphology.coastClassification` so terrain maintenance cannot leave stale coast/ocean classes)
 - `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotMountains.contract.ts` (`PlotMountainsStepContract.requires/provides`)
 - `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotVolcanoes.contract.ts` (`PlotVolcanoesStepContract.requires/provides`)
 - `mods/mod-swooper-maps/src/recipes/standard/stages/map-elevation/steps/buildElevation.contract.ts` (`BuildElevationStepContract.requires/provides`)
+
+**Coast terrain maintenance invariant**
+
+`artifact:map.morphology.coastClassification.waterClass` is the declared
+projection surface for topography-water coast/ocean terrain after `plot-coasts`.
+It is intentionally a post-policy engine surface, not a synonym for
+`artifact:morphology.coastlineMetrics.shelfMask`. The exact pre-policy source
+selection is
+`artifact:map.morphology.coastClassification.sourceCoastMask`, where a water
+tile is selected when `coastalWater || shelfMask`; policy-only additions are
+reported in `policyCoastMask`. Therefore `shelfMask` must be a subset of source
+coast selection, source coast selection must be a subset of stamped coast
+terrain, and stamped coast terrain may be wider than shelf water because of
+coastal-water adjacency and Civ7 compatibility promotion.
+Any later adapter-owned terrain maintenance boundary that may rewrite coast or
+ocean terrain must consume that artifact and restore the declared coast/ocean
+terrain class before publishing a downstream terrain snapshot or effect relied
+on by placement/resource/start planning. This applies at the current
+`plot-continents`, `map-rivers/plot-rivers`, and
+`placement/prepare-placement-surface` validation boundaries. Land-class terrain
+remains owned by the mountain, volcano, natural-wonder, and other land
+projection steps.
 
 ### Drift notes (only where it affects the contract surface)
 

--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -836,6 +836,7 @@ function buildTerrainProjectionEvidence(
       "width",
       "height",
       "baseWaterClass",
+      "sourceCoastMask",
       "waterClass",
       "policyCoastMask",
       "coastBufferTiles",

--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -402,6 +402,7 @@ export type TerrainMorphologyProjectionRowContext = Readonly<{
 
 export type TerrainMapMorphologyCoastPolicyRowContext = Readonly<{
   baseWaterClass: number | null;
+  sourceCoastMask: number | null;
   waterClass: number | null;
   policyCoastMask: number | null;
   coastBufferTiles: number | null;
@@ -1737,6 +1738,7 @@ function terrainProjectionRowContext(
     mapMorphologyCoastPolicy: mapMorphologyCoastPolicy
       ? {
           baseWaterClass: indexedInteger(mapMorphologyCoastPolicy.baseWaterClass, plotIndex),
+          sourceCoastMask: indexedInteger(mapMorphologyCoastPolicy.sourceCoastMask, plotIndex),
           waterClass: indexedInteger(mapMorphologyCoastPolicy.waterClass, plotIndex),
           policyCoastMask: indexedInteger(mapMorphologyCoastPolicy.policyCoastMask, plotIndex),
           coastBufferTiles: finiteInteger(mapMorphologyCoastPolicy.coastBufferTiles),

--- a/mods/mod-swooper-maps/src/recipes/standard/projection-policies/coastProjectionParity.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/projection-policies/coastProjectionParity.ts
@@ -1,0 +1,131 @@
+import { COAST_TERRAIN, type ExtendedMapContext, OCEAN_TERRAIN } from "@swooper/mapgen-core";
+
+const WATER_CLASS_COAST = 1;
+const WATER_CLASS_OCEAN = 2;
+const DEFAULT_SAMPLE_LIMIT = 16;
+
+export interface CoastClassificationSurface {
+  width: number;
+  height: number;
+  waterClass: Uint8Array;
+}
+
+export interface CoastProjectionRepairSample {
+  index: number;
+  x: number;
+  y: number;
+  expectedTerrain: number;
+  actualTerrain: number;
+}
+
+export interface CoastProjectionRepairReport {
+  label: string;
+  width: number;
+  height: number;
+  repairedCount: number;
+  coastRepairCount: number;
+  oceanRepairCount: number;
+  samples: CoastProjectionRepairSample[];
+}
+
+function validateCoastSurface(
+  context: ExtendedMapContext,
+  coastClassification: CoastClassificationSurface,
+  label: string
+): void {
+  const { width, height } = context.dimensions;
+  const size = Math.max(0, (width | 0) * (height | 0));
+  if ((coastClassification.width | 0) !== (width | 0)) {
+    throw new Error(
+      `[${label}] coastClassification width ${coastClassification.width} does not match ${width}.`
+    );
+  }
+  if ((coastClassification.height | 0) !== (height | 0)) {
+    throw new Error(
+      `[${label}] coastClassification height ${coastClassification.height} does not match ${height}.`
+    );
+  }
+  if (!(coastClassification.waterClass instanceof Uint8Array)) {
+    throw new Error(`[${label}] coastClassification.waterClass must be a Uint8Array.`);
+  }
+  if (coastClassification.waterClass.length !== size) {
+    throw new Error(
+      `[${label}] coastClassification.waterClass length ${coastClassification.waterClass.length} does not match ${size}.`
+    );
+  }
+}
+
+function expectedTerrainForWaterClass(waterClass: number): number | null {
+  if (waterClass === WATER_CLASS_COAST) return COAST_TERRAIN;
+  if (waterClass === WATER_CLASS_OCEAN) return OCEAN_TERRAIN;
+  return null;
+}
+
+/**
+ * Restores the declared map-morphology water terrain surface after adapter-owned
+ * maintenance calls such as validateAndFixTerrain(). Land terrain is deliberately
+ * skipped so mountains, hills, volcanoes, and natural-wonder terrain remain owned
+ * by their projection steps.
+ */
+export function restoreProjectedCoastTerrain(
+  context: ExtendedMapContext,
+  coastClassification: CoastClassificationSurface,
+  label: string,
+  options: { sampleLimit?: number } = {}
+): CoastProjectionRepairReport {
+  validateCoastSurface(context, coastClassification, label);
+
+  const { width, height } = context.dimensions;
+  const sampleLimit = Math.max(0, options.sampleLimit ?? DEFAULT_SAMPLE_LIMIT);
+  let repairedCount = 0;
+  let coastRepairCount = 0;
+  let oceanRepairCount = 0;
+  const samples: CoastProjectionRepairSample[] = [];
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const index = y * width + x;
+      const expectedTerrain = expectedTerrainForWaterClass(
+        coastClassification.waterClass[index] | 0
+      );
+      if (expectedTerrain == null) continue;
+
+      const actualTerrain = context.adapter.getTerrainType(x, y) | 0;
+      if (actualTerrain === expectedTerrain) continue;
+
+      context.adapter.setTerrainType(x, y, expectedTerrain);
+      repairedCount += 1;
+      if (expectedTerrain === COAST_TERRAIN) coastRepairCount += 1;
+      if (expectedTerrain === OCEAN_TERRAIN) oceanRepairCount += 1;
+      if (samples.length < sampleLimit) {
+        samples.push({ index, x, y, expectedTerrain, actualTerrain });
+      }
+    }
+  }
+
+  if (repairedCount > 0) {
+    context.adapter.storeWaterData();
+    const payload = {
+      type: "map.projection.coastTerrainRestored",
+      label,
+      width,
+      height,
+      repairedCount,
+      coastRepairCount,
+      oceanRepairCount,
+      samples,
+    };
+    context.trace.event(() => payload);
+    console.log(`[SWOOPER_MOD] COAST_TERRAIN_RESTORED_V1 ${JSON.stringify(payload)}`);
+  }
+
+  return {
+    label,
+    width,
+    height,
+    repairedCount,
+    coastRepairCount,
+    oceanRepairCount,
+    samples,
+  };
+}

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/artifacts.ts
@@ -8,6 +8,10 @@ const MapMorphologyCoastClassificationArtifactSchema = Type.Object(
       description:
         "Pre-policy water class derived from Morphology truth (0=land, 1=coast, 2=ocean).",
     }),
+    sourceCoastMask: TypedArraySchemas.u8({
+      description:
+        "Pre-policy mask of water tiles selected for coast projection from coastlineMetrics coastalWater or shelfMask.",
+    }),
     waterClass: TypedArraySchemas.u8({
       description:
         "Post-policy water class stamped into engine terrain (0=land, 1=coast, 2=ocean).",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.ts
@@ -37,15 +37,16 @@ export default createStep(PlotCoastsStepContract, {
 
     // 0=land, 1=coast, 2=ocean
     const baseWaterClass = new Uint8Array(size);
+    const sourceCoastMask = new Uint8Array(size);
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
         const idx = y * width + x;
-        // Coasts are shallow shelf water derived from Morphology truth (our analogue of Civ's
-        // validateAndFixTerrain + expandCoasts pipeline). We intentionally avoid Civ's coast expansion.
+        // The source mask is Morphology truth; the later policy pass is a separate engine-compatibility band.
         const isLand = topography.landMask[idx] === 1;
         const isCoast =
           !isLand &&
           (coastlineMetrics.coastalWater[idx] === 1 || coastlineMetrics.shelfMask[idx] === 1);
+        if (isCoast) sourceCoastMask[idx] = 1;
         baseWaterClass[idx] = isLand
           ? WATER_CLASS_LAND
           : isCoast
@@ -65,6 +66,7 @@ export default createStep(PlotCoastsStepContract, {
       width,
       height,
       baseWaterClass,
+      sourceCoastMask,
       waterClass,
       policyCoastMask: coastPolicy.policyCoastMask,
       coastBufferTiles: coastPolicy.coastBufferTiles,
@@ -114,16 +116,56 @@ export default createStep(PlotCoastsStepContract, {
       format: "u8",
       values: waterClass,
       meta: defineVizMeta("map.morphology.coasts.waterClass", {
-        label: "Water Class (Stamped)",
+        label: "Water Class (Engine Policy)",
         group: GROUP_MAP_MORPHOLOGY,
         description:
-          "What the engine actually receives after Morphology coast projection (0=land, 1=coast, 2=ocean).",
+          "Post-policy water class stamped into engine terrain (0=land, 1=coast, 2=ocean). This includes source coast tiles plus Civ7 compatibility coast-band promotions.",
         role: "membership",
         palette: "categorical",
         categories: [
           { value: 0, label: "Land", color: [156, 163, 175, 200] },
           { value: 1, label: "Coast", color: [56, 189, 248, 235] },
           { value: 2, label: "Ocean", color: [37, 99, 235, 235] },
+        ],
+      }),
+    });
+    context.viz?.dumpGrid(context.trace, {
+      dataTypeKey: "map.morphology.coasts.sourceCoastMask",
+      spaceId: TILE_SPACE_ID,
+      dims: { width, height },
+      format: "u8",
+      values: sourceCoastMask,
+      meta: defineVizMeta("map.morphology.coasts.sourceCoastMask", {
+        label: "Source Coast Mask",
+        group: GROUP_MAP_MORPHOLOGY,
+        description:
+          "Pre-policy water tiles selected for coast terrain from coastlineMetrics coastalWater or shelfMask.",
+        visibility: "default",
+        role: "membership",
+        palette: "categorical",
+        categories: [
+          { value: 0, label: "Not source coast", color: [15, 23, 42, 40] },
+          { value: 1, label: "Source coast", color: [14, 165, 233, 235] },
+        ],
+      }),
+    });
+    context.viz?.dumpGrid(context.trace, {
+      dataTypeKey: "map.morphology.coasts.policyCoastMask",
+      spaceId: TILE_SPACE_ID,
+      dims: { width, height },
+      format: "u8",
+      values: coastPolicy.policyCoastMask,
+      meta: defineVizMeta("map.morphology.coasts.policyCoastMask", {
+        label: "Policy Coast Additions",
+        group: GROUP_MAP_MORPHOLOGY,
+        description:
+          "Ocean tiles promoted to coast by the Civ7 compatibility policy after source coast selection.",
+        visibility: "debug",
+        role: "membership",
+        palette: "categorical",
+        categories: [
+          { value: 0, label: "Not policy-added", color: [15, 23, 42, 40] },
+          { value: 1, label: "Policy-added coast", color: [125, 211, 252, 235] },
         ],
       }),
     });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotContinents.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotContinents.contract.ts
@@ -10,7 +10,7 @@ const PlotContinentsStepContract = defineStep({
   requires: [MAP_PROJECTION_EFFECT_TAGS.map.coastsPlotted],
   provides: [MAP_PROJECTION_EFFECT_TAGS.map.continentsPlotted],
   artifacts: {
-    requires: [morphologyArtifacts.topography],
+    requires: [morphologyArtifacts.topography, mapMorphologyArtifacts.coastClassification],
     provides: [mapMorphologyArtifacts.continentValidationTerrainSnapshot],
   },
   schema: Type.Object({}),

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotContinents.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotContinents.ts
@@ -1,5 +1,6 @@
 import { defineVizMeta, logLandmassAscii, snapshotEngineHeightfield } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
+import { restoreProjectedCoastTerrain } from "../../../projection-policies/coastProjectionParity.js";
 import { assertWaterDriftWithinPolicy } from "../../../projection-policies/noWaterDrift.js";
 import { mapMorphologyArtifacts } from "../artifacts.js";
 import PlotContinentsStepContract from "./plotContinents.contract.js";
@@ -13,11 +14,13 @@ export default createStep(PlotContinentsStepContract, {
   }),
   run: (context, _config, _ops, deps) => {
     const topography = deps.artifacts.topography.read(context);
+    const coastClassification = deps.artifacts.coastClassification.read(context);
     const { width, height } = context.dimensions;
 
     context.adapter.validateAndFixTerrain();
     context.adapter.recalculateAreas();
     context.adapter.stampContinents();
+    restoreProjectedCoastTerrain(context, coastClassification, "map-morphology/plot-continents");
 
     const physics = context.buffers.heightfield;
     const engine = snapshotEngineHeightfield(context);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.contract.ts
@@ -3,6 +3,7 @@ import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { MAP_PROJECTION_EFFECT_TAGS } from "../../../tag-contracts.js";
 import { hydrologyHydrographyArtifacts } from "../../hydrology-hydrography/artifacts.js";
+import { mapMorphologyArtifacts } from "../../map-morphology/artifacts.js";
 import { mapRiversArtifacts } from "../artifacts.js";
 
 const PlotRiversStepConfigSchema = Type.Object(
@@ -27,6 +28,7 @@ const PlotRiversStepContract = defineStep({
       hydrologyHydrographyArtifacts.hydrography,
       hydrologyHydrographyArtifacts.lakePlan,
       hydrologyHydrographyArtifacts.riverNetworkMetrics,
+      mapMorphologyArtifacts.coastClassification,
     ],
     provides: [
       mapRiversArtifacts.projectedNavigableRivers,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.ts
@@ -14,6 +14,7 @@ import {
   snapshotEngineHeightfield,
 } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
+import { restoreProjectedCoastTerrain } from "../../../projection-policies/coastProjectionParity.js";
 import { mapRiversArtifacts } from "../artifacts.js";
 import PlotRiversStepContract from "./plotRivers.contract.js";
 
@@ -121,6 +122,7 @@ export default createStep(PlotRiversStepContract, {
     const hydrography = deps.artifacts.hydrography.read(context);
     const lakePlan = deps.artifacts.lakePlan.read(context);
     const riverNetworkMetrics = deps.artifacts.riverNetworkMetrics.read(context);
+    const coastClassification = deps.artifacts.coastClassification.read(context);
     const { width, height } = context.dimensions;
 
     // Map-stage visualization: hydrology river fields are inputs to engine river modeling (not 1:1 with engine results).
@@ -328,6 +330,7 @@ export default createStep(PlotRiversStepContract, {
     }));
     logStats("POST-MODEL-RIVERS");
     context.adapter.validateAndFixTerrain();
+    restoreProjectedCoastTerrain(context, coastClassification, "map-rivers/plot-rivers");
     logStats("POST-VALIDATE");
     context.adapter.defineNamedRivers();
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/contract.ts
@@ -5,6 +5,7 @@ import {
   PLACEMENT_PRODUCT_EFFECT_TAGS,
 } from "../../../../tag-contracts.js";
 import { mapHydrologyArtifacts } from "../../../map-hydrology/artifacts.js";
+import { mapMorphologyArtifacts } from "../../../map-morphology/artifacts.js";
 import { placementArtifacts } from "../../artifacts.js";
 
 /**
@@ -25,7 +26,11 @@ const PreparePlacementSurfaceStepContract = defineStep({
   ],
   provides: [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.surfacePrepared],
   artifacts: {
-    requires: [mapHydrologyArtifacts.engineProjectionLakes, mapArtifacts.landmassRegionSlotByTile],
+    requires: [
+      mapHydrologyArtifacts.engineProjectionLakes,
+      mapArtifacts.landmassRegionSlotByTile,
+      mapMorphologyArtifacts.coastClassification,
+    ],
     provides: [
       placementArtifacts.placementSurfacePreparation,
       mapArtifacts.placementSurfaceValidationBoundary,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/index.ts
@@ -1,6 +1,7 @@
 import { defineVizMeta, type ExtendedMapContext } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { mapArtifacts } from "../../../../map-artifacts.js";
+import { restoreProjectedCoastTerrain } from "../../../../projection-policies/coastProjectionParity.js";
 import { placementArtifacts } from "../../artifacts.js";
 import {
   PLACEMENT_TILE_SPACE_ID,
@@ -39,6 +40,7 @@ export default createStep(PreparePlacementSurfaceStepContract, {
   run: (context, _config, _ops, deps) => {
     const engineProjectionLakes = deps.artifacts.engineProjectionLakes.read(context);
     const landmassRegionSlotByTile = deps.artifacts.landmassRegionSlotByTile.read(context);
+    const coastClassification = deps.artifacts.coastClassification.read(context);
     const { adapter, trace } = context;
     const { width, height } = context.dimensions;
     const slotByTile = landmassRegionSlotByTile.slotByTile as Uint8Array;
@@ -58,6 +60,11 @@ export default createStep(PreparePlacementSurfaceStepContract, {
     let afterValidate = beforeValidate;
     runPlacementProductStep("placement.terrain.validate", emit, () => {
       adapter.validateAndFixTerrain();
+      restoreProjectedCoastTerrain(
+        context,
+        coastClassification,
+        "placement/prepare-surface/after-validate"
+      );
       afterValidate = readTerrainValidationBoundarySnapshot(
         adapter,
         width,

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -80,6 +80,7 @@ describe("surface delta context diagnostics", () => {
           },
           mapMorphologyCoastPolicy: {
             baseWaterClass: [1, 2, 1, 0, 1, 2],
+            sourceCoastMask: [1, 0, 1, 0, 1, 0],
             waterClass: [1, 2, 1, 0, 1, 2],
             policyCoastMask: [0, 0, 0, 0, 0, 0],
             coastBufferTiles: 4,
@@ -203,6 +204,7 @@ describe("surface delta context diagnostics", () => {
         },
         mapMorphologyCoastPolicy: {
           baseWaterClass: 2,
+          sourceCoastMask: 0,
           waterClass: 2,
           policyCoastMask: 0,
           coastBufferTiles: 4,

--- a/mods/mod-swooper-maps/test/map-hydrology/lakes-runtime-fill-drift.test.ts
+++ b/mods/mod-swooper-maps/test/map-hydrology/lakes-runtime-fill-drift.test.ts
@@ -5,6 +5,7 @@ import { COAST_TERRAIN, createExtendedMapContext, FLAT_TERRAIN } from "@swooper/
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 import selectNavigableRiverTerrain from "../../src/domain/hydrology/ops/select-navigable-river-terrain/index.js";
 import lakes from "../../src/recipes/standard/stages/map-hydrology/steps/lakes.js";
+import { mapMorphologyArtifacts } from "../../src/recipes/standard/stages/map-morphology/artifacts.js";
 import plotRivers from "../../src/recipes/standard/stages/map-rivers/steps/plotRivers.js";
 import { buildTestDeps } from "../support/step-deps.js";
 
@@ -91,6 +92,16 @@ describe("map-hydrology/lakes runtime fill drift", () => {
       lakeMask: sinkLakeMask,
       plannedLakeTileCount: 1,
       sinkLakeCount: 1,
+    });
+    context.artifacts.set(mapMorphologyArtifacts.coastClassification.id, {
+      width,
+      height,
+      baseWaterClass: new Uint8Array(size),
+      sourceCoastMask: new Uint8Array(size),
+      waterClass: new Uint8Array(size),
+      policyCoastMask: new Uint8Array(size),
+      coastBufferTiles: 0,
+      promotedOceanToCoast: 0,
     });
 
     lakes.run(context as any, { projectionReadback: true }, {} as any, buildTestDeps(lakes));

--- a/mods/mod-swooper-maps/test/map-morphology/plot-coasts.test.ts
+++ b/mods/mod-swooper-maps/test/map-morphology/plot-coasts.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, it } from "bun:test";
 
 import { createMockAdapter } from "@civ7/adapter";
-import { COAST_TERRAIN, createExtendedMapContext, FLAT_TERRAIN } from "@swooper/mapgen-core";
+import {
+  COAST_TERRAIN,
+  createExtendedMapContext,
+  FLAT_TERRAIN,
+  OCEAN_TERRAIN,
+} from "@swooper/mapgen-core";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 import { mapMorphologyArtifacts } from "../../src/recipes/standard/stages/map-morphology/artifacts.js";
 import plotCoasts from "../../src/recipes/standard/stages/map-morphology/steps/plotCoasts.js";
+import plotContinents from "../../src/recipes/standard/stages/map-morphology/steps/plotContinents.js";
 import { buildTestDeps } from "../support/step-deps.js";
 
 describe("map-morphology/plot-coasts", () => {
-  it("stamps coast terrain from coastlineMetrics coastalWater || shelfMask (no Civ expandCoasts)", () => {
+  it("separates source coast selection from policy-expanded engine coast terrain", () => {
     const width = 4;
     const height = 3;
     const seed = 1234;
@@ -53,16 +59,83 @@ describe("map-morphology/plot-coasts", () => {
     expect(adapter.getTerrainType(1, 0)).toBe(COAST_TERRAIN);
     // shelfMask becomes COAST terrain
     expect(adapter.getTerrainType(2, 1)).toBe(COAST_TERRAIN);
-    // Civ7 coast classification policy can promote neighboring ocean to coast.
+    // Civ7 coast classification policy can promote neighboring ocean to coast
+    // without making that tile part of the Morphology source coast mask.
     expect(adapter.getTerrainType(2, 0)).toBe(COAST_TERRAIN);
     const coastClassification = context.artifacts.get(
       mapMorphologyArtifacts.coastClassification.id
-    ) as { baseWaterClass?: Uint8Array; waterClass?: Uint8Array } | undefined;
+    ) as
+      | {
+          baseWaterClass?: Uint8Array;
+          sourceCoastMask?: Uint8Array;
+          waterClass?: Uint8Array;
+          policyCoastMask?: Uint8Array;
+        }
+      | undefined;
     expect(coastClassification?.baseWaterClass?.[2]).toBe(2);
+    expect(coastClassification?.sourceCoastMask?.[1]).toBe(1);
+    expect(coastClassification?.sourceCoastMask?.[6]).toBe(1);
+    expect(coastClassification?.sourceCoastMask?.[2]).toBe(0);
     expect(coastClassification?.waterClass?.[2]).toBe(1);
+    expect(coastClassification?.policyCoastMask?.[2]).toBe(1);
     expect([...(coastClassification?.baseWaterClass ?? [])]).toContain(2);
 
     // expandCoasts is intentionally not invoked by this step.
     expect((adapter as any).calls?.expandCoasts?.length ?? 0).toBe(0);
+  });
+
+  it("restores shelf coast terrain after downstream terrain maintenance rewrites it", () => {
+    const width = 4;
+    const height = 3;
+    const seed = 4321;
+    const mapInfo = { GridWidth: width, GridHeight: height, MinLatitude: -60, MaxLatitude: 60 };
+    const env = {
+      seed,
+      dimensions: { width, height },
+      latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
+    };
+
+    const adapter = createMockAdapter({
+      width,
+      height,
+      mapInfo,
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
+    });
+    const context = createExtendedMapContext({ width, height }, adapter, env);
+    const size = width * height;
+    const landMask = new Uint8Array(size).fill(0);
+    landMask[0] = 1;
+
+    const coastalWater = new Uint8Array(size).fill(0);
+    coastalWater[1] = 1;
+    const shelfMask = new Uint8Array(size).fill(0);
+    const shelfIndex = 6;
+    shelfMask[shelfIndex] = 1;
+
+    context.artifacts.set("artifact:morphology.topography", { landMask });
+    context.artifacts.set("artifact:morphology.coastlineMetrics", {
+      coastalLand: new Uint8Array(size),
+      coastalWater,
+      shelfMask,
+      distanceToCoast: new Uint16Array(size),
+    });
+
+    plotCoasts.run(context as any, {}, {} as any, buildTestDeps(plotCoasts));
+    expect(adapter.getTerrainType(2, 1)).toBe(COAST_TERRAIN);
+
+    const originalValidate = adapter.validateAndFixTerrain.bind(adapter);
+    adapter.validateAndFixTerrain = () => {
+      originalValidate();
+      adapter.setTerrainType(2, 1, OCEAN_TERRAIN);
+    };
+
+    plotContinents.run(context as any, {}, {} as any, buildTestDeps(plotContinents));
+
+    expect(adapter.getTerrainType(2, 1)).toBe(COAST_TERRAIN);
+    const snapshot = context.artifacts.get(
+      mapMorphologyArtifacts.continentValidationTerrainSnapshot.id
+    ) as { terrain?: Uint8Array } | undefined;
+    expect(snapshot?.terrain?.[shelfIndex]).toBe(COAST_TERRAIN);
   });
 });

--- a/mods/mod-swooper-maps/test/map-rivers/plot-rivers-post-refresh.test.ts
+++ b/mods/mod-swooper-maps/test/map-rivers/plot-rivers-post-refresh.test.ts
@@ -11,6 +11,7 @@ import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 
 import { RIVER_CLASS_MAJOR, RIVER_CLASS_MINOR } from "../../src/domain/hydrology/index.js";
 import selectNavigableRiverTerrain from "../../src/domain/hydrology/ops/select-navigable-river-terrain/index.js";
+import { mapMorphologyArtifacts } from "../../src/recipes/standard/stages/map-morphology/artifacts.js";
 import { mapRiversArtifacts } from "../../src/recipes/standard/stages/map-rivers/artifacts.js";
 import plotRivers from "../../src/recipes/standard/stages/map-rivers/steps/plotRivers.js";
 import { buildTestDeps } from "../support/step-deps.js";
@@ -142,6 +143,16 @@ describe("map-rivers/plot-rivers", () => {
       lakeMask: new Uint8Array(size),
       plannedLakeTileCount: 0,
       sinkLakeCount: 0,
+    });
+    context.artifacts.set(mapMorphologyArtifacts.coastClassification.id, {
+      width,
+      height,
+      baseWaterClass: new Uint8Array(size),
+      sourceCoastMask: new Uint8Array(size),
+      waterClass: new Uint8Array(size),
+      policyCoastMask: new Uint8Array(size),
+      coastBufferTiles: 0,
+      promotedOceanToCoast: 0,
     });
 
     expect(adapter.getTerrainType(0, 0)).toBe(FLAT_TERRAIN);

--- a/mods/mod-swooper-maps/test/pipeline/viz-emissions.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/viz-emissions.test.ts
@@ -78,6 +78,8 @@ describe("standard pipeline viz emissions", () => {
       "morphology.shelf.capTiles",
       "morphology.routing.flowAccum",
       "map.morphology.coasts.waterClass",
+      "map.morphology.coasts.sourceCoastMask",
+      "map.morphology.coasts.policyCoastMask",
       "morphology.mountains.mountainMask",
       "hydrology.climate.rainfall",
       "hydrology.hydrography.discharge",
@@ -441,6 +443,20 @@ describe("standard pipeline viz emissions", () => {
     const waterClassMetas = metasByKey.get("map.morphology.coasts.waterClass") as any[] | undefined;
     expect(
       waterClassMetas?.some((m) => m?.visibility === "default" && m?.role === "membership")
+    ).toBe(true);
+
+    const sourceCoastMetas = metasByKey.get("map.morphology.coasts.sourceCoastMask") as
+      | any[]
+      | undefined;
+    expect(
+      sourceCoastMetas?.some((m) => m?.visibility === "default" && m?.role === "membership")
+    ).toBe(true);
+
+    const policyCoastMetas = metasByKey.get("map.morphology.coasts.policyCoastMask") as
+      | any[]
+      | undefined;
+    expect(
+      policyCoastMetas?.some((m) => m?.visibility === "debug" && m?.role === "membership")
     ).toBe(true);
 
     const projectedRiverMetas = metasByKey.get("map.rivers.projectedRiverMask") as


### PR DESCRIPTION
Introduces a `sourceCoastMask` field to the coast classification artifact that records which water tiles were selected for coast terrain directly from Morphology truth (`coastalWater || shelfMask`), keeping that distinct from tiles promoted to coast by the Civ7 compatibility policy (`policyCoastMask`). The `waterClass` surface now represents the full post-policy engine result, and the documentation invariant is updated to reflect the subset relationship: shelf mask ⊆ source coast selection ⊆ stamped coast terrain ⊆ post-policy coast terrain.

Adds `restoreProjectedCoastTerrain` in `coastProjectionParity.ts`, which walks the `waterClass` surface after any adapter-owned `validateAndFixTerrain` call and writes back the declared coast or ocean terrain class for any tile that was silently rewritten. Land-class terrain is deliberately left alone. This repair is applied at three maintenance boundaries: `map-morphology/plot-continents`, `map-rivers/plot-rivers`, and `placement/prepare-placement-surface`. The `plot-continents` contract now declares `coastClassification` as a required artifact so the dependency is explicit.

Two new visualization grids are emitted from `plot-coasts`: `map.morphology.coasts.sourceCoastMask` (default visibility) and `map.morphology.coasts.policyCoastMask` (debug visibility), making the pre- and post-policy coast layers independently inspectable. The live-parity diagnostic surface is updated to include `sourceCoastMask` in its per-tile evidence.