### PR TITLE
`feat(studio-server): classify run-in-game lifecycle failures by phase`

### DIFF
--- a/openspec/changes/studio-operation-lifecycle-failure-classification/tasks.md
+++ b/openspec/changes/studio-operation-lifecycle-failure-classification/tasks.md
@@ -1,15 +1,15 @@
 ## 1. Failure Taxonomy
 
-- [ ] 1.1 Enumerate OP-01 through OP-08 and STUDIO-01 in the phase record.
-- [ ] 1.2 Distinguish admission validation from worker/runtime failures.
-- [ ] 1.3 Define restart and cleanup terminal DTO behavior.
+- [x] 1.1 Enumerate OP-01 through OP-08 and STUDIO-01 in the phase record.
+- [x] 1.2 Distinguish admission validation from worker/runtime failures.
+- [x] 1.3 Define restart and cleanup terminal DTO behavior.
 
 ## 2. Implementation
 
-- [ ] 2.1 Repair phase-specific failure conversion only where tests prove gaps.
-- [ ] 2.2 Preserve duplicate-operation and registry-truth behavior.
+- [x] 2.1 Repair phase-specific failure conversion only where tests prove gaps.
+- [x] 2.2 Preserve duplicate-operation and registry-truth behavior.
 
 ## 3. Verification
 
-- [ ] 3.1 Run focused operation runtime and error-spine tests.
-- [ ] 3.2 Run package build and OpenSpec validation.
+- [x] 3.1 Run focused operation runtime and error-spine tests.
+- [x] 3.2 Run package build and OpenSpec validation.

--- a/openspec/changes/studio-operation-lifecycle-failure-classification/workstream/phase-record.md
+++ b/openspec/changes/studio-operation-lifecycle-failure-classification/workstream/phase-record.md
@@ -1,7 +1,61 @@
 # Phase Record: Studio Operation Lifecycle Failure Classification
 
-Status: scaffolded; implementation blocked until packet train acceptance.
+Status: implemented and verified.
 
 Normative packet: `docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/PACKET-TRAIN.md#smr-02---operation-lifecycle-failure-classification`.
 
 Priority rows: OP-01 through OP-08, STUDIO-01, EB-05 through EB-08.
+
+## Scope Boundary
+
+This packet classifies operation lifecycle failures after runtime admission. It
+does not prove that Civ7 can load `{swooper-maps}/maps/studio-current.js`; that
+live deploy/setup visibility proof remains owned by the later live Civ7 proof
+packet. The setup-row symptom is nevertheless represented here as a typed
+`ProofFailed` terminal state so the runtime no longer reports it as invalid user
+input.
+
+## Implemented Failure Mapping
+
+- OP-01 admission validation remains `InvalidRequest` before worker leaf ports
+  run.
+- OP-02 materialization worker failures map to `MaterializationFailed` with
+  `run-in-game-materialization-failed`.
+- OP-03 deploy worker failures map to `DeployFailed` with
+  `run-in-game-deploy-failed`.
+- OP-04 setup-row visibility failures, including
+  `Civ7 setup cannot see {swooper-maps}/maps/studio-current.js`, map to
+  `ProofFailed` with `setup-row-unavailable` and failed phase
+  `preparing-setup`.
+- OP-05 start-game failures map to `ProofFailed` with `start-game-failed` and
+  terminal `uncertain` status.
+- OP-06 waiting-for-proof failures map to `ProofFailed` with
+  `log-proof-missing`.
+- OP-07 restart failures map to `DependencyUnavailable` with `restart-failed`;
+  the workflow now sets the local failure phase to `restarting-civ` before the
+  restart leaf runs.
+- OP-08 cleanup failures continue to preserve their cleanup-specific typed
+  failure.
+- STUDIO-01 status projections now include recovery actions from the typed
+  failure, rather than only generic phase-derived actions.
+
+## Verification
+
+- `bun run --cwd packages/studio-server test test/operationRuntime.test.ts`
+  passed with 31 tests.
+- `bun run nx run @civ7/studio-server:test --outputStyle=static` passed with
+  73 tests.
+- `bun run nx run @civ7/studio-server:check --outputStyle=static` passed.
+- `bun run nx run @civ7/studio-server:build --outputStyle=static` passed.
+- `bun run openspec -- validate studio-operation-lifecycle-failure-classification --strict`
+  passed.
+- `bun run openspec:validate` passed with 194 items.
+
+## Remaining Boundaries
+
+- Live Civ7/FireTuner happy-path proof was not performed in this packet.
+- Browser adoption of the new terminal DTO fields is owned by
+  `studio-browser-defined-error-projection` and
+  `studio-browser-scenario-proof`.
+- Actual deployment and Civ7 setup visibility of `studio-current.js` remains a
+  priority blocker for `studio-live-civ7-proof-gates`.

