### PR TITLE
fix(mod-swooper-maps): deep-import resource policy symbols in tests/scripts

### DIFF
--- a/mods/mod-swooper-maps/scripts/placement/verify-live-legality-agreement.ts
+++ b/mods/mod-swooper-maps/scripts/placement/verify-live-legality-agreement.ts
@@ -47,11 +47,13 @@ import {
   executeCiv7TunerCommand,
 } from "@civ7/direct-control";
 import {
-  buildResourceLegalityMask,
   type OfficialResourceType,
-  type ResourceLegalitySurface,
   resolveResourceRuntimeIds,
 } from "../../src/domain/resources/index.js";
+import {
+  buildResourceLegalityMask,
+  type ResourceLegalitySurface,
+} from "../../src/domain/resources/policy/resource-legality.js";
 
 const AGREEMENT_GATE_THRESHOLD = 0.95;
 const DEFAULT_SAMPLE_SIZE = 400;

--- a/mods/mod-swooper-maps/test/placement/plan-ops.test.ts
+++ b/mods/mod-swooper-maps/test/placement/plan-ops.test.ts
@@ -5,12 +5,14 @@ import { CIV7_BROWSER_TABLES_V0 } from "@civ7/map-policy";
 import placementDomain from "../../src/domain/placement/ops.js";
 import {
   EARTHLIKE_RESOURCE_EXPECTATIONS,
-  getInitialMapResourcePolicyForType,
-  RESOURCE_HABITAT_SIGNALS,
-  type ResourceLegalitySurface,
-  resolveActiveResourceAge,
   resolveResourceRuntimeIds,
 } from "../../src/domain/resources/index.js";
+import { RESOURCE_HABITAT_SIGNALS } from "../../src/domain/resources/policy/habitat-eligibility.js";
+import {
+  getInitialMapResourcePolicyForType,
+  resolveActiveResourceAge,
+} from "../../src/domain/resources/policy/initial-map-authoring.js";
+import type { ResourceLegalitySurface } from "../../src/domain/resources/policy/resource-legality.js";
 import {
   buildResourceDemands,
   buildRiverResourceExclusionMask,

--- a/mods/mod-swooper-maps/test/resources/resource-earthlike-expectations-artifact.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-earthlike-expectations-artifact.test.ts
@@ -7,13 +7,15 @@ import {
   resourceEarthlikeExpectationsArtifact,
 } from "../../src/domain/resources/artifacts/contract/earthlike-expectations.contract.js";
 import {
-  DEFERRED_INITIAL_MAP_RESOURCE_TYPES,
   EARTHLIKE_RESOURCE_EXPECTATIONS,
   EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT,
-  INITIAL_MAP_RESOURCE_TYPES,
   OFFICIAL_RESOURCE_BY_TYPE,
   OFFICIAL_RESOURCE_TYPE_ORDER,
 } from "../../src/domain/resources/index.js";
+import {
+  DEFERRED_INITIAL_MAP_RESOURCE_TYPES,
+  INITIAL_MAP_RESOURCE_TYPES,
+} from "../../src/domain/resources/policy/initial-map-authoring.js";
 
 const blockedResources = [
   "RESOURCE_CLOVES",

--- a/mods/mod-swooper-maps/test/resources/resource-habitat-fields-op-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-habitat-fields-op-contract.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test";
 
 import resources from "@mapgen/domain/resources/ops";
-import { RESOURCE_HABITAT_SIGNALS } from "../../src/domain/resources/index.js";
 import { HABITAT_MASK_FIELD_NAMES } from "../../src/domain/resources/ops/derive-habitat-fields/contract.js";
+import { RESOURCE_HABITAT_SIGNALS } from "../../src/domain/resources/policy/habitat-eligibility.js";
 
 import { runOpValidated } from "../support/compiler-helpers.js";
 

--- a/mods/mod-swooper-maps/test/resources/resource-initial-map-authoring-policy.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-initial-map-authoring-policy.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 
+import { OFFICIAL_RESOURCE_CORPUS } from "../../src/domain/resources/index.js";
 import {
   DEFERRED_INITIAL_MAP_RESOURCE_TYPE_IDS,
   DEFERRED_INITIAL_MAP_RESOURCE_TYPES,
@@ -11,9 +12,8 @@ import {
   INITIAL_MAP_RESOURCE_AUTHORING_POLICY,
   INITIAL_MAP_RESOURCE_TYPE_IDS,
   INITIAL_MAP_RESOURCE_TYPES,
-  OFFICIAL_RESOURCE_CORPUS,
   resolveActiveResourceAge,
-} from "../../src/domain/resources/index.js";
+} from "../../src/domain/resources/policy/initial-map-authoring.js";
 
 type RuntimeGlobals = typeof globalThis & {
   Game?: { age?: unknown };


### PR DESCRIPTION
#1742 (04e206da8) intentionally removed the policy re-exports
(habitat-eligibility, initial-map-authoring, resource-legality) from the
resources domain barrel and migrated runtime callers to deep imports, but
4 test files and 1 script were left importing those symbols from the barrel,
breaking their module load ("Export named 'resolveActiveResourceAge' not
found"). Migrate them to the deep policy paths to match #1742 and the
runtime; corpus/earthlike imports stay on the barrel. Barrel unchanged; no
runtime/behavior change.

Verified: biome clean, nx check (tsc) green, affected tests 26/26 pass.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>