### PR TITLE
`docs(studio): record SMR-08 closeout reconciliation and resume proof pass`

### DIFF
--- a/apps/mapgen-studio/src/features/configOverrides/rjsfTemplates.tsx
+++ b/apps/mapgen-studio/src/features/configOverrides/rjsfTemplates.tsx
@@ -5,7 +5,7 @@ import type {
   RJSFSchema,
 } from "@rjsf/utils";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import { FieldRow } from "../../ui/components/fields";
 import { pathToPointer } from "./schemaPresentation";
 
@@ -282,7 +282,9 @@ function FlatObjectChildren(args: {
           <div key={run.item.name ?? index}>{run.item.content}</div>
         ) : (
           <div key={index} className={`flex flex-col ${FORM.rhythm.siblings} ${args.fieldsClass}`}>
-            {run.items.map((p) => p.content)}
+            {run.items.map((p, itemIndex) => (
+              <Fragment key={p.name ?? itemIndex}>{p.content}</Fragment>
+            ))}
           </div>
         )
       )}
@@ -310,13 +312,25 @@ export function BrowserConfigObjectFieldTemplate(
     // only volume change (a recessed slab opens under the row).
     return (
       <div className={`flex flex-col divide-y divide-border-subtle border-y ${FORM.borderSubtle}`}>
-        {properties.filter((p) => !p.hidden).map((p) => p.content)}
+        {properties
+          .filter((p) => !p.hidden)
+          .map((p, index) => (
+            <Fragment key={p.name ?? index}>{p.content}</Fragment>
+          ))}
       </div>
     );
   }
 
   if (isTransparent) {
-    return <div>{properties.filter((p) => !p.hidden).map((p) => p.content)}</div>;
+    return (
+      <div>
+        {properties
+          .filter((p) => !p.hidden)
+          .map((p, index) => (
+            <Fragment key={p.name ?? index}>{p.content}</Fragment>
+          ))}
+      </div>
+    );
   }
 
   const prettyTitle = title

--- a/docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/ERROR-BOUNDARY-LEDGER.md
+++ b/docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/ERROR-BOUNDARY-LEDGER.md
@@ -4,6 +4,12 @@ Date: 2026-06-16
 
 This ledger names the boundaries that the next objective must design and verify. It is not a claim that the current implementation is correct.
 
+Closeout note: this ledger is the prework error-boundary corpus. Final
+row-by-row disposition for SMR-08 is recorded in
+`openspec/changes/studio-effect-state-machine-closeout/workstream/reconciliation-ledger.md`.
+The closeout ledger preserves boundary ownership while separating source,
+browser, generated, deployed, tuner, log, in-game, Graphite, and product labels.
+
 | ID | Boundary | Known evidence | Risk | Next objective requirement |
 |---|---|---|---|---|
 | EB-01 | `packages/studio-server/src/router/**` effect-oRPC leaves | Router is the right place for declared runtime error projection. | Router leaves can convert expected runtime failures into defects or generic errors. | Enumerate every leaf and assert declared error mapping plus defect behavior. |

--- a/docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/REVIEW-DISPOSITION.md
+++ b/docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/REVIEW-DISPOSITION.md
@@ -8,7 +8,7 @@ Accepted P1/P2 findings must be repaired in this package, rejected with evidence
 
 | ID | Severity | Source | Finding | Disposition | Repair or evidence |
 |---|---:|---|---|---|---|
-| R-01 | P1 | Operational reviewer | Do not claim live proof without direct tuner/runtime action, fresh bounded logs, and exact-authorship/in-game evidence. | Accepted, repaired. | `FRAME.md`, `SCENARIO-CORPUS-LEDGER.md`, and `WORKSTREAM-RECORD.md` separate proof labels and mark live rows unresolved. |
+| R-01 | P1 | Operational reviewer | Do not claim live proof without direct tuner/runtime action, fresh bounded logs, and exact-authorship/in-game evidence. | Accepted, repaired. | `FRAME.md`, `SCENARIO-CORPUS-LEDGER.md`, and `WORKSTREAM-RECORD.md` separate proof labels; SMR-08 closeout records earned bounded `Scripting.log`, direct tuner, exact-authorship, and in-game labels while keeping Graphite/product proof separate. |
 | R-02 | P1 | Operational reviewer | Direct tuner unavailability should not block prework; it blocks later live proof labels only. | Accepted, repaired. | `INVESTIGATION-BRIEF.md` stop rules and `SCENARIO-CORPUS-LEDGER.md` mark tuner rows unresolved rather than inferred. |
 | R-03 | P1 | Graphite/worktree reviewer | Current checkout has pre-existing untracked `docs/projects/mapgen-workstream-skill/`; do not contaminate this slice. | Accepted, repaired by exclusion. | `WORKSTREAM-RECORD.md` records the untracked directory as pre-existing and excluded; only this package may be staged. |
 | R-04 | P1 | Graphite/worktree reviewer | Graphite metadata renders Studio stack under unrelated habitat state; avoid broad restack/sync/submit. | Accepted, repaired. | `WORKSTREAM-RECORD.md` records the render risk and forbids broad stack mutation from this lane. |

--- a/docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/SCENARIO-CORPUS-LEDGER.md
+++ b/docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/SCENARIO-CORPUS-LEDGER.md
@@ -4,6 +4,15 @@ Date: 2026-06-16
 
 Status values: `corpus-only`, `designed`, `tested`, `built`, `generated`, `deployed`, `tuner-exercised`, `logged`, `in-game observed`, `unresolved`.
 
+Closeout note: this ledger is the prework corpus. Final row-by-row disposition
+for SMR-08 is recorded in
+`openspec/changes/studio-effect-state-machine-closeout/workstream/reconciliation-ledger.md`.
+The closeout ledger preserves this corpus while adding current proof labels and
+explicitly marking claimed and unclaimed labels. As of the SMR-08 closeout
+evidence update, bounded `Scripting.log` proof is claimed for request
+`studio-run-in-game-mqhog22i-13if-2`; Graphite submission, broad product proof,
+and sibling load-diagnostic logs remain separate.
+
 ## Server Read RPCs
 
 | ID | Surface | User scenario | Current evidence | Required next proof | Status |

--- a/docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/WORKSTREAM-RECORD.md
+++ b/docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/WORKSTREAM-RECORD.md
@@ -20,18 +20,21 @@ Primary worktree:
 
 Current branch:
 
-`codex/studio-effect-state-machine-prework`
+`codex/studio-effect-state-machine-closeout`
 
-Current HEAD:
+Pre-update HEAD for the fresh closeout evidence docs:
 
-`f107448a3137 docs(studio): frame state-machine recovery workstream`
+`0444e6188 docs(studio): reconcile state-machine closeout`
 
-Dirty state observed during packet-train design:
+Dirty state observed during SMR-08 closeout audit:
 
 - Pre-existing untracked `docs/projects/mapgen-workstream-skill/`.
-- Modified `WORKSTREAM-RECORD.md`.
-- Untracked packet-design artifacts in this workstream directory.
-- This package is a separate docs/control slice and must not stage or claim the unrelated `docs/projects/mapgen-workstream-skill/` directory.
+- Pre-existing modified `.agents/skills/README.md`.
+- Pre-existing untracked `.agents/skills/civ7-mapgen-workstream/`.
+- SMR-08 documentation/control edits under this workstream and OpenSpec packet
+  records.
+- This package is a separate docs/control slice and must not stage or claim the
+  unrelated skill/mapgen-workstream files.
 
 Formatter-only validation hygiene performed after `bun run lint` exposed workspace Biome failures:
 
