### PR TITLE
fix(mod-swooper-maps): complete shipped map config resource/start shape

### DIFF
--- a/mods/mod-swooper-maps/package.json
+++ b/mods/mod-swooper-maps/package.json
@@ -206,6 +206,8 @@
     "build:studio-deploy": "tsup",
     "build:studio-recipes": "node -e \"\"",
     "gen:maps": "bun ./scripts/generate-map-artifacts.ts",
+    "migrate:configs": "bun ./scripts/migrate-config-shapes.ts && biome format --write src/maps/configs && bun run gen:maps",
+    "migrate:configs:check": "bun ./scripts/migrate-config-shapes.ts --dry",
     "gen:studio-recipes-types": "bun ./scripts/generate-studio-recipe-types.ts",
     "lint": "biome check .",
     "check": "tsc --noEmit",

--- a/mods/mod-swooper-maps/package.json
+++ b/mods/mod-swooper-maps/package.json
@@ -113,8 +113,24 @@
         ],
         "cache": true
       },
+      "migrate:configs:check": {
+        "dependsOn": [
+          {
+            "projects": [
+              "@swooper/mapgen-core"
+            ],
+            "target": "build"
+          }
+        ],
+        "inputs": [
+          "default",
+          "^default"
+        ],
+        "cache": true
+      },
       "gen:maps": {
         "dependsOn": [
+          "migrate:configs:check",
           {
             "projects": [
               "@swooper/mapgen-core"
@@ -165,6 +181,7 @@
       },
       "build:studio-recipes:maps": {
         "dependsOn": [
+          "migrate:configs:check",
           "gen:studio-recipes-types"
         ],
         "cache": true,

--- a/mods/mod-swooper-maps/scripts/migrate-config-shapes.ts
+++ b/mods/mod-swooper-maps/scripts/migrate-config-shapes.ts
@@ -1,0 +1,127 @@
+/**
+ * Generic, schema-driven map-config migrator.
+ *
+ * Reconciles every `src/maps/configs/*.config.json` to the CURRENT recipe
+ * schema (`deriveRecipeConfigSchema(STANDARD_STAGES)`) — no per-field values are
+ * hard-coded here; everything is pulled from the schema's own `required` lists
+ * and `default` values. Run it after any recipe schema change to migrate the
+ * shipped configs forward.
+ *
+ * Policy (value-preserving, unlike TypeBox `Value.Repair`, which drops
+ * incomplete optional objects and so loses authored partial values):
+ *   - PRUNE keys the schema no longer knows (e.g. a retired `placement.discoveries`)
+ *     via `Value.Clean`.
+ *   - COMPLETE every present-but-incomplete object: add each missing REQUIRED key
+ *     using the schema's `default` (recursively for nested required objects),
+ *     while preserving every value the author already set.
+ *
+ * What it intentionally does NOT do (no generic tool can infer intent):
+ *   - rename keys, or migrate a value whose meaning changed. Those need an
+ *     explicit mapping; add a targeted step here when such a change lands.
+ *
+ * Output is written 2-space JSON (matching gen:maps); run `biome format` +
+ * `bun run gen:maps` afterwards (the `migrate:configs` package script chains all
+ * three). Idempotent: a no-op on already-conformant configs.
+ *
+ * Usage:
+ *   bun ./scripts/migrate-config-shapes.ts          # apply
+ *   bun ./scripts/migrate-config-shapes.ts --dry     # report only, exit 1 if drift
+ */
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { deriveRecipeConfigSchema } from "@swooper/mapgen-core/authoring";
+import { Value } from "typebox/value";
+import { STANDARD_STAGES } from "../src/recipes/standard/recipe.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const configsDir = resolve(__dirname, "../src/maps/configs");
+const transientStudioCurrent = "studio-current.config.json";
+
+type Json = Record<string, unknown>;
+
+/** Unwrap to the object-shaped schema variant (handles anyOf/oneOf unions). */
+function objectSchema(schema: unknown): any {
+  if (!schema || typeof schema !== "object") return schema;
+  const s = schema as any;
+  if (s.type === "object" && s.properties) return s;
+  const variants = [...(s.anyOf ?? []), ...(s.oneOf ?? [])];
+  return variants.find((v: any) => v?.type === "object" && v.properties) ?? s;
+}
+
+/** Build the default value for a required key purely from its schema. */
+function schemaDefault(childSchema: unknown): unknown {
+  const s = objectSchema(childSchema);
+  if (s?.type === "object" && s.properties) {
+    const out: Json = {};
+    for (const key of s.required ?? []) out[key] = schemaDefault(s.properties[key]);
+    return out;
+  }
+  if (s && "default" in s) return s.default;
+  if (s?.type === "array") return [];
+  return undefined;
+}
+
+/** Add missing REQUIRED keys (schema defaults) to PRESENT objects; preserve existing. */
+function completeRequired(schema: unknown, data: unknown): unknown {
+  const s = objectSchema(schema);
+  if (s?.type === "object" && data && typeof data === "object" && !Array.isArray(data)) {
+    const src = data as Json;
+    const out: Json = {};
+    for (const key of Object.keys(src)) {
+      const childSchema = s.properties?.[key];
+      out[key] = childSchema ? completeRequired(childSchema, src[key]) : src[key];
+    }
+    for (const key of s.required ?? []) {
+      if (!(key in out)) out[key] = schemaDefault(s.properties?.[key]);
+    }
+    return out;
+  }
+  if (s?.type === "array" && Array.isArray(data) && s.items) {
+    return data.map((item) => completeRequired(s.items, item));
+  }
+  return data;
+}
+
+async function main(): Promise<void> {
+  const dry = process.argv.includes("--dry");
+  const schema = deriveRecipeConfigSchema(STANDARD_STAGES);
+  const entries = (await readdir(configsDir)).filter(
+    (f) => f.endsWith(".config.json") && f !== transientStudioCurrent
+  );
+
+  let drifted = 0;
+  for (const fileName of entries.sort()) {
+    const path = resolve(configsDir, fileName);
+    const raw = JSON.parse(await readFile(path, "utf-8")) as Json;
+    const before = JSON.stringify(raw.config);
+
+    // 1) prune keys the schema no longer knows, 2) complete missing required keys.
+    const pruned = Value.Clean(schema, structuredClone(raw.config));
+    raw.config = completeRequired(schema, pruned) as Json;
+
+    const after = JSON.stringify(raw.config);
+    if (before === after) {
+      console.log(`ok    ${fileName}`);
+      continue;
+    }
+    drifted++;
+    const valid = Value.Check(schema, raw.config);
+    console.log(`${dry ? "DRIFT" : "fixed"} ${fileName}  (schema-valid after: ${valid})`);
+    if (!dry) await writeFile(path, `${JSON.stringify(raw, null, 2)}\n`);
+  }
+
+  if (dry && drifted > 0) {
+    console.log(
+      `\n${drifted} config(s) drift from the recipe schema. Run: bun run migrate:configs`
+    );
+    process.exit(1);
+  }
+  console.log(
+    drifted === 0
+      ? "\nAll configs conform to the current recipe schema."
+      : `\nMigrated ${drifted} config(s). Next: biome format + bun run gen:maps (or: bun run migrate:configs).`
+  );
+}
+
+await main();

--- a/mods/mod-swooper-maps/src/maps/configs/mountain-patch.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountain-patch.config.json
@@ -674,7 +674,21 @@
       "naturalWonders": {
         "minSpacingTiles": 6
       },
-      "resources": {},
+      "resources": {
+        "density": 1,
+        "sparsity": 0,
+        "rarityFidelity": 1,
+        "siteSpacingTiles": 3,
+        "perTypeSpacingFloorScale": 1,
+        "equityMaxDensityRatio": 1.8,
+        "familyDensity": {
+          "aquatic": 1,
+          "cultivated": 1,
+          "terrestrial": 1,
+          "geological": 1
+        },
+        "affinityRules": []
+      },
       "starts": {
         "minContiguousLandTiles": 24,
         "expansionRadiusTiles": 8,
@@ -689,7 +703,22 @@
         "fertilityWeight": 1.3,
         "freshwaterWeight": 0.8,
         "largeLandmassWeight": 2,
-        "roughnessPenaltyWeight": 0.2
+        "roughnessPenaltyWeight": 0.2,
+        "marginalLandRatio": 0.5,
+        "marginalExpansionRatio": 0.65,
+        "climateWeight": 1.6,
+        "climateExtremePenaltyWeight": 1.5,
+        "roughnessDivisor": 900,
+        "tierBias": {
+          "primary": 0.08,
+          "islandCluster": 0.02,
+          "marginal": -0.08
+        },
+        "rankingBlend": 0.86,
+        "fairnessTolerance": 0.3,
+        "coastalPreferenceWeight": 0,
+        "riverPreferenceWeight": 0,
+        "startBiasWeight": 1
       },
       "knobs": {}
     }

--- a/mods/mod-swooper-maps/src/maps/configs/mountain-rivers-patch.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountain-rivers-patch.config.json
@@ -674,7 +674,21 @@
       "naturalWonders": {
         "minSpacingTiles": 6
       },
-      "resources": {},
+      "resources": {
+        "density": 1,
+        "sparsity": 0,
+        "rarityFidelity": 1,
+        "siteSpacingTiles": 3,
+        "perTypeSpacingFloorScale": 1,
+        "equityMaxDensityRatio": 1.8,
+        "familyDensity": {
+          "aquatic": 1,
+          "cultivated": 1,
+          "terrestrial": 1,
+          "geological": 1
+        },
+        "affinityRules": []
+      },
       "starts": {
         "minContiguousLandTiles": 24,
         "expansionRadiusTiles": 8,
@@ -689,7 +703,22 @@
         "fertilityWeight": 1.3,
         "freshwaterWeight": 0.8,
         "largeLandmassWeight": 2,
-        "roughnessPenaltyWeight": 0.2
+        "roughnessPenaltyWeight": 0.2,
+        "marginalLandRatio": 0.5,
+        "marginalExpansionRatio": 0.65,
+        "climateWeight": 1.6,
+        "climateExtremePenaltyWeight": 1.5,
+        "roughnessDivisor": 900,
+        "tierBias": {
+          "primary": 0.08,
+          "islandCluster": 0.02,
+          "marginal": -0.08
+        },
+        "rankingBlend": 0.86,
+        "fairnessTolerance": 0.3,
+        "coastalPreferenceWeight": 0,
+        "riverPreferenceWeight": 0,
+        "startBiasWeight": 1
       },
       "knobs": {}
     }

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.json
@@ -504,7 +504,8 @@
           "tempWarmEndC": 30,
           "shallowDepthM": 0,
           "deepDepthM": 100,
-          "minDistanceToCoast": 4
+          "minDistanceToCoast": 4,
+          "maxDistanceToCoast": 8
         },
         "lotus": {
           "tempWarmStartC": 16,
@@ -627,7 +628,21 @@
       "naturalWonders": {
         "minSpacingTiles": 6
       },
-      "resources": {}
+      "resources": {
+        "density": 1,
+        "sparsity": 0,
+        "rarityFidelity": 1,
+        "siteSpacingTiles": 3,
+        "perTypeSpacingFloorScale": 1,
+        "equityMaxDensityRatio": 1.8,
+        "familyDensity": {
+          "aquatic": 1,
+          "cultivated": 1,
+          "terrestrial": 1,
+          "geological": 1
+        },
+        "affinityRules": []
+      }
     }
   }
 }