--- a/packages/studio-server/src/operationRuntime/projection.ts
+++ b/packages/studio-server/src/operationRuntime/projection.ts
@@ -45,7 +45,7 @@ export function projectRunInGame(operation: RunInGameInternalOperation): RunInGa
     recoveryActions:
       operation.failure === undefined && operation.phase === "complete"
         ? ["copy-diagnostics"]
-        : runInGameRecoveryActions({ phase, status: operation.status, details }),
+        : runInGameRecoveryActions({ phase, status: operation.status, details }, operation.failure),
   };
 }
 
@@ -199,7 +199,8 @@ function diagnosticSummary(value: unknown): string {
 }
 
 function runInGameRecoveryActions(
-  state: Pick<RunInGameOperationStatus, "phase" | "status" | "details">
+  state: Pick<RunInGameOperationStatus, "phase" | "status" | "details">,
+  failure?: StudioRuntimeFailure
 ): StudioRecoveryAction[] {
   const actions: StudioRecoveryAction[] = ["copy-diagnostics"];
   if (
@@ -225,6 +226,7 @@ function runInGameRecoveryActions(
   ) {
     actions.push("dismiss-civ-notification-and-retry");
   }
+  if (failure) actions.push(...failure.recoveryActions);
   return [...new Set(actions)];
 }
 

--- a/packages/studio-server/src/operationRuntime/registry.ts
+++ b/packages/studio-server/src/operationRuntime/registry.ts
@@ -9,12 +9,18 @@ import type {
   RunInGameProcessRestartStatus,
 } from "../contract/runInGame.js";
 import {
+  dependencyUnavailable,
+  deployFailed,
   invalidRequest,
   isStudioRuntimeFailure,
+  materializationFailed,
   operationBlocked,
   operationExpired,
   operationNotFound,
+  proofFailed,
   runtimeDisposed,
+  type StudioBoundedDiagnostics,
+  type StudioBoundedDiagnosticValue,
   type StudioRuntimeFailure,
 } from "../errors/index.js";
 import type {
@@ -270,12 +276,18 @@ export function failRunInGame(
             startedAt: args.nowIso,
             updatedAt: args.nowIso,
             completedPhases: [],
-            failure: toRuntimeFailure(args.err, "Run in Game failed"),
+            failure: toRuntimeFailure(args.err, "Run in Game failed", {
+              operation: "run-in-game",
+              phase: args.phase,
+            }),
           } satisfies RunInGameInternalOperation),
         state,
       ] as const;
     }
-    const failure = toRuntimeFailure(args.err, "Run in Game failed");
+    const failure = toRuntimeFailure(args.err, "Run in Game failed", {
+      operation: "run-in-game",
+      phase: args.phase,
+    });
     const operation = failRunOperation(current, args.nowIso, failure, args.phase);
     return [
       operation,
@@ -439,12 +451,18 @@ export function failSaveDeploy(
             status: "failed",
             startedAt: args.nowIso,
             updatedAt: args.nowIso,
-            failure: toRuntimeFailure(args.err, "Save failed"),
+            failure: toRuntimeFailure(args.err, "Save failed", {
+              operation: "save-deploy",
+              phase: args.phase,
+            }),
           } satisfies SaveDeployInternalOperation),
         state,
       ] as const;
     }
-    const failure = toRuntimeFailure(args.err, "Save failed");
+    const failure = toRuntimeFailure(args.err, "Save failed", {
+      operation: "save-deploy",
+      phase: args.phase,
+    });
     const operation = failSaveOperation(current, args.nowIso, failure, args.phase);
     return [
       operation,
@@ -651,15 +669,175 @@ function failSaveOperation(
   };
 }
 