@@ -45,7 +48,7 @@ Relevant worktrees:
 
 | Worktree | State |
 |---|---|
-| `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools` | `codex/studio-effect-state-machine-prework` |
+| `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools` | `codex/studio-effect-state-machine-closeout` |
 | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-runtime-effect-prework` | `codex/studio-tuner-session-serialization`, duplicate downstack Studio worktree |
 | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-S-studio-runtime-effect-refactor` | detached at `654f58d8f`, ancestor already contained by current runtime branches |
 | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-HG-habitat-grit-pattern-chain` | unrelated habitat stack |
@@ -158,6 +161,25 @@ Expected packet families:
 7. Documentation and closeout packet.
 
 Each packet needs explicit write set, tests, proof labels, review lane, and stop condition before implementation begins.
+
+SMR-08 closeout status:
+
+- Packet train was accepted and implemented sequentially through SMR-07.
+- A post-SMR-07 user-review correction is recorded at
+  `codex/studio-run-restart-relation-scope`: stale browser operation state no
+  longer carries process-restart recovery into a changed authored Studio run.
+- Final row-by-row scenario and error-boundary disposition is recorded in
+  `openspec/changes/studio-effect-state-machine-closeout/workstream/reconciliation-ledger.md`.
+- Closeout live evidence for request `studio-run-in-game-mqhog22i-13if-2`
+  now claims generated, deployed, tuner-exercised, bounded `Scripting.log`, and
+  in-game observed labels for that request.
+- Final SMR-08 validation reran on the original
+  `codex/studio-effect-state-machine-closeout` stack: strict closeout OpenSpec,
+  full OpenSpec, habitat classification, `bun run lint`, and `git diff --check`
+  passed.
+- Product proof and Graphite submission are not claimed by local closeout
+  evidence. Sibling `Modding.log`, `Database.log`, and `UI.log` ranges remain
+  unclaimed unless a later product/load diagnostic requires them.
 
 Packet-train validation recorded during design:
 

--- a/openspec/changes/studio-browser-scenario-proof/workstream/browser-proof-ledger.md
+++ b/openspec/changes/studio-browser-scenario-proof/workstream/browser-proof-ledger.md
@@ -45,3 +45,31 @@ Interpretation:
 Known console noise:
 
 - Browser console retained one pre-existing error entry from page boot; it did not block the scenario and no Run in Game terminal error was observed.
+
+## 2026-06-17 Restart Recovery Scope Regression
+
+Branch/worktree:
+
+- branch: `codex/studio-run-restart-relation-scope`
+- commit: `1b9ec418e fix(studio): scope restart recovery to current run state`
+
+Evidence:
+
+- `bun run --cwd apps/mapgen-studio test test/runInGame/status.test.ts test/runInGame/GameConsole.test.tsx`
+  passed with 21 tests.
+- `bun run nx run mapgen-studio:check --outputStyle=static` passed.
+
+Observed behavior:
+
+- A current operation with `reloadBoundary: "process-restart-required"` still
+  renders `Restart Civ & Run`.
+- A stale prior operation with the same diagnostic renders `Run Current` and no
+  longer carries process-restart intent into the next authored Studio run.
+
+Interpretation:
+
+- Browser restart recovery is scoped to the operation relation. It remains an
+  explicit recovery affordance for the current failure, not a sticky global
+  setting for later map reruns.
+- No new live Civ7, generated, deployed, tuner, log, or product proof is claimed
+  by this regression test.

--- a/openspec/changes/studio-effect-state-machine-closeout/tasks.md
+++ b/openspec/changes/studio-effect-state-machine-closeout/tasks.md
@@ -1,16 +1,16 @@
 ## 1. Reconciliation
 
-- [ ] 1.1 Reconcile every scenario and error-boundary row.
-- [ ] 1.2 Reconcile every accepted review finding.
-- [ ] 1.3 Reconcile proof labels without substitution.
+- [x] 1.1 Reconcile every scenario and error-boundary row.
+- [x] 1.2 Reconcile every accepted review finding.
+- [x] 1.3 Reconcile proof labels without substitution.
 
 ## 2. Documentation
 
-- [ ] 2.1 Promote accepted durable docs only.
-- [ ] 2.2 Archive or mark stale project-only claims.
+- [x] 2.1 Promote accepted durable docs only.
+- [x] 2.2 Archive or mark stale project-only claims.
 
 ## 3. Verification
 
-- [ ] 3.1 Run OpenSpec validation.
-- [ ] 3.2 Run habitat-classified checks.
-- [ ] 3.3 Record Graphite, worktree, and git status.
+- [x] 3.1 Run OpenSpec validation.
+- [x] 3.2 Run habitat-classified checks.
+- [x] 3.3 Record Graphite, worktree, and git status.

--- a/openspec/changes/studio-effect-state-machine-closeout/workstream/phase-record.md
+++ b/openspec/changes/studio-effect-state-machine-closeout/workstream/phase-record.md
@@ -1,7 +1,98 @@
 # Phase Record: Studio Effect State-Machine Closeout
 
-Status: scaffolded; implementation blocked until packet train acceptance.
+Status: closeout reconciliation implemented and locally verified.
 
 Normative packet: `docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/PACKET-TRAIN.md#smr-08---state-machine-closeout`.
 
 Priority rows: all scenario and error-boundary rows.