--- a/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.json
@@ -504,7 +504,8 @@
           "tempWarmEndC": 30,
           "shallowDepthM": 0,
           "deepDepthM": 100,
-          "minDistanceToCoast": 4
+          "minDistanceToCoast": 4,
+          "maxDistanceToCoast": 8
         },
         "lotus": {
           "tempWarmStartC": 16,
@@ -627,7 +628,21 @@
       "naturalWonders": {
         "minSpacingTiles": 6
       },
-      "resources": {}
+      "resources": {
+        "density": 1,
+        "sparsity": 0,
+        "rarityFidelity": 1,
+        "siteSpacingTiles": 3,
+        "perTypeSpacingFloorScale": 1,
+        "equityMaxDensityRatio": 1.8,
+        "familyDensity": {
+          "aquatic": 1,
+          "cultivated": 1,
+          "terrestrial": 1,
+          "geological": 1
+        },
+        "affinityRules": []
+      }
     }
   }
 }

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.json
@@ -508,7 +508,8 @@
           "tempWarmEndC": 30,
           "shallowDepthM": 0,
           "deepDepthM": 100,
-          "minDistanceToCoast": 4
+          "minDistanceToCoast": 4,
+          "maxDistanceToCoast": 8
         },
         "lotus": {
           "tempWarmStartC": 16,
@@ -631,7 +632,21 @@
       "naturalWonders": {
         "minSpacingTiles": 6
       },
-      "resources": {}
+      "resources": {
+        "density": 1,
+        "sparsity": 0,
+        "rarityFidelity": 1,
+        "siteSpacingTiles": 3,
+        "perTypeSpacingFloorScale": 1,
+        "equityMaxDensityRatio": 1.8,
+        "familyDensity": {
+          "aquatic": 1,
+          "cultivated": 1,
+          "terrestrial": 1,
+          "geological": 1
+        },
+        "affinityRules": []
+      }
     }
   }
 }

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -679,7 +679,16 @@
         "density": 1,
         "sparsity": 0,
         "rarityFidelity": 1,
