### PR TITLE
`fix(mapgen-studio): skip process-restart requirement for stale run-in-game relation`

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -2623,7 +2623,10 @@ export function StudioShell(props: StudioShellProps) {
           runInGameCurrentRelation={runInGameCurrentRelation}
           onRunInGame={() => {
             void handleRunInGame({
-              restartCivProcess: runInGameRequiresProcessRestart(runInGameOperation),
+              restartCivProcess: runInGameRequiresProcessRestart(
+                runInGameOperation,
+                runInGameCurrentRelation
+              ),
             });
           }}
           onCopyRunInGameDiagnostics={copyRunInGameDiagnostics}

--- a/apps/mapgen-studio/src/features/runInGame/status.ts
+++ b/apps/mapgen-studio/src/features/runInGame/status.ts
@@ -20,6 +20,8 @@ const RUNNING_PHASES = new Set<RunInGamePhase>([
   "waiting-for-proof",
 ]);
 
+export type RunInGameActionRelation = "current" | "stale" | "unknown";
+
 export function isRunInGameTerminalPhase(phase: RunInGamePhase): boolean {
   return TERMINAL_PHASES.has(phase);
 }
@@ -64,16 +66,19 @@ export function formatRunInGamePhaseLabel(phase: RunInGamePhase): string {
   }
 }
 
-export function runInGameRequiresProcessRestart(status?: RunInGameOperationStatus | null): boolean {
-  return status?.details?.reloadBoundary === "process-restart-required";
+export function runInGameRequiresProcessRestart(
+  status?: RunInGameOperationStatus | null,
+  relation: RunInGameActionRelation = "unknown"
+): boolean {
+  return relation !== "stale" && status?.details?.reloadBoundary === "process-restart-required";
 }
 
 export function runInGamePrimaryActionLabel(
   status?: RunInGameOperationStatus | null,
-  relation: "current" | "stale" | "unknown" = "unknown"
+  relation: RunInGameActionRelation = "unknown"
 ): string {
   if (status?.status === "running") return formatRunInGamePhaseLabel(status.phase);
-  if (status && runInGameRequiresProcessRestart(status)) return "Restart Civ & Run";
+  if (status && runInGameRequiresProcessRestart(status, relation)) return "Restart Civ & Run";
   if (
     status?.status === "failed" ||
     status?.status === "blocked" ||

--- a/apps/mapgen-studio/test/runInGame/GameConsole.test.tsx
+++ b/apps/mapgen-studio/test/runInGame/GameConsole.test.tsx
@@ -108,6 +108,29 @@ describe("GameConsole Run in Game status", () => {
     expect(html).toContain("Restart Civ &amp; Run");
   });
 
+  it("does not carry restart-Civ recovery onto stale authored Studio state", () => {
+    const html = renderWithStatus(
+      {
+        ok: false,
+        requestId: "studio-run-in-game-stale-restart-needed",
+        phase: "blocked",
+        status: "blocked",
+        startedAt: "2026-06-01T00:00:00.000Z",
+        updatedAt: "2026-06-01T00:00:01.000Z",
+        completedPhases: ["materializing", "deploying", "checking-civ7"],
+        error: "Civ7 setup cannot see {swooper-maps}/maps/studio-current.js",
+        details: {
+          code: "setup-map-row-not-visible",
+          reloadBoundary: "process-restart-required",
+        },
+      },
+      "stale"
+    );
+
+    expect(html).toContain("Run Current");
+    expect(html).not.toContain("Restart Civ &amp; Run");
+  });
+
   it("keeps map script fatal recovery on retry instead of process restart", () => {
     const html = renderWithStatus(
       {

--- a/apps/mapgen-studio/test/runInGame/status.test.ts
+++ b/apps/mapgen-studio/test/runInGame/status.test.ts
@@ -66,7 +66,9 @@ describe("Run in Game status helpers", () => {
     };
 
     expect(runInGameRequiresProcessRestart(status)).toBe(true);
+    expect(runInGameRequiresProcessRestart(status, "stale")).toBe(false);
     expect(runInGamePrimaryActionLabel(status, "current")).toBe("Restart Civ & Run");
+    expect(runInGamePrimaryActionLabel(status, "stale")).toBe("Run Current");
     expect(runInGamePrimaryActionLabel({ ...status, details: { code: "other" } }, "current")).toBe(
       "Retry Run"
     );


### PR DESCRIPTION
When a previous Run in Game operation required a Civ process restart, that restart requirement was incorrectly carried forward when the Studio state had since changed (i.e., the relation was "stale"). This caused the action button to show "Restart Civ & Run" even though the user was about to run a fresh, current map — not retry the failed one.

`runInGameRequiresProcessRestart` now accepts the `RunInGameActionRelation` parameter and returns `false` when the relation is `"stale"`, preventing the restart requirement from bleeding into unrelated runs. The primary action label and the actual `handleRunInGame` call both benefit from this fix, correctly showing "Run Current" and skipping the process restart when the prior operation is no longer relevant.