+
+## Scope
+
+SMR-08 is a documentation/control packet. Runtime implementation files and
+generated/deployed artifacts are protected here. Stale implementation findings
+reopen the owning packet; they are not silently folded into closeout.
+
+## Reconciliation
+
+Final row-by-row scenario and error-boundary disposition is recorded in
+`workstream/reconciliation-ledger.md`.
+
+The source prework ledgers remain preserved:
+
+- `docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/SCENARIO-CORPUS-LEDGER.md`
+- `docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/ERROR-BOUNDARY-LEDGER.md`
+
+Those ledgers now point to this packet's reconciliation ledger for final proof
+labels.
+
+## Review Disposition
+
+No accepted packet-design P1/P2 finding remains open. Implementation-time user
+review findings were accepted and repaired:
+
+- Disposable `studio-current` map reruns no longer default to Civ process
+  restart. Normal reruns use deploy plus setup visibility; process restart is a
+  fallback only after typed setup-row proof failure with
+  `reloadBoundary: "process-restart-required"`.
+- Production process restart no longer uses generic coordinate clicking.
+  Restart readiness is passive App UI shell proof, with only direct-control
+  `Cinematic` display-queue dismissal as an accelerator.
+- Browser restart recovery is scoped to the current authored Studio state.
+  Stale prior operation diagnostics now render `Run Current` and do not carry
+  `restartCivProcess` into a changed run.
+
+## Proof Labels
+
+Claimed locally:
+
+- `tested`
+- `built`
+- browser API projection proof
+- browser state/component proof
+- manual rendered browser fast-path proof
+- dev startup observed
+- `generated`
+- `deployed`
+- `tuner-exercised`
+- bounded `Scripting.log` proof for request
+  `studio-run-in-game-mqhog22i-13if-2`
+- `in-game observed`
+- OpenSpec validation
+- habitat-classified lint/habitat validation
+
+Not claimed:
+
+- sibling `Modding.log`, `Database.log`, and `UI.log` ranges for broader
+  load/product diagnostics
+- Graphite submitted
+- broad product proof
+
+## Validation Record
+
+Validation commands run:
+
+- `bun run openspec -- validate studio-effect-state-machine-closeout --strict`
+  passed on the original `codex/studio-effect-state-machine-closeout` stack.
+- `bun run openspec:validate` passed: 194 items, 0 failed.
+- `bun run habitat classify docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery`
+  returned required target `bun run lint`.
+- `bun run habitat classify openspec/changes/studio-effect-state-machine-closeout`
+  returned required target `bun run lint`.
+- `bun run habitat classify openspec/changes/studio-browser-scenario-proof`
+  returned required target `bun run lint`.
+- `bun run habitat classify openspec/changes/studio-live-civ7-proof-gates`
+  returned required target `bun run lint`.
+- `bun run lint` passed. Existing `doc-ambiguity` advisory remained advisory;
+  no enforced lint or habitat check failed.
+- `git diff --check` passed.
+- `git status --short --branch` recorded current branch
+  `codex/studio-effect-state-machine-closeout`, SMR-08 docs dirty, and
+  unrelated pre-existing skill/mapgen-workstream dirt excluded.
+- `gt status` recorded the same unstaged state through Graphite.
+- `git worktree list` recorded the current worktree plus agent/habitat
+  worktrees. The only extra worktree checking out a Studio-stack branch is
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-A-civ7-discoveries-live-placement`
+  at `agent-A-civ7-discoveries-live-placement`.
+- `gt ls` and `gt log short` recorded the Studio stack rendered below unrelated
+  habitat branches marked `needs restack`; no broad restack/sync/submit was
+  performed.

--- a/openspec/changes/studio-effect-state-machine-closeout/workstream/phase-record.md
+++ b/openspec/changes/studio-effect-state-machine-closeout/workstream/phase-record.md
@@ -1,6 +1,8 @@
 # Phase Record: Studio Effect State-Machine Closeout
 
-Status: closeout reconciliation implemented and locally verified.
+Status: resumed proof pass recorded; the priority Run in Game
+`studio-current` path is product-proven on the current top, while broad
+state-machine product proof and Graphite submission remain unclaimed.
 
 Normative packet: `docs/projects/studio-runtime-simplification/workstream/studio-effect-state-machine-recovery/PACKET-TRAIN.md#smr-08---state-machine-closeout`.
 
@@ -96,3 +98,48 @@ Validation commands run:
 - `gt ls` and `gt log short` recorded the Studio stack rendered below unrelated
   habitat branches marked `needs restack`; no broad restack/sync/submit was
   performed.
+
+## 2026-06-17 Resume Proof Pass
+
+Current branch is `codex/studio-effect-state-machine-closeout` at
+`baa9d7f8e docs(studio): reconcile state-machine closeout`.
+
+The resumed objective is to prove, or explicitly keep unresolved, the remaining
+product-facing labels without changing Graphite topology:
+
+- keep using the original Studio stack; do not create a parallel replacement
+  stack;
+- use isolated dev ports because other worktrees currently have
+  `mapgen-studio`/Nx processes running;
+- treat Civ7 tuner availability on `127.0.0.1:4318` as live-runtime
+  opportunity, not proof by itself;
+- re-run source/build/dev gates before another live Run in Game proof;
+- if a new branch must be inserted later, use Graphite insert from the current
+  stack rather than a separate stack.
+
+Current excluded dirt remains unrelated to this closeout pass:
+
+- `.agents/skills/README.md`
+- `.agents/skills/civ7-mapgen-workstream/`
+- `docs/projects/mapgen-workstream-skill/`
+
+The next proof pass must update `workstream/reconciliation-ledger.md` and
+`openspec/changes/studio-live-civ7-proof-gates/workstream/live-proof-ledger.md`
+with the fresh request id, commands, ports, generated/deployed hashes, bounded
+logs, and any unresolved browser/product conditions.
+
+Resume pass outcome:
+
+- browser Run in Game proof succeeded for request
+  `studio-run-in-game-mqhqd5ic-jrj-5`;
+- Civ7 selected and loaded `{swooper-maps}/maps/studio-current.js`;
+- direct tuner/readback observed the started game at turn `1`, seed `123`, and
+  map dimensions `84x54`;
+- bounded `Scripting.log` and `Modding.log` contain the Swooper
+  `studio-current` proof/load signals for the same request;
+- bounded `Database.log` and `UI.log` contain no Swooper/studio-current
+  matches, while `UI.log` still has unrelated local third-party UI noise;
+- after the proof, the daemon restarted under a new server identity and
+  `runInGame.status` no longer had the old request, so operation-history
+  durability across daemon restarts remains outside the current product-proof
+  claim.

