### PR TITLE
`fix(studio-server): suppress defined RPC errors from console and preserve rejection causes across Effect boundary`

### DIFF
--- a/packages/studio-server/src/handler.ts
+++ b/packages/studio-server/src/handler.ts
@@ -1,5 +1,5 @@
 import { type Civ7ControlOrpcContext, Civ7ControlOrpcRouter } from "@civ7/control-orpc";
-import { onError, type Router } from "@orpc/server";
+import { isDefinedError, onError, type Router } from "@orpc/server";
 import { RPCHandler } from "@orpc/server/fetch";
 import { Effect } from "effect";
 import type { StudioServerContext } from "./context.js";
@@ -89,6 +89,7 @@ export function createStudioRpcHandler(
       onError((error) => {
         // Surface unexpected (non-ORPCError) defects in the host console; expected
         // status-mapped errors flow through quietly.
+        if (isDefinedError(error)) return;
         console.error("[studio-server] rpc error", error);
       }),
     ],

--- a/packages/studio-server/src/ports/Civ7WorkflowControl.ts
+++ b/packages/studio-server/src/ports/Civ7WorkflowControl.ts
@@ -354,9 +354,7 @@ function diagnosticString(value: unknown): string | undefined {
     const cause = errorCause(value);
     const causeMessage = cause === undefined ? undefined : diagnosticString(cause);
     if (!causeMessage) return value.message;
-    return value.message === "An unknown error occurred in Effect.tryPromise"
-      ? causeMessage
-      : `${value.message}: ${causeMessage}`;
+    return `${value.message}: ${causeMessage}`;
   }
   try {
     return JSON.stringify(value);

--- a/packages/studio-server/src/router/index.ts
+++ b/packages/studio-server/src/router/index.ts
@@ -153,14 +153,14 @@ export function createStudioRouter(
       // #12 civ7.setupCatalog - host loader; error 500
       setupCatalog: oe.civ7.setupCatalog.effect(function* ({ errors }) {
         const config = yield* StudioConfig;
-        const catalog = yield* Effect.tryPromise(() => config.loadSetupCatalog()).pipe(
-          Effect.mapError((err) =>
+        const catalog = yield* Effect.tryPromise({
+          try: () => config.loadSetupCatalog(),
+          catch: (err) =>
             errors.SETUP_CATALOG_UNAVAILABLE({
               message: errorMessage(err, "Civ7 setup catalog unavailable"),
               data: { observedAt: new Date().toISOString() },
-            })
-          )
-        );
+            }),
+        });
         return { ok: true as const, catalog };
       }),
 

--- a/packages/studio-server/src/services/Civ7TunerClient.ts
+++ b/packages/studio-server/src/services/Civ7TunerClient.ts
@@ -65,7 +65,11 @@ export class Civ7TunerClient extends Effect.Service<Civ7TunerClient>()(
         setupSnapshot: () => tuner.use((o) => getCiv7SetupSnapshot({ timeoutMs, ...o })),
 
         // #11 savedConfigs — filesystem read; no tuner socket, no gate.
-        savedConfigurations: () => Effect.tryPromise(() => listCiv7SavedGameConfigurations()),
+        savedConfigurations: () =>
+          Effect.tryPromise({
+            try: () => listCiv7SavedGameConfigurations(),
+            catch: (err) => err,
+          }),
 
         // #5 live.snapshot — getCiv7MapGrid(input, { timeoutMs })
         mapGrid: (input: Parameters<typeof getCiv7MapGrid>[0]) =>

--- a/packages/studio-server/src/services/Civ7TunerSession.ts
+++ b/packages/studio-server/src/services/Civ7TunerSession.ts
@@ -1,6 +1,5 @@
 import { type Civ7DirectControlOptions, Civ7DirectControlSession } from "@civ7/direct-control";
 import { Clock, Context, Data, Effect, Layer, Ref, type Scope } from "effect";
-import type { UnknownException } from "effect/Cause";
 
 /**
  * `Civ7TunerSession` — the ONE Effect-scoped owner of the shared FireTuner
@@ -70,7 +69,7 @@ export interface Civ7TunerSessionApi {
   /** Run a direct-control promise against the shared session, behind the gate. */
   readonly use: <A>(
     run: (options: { readonly session: Civ7DirectControlSession }) => Promise<A>
-  ) => Effect.Effect<A, Civ7TunerBackoffError | UnknownException>;
+  ) => Effect.Effect<A, unknown>;
   readonly health: Effect.Effect<Civ7TunerSessionHealth>;
 }
 
@@ -105,7 +104,10 @@ const make = (
               retryAtMs: openUntil,
             });
           }