-        "siteSpacingTiles": 3
+        "siteSpacingTiles": 3,
+        "perTypeSpacingFloorScale": 1,
+        "equityMaxDensityRatio": 1.8,
+        "familyDensity": {
+          "aquatic": 1,
+          "cultivated": 1,
+          "terrestrial": 1,
+          "geological": 1
+        },
+        "affinityRules": []
       },
       "starts": {
         "minContiguousLandTiles": 24,
@@ -692,12 +701,25 @@
         "desiredSpacingTiles": 9,
         "resourceSupportRadiusTiles": 1,
         "resourceSupportWeight": 0.5,
-        "fertilityWeight": 3.0,
+        "fertilityWeight": 3,
         "freshwaterWeight": 1.3,
         "climateWeight": 1.6,
         "climateExtremePenaltyWeight": 1.5,
         "largeLandmassWeight": 1,
-        "roughnessPenaltyWeight": 0.6
+        "roughnessPenaltyWeight": 0.6,
+        "marginalLandRatio": 0.5,
+        "marginalExpansionRatio": 0.65,
+        "roughnessDivisor": 900,
+        "tierBias": {
+          "primary": 0.08,
+          "islandCluster": 0.02,
+          "marginal": -0.08
+        },
+        "rankingBlend": 0.86,
+        "fairnessTolerance": 0.3,
+        "coastalPreferenceWeight": 0,
+        "riverPreferenceWeight": 0,
+        "startBiasWeight": 1
       }
     }
   }