--- a/openspec/changes/studio-effect-state-machine-closeout/workstream/reconciliation-ledger.md
+++ b/openspec/changes/studio-effect-state-machine-closeout/workstream/reconciliation-ledger.md
@@ -1,0 +1,144 @@
+# Reconciliation Ledger: Studio Effect State-Machine Closeout
+
+Date: 2026-06-17
+
+Status: closeout reconciliation in progress on
+`codex/studio-effect-state-machine-closeout`. The fresh live/log proof below
+was recorded before this evidence update commit, with pre-update head
+`0444e6188 docs(studio): reconcile state-machine closeout`.
+
+This ledger is the SMR-08 final accounting surface. It reconciles the prework
+scenario corpus, error-boundary ledger, packet records, review findings, and
+proof labels without substituting one proof type for another.
+
+## Current Stack And Worktree
+
+- Current branch: `codex/studio-effect-state-machine-closeout`.
+- Pre-update head: `0444e6188 docs(studio): reconcile state-machine closeout`.
+- Downstack Studio packet heads:
+  - `1b9ec418e fix(studio): scope restart recovery to current run state`
+  - `2a3d126ac docs(studio): record browser scenario proof`
+  - `db1e3b7df fix(studio): restart disposable run-in-game launches`
+  - `ad906119d docs(studio): record dev startup proof`
+  - `f01ebcf29 fix(studio): recover event adoption state`
+  - `2620937c1 fix(studio): preserve browser defined errors`
+  - `2ce09b6f4 fix(studio): classify operation lifecycle failures`
+  - `7330a48bb fix(studio): complete rpc boundary coverage`
+  - `c10c4212d docs(studio): design state-machine recovery packet train`
+  - `f107448a3 docs(studio): frame state-machine recovery workstream`
+- Existing unrelated dirty state remains excluded:
+  - `.agents/skills/README.md`
+  - `.agents/skills/civ7-mapgen-workstream/`
+  - `docs/projects/mapgen-workstream-skill/`
+- Graphite render remains high-risk for broad mutation: Studio branches render
+  below unrelated habitat branches marked `needs restack`. SMR-08 does not
+  claim Graphite submission until a deliberate stack ownership pass runs.
+
+## Packet Disposition
+
+| Packet | Status | Proof labels earned | Labels not claimed |
+|---|---|---|---|
+| SMR-01 RPC boundary completion | Implemented and locally verified. | `tested`, `built`, OpenSpec validation. | browser rendered proof, live happy path, `logged`, product proof. |
+| SMR-02 operation lifecycle classification | Implemented and locally verified. | `tested`, `built`, OpenSpec validation. | browser rendered proof, generated/deployed/live proof, product proof. |
+| SMR-03 browser defined error projection | Implemented and locally verified. | `tested`, browser API projection, `built`, OpenSpec validation. | rendered full-shell proof, live proof, product proof. |
+| SMR-04 event recovery and adoption | Implemented and locally verified. | `tested`, browser state proof, `built`, OpenSpec validation. | live proof, in-game observation, product proof. |
+| SMR-05 dev startup proof | Recorded and locally verified. | `tested`, `built`, dev startup observed, bounded cleanup. | live tuner success, generated/deployed/in-game proof, product proof. |
+| SMR-06 browser scenario proof | Rendered browser fast path recorded. | manual browser scenario evidence, `tested`, `built`. | automated browser proof, fallback process-restart rendered proof, product proof by itself. |
+| SMR-07 live Civ7 proof gates | Priority blocker repaired and live setup/start path observed. | `tested`, `built`, `generated`, `deployed`, `tuner-exercised`, `in-game observed`, bounded `Scripting.log` proof for request `studio-run-in-game-mqhog22i-13if-2`. | sibling logs if required for broader product/load diagnostics; Graphite submitted; product proof as a broad release claim. |
+| Restart relation-scope correction | Implemented after user review of restart policy. | `tested`, `built` through app check; browser component proof. | live/browser manual rerun after this exact top commit. |
+| SMR-08 closeout | Locally reconciled and validated. | closeout evidence, strict OpenSpec validation, full OpenSpec validation, habitat-classified lint/habitat validation. | Graphite submitted, product proof until final stack/product review. |
+
+## Accepted Review Findings
+
+No accepted P1/P2 packet-design finding remains open:
+
+- `PRD-01` through `PRD-12` are repaired in `PACKET-TRAIN.md` and packet
+  records.
+- Prework findings `R-01` through `R-13` are either repaired in the prework
+  artifacts or carried into packet implementation records.
+- Implementation-time restart findings are accepted and repaired:
+  - Unconditional process restart for disposable `studio-current` was narrowed
+    to fallback only after typed setup-row proof failure.
+  - Generic coordinate clicking during process restart was removed from the
+    production path; readiness is passive App UI shell proof, with only
+    direct-control `Cinematic` display-queue dismissal as an accelerator.
+  - Stale browser operation state no longer carries `Restart Civ & Run` onto a
+    changed authored Studio state.
+
+## Scenario Final Disposition
+
+Proof labels are cumulative but not substitutable. `partial` means the row has
+some earned evidence while a named label remains unclaimed.
+
+| ID | Final disposition | Earned labels | Unclaimed or bounded labels |
+|---|---|---|---|
+| READ-01 | Declared unavailable mapping covered by server tests. | `tested`, `built`. | live happy-path browser product proof. |
+| READ-02 | Declared unavailable mapping covered by server tests. | `tested`, `built`. | separate happy-path tuner probe. |
+| READ-03 | Declared unavailable mapping covered by server tests. | `tested`, `built`. | separate happy-path tuner probe. |
+| READ-04 | `SETUP_CONFIG_UNAVAILABLE` is declared and browser projection preserves code/status/observedAt. | `tested`, browser API projection, `built`. | rendered setup-unavailable browser scenario after this top commit. |
+| READ-05 | Non-Civ saved-config read remains source-level only. | `tested`, `built`. | rendered startup-specific assertion. |
+| READ-06 | Non-Civ setup-catalog read remains source-level only. | `tested`, `built`. | rendered startup-specific assertion. |
+| RPC-01 | `recipeDag.get` declared errors and defects are tested through the handler. | `tested`, `built`. | none for this closeout claim. |
+| LIVE-01 | Partial live status parity is tested; rendered browser fast path observed live status update. | `tested`, manual browser evidence. | product proof by itself. |
+| LIVE-02 | Snapshot failure mapping is covered at source boundary. | `tested`, `built`. | happy-path tuner probe for this exact RPC. |
+| LIVE-03 | Entity failure mapping is covered at source boundary. | `tested`, `built`. | happy-path tuner probe for this exact RPC. |
+| LIVE-04 | Live game-info failure mapping is covered at source boundary. | `tested`, `built`. | happy-path tuner probe for this exact RPC. |
+| OP-01 | Run in Game admission validation is tested before worker start. | `tested`, `built`. | rendered validation UX. |
+| OP-02 | Duplicate active and terminal Run in Game fingerprints are tested. | `tested`, `built`. | rendered duplicate-adoption UX. |
+| OP-03 | Missing, expired, and daemon-mismatch status paths are tested. | `tested`, `built`. | rendered daemon-mismatch browser proof. |
+| OP-04 | Run in Game worker phases are tested; priority `studio-current.js` local/deploy/setup/start blocker is repaired and live observed. | `tested`, `built`, `generated`, `deployed`, `tuner-exercised`, `in-game observed`, bounded `Scripting.log` proof. | sibling logs if required for broader load/product diagnostics; product proof as broad release claim. |
+| OP-05 | Runtime disposal, active worker failure, and new-start rejection are tested. | `tested`, `built`. | rendered disposal UX. |
+| OP-06 | Save/deploy validation and browser defined-error projection are tested. | `tested`, browser API projection, `built`. | rendered terminal save/deploy UX. |
+| OP-07 | Save/deploy phase, rollback, cleanup, and registry-truth failures are tested. | `tested`, `built`. | live deploy UX beyond source tests. |
+| OP-08 | Autoplay declared error projection and busy feedback are tested. | `tested`, browser API/state proof, `built`. | live autoplay happy-path proof. |
+| OP-09 | Explore busy feedback and control error projection decision are tested at UI/helper boundary. | `tested`, browser state proof. | direct-control explore failure rendered proof. |
+| STUDIO-01 | Registry truth survives event publish failure. | `tested`, `built`. | none for this closeout claim. |
+| STUDIO-02 | Stream recovery, hello/current clearing, and daemon identity mismatch are tested through coordinator/hook seams. | `tested`, browser state proof, `built`. | full manual reconnect scenario after top commit. |
+| STUDIO-03 | Subscription cleanup, cancellation, and runtime disposal are tested. | `tested`, `built`. | external log assertion. |
+| UI-01 | Setup unavailable has API projection proof. | `tested`, browser API projection. | rendered setup-unavailable flow after top commit. |
+| UI-02 | Rendered Run in Game fast path observed from button to `Complete`/`Current`. | manual browser evidence, `tested`, `built`. | fallback restart rendered proof; product proof. |
+| UI-03 | Diagnostics/retry/restart components are tested; stale restart carryover is repaired. | `tested`, browser component proof. | manual fallback restart browser flow after top commit. |
+| UI-04 | Operation adoption after reload/reconnect is tested through adoption seams. | `tested`, browser state proof. | full manual reload proof after top commit. |
+| UI-05 | Run/autoplay/explore busy states have visible feedback tests. | `tested`, browser component proof. | none for source-level claim. |
+| UI-06 | Run, save/deploy, autoplay, and setup defined errors preserve declared fields. | `tested`, browser API projection. | rendered copy/diagnostic proof for every error family. |
+| DEV-01 | Isolated dev startup with daemon/Vite/RPC target was recorded and reused for browser proof. | dev startup observed, `built`. | product proof. |
+| DEV-02 | Root Nx orchestration remains the dev entrypoint. | `tested`, `built`, dev startup observed. | none for this closeout claim. |
+| PROOF-01 | Server, app, and mod proof commands have been run across packets; final SMR-08 closeout validation reran on the original stack. | `tested`, `built`, strict OpenSpec validation, full OpenSpec validation, habitat-classified lint/habitat validation. | Graphite submission and broad product proof remain separate. |
+| PROOF-02 | `studio-current` was command-generated with request markers for request `studio-run-in-game-mqhog22i-13if-2`. | `generated`. | none for this generated claim. |
+| PROOF-03 | Deployed Mods target contained matching `studio-current.js`; setup row appeared and the game started. | `deployed`, `tuner-exercised`, `in-game observed`. | sibling log families if needed for broader load diagnostics. |
+| PROOF-04 | Direct-control App UI and setup/start commands recorded host/port/state/result. | `tuner-exercised`. | independent non-run health probe is separate. |
+| PROOF-05 | Bounded Civ7 `Scripting.log` proof recorded `[mapgen-proof]` and `[mapgen-complete]` for request `studio-run-in-game-mqhog22i-13if-2`. | `tested`, `logged`. | sibling `Modding.log`, `Database.log`, and `UI.log` ranges are not claimed. |
+| PROOF-06 | Direct-control readback observed started game turn/date/map summary for the request. | `tuner-exercised`, `in-game observed`. | product proof as broad release claim. |
+
+## Error Boundary Final Disposition
+
+| ID | Final disposition | Earned labels | Unclaimed or bounded labels |
+|---|---|---|---|
+| EB-01 | Router leaves for Studio read/live/stateful surfaces are enumerated and tested. | `tested`, `built`. | none for source claim. |
+| EB-02 | `Civ7TunerSession` cause preservation uses current code/tests as authority. | `tested`, `built`. | none for source claim. |
+| EB-03 | Tuner client unavailable conversions retain actionable context in declared errors. | `tested`, `built`. | happy-path per-RPC tuner probes. |
+| EB-04 | Handler `onError` separates declared errors from unexpected defects. | `tested`, `built`. | none for source claim. |
+| EB-05 | Run in Game workflow promise boundaries map plain errors to phase-specific failures; closeout live run recorded bounded `Scripting.log` proof for the successful path. | `tested`, `built`, `logged`. | failure-path log proof is separate. |
+| EB-06 | Save/deploy workflow failure projection is phase-aware and tested. | `tested`, `built`. | rendered save/deploy terminal flow. |
+| EB-07 | Autoplay failures preserve declared browser projection or intentional simplification. | `tested`, browser API projection. | live autoplay happy path. |
+| EB-08 | Operation runtime admission, worker, duplicate, disposed, expired, and mismatch states are tested. | `tested`, `built`. | full manual browser adoption sweep after top commit. |
+| EB-09 | Run in Game browser API projection preserves code/details. | `tested`, browser API projection. | none for API claim. |
+| EB-10 | Save/deploy browser API projection preserves declared code/data. | `tested`, browser API projection. | rendered save/deploy copy proof. |
+| EB-11 | Setup and autoplay browser API projection preserve declared fields. | `tested`, browser API projection. | rendered setup-unavailable proof. |
+| EB-12 | Event recovery coordinator/hook clears stale stream errors only on proven recovery. | `tested`, browser state proof. | full manual reconnect proof. |
+| EB-13 | Explore busy/error portions are covered as browser/control boundary, with control-oRPC authority exterior. | `tested`, browser state proof. | direct-control failure rendered proof. |
+| EB-14 | Dev, browser, and live labels are separated in packet records and this ledger. | closeout evidence. | product proof. |
+| EB-15 | Generated/deployed outputs are evidence surfaces and were regenerated/restored by commands. | `generated`, `deployed` where claimed. | generated proof after this exact top commit. |
+| EB-16 | `recipeDag.get` declared-error and defect behavior is tested under shared handler behavior. | `tested`, `built`. | none for source claim. |
+| EB-17 | `studio-current.js` local bundle, deployed bundle, setup visibility, setup/start readback, and bounded `Scripting.log` markers were proven; restart fallback narrowed. | `generated`, `deployed`, `tuner-exercised`, `in-game observed`, `logged`. | sibling logs if required for broader diagnostics; final product proof. |
+
+## Product And Graphite Labels
+
+Product proof is not claimed by this ledger. The workstream has strong source,
+browser fast-path, generated/deployed, direct-control, bounded `Scripting.log`,
+and in-game evidence, but final Graphite submission and broad product/release
+proof remain separate labels.
+
+Graphite submitted is not claimed. The stack is locally committed but not
+submitted from this lane because current Graphite metadata interleaves unrelated
+habitat branches and needs an intentional stack ownership pass.

