### PR TITLE
`feat(mapgen-studio): add event stream recovery, time-aware operation adoption, and visible busy-gate feedback`

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -146,6 +146,7 @@ import { useToast } from "./hooks/useToast";
 import { LeftDock } from "./LeftDock";
 import { readAndAdoptStudioOperationsCurrent } from "./operationAdoption";
 import { RightDock } from "./RightDock";
+import { studioBusyGateMessage } from "./studioEventRecovery";
 
 export type StudioShellProps = {
   themePreference: "system" | "light" | "dark";
@@ -494,9 +495,16 @@ export function StudioShell(props: StudioShellProps) {
 
   const browserRunning = browserRunner.state.running;
   const [localError, setLocalError] = useState<string | null>(null);
+  const clearLocalErrorIfCurrent = useCallback((message: string) => {
+    setLocalError((current) => (current === message ? null : current));
+  }, []);
   const [saveDeployOperation, setSaveDeployOperation] = useState<MapConfigSaveDeployStatus | null>(
     null
   );
+  const runInGameOperationRef = useRef<RunInGameOperationStatus | null>(null);
+  const saveDeployOperationCurrentRef = useRef<MapConfigSaveDeployStatus | null>(null);
+  runInGameOperationRef.current = runInGameOperation;
+  saveDeployOperationCurrentRef.current = saveDeployOperation;
   const saveDeployOperationRef = useRef<MapConfigSaveDeployStatus | null>(null);
   const saveDeployWaitersRef = useRef<Map<string, SaveDeployTerminalWaiter>>(new Map());
   // Run presentation state is session-only; cross-reload operation recovery is
@@ -1655,6 +1663,8 @@ export function StudioShell(props: StudioShellProps) {
         markRunInGameToastHandled,
       },
       isCancelled: () => cancelled,
+      getCurrentRunInGameOperation: () => runInGameOperationRef.current,
+      getCurrentSaveDeployOperation: () => saveDeployOperationCurrentRef.current,
       onError: setLocalError,
     });
     return () => {
@@ -1664,10 +1674,13 @@ export function StudioShell(props: StudioShellProps) {
 
   useStudioEvents({
     applyLiveGameState,
+    currentRunInGameOperation: runInGameOperation,
+    currentSaveDeployOperation: saveDeployOperation,
     setRunInGameOperation,
     setSaveDeployOperation,
     markRunInGameToastHandled,
     setLocalError,
+    clearLocalError: clearLocalErrorIfCurrent,
   });
 
   useRunInGameTerminalToast({
@@ -1917,7 +1930,20 @@ export function StudioShell(props: StudioShellProps) {
   ]);
 
   const handleToggleAutoplay = useCallback(async () => {
-    if (autoplayActionRunning || browserRunning || runInGameRunning || saveDeployRunning) return;
+    if (autoplayActionRunning) {
+      toast("Autoplay request is already in flight.", { variant: "info" });
+      return;
+    }
+    const busyMessage = studioBusyGateMessage({
+      subject: "Autoplay",
+      browserRunning,
+      runInGameRunning,
+      saveDeployRunning,
+    });
+    if (busyMessage) {
+      toast(busyMessage, { variant: "info" });
+      return;
+    }
     const action = liveRuntime.autoplayActive ? "stop" : "start";
     setAutoplayActionRunning(true);
     try {
@@ -1959,7 +1985,20 @@ export function StudioShell(props: StudioShellProps) {
    * session; player 0 is the canonical local player, matching the CLI.
    */
   const handleExplore = useCallback(async () => {
-    if (exploreActionRunning || browserRunning || runInGameRunning || saveDeployRunning) return;
+    if (exploreActionRunning) {
+      toast("Explore request is already in flight.", { variant: "info" });
+      return;
+    }
+    const busyMessage = studioBusyGateMessage({
+      subject: "Explore",
+      browserRunning,
+      runInGameRunning,
+      saveDeployRunning,
+    });
+    if (busyMessage) {
+      toast(busyMessage, { variant: "info" });
+      return;
+    }
     setExploreActionRunning(true);
     try {
       const result = await liveControlPort.display.explore.request({ playerId: 0 });
@@ -1990,6 +2029,19 @@ export function StudioShell(props: StudioShellProps) {
       );
     }
   }, [runInGameOperation, toast]);
+
+  const gameOperationBusyLabel = studioBusyGateMessage({
+    subject: "Game controls",
+    browserRunning,
+    runInGameRunning,
+    saveDeployRunning,
+  });
+  const worldOperationBusyLabel = studioBusyGateMessage({
+    subject: "World controls",
+    browserRunning,
+    runInGameRunning,
+    saveDeployRunning,
+  });
 
   const dataTypeModel = viz.dataTypeModel;
   const dataTypeOptions: DataTypeOption[] = useMemo(() => {
@@ -2565,6 +2617,7 @@ export function StudioShell(props: StudioShellProps) {
           onExplore={handleExplore}
           isExploreActionRunning={exploreActionRunning}
           operationControlsDisabled={browserRunning || runInGameRunning || saveDeployRunning}
+          operationBusyLabel={gameOperationBusyLabel}
           isRunInGameRunning={runInGameRunning}
           runInGameStatus={runInGameOperation}
           runInGameCurrentRelation={runInGameCurrentRelation}
@@ -2691,6 +2744,7 @@ export function StudioShell(props: StudioShellProps) {
       isRunning={browserRunning}
       isRunInGameRunning={runInGameRunning}
       isSaveDeployRunning={saveDeployRunning}
+      operationBusyLabel={worldOperationBusyLabel}
       isDirty={isDirty}
       onToast={(message) => toast(message, { variant: "success" })}
       autoRunEnabled={autoRunEnabled}

--- a/apps/mapgen-studio/src/app/hooks/useStudioEvents.ts
+++ b/apps/mapgen-studio/src/app/hooks/useStudioEvents.ts
@@ -1,6 +1,10 @@
-import type { StudioEvent } from "@civ7/studio-server";
+import type {
+  MapConfigSaveDeployStatus,
+  RunInGameOperationStatus,
+  StudioEvent,
+} from "@civ7/studio-server";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { LiveRuntimeStatusState } from "../../features/liveRuntime/model";
 import { orpc, orpcClient } from "../../lib/orpc";
 import {
@@ -9,6 +13,13 @@ import {
   readAndAdoptStudioOperationsCurrent,
   type StudioOperationAdoptionTargets,
 } from "../operationAdoption";
+import {
+  formatStudioDaemonIdentityMismatch,
+  formatStudioEventStreamError,
+  identityFromStudioEvent,
+  identityFromStudioOperationsCurrent,
+  studioEventClearsStreamError,
+} from "../studioEventRecovery";
 
 export const STUDIO_EVENT_STREAM_RETRY_ATTEMPTS = Number.POSITIVE_INFINITY;
 
@@ -38,16 +49,27 @@ export function studioEventsWatchLiveOptionsFor(watch: StudioEventsWatchProcedur
 export function useStudioEvents(
   args: StudioOperationAdoptionTargets & {
     applyLiveGameState(state: LiveRuntimeStatusState): void;
+    currentRunInGameOperation?: RunInGameOperationStatus | null;
+    currentSaveDeployOperation?: MapConfigSaveDeployStatus | null;
     setLocalError(message: string | null): void;
+    clearLocalError(message: string): void;
   }
 ): void {
   const {
     applyLiveGameState,
+    currentRunInGameOperation,
+    currentSaveDeployOperation,
     setRunInGameOperation,
     setSaveDeployOperation,
     markRunInGameToastHandled,
     setLocalError,
+    clearLocalError,
   } = args;
+  const eventRecoveryErrorRef = useRef<string | null>(null);
+  const currentRunInGameOperationRef = useRef<RunInGameOperationStatus | null>(null);
+  const currentSaveDeployOperationRef = useRef<MapConfigSaveDeployStatus | null>(null);
+  currentRunInGameOperationRef.current = currentRunInGameOperation ?? null;
+  currentSaveDeployOperationRef.current = currentSaveDeployOperation ?? null;
   const eventQuery = useQuery(studioEventsWatchLiveOptions());
   const event = eventQuery.data as StudioEvent | undefined;
   const helloKey =
@@ -63,9 +85,25 @@ export function useStudioEvents(
       ? `${event.state.snapshotId ?? event.state.snapshotHash ?? event.state.status}:${event.observedAt}`
       : null;
 
+  const setEventRecoveryError = useCallback(
+    (message: string) => {
+      eventRecoveryErrorRef.current = message;
+      setLocalError(message);
+    },
+    [setLocalError]
+  );
+
+  const clearEventRecoveryError = useCallback(() => {
+    const message = eventRecoveryErrorRef.current;
+    if (!message) return;
+    eventRecoveryErrorRef.current = null;
+    clearLocalError(message);
+  }, [clearLocalError]);
+
   useEffect(() => {
-    if (!helloKey) return;
+    if (!helloKey || event?.type !== "hello") return;
     let cancelled = false;
+    const expectedIdentity = identityFromStudioEvent(event);
     void readAndAdoptStudioOperationsCurrent({
       readCurrent: () => orpcClient.studio.operations.current({}),
       targets: {
@@ -74,40 +112,56 @@ export function useStudioEvents(
         markRunInGameToastHandled,
       },
       isCancelled: () => cancelled,
-      onError: setLocalError,
+      getCurrentRunInGameOperation: () => currentRunInGameOperationRef.current,
+      getCurrentSaveDeployOperation: () => currentSaveDeployOperationRef.current,
+      shouldAdopt: (current) => {
+        const observedIdentity = identityFromStudioOperationsCurrent(current);
+        const mismatch =
+          expectedIdentity === null
+            ? null
+            : formatStudioDaemonIdentityMismatch(expectedIdentity, observedIdentity);
+        if (!mismatch) return true;
+        setEventRecoveryError(mismatch);
+        return false;
+      },
+      onAdopted: () => {
+        if (cancelled) return;
+        clearEventRecoveryError();
+      },
+      onError: setEventRecoveryError,
     });
     return () => {
       cancelled = true;
     };
   }, [
+    clearEventRecoveryError,
+    event,
     helloKey,
     markRunInGameToastHandled,
-    setLocalError,
+    setEventRecoveryError,
     setRunInGameOperation,
     setSaveDeployOperation,
   ]);
 
   useEffect(() => {
     if (!operationKey || event?.type !== "operation") return;
+    if (studioEventClearsStreamError(event)) clearEventRecoveryError();
     applyStudioOperationEvent(event, {
       setRunInGameOperation,
       setSaveDeployOperation,
     });
-  }, [event, operationKey, setRunInGameOperation, setSaveDeployOperation]);
+  }, [clearEventRecoveryError, event, operationKey, setRunInGameOperation, setSaveDeployOperation]);
 
   useEffect(() => {
     if (!liveGameKey || event?.type !== "live-game") return;
+    if (studioEventClearsStreamError(event)) clearEventRecoveryError();
     applyStudioLiveGameEvent(event, {
       applyLiveGameState,
     });
-  }, [applyLiveGameState, event, liveGameKey]);
+  }, [applyLiveGameState, clearEventRecoveryError, event, liveGameKey]);
 
   useEffect(() => {
     if (!eventQuery.error) return;
-    setLocalError(
-      eventQuery.error instanceof Error
-        ? eventQuery.error.message
-        : "Studio event stream unavailable"
-    );
-  }, [eventQuery.error, setLocalError]);
+    setEventRecoveryError(formatStudioEventStreamError(eventQuery.error));
+  }, [eventQuery.error, setEventRecoveryError]);
 }

--- a/apps/mapgen-studio/src/app/operationAdoption.ts
+++ b/apps/mapgen-studio/src/app/operationAdoption.ts
@@ -16,9 +16,17 @@ export interface StudioOperationAdoptionTargets {
 
 export function adoptStudioOperationsCurrent(
   current: StudioOperationsCurrent,
-  targets: StudioOperationAdoptionTargets
+  targets: StudioOperationAdoptionTargets,
+  options: Readonly<{
+    currentRunInGameOperation?: RunInGameOperationStatus | null;
+    currentSaveDeployOperation?: MapConfigSaveDeployStatus | null;
+  }> = {}
 ): void {
-  const runInGame = current.runInGame.active ?? current.runInGame.recent[0] ?? null;
+  const runInGame = selectOperationForAdoption(
+    current.runInGame.active ?? current.runInGame.recent[0] ?? null,
+    options.currentRunInGameOperation ?? null,
+    current.observedAt
+  );
   if (runInGame) {
     const operation = runInGame;
     targets.setRunInGameOperation(operation);
@@ -29,7 +37,11 @@ export function adoptStudioOperationsCurrent(
     targets.setRunInGameOperation(null);
   }
 
-  const saveDeploy = current.saveDeploy.active ?? current.saveDeploy.recent[0] ?? null;
+  const saveDeploy = selectOperationForAdoption(
+    current.saveDeploy.active ?? current.saveDeploy.recent[0] ?? null,
+    options.currentSaveDeployOperation ?? null,
+    current.observedAt
+  );
   targets.setSaveDeployOperation(saveDeploy);
 }
 
@@ -56,15 +68,41 @@ export async function readAndAdoptStudioOperationsCurrent(
     readCurrent(): Promise<StudioOperationsCurrent>;
     targets: StudioOperationAdoptionTargets;
     isCancelled?: () => boolean;
+    getCurrentRunInGameOperation?: () => RunInGameOperationStatus | null;
+    getCurrentSaveDeployOperation?: () => MapConfigSaveDeployStatus | null;
+    shouldAdopt?(current: StudioOperationsCurrent): boolean;
+    onAdopted?(current: StudioOperationsCurrent): void;
     onError(message: string): void;
   }>
 ): Promise<void> {
   try {
     const current = await args.readCurrent();
     if (args.isCancelled?.()) return;
-    adoptStudioOperationsCurrent(current, args.targets);
+    if (args.shouldAdopt && !args.shouldAdopt(current)) return;
+    adoptStudioOperationsCurrent(current, args.targets, {
+      currentRunInGameOperation: args.getCurrentRunInGameOperation?.() ?? null,
+      currentSaveDeployOperation: args.getCurrentSaveDeployOperation?.() ?? null,
+    });
+    args.onAdopted?.(current);
   } catch (err) {
     if (args.isCancelled?.()) return;
     args.onError(err instanceof Error ? err.message : "Unable to read current Studio operations");
   }
+}
+
+function selectOperationForAdoption<Operation extends { status: string; updatedAt: string }>(
+  incoming: Operation | null,
+  local: Operation | null,
+  observedAt: string
+): Operation | null {
+  if (!local || local.status === "running") return incoming;
+  if (incoming?.status === "running") return incoming;
+  if (!incoming) return isLocalNewerThanObserved(local, observedAt) ? local : null;
+  return Date.parse(local.updatedAt) > Date.parse(incoming.updatedAt) ? local : incoming;
+}
+
+function isLocalNewerThanObserved(local: { updatedAt: string }, observedAt: string): boolean {
+  const localTime = Date.parse(local.updatedAt);
+  const observedTime = Date.parse(observedAt);
+  return Number.isFinite(localTime) && Number.isFinite(observedTime) && localTime > observedTime;
 }

--- a/apps/mapgen-studio/src/app/studioEventRecovery.ts
+++ b/apps/mapgen-studio/src/app/studioEventRecovery.ts
@@ -1,0 +1,70 @@
+import type { StudioEvent, StudioOperationsCurrent } from "@civ7/studio-server";
+
+export interface StudioDaemonIdentity {
+  serverInstanceId: string;
+  serverStartedAt: string;
+}
+
+export type StudioBusyGateSubject =
+  | "Run in Game"
+  | "Autoplay"
+  | "Explore"
+  | "Game controls"
+  | "World controls";
+
+export function formatStudioEventStreamError(error: unknown): string {
+  return error instanceof Error ? error.message : "Studio event stream unavailable";
+}
+
+export function identityFromStudioEvent(event: StudioEvent): StudioDaemonIdentity | null {
+  if (event.type !== "hello") return null;
+  return {
+    serverInstanceId: event.serverInstanceId,
+    serverStartedAt: event.serverStartedAt,
+  };
+}
+
+export function identityFromStudioOperationsCurrent(
+  current: StudioOperationsCurrent
+): StudioDaemonIdentity {
+  return {
+    serverInstanceId: current.serverInstanceId,
+    serverStartedAt: current.serverStartedAt,
+  };
+}
+
+export function sameStudioDaemonIdentity(
+  left: StudioDaemonIdentity | null | undefined,
+  right: StudioDaemonIdentity | null | undefined
+): boolean {
+  return Boolean(
+    left &&
+      right &&
+      left.serverInstanceId === right.serverInstanceId &&
+      left.serverStartedAt === right.serverStartedAt
+  );
+}
+
+export function formatStudioDaemonIdentityMismatch(
+  expected: StudioDaemonIdentity,
+  observed: StudioDaemonIdentity
+): string | null {
+  if (sameStudioDaemonIdentity(expected, observed)) return null;
+  return `Studio daemon restarted while recovering operations; adopted current daemon state (${observed.serverInstanceId}).`;
+}
+
+export function studioEventClearsStreamError(event: StudioEvent): boolean {
+  return event.type === "hello" || event.type === "operation" || event.type === "live-game";
+}
+
+export function studioBusyGateMessage(args: {
+  subject: StudioBusyGateSubject;
+  browserRunning?: boolean;
+  runInGameRunning?: boolean;
+  saveDeployRunning?: boolean;
+}): string | null {
+  if (args.browserRunning) return `${args.subject} is paused while map generation is running.`;
+  if (args.runInGameRunning) return `${args.subject} is paused while Run in Game is running.`;
+  if (args.saveDeployRunning) return `${args.subject} is paused while Save & Deploy is running.`;
+  return null;
+}

--- a/apps/mapgen-studio/src/ui/components/AppFooter.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppFooter.tsx
@@ -54,6 +54,8 @@ export interface AppFooterProps {
   isRunInGameRunning: boolean;
   /** Whether config save/deploy is currently running (shared operation gate) */
   isSaveDeployRunning?: boolean;
+  /** Visible reason shown when shared operation gates disable world/map controls */
+  operationBusyLabel?: string | null;
   /** Whether current settings differ from last run */
   isDirty: boolean;
   /** Toast function for notifications */
@@ -77,6 +79,7 @@ export const AppFooter: React.FC<AppFooterProps> = ({
   isRunning,
   isRunInGameRunning,
   isSaveDeployRunning = false,
+  operationBusyLabel,
   isDirty,
   onToast,
   autoRunEnabled,
@@ -111,6 +114,8 @@ export const AppFooter: React.FC<AppFooterProps> = ({
           : "Ready";
   const displaySize = MAP_SIZE_SHORT[lastGlobalSettings.mapSize] || lastGlobalSettings.mapSize;
   const operationControlsDisabled = isRunning || isRunInGameRunning || isSaveDeployRunning;
+  const busyTitle =
+    operationControlsDisabled && operationBusyLabel ? operationBusyLabel : undefined;
   const updateSetting = <K extends keyof RecipeSettings>(key: K, value: RecipeSettings[K]) => {
     onSettingsChange({
       ...currentSettings,
@@ -169,6 +174,14 @@ export const AppFooter: React.FC<AppFooterProps> = ({
           <div className="flex items-center gap-2">
             <div className={`w-2 h-2 rounded-full ${statusDotClass}`} />
             <span className={`text-data font-medium ${textPrimary}`}>{statusText}</span>
+            {busyTitle ? (
+              <span
+                className="rounded border border-warning/40 px-1.5 py-0.5 text-label text-warning"
+                title={busyTitle}
+              >
+                Busy
+              </span>
+            ) : null}
           </div>
 
           {/* Run history — the collapsed last-run cluster. */}
@@ -260,6 +273,7 @@ export const AppFooter: React.FC<AppFooterProps> = ({
                 max={CIV7_STUDIO_SEED_MAX}
                 aria-label={`Generation seed (${CIV7_STUDIO_SEED_MIN}-${CIV7_STUDIO_SEED_MAX})`}
                 disabled={operationControlsDisabled}
+                title={busyTitle}
                 className="w-20 font-mono"
               />
             </TooltipTrigger>
@@ -274,7 +288,8 @@ export const AppFooter: React.FC<AppFooterProps> = ({
                 size="icon"
                 onClick={onReroll}
                 disabled={operationControlsDisabled}
-                aria-label="Re-roll: New seed and run"
+                aria-label={busyTitle ?? "Re-roll: New seed and run"}
+                title={busyTitle}
               >
                 <Dices className="w-3.5 h-3.5" />
               </Button>
@@ -291,7 +306,8 @@ export const AppFooter: React.FC<AppFooterProps> = ({
                 onClick={() => onAutoRunEnabledChange(!autoRunEnabled)}
                 disabled={operationControlsDisabled}
                 aria-pressed={autoRunEnabled}
-                aria-label="Toggle auto-run: run current seed on config changes"
+                aria-label={busyTitle ?? "Toggle auto-run: run current seed on config changes"}
+                title={busyTitle}
                 className={
                   autoRunEnabled ? "ring-1 ring-ring border-primary text-primary" : undefined
                 }
@@ -306,6 +322,8 @@ export const AppFooter: React.FC<AppFooterProps> = ({
           <Button
             onClick={onRun}
             disabled={operationControlsDisabled}
+            aria-label={busyTitle ?? "Run current map generation"}
+            title={busyTitle}
             className={`
             ${isDirty ? "ring-1 ring-ring border-primary" : ""}
             ${isRunning ? "opacity-70 cursor-wait" : ""}

--- a/apps/mapgen-studio/src/ui/components/GameConsole.tsx
+++ b/apps/mapgen-studio/src/ui/components/GameConsole.tsx
@@ -74,6 +74,8 @@ export interface GameConsoleProps {
   isExploreActionRunning?: boolean;
   /** Whether any studio/game operation is in flight (shared control gating) */
   operationControlsDisabled: boolean;
+  /** Visible reason shown when shared operation gates disable game controls */
+  operationBusyLabel?: string | null;
   /** Whether Civ7 Run in Game is currently running */
   isRunInGameRunning: boolean;
   /** Request-correlated Civ7 Run in Game status */
@@ -111,6 +113,7 @@ export const GameConsole: React.FC<GameConsoleProps> = ({
   onExplore,
   isExploreActionRunning = false,
   operationControlsDisabled,
+  operationBusyLabel,
   isRunInGameRunning,
   runInGameStatus,
   runInGameCurrentRelation = "unknown",
@@ -216,14 +219,18 @@ export const GameConsole: React.FC<GameConsoleProps> = ({
   // used to carry lives entirely in the accessible name + tooltip.
   const autoplayTitle = isAutoplayActionRunning
     ? "Autoplay request in flight"
-    : liveRuntime?.autoplayActive
-      ? `Stop Civ7 autoplay${liveRuntime.autoplayPaused ? " (paused)" : ""}`
-      : "Start Civ7 autoplay";
+    : operationControlsDisabled && operationBusyLabel
+      ? operationBusyLabel
+      : liveRuntime?.autoplayActive
+        ? `Stop Civ7 autoplay${liveRuntime.autoplayPaused ? " (paused)" : ""}`
+        : "Start Civ7 autoplay";
   const exploreTitle = !onExplore
     ? "Explore: tile visibility control is not yet available"
     : isExploreActionRunning
       ? "Explore request in flight"
-      : "Explore: reveal the full map in the live game";
+      : operationControlsDisabled && operationBusyLabel
+        ? operationBusyLabel
+        : "Explore: reveal the full map in the live game";
   const saveDeployLabel = saveDeployStatus
     ? formatMapConfigSaveDeployPhaseLabel(saveDeployStatus.phase)
     : null;
@@ -297,6 +304,7 @@ export const GameConsole: React.FC<GameConsoleProps> = ({
     runInGameStatus?.details?.recoveryHint
       ? `Recovery: ${runInGameStatus.details.recoveryHint}`
       : null,
+    operationControlsDisabled && operationBusyLabel ? operationBusyLabel : null,
   ]
     .filter(Boolean)
     .join("\n");
@@ -342,6 +350,15 @@ export const GameConsole: React.FC<GameConsoleProps> = ({
         </TooltipTrigger>
         <TooltipContent className="whitespace-pre-line">{chipTitle}</TooltipContent>
       </Tooltip>
+
+      {operationControlsDisabled && operationBusyLabel ? (
+        <span
+          className="shrink-0 rounded border border-warning/40 px-1.5 py-0.5 text-label text-warning"
+          title={operationBusyLabel}
+        >
+          Busy
+        </span>
+      ) : null}
 
       <Tooltip>
         <TooltipTrigger asChild>

--- a/apps/mapgen-studio/test/runInGame/AppFooter.test.tsx
+++ b/apps/mapgen-studio/test/runInGame/AppFooter.test.tsx
@@ -80,17 +80,26 @@ describe("AppFooter world/map console", () => {
   });
 
   it("disables map settings and run controls while Run in Game is running (shared operation gate)", () => {
-    const html = renderFooter({ isRunInGameRunning: true });
+    const html = renderFooter({
+      isRunInGameRunning: true,
+      operationBusyLabel: "World controls are paused while Run in Game is running.",
+    });
 
     expect(html).toContain("disabled");
+    expect(html).toContain("World controls are paused while Run in Game is running.");
+    expect(html).toContain("Busy");
     // The relocated selects ride the same gate as seed/reroll/run.
     const sizeTrigger = html.match(/<button[^>]*aria-label="World size"[^>]*>/)?.[0] ?? "";
     expect(sizeTrigger).toContain("disabled");
   });
 
   it("disables run controls while config save/deploy is running (shared operation gate)", () => {
-    const html = renderFooter({ isSaveDeployRunning: true });
+    const html = renderFooter({
+      isSaveDeployRunning: true,
+      operationBusyLabel: "World controls are paused while Save & Deploy is running.",
+    });
 
     expect(html).toContain("disabled");
+    expect(html).toContain("World controls are paused while Save &amp; Deploy is running.");
   });
 });

--- a/apps/mapgen-studio/test/runInGame/GameConsole.test.tsx
+++ b/apps/mapgen-studio/test/runInGame/GameConsole.test.tsx
@@ -171,6 +171,7 @@ describe("GameConsole live runtime and save/deploy", () => {
   it("renders save/deploy status with its request id", () => {
     const html = renderConsole({
       operationControlsDisabled: true,
+      operationBusyLabel: "Game controls are paused while Save & Deploy is running.",
       saveDeployStatus: {
         ok: true,
         requestId: "studio-save-deploy-test",
@@ -184,6 +185,8 @@ describe("GameConsole live runtime and save/deploy", () => {
 
     expect(html).toContain("Save/Deploy: Deploying");
     expect(html).toContain("studio-save-deploy-test");
+    expect(html).toContain("Game controls are paused while Save &amp; Deploy is running.");
+    expect(html).toContain("Busy");
     expect(html).toContain("disabled");
   });
 
@@ -229,6 +232,19 @@ describe("GameConsole live runtime and save/deploy", () => {
     });
 
     expect(html).toContain("Explore request in flight");
+  });
+
+  it("shows the shared busy reason on disabled Autoplay and Explore controls", () => {
+    const html = renderConsole({
+      liveRuntime: { status: "ok", readiness: "ready" },
+      onToggleAutoplay: vi.fn(),
+      onExplore: vi.fn(),
+      operationControlsDisabled: true,
+      operationBusyLabel: "Game controls are paused while Run in Game is running.",
+    });
+
+    expect(html).toContain("Game controls are paused while Run in Game is running.");
+    expect(html).toContain("Busy");
   });
 
   it("highlights live seed status when a proved live game is out of sync with Studio", () => {

--- a/apps/mapgen-studio/test/studioEvents/operationAdoption.test.ts
+++ b/apps/mapgen-studio/test/studioEvents/operationAdoption.test.ts
@@ -23,6 +23,14 @@ import {
   applyStudioOperationEvent,
   readAndAdoptStudioOperationsCurrent,
 } from "../../src/app/operationAdoption";
+import {
+  formatStudioDaemonIdentityMismatch,
+  formatStudioEventStreamError,
+  identityFromStudioOperationsCurrent,
+  sameStudioDaemonIdentity,
+  studioBusyGateMessage,
+  studioEventClearsStreamError,
+} from "../../src/app/studioEventRecovery";
 import type { LiveRuntimeStatusState } from "../../src/features/liveRuntime/model";
 
 const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url));
@@ -123,6 +131,104 @@ describe("Studio event operation adoption", () => {
     expect(state.saveDeploy).toBeNull();
   });
 
+  test("does not erase newer local terminal Run in Game diagnostics with older current truth", () => {
+    const state = adoptionState({
+      runInGame: {
+        ok: false,
+        requestId: "run-local-failed",
+        phase: "failed",
+        status: "failed",
+        startedAt: "2026-06-13T00:00:02.000Z",
+        updatedAt: "2026-06-13T00:00:03.000Z",
+        completedPhases: ["materializing", "deploying", "preparing-setup"],
+        error: "Civ7 setup cannot see {swooper-maps}/maps/studio-current.js",
+      },
+    });
+
+    adoptStudioOperationsCurrent(currentOperations(), state.targets, {
+      currentRunInGameOperation: state.runInGame,
+    });
+
+    expect(state.runInGame?.requestId).toBe("run-local-failed");
+    expect(state.runInGame?.error).toContain("{swooper-maps}/maps/studio-current.js");
+  });
+
+  test("does not replace newer local terminal Run in Game diagnostics with an older recent operation", () => {
+    const state = adoptionState({
+      runInGame: {
+        ok: false,
+        requestId: "run-local-failed",
+        phase: "failed",
+        status: "failed",
+        startedAt: "2026-06-13T00:00:02.000Z",
+        updatedAt: "2026-06-13T00:00:05.000Z",
+        completedPhases: ["materializing", "deploying", "preparing-setup"],
+        error: "Civ7 setup cannot see {swooper-maps}/maps/studio-current.js",
+      },
+    });
+
+    adoptStudioOperationsCurrent(
+      currentOperations({
+        observedAt: "2026-06-13T00:00:06.000Z",
+        runInGame: {
+          active: null,
+          recent: [
+            {
+              ok: true,
+              requestId: "older-terminal",
+              phase: "complete",
+              status: "complete",
+              startedAt: "2026-06-13T00:00:00.000Z",
+              updatedAt: "2026-06-13T00:00:01.000Z",
+              completedPhases: ["complete"],
+            },
+          ],
+        },
+      }),
+      state.targets,
+      { currentRunInGameOperation: state.runInGame }
+    );
+
+    expect(state.runInGame?.requestId).toBe("run-local-failed");
+  });
+
+  test("adopts newer active current operations over local terminal state", () => {
+    const state = adoptionState({
+      runInGame: {
+        ok: false,
+        requestId: "run-local-failed",
+        phase: "failed",
+        status: "failed",
+        startedAt: "2026-06-13T00:00:02.000Z",
+        updatedAt: "2026-06-13T00:00:05.000Z",
+        completedPhases: ["materializing"],
+        error: "old local error",
+      },
+    });
+
+    adoptStudioOperationsCurrent(
+      currentOperations({
+        observedAt: "2026-06-13T00:00:06.000Z",
+        runInGame: {
+          active: {
+            ok: true,
+            requestId: "run-active-new",
+            phase: "deploying",
+            status: "running",
+            startedAt: "2026-06-13T00:00:06.000Z",
+            updatedAt: "2026-06-13T00:00:07.000Z",
+            completedPhases: ["materializing"],
+          },
+          recent: [],
+        },
+      }),
+      state.targets,
+      { currentRunInGameOperation: state.runInGame }
+    );
+
+    expect(state.runInGame?.requestId).toBe("run-active-new");
+  });
+
   test("shell boot adoption reads daemon current without status replay", async () => {
     const state = adoptionState();
     let currentReads = 0;
@@ -170,6 +276,68 @@ describe("Studio event operation adoption", () => {
     expect(bootEffect).toContain("orpcClient.studio.operations.current({})");
     expect(bootEffect).not.toMatch(
       /fetchRunInGameStatus|fetchSaveDeployStatus|runInGame\.status|mapConfigs\.status/
+    );
+  });
+
+  test("current adoption reads latest local operation at adoption time", async () => {
+    const state = adoptionState();
+    let localOperation: RunInGameOperationStatus | null = null;
+    let resolveCurrent: ((current: StudioOperationsCurrent) => void) | null = null;
+    const currentPromise = new Promise<StudioOperationsCurrent>((resolve) => {
+      resolveCurrent = resolve;
+    });
+
+    const read = readAndAdoptStudioOperationsCurrent({
+      readCurrent: () => currentPromise,
+      targets: state.targets,
+      getCurrentRunInGameOperation: () => localOperation,
+      onError: () => {
+        throw new Error("unexpected current read failure");
+      },
+    });
+
+    localOperation = {
+      ok: false,
+      requestId: "run-local-after-read-start",
+      phase: "failed",
+      status: "failed",
+      startedAt: "2026-06-13T00:00:02.000Z",
+      updatedAt: "2026-06-13T00:00:03.000Z",
+      completedPhases: ["materializing", "deploying", "preparing-setup"],
+      error: "Civ7 setup cannot see {swooper-maps}/maps/studio-current.js",
+    };
+    resolveCurrent?.(currentOperations());
+    await read;
+
+    expect(state.runInGame?.requestId).toBe("run-local-after-read-start");
+  });
+
+  test("classifies stream recovery, daemon identity mismatch, and busy gates", () => {
+    const hello: TestStudioEvent = {
+      type: "hello",
+      serverInstanceId: "studio-a",
+      serverStartedAt: "2026-06-13T00:00:00.000Z",
+      observedAt: "2026-06-13T00:00:01.000Z",
+    };
+    const current = currentOperations({
+      serverInstanceId: "studio-a",
+      serverStartedAt: "2026-06-13T00:00:00.000Z",
+    });
+    const restarted = currentOperations({
+      serverInstanceId: "studio-b",
+      serverStartedAt: "2026-06-13T00:00:02.000Z",
+    });
+
+    expect(formatStudioEventStreamError(new Error("stream down"))).toBe("stream down");
+    expect(studioEventClearsStreamError(hello)).toBe(true);
+    expect(sameStudioDaemonIdentity(identityFromStudioOperationsCurrent(current), hello)).toBe(
+      true
+    );
+    expect(
+      formatStudioDaemonIdentityMismatch(hello, identityFromStudioOperationsCurrent(restarted))
+    ).toContain("Studio daemon restarted");
+    expect(studioBusyGateMessage({ subject: "Explore", runInGameRunning: true })).toContain(
+      "Run in Game"
     );
   });
 

--- a/openspec/changes/studio-event-recovery-and-adoption/tasks.md
+++ b/openspec/changes/studio-event-recovery-and-adoption/tasks.md
@@ -1,15 +1,15 @@
 ## 1. Recovery Design
 
-- [ ] 1.1 Define event error, recovery, cancellation, and identity mismatch transitions.
-- [ ] 1.2 Define operation adoption rules after hello/current replay.
+- [x] 1.1 Define event error, recovery, cancellation, and identity mismatch transitions.
+- [x] 1.2 Define operation adoption rules after hello/current replay.
 
 ## 2. Implementation
 
-- [ ] 2.1 Add and test the pure recovery coordinator.
-- [ ] 2.2 Connect hook/UI behavior to the coordinator.
-- [ ] 2.3 Add visible busy-gate feedback.
+- [x] 2.1 Add and test the pure recovery coordinator.
+- [x] 2.2 Connect hook/UI behavior to the coordinator.
+- [x] 2.3 Add visible busy-gate feedback.
 
 ## 3. Verification
 
-- [ ] 3.1 Run focused app state tests.
-- [ ] 3.2 Run app build and OpenSpec validation.
+- [x] 3.1 Run focused app state tests.
+- [x] 3.2 Run app build and OpenSpec validation.

--- a/openspec/changes/studio-event-recovery-and-adoption/workstream/phase-record.md
+++ b/openspec/changes/studio-event-recovery-and-adoption/workstream/phase-record.md
@@ -1,7 +1,75 @@
 # Phase Record: Studio Event Recovery And Operation Adoption
 
-Status: scaffolded; implementation blocked until packet train acceptance.
+Status: implemented and locally verified.
 
 Normative packet: `docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/PACKET-TRAIN.md#smr-04---event-recovery-and-operation-adoption`.
 
 Priority rows: STUDIO-01 through STUDIO-03, UI-03 through UI-05, EB-12, EB-13 busy/error portions.
+
+## Frame
+
+SMR-04 treats browser event recovery as a state-machine problem, not as a visual
+banner cleanup. Event-stream errors are local browser recovery diagnostics that
+may be cleared only by a later proven stream/current/live recovery event. They
+must not erase or mask operation failures such as `Civ7 setup cannot see
+{swooper-maps}/maps/studio-current.js`.
+
+## Implementation
+
+- Added `apps/mapgen-studio/src/app/studioEventRecovery.ts` as the pure recovery
+  seam for stream-error formatting, daemon identity comparison, recovery-event
+  classification, and shared busy-gate messages.
+- Updated `useStudioEvents` so stream errors are source-tracked, later
+  hello/current, operation, or live-game recovery clears only that stream error,
+  and hello/current daemon identity mismatch is visible without server contract
+  expansion.
+- Updated current-operation adoption so delayed `studio.operations.current`
+  responses cannot replace newer local terminal diagnostics with empty or older
+  daemon state, while newer active daemon operations still adopt.
+- Added visible shared busy feedback for Game and World controls and replaced
+  silent Autoplay/Explore busy returns with toasts.
+
+## Review Disposition
+
+Read-only SMR-04 reviewer findings:
+
+- P1 stream recovery never cleared stale local error: accepted and repaired by
+  source-tracked event recovery clearing.
+- P1 adoption could erase newer local terminal diagnostics: accepted and
+  repaired by time-aware adoption selection and adoption-time local getters.
+- P2 daemon identity mismatch not explicit: accepted and repaired with existing
+  hello/current identity comparison; no event contract expansion.
+- P2 busy gates silent for disabled/in-flight controls: accepted and repaired
+  with visible Busy labels and toasts for active Autoplay/Explore handlers.
+- P3 deterministic recovery seam absent: accepted and repaired by
+  `studioEventRecovery.ts` plus focused tests.
+
+No accepted P1/P2 findings remain open in this packet.
+
+## Verification
+
+- `bun run --cwd apps/mapgen-studio test test/studioEvents/operationAdoption.test.ts`
+  passed: 18 tests.
+- `bun run --cwd apps/mapgen-studio test test/runInGame/GameConsole.test.tsx test/runInGame/AppFooter.test.tsx`
+  passed: 21 tests.
+- `bun run nx run mapgen-studio:check --outputStyle=static` passed.
+- `bun run nx run mapgen-studio:test --outputStyle=static` passed: 51 files,
+  257 tests.
+- `bun run nx run mapgen-studio:build:vite --outputStyle=static` passed.
+- `bun run openspec -- validate studio-event-recovery-and-adoption --strict`
+  passed.
+- `bun run openspec:validate` passed: 194 items.
+- `bun run lint` passed with the existing doc-ambiguity advisory only.
+
+## Proof Labels
+
+Claimed in this packet after pending gates pass: tested, browser state proof,
+built, OpenSpec validation.
+
+Not claimed: live Civ7 proof, deployed proof, tuner-exercised proof, logged
+proof, in-game observation, product proof.
+
+The reported `{swooper-maps}/maps/studio-current.js` setup-visibility failure is
+preserved as operation diagnostic state and remains a priority live-proof blocker
+for `studio-live-civ7-proof-gates`; this packet does not claim the file is
+generated, deployed, visible to Civ7 setup, or in-game observed.


### PR DESCRIPTION
Implements studio event stream recovery and operation adoption hardening (SMR-04).

**Stream error recovery** errors set by the event stream are now source-tracked so they can only be cleared by a subsequent proven recovery event (hello, operation, or live-game). This prevents stale browser-side error banners from persisting after the stream reconnects, and prevents stream errors from masking real operation failures like `Civ7 setup cannot see {swooper-maps}/maps/studio-current.js`.

**Operation adoption safety** — delayed `studio.operations.current` responses can no longer replace newer local terminal diagnostics with empty or older daemon state. Adoption now reads the current local operation at resolution time (not at request time) and applies time-aware selection: local terminal state is preserved when it is newer than the observed snapshot, while newer active daemon operations still win.

**Daemon identity mismatch** — when a `hello` event and the subsequent `operations.current` response disagree on `serverInstanceId`/`serverStartedAt`, adoption is skipped and a visible error is shown. This surfaces daemon restarts that occur mid-recovery without requiring any server contract changes.

**Busy-gate feedback** — `GameConsole` and `AppFooter` now receive an `operationBusyLabel` prop that renders a visible `Busy` badge and populates `title` attributes on disabled controls when map generation, Run in Game, or Save & Deploy is active. Autoplay and Explore handlers that previously returned silently now show an informational toast explaining why the action is blocked.

A new `studioEventRecovery.ts` module centralises the pure recovery logic: stream-error formatting, daemon identity comparison, recovery-event classification, and busy-gate message generation. This seam is covered by focused unit tests alongside expanded adoption tests for the time-aware selection rules.