### PR TITLE
`feat(studio-server): complete RPC boundary corpus, narrow recipeDag defect handling, and pin handler tests`

### DIFF
--- a/openspec/changes/studio-effect-rpc-boundary-completion/tasks.md
+++ b/openspec/changes/studio-effect-rpc-boundary-completion/tasks.md
@@ -1,15 +1,15 @@
 ## 1. RPC Boundary Corpus
 
-- [ ] 1.1 Enumerate READ-01 through READ-06 and LIVE-01 through LIVE-04 in the implementation phase record.
-- [ ] 1.2 Add RPC-01 `recipeDag.get` declared-error and defect coverage.
-- [ ] 1.3 Record `@civ7/control-orpc` exterior boundaries.
+- [x] 1.1 Enumerate READ-01 through READ-06 and LIVE-01 through LIVE-04 in the implementation phase record.
+- [x] 1.2 Add RPC-01 `recipeDag.get` declared-error and defect coverage.
+- [x] 1.3 Record `@civ7/control-orpc` exterior boundaries.
 
 ## 2. Implementation
 
-- [ ] 2.1 Repair router leaves and handler logging only where current tests prove a gap.
-- [ ] 2.2 Preserve `civ7.live.status` partial-success parity.
+- [x] 2.1 Repair router leaves and handler logging only where current tests prove a gap.
+- [x] 2.2 Preserve `civ7.live.status` partial-success parity.
 
 ## 3. Verification
 
-- [ ] 3.1 Run focused server tests for declared errors, defects, and `onError`.
-- [ ] 3.2 Run package build and OpenSpec validation.
+- [x] 3.1 Run focused server tests for declared errors, defects, and `onError`.
+- [x] 3.2 Run package build and OpenSpec validation.

--- a/openspec/changes/studio-effect-rpc-boundary-completion/workstream/phase-record.md
+++ b/openspec/changes/studio-effect-rpc-boundary-completion/workstream/phase-record.md
@@ -1,7 +1,22 @@
 # Phase Record: Studio Effect RPC Boundary Completion
 
-Status: scaffolded; implementation blocked until packet train acceptance.
+Status: implemented and locally verified.
 
 Normative packet: `docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/PACKET-TRAIN.md#smr-01---server-rpc-boundary-completion`.
 
 Priority rows: READ-01 through READ-06, RPC-01, LIVE-01 through LIVE-04, EB-01 through EB-04, EB-08 mapping portions, EB-16.
+
+## Implementation Notes
+
+- `recipeDag.get` now treats only `RecipeDagNotFound` and `RecipeDagUnavailable` as declared expected errors.
+- Unexpected recipe DAG exceptions remain defects and reach shared handler logging instead of being converted to `RECIPE_DAG_UNAVAILABLE`.
+- Read/live unavailable mappings are pinned by handler tests with an injected `Civ7TunerClient`.
+- `civ7.live.status` partial-error parity is pinned at 200 with per-field `{ error }` entries.
+- Merged `@civ7/control-orpc` procedures remain exterior except shared handler behavior.
+
+## Verification
+
+- `nx run @civ7/studio-server:test --outputStyle=static` passed with 72 tests.
+- `nx run @civ7/studio-server:build --outputStyle=static` passed.
+- `bun run openspec -- validate studio-effect-rpc-boundary-completion --strict` passed.
+- `bun run openspec:validate` passed with 194 items.

--- a/packages/studio-server/src/router/index.ts
+++ b/packages/studio-server/src/router/index.ts
@@ -404,13 +404,16 @@ export function createStudioRouter(
                 },
               });
             }
-            return errors.RECIPE_DAG_UNAVAILABLE({
-              data: {
-                procedureKey: "recipeDag.get",
-                recipeId: input.recipeId,
-                source: "recipe-dag-service",
-              },
-            });
+            if (err instanceof Error && err.name === "RecipeDagUnavailable") {
+              return errors.RECIPE_DAG_UNAVAILABLE({
+                data: {
+                  procedureKey: "recipeDag.get",
+                  recipeId: input.recipeId,
+                  source: "recipe-dag-service",
+                },
+              });
+            }
+            throw err;
           },
         });
       }),