--- a/openspec/changes/studio-effect-state-machine-closeout/workstream/reconciliation-ledger.md
+++ b/openspec/changes/studio-effect-state-machine-closeout/workstream/reconciliation-ledger.md
@@ -2,10 +2,10 @@
 
 Date: 2026-06-17
 
-Status: closeout reconciliation in progress on
-`codex/studio-effect-state-machine-closeout`. The fresh live/log proof below
-was recorded before this evidence update commit, with pre-update head
-`0444e6188 docs(studio): reconcile state-machine closeout`.
+Status: closeout reconciliation resumed on
+`codex/studio-effect-state-machine-closeout`. A fresh current-top browser/live
+proof pass was recorded on head
+`baa9d7f8e docs(studio): reconcile state-machine closeout`.
 
 This ledger is the SMR-08 final accounting surface. It reconciles the prework
 scenario corpus, error-boundary ledger, packet records, review findings, and
@@ -14,7 +14,7 @@ proof labels without substituting one proof type for another.
 ## Current Stack And Worktree
 
 - Current branch: `codex/studio-effect-state-machine-closeout`.
-- Pre-update head: `0444e6188 docs(studio): reconcile state-machine closeout`.
+- Proof-pass head: `baa9d7f8e docs(studio): reconcile state-machine closeout`.
 - Downstack Studio packet heads:
   - `1b9ec418e fix(studio): scope restart recovery to current run state`
   - `2a3d126ac docs(studio): record browser scenario proof`
@@ -132,12 +132,127 @@ some earned evidence while a named label remains unclaimed.
 | EB-16 | `recipeDag.get` declared-error and defect behavior is tested under shared handler behavior. | `tested`, `built`. | none for source claim. |
 | EB-17 | `studio-current.js` local bundle, deployed bundle, setup visibility, setup/start readback, and bounded `Scripting.log` markers were proven; restart fallback narrowed. | `generated`, `deployed`, `tuner-exercised`, `in-game observed`, `logged`. | sibling logs if required for broader diagnostics; final product proof. |
 
