### PR TITLE
chore: inline single-element JSON arrays across configs and nx.json

### DIFF
--- a/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
@@ -63,20 +63,8 @@
         "regimeMinIntensity": 4
       },
       "tectonicEras": {
-        "eraWeights": [
-          0.3,
-          0.25,
-          0.2,
-          0.15,
-          0.1
-        ],
-        "driftStepsByEra": [
-          12,
-          9,
-          6,
-          3,
-          1
-        ]
+        "eraWeights": [0.3, 0.25, 0.2, 0.15, 0.1],
+        "driftStepsByEra": [12, 9, 6, 3, 1]
       },
       "tectonicFields": {
         "beltInfluenceDistance": 8,
@@ -460,12 +448,7 @@
           "tropicalThreshold": 30
         },
         "moisture": {
-          "thresholds": [
-            90,
-            188,
-            228,
-            252
-          ]
+          "thresholds": [90, 188, 228, 252]
         },
         "aridity": {
           "temperatureMin": 0,
@@ -476,10 +459,7 @@
           "rainfallWeight": 1.08,
           "bias": 2,
           "normalization": 118,
-          "moistureShiftThresholds": [
-            0.2,
-            0.66
-          ],
+          "moistureShiftThresholds": [0.2, 0.66],
           "vegetationPenalty": 0.78
         },
         "vegetation": {
@@ -650,10 +630,7 @@
           "maxFreeze": 0.3,
           "maxVegetation": 0.23,
           "maxMoisture": 90,
-          "allowedBiomes": [
-            "desert",
-            "temperateDry"
-          ]
+          "allowedBiomes": ["desert", "temperateDry"]
         },
         "burned": {
           "minAridity": 0.52,
@@ -661,10 +638,7 @@
           "maxFreeze": 0.22,
           "maxVegetation": 0.26,
           "maxMoisture": 98,
-          "allowedBiomes": [
-            "temperateDry",
-            "tropicalSeasonal"
-          ]
+          "allowedBiomes": ["temperateDry", "tropicalSeasonal"]
         }
       },
       "plotEffectCoverage": {

--- a/nx.json
+++ b/nx.json
@@ -14,9 +14,7 @@
   ],
   "targetDefaults": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "outputs": [
         "{projectRoot}/dist/**",
         "{projectRoot}/types/**",
@@ -26,9 +24,7 @@
       "cache": true
     },
     "build:studio-recipes": {
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "outputs": [
         "{projectRoot}/dist/**",
         "{projectRoot}/mod/**",
@@ -40,9 +36,7 @@
       "dependsOn": [
         "build",
         {
-          "projects": [
-            "@mateicanavra/civ7-cli"
-          ],
+          "projects": ["@mateicanavra/civ7-cli"],
           "target": "build"
         }
       ],
@@ -52,9 +46,7 @@
       "dependsOn": [
         "build",
         {
-          "projects": [
-            "@mateicanavra/civ7-cli"
-          ],
+          "projects": ["@mateicanavra/civ7-cli"],
           "target": "build"
         }
       ],
@@ -65,38 +57,26 @@
       "continuous": true
     },
     "check": {
-      "dependsOn": [
-        "^build",
-        "^check"
-      ],
+      "dependsOn": ["^build", "^check"],
       "cache": true
     },
     "lint": {
       "cache": true
     },
     "test": {
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "cache": true
     },
     "test:studio-run-in-game": {
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "cache": true
     },
     "test:architecture-cutover": {
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "cache": true
     },
     "verify": {
-      "dependsOn": [
-        "build",
-        "^build"
-      ],
+      "dependsOn": ["build", "^build"],
       "cache": false
     },
     "clean": {

--- a/packages/studio-server/test/workflowSessionGraph.test.ts
+++ b/packages/studio-server/test/workflowSessionGraph.test.ts
@@ -12,8 +12,8 @@ import {
 } from "../src/ports";
 import {
   Civ7TunerSession,
-  makeCiv7TunerSessionLayer,
   type Civ7TunerSessionApi,
+  makeCiv7TunerSessionLayer,
 } from "../src/services/Civ7TunerSession";
 
 describe("Studio workflow session graph", () => {


### PR DESCRIPTION
Reformats multi-line arrays to single-line arrays across the map config, NX configuration, and test imports for improved readability and conciseness. Also reorders import statements in the workflow session graph test to follow alphabetical ordering.