--- a/mods/mod-swooper-maps/src/maps/generated/mountain-patch.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/mountain-patch.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "mountain-patch",
-  configHash: "b2a0e1fee3e215376a6cb1feae27c57849c8498f3038740b3a3f958ea9fc5cfe",
-  envelopeHash: "010416b1ad7d0532b3ad9bce3749691c4211de213ca68d0f96e4c6bc08195ef7",
+  configHash: "e4c2fb8cf1740ed089d40e9e6d0c045e8bcb7f693302d83c71ecceb688c503da",
+  envelopeHash: "b89963ba3c00796b5b163c4955fbc4999c2a2a22b25112d52e915c050653944e",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/mountain-rivers-patch.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/mountain-rivers-patch.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "mountain-rivers-patch",
-  configHash: "b2a0e1fee3e215376a6cb1feae27c57849c8498f3038740b3a3f958ea9fc5cfe",
-  envelopeHash: "f5b018f10e7956fe19297a1a0e119dff7542add2cb2321d41da9c3d778978e4d",
+  configHash: "e4c2fb8cf1740ed089d40e9e6d0c045e8bcb7f693302d83c71ecceb688c503da",
+  envelopeHash: "9fb2c3857aeb891946840bb70eca52b1d446d3d7327951ba4c4dd30f8ffe13f8",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/shattered-ring.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/shattered-ring.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "shattered-ring",
-  configHash: "d57e1baa090c7ffd2c52ed4c915c0e03482d8cabea764755356a7eb075505b1e",
-  envelopeHash: "7e6d388295646f6f58d8c2932db0ece36c05e7f47da73879cfca2b3e1d27748d",
+  configHash: "6df62f2c03691d86712b4a0cc255a6ac4d8538ed4f4416b61277f1383a755c8d",
+  envelopeHash: "23d3259620dd415f39ba3edad29d88eea5aabdef739d4ad4a4ec6718c185d327",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/sundered-archipelago.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/sundered-archipelago.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "sundered-archipelago",
-  configHash: "23c0bae0c905afd12de464844d88d57e5f47d47f0a983464ad480a30d5e76063",
-  envelopeHash: "3e6b44d1c7d9f4038577e9ada576cfd6f9824896c004d6f8ba84ed88f53ad44a",
+  configHash: "089937b5a852b58dea8e69b2341affd6c687c349aeafa33c9aa601b162323115",
+  envelopeHash: "72c9c33110358312c814ca5d67ec64d5cc25c9851fe8b76b69ce16850b539178",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/swooper-desert-mountains.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/swooper-desert-mountains.ts
@@ -21,7 +21,7 @@ export default createMap({
     "bottomLatitude": -40
   },
   sourceConfigId: "swooper-desert-mountains",
-  configHash: "ca69e8985db4f9696dc29661f042a7d4cc43296fe0e0b0ec75dd67720834cd87",
-  envelopeHash: "f2f13c70eeb457ac71da565ec9fc95ff5cdb41eff5a8b92b5e60dc4d0fa0ab57",
+  configHash: "62c2b04668acebe4b0acdb380a47b348f0ec2544b8544fb19e77b9997bc26599",
+  envelopeHash: "345922cf8928b4a23ae04d781c4fce9ad2952c425076092b41b4aa6ec2c96e9a",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/swooper-earthlike.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/swooper-earthlike.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "swooper-earthlike",
-  configHash: "ce5e87eb3b1b15e6c8c8fc8c6697b5f3c9be5edf283790e3d37bdc6a6ba44033",
-  envelopeHash: "8097aa7214472cdfbc481c6e45972752855ac247fee4e790c667cf18b150ca0e",
+  configHash: "59e61a6ec828f214c098e57278848a039f8e67352e8132dd6950e2c08229713f",
+  envelopeHash: "554ea8316efb2d7f50e370216b163cdeedcbd67817cc0dd48926537727ea6b84",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts
+++ b/mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts
@@ -168,7 +168,6 @@ const PROJECTION_INTERNAL_STAGE_KEYS: Record<string, readonly string[]> = {
 const PLACEMENT_PUBLIC_KEYS = [
   "knobs",
   "naturalWonders",
-  "discoveries",
   "resources",
   "starts",
   "support",
@@ -916,10 +915,7 @@ describe("Shipped map configs", () => {
       strategy: "default",
       config: { minSpacingTiles: 6 },
     });
-    expect(compiled.placement["derive-placement-inputs"].discoveries).toEqual({
-      strategy: "default",
-      config: { densityPer100Tiles: 3, minSpacingTiles: 3 },
-    });
+    expect(compiled.placement["derive-placement-inputs"].discoveries).toBeUndefined();
     expect(compiled.placement["derive-placement-inputs"].resources).toBeUndefined();
     expect(compiled.placement["plan-resources"].selectSites.strategy).toBe("default");
     expect(compiled.placement["plan-resources"].selectSites.config).toMatchObject({

--- a/mods/mod-swooper-maps/test/config/shipped-map-identity.test.ts
+++ b/mods/mod-swooper-maps/test/config/shipped-map-identity.test.ts
@@ -81,6 +81,10 @@ describe("shipped map config identity", () => {
       sparsity: 0,
       rarityFidelity: 1,
       siteSpacingTiles: 3,
+      perTypeSpacingFloorScale: 1,
+      equityMaxDensityRatio: 1.8,
+      familyDensity: { aquatic: 1, cultivated: 1, terrestrial: 1, geological: 1 },
+      affinityRules: [],
     });
 
     expect(earthlike.placement).not.toHaveProperty("floodplains");


### PR DESCRIPTION
fix(mod-swooper-maps): complete shipped map config resource/start shape

Six shipped map configs carried empty/partial placement.resources (plus
partial placement.starts and reefScoring.atoll) that omit keys the recipe
schema marks required. The runtime normalizer defaults them so they ran,
but the published $schema (Studio/editor validation) flags them as missing
required properties. Fill missing required keys with their schema defaults
(behavior-preserving — identical to the runtime-applied defaults) via a
schema-driven pass, regenerate map artifacts, and update the earthlike
identity lock to the completed shape.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

test(mod-swooper-maps): retire placement.discoveries from shape locks

The discoveries rework removed the placement.discoveries public knob from
the recipe schema, but maps-schema-valid still expected it in the placement
public-key set and in compiled derive-placement-inputs output (2 failures
pre-existing on this branch, independent of the config migration). Align the
shape locks with the current schema: discoveries now route through the
official generator with no public density/spacing knob; place-discoveries
stays as an internal step.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

feat(mod-swooper-maps): add generic schema-driven config migrator

scripts/migrate-config-shapes.ts reconciles every map config to the current
recipe schema with NO hard-coded values — required keys and defaults are pulled
from deriveRecipeConfigSchema(STANDARD_STAGES). It prunes keys the schema no
longer knows (Value.Clean) and completes present-but-incomplete objects with
their schema defaults while preserving every authored value.

This is the value-preserving policy TypeBox's built-in Value.Repair lacks:
Repair reaches validity by DELETING incomplete optional objects, which loses
authored partial values (verified — it dropped a real starts.fertilityWeight).
A GritQL pattern is not the fit either: the migration is schema-DRIVEN data
reconciliation (load the schema as data, recursively reconcile arbitrary JSON
to it); Grit is a static structural matcher over the target file with no
primitive to consume an external schema as its rewrite driver.

Idempotent. Run after any recipe schema change via 'bun run migrate:configs'
(migrate -> biome -> gen:maps) or 'migrate:configs:check' for CI drift gating.
Feeding it the pre-migration configs reproduces the parent commit's migration
exactly. Scope: adds net-new required defaults + prunes retired keys; key
renames / semantic value changes still need an explicit per-change step.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

build(mod-swooper-maps): gate map generation on config schema-drift check

Wire migrate:configs:check into the nx graph as a verification target and make
both map-artifact generators depend on it, so configs are proven strictly
conformant to the recipe schema BEFORE any artifacts are generated from them.

Ordering: migrate:configs:check dependsOn @swooper/mapgen-core:build (it derives
the recipe schema via deriveRecipeConfigSchema, so it must run after that build
- mirroring gen:maps). Then:
  - gen:maps                  dependsOn migrate:configs:check  (feeds build -> check, build:studio-deploy, deploy)
  - build:studio-recipes:maps dependsOn migrate:configs:check  (feeds build:studio-recipes -> test)

The existing maps-schema-valid test uses the lenient validateCanonicalMapConfig
(it defaults missing keys), so it did NOT catch shape drift; this gate does.
Verified: a drifted config fails the gate and blocks gen:maps generation;
conformant configs pass on both the check and studio-recipes paths. cache:true
with [default, ^default] inputs so it re-runs only when configs or the recipe
schema change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>