+## 2026-06-17 Resume Proof On Current Top
+
+This pass was run after the closeout reconciliation commit at current stack top:
+
+- Branch/head: `codex/studio-effect-state-machine-closeout` at
+  `baa9d7f8e docs(studio): reconcile state-machine closeout`.
+- Dev command:
+  `STUDIO_DAEMON_PORT=5298 STUDIO_DEV_PORT=5198 NX_DAEMON=false bun run dev:mapgen-studio`.
+- Dev surfaces observed:
+  - daemon `http://127.0.0.1:5298`;
+  - Vite `http://localhost:5198/`.
+- Browser action: clicked the rendered `Run in Game` action in Chrome.
+- Request id: `studio-run-in-game-mqhqd5ic-jrj-5`.
+- Initial browser state before click: `Ready`, live Civ7 turn `1`, seed
+  `1337`, previous request shown as `studio-run-in-game-mqhq4d24-jrj-4`.
+- Running browser state after click: `Run in Game deploying`, disabled action
+  button, current request `studio-run-in-game-mqhqd5ic-jrj-5`.
+- Final browser state: `Ready. Live Civ7 turn 1 seed 123. Run in Game complete`;
+  action affordance reported `Run in Game: Complete`, map
+  `{swooper-maps}/maps/studio-current.js`, and `Studio state: Current`.
+- Browser console/fetch failures: no page errors and no failed requests were
+  captured; the only network miss was the Vite favicon `404`.
+- Screenshots:
+  - `/tmp/studio-proof-initial.png`
+  - `/tmp/studio-proof-after-action-click.png`
+  - `/tmp/studio-proof-final-run.png`
+
+Fresh source/build gates from this pass:
+
+- `bun run nx run @civ7/studio-server:test --outputStyle=static`: passed, 76
+  tests.
+- `bun run nx run mapgen-studio:test --outputStyle=static`: passed, 258 tests.
+- RJSF key-warning cleanup:
+  `bun run nx run mapgen-studio:test --outputStyle=static -- test/config/rjsfFieldTemplateErrors.test.tsx`
+  passed, 10 tests, after keying the RJSF object-template child lists.
+- `bun run nx run mod-swooper-maps:test:studio-run-in-game --outputStyle=static`:
+  passed, 45 tests.
+- `bun run nx run @civ7/studio-server:build --outputStyle=static`: passed.
+- `bun run nx run mapgen-studio:build:vite --outputStyle=static`: passed with
+  the existing Vite chunk-size warning.
+- `SWOOPER_INCLUDE_STUDIO_CURRENT=1 SWOOPER_STUDIO_RUN_ID=studio-proof-resume-20260617 bun run nx run mod-swooper-maps:build:studio-deploy --outputStyle=static`:
+  passed and generated/deployed `studio-current`.
+
+Fresh generated/deployed proof from this pass:
+
+- Source config:
+  `mods/mod-swooper-maps/src/maps/configs/studio-current.config.json` sha256
+  `480d8d38cd6ebd17887c12e99aab956440886e365571d89d8981739bf2953d3f`.
+- Post-run disposable local paths were absent, which is expected cleanup for
+  this flow:
+  - `mods/mod-swooper-maps/src/maps/generated/studio-current.ts`;
+  - `mods/mod-swooper-maps/mod/maps/studio-current.js`.
+- Deployed script:
+  `/Users/mateicanavra/Library/Application Support/Civilization VII/Mods/mod-swooper-maps/maps/studio-current.js`.
+- Deployed script sha256:
+  `1b9aee5f882e329371d9e16384290eab357d143c4d06e78ff7e5e67eb2ca218a`.
+- Deployed script mtime: `2026-06-17 03:09:23`.
+- Deployed marker proofs:
+  - `requestId: "studio-run-in-game-mqhqd5ic-jrj-5"`;
+  - `configHash: "6e7a3f18679ef2dbebba8992f7b7b6e89226132b6a2a60e9b6d59d2c9fd1ec9c"`;
+  - `envelopeHash: "523d45759fda3f03fcf2c96810dc5014838fc52fd7567e418e320028667488df"`;
+  - `map.rivers.authoredTerrainMaterialization`;
+  - `POST-AUTHORED-RIVERS`.
+
+Fresh tuner/readback proof from this pass:
+
+- Direct health command:
+  `bun packages/cli/bin/run.js game health --tuner --json`.
+- Direct health result: `ok=true`, host `127.0.0.1`, port `4318`, state
+  `{ id: "1", name: "Tuner" }`, ready `true`, turn `1`, date `4000 BCE`, map
+  width `84`, height `54`, alive human ids `[0]`.
+- `civ7.setupConfig` readback at `2026-06-17T07:15:21.658Z`: `phase` was
+  `running-game`; selected setup row was
+  `{swooper-maps}/maps/studio-current.js`; config readback had `mapSeed=123`,
+  `gameSeed=123`, and `playerCount=6`.
+- `civ7.live.snapshot` readback at `2026-06-17T07:15:22.035Z`: state
+  `{ id: "1", name: "Tuner" }`, map width `84`, height `54`, sampled plot count
+  `432`.
+
+Fresh bounded Civ7 log proof from this pass:
+
+- Log bounds were captured before the browser action:
+  - `Scripting.log` offset `319766`;
+  - `Modding.log` offset `3557789`;
+  - `Database.log` offset `10511`;
+  - `UI.log` offset `19054504`.
+- `Scripting.log` after the bound contains
+  `[SWOOPER_MOD] [mapgen-proof]` and `[SWOOPER_MOD] [mapgen-complete]` for
+  request `studio-run-in-game-mqhqd5ic-jrj-5` with seed `123`, dimensions
+  `84x54`, and the config/envelope hashes listed above.
+- `Modding.log` after the bound contains
+  `Map Script: {swooper-maps}/maps/studio-current.js` and
+  `Loading maps/studio-current.js`.
+- `Database.log` after the bound has no `mod-swooper-maps`, `swooper`, or
+  `studio-current` matches.
+- `UI.log` after the bound has no `mod-swooper-maps`, `swooper`, or
+  `studio-current` matches. It still contains unrelated third-party/UI noise
+  from the local mod environment, so this pass does not claim a globally clean
+  Civ7 UI log.
+
+State-machine gap found during the resume pass:
+
+- After the browser proof, the daemon serving `5298` restarted with
+  `serverInstanceId=studio-server-mqhqkd0r-23o4-1` and
+  `serverStartedAt=2026-06-17T07:14:55.851Z`.
+- `runInGame.status` for `studio-run-in-game-mqhqd5ic-jrj-5` then returned
+  `404 RUN_IN_GAME_STATUS_NOT_FOUND`.
+- `studio.operations.current` returned empty `runInGame.recent` and
+  `saveDeploy.recent` arrays for the new server identity.
+- This does not invalidate the browser/deployed/log/tuner proof above, but it
+  keeps daemon-restart operation-history recovery outside the product-proof
+  claim.
+
 ## Product And Graphite Labels
 
-Product proof is not claimed by this ledger. The workstream has strong source,
-browser fast-path, generated/deployed, direct-control, bounded `Scripting.log`,
-and in-game evidence, but final Graphite submission and broad product/release
-proof remain separate labels.
+Product proof is satisfied for the priority user-reported path exercised in the
+fresh resume pass: from the rendered Studio button, disposable
+`studio-current` was generated, deployed, selected by Civ7 setup, loaded by the
+game, and observed in-game with bounded logs and tuner readback. Broad
+state-machine product proof remains unresolved for daemon-restart operation
+history, fallback restart rendering, and full release/environment cleanliness.
 
 Graphite submitted is not claimed. The stack is locally committed but not
 submitted from this lane because current Graphite metadata interleaves unrelated