--- a/packages/studio-server/test/handler.test.ts
+++ b/packages/studio-server/test/handler.test.ts
@@ -7,6 +7,7 @@ import { Effect, Layer, ManagedRuntime } from "effect";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import {
+  Civ7TunerClient,
   createStudioRouter,
   createStudioRpcHandler,
   StudioConfig,
@@ -194,6 +195,153 @@ describe("studio-server RPC handler", () => {
       serverStartedAt: "2026-06-10T00:00:00.000Z",
       diagnostics: { code: "save-deploy-request-not-found" },
     });
+  });
+
+  test("maps recipeDag.get not-found and explicit unavailable errors as defined errors without stack spam", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      const notFound = namedError("RecipeDagNotFound", "missing recipe");
+      const unavailable = namedError("RecipeDagUnavailable", "recipe DAG unavailable");
+      const client = await listenWithClient(
+        makeContext({
+          recipeDagService: {
+            getRecipeDag: async (recipeId) => {
+              if (recipeId === "missing/recipe") throw notFound;
+              if (recipeId === "unavailable/recipe") throw unavailable;
+              return recipeDagResult(recipeId);
+            },
+          },
+        })
+      );
+
+      await expect(
+        client.recipeDag.get({ recipeId: "mod-swooper-maps/standard" })
+      ).resolves.toMatchObject({
+        recipeId: "mod-swooper-maps/standard",
+        recipeKey: "mod-swooper-maps/standard",
+      });
+
+      const missing = await safe(client.recipeDag.get({ recipeId: "missing/recipe" }));
+      expect(missing.error).toBeInstanceOf(ORPCError);
+      if (!(missing.error instanceof ORPCError)) throw new Error("expected an ORPCError");
+      expect(isDefinedError(missing.error)).toBe(true);
+      expect(missing.error.code).toBe("RECIPE_DAG_RECIPE_NOT_FOUND");
+      expect(missing.error.status).toBe(404);
+      expect(missing.error.data).toEqual({
+        procedureKey: "recipeDag.get",
+        recipeId: "missing/recipe",
+      });
+
+      const failed = await safe(client.recipeDag.get({ recipeId: "unavailable/recipe" }));
+      expect(failed.error).toBeInstanceOf(ORPCError);
+      if (!(failed.error instanceof ORPCError)) throw new Error("expected an ORPCError");
+      expect(isDefinedError(failed.error)).toBe(true);
+      expect(failed.error.code).toBe("RECIPE_DAG_UNAVAILABLE");
+      expect(failed.error.status).toBe(503);
+      expect(failed.error.data).toEqual({
+        procedureKey: "recipeDag.get",
+        recipeId: "unavailable/recipe",
+        source: "recipe-dag-service",
+      });
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test("logs unexpected recipeDag.get defects exactly once instead of declaring them expected", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      const client = await listenWithClient(
+        makeContext({
+          recipeDagService: {
+            getRecipeDag: async () => {
+              throw new TypeError("recipe graph invariant exploded");
+            },
+          },
+        })
+      );
+
+      const { error } = await safe(client.recipeDag.get({ recipeId: "broken/recipe" }));
+
+      expect(error).toBeInstanceOf(ORPCError);
+      if (!(error instanceof ORPCError)) throw new Error("expected an ORPCError");
+      expect(isDefinedError(error)).toBe(false);
+      expect(error.code).not.toBe("RECIPE_DAG_UNAVAILABLE");
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError.mock.calls[0]?.[0]).toBe("[studio-server] rpc error");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test("maps read and live RPC unavailable paths to their declared statuses", async () => {
+    await withRouterCiv7Client(unavailableTunerClient("tuner unavailable"), async ({ client }) => {
+      const status = await safe(client.civ7.status({}));
+      expect(status.error).toMatchObject({
+        code: "CIV7_STATUS_UNAVAILABLE",
+        status: 500,
+      });
+
+      const mapSummary = await safe(client.civ7.mapSummary({}));
+      expect(mapSummary.error).toMatchObject({
+        code: "CIV7_MAP_SUMMARY_UNAVAILABLE",
+        status: 500,
+      });
+
+      const gameInfo = await safe(client.civ7.gameInfo({ table: "Terrains" }));
+      expect(gameInfo.error).toMatchObject({
+        code: "CIV7_GAMEINFO_FAILED",
+        status: 400,
+      });
+
+      const setupConfig = await safe(client.civ7.setupConfig({}));
+      expect(setupConfig.error).toMatchObject({
+        code: "SETUP_CONFIG_UNAVAILABLE",
+        status: 503,
+        data: { observedAt: expect.any(String) },
+      });
+
+      const snapshot = await safe(client.civ7.live.snapshot({}));
+      expect(snapshot.error).toMatchObject({
+        code: "CIV7_LIVE_SNAPSHOT_FAILED",
+        status: 400,
+      });
+
+      const entities = await safe(client.civ7.live.entities({}));
+      expect(entities.error).toMatchObject({
+        code: "CIV7_LIVE_ENTITIES_FAILED",
+        status: 400,
+      });
+
+      const liveGameInfo = await safe(client.civ7.live.gameInfo({ tables: "Terrains" }));
+      expect(liveGameInfo.error).toMatchObject({
+        code: "CIV7_LIVE_GAMEINFO_FAILED",
+        status: 400,
+      });
+    });
+  });
+
+  test("keeps civ7.live.status at 200 with per-field errors for partial tuner failures", async () => {
+    await withRouterCiv7Client(
+      {
+        ...unavailableTunerClient("unused"),
+        playableStatus: () => Effect.succeed({ playable: true, readiness: "ready" }),
+        appUiSnapshot: () => Effect.fail(new Error("app-ui down")),
+        liveMapSummary: () => Effect.succeed({ map: "visible" }),
+        autoplayStatus: () => Effect.fail("autoplay unavailable"),
+      },
+      async ({ client }) => {
+        await expect(client.civ7.live.status({})).resolves.toMatchObject({
+          ok: true,
+          playable: true,
+          status: { playable: true, readiness: "ready" },
+          appUi: { error: "Error: app-ui down" },
+          mapSummary: { map: "visible" },
+          autoplay: { error: "autoplay unavailable" },
+        });
+      }
+    );
   });
 
   test("passes non-rpc paths through for host fallback middleware", async () => {
@@ -586,6 +734,44 @@ function makeContext(overrides: Partial<StudioServerContext> = {}): StudioServer
   };
 }
 
+function namedError(name: string, message: string): Error {
+  const err = new Error(message);
+  err.name = name;
+  return err;
+}
+
+function recipeDagResult(
+  recipeId: string
+): Awaited<ReturnType<StudioServerContext["recipeDagService"]["getRecipeDag"]>> {
+  return {
+    recipeId,
+    recipeKey: recipeId,
+    title: "Test Recipe",
+    phases: [],
+    stages: [],
+    edges: [],
+    diagnostics: [],
+  };
+}
+
+function unavailableTunerClient(message: string): Civ7TunerClient {
+  const fail = () => Effect.fail(new Error(message));
+  return {
+    playableStatus: fail,
+    mapSummary: fail,
+    liveMapSummary: fail,
+    appUiSnapshot: fail,
+    autoplayStatus: fail,
+    gameInfoRows: fail,
+    setupSnapshot: fail,
+    savedConfigurations: fail,
+    mapGrid: fail,
+    playerSummary: fail,
+    unitSummary: fail,
+    citySummary: fail,
+  } as unknown as Civ7TunerClient;
+}
+
 function makeOperationRuntimePorts(
   overrides: Partial<StudioOperationRuntimePorts> = {}
 ): StudioOperationRuntimePorts {
@@ -714,6 +900,39 @@ async function withRouterEventHub<T>(
     );
 
     return await fn({ client, eventHub, runtime });
+  } finally {
+    await runtime.dispose();
+  }
+}
+
+async function withRouterCiv7Client<T>(
+  tunerClient: Civ7TunerClient,
+  fn: (args: { client: RouterClient<StudioRouter>; runtime: StudioRuntime }) => Promise<T>
+): Promise<T> {
+  const runtime = ManagedRuntime.make(
+    Layer.mergeAll(
+      Layer.succeed(Civ7TunerClient, tunerClient),
+      Layer.succeed(StudioConfig, makeContext()),
+      StudioEventHubLive,
+      Layer.succeed(StudioOperationRuntime, makeOperationRuntimeApi())
+    )
+  ) as unknown as StudioRuntime;
+  try {
+    const rpcHandler = new RPCHandler(createStudioRouter(runtime));
+    const client = createORPCClient<RouterClient<StudioRouter>>(
+      new RPCLink({
+        url: "http://studio.test/rpc",
+        fetch: async (request) => {
+          const result = await rpcHandler.handle(request, { prefix: "/rpc" });
+          if (!result.matched || !result.response) {
+            return new Response("not found", { status: 404 });
+          }
+          return result.response;
+        },
+      })
+    );
+
+    return await fn({ client, runtime });
   } finally {
     await runtime.dispose();
   }


### PR DESCRIPTION
This PR completes the RPC boundary work for the studio effect server by tightening error classification in `recipeDag.get` and adding comprehensive handler tests that pin the declared-error and defect contracts.

## Changes

### `recipeDag.get` error handling

Previously, any exception thrown by the recipe DAG service was silently converted to a `RECIPE_DAG_UNAVAILABLE` declared error, which masked genuine defects and suppressed shared handler logging. The catch block now checks the error name explicitly:

- `RecipeDagNotFound` → `RECIPE_DAG_RECIPE_NOT_FOUND` (404)
- `RecipeDagUnavailable` → `RECIPE_DAG_UNAVAILABLE` (503)
- Anything else → re-thrown as a defect, reaching the shared `onError` logger exactly once

### New handler tests

Four tests are added to `handler.test.ts` to lock in the contracts verified during this workstream:

- **Not-found and explicit unavailable** — confirms both named errors produce their correct declared-error codes and statuses, and that `console.error` is not called for expected paths.
- **Unexpected defects** — confirms a `TypeError` from the DAG service is not promoted to `RECIPE_DAG_UNAVAILABLE`, is not a defined error, and triggers exactly one `[studio-server] rpc error` log.
- **Read and live unavailable paths** — uses an injected `Civ7TunerClient` that fails every call to pin `CIV7_STATUS_UNAVAILABLE`, `CIV7_MAP_SUMMARY_UNAVAILABLE`, `CIV7_GAMEINFO_FAILED`, `SETUP_CONFIG_UNAVAILABLE`, `CIV7_LIVE_SNAPSHOT_FAILED`, `CIV7_LIVE_ENTITIES_FAILED`, and `CIV7_LIVE_GAMEINFO_FAILED` to their declared codes and HTTP statuses.
- **`civ7.live.status` partial-success parity** — confirms the endpoint stays at HTTP 200 and returns per-field `{ error }` entries for failing fields alongside successful values for passing ones.

Supporting test helpers (`namedError`, `recipeDagResult`, `unavailableTunerClient`, `withRouterCiv7Client`) are added to enable injecting a `Civ7TunerClient` layer directly into a managed runtime without going through the full context factory.

### Workstream record

All six tasks across the RPC corpus, implementation, and verification phases are marked complete. The phase record is updated to `implemented and locally verified` and documents the passing counts: 72 server tests, a clean build, and 194-item OpenSpec validation.