-function toRuntimeFailure(err: unknown, fallbackMessage: string): StudioRuntimeFailure {
+type RuntimeFailureContext =
+  | Readonly<{ operation: "run-in-game"; phase: RunInGameFailurePhase }>
+  | Readonly<{ operation: "save-deploy"; phase: "saving" | "deploying" }>;
+
+function toRuntimeFailure(
+  err: unknown,
+  fallbackMessage: string,
+  context?: RuntimeFailureContext
+): StudioRuntimeFailure {
   if (isStudioRuntimeFailure(err)) return err;
+  if (context?.operation === "run-in-game") {
+    return runInGameFailureForPhase(err, fallbackMessage, context.phase);
+  }
+  if (context?.operation === "save-deploy") {
+    return deployFailed({
+      message: errorMessage(err, fallbackMessage),
+      reason: context.phase === "saving" ? "save-failed" : "deploy-failed",
+      diagnostics: boundedDiagnostics({
+        code: `save-deploy-${context.phase === "saving" ? "save-failed" : "deploy-failed"}`,
+        failureTag: "DeployFailed",
+        reason: context.phase === "saving" ? "save-failed" : "deploy-failed",
+        failedAtPhase: context.phase,
+        cause: diagnosticString(err),
+      }),
+    });
+  }
   return invalidRequest({
-    message: err instanceof Error && err.message ? err.message : fallbackMessage,
+    message: errorMessage(err, fallbackMessage),
     diagnostics: {
       code: "studio-operation-runtime-unclassified-error",
-      cause: err instanceof Error && err.message ? err.message : String(err),
+      cause: diagnosticString(err) ?? String(err),
     },
   });
+}
+
+function runInGameFailureForPhase(
+  err: unknown,
+  fallbackMessage: string,
+  phase: RunInGameFailurePhase
+): StudioRuntimeFailure {
+  const message = errorMessage(err, fallbackMessage);
+  switch (phase) {
+    case "materializing":
+      return materializationFailed({
+        message,
+        diagnostics: runInGameDiagnostics(err, phase, {
+          code: "run-in-game-materialization-failed",
+          failureTag: "MaterializationFailed",
+          reason: "materialization-proof-missing",
+        }),
+      });
+    case "deploying":
+      return deployFailed({
+        message,
+        reason: "deploy-failed",
+        diagnostics: runInGameDiagnostics(err, phase, {
+          code: "run-in-game-deploy-failed",
+          failureTag: "DeployFailed",
+          reason: "deploy-failed",
+        }),
+        recoveryActions: ["inspect-deploy-output", "retry-run", "copy-diagnostics"],
+      });
+    case "restarting-civ":
+      return dependencyUnavailable({
+        message,
+        reason: "restart-failed",
+        dependency: "civ7-process",
+        diagnostics: runInGameDiagnostics(err, phase, {
+          code: "run-in-game-restart-failed",
+          failureTag: "DependencyUnavailable",
+          reason: "restart-failed",
+        }),
+        recoveryActions: ["restart-civ-process-and-retry", "retry-run", "copy-diagnostics"],
+      });
+    case "checking-civ7":
+      return dependencyUnavailable({
+        message,
+        reason: "direct-control-unavailable",
+        dependency: "direct-control",
+        diagnostics: runInGameDiagnostics(err, phase, {
+          code: "run-in-game-civ7-check-failed",
+          failureTag: "DependencyUnavailable",
+          reason: "direct-control-unavailable",
+        }),
+        recoveryActions: ["check-dev-server", "retry-run", "copy-diagnostics"],
+      });
+    case "preparing-setup":
+    case "reload-needed":
+      return proofFailed({
+        message,
+        reason: "setup-row-unavailable",
+        diagnostics: runInGameDiagnostics(err, phase, {
+          code: "run-in-game-setup-row-unavailable",
+          failureTag: "ProofFailed",
+          reason: "setup-row-unavailable",
+        }),
+        recoveryActions: ["exit-to-shell-and-continue", "retry-run", "copy-diagnostics"],
+      });
+    case "starting-game":
+      return proofFailed({
+        message,
+        reason: "start-game-failed",
+        diagnostics: runInGameDiagnostics(err, phase, {
+          code: "run-in-game-start-game-failed",
+          failureTag: "ProofFailed",
+          reason: "start-game-failed",
+        }),
+        recoveryActions: ["dismiss-civ-notification-and-retry", "retry-run", "copy-diagnostics"],
+      });
+    case "waiting-for-proof":
+      return proofFailed({
+        message,
+        reason: "log-proof-missing",
+        diagnostics: runInGameDiagnostics(err, phase, {
+          code: "run-in-game-log-proof-missing",
+          failureTag: "ProofFailed",
+          reason: "log-proof-missing",
+        }),
+      });
+  }
+}
+
+function runInGameDiagnostics(
+  err: unknown,
+  phase: RunInGameFailurePhase,
+  fields: Record<string, unknown>
+): StudioBoundedDiagnostics {
+  return boundedDiagnostics({
+    ...fields,
+    failedAtPhase: phase,
+    cause: diagnosticString(err),
+  });
+}
+
+function boundedDiagnostics(value: Record<string, unknown>): StudioBoundedDiagnostics {
+  const out: Record<string, StudioBoundedDiagnosticValue> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry !== undefined) out[key] = boundedDiagnosticValue(entry);
+  }
+  return out;
+}
+
+function boundedDiagnosticValue(value: unknown): StudioBoundedDiagnosticValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => diagnosticString(entry) ?? "");
+  }
+  return diagnosticString(value) ?? "";
+}
+
+function errorMessage(err: unknown, fallbackMessage: string): string {
+  return err instanceof Error && err.message ? err.message : fallbackMessage;
+}
+
+function diagnosticString(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (value instanceof Error && value.message) return value.message;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }
 
 function runtimeDisposedFailure(): StudioRuntimeFailure {

--- a/packages/studio-server/src/workflows/RunInGameWorkflow.ts
+++ b/packages/studio-server/src/workflows/RunInGameWorkflow.ts
@@ -130,6 +130,9 @@ function makeRunInGameWorkflow(
             materialization: deployment.materialization ?? materialized.materialization,
           });
 
+          if (workflow.prepared.request.restartCivProcess && args.ports.restartCivForRunInGame) {
+            phase = "restarting-civ";
+          }
           const restart = yield* maybeRestart(workflow, deployment);
           phase = "checking-civ7";
           yield* workflow.transitions.transition({

--- a/packages/studio-server/test/operationRuntime.test.ts
+++ b/packages/studio-server/test/operationRuntime.test.ts
@@ -865,6 +865,155 @@ describe("StudioOperationRuntime", () => {
     });
   });
 
+  test("Run in Game worker failures are classified by lifecycle phase", async () => {
+    const cases: Array<{
+      requestId: string;
+      input?: Partial<StudioInputs["runInGame"]["start"]>;
+      ports?: Partial<StudioOperationRuntimePorts>;
+      civ7?: Partial<Civ7WorkflowControlApi>;
+      expected: {
+        status: "failed" | "uncertain";
+        code: string;
+        reason: string;
+        failedAtPhase: string;
+        recoveryActions?: string[];
+      };
+    }> = [
+      {
+        requestId: "run-materialize-fail",
+        ports: {
+          materializeRunInGame: async () => {
+            throw new Error("materialize failed");
+          },
+        },
+        expected: {
+          status: "failed",
+          code: "run-in-game-materialization-failed",
+          reason: "materialization-proof-missing",
+          failedAtPhase: "materializing",
+        },
+      },
+      {
+        requestId: "run-deploy-fail",
+        ports: {
+          deployRunInGame: async () => {
+            throw new Error("deploy failed");
+          },
+        },
+        expected: {
+          status: "failed",
+          code: "run-in-game-deploy-failed",
+          reason: "deploy-failed",
+          failedAtPhase: "deploying",
+          recoveryActions: ["inspect-deploy-output"],
+        },
+      },
+      {
+        requestId: "run-restart-fail",
+        input: { recovery: { restartCivProcess: true } },
+        ports: {
+          restartCivForRunInGame: async () => {
+            throw new Error("restart failed");
+          },
+        },
+        expected: {
+          status: "failed",
+          code: "run-in-game-restart-failed",
+          reason: "restart-failed",
+          failedAtPhase: "restarting-civ",
+          recoveryActions: ["restart-civ-process-and-retry"],
+        },
+      },
+      {
+        requestId: "run-setup-row-fail",
+        civ7: {
+          prepareSetup: () =>
+            Effect.fail(new Error("Civ7 setup cannot see {swooper-maps}/maps/studio-current.js")),
+        },
+        expected: {
+          status: "failed",
+          code: "run-in-game-setup-row-unavailable",
+          reason: "setup-row-unavailable",
+          failedAtPhase: "preparing-setup",
+          recoveryActions: ["exit-to-shell-and-continue"],
+        },
+      },
+      {
+        requestId: "run-start-game-fail",
+        civ7: {
+          startGame: () => Effect.fail(new Error("start game failed")),
+        },
+        expected: {
+          status: "uncertain",
+          code: "run-in-game-start-game-failed",
+          reason: "start-game-failed",
+          failedAtPhase: "starting-game",
+          recoveryActions: ["dismiss-civ-notification-and-retry"],
+        },
+      },
+      {
+        requestId: "run-log-proof-fail",
+        ports: {
+          waitForRunInGameLogProof: async () => {
+            throw new Error("log proof missing");
+          },
+        },
+        expected: {
+          status: "failed",
+          code: "run-in-game-log-proof-missing",
+          reason: "log-proof-missing",
+          failedAtPhase: "waiting-for-proof",
+        },
+      },
+    ];
+
+    for (const entry of cases) {
+      const { runtime } = makeRuntime({
+        ports: entry.ports,
+        civ7: entry.civ7,
+      });
+      const service = await runtime.runPromise(StudioOperationRuntime);
+
+      const accepted = await runtime.runPromise(
+        service.runInGameStart(
+          runInGameInput({
+            requestId: entry.requestId,
+            ...(entry.input ?? {}),
+          })
+        )
+      );
+      await expect
+        .poll(async () => {
+          const status = await runtime.runPromise(
+            service.runInGameStatus({ requestId: accepted.requestId })
+          );
+          return status.status;
+        })
+        .toBe(entry.expected.status);
+
+      const failed = await runtime.runPromise(
+        service.runInGameStatus({ requestId: accepted.requestId })
+      );
+      expect(failed).toMatchObject({
+        ok: false,
+        requestId: accepted.requestId,
+        phase: entry.expected.status,
+        status: entry.expected.status,
+        details: {
+          failureClass: entry.expected.status,
+          code: entry.expected.code,
+          reason: entry.expected.reason,
+          failedAtPhase: entry.expected.failedAtPhase,
+        },
+      });
+      for (const action of entry.expected.recoveryActions ?? []) {
+        expect(failed.recoveryActions).toContain(action);
+      }
+      expect(failed.details?.cause).toEqual(failed.error);
+      expectTypeboxValid(operationStatusTypeSchema, failed);
+    }
+  });
+
   test("maps status misses to runtime-owned not-found failures with identity available", async () => {
     const { runtime } = makeRuntime();
     const service = await runtime.runPromise(StudioOperationRuntime);


### PR DESCRIPTION
Each run-in-game lifecycle phase previously fell through to a generic `invalidRequest` failure regardless of where in the workflow the error occurred. This made it impossible for callers to distinguish a materialization failure from a deploy failure, a restart failure, or a proof-visibility failure, and recovery action lists were derived solely from phase name rather than from the typed failure itself.

This change introduces phase-specific failure classification for `run-in-game` and `save-deploy` operations:

- **OP-02 (materializing)** → `MaterializationFailed` with `run-in-game-materialization-failed`
- **OP-03 (deploying)** → `DeployFailed` with `run-in-game-deploy-failed` and deploy-specific recovery actions
- **OP-04 (preparing-setup / reload-needed)** → `ProofFailed` with `setup-row-unavailable`, covering the `Civ7 setup cannot see {swooper-maps}/maps/studio-current.js` symptom so it is no longer misreported as invalid user input
- **OP-05 (starting-game)** → `ProofFailed` with `start-game-failed` and `uncertain` terminal status
- **OP-06 (waiting-for-proof)** → `ProofFailed` with `log-proof-missing`
- **OP-07 (restarting-civ)** → `DependencyUnavailable` with `restart-failed`; the workflow now sets the local failure phase to `restarting-civ` before the restart leaf executes so the phase is captured correctly
- **OP-08 (cleanup)** → existing typed failure preserved unchanged
- **OP-01 (admission)** → `InvalidRequest` preserved for pre-worker validation failures

Recovery actions on the projected status DTO are now sourced from the typed failure in addition to the phase-derived defaults, so callers receive actions such as `restart-civ-process-and-retry`, `inspect-deploy-output`, and `exit-to-shell-and-continue` that were previously absent.

A parameterized test covering all six failure paths is added, asserting the failure class, diagnostic code, reason, `failedAtPhase`, and phase-specific recovery actions for each case.