-          return yield* Effect.tryPromise(() => run({ session })).pipe(
+          return yield* Effect.tryPromise({
+            try: () => run({ session }),
+            catch: (err) => err,
+          }).pipe(
             Effect.tapError(() =>
               // The session's counter only moves on response-timeouts (the
               // wedge/busy signature) — connection-refused (game not running)

--- a/packages/studio-server/test/handler.test.ts
+++ b/packages/studio-server/test/handler.test.ts
@@ -4,7 +4,7 @@ import { RPCLink } from "@orpc/client/fetch";
 import type { RouterClient } from "@orpc/server";
 import { RPCHandler } from "@orpc/server/fetch";
 import { Effect, Layer, ManagedRuntime } from "effect";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import {
   createStudioRouter,
@@ -101,43 +101,50 @@ describe("studio-server RPC handler", () => {
   }, 10_000);
 
   test("maps runtime operation conflicts as the DEFINED SAVE_DEPLOY_BLOCKED error", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const blocker = deferred<void>();
-    const context = makeContext({
-      operationRuntime: makeOperationRuntimePorts({
-        deployRunInGame: async () => {
-          await blocker.promise;
-          return {};
-        },
-      }),
-    });
-    const client = await listenWithClient(context);
-    const run = await client.runInGame.start({
-      recipeId: "mod-swooper-maps/standard",
-      seed: 43,
-      mapSize: "MAPSIZE_STANDARD",
-      config: {},
-    });
+    try {
+      const context = makeContext({
+        operationRuntime: makeOperationRuntimePorts({
+          deployRunInGame: async () => {
+            await blocker.promise;
+            return {};
+          },
+        }),
+      });
+      const client = await listenWithClient(context);
+      const run = await client.runInGame.start({
+        recipeId: "mod-swooper-maps/standard",
+        seed: 43,
+        mapSize: "MAPSIZE_STANDARD",
+        config: {},
+      });
 
-    const { error } = await safe(
-      client.mapConfigs.saveDeploy({ requestId: "save-1", id: "test-config", envelope: {} })
-    );
-    blocker.resolve();
+      const { error } = await safe(
+        client.mapConfigs.saveDeploy({ requestId: "save-1", id: "test-config", envelope: {} })
+      );
+      blocker.resolve();
 
-    expect(error).toBeInstanceOf(ORPCError);
-    if (!(error instanceof ORPCError)) throw new Error("expected an ORPCError");
-    expect(isDefinedError(error)).toBe(true);
-    expect(error.code).toBe("SAVE_DEPLOY_BLOCKED");
-    expect(error.status).toBe(409);
-    expect(error.message).toBe(
-      "run-in-game is running; wait for it to finish before starting another Studio operation."
-    );
-    expect(error.data).toMatchObject({
-      tag: "OperationBlocked",
-      namespace: "saveDeploy",
-      reason: "active-operation-conflict",
-      activeRequestId: run.requestId,
-      diagnostics: { code: "studio-operation-active" },
-    });
+      expect(error).toBeInstanceOf(ORPCError);
+      if (!(error instanceof ORPCError)) throw new Error("expected an ORPCError");
+      expect(isDefinedError(error)).toBe(true);
+      expect(error.code).toBe("SAVE_DEPLOY_BLOCKED");
+      expect(error.status).toBe(409);
+      expect(error.message).toBe(
+        "run-in-game is running; wait for it to finish before starting another Studio operation."
+      );
+      expect(error.data).toMatchObject({
+        tag: "OperationBlocked",
+        namespace: "saveDeploy",
+        reason: "active-operation-conflict",
+        activeRequestId: run.requestId,
+        diagnostics: { code: "studio-operation-active" },
+      });
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      blocker.resolve();
+      consoleError.mockRestore();
+    }
   });
 
   test("delivers a run-in-game status miss as RUN_IN_GAME_STATUS_NOT_FOUND with the server-identity echo", async () => {

--- a/packages/studio-server/test/workflowSessionGraph.test.ts
+++ b/packages/studio-server/test/workflowSessionGraph.test.ts
@@ -10,7 +10,11 @@ import {
   type RunInGameDeployment,
   type RunInGamePreparedRequest,
 } from "../src/ports";
-import { Civ7TunerSession, type Civ7TunerSessionApi } from "../src/services/Civ7TunerSession";
+import {
+  Civ7TunerSession,
+  makeCiv7TunerSessionLayer,
+  type Civ7TunerSessionApi,
+} from "../src/services/Civ7TunerSession";
 
 describe("Studio workflow session graph", () => {
   test("workflow control depends on the runtime-owned Civ7TunerSession layer", () => {
@@ -73,5 +77,18 @@ describe("Studio workflow session graph", () => {
     );
 
     expect(useCalls).toBe(1);
+  });
+
+  test("tuner session preserves direct-control rejection causes across the Effect boundary", async () => {
+    const directControlError = new Error("Unable to reach Civ7 tuner socket on 127.0.0.1:4318");
+
+    const failure = await Effect.runPromise(
+      Effect.gen(function* () {
+        const tuner = yield* Civ7TunerSession;
+        return yield* Effect.flip(tuner.use(() => Promise.reject(directControlError)));
+      }).pipe(Effect.provide(makeCiv7TunerSessionLayer()))
+    );
+
+    expect(failure).toBe(directControlError);
   });
 });


### PR DESCRIPTION
Defined RPC errors (e.g. `SAVE_DEPLOY_BLOCKED`) are now silenced in the `onError` console logger by checking `isDefinedError` before logging, so only unexpected defects surface in the host console.

`Effect.tryPromise` calls that previously used the single-argument form (which wraps rejections in an `UnknownException`) have been switched to the `{ try, catch }` object form, passing the raw rejection through as-is. This preserves the original error cause across the Effect boundary instead of wrapping it in a generic exception. The `diagnosticString` helper's special-case for the `"An unknown error occurred in Effect.tryPromise"` message has been removed since that wrapper no longer appears. The `Civ7TunerSessionApi.use` return type has been updated from `Civ7TunerBackoffError | UnknownException` to `unknown` to reflect that the error channel now carries the raw rejection.

A new test asserts that a direct-control promise rejection is preserved as the exact error instance across the Effect boundary. The existing conflict-blocking test has been hardened with a `try/finally` to ensure the blocker is always resolved, and now also asserts that `console.error` is not called for defined errors.