--- a/openspec/changes/studio-live-civ7-proof-gates/workstream/live-proof-ledger.md
+++ b/openspec/changes/studio-live-civ7-proof-gates/workstream/live-proof-ledger.md
@@ -152,10 +152,110 @@ Production error handling remains Effect-based:
 - Missing setup rows map to `proofFailed` with reason `setup-row-unavailable`.
 - Materialization/deploy proof failures map to `materializationFailed`.
 
+## 2026-06-17 Closeout Logged Proof
+
+Closeout request:
+
+- Branch: `codex/studio-effect-state-machine-closeout`.
+- Request id: `studio-run-in-game-mqhog22i-13if-2`.
+- Studio daemon: `127.0.0.1:5297`.
+- Server instance:
+  `studio-server-mqhoepc2-13if-1`.
+- Result: `phase=complete`, `status=complete`, `ok=true`.
+- Completed phases: `materializing`, `deploying`, `checking-civ7`,
+  `preparing-setup`, `starting-game`, `waiting-for-proof`.
+
+Generated and deployed evidence:
+
+- Materialization mode: `disposable`.
+- Map script: `{swooper-maps}/maps/studio-current.js`.
+- Config hash:
+  `6e7a3f18679ef2dbebba8992f7b7b6e89226132b6a2a60e9b6d59d2c9fd1ec9c`.
+- Envelope hash:
+  `523d45759fda3f03fcf2c96810dc5014838fc52fd7567e418e320028667488df`.
+- Source config:
+  `mods/mod-swooper-maps/src/maps/configs/studio-current.config.json`
+  sha256
+  `48000de5ac26ccf232dabd65813e5181e66067fd0534fa2449e433bb35ba6e91`.
+- Generated source:
+  `mods/mod-swooper-maps/src/maps/generated/studio-current.ts`
+  sha256
+  `78333249eeb5f311ba4b670149f6f59baf4072933ebd778f574041f165afef44`.
+- Local mod script:
+  `mods/mod-swooper-maps/mod/maps/studio-current.js` sha256
+  `85d3eb03ac4709bc2f5bef27d6cdfec630bd53660a0162c526fcb3a6079a6632`.
+- Deployed mod script:
+  `/Users/mateicanavra/Library/Application Support/Civilization VII/Mods/mod-swooper-maps/maps/studio-current.js`
+  sha256
+  `85d3eb03ac4709bc2f5bef27d6cdfec630bd53660a0162c526fcb3a6079a6632`.
+- Marker proofs present in both local and deployed script:
+  request id, config hash, envelope hash,
+  `map.rivers.authoredTerrainMaterialization`, and
+  `POST-AUTHORED-RIVERS`.
+- Deploy task: `mod-swooper-maps:build:studio-deploy`, files copied `12`.
+
+Setup/start evidence:
+
+- Direct-control host: `127.0.0.1`.
+- Port: `4318`.
+- State: `{ id: "65535", name: "App UI" }`.
+- Setup row proof found setup-domain and config-db rows for
+  `{swooper-maps}/maps/studio-current.js`.
+- Row visibility: initial and final match present, `refreshed=false`,
+  `verified=true`.
+- Applied setup values:
+  - `Map: {swooper-maps}/maps/studio-current.js`
+  - `MapSize: MAPSIZE_STANDARD`
+  - `MapRandomSeed: 1781676935`
+  - `GameRandomSeed: 1781676935`
+  - `MaxMajorPlayers: 6`
+- Start result:
+  - `beginAttempted=true`
+  - final App UI observation reached `loadingStateName=GameStarted`,
+    `inGame=true`
+  - map summary width `84`, height `54`, plot count `4536`, random seed
+    `1781676935`
+  - game readback turn `1`, turn date `4000 BCE`
+
+Bounded log evidence:
+
+- Log path:
+  `/Users/mateicanavra/Library/Application Support/Civilization VII/Logs/Scripting.log`.
+- Observed at: `2026-06-17T06:16:10.396Z`.
+- Start offset: `61590`.
+- Matched markers:
+  `[mapgen-proof]`, `studio-run-in-game-mqhog22i-13if-2`, config hash,
+  envelope hash, and `[mapgen-complete]`.
+- Direct grep evidence:
+  - line 369:
+    `[2026-06-17 02:15:52] [SWOOPER_MOD] [mapgen-proof] ... requestId studio-run-in-game-mqhog22i-13if-2 ...`
+  - line 539:
+    `[2026-06-17 02:15:54] [SWOOPER_MOD] [mapgen-complete] ... requestId studio-run-in-game-mqhog22i-13if-2 ...`
+
+Exact authorship proof:
+
+- Status: `complete`.
+- Created at: `2026-06-17T06:16:10.399Z`.
+- Request fingerprint:
+  `db27c8581b359efea928e4b5778edc117124a6c01f2d10b1603c0149b57e9e43`.
+- Runtime readback: seed `1781676935`, width `84`, height `54`, plot count
+  `4536`, turn `1`, game hash `0`, source snapshot id
+  `status:1:4cd3196d`.
+- `unresolvedLinks: []`.
+
 ## Unresolved Labels
 
-- Fresh bounded `Scripting.log`, `Modding.log`, `Database.log`, and `UI.log`
-  ranges were not used for the current claim and remain unclaimed.
-- Full Studio browser-button execution after this branch was not yet run in the
-  rendered UI; the core live setup/start boundary was proven through the
-  repo-owned direct-control API.
+- Fresh bounded `Scripting.log` proof is claimed for request
+  `studio-run-in-game-mqhog22i-13if-2`.
+- Sibling `Modding.log`, `Database.log`, and `UI.log` ranges are not claimed
+  for broader load/product diagnostics.
+- Full Studio browser-button execution after this branch was later recorded in
+  `openspec/changes/studio-browser-scenario-proof/workstream/browser-proof-ledger.md`
+  for request `studio-run-in-game-mqhng9hg-1pku-2`. That browser fast path
+  reached `Complete` / `Current` without a process restart. The process-restart
+  fallback remains unit-tested rather than manually rendered in the browser.
+- A later top-of-stack correction
+  `1b9ec418e fix(studio): scope restart recovery to current run state`
+  prevents stale browser operation state from carrying `Restart Civ & Run` onto
+  a changed authored Studio state. No new live generated/deployed/tuner/log
+  proof is claimed from that UI-scoping correction.

--- a/openspec/changes/studio-live-civ7-proof-gates/workstream/live-proof-ledger.md
+++ b/openspec/changes/studio-live-civ7-proof-gates/workstream/live-proof-ledger.md
@@ -243,12 +243,98 @@ Exact authorship proof:
   `status:1:4cd3196d`.
 - `unresolvedLinks: []`.
 
+## 2026-06-17 Resume Current-Top Proof
+
+This is the current-top rerun after the closeout reconciliation branch resumed:
+
+- Branch/head: `codex/studio-effect-state-machine-closeout` at
+  `baa9d7f8e docs(studio): reconcile state-machine closeout`.
+- Dev server: `STUDIO_DAEMON_PORT=5298 STUDIO_DEV_PORT=5198 NX_DAEMON=false bun run dev:mapgen-studio`.
+- Browser entrypoint: `http://localhost:5198/`.
+- Studio daemon: `http://127.0.0.1:5298/`.
+- Browser action: clicked the rendered Run in Game button.
+- Request id: `studio-run-in-game-mqhqd5ic-jrj-5`.
+- Final browser state: `Ready. Live Civ7 turn 1 seed 123. Run in Game complete`.
+- Final action state: `Run in Game: Complete`, map
+  `{swooper-maps}/maps/studio-current.js`, `Studio state: Current`.
+- Screenshots:
+  - `/tmp/studio-proof-initial.png`
+  - `/tmp/studio-proof-after-action-click.png`
+  - `/tmp/studio-proof-final-run.png`
+
+Current-top generated/deployed evidence:
+
+- Source config:
+  `mods/mod-swooper-maps/src/maps/configs/studio-current.config.json` sha256
+  `480d8d38cd6ebd17887c12e99aab956440886e365571d89d8981739bf2953d3f`.
+- Deployed script:
+  `/Users/mateicanavra/Library/Application Support/Civilization VII/Mods/mod-swooper-maps/maps/studio-current.js`.
+- Deployed script sha256:
+  `1b9aee5f882e329371d9e16384290eab357d143c4d06e78ff7e5e67eb2ca218a`.
+- Deployed script mtime: `2026-06-17 03:09:23`.
+- Deployed marker proofs:
+  - `requestId: "studio-run-in-game-mqhqd5ic-jrj-5"`;
+  - `configHash: "6e7a3f18679ef2dbebba8992f7b7b6e89226132b6a2a60e9b6d59d2c9fd1ec9c"`;
+  - `envelopeHash: "523d45759fda3f03fcf2c96810dc5014838fc52fd7567e418e320028667488df"`;
+  - `map.rivers.authoredTerrainMaterialization`;
+  - `POST-AUTHORED-RIVERS`.
+- Disposable local paths were absent after the completed run, which preserves
+  the intended cleanup boundary:
+  - `mods/mod-swooper-maps/src/maps/generated/studio-current.ts`;
+  - `mods/mod-swooper-maps/mod/maps/studio-current.js`.
+
+Current-top Civ7 readback:
+
+- Direct health command:
+  `bun packages/cli/bin/run.js game health --tuner --json`.
+- Health result: `ok=true`, host `127.0.0.1`, port `4318`, state
+  `{ id: "1", name: "Tuner" }`, ready `true`, turn `1`, date `4000 BCE`,
+  width `84`, height `54`, alive human ids `[0]`.
+- `civ7.setupConfig` at `2026-06-17T07:15:21.658Z`: `phase=running-game`,
+  selected map row `{swooper-maps}/maps/studio-current.js`, `mapSeed=123`,
+  `gameSeed=123`, player count `6`.
+- `civ7.live.snapshot` at `2026-06-17T07:15:22.035Z`: state
+  `{ id: "1", name: "Tuner" }`, map width `84`, height `54`, sampled plot count
+  `432`.
+
+Current-top bounded log evidence:
+
+- Bounds before browser action:
+  - `Scripting.log` offset `319766`;
+  - `Modding.log` offset `3557789`;
+  - `Database.log` offset `10511`;
+  - `UI.log` offset `19054504`.
+- `Scripting.log` contains `[SWOOPER_MOD] [mapgen-proof]` and
+  `[SWOOPER_MOD] [mapgen-complete]` for
+  `studio-run-in-game-mqhqd5ic-jrj-5`, seed `123`, dimensions `84x54`, and the
+  config/envelope hashes above.
+- `Modding.log` contains `Map Script: {swooper-maps}/maps/studio-current.js`
+  and `Loading maps/studio-current.js`.
+- `Database.log` has no Swooper/studio-current matches in the bounded search.
+- `UI.log` has no Swooper/studio-current matches in the bounded search; it is
+  not claimed as globally clean because unrelated third-party UI errors exist
+  in the local Civ7 environment.
+
+Current-top operation-history caveat:
+
+- After the browser proof, the Studio daemon serving `5298` restarted with
+  `serverInstanceId=studio-server-mqhqkd0r-23o4-1`.
+- `runInGame.status` for `studio-run-in-game-mqhqd5ic-jrj-5` returned
+  `404 RUN_IN_GAME_STATUS_NOT_FOUND` under the new identity.
+- `studio.operations.current` returned no active or recent operations under the
+  new identity.
+- Therefore this pass proves the user-reported generated/deployed/setup/start
+  path, but not durable operation-history recovery across daemon restarts.
+
 ## Unresolved Labels
 
-- Fresh bounded `Scripting.log` proof is claimed for request
-  `studio-run-in-game-mqhog22i-13if-2`.
-- Sibling `Modding.log`, `Database.log`, and `UI.log` ranges are not claimed
-  for broader load/product diagnostics.
+- Fresh bounded `Scripting.log`, `Modding.log`, `Database.log`, and `UI.log`
+  searches are claimed for the current-top request
+  `studio-run-in-game-mqhqd5ic-jrj-5` within the limits above.
+- `UI.log` is not globally clean because the local Civ7 environment includes
+  unrelated third-party UI errors outside Swooper/studio-current.
+- Operation history across a Studio daemon restart is unresolved for
+  `studio-run-in-game-mqhqd5ic-jrj-5`.
 - Full Studio browser-button execution after this branch was later recorded in
   `openspec/changes/studio-browser-scenario-proof/workstream/browser-proof-ledger.md`
   for request `studio-run-in-game-mqhng9hg-1pku-2`. That browser fast path


### PR DESCRIPTION
This PR completes the SMR-08 state-machine closeout by recording and reconciling all earned proof labels across the full packet train (SMR-01 through SMR-07 plus the restart relation-scope correction).

**Live proof recorded:**
- Two full Run in Game browser-to-in-game passes are documented: the original closeout request `studio-run-in-game-mqhog22i-13if-2` and a fresh current-top resume pass `studio-run-in-game-mqhqd5ic-jrj-5`.
- Both passes claim `generated`, `deployed`, `tuner-exercised`, `in-game observed`, and bounded `Scripting.log` and `Modding.log` proof. `Database.log` and `UI.log` bounded searches found no Swooper/studio-current matches; `UI.log` is not claimed globally clean due to unrelated third-party noise in the local environment.
- Direct tuner readback confirmed turn 1, seed 123, and map dimensions 84×54 for the resume pass.

**Reconciliation ledger added** (`openspec/changes/studio-effect-state-machine-closeout/workstream/reconciliation-ledger.md`): final row-by-row disposition for every scenario (READ, RPC, LIVE, OP, STUDIO, UI, DEV, PROOF) and every error boundary (EB-01 through EB-17), with earned and unclaimed labels separated explicitly.

**Known gaps explicitly bounded:**
- Operation-history durability across a Studio daemon restart is unresolved; the daemon restarted after both proof passes and returned `RUN_IN_GAME_STATUS_NOT_FOUND` for the completed request.
- Fallback process-restart browser rendering remains unit-tested only, not manually rendered.
- Graphite submission is not claimed; the stack is locally committed but the current Graphite metadata interleaves unrelated habitat branches requiring a deliberate ownership pass before submission.
- Sibling `Database.log` and `UI.log` ranges for broader load/product diagnostics remain unclaimed.

**RJSF key-warning fix:** child lists in `FlatObjectChildren` and `BrowserConfigObjectFieldTemplate` now wrap rendered property content in keyed `Fragment` elements, eliminating React missing-key warnings when RJSF object templates render sibling property runs.

**All closeout tasks marked complete:** reconciliation, documentation promotion, OpenSpec strict and full validation (194 items, 0 failed), habitat-classified lint, and `git diff --check` all passed on the original `codex/studio-effect-state-machine-closeout` stack.