### PR TITLE
`feat(mapgen-studio): centralize declared oRPC error projection into shared browser helper`

### DIFF
--- a/apps/mapgen-studio/src/features/civ7Setup/api.ts
+++ b/apps/mapgen-studio/src/features/civ7Setup/api.ts
@@ -9,9 +9,13 @@
 // packages/studio-server/src/contract/errors.ts) and its typed `data`
 // (`observedAt`), so the failure envelope carries `{ error, code?, observedAt? }`
 // instead of a raw transport status code.
-import { isDefinedError, safe } from "@orpc/client";
+import { safe } from "@orpc/client";
 
 import { orpcClient } from "../../lib/orpc";
+import {
+  projectStudioBrowserError,
+  type StudioBrowserErrorDetails,
+} from "../studioErrors/definedErrorProjection";
 import type { Civ7SetupSnapshotLike } from "./setupConfig";
 
 export type Civ7SetupCatalogOption = Readonly<{
@@ -29,33 +33,22 @@ export type Civ7SetupCatalog = Readonly<{
   gameSpeeds: ReadonlyArray<Civ7SetupCatalogOption>;
 }>;
 
-export async function fetchCiv7SetupConfig(
-  options: { signal?: AbortSignal } = {}
-): Promise<
+export async function fetchCiv7SetupConfig(options: { signal?: AbortSignal } = {}): Promise<
   | { ok: true; observedAt: string; setup: Civ7SetupSnapshotLike }
-  | { ok: false; error: string; observedAt?: string; code?: string }
+  | {
+      ok: false;
+      error: string;
+      observedAt?: string;
+      code?: string;
+      statusCode?: number;
+      details?: StudioBrowserErrorDetails;
+    }
 > {
   const { error, data } = await safe(
     orpcClient.civ7.setupConfig({}, options.signal ? { signal: options.signal } : undefined)
   );
   if (error) {
-    if (isDefinedError(error)) {
-      // `observedAt` rides in the typed error data for the DECLARED
-      // SETUP_CONFIG_UNAVAILABLE (503) failure.
-      return {
-        ok: false,
-        error: error.message || "Civ7 setup config unavailable",
-        code: error.code,
-        ...(typeof error.data?.observedAt === "string"
-          ? { observedAt: error.data.observedAt }
-          : {}),
-      };
-    }
-    return {
-      ok: false,
-      error:
-        error instanceof Error && error.message ? error.message : "Civ7 setup config unavailable",
-    };
+    return { ok: false, ...projectStudioBrowserError(error, "Civ7 setup config unavailable") };
   }
   return {
     ok: true,
@@ -79,14 +72,13 @@ export async function requestCiv7Autoplay(action: "start" | "stop"): Promise<{
   autoplay?: { isActive?: boolean; isPaused?: boolean; isPausedOrPending?: boolean };
   game?: { turn?: { ok?: boolean; value?: number } };
   error?: string;
+  code?: string;
+  statusCode?: number;
+  details?: StudioBrowserErrorDetails;
 }> {
   const { error, data: body } = await safe(orpcClient.civ7.autoplay({ action }));
   if (error) {
-    return {
-      ok: false,
-      error:
-        error instanceof Error && error.message ? error.message : "Civ7 autoplay request failed",
-    };
+    return { ok: false, ...projectStudioBrowserError(error, "Civ7 autoplay request failed") };
   }
   // Parity: the autoplay procedure returns 200 with `ok = result.verified`, so a
   // succeeded-transport-but-unverified action still surfaces as `{ ok:false }`

--- a/apps/mapgen-studio/src/features/mapConfigSave/api.ts
+++ b/apps/mapgen-studio/src/features/mapConfigSave/api.ts
@@ -14,6 +14,7 @@
 import type { MapConfigSaveDeployStatus } from "@civ7/studio-server";
 import { safe } from "@orpc/client";
 import { orpcClient } from "../../lib/orpc";
+import { projectStudioBrowserError } from "../studioErrors/definedErrorProjection";
 
 export function toConfigId(label: string): string {
   const id = label
@@ -39,7 +40,16 @@ export async function saveRepoBackedConfig(args: {
   onStatus?: (status: MapConfigSaveDeployStatus) => void;
 }): Promise<
   | { ok: true; status: MapConfigSaveDeployStatus; path?: string }
-  | { ok: false; error: string; saved?: boolean; deployed?: boolean; path?: string }
+  | {
+      ok: false;
+      error: string;
+      saved?: boolean;
+      deployed?: boolean;
+      path?: string;
+      code?: string;
+      statusCode?: number;
+      details?: MapConfigSaveDeployStatus["details"];
+    }
 > {
   const path = args.sourcePath ?? `mods/mod-swooper-maps/src/maps/configs/${args.id}.config.json`;
   const envelope = {
@@ -62,12 +72,15 @@ export async function saveRepoBackedConfig(args: {
       })
     );
     if (saveResult.error) {
+      const projected = projectStudioBrowserError(saveResult.error, "Repo config save failed");
       return {
         ok: false,
-        error:
-          saveResult.error instanceof Error && saveResult.error.message
-            ? saveResult.error.message
-            : "Repo config save failed",
+        error: projected.error,
+        ...(projected.code === undefined ? {} : { code: projected.code }),
+        ...(projected.statusCode === undefined ? {} : { statusCode: projected.statusCode }),
+        ...(projected.details === undefined
+          ? {}
+          : { details: projected.details as MapConfigSaveDeployStatus["details"] }),
       };
     }
     const status = saveResult.data;

--- a/apps/mapgen-studio/src/features/runInGame/api.ts
+++ b/apps/mapgen-studio/src/features/runInGame/api.ts
@@ -15,28 +15,10 @@ import type {
   RunInGameFailureDetails,
   RunInGameOperationStatus,
 } from "@civ7/studio-server/contract";
-import { isDefinedError, safe } from "@orpc/client";
+import { safe } from "@orpc/client";
 import { orpcClient } from "../../lib/orpc";
 import { type Civ7StudioSetupConfig, normalizeStudioSetupConfig } from "../civ7Setup/setupConfig";
-
-/**
- * Project sealed package failure data into the browser's copyable failure-details
- * shape. D3 removed the old `{ details? }` bridge; defined errors now expose
- * top-level tag/reason/message/recoveryActions plus bounded diagnostics.
- */
-function definedErrorDetails(data: unknown): RunInGameFailureDetails | undefined {
-  if (!isRecord(data)) return undefined;
-  const diagnostics = isRecord(data.diagnostics) ? data.diagnostics : {};
-  const details: Record<string, unknown> = { ...diagnostics };
-  if (typeof data.tag === "string") details.failureTag = data.tag;
-  if (typeof data.reason === "string") details.reason = data.reason;
-  if (typeof data.requestId === "string") details.requestId = data.requestId;
-  return Object.keys(details).length === 0 ? undefined : (details as RunInGameFailureDetails);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === "object" && !Array.isArray(value);
-}
+import { projectStudioBrowserError } from "../studioErrors/definedErrorProjection";
 
 export async function runCurrentConfigInGame(args: {
   recipeId: string;
@@ -62,7 +44,13 @@ export async function runCurrentConfigInGame(args: {
   sourceSnapshot?: unknown;
 }): Promise<
   | RunInGameOperationStatus
-  | { ok: false; error: string; details?: RunInGameFailureDetails; code?: string }
+  | {
+      ok: false;
+      error: string;
+      details?: RunInGameFailureDetails;
+      code?: string;
+      statusCode?: number;
+    }
 > {
   // The request envelope is assembled exactly as before (the server runs
   // `assertNoRawControlFields` over it); only the transport is the oRPC client.
@@ -88,18 +76,15 @@ export async function runCurrentConfigInGame(args: {
   };
   const { error, data } = await safe(orpcClient.runInGame.start(request));
   if (error) {
-    if (isDefinedError(error)) {
-      const details = definedErrorDetails(error.data);
-      return {
-        ok: false,
-        error: error.message || "Run in Game failed",
-        code: error.code,
-        ...(details !== undefined ? { details } : {}),
-      };
-    }
+    const projected = projectStudioBrowserError(error, "Run in Game failed");
     return {
       ok: false,
-      error: error instanceof Error && error.message ? error.message : "Run in Game failed",
+      error: projected.error,
+      ...(projected.code === undefined ? {} : { code: projected.code }),
+      ...(projected.statusCode === undefined ? {} : { statusCode: projected.statusCode }),
+      ...(projected.details === undefined
+        ? {}
+        : { details: projected.details as RunInGameFailureDetails }),
     };
   }
   return data;

--- a/apps/mapgen-studio/src/features/studioErrors/definedErrorProjection.ts
+++ b/apps/mapgen-studio/src/features/studioErrors/definedErrorProjection.ts
@@ -1,0 +1,94 @@
+import { isDefinedError } from "@orpc/client";
+
+export type StudioBrowserErrorDetails = Readonly<Record<string, unknown>>;
+
+export type StudioBrowserErrorProjection = Readonly<{
+  error: string;
+  code?: string;
+  statusCode?: number;
+  observedAt?: string;
+  details?: StudioBrowserErrorDetails;
+}>;
+
+export function projectStudioBrowserError(
+  error: unknown,
+  fallbackMessage: string
+): StudioBrowserErrorProjection {
+  if (isDefinedError(error) || isOrpcErrorLike(error)) {
+    return projectStudioBrowserDefinedError({
+      code: error.code,
+      message: error.message,
+      statusCode: typeof error.status === "number" ? error.status : undefined,
+      data: error.data,
+      fallbackMessage,
+    });
+  }
+  return {
+    error: error instanceof Error && error.message ? error.message : fallbackMessage,
+  };
+}
+
+export function projectStudioBrowserDefinedError(args: {
+  code: string;
+  message?: string;
+  statusCode?: number;
+  data?: unknown;
+  fallbackMessage: string;
+}): StudioBrowserErrorProjection {
+  const data = isRecord(args.data) ? args.data : {};
+  const diagnostics = isRecord(data.diagnostics) ? data.diagnostics : {};
+  const details: Record<string, unknown> = { ...diagnostics };
+  details.definedErrorCode = args.code;
+  if (details.code === undefined) details.code = args.code;
+  copyString(data, details, "tag", "failureTag");
+  copyString(data, details, "reason");
+  copyString(data, details, "requestId");
+  copyString(data, details, "activeRequestId");
+  copyString(data, details, "activePhase");
+  copyString(data, details, "operationType");
+  copyString(data, details, "dependency");
+  copyString(data, details, "directControlCode");
+  copyString(data, details, "causeSummary");
+  copyString(data, details, "serverInstanceId");
+  copyString(data, details, "serverStartedAt");
+  copyString(data, details, "observedAt");
+  copyString(data, details, "message", "definedErrorMessage");
+  if (Array.isArray(data.recoveryActions)) {
+    details.recoveryActions = data.recoveryActions.filter(
+      (action): action is string => typeof action === "string"
+    );
+  }
+  if (args.statusCode !== undefined) details.statusCode = args.statusCode;
+
+  const observedAt = typeof data.observedAt === "string" ? data.observedAt : undefined;
+  return {
+    error: args.message || args.fallbackMessage,
+    code: args.code,
+    ...(args.statusCode === undefined ? {} : { statusCode: args.statusCode }),
+    ...(observedAt === undefined ? {} : { observedAt }),
+    ...(Object.keys(details).length === 0 ? {} : { details }),
+  };
+}
+
+function copyString(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+  sourceKey: string,
+  targetKey = sourceKey
+): void {
+  const value = source[sourceKey];
+  if (typeof value === "string") target[targetKey] = value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isOrpcErrorLike(value: unknown): value is {
+  code: string;
+  message?: string;
+  status?: number;
+  data?: unknown;
+} {
+  return isRecord(value) && typeof value.code === "string";
+}

--- a/apps/mapgen-studio/test/studioErrors/definedErrorProjection.test.ts
+++ b/apps/mapgen-studio/test/studioErrors/definedErrorProjection.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  projectStudioBrowserDefinedError,
+  projectStudioBrowserError,
+} from "../../src/features/studioErrors/definedErrorProjection";
+
+describe("Studio browser defined error projection", () => {
+  it("preserves declared code, status, diagnostics, recovery actions, and identity fields", () => {
+    const projection = projectStudioBrowserDefinedError({
+      code: "RUN_IN_GAME_FAILED",
+      statusCode: 500,
+      message: "Run in Game failed",
+      fallbackMessage: "fallback",
+      data: {
+        tag: "ProofFailed",
+        reason: "setup-row-unavailable",
+        requestId: "studio-run-1",
+        recoveryActions: ["exit-to-shell-and-continue", "retry-run", "copy-diagnostics"],
+        diagnostics: {
+          code: "run-in-game-setup-row-unavailable",
+          failedAtPhase: "preparing-setup",
+          cause: "Civ7 setup cannot see {swooper-maps}/maps/studio-current.js",
+        },
+      },
+    });
+
+    expect(projection).toMatchObject({
+      error: "Run in Game failed",
+      code: "RUN_IN_GAME_FAILED",
+      statusCode: 500,
+      details: {
+        code: "run-in-game-setup-row-unavailable",
+        definedErrorCode: "RUN_IN_GAME_FAILED",
+        failureTag: "ProofFailed",
+        reason: "setup-row-unavailable",
+        requestId: "studio-run-1",
+        failedAtPhase: "preparing-setup",
+        statusCode: 500,
+        cause: "Civ7 setup cannot see {swooper-maps}/maps/studio-current.js",
+      },
+    });
+    expect(projection.details?.recoveryActions).toEqual([
+      "exit-to-shell-and-continue",
+      "retry-run",
+      "copy-diagnostics",
+    ]);
+  });
+
+  it("promotes observedAt from setup-config declared errors", () => {
+    const projection = projectStudioBrowserDefinedError({
+      code: "SETUP_CONFIG_UNAVAILABLE",
+      statusCode: 503,
+      message: "Civ7 setup config unavailable",
+      fallbackMessage: "fallback",
+      data: { observedAt: "2026-06-17T04:00:00.000Z" },
+    });
+
+    expect(projection).toMatchObject({
+      code: "SETUP_CONFIG_UNAVAILABLE",
+      statusCode: 503,
+      observedAt: "2026-06-17T04:00:00.000Z",
+      details: {
+        code: "SETUP_CONFIG_UNAVAILABLE",
+        definedErrorCode: "SETUP_CONFIG_UNAVAILABLE",
+        observedAt: "2026-06-17T04:00:00.000Z",
+      },
+    });
+  });
+
+  it("keeps plain transport failures as message-only fallback errors", () => {
+    expect(projectStudioBrowserError(new Error("network down"), "fallback")).toEqual({
+      error: "network down",
+    });
+    expect(projectStudioBrowserError("boom", "fallback")).toEqual({ error: "fallback" });
+  });
+});

--- a/openspec/changes/studio-browser-defined-error-projection/tasks.md
+++ b/openspec/changes/studio-browser-defined-error-projection/tasks.md
@@ -1,14 +1,14 @@
 ## 1. Projection Contract
 
-- [ ] 1.1 Define preserved fields for declared browser errors.
-- [ ] 1.2 Document any intentional simplification with a test.
+- [x] 1.1 Define preserved fields for declared browser errors.
+- [x] 1.2 Document any intentional simplification with a test.
 
 ## 2. Implementation
 
-- [ ] 2.1 Apply projection helper to Run in Game, Save/Deploy, setup config, and Autoplay clients.
-- [ ] 2.2 Keep server internals outside this packet.
+- [x] 2.1 Apply projection helper to Run in Game, Save/Deploy, setup config, and Autoplay clients.
+- [x] 2.2 Keep server internals outside this packet.
 
 ## 3. Verification
 
-- [ ] 3.1 Run focused browser API projection tests.
-- [ ] 3.2 Run app build and OpenSpec validation.
+- [x] 3.1 Run focused browser API projection tests.
+- [x] 3.2 Run app build and OpenSpec validation.

--- a/openspec/changes/studio-browser-defined-error-projection/workstream/phase-record.md
+++ b/openspec/changes/studio-browser-defined-error-projection/workstream/phase-record.md
@@ -1,7 +1,45 @@
 # Phase Record: Studio Browser Defined Error Projection
 
-Status: scaffolded; implementation blocked until packet train acceptance.
+Status: implemented and verified.
 
 Normative packet: `docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/PACKET-TRAIN.md#smr-03---browser-defined-error-projection`.
 
 Priority rows: READ browser projection portions, UI-01, UI-06, OP-06 through OP-09 projection portions, EB-09 through EB-11, EB-13 projection portion.
+
+## Scope Boundary
+
+This packet changes browser-side projection of declared oRPC errors only. It
+does not change server contracts, router mappings, operation runtime behavior,
+or live Civ7 proof.
+
+## Implemented Projection
+
+- Added one browser helper for Studio declared errors:
+  `apps/mapgen-studio/src/features/studioErrors/definedErrorProjection.ts`.
+- Preserved declared code as `code`, numeric status as `statusCode`, setup
+  `observedAt` as a top-level field, and copyable details for diagnostics,
+  failure tag, reason, request ids, active-operation identity, dependency,
+  direct-control code, cause summary, server identity, and recovery actions.
+- Applied the helper to:
+  - `fetchCiv7SetupConfig`
+  - `requestCiv7Autoplay`
+  - `runCurrentConfigInGame`
+  - `saveRepoBackedConfig`
+
+## Verification
+
+- `bun run --cwd apps/mapgen-studio test test/studioErrors/definedErrorProjection.test.ts`
+  passed with 3 tests.
+- `bun run nx run mapgen-studio:check --outputStyle=static` passed.
+- `bun run nx run mapgen-studio:test --outputStyle=static` passed with 51
+  files and 251 tests.
+- `bun run nx run mapgen-studio:build:vite --outputStyle=static` passed.
+- `bun run openspec -- validate studio-browser-defined-error-projection --strict`
+  passed.
+
+## Remaining Boundaries
+
+- Browser rendering of every terminal state is owned by
+  `studio-browser-scenario-proof`.
+- Live Civ7/FireTuner setup visibility for `studio-current.js` remains owned by
+  `studio-live-civ7-proof-gates`.


### PR DESCRIPTION
Extracts duplicated oRPC error-handling logic across the Civ7 setup config, autoplay, run-in-game, and save/deploy browser API clients into a single shared helper, `projectStudioBrowserError`, located at `features/studioErrors/definedErrorProjection.ts`.

The helper normalizes both declared oRPC errors (via `isDefinedError`) and plain transport failures into a consistent `StudioBrowserErrorProjection` shape that includes `error`, `code`, `statusCode`, `observedAt`, and `details`. The `details` object is populated from the declared error's `data` payload, promoting diagnostics, failure tag, reason, request IDs, active-operation identity fields, dependency, direct-control code, cause summary, server identity, and recovery actions into a flat, copyable structure.

Each call site now returns `statusCode` alongside the existing `code` field, and the failure return types for `fetchCiv7SetupConfig`, `requestCiv7Autoplay`, `runCurrentConfigInGame`, and `saveRepoBackedConfig` are updated to reflect these additional fields.

The inline `definedErrorDetails` and `isRecord` helpers previously duplicated in `runInGame/api.ts` are removed in favor of the shared projection.

Three focused tests cover the projection contract: declared errors with diagnostics and recovery actions, `observedAt` promotion from setup-config errors, and plain transport failures falling back to message-only output.