### PR TITLE
skill(typescript-refactoring): add first-principles TS complexity-reduction skill

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -21,6 +21,7 @@ discipline; they should not duplicate the packet as a parallel spec.
 | `civ7-orpc-control-architecture` | Designing or reviewing oRPC/Effect procedure, router, middleware, and context surfaces for Civ7 direct-control, CLI game/play commands, Studio endpoints, and live-play support refactors (`@civ7/control-orpc`). |
 | `dra-structural-watcher` | Running or setting up a separate watcher DRA for OpenSpec workstreams: heartbeat/cron monitoring, NOTE-TO-DRA scans, correction logs, closure-drift checks, and branch/stack watcher passes without owning implementation. |
 | `graphite-stack-drain` | Managing complex Graphite stack/worktree cleanup: deterministic stack census, source/sink accounting, folding over-atomized stacks, targeted restacks, submit/merge drains, and safe branch/worktree retirement. |
+| `typescript-refactoring` | Refactoring or reducing complexity in TypeScript/JavaScript anywhere in the repo: detecting code smells, executing safe compiler-gated refactors, collapsing the reachable-state space, choosing functions vs classes, judging over-/under-engineering, and cleaning up LLM-generated slop. |
 
 ## Operating Rules
 

--- a/.agents/skills/typescript-refactoring/SKILL.md
+++ b/.agents/skills/typescript-refactoring/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: typescript-refactoring
+description: |
+  Use when refactoring, simplifying, or reducing complexity in TypeScript/JavaScript
+  code. Trigger phrases include "refactor this", "clean up this code", "reduce the
+  complexity", "this file/module is a mess", "fix this LLM slop", "simplify this",
+  "is this over-engineered?", "untangle this", "functional vs class here?",
+  "improve the structure/naming", "this is too abstract", and "review this TS for
+  quality". Owns the TypeScript substance: a code-smell catalog with detection
+  signals, safe compiler-gated refactoring mechanics, first-principles complexity
+  reduction (collapse the reachable-state space), the functions-vs-classes decision,
+  over-/under-engineering detection, and cleaning up arbitrarily-named, tangled,
+  structureless generated code. Defers WHAT good TypeScript looks like and target
+  patterns to dev:typescript; whether to refactor at all to cognition:solution-design;
+  module ownership/boundaries to cognition:domain-design; the test safety net to
+  cognition:testing-design; large target-state migrations to dev:architecture; and
+  public/exported surface contracts to dev:api-design. Not a language tutorial; not
+  a diff-scoped bug hunt (use /code-review for that).
+---
+
+# TypeScript Refactoring — Thermonuclear Complexity Reduction
+
+Refactoring is not tidying. It is **collapsing the state space** — shrinking the
+set of states the program (and the reader) can be in, ideally so the compiler
+proves the collapse. Hold the bar high: assume a dramatically simpler design
+exists, find it, and close the diff to it.
+
+This skill is the TypeScript-deep sibling of the Thermonuclear Code Quality
+Review. That skill is language-agnostic and review-only; this one carries the
+TypeScript substance and the mechanics to *execute* the refactor.
+
+## The Spine: complexity is reachable states
+
+In TypeScript, complexity is the **count of reachable states**. Every `any`,
+every optional field, every boolean flag, every non-exhaustive branch multiplies
+the states a reader must hold and the program can reach. Three forces follow:
+
+- **Type-level judo.** The highest-leverage move changes the *types* so whole
+  categories of runtime branches and bugs become impossible — and code deletes
+  itself. The win is **fewer reachable states, not fewer lines.**
+- **Delete > rearrange.** Prefer removing complexity over relocating it. A
+  refactor that only moves the mess around has not earned its diff. If you can
+  delete a concept rather than restructure it, push hard for that path.
+- **A repeated branch is a missing model.** Duplicated conditionals or flag
+  checks are evidence of a type — usually a discriminated union — that wants to
+  exist. Build the model; the branches collapse into it.
+
+Prefer the solution that makes the code feel inevitable in hindsight.
+
+## Scope
+
+**Use this skill when** you are reducing complexity in TypeScript: a file or
+module is a mess, code is over- or under-engineered, generated/LLM code needs
+untangling, you must choose functions vs classes, or you are doing a quality
+review with intent to fix.
+
+**When *not* to use** (hand off — see Boundaries):
+- "*Should* we even change this / what's the real problem?" → `cognition:solution-design`.
+- "What does good TS / the target pattern look like?" → `dev:typescript`.
+- "Where should this live / who owns it?" → `cognition:domain-design`.
+- "How do I make this change safe?" (the test net) → `cognition:testing-design`.
+- A multi-file target-state migration with a cutover → `dev:architecture`.
+- The change reshapes a public/exported API → `dev:api-design`.
+
+## Before you touch code
+
+Answer these out loud first. If you cannot, **ask and stop** — do not guess.
+1. **Intent** — what is this code *supposed* to do? What is the simpler model it
+   is failing to be?
+2. **Contract** — what external behavior and *public types* must stay fixed?
+   That is the invariant a refactor may not break.
+3. **Safety net** — are there tests that pin the behavior? If not, design a
+   characterization net first (→ `cognition:testing-design`), or work in steps
+   small enough that `tsc --strict` is your net.
+4. **Blast radius** — does this cross a module/published boundary
+   (→ `cognition:domain-design`, `dev:api-design`) or is it local?
+
+## The Core Prompt
+
+> Review and refactor this TypeScript for the *simplest correct model*, not a
+> cleaner version of the same mess. Count the reachable states: every `any`,
+> optional, flag, and unchecked branch is complexity. Find the type-level move
+> that makes illegal states unrepresentable and lets the compiler delete the
+> branches for you. Prefer deleting a concept over relocating it. Preserve
+> external behavior and public types; keep `tsc --strict` and tests green after
+> every step. Be thorough and demanding. Measure twice, cut once.
+
+## Refactor decision axes
+
+The dials you turn when *reducing* complexity. Each one changes the output when
+you move it. (For greenfield design-time dials — Safety Budget, API Shape,
+Boundary Rigidity, Type Origin, Error Channel, Extension Model — see
+`dev:typescript` `references/axes.md`; do not re-derive them here.)
+
+| Axis | Spectrum | What moving it changes |
+| --- | --- | --- |
+| **State space** *(master)* | many reachable states (flags/optionals/`any`) ↔ illegal states unrepresentable (DU + `never`) | how many cases the reader and compiler must track |
+| **Abstraction** | premature/over-generic indirection ↔ inlined concrete ↔ abstraction earned by ≥2 real call sites | over- vs under-engineering |
+| **Paradigm** | class + inheritance ↔ functions + data + discriminated unions | who holds state, how dispatch happens |
+| **Cohesion / placement** | scattered or god-module ↔ one canonical owner | where a change has to be made |
+| **Type-safety budget** | escape hatches inside the core ↔ sound, parse at the boundary | where unsafety is allowed to live (full Safety-Budget treatment → `dev:typescript` `references/axes.md`) |
+| **Delete vs rearrange** | relocate the mess ↔ delete the model that caused it | whether complexity drops or just moves |
+
+## Non-Negotiable Standards
+
+0. **(meta)** Pursue the simpler *model*, not a tidier version of the same mess.
+   Collapse the state space; prefer deletion over rearrangement. Everything
+   below serves this rule.
+1. **Decompose by responsibility.** Don't grow a module toward ~400+ LOC, a
+   function past ~40–50 LOC, or cyclomatic complexity past ~10 without a
+   structural reason. *Why: size and branching are the readable proxy for state.*
+2. **No new escape hatches.** `any`, `as`, `as any`, `!`, `@ts-ignore`,
+   `Record<string, any>` need a written justification; push unsafety to a typed
+   boundary (parse, don't validate). *Why: each hatch re-admits the states the
+   types were collapsing.*
+3. **Make illegal states unrepresentable.** Flag/boolean soup and sometimes-set
+   optionals → discriminated unions; non-exhaustive `switch` → `never`
+   exhaustiveness. *Why: this is type-level judo — the compiler deletes branches.*
+4. **Boring over magical.** No abstraction without ≥2 real call sites; functions
+   over classes unless a class earns it (identity + lifecycle + multiple methods
+   sharing state). *Why: speculative generality is complexity with no payoff.*
+5. **One canonical home; reuse, don't reimplement.** Keep logic in its owning
+   module; use existing repo helpers. *Why: duplication is the parent of
+   divergent change and shotgun surgery.*
+6. **Behavior- and contract-preserving.** `tsc --strict` green and tests passing
+   after **every** step; no silent public-type drift. *Why: a refactor that
+   changes behavior is a bug with good intentions.*
+7. **Clean the slop you touch.** Coherent names, no dead scaffolding, no
+   narration comments. *Why: the next reader inherits what you leave.*
+
+## The Mandate — self-checks on your own output
+
+Run these on the refactor you just produced. A "no" is a finding against
+yourself.
+- **State-collapse test** — did the reachable-state count actually drop (fewer
+  optionals/flags/`any`, or a DU the compiler now checks)?
+- **Deletion test** — did I delete complexity, or just move it? Could the model
+  be simpler still?
+- **Compiler-proof test** — is the invariant enforced by the type checker, not a
+  comment, convention, or runtime guard?
+- **Reuse test** — did I reimplement something the repo already provides?
+- **Naming-coherence test** — do file names ↔ export names ↔ concepts line up?
+- **Swap test** — would the opposite choice (class/function, generic/concrete)
+  give an equivalent result? If yes, the abstraction isn't earned.
+- **Behavior-preservation test** — external behavior and public types unchanged,
+  or intentionally changed and recorded?
+- **Reader test** — fewer concepts to hold in the head than before?
+
+## Default Workflow
+
+1. **Detect.** Inventory smells with `references/smell-catalog.md`; run the
+   detection toolkit (knip/ts-prune, jscpd, madge, ESLint complexity, escape-hatch
+   grep) to ground intuition in signals.
+2. **Triage & rank.** Order targets by leverage: state-space collapse first,
+   then deletions, then placement. Note blast radius and what's load-bearing.
+3. **Plan.** Fill `assets/refactor-plan-template.md` — targets, the safety net,
+   per-step sequence, definition of done. For generated code, run the
+   `references/llm-slop-cleanup.md` triage first.
+4. **Characterize.** Ensure behavior is pinned (tests, or steps small enough that
+   `tsc --strict` is the net). → `cognition:testing-design` for the net's design.
+5. **Transform in safe steps.** Apply mechanics from
+   `references/refactoring-mechanics.md`; keep `tsc --strict` and tests green
+   **after each step**; commit one logical move at a time.
+6. **Verify & report.** Confirm behavior/contract held; capture findings and
+   before/after with `assets/refactor-findings-template.md`; check against The
+   Mandate and the Approval Bar.
+
+## Reference Map
+
+| Reference | Open when |
+| --- | --- |
+| `references/smell-catalog.md` | Detecting/naming smells — 29 smells (5 classic categories + a TypeScript-native group), TS manifestations + detection signals + tooling cheat-sheet |
+| `references/refactoring-mechanics.md` | Executing a transform — the top TS techniques as safe compiler-gated steps, the gated workflow + definition of done, what to skip in idiomatic TS |
+| `references/llm-slop-cleanup.md` | The code is AI-generated or structureless — the triage pass for arbitrary names, mega-files, premature abstraction, reimplementation, dead scaffolding |
+| `references/paradigms-and-patterns.md` | Choosing functions vs classes, judging over-/under-engineering, or evaluating a design pattern (GoF-in-TS verdicts, the indirection audit, migration mechanics) |
+| `references/worked-examples.md` | You want a concrete before→after — six full TS refactors with the state-space delta named |
+
+## Asset Map
+
+| Asset | Use when |
+| --- | --- |
+| `assets/refactor-plan-template.md` | Starting a refactor — copy and fill before touching code; doubles as execution log + DoD checklist |
+| `assets/refactor-findings-template.md` | Reporting a review/refactor — priority-ranked findings, blockers, before/after, in the good-phrase voice |
+
+## Anti-Patterns / Failure Signals
+
+- **Rearranged, not reduced** — files moved, folders renamed, state count
+  unchanged. The classic "looks refactored, isn't."
+- **Abstraction theatre** — interfaces with one implementation, factories of
+  factories, generics that earn nothing (the Swap test fails).
+- **Escape-hatch creep** — `as any`, `!`, `@ts-ignore` quietly re-admitting the
+  states the types were collapsing.
+- **Flag/optional soup** — booleans and sometimes-set optionals encoding a state
+  machine that wants to be a discriminated union.
+- **LLM-slop tells** — `utils2.ts`, `final`, `helper`, `Manager`; mega-files
+  with no internal structure; re-implementations of existing repo utilities;
+  narration comments restating the next line.
+- **Inheritance for reuse** — class trees where a function + data + DU is simpler
+  and safer (exhaustiveness > polymorphism for closed sets).
+
+## Boundaries — related skills / when to hand off
+
+| Skill | Use instead when | What it owns |
+| --- | --- | --- |
+| `dev:typescript` | You need *what good looks like* / the target pattern | TS philosophy, design-time axes, target patterns (DU, brands, ports, FC/IS, type-state), module-organization, SDK design |
+| `cognition:solution-design` | The question is *whether/what* to change | Problem reframing, depth calibration, solution-space navigation |
+| `cognition:system-design` | Complexity keeps coming back | Feedback loops, coupling, second-order effects, leverage points |
+| `cognition:domain-design` | "Where should this live / who owns it?" | Boundaries, single-authority ownership, bounded contexts |
+| `cognition:testing-design` | You need the safety net before changing behavior | What to test, risk-proportional effort, falsification, oracles |
+| `cognition:information-design` | Structuring a doc the refactor emits | Hierarchy, progressive disclosure, reader scent |
+| `dev:architecture` | A multi-file target-state migration + cutover | Target SPEC, decision packets, migration slices, dependency order |
+| `dev:api-design` | The refactor reshapes a public/exported surface | Contracts, consumer model, versioning/evolution |
+| `gitnexus-refactoring` | You want graph-safe mechanical rename/move/extract | Reference-safe structural edits across the repo |
+| `/simplify`, `/code-review` | A quick diff-scoped cleanup or bug hunt | Changed-code-only review and fixes |
+
+## Review tone & good phrases
+
+Be direct, serious, and demanding about quality. Do not be rude, and do not
+soften real maintainability problems into mild suggestions. Lead with the
+simpler design; phrase findings as questions that propose the fix:
+- "this moves complexity around but doesn't delete it — can the model itself be simpler?"
+- "these three booleans encode one state machine; a discriminated union makes the impossible combos unrepresentable."
+- "this `as any` re-opens the states the type was closing — can we parse at the boundary instead?"
+- "one-implementation interface — what does this abstraction buy us today?"
+- "we already have this helper in `<module>`; reuse it rather than reimplement."
+- "non-exhaustive switch — add a `never` default so the compiler catches the next case."
+- "this file is doing four jobs; splitting by responsibility makes each change local."
+
+## Approval bar / definition of done
+
+Do not approve a refactor merely because behavior seems correct. Presumptive
+blockers:
+- Reachable-state count did not drop (state-collapse test fails).
+- Incidental complexity a type-level move would delete is left in place.
+- A new escape hatch was added without justification.
+- An abstraction was introduced with one call site / failing the swap test.
+- A module crossed the size tripwire without being decomposed.
+- A helper was reimplemented instead of reused.
+- Public types drifted silently, or `tsc --strict`/tests are not green.
+
+Done when: smells are detected and triaged; the state space is measurably
+smaller and compiler-enforced where possible; behavior and public types are
+preserved; each step left the build green; The Mandate passes; findings are
+recorded.
+
+<invariants>
+<invariant name="behavior-preserving">External behavior and public type signatures are held fixed unless a change is intended and recorded. `tsc --strict` and tests are green after every step.</invariant>
+<invariant name="state-space-down">A refactor must reduce the reachable-state count or it has not earned its diff. Deletion beats rearrangement.</invariant>
+<invariant name="compiler-enforced">Invariants are pushed into the type system (DU + `never`, branded types, parse-at-boundary), not maintained by comment, convention, or runtime guard.</invariant>
+<invariant name="compose-dont-duplicate">When another skill owns a topic (target patterns, ownership, the test net, migrations, API contracts), link to it; never restate it here as a second spec.</invariant>
+<invariant name="earned-abstraction">No abstraction without ≥2 real call sites and a failing swap test. Speculative generality is a smell, not foresight.</invariant>
+</invariants>
+
+## Quick start
+
+1. Read this SKILL.md.
+2. Open `references/smell-catalog.md`, inventory the smells, run the detection toolkit.
+3. Copy `assets/refactor-plan-template.md`; rank targets by state-space leverage.
+4. Transform with `references/refactoring-mechanics.md`, compiler green each step.
+5. For generated code, run `references/llm-slop-cleanup.md` first.
+6. Report with `assets/refactor-findings-template.md`; check The Mandate and the Approval Bar.
+
+---
+
+*Skill usage disclosure: on completion, state "Skills used: typescript-refactoring"
+(add others as applicable).*

--- a/.agents/skills/typescript-refactoring/assets/refactor-findings-template.md
+++ b/.agents/skills/typescript-refactoring/assets/refactor-findings-template.md
@@ -1,0 +1,58 @@
+<!--
+COPY this file to report a refactor/quality review. Findings are ranked by the
+priority tiers below; lead with the simpler design, phrase each as a question
+that proposes the fix (the "good phrases" voice in SKILL.md). Be demanding, not
+rude. Cut nit-floods — group trivia into one line.
+-->
+
+# Refactor Findings — <target> (<date>)
+
+## Verdict
+<!-- One of: approved · approved-with-changes · blocked. Behavior-correct is NOT the bar. -->
+**Verdict:** 
+**The simpler model:** <one sentence — the design this should become>
+**State-space delta if applied:** <reachable states before → after; what the compiler would enforce>
+
+## Presumptive blockers
+<!-- Any one of these blocks approval. Quote the location. -->
+- [ ] Incidental complexity a type-level move would delete is left in place — `<file:line>`
+- [ ] New escape hatch without justification (`any`/`as`/`!`/`@ts-ignore`) — `<file:line>`
+- [ ] Abstraction with one call site / fails the swap test — `<file:line>`
+- [ ] Module crossed the size tripwire without decomposition — `<file:line>`
+- [ ] Helper reimplemented instead of reused — `<file:line>`
+- [ ] Public types drifted silently, or `tsc --strict`/tests not green — `<file:line>`
+
+## Findings (ranked)
+<!-- Priority tiers, highest first. Drop tiers with nothing to report. -->
+
+### P1 — Structural regression / missed state-space collapse
+- **Finding:** `<file:line>` — <what>
+  - **Why:** <state-space / maintainability cost>
+  - **Move:** <technique → refactoring-mechanics.md> · target shape → <paradigms-and-patterns.md / dev:typescript>
+  - **Comment:** "<lowercase PR-comment proposing the fix>"
+
+### P2 — Avoidable branching / flag or optional soup (a missing model)
+- **Finding:** …
+
+### P3 — Boundary / type-contract / escape-hatch leak
+- **Finding:** …
+
+### P4 — Over-/under-engineering · file size / decomposition
+- **Finding:** …
+
+### P5 — Naming / style / slop / legibility
+<!-- Group trivia; do not flood. -->
+- **Finding:** …
+
+## Before → after (for the top finding)
+```ts
+// before
+
+```
+```ts
+// after
+
+```
+
+## Mandate self-check (if you did the refactor)
+- [ ] state-collapse · [ ] deletion · [ ] compiler-proof · [ ] reuse · [ ] naming-coherence · [ ] swap · [ ] behavior-preservation · [ ] reader

--- a/.agents/skills/typescript-refactoring/assets/refactor-plan-template.md
+++ b/.agents/skills/typescript-refactoring/assets/refactor-plan-template.md
@@ -1,0 +1,57 @@
+<!--
+COPY this file to your working notes before touching code. Fill it as you go;
+it doubles as the execution log and the definition-of-done checklist.
+Driven by .agents/skills/typescript-refactoring/SKILL.md (the Default Workflow).
+Delete these comment blocks once filled.
+-->
+
+# Refactor Plan — <target: file / module / subsystem>
+
+## 1. Intent & contract (answer before touching code)
+- **What this code is supposed to do:**
+- **The simpler model it is failing to be:**
+- **Behavior that MUST stay fixed (the contract):**
+- **Public types / exported surface that MUST stay fixed:** <!-- if this changes, hand off to dev:api-design -->
+- **Blast radius:** local module / crosses a boundary (→ cognition:domain-design) / public API (→ dev:api-design)
+
+## 2. Safety net
+<!-- The compiler is a net; tests pin behavior. Design the net before changing behavior. → cognition:testing-design -->
+- **Existing tests that pin behavior:**
+- **Characterization tests to add first (if behavior is unpinned):**
+- **Green baseline command(s):** `tsc --noEmit` (strict) · `<test cmd>` · `<lint cmd>`
+
+## 3. Smell inventory (detect)
+<!-- Use references/smell-catalog.md + the detection toolkit. -->
+| # | Smell | Location | Detection signal (grep/tool) | Reachable-state cost |
+|---|---|---|---|---|
+| 1 |  |  |  |  |
+
+## 4. Ranked targets (triage)
+<!-- Order by leverage: state-space collapse first, then deletions, then placement. -->
+| Rank | Target | Move (→ refactoring-mechanics.md) | Expected state-space delta | Risk |
+|---|---|---|---|---|
+| 1 |  |  |  |  |
+
+## 5. Step sequence (transform)
+<!-- One logical move per step; tsc --strict + tests green after EACH. One commit per step. -->
+- [ ] Step 1: <move> — checkpoint: tsc green · tests green · committed
+- [ ] Step 2: …
+
+## 6. Generated/LLM code? (run first)
+<!-- If the target is AI-generated or structureless, run the triage in references/llm-slop-cleanup.md before deeper refactoring. -->
+- [ ] Slop triage done (names, dead code, premature abstraction, reimplementation, escape hatches)
+
+## 7. Definition of done (the Approval Bar)
+- [ ] Reachable-state count measurably dropped (state-collapse test)
+- [ ] Complexity deleted, not relocated (deletion test)
+- [ ] Invariants compiler-enforced (DU + `never` / branded / parse-at-boundary), not by comment/convention
+- [ ] No new escape hatch (`any`/`as`/`!`/`@ts-ignore`) without written justification
+- [ ] No abstraction with <2 call sites / failing the swap test
+- [ ] Existing helpers reused, nothing reimplemented (reuse test)
+- [ ] Names coherent: file ↔ export ↔ concept (naming-coherence test)
+- [ ] Behavior + public types preserved (or changed intentionally and recorded)
+- [ ] `tsc --strict`, tests, lint green
+- [ ] Fewer concepts to hold in the head (reader test)
+
+## 8. Notes / deferrals
+- 

--- a/.agents/skills/typescript-refactoring/references/llm-slop-cleanup.md
+++ b/.agents/skills/typescript-refactoring/references/llm-slop-cleanup.md
@@ -1,0 +1,589 @@
+# LLM-Slop Cleanup — the generated-code triage pass
+
+Generated TypeScript fails in a *characteristic* way, and it is not the way
+human code fails. Human code rots: it starts coherent and drifts under deadline
+pressure, so its mess has history and intent buried in it. Generated code is
+born incoherent. A model emits the *most plausible next token*, file by file,
+with no standing model of your repo — so it produces code that **compiles, reads
+fluently, and is locally reasonable everywhere while being globally wrong.** That
+is the trap: nothing looks broken. `tsc --strict` is green. The tests it wrote
+pass. And yet the change multiplied the reachable-state count, named three things
+arbitrarily, abstracted a thing used once, and re-implemented a helper you
+already ship.
+
+This is why slop needs a *triage pass before refactoring*, not refactoring
+itself. Refactoring (→ [`refactoring-mechanics.md`](./refactoring-mechanics.md))
+assumes a coherent starting point you transform in behavior-preserving steps.
+Slop has no coherent starting point. Triage **restores coherence** — deletes the
+unearned, names by responsibility, reuses what exists, normalizes conventions —
+so that the deeper state-space collapse has something real to work on. You are
+not improving a design here; you are finding out whether there is one.
+
+---
+
+## The slop triage checklist
+
+Run top to bottom. **Deletions come first** — every line you delete is a line
+you do not have to name, type, reuse-check, or restructure. Restructuring a
+file you are about to split in half is wasted work; deleting the dead half first
+makes the split obvious. Order matters: do not skip ahead.
+
+```
+DELETE first — shrink the surface before you reason about it
+[ ] 1. Dead scaffolding & stubs — TODO stubs, unused exports/params,
+       commented-out alternates, stray console.log, empty catch.        → §6
+[ ] 2. Narration comments — comments restating the next line.           → §7
+[ ] 3. Defensive over-checking — redundant guards, re-validation of
+       already-typed data, try/catch that swallows.                     → §8
+[ ] 4. Premature / speculative abstraction — one-impl interfaces,
+       factory-of-factory, generics with one instantiation, config
+       objects no one varies. (Run the indirection audit, below.)       → §3
+[ ] 5. Reimplementation of existing repo utilities — re-rolled
+       debounce/clamp/group-by/Result. Find-and-reuse; delete the dupe. → §4
+
+THEN restructure — what survives, made coherent
+[ ] 6. Escape-hatch smuggling — as any / as unknown as / ! / @ts-ignore
+       added to make generated code compile.                            → §9
+[ ] 7. Cargo-culted patterns — XStrategy/getInstance/Visitor over an
+       owned closed set. Collapse to function / module / DU+switch.     → §10
+[ ] 8. Arbitrary file/symbol names — rename by responsibility; make
+       file ↔ export coherent.                                          → §1
+[ ] 9. Structureless mega-files — split by responsibility.              → §2
+[ ] 10. Mixed conventions — type vs interface, default vs named export,
+        error style, casing — normalize to the repo's choice.           → §5
+
+VERIFY — the change is real, not cosmetic
+[ ] 11. Run the indirection audit on every surviving layer.             → audit
+[ ] 12. Confirm against "definition of de-slopped".                     → close
+```
+
+A note on order discipline: it is tempting to rename and re-section first because
+it *feels* like progress. Resist it. You will rename symbols you are about to
+delete and section files you are about to collapse. Delete, then reuse, then
+name what remains.
+
+---
+
+## 1. Arbitrary file & symbol names
+
+**Tell.** Names that encode authoring order or vague catch-all roles instead of
+responsibility. The model needed *a* name and picked a filler.
+
+```bash
+# files named by version/sequence/vagueness, not by what they hold
+git ls-files '*.ts' | grep -nEi '(utils?2?|helpers?|misc|common|shared|index[-_]?(new|2|copy)|[-_](v2|final|new|old|tmp|temp|backup))\.ts$'
+# grab-bag suffixes on symbols
+grep -rnE '\b(class|const|function|type|interface)\s+\w*(Manager|Helper|Processor|Handler|Util|Service|Data|Wrapper)\b' src
+# vacuous local names
+grep -rnE '\b(const|let)\s+(data|result|temp|obj|res|ret|val|item|thing|stuff)\b' src
+```
+
+**Why it's slop.** A name is a *promise about contents*. `userBalances.ts`
+promises one thing; `utils2.ts` promises nothing and invites anything — so it
+becomes a junk drawer (a Large Class / god module in disguise; see
+[`smell-catalog.md`](./smell-catalog.md)). `Manager`/`Helper`/`Processor` are
+not responsibilities, they are the absence of one: a `UserManager` that
+validates, persists, *and* emails has three reasons to change wearing one name.
+Vacuous locals (`data`, `result`, `temp`) force a re-derivation on every line,
+and "stuttering" (`user.userId`) is the same failure at field level.
+
+**Fix.** Name by *what it is responsible for*, then enforce **file ↔ export
+coherence**: a file's name should match its primary export, and a module of
+functions should be named for the concept they operate on
+(`balances.ts` exports `computeBalance`, not `utils2.ts` exports `helper`). If
+you cannot find a responsibility-name for a file, that is a finding — the file
+has no single responsibility (→ §2). Rename through the language server / a
+graph-safe tool so references move with the symbol, not a blind find-replace
+that hits strings and comments — hand off mechanical repo-wide renames to
+`gitnexus-refactoring`. This is the **naming-coherence test** from the Mandate;
+for *what* coherent names look like in TS, defer to `dev:typescript`.
+
+---
+
+## 2. Structureless mega-files
+
+**Tell.** One file, hundreds of lines, no internal sectioning, multiple
+unrelated concerns interleaved — types, HTTP, validation, business rules, and a
+React component all in `feature.ts`.
+
+```bash
+# files over the tripwire (~400 LOC), sorted worst-first
+git ls-files '*.ts' '*.tsx' | xargs wc -l 2>/dev/null | sort -rn | awk '$1 > 400'
+# concern density in one file: imports spanning unrelated layers
+grep -nE "from '(react|express|fs|node:|\./db|zod)'" src/feature.ts
+```
+
+**Why it's slop.** The model has no spatial model of your repo, so it pours
+everything into the file it was told to edit. A mega-file is a **Divergent
+Change** magnet (refactoring.guru): touched for every reason, so unrelated
+changes collide and the file becomes a merge-conflict zone. It is also the
+readable proxy for an oversized state space — which is why Standard 1 puts a size
+tripwire on it.
+
+**Fix.** Split by **responsibility** — one reason to change per module. The cut
+lines are the concern seams the grep above reveals: types to a `*.types.ts` or
+domain module, IO to an adapter, pure logic to its own file. *Where* each split
+piece should live, who owns it, and how to enforce the boundary is a
+domain-design question, not a slop question — hand off to
+`cognition:domain-design` for placement and `dev:typescript` for the
+module-organization mechanics. Triage's job is only to recognize that the file
+is doing N jobs and to make the seams visible; do the actual extraction with
+Extract Module from [`refactoring-mechanics.md`](./refactoring-mechanics.md),
+green after each move.
+
+---
+
+## 3. Premature / speculative abstraction
+
+**Tell.** Indirection built for a second use case that never arrived. The
+fingerprints:
+
+```bash
+# interfaces with exactly one implementation
+grep -rnE '\binterface\s+I?[A-Z]\w+' src        # then check each for >1 `implements`/value
+grep -rnE '\bimplements\s+\w+' src | sort | uniq -c | sort -n   # 1 ⇒ suspect
+# factories that build factories / configs nobody varies
+grep -rnE '\b(create|make|build)\w*Factory\b|Factory\w*Factory' src
+# high-arity generics — count instantiations per param
+grep -rnE '<\s*[A-Z]\w*\s*,\s*[A-Z]\w*\s*,\s*[A-Z]' src
+```
+
+```ts
+// slop: an interface, a factory, and a generic — for ONE concrete path
+interface IPaymentProcessor<TInput, TResult> {
+  process(input: TInput): TResult;
+}
+class StripeProcessorFactory {
+  static create(): IPaymentProcessor<Charge, Receipt> { return new StripeProcessor(); }
+}
+// the only call site, ever:
+const receipt = StripeProcessorFactory.create().process(charge);
+```
+
+**Why it's slop.** This is **Speculative Generality** (refactoring.guru): YAGNI
+flexibility you pay for *now* in indirection and never cash in. The model has
+read ten thousand "enterprise" tutorials and reaches for the ceremony reflexively.
+Each layer is a hop to trace and an extra reachable shape; an unused type
+parameter is *dead code at the type level*.
+
+**Fix.** Inline until there are **≥2 real call sites** (the Rule of Three's
+floor; abstract on the third, not the first). Apply the **swap test** from the
+Mandate: if the opposite choice — concrete instead of generic, function instead
+of factory — gives an equivalent result, the abstraction is not earned. The
+example above collapses to:
+
+```ts
+const receipt = processStripeCharge(charge);
+```
+
+Run the **indirection audit** (below) on every layer you are unsure about. For
+the broader over-/under-engineering treatment and the GoF-pattern verdicts that
+sit behind this, see
+[`paradigms-and-patterns.md`](./paradigms-and-patterns.md).
+
+---
+
+## 4. Reimplementation of existing repo utilities
+
+**Tell.** A freshly minted `debounce`, `clamp`, `groupBy`, `pick`, `omit`,
+`sleep`, `isEmpty`, or a bespoke `Result`/`Either` type — when your repo (or a
+dependency you already ship) has exactly that.
+
+```bash
+# did the model re-roll a utility you already have?
+grep -rnE '\b(function|const)\s+(debounce|throttle|clamp|groupBy|pick|omit|chunk|uniq|sleep|delay|isEmpty|deepEqual)\b' src
+# a second Result/Either type appearing
+grep -rnE '\btype\s+(Result|Either|Option|Maybe)\b' src | sort | uniq -c
+# then confirm what already exists before you delete the dupe:
+grep -rnE 'export (function|const|type)\s+(groupBy|Result|clamp)\b' src node_modules/<your-utils-pkg>
+```
+
+**Why it's slop.** The model cannot see your repo's existing helpers, so it
+rebuilds them — confidently and slightly differently. Now you have two
+`groupBy`s with divergent edge cases and the **Duplicate Code** tax: every fix
+applied in lockstep forever, the divergence a latent bug (refactoring.guru).
+Worse, a parallel `Result` type fractures your error channel — half the code
+can't compose with the other half.
+
+**Fix.** **Find-and-reuse, then delete the dupe.** Search the repo and its
+deps for the canonical implementation (use semantic/structural search — code-intel
+`find_semantic_clones` / `hybrid_search`, or `grep` on the symbol; `jscpd` will
+surface token-level twins). Re-point call sites at the existing helper, delete
+the generated copy, and confirm green. This is the **reuse test** from the
+Mandate. If the repo genuinely *lacks* the helper, that is a different finding —
+add one canonical version in its owning module, don't leave the inline copy. See
+**Duplicate Code** and **Alternative Classes with Different Interfaces** in
+[`smell-catalog.md`](./smell-catalog.md).
+
+---
+
+## 5. Mixed conventions across generated files
+
+**Tell.** Within a *single change*, the model picks different conventions in
+different files — because each file was generated against the local context of
+its own prompt window, not against the repo's house style.
+
+```bash
+# type vs interface — is the change consistent with the repo's dominant choice?
+grep -rcE '^\s*interface ' src | awk -F: '$2>0'    # vs:
+grep -rcE '^\s*(export )?type \w+ =' src | awk -F: '$2>0'
+# default vs named exports mixed in new files
+grep -rnE '^export default' src
+# error styles: throw string vs throw Error vs Result, all in one change
+grep -rnE 'throw (new )?(Error|"|`|'\'')' src
+# casing drift in filenames
+git ls-files '*.ts' | grep -E '[A-Z]' ; git ls-files '*.ts' | grep -E '-'
+```
+
+**Why it's slop.** Inconsistency is itself a cost: every convention switch is a
+micro-decision the reader must notice and reconcile ("is this `type` alias
+meaningful, or just a different file's mood?"). Mixed error channels are the
+worst case — `throw` here, `Result` there, swallowed `catch` elsewhere — because
+they don't compose and each call site must guess which discipline applies. This
+is the slop version of *One Strategy Per Subsystem*.
+
+**Fix.** Pick the **repo's** convention (the dominant one in the grep counts, or
+the documented one), and **normalize the whole change to it** — not file by file,
+the entire diff. Don't invent a new convention to "harmonize"; conform to what
+exists. This is categorical: a mixed convention is a *class* of defect, so sweep
+every file the change touched, not just the one you noticed. For *what* the right
+convention is (when to prefer `type` vs `interface`, the error-channel decision),
+defer to `dev:typescript`; triage only enforces *internal consistency*.
+
+---
+
+## 6. Dead scaffolding & stubs
+
+**Tell.** The leftover apparatus of generation: stubs the model wrote "to be
+filled in," alternates it kept "just in case," and debug output it forgot.
+
+```bash
+grep -rnE 'TODO|FIXME|XXX|placeholder|implement me|not implemented' src
+grep -rnE 'console\.(log|debug|info|warn)' src
+grep -rnE '^\s*//.*[;{}()]\s*$' src                 # commented-out code
+grep -rnE 'catch\s*\([^)]*\)\s*\{\s*\}' src         # empty catch
+# unused exports / params / files — the export-graph cases tooling must find:
+npx knip            # unused files, exports, deps
+npx ts-prune        # unused exports
+# tsc: noUnusedLocals / noUnusedParameters catch the local cases
+```
+
+**Why it's slop.** Dead code is **Dispensable** (refactoring.guru): it bloats
+the surface, misleads the next reader into thinking it matters, and inflates the
+build/test footprint. A stubbed `function processRefund() { /* TODO */ }` that's
+already exported and imported is a live lie; an empty `catch {}` is worse than
+dead — an active bug that swallows failures silently (→ §8); generated
+`console.log`s leak into production.
+
+**Fix.** **Delete it.** Version control is your undo; you can always recover.
+Unused exports/files → confirm with `knip`/`ts-prune` then remove; commented-out
+alternates → delete (the model's other idea is not documentation); `console.log`
+→ remove or route through the real logger; empty `catch` → either handle the
+error or let it propagate, never swallow. For the safe mechanics of dead-code
+removal (confirm-then-delete, watch for dynamic references the graph can't see),
+see Remove Dead Code in
+[`refactoring-mechanics.md`](./refactoring-mechanics.md) and **Dead Code** in
+[`smell-catalog.md`](./smell-catalog.md).
+
+---
+
+## 7. Narration comments
+
+**Tell.** Comments that restate the line below them, or play-by-play a sequence
+the code already shows.
+
+```bash
+# step-narration and "what" comments (not "why")
+grep -rnE '//\s*(now |then |first |next |loop (over|through)|iterate|create (a|the|new)|get the|set the|return the|check if)' src
+```
+
+```ts
+// slop
+// loop over the active users and sum their balances
+let total = 0;                          // initialize total
+for (const user of users) {             // for each user
+  if (user.active) total += user.balance; // if active, add balance
+}
+```
+
+**Why it's slop.** Narration comments are **Comments-as-deodorant**
+(refactoring.guru): they compensate for code that should explain itself and drift
+out of sync the moment the line below changes — a comment that lies is worse than
+no comment. The model emits them because tutorials are full of them; they add
+reading volume and zero information. In TypeScript the *type and the name* are
+the primary documentation — a narration comment is usually a missing well-named
+helper.
+
+**Fix.** **Delete them; let names and types carry the meaning.** The example
+collapses to a named function whose name *is* the comment:
+
+```ts
+const total = sumActiveBalances(users);
+```
+
+Keep the comments that earn their place: `// why:` rationale, non-obvious
+algorithm notes, and tooling-read JSDoc (`@deprecated`, `@internal`). The test
+is *what vs why* — cut every comment that says *what* the next line does; keep
+the ones that say *why* it's there. See **Comments** in
+[`smell-catalog.md`](./smell-catalog.md).
+
+---
+
+## 8. Defensive over-checking
+
+**Tell.** Guards and re-validation for conditions the types already guarantee —
+the model hedging because it has no proof the value is safe, even when the
+compiler does.
+
+```bash
+# guards on values that are already non-optional in their type
+grep -rnE 'if\s*\(!\w+\)\s*(return|throw)' src
+# re-validating an already-typed param at the top of every function
+grep -rnE 'typeof \w+ (!==|===) ('\''string'\''|'\''number'\''|'\''undefined'\'')' src
+# try/catch wrapping pure, non-throwing code
+grep -rnE 'try\s*\{' src
+```
+
+**These greps surface candidates, not verdicts.** Most `try`/`catch` and most
+`if (!x)` guards are legitimate — a guard on data from a boundary (I/O, JSON,
+user input, `any`/`unknown`) is load-bearing and must stay. Only delete a guard
+when the value's *type* already excludes the state it checks. When in doubt, keep
+it and parse once at the boundary instead.
+
+```ts
+// slop: user is already User (non-optional), id is already string
+function greet(user: User) {
+  if (!user) throw new Error("user required");        // can't happen — typed non-null
+  if (typeof user.name !== "string") return "";        // name: string already
+  return `Hello, ${user.name}`;
+}
+```
+
+**Why it's slop.** Each redundant guard *re-admits a state the type already
+excluded* — it tells the reader "this might be null" when it can't be, expanding
+the apparent state space and contradicting the type. It's cargo-culted safety:
+the model can't tell trusted-interior from untrusted-boundary, so it validates
+everywhere. Worst is `try/catch` that swallows — it converts a typed failure
+into a silent wrong answer.
+
+**Fix.** **Trust the types; parse once at the boundary.** Inside the fortress —
+code reachable only through a parsed boundary — the types are proof; delete the
+interior guards. Do the validation *once*, at the edge, where `unknown` becomes a
+real type (parse, don't validate). The example collapses to:
+
+```ts
+function greet(user: User) {
+  return `Hello, ${user.name}`;
+}
+```
+
+If a guard *is* load-bearing (the value genuinely arrives untyped), that's a
+boundary that wants a parser, not a scattering of `if`s. The full
+parse-at-boundary discipline belongs to `dev:typescript`; triage's job is to
+delete interior re-checking. Defensive `!` and `as` are the same instinct — §9.
+
+---
+
+## 9. Escape-hatch smuggling
+
+**Tell.** `as any`, `as unknown as`, `!`, `@ts-ignore`, `@ts-expect-error`, and
+`Record<string, any>` sprinkled to make generated code *compile* — the model
+hitting a type error and reaching for the silencer instead of the fix.
+
+```bash
+# the global escape-hatch census — track this number; it should fall, never rise
+grep -rnE 'as any|as unknown as|@ts-(ignore|expect-error)|\bany\b|Record<string,\s*any>|\w+!' src | wc -l
+grep -rnE 'as any|as unknown as' src
+grep -rnE '@ts-(ignore|expect-error)' src
+grep -rnE '!\.' src        # non-null assertions on property access
+```
+
+```ts
+// slop: silence the checker rather than model the data
+const config = JSON.parse(raw) as any;            // now everything downstream is unsound
+const port = (config as any).server!.port as number;
+```
+
+**Why it's slop.** Every escape hatch **re-admits exactly the states the type was
+collapsing** (Standard 2). `as any` doesn't make the value safe — it makes the
+*compiler stop telling you it isn't*, so the unsafety propagates invisibly to
+every downstream read. `!` asserts "trust me, not null" with no proof; the next
+refactor makes it a runtime crash. These are the master signal of generated
+code that was *forced* to compile rather than *designed* to.
+
+**Fix.** **Parse at the boundary; remove the hatch.** Where untyped data enters
+(`JSON.parse`, `fetch`, env, FFI), run it through a real parser so it leaves the
+boundary as a sound type — then the interior needs no `as`:
+
+```ts
+const config = ConfigSchema.parse(JSON.parse(raw)); // unknown → Config, validated
+const port = config.server.port;                     // sound, no hatch
+```
+
+A hatch that *cannot* be removed needs a written justification at the call site
+(Standard 2) and should be isolated to one typed boundary, never scattered. The
+escape-hatch census above is your scorecard — a de-slopped change *lowers* it.
+For TS-native escape-hatch smells (the `as` chain, `!` overuse, index-signature
+`any`) and their detection thresholds, see
+[`smell-catalog.md`](./smell-catalog.md); for the parse-at-boundary pattern
+itself, defer to `dev:typescript`.
+
+---
+
+## 10. Cargo-culted patterns
+
+**Tell.** GoF pattern *machinery* applied where a language feature already does
+the job — the model reproducing the class skeletons from its training data.
+
+```bash
+grep -rnE 'class\s+\w+Strategy\b|interface\s+\w*Strategy\b|implements\s+\w*Strategy' src
+grep -rnE 'getInstance\b|private\s+static\s+instance' src         # Singleton
+grep -rnE 'class\s+\w+(Factory|Manager|Mediator|Coordinator)\b' src
+grep -rnE 'accept\(.*[Vv]isitor|interface\s+\w*Visitor' src       # Visitor
+grep -rnE '\bhasNext\b|\bnext\(\)\s*:' src                        # hand-rolled Iterator
+```
+
+```ts
+// slop: a Strategy interface + one-method classes to pick between two functions
+interface DiscountStrategy { apply(price: number): number; }
+class TenPercent implements DiscountStrategy { apply(p: number) { return p * 0.9; } }
+class NoDiscount  implements DiscountStrategy { apply(p: number) { return p; } }
+```
+
+**Why it's slop.** This is the **"kludge for a weak language"** criticism, made
+concrete (refactoring.guru, *Criticism of patterns*; Paul Graham via RG): GoF
+patterns largely exist to fake first-class functions, closures, modules, and
+sum types in languages that lack them. TypeScript has all four. A `Strategy`
+interface + one-method classes is *a function* wearing five files of ceremony;
+`getInstance()` is *a module export* in a costume; a `Visitor` + `accept()` over
+a set you own is *a discriminated union + a `switch`* with worse ergonomics and
+no exhaustiveness. The pattern's **name** survives as vocabulary; its **class
+machinery** should not.
+
+**Fix.** Collapse to the language feature — the cargo-cult tells and their
+one-line fixes (refactoring.guru r4c §6.5):
+
+| Generated machinery | Collapse to |
+| --- | --- |
+| `class XStrategy implements Strategy` | a function / `Record<K, Fn>` |
+| `class XFactory` wrapping one `switch` | a factory function |
+| `class XManager` / `XMediator` coordinating two things | direct calls or a store |
+| `getInstance()` singleton | a module export (inject for testability) |
+| hand-rolled `hasNext()/next()` | a generator / `for…of` |
+| `Subject`/`Observer` interface pair | `EventTarget` or a typed emitter |
+| `Visitor` + `accept()` over an owned closed set | a DU + `switch` (+ `assertNever`) |
+| `AbstractBaseX` hosting one template method | a higher-order function |
+
+The Strategy example collapses to:
+
+```ts
+const discounts = { ten: (p: number) => p * 0.9, none: (p: number) => p };
+const price = discounts[kind](base);
+```
+
+The decision rule — *which* collapse target a pattern has, and the rare cases
+where the full pattern is genuinely earned (a measured variant matrix, two
+independently-growing axes, an open foreign hierarchy) — lives in
+[`paradigms-and-patterns.md`](./paradigms-and-patterns.md). Triage only spots
+the reflex and collapses the obvious cases.
+
+---
+
+## The indirection audit
+
+Premature abstraction (§3) and cargo-cult (§10) both leave *layers*. The audit
+is the procedure that decides, per layer, whether it earns its existence. Run it
+on every wrapper, interface, factory, adapter, base class, barrel re-export, and
+"service" the generated code introduced.
+
+For each layer, in order:
+
+1. **Name the force it claims to serve.** A layer must name a *present* reason:
+   a varying axis, a stable boundary worth enforcing, a coupling it breaks. Say
+   it out loud. "This `IFooRepository` interface exists because…" — if the
+   sentence ends in "…we might swap the DB someday," that's speculative, not
+   present.
+2. **Count the real call sites / implementations.** One implementation behind an
+   interface ⇒ the interface is decoration. One caller through a wrapper ⇒ the
+   wrapper is a hop. `grep` the symbol; count.
+3. **Run the swap test.** Would inlining the layer — replacing the interface with
+   its single concrete type, the factory with a direct call, the wrapper with its
+   target — produce equivalent behavior with fewer concepts? If yes, the layer is
+   not earned.
+4. **Ask the deletion question:** *"Delete this and lose nothing?"* If the only
+   loss is "flexibility we don't use yet," delete it. The Rule of Three is the
+   bar: abstraction is earned at the *third* real instance, not the first.
+5. **If it survives, write down why** — one line, at the layer, naming the force
+   from step 1. A layer worth keeping is worth justifying.
+
+```bash
+# audit fuel: interfaces with one implementor, factories, thin wrappers
+grep -rnE 'implements\s+\w+' src | sed -E 's/.*implements\s+(\w+).*/\1/' | sort | uniq -c | sort -n
+grep -rnE '\b(make|create|build)\w+\b' src        # candidate factories — count call sites each
+```
+
+The audit is just the **swap test** and the **deletion test** from the Mandate,
+applied mechanically to every layer. Most generated indirection fails step 2.
+
+---
+
+## Under-engineering tells (the opposite failure)
+
+Slop is usually over-built, but the same model under-builds where types are
+hard. These are the inverse findings — push *toward* types, not away from
+structure:
+
+- **Stringly-typed everything.** `status: string`, `kind: string`, mode flags as
+  free strings. → a union (`status: "active" | "suspended" | "closed"`); a repeated
+  branch on a string is a missing discriminated union.
+  `grep -rnE ':\s*string\b' src` density on domain fields.
+- **No boundary parsing.** `JSON.parse(...) as Foo`, `fetch` results read
+  directly, env vars used raw. → parse once at the boundary into a sound type
+  (this is the cure for §8/§9 both). `grep -rnE 'JSON\.parse|process\.env\.' src`.
+- **Copy-paste instead of a shared function.** The same fetch-wrap / try-catch /
+  mapper inlined in every handler. → extract one function (this is §4 from the
+  other direction — the model duplicated instead of reusing *or* abstracting).
+  `jscpd` flags it.
+- **Everything `any` (or implicit `any`).** Untyped params, `any[]`,
+  `Record<string, any>` as a "flexible" shape. → model the actual shape; `any`
+  is the absence of a type, not a type. `grep -rnE '\bany\b' src | wc -l`.
+
+The throughline: under-engineered slop has a *small text* but a *large state
+space* — `string` admits infinitely more states than a three-member union. **Push
+the invariant into the types** so the compiler shrinks the state space for you.
+For the target shapes (unions, brands, parse-at-boundary), defer to
+`dev:typescript`; for the smells themselves (Primitive Obsession, etc.), see
+[`smell-catalog.md`](./smell-catalog.md).
+
+---
+
+## Definition of de-slopped
+
+The triage pass is done when the change clears every line. This is the slop
+analog of the skill's Approval Bar — not "behavior is correct" (it was, the
+whole time; that's the trap) but **"the code is now coherent."**
+
+- [ ] **Coherent names** — every file and symbol named by responsibility; no
+  `utils2`/`Manager`/`data`; file name ↔ primary export agree.
+- [ ] **No dead code** — no stubs, unused exports/params, commented-out
+  alternates, stray `console.log`, or empty `catch`; `knip`/`ts-prune` clean.
+- [ ] **No narration comments** — comments explain *why*, never *what*.
+- [ ] **No unearned abstraction** — every surviving layer passed the indirection
+  audit; nothing abstracted below ≥2 real call sites; no cargo-culted pattern
+  machinery.
+- [ ] **No reimplementation** — every re-rolled helper/`Result` replaced with the
+  repo's canonical one; the dupe deleted.
+- [ ] **Consistent conventions** — `type`/`interface`, exports, error channel,
+  and casing normalized to the repo's choice across the *whole* change.
+- [ ] **No escape hatches** — no `as any`/`as unknown as`/`!`/`@ts-ignore` added;
+  the escape-hatch census is lower than before, not higher; unsafety lives at one
+  typed boundary with a written reason.
+- [ ] **State space reduced** — defensive over-checking removed, stringly-typed
+  fields pushed to unions, illegal states made unrepresentable where they
+  appeared. The reachable-state count *dropped*.
+
+When all eight hold, the generated code has a real design to refactor. *Now* open
+[`refactoring-mechanics.md`](./refactoring-mechanics.md) and collapse the state
+space further; or, if you want to see a full slop file cleaned end to end, the
+LLM-slop case in [`worked-examples.md`](./worked-examples.md). De-slopping is not
+the refactor — it is the precondition that makes the refactor honest.

--- a/.agents/skills/typescript-refactoring/references/paradigms-and-patterns.md
+++ b/.agents/skills/typescript-refactoring/references/paradigms-and-patterns.md
@@ -1,0 +1,494 @@
+# Paradigms & Patterns — JUDGE THE ABSTRACTION
+
+The decision reference. Open it when you must choose **functions vs classes**, judge
+whether a design is **over- or under-engineered**, or evaluate a **GoF pattern** before
+reaching for it. This file does not teach the target patterns themselves — for *what*
+the good shapes look like (discriminated unions, branded types, type-state builders,
+ports/adapters, FC/IS, the expression problem) it links to `dev:typescript`
+(`references/design-patterns.md`). It owns the *verdict* and the *migration*.
+
+**Spine framing.** A pattern is machinery, and machinery has a state-space cost: every
+interface, base class, factory, and wrapper is another shape the reader must hold and
+another seam the program can be wrong at. A pattern earns that cost only when it
+*collapses* more states than it adds — when it names a real, present force in the code.
+Most GoF patterns, in TypeScript, do the opposite: they reintroduce ceremony to fake a
+feature the language already gives you for free. Judging a pattern is judging whether it
+pays for itself.
+
+---
+
+## 1. Patterns are vocabulary; in TypeScript most are workarounds
+
+A design pattern is a *typical solution to a recurring design problem* — a blueprint you
+adapt, not a snippet you paste ([refactoring.guru](https://refactoring.guru/design-patterns),
+*What's a design pattern?*). That definition has a hard consequence: a pattern is a
+**concept**, not a library. You can't `npm install` it. And because it's a concept, a
+sufficiently expressive language can *satisfy the concept with a built-in feature* — at
+which point the pattern stops being a structure you build and becomes a one-liner you
+already write. The problem it solved still gets solved; the named artifact vanishes.
+
+This is exactly what happens in TypeScript, and refactoring.guru says so itself. Its
+*Criticism of patterns* page makes three arguments; all three anchor a rule in this
+skill.
+
+- **"Kludges for a weak programming language."** RG quotes Paul Graham's *Revenge of the
+  Nerds*: the need for patterns "arises when people choose a programming language … that
+  lacks the necessary level of abstraction," and patterns become "a kludge that gives
+  the language much-needed super-abilities." RG's own example is the load-bearing one:
+  *"the Strategy pattern can be implemented with a simple anonymous (lambda) function in
+  most modern programming languages."* TypeScript **is** one of those languages —
+  first-class functions, closures, modules, structural typing, generators, union types.
+  So a large fraction of the GoF catalog is, by RG's own admission, a workaround for a
+  missing feature TS already ships.
+- **Dogmatic application produces ceremony.** Patterns systematize common approaches;
+  applied "to the letter" without adapting to context, they generate boilerplate. The
+  translation for us: **implement the *intent*, not the UML.** A five-class Strategy
+  hierarchy to pick between two functions is the textbook offense.
+- **The hammer/nail problem.** RG names the dominant failure mode: novices "try to apply
+  [patterns] everywhere, even in situations where simpler code would do just fine." This
+  is **cargo-culting**, and it is the single most common defect in LLM-generated
+  TypeScript — the model has read ten thousand pattern tutorials and reaches for a
+  `Factory`/`Manager`/`AbstractBaseStrategy` where a function literal would do.
+
+Keep the half that survives: the **names are an asset even when the classes are a
+liability.** "Use a strategy map here" communicates intent in four words, and it's true
+even when the implementation is a `Record<K, Fn>`. Teach the vocabulary as
+*communication*; refuse the class machinery unless a present force demands it.
+
+> **The over-engineering rule.** A pattern is justified only when it names a real,
+> present force in your code — a varying axis, a stable boundary, a coupling you must
+> break. If the pattern's machinery (interface + concrete classes + wiring) is larger
+> than the problem, you are paying the **kludge tax** for an abstraction TypeScript
+> already gives you for free. Name the role in plain language; reach for the class
+> skeleton only when the language feature genuinely falls short.
+
+---
+
+## 2. The functions-vs-classes decision procedure
+
+This is the core of the file. The skill's bias is settled — *functions + data +
+discriminated unions are the default; a class is the exception that must earn its place.*
+This section is the rule that decides when the exception holds, so the choice is
+reproducible instead of a matter of taste.
+
+### 2.1 The rule
+
+> **A class (or a stateful object — TS lets you encapsulate state without `class`) earns
+> its place only when ALL THREE hold:**
+>
+> 1. **Identity + lifecycle.** The thing has its own mutable state that evolves over time
+>    and that callers reference *by identity* — a connection, a parser cursor, a live
+>    subscription, a game entity. Functions are stateless; this is the strongest pro-object
+>    signal. *No mutable state referenced by identity ⇒ no class.*
+> 2. **Multiple methods sharing that state.** A *cohesive* cluster of operations over the
+>    same private data. One operation over the state is a function that takes the state as
+>    an argument; many operations over shared mutable state is an object.
+> 3. **A boundary worth naming.** Wrapping a vendor edge, a subsystem, or an access-control
+>    seam in one named unit is a real design win (this is why Adapter/Facade/Proxy survive).
+>
+> **Fail any one and you do not have a class — you have functions + data + a discriminated
+> union wearing a costume.**
+
+A corollary that resolves most cases on sight:
+
+> **The one-method-interface rule.** If an interface has exactly one method, it is a
+> *function type*. `interface Strategy { execute(x: X): Y }` is `type Strategy = (x: X) => Y`.
+> A class implementing a one-method interface is a function with extra steps. This is the
+> direct cash-out of RG's "Strategy = a lambda," generalized across the catalog.
+
+### 2.2 The checklist
+
+Run it in order; the first "no" is your answer.
+
+1. Does the thing hold **mutable state referenced by identity**? — No ⇒ functions + data.
+2. Do **≥2 methods share** that state cohesively? — No (one method) ⇒ a function.
+3. Is there a **boundary** (vendor/subsystem/access) worth encapsulating? — Yes ⇒ a
+   stateful object is legitimate even if (1)/(2) are weak.
+4. Is the thing really a **closed set of shapes** with operations over them (a tree, a
+   state machine, a serializable command)? — Yes ⇒ a **discriminated union + functions**,
+   *not* a class. Exhaustiveness beats polymorphism for closed sets.
+5. Would the **swap test** pass — does the opposite choice (function ↔ class,
+   generic ↔ concrete) give an equivalent result? — Yes ⇒ the heavier choice isn't earned.
+
+### 2.3 Contrasts
+
+A one-method "strategy" class is a function. The interface is the function's type:
+
+```ts
+// over-built: an interface + N one-method classes to pick a discount
+interface DiscountStrategy { apply(price: number): number; }
+class TenPercent implements DiscountStrategy { apply(p: number) { return p * 0.9; } }
+class NoDiscount  implements DiscountStrategy { apply(p: number) { return p; } }
+const strategy: DiscountStrategy = pickStrategy(kind);
+const final = strategy.apply(base);
+
+// earned: a function type and a map keyed by a union
+type Discount = (price: number) => number;
+const discounts: Record<DiscountKind, Discount> = {
+  ten:  (p) => p * 0.9,
+  none: (p) => p,
+};
+const final = discounts[kind](base);
+```
+
+A "service" with no state is a module of functions, not an instantiated class:
+
+```ts
+// over-built: a class you new up once, with no state to hold
+class PriceCalculator {
+  calcSubtotal(items: Item[]) { /* pure */ }
+  calcTax(subtotal: number, region: Region) { /* pure */ }
+}
+const calc = new PriceCalculator();   // why does this object exist?
+
+// earned: exported functions; the module is the namespace
+export const calcSubtotal = (items: Item[]) => { /* pure */ };
+export const calcTax = (subtotal: number, region: Region) => { /* pure */ };
+```
+
+A class is *correct* when identity + lifecycle + cohesion all hold:
+
+```ts
+// legitimately a stateful object: identity, lifecycle, multiple methods over shared state
+class RateLimiter {
+  private hits = new Map<string, number[]>();      // mutable state, referenced by identity
+  allow(key: string): boolean { /* reads + mutates this.hits */ }
+  reset(key: string): void { this.hits.delete(key); }
+  snapshot(): Readonly<Map<string, number[]>> { return this.hits; }
+}
+```
+
+The `RateLimiter` passes all three gates: callers hold *one* limiter and reference it by
+identity, `allow`/`reset`/`snapshot` share `hits`, and it names a coherent
+rate-limiting boundary. A class is the right tool here — don't reflexively functionalize
+genuine stateful objects (that's the inverse over-correction; see §6 and §5's migration
+*the other way*).
+
+---
+
+## 3. GoF-in-TypeScript verdict tables
+
+Each pattern carries a **TS verdict**:
+
+- **IDIOMATIC** — still pulls its weight; the TS form (often a function or small object,
+  not a class hierarchy) is the right call.
+- **SUPERSEDED-BY-LANGUAGE** — a TS/JS feature does it better; the pattern becomes a
+  *description of a one-liner*, not a structure you build.
+- **OVER-ENGINEERING-RISK** — solves a real but *rare* problem; defaults to ceremony.
+  Worth it only when a specific, present, often *measured* force justifies it.
+
+Verdicts and the language-feature mappings are synthesized from the GoF catalog read
+through TypeScript ([refactoring.guru](https://refactoring.guru/design-patterns); see the
+research digest behind this skill). Intents are one line; the **Modern TS alternative**
+names the language feature; **Worth it when** is the genuine trigger that flips the
+verdict back toward "build it."
+
+### 3.1 Creational
+
+| Pattern | Intent | TS verdict | Modern TS alternative | Worth it when |
+| --- | --- | --- | --- | --- |
+| **Factory Method** | Subclass decides which concrete type to instantiate | SUPERSEDED-BY-LANGUAGE | a factory *function* returning the interface; inject the creator | an overridable creation hook on a class hierarchy that *already exists* for other reasons |
+| **Abstract Factory** | Produce *families* of compatible objects | OVER-ENGINEERING-RISK | an object of factory functions (`UIKit` literal), structurally checked | a real family × type *matrix*, swapped wholesale, cross-family mixing must be statically blocked |
+| **Builder** | Construct a complex object step by step | SUPERSEDED (config) / IDIOMATIC (staged) | an **options object** with optional props; a type-state builder for staged APIs | a fluent SDK where the type forbids `.build()` until required steps ran, or genuinely *different representations* from one sequence |
+| **Prototype** | Copy objects without coupling to their class | SUPERSEDED-BY-LANGUAGE | `structuredClone` for **plain data** (handles cycles; **drops methods/prototype and throws on functions — not for class instances**); spread for shallow override | clone semantics structural copy can't capture (reattach live handles, named-prototype registry) |
+| **Singleton** | One instance, globally accessible | SUPERSEDED-BY-LANGUAGE | an **ES module** export (evaluates once); prefer **DI** for testability | ~never as a class; the need is a module export, the *concern* (testing) pushes you to DI |
+
+### 3.2 Structural
+
+| Pattern | Intent | TS verdict | Modern TS alternative | Worth it when |
+| --- | --- | --- | --- | --- |
+| **Adapter** | Make incompatible interfaces collaborate | **IDIOMATIC** | a wrapper function/object at a boundary | integrating any external/legacy API; isolating your domain from a vendor's shape |
+| **Bridge** | Split abstraction from implementation (vary separately) | OVER-ENGINEERING-RISK | inject an implementation (composition over a 2-D inheritance grid) | two axes that *both* genuinely grow and must ship independently (N drivers × M frontends) |
+| **Composite** | Treat individual objects and trees uniformly | **IDIOMATIC** | a recursive **discriminated union** + a fold function | your core model genuinely *is* a tree (filesystem, UI tree) |
+| **Decorator** | Stack behavior by wrapping (runtime) | SUPERSEDED-BY-LANGUAGE | higher-order function composition (≠ TS `@decorators`, an unrelated AOP feature) | stacked wrappers must preserve an *object* interface and carry state |
+| **Facade** | Simplified interface to a complex subsystem | **IDIOMATIC** | a **module** exporting a few named functions | wrapping a complex dependency; decoupling subsystems so they talk only through facades |
+| **Flyweight** | Share intrinsic state to fit more in RAM | OVER-ENGINEERING-RISK | an intern pool / memoized factory (`Map<key, shared>`) | a *profiler-measured* memory ceiling with a huge number of shared-state objects |
+| **Proxy** | Same-interface stand-in controlling access | **IDIOMATIC** | a wrapper, or the native runtime `Proxy` for dynamic traps | lazy/expensive resources, caching, access guards, remote stubs, reactivity |
+
+### 3.3 Behavioral
+
+| Pattern | Intent | TS verdict | Modern TS alternative | Worth it when |
+| --- | --- | --- | --- | --- |
+| **Chain of Responsibility** | Pass a request along a chain of handlers | IDIOMATIC (concept) | an **array of middleware functions** | pluggable, runtime-configurable pipelines where order + short-circuit matter |
+| **Command** | A request as a standalone object | SUPERSEDED-BY-LANGUAGE | a **closure**; a DU-of-data + interpreter for *serializable* commands | undo/redo, event sourcing, job queues — commands need identity + data |
+| **Iterator** | Traverse without exposing representation | SUPERSEDED-BY-LANGUAGE | the iteration protocol — **generators**, `[Symbol.iterator]`, `for…of` | ~never; implement the protocol, not a `hasNext()/next()` class |
+| **Mediator** | Centralize many-to-many communication | OVER-ENGINEERING-RISK | an **event bus / store / reducer** | genuine N×N coupling that no off-the-shelf store/bus fits |
+| **Memento** | Capture/restore state without breaking encapsulation | SUPERSEDED-BY-LANGUAGE | an **immutable snapshot** (`structuredClone` of **plain data** — not class instances; or a `readonly` history) | a class with private complex internals must control what's snapshotted |
+| **Observer** | Notify many subscribers of state changes | SUPERSEDED-BY-LANGUAGE/ECOSYSTEM | `EventTarget`, signals, RxJS, or a tiny typed emitter | always *use* the pattern — via these tools, not a hand-rolled `Subject`/`Observer` pair |
+| **State** | Change behavior when internal state changes | **IDIOMATIC** | a **DU of states + a transition function** (a typed FSM; XState at scale) | a real finite-state machine with many states / frequent change |
+| **Strategy** | Interchangeable algorithms, swapped at runtime | SUPERSEDED-BY-LANGUAGE | a **function** (or `Record<K, Fn>`) | the strategy needs multiple methods *or* its own state |
+| **Template Method** | Algorithm skeleton, overridable steps | SUPERSEDED-BY-LANGUAGE | a **higher-order function** taking step functions | a real base-class lifecycle consumers extend (framework hooks) |
+| **Visitor** | New operations over a fixed object structure | OVER-ENGINEERING-RISK | a **DU + a `switch` function** (+ `assertNever`) | an *open* hierarchy you don't own, with operations that keep growing |
+
+For the **positive** TS pattern catalog — how to actually *build* a discriminated union,
+branded types, a type-state builder, ports/adapters, FC/IS, and the **expression problem**
+that decides Visitor-vs-DU — do not restate it here; read `dev:typescript`
+(`references/design-patterns.md`). This file decides *against*; that file shows what to
+build *instead*, and the two are meant to be read side by side.
+
+---
+
+## 4. The functional-vs-class collapse map
+
+The catalog above sorts cleanly once you ask the right question: **what does the pattern
+collapse into?** That collapse target *is* the functional-vs-class discriminator.
+
+### 4.1 The map
+
+| GoF pattern | Verdict | Collapses into (idiomatic TS) | Wants a class/object when… |
+| --- | --- | --- | --- |
+| **Strategy** | SUPERSEDED | a function / `Record<K, Fn>` | multiple methods or own state |
+| **Command** | SUPERSEDED | a closure; DU-of-data if serializable | undo/event-sourcing needs identity + data |
+| **Template Method** | SUPERSEDED | an HOF taking step functions | a real base-class lifecycle consumers extend |
+| **Factory Method** | SUPERSEDED | a factory function / injected creator | overridable hook on an existing hierarchy |
+| **Iterator** | SUPERSEDED | a generator / `[Symbol.iterator]` / `for…of` | ~never |
+| **Observer** | SUPERSEDED | `EventTarget` / signals / RxJS / tiny emitter | a tiny typed dependency-free emitter |
+| **Decorator** | SUPERSEDED | HOF composition (≠ `@decorators`) | stacked wrappers preserving an object interface + state |
+| **Prototype** | SUPERSEDED | `structuredClone` / spread | custom clone semantics (reattach handles) |
+| **Singleton** | SUPERSEDED | an ES module export (prefer DI) | ~never |
+| **Memento** | SUPERSEDED | immutable snapshot / `structuredClone` | private complex internals control snapshot |
+| **Adapter** | IDIOMATIC | a wrapper fn/object at a boundary | wrapping a stateful multi-method service |
+| **Facade** | IDIOMATIC | a module of named functions | (rarely) a stateful subsystem handle |
+| **Proxy** | IDIOMATIC | a wrapper or native `Proxy` | access control / lazy / caching / reactivity |
+| **Composite** | IDIOMATIC | a recursive DU + fold | nodes carry real behavior + identity |
+| **State** | IDIOMATIC | a DU + transition fn (XState at scale) | complex orchestration + side-effects |
+| **Chain of Resp.** | IDIOMATIC | an array of middleware functions | handlers are stateful objects |
+| **Abstract Factory** | OVER-ENG | an object of factory functions | real family × type matrix, swapped wholesale |
+| **Builder** | OVER-ENG | an options object | fluent type-state SDK; multiple representations |
+| **Bridge** | OVER-ENG | inject an implementation (composition) | two axes both grow + ship independently |
+| **Flyweight** | OVER-ENG | an intern pool / memoized factory | measured memory ceiling, huge object counts |
+| **Mediator** | OVER-ENG | an event bus / store / reducer | genuine N×N coupling no store fits |
+| **Visitor** | OVER-ENG | a DU + `switch` function | open hierarchy you don't own + growing ops |
+
+### 4.2 The three collapse targets
+
+Read top to bottom; almost every "becomes a function" reduces to one of these.
+
+1. **Single-method patterns → a function or `Record<K, Fn>`.** Strategy, Command,
+   Template Method, Factory Method, and Visitor-over-a-closed-set all reduce to "pass
+   behavior as a value." If a pattern's interface has exactly one method, it is a function
+   type — this is the one-method-interface rule (§2.1) applied to the catalog.
+
+2. **One-shared-instance / copied-state patterns → modules and value semantics.**
+   Singleton → a module export. Prototype/Memento → `structuredClone` / `readonly`
+   immutable values. Flyweight → an intern `Map`. The OO ceremony existed to manage
+   *access to shared or copied state*; modules and value semantics handle that without a
+   class.
+
+3. **Iteration & notification patterns → built-in protocols and platform APIs.**
+   Iterator → the iteration protocol / generators; Observer → `EventTarget` / signals /
+   RxJS. The platform *is* the pattern. Reimplementing it by hand is the purest
+   cargo-cult.
+
+### 4.3 The data-shaped patterns → discriminated union + functions
+
+A separate group doesn't collapse into a *function* — it collapses into a **shape**.
+Composite, State, serializable Command, and Visitor-over-a-closed-set are all "model the
+closed set of cases as a tagged union and fold over it." The functional form here isn't
+just lighter; it's **strictly safer**, because exhaustiveness checking turns "did I
+handle every case?" into a compile error instead of a runtime surprise.
+
+```ts
+// State, Composite, serializable Command, and closed-set Visitor share this shape:
+type Node =
+  | { kind: "leaf"; price: number }
+  | { kind: "box"; packaging: number; children: Node[] };
+
+const total = (n: Node): number => {
+  switch (n.kind) {
+    case "leaf": return n.price;
+    case "box":  return n.packaging + n.children.reduce((s, c) => s + total(c), 0);
+    default:     return assertNever(n);   // compiler enforces totality
+  }
+};
+
+// "Add a new operation" = write another function. Zero edits to existing cases —
+// the open/closed property Visitor exists to fake, for free.
+const depth = (n: Node): number =>
+  n.kind === "leaf" ? 1 : 1 + Math.max(0, ...n.children.map(depth));
+```
+
+The trade-off is the **expression problem**: a DU + `switch` makes adding *operations*
+free but adding *cases* costly; classes/Visitor are the inverse. Choose by which axis
+actually changes in your code. For the full framing, see `dev:typescript`
+(`references/design-patterns.md`).
+
+---
+
+## 5. Bidirectional migration mechanics
+
+When a pattern is on the wrong side of the collapse map, migrate it. Both directions are
+behavior-preserving and compiler-gated; for the general safe-step cadence (green after
+every step, commit one move at a time, characterize first) see
+[`refactoring-mechanics.md`](./refactoring-mechanics.md). Below are the two
+pattern-specific shapes.
+
+### 5.1 Class → factory-closure
+
+For a stateless "service" class, or a stateful one whose state is private and small. The
+goal is to drop the `class` keyword and `this` while preserving the public surface.
+
+1. **Pin the public surface.** Note every method the class exposes; that signature set is
+   the contract a migration may not break.
+2. **Move construction into a function.** Replace `class X { constructor(deps) }` with
+   `const makeX = (deps) => { … }`. Constructor params become factory params.
+3. **Lift fields into closure variables.** Private fields become `let`/`const` in the
+   factory body; `this.x` becomes `x`. Mutable state stays mutable — it's now closed-over.
+4. **Return the methods as an object.** Each method becomes a function in the returned
+   literal; they close over the same variables, so they share state exactly as before.
+5. **Re-point call sites.** `new X(deps)` → `makeX(deps)`. The call shape (`.method()`)
+   is unchanged, so consumers don't move.
+6. **Green after each step**; the public type of the returned object should match the old
+   class's instance type.
+
+```ts
+// before
+class Counter {
+  private n = 0;
+  constructor(private step: number) {}
+  inc() { this.n += this.step; return this.n; }
+  value() { return this.n; }
+}
+
+// after — same surface, no `this`, no `class`
+const makeCounter = (step: number) => {
+  let n = 0;
+  return {
+    inc()   { n += step; return n; },
+    value() { return n; },
+  };
+};
+```
+
+### 5.2 Inheritance hierarchy → discriminated union + dispatch function
+
+For a base class with subclass-per-variant where subclasses are *data with a little
+behavior* (the State / Visitor / closed-set Command shape). This is the highest-leverage
+migration in the file: it trades runtime polymorphism for compile-time exhaustiveness.
+
+1. **Enumerate the subclasses.** Each becomes a variant of the union, tagged by a literal
+   discriminant (`kind`).
+2. **Turn fields into the variant's data.** Each subclass's fields become that variant's
+   properties; drop the class wrapper.
+3. **Collect the per-subclass method bodies.** For each polymorphic method, the
+   subclass overrides become the `case` arms of a `switch` over the discriminant.
+4. **Write the dispatch function** with a `default: assertNever(x)` arm so the compiler
+   forces you to handle every variant — the guarantee the class form never gave you.
+5. **Re-point call sites.** `shape.area()` → `area(shape)`. Construction `new Circle(r)`
+   → the data literal `{ kind: "circle", r }`.
+6. **Green after each step.** The exhaustiveness error *is* your migration checklist:
+   `tsc` will name any case you forgot.
+
+```ts
+// before: a class hierarchy for a closed set of shapes
+abstract class Shape { abstract area(): number; }
+class Circle extends Shape { constructor(public r: number) { super(); } area() { return Math.PI * this.r ** 2; } }
+class Square extends Shape { constructor(public s: number) { super(); } area() { return this.s ** 2; } }
+
+// after: a DU + a dispatch function the compiler proves total
+type Shape =
+  | { kind: "circle"; r: number }
+  | { kind: "square"; s: number };
+
+const area = (shape: Shape): number => {
+  switch (shape.kind) {
+    case "circle": return Math.PI * shape.r ** 2;
+    case "square": return shape.s ** 2;
+    default:       return assertNever(shape);   // add a variant → compile error here
+  }
+};
+```
+
+### 5.3 When to migrate the *other* way
+
+Migration is not unidirectional. If functions-and-data have drifted into a pile of
+free functions all threading the same mutable record through every signature — and that
+record has identity, a lifecycle, and a cohesive cluster of operations (§2.1) — then the
+*honest* shape is a stateful object, and you should migrate **toward** a class:
+
+```ts
+// drifted: every function re-threads the same evolving state, by hand
+let cursor = { pos: 0, src };
+const advance = (c: typeof cursor) => ({ ...c, pos: c.pos + 1 });
+const peek    = (c: typeof cursor) => c.src[c.pos];
+// …state passed in and out of a dozen call sites — that's a parser cursor
+
+// honest: identity + lifecycle + cohesion ⇒ a stateful object earns it
+class Cursor {
+  constructor(private src: string, private pos = 0) {}
+  advance() { this.pos++; }
+  peek() { return this.src[this.pos]; }
+  done() { return this.pos >= this.src.length; }
+}
+```
+
+The mechanics are §5.1 run in reverse. The point of §2's rule is to make this call
+*symmetric*: don't functionalize a genuine stateful object any more than you'd classify a
+pure function. The test is the three gates, not a paradigm preference.
+
+---
+
+## 6. Over-engineering vs under-engineering — the pattern-level view
+
+Patterns are where over-engineering hides, because each pattern leaves a *layer* — a
+wrapper, interface, factory, base class, or "service" — and a layer is exactly what an
+over-engineered design has too many of. The diagnostic is the **indirection audit**:
+*"delete this layer and lose nothing?"* If the only loss is "flexibility we don't use
+yet," delete it.
+
+This file does not own the full audit. The five-step procedure (name the force → count
+call sites → swap test → deletion question → justify survivors) and its detection greps
+live in [`llm-slop-cleanup.md`](./llm-slop-cleanup.md#the-indirection-audit), because the
+audit is the spine of the generated-code triage pass. Here is the pattern-level framing:
+**a pattern is a layer that must pass the audit like any other.** Run the audit on every
+abstraction a pattern introduced — an `IFooRepository` with one implementor, a `Factory`
+wrapping one `switch`, a `BaseDecorator` with three one-line subclasses — and collapse the
+ones that fail.
+
+The cargo-cult tells — the layers that *predictably* fail the audit, with the one-line
+collapse:
+
+| Cargo-cult tell | Why it fails | Collapse to |
+| --- | --- | --- |
+| `getInstance()` / `private static instance` | a module is already a singleton | a module export (inject for testing) |
+| one-implementation interface (`IFoo` + one `class Foo`) | the interface decorates a single concrete type | the concrete type; the swap test passes |
+| `class XStrategy implements Strategy` | one-method interface = a function type | a function / `Record<K, Fn>` |
+| `class XFactory` wrapping one `switch` | a function holds a `switch` fine | a factory function |
+| `Visitor` + `accept()` over an *owned, closed* set | fakes dispatch TS gives natively | a DU + `switch` (+ `assertNever`) |
+| `AbstractBaseX` hosting one template method | inheritance to share one skeleton | a higher-order function |
+| hand-rolled `hasNext()/next()` | reinvents the iteration protocol | a generator / `for…of` |
+
+The opposite failure — **under-engineering** — is the same audit run with the polarity
+flipped: not "too many layers" but "no model where one is owed." Its pattern-level form is
+a *repeated branch that's a missing discriminated union*: `switch (kind)` copy-pasted
+across five functions, a `status: string` that admits infinite states for a three-member
+domain, primitives standing in for a type-state machine. The fix is to *introduce* the
+shape from §4.3, not to delete a layer. The throughline across both directions:
+**match the machinery to the force.** Over-engineering is machinery with no force;
+under-engineering is a force with no machinery. The audit catches the first; the
+missing-model heuristic catches the second. For under-engineering's full detection grep
+set, see [`llm-slop-cleanup.md`](./llm-slop-cleanup.md#under-engineering-tells-the-opposite-failure);
+for the smells these manifest as (Speculative Generality, Primitive Obsession, Switch
+Statements), see [`smell-catalog.md`](./smell-catalog.md).
+
+---
+
+## Definition of a justified pattern
+
+A pattern (or the abstraction it leaves behind) is justified when it clears every line —
+the pattern-level analog of the skill's Approval Bar:
+
+- [ ] **Names a present force** — a varying axis, a stable boundary, or a coupling it
+  breaks; not "we might need it someday."
+- [ ] **Passes the swap test** — the opposite choice (function ↔ class, generic ↔
+  concrete, pattern ↔ language feature) would *not* give an equivalent result.
+- [ ] **Earns its layers** — every wrapper/interface/factory it introduces survives the
+  indirection audit; no one-implementation interface, no `getInstance()`, no
+  Visitor/`accept()` over an owned closed set.
+- [ ] **Sits on the right side of the collapse map** — if §4 says SUPERSEDED, the
+  language feature is used instead; if a class, the three gates of §2.1 all hold.
+- [ ] **Collapses more states than it adds** — the machinery shrinks the reachable-state
+  count (exhaustive DU, parsed boundary), it doesn't merely relocate it.
+
+When all five hold, the pattern is design, not ceremony. When any fails, you are paying
+the kludge tax — name the role in plain language and reach for the language feature.

--- a/.agents/skills/typescript-refactoring/references/refactoring-mechanics.md
+++ b/.agents/skills/typescript-refactoring/references/refactoring-mechanics.md
@@ -1,0 +1,724 @@
+# Refactoring Mechanics — Transform Safely
+
+This is the **TRANSFORM-SAFELY** reference: the compiler-gated mechanics for
+executing a refactor, the gated workflow that wraps them, and the definition of
+done. Open it once you have *detected* a smell (→ `smell-catalog.md`) and decided
+to fix it. For *what good looks like* — the target shapes you refactor toward —
+this file links out and never restates: `paradigms-and-patterns.md` (functional
+vs class, GoF verdicts, the indirection audit) and the `dev:typescript` skill
+(`references/design-patterns.md`, `references/refactoring-patterns.md`,
+`references/axes.md`).
+
+Technique names follow the Fowler catalog as re-illustrated by
+[Refactoring.Guru](https://refactoring.guru/refactoring/techniques); the
+mechanics below are an original, TypeScript-specialized synthesis, not the source
+prose.
+
+## The compiler-as-safety-net cadence
+
+A refactor is **behavior-preserving by construction**, not by hope. The way you
+get that guarantee is rhythm, not care:
+
+- **Small steps.** Each transform is the smallest edit that compiles. A move you
+  cannot do in one green step is two moves wearing a trenchcoat — split it.
+- **Green after every step.** `tsc --strict --noEmit` clean *and* tests passing
+  is the gate between steps. If the build is red, you are no longer refactoring;
+  you are debugging a half-applied edit. Get back to green before the next move.
+- **The compiler is the net the source catalog never had.** Fowler's mechanics
+  say "compile and test" after each step because Java lacked the type density to
+  prove the step. In strict TS, the type checker *is* most of the net: rename,
+  extract, move, and signature changes surface every stale reference as an error.
+  Exploit that — let red squiggles drive the edit, then run tests for the
+  behavior the types can't see.
+- **Where the net has holes.** Structural typing means a *wrong* rename can still
+  type-check (two unrelated types with the same shape). `as` / `as any` / `!`
+  mask the breakage a refactor would otherwise reveal. `noUncheckedIndexedAccess`
+  off hides index errors a decomposition introduces. Before a risky move, grep
+  the blast zone for escape hatches and strip them, or the net is lying to you.
+- **Refactor and add-feature are separate hats — and separate commits.** Never
+  change behavior and structure in the same diff. If you discover a bug
+  mid-refactor, note it, finish the structural move green, commit, *then* switch
+  hats and fix the bug as its own change. Mixing the two makes both unreviewable
+  and destroys the "behavior is unchanged" guarantee that makes a refactor safe.
+
+> **Categorical, not instance.** A smell you found once is a *class*. When a
+> mechanic below fixes one site, sweep the module (or repo) for siblings and fix
+> them in the same pass — one fix, many sites. A `codemod` / `ts-morph` script
+> earns its keep past ~20–50 call sites.
+
+---
+
+## The gated refactor workflow
+
+The six SKILL.md steps, expanded into procedure. Every step has a gate; you do
+not advance past a red gate.
+
+### 1. Detect
+
+Inventory smells with `smell-catalog.md` and ground intuition in tooling, not
+vibes: `knip` / `ts-prune` (dead exports), `jscpd` (duplication), `madge` /
+`dpdm` (cycles), ESLint `complexity` / `max-lines` / `max-depth` / `sonarjs`,
+`tsc --noUnusedLocals --noUnusedParameters`, and an escape-hatch grep
+(`as any`, `as unknown as`, `@ts-ignore`, `!`, `Record<string, any>`). The
+catalog's *Detection toolkit cheat-sheet* has the exact invocations.
+
+**Gate:** a written smell inventory, each with a concrete signal — not "this
+feels messy."
+
+### 2. Triage & rank by state-space leverage
+
+Order targets so the highest-leverage move lands first. The ranking key is **how
+much a fix collapses the reachable-state space**, traded against blast radius:
+
+1. **State-space collapses first** — flags/optionals/`any` → discriminated union
+   + exhaustive `switch`. One such move can delete a dozen downstream branches.
+2. **Deletions next** — dead code, lazy classes, one-line wrappers, speculative
+   generality. Deleting a concept beats restructuring it (Delete > rearrange).
+3. **Placement last** — moving a function to its owning module reduces coupling
+   but doesn't shrink the state space; do it after the high-leverage cuts.
+
+Note what is load-bearing and what crosses a published boundary (defer surface
+contracts to `dev:api-design`). For *whether to refactor at all* and *where the
+boundary goes*, this is the moment to hand off to `cognition:solution-design` /
+`cognition:domain-design` — not later.
+
+**Gate:** a ranked list; the top item is a state-space collapse or a deletion,
+not a rename.
+
+### 3. Characterize (build the safety net)
+
+Before you change untested code, pin its behavior. Either there are tests that
+already lock the contract, or you write a characterization net first (see
+*Refactoring without tests*, below), or each step is small enough that
+`tsc --strict` alone proves it. Design of the net — what to test, how much, the
+oracle — is owned by `cognition:testing-design`; do not re-derive it here.
+
+**Gate:** behavior is pinned. You can name *how you would know* if a step broke
+something. If you can't, you are not ready to transform.
+
+### 4. Transform step-by-step
+
+Apply one mechanic from this file at a time. Each mechanic below carries its own
+numbered steps with the compile/test checkpoint marked. The discipline across
+mechanics:
+
+- One logical move per edit; `tsc --strict --noEmit` + tests green between edits.
+- **Commit granularity: one logical move per commit.** A commit should be
+  revertable in isolation and describable in one line ("extract `isEligible`
+  predicate", "flags → `Status` DU"). Squash typo-fix churn; never bundle two
+  independent moves. This keeps `git bisect` and review sane and makes rollback a
+  scalpel, not a sledgehammer.
+
+**Gate:** green build + green tests after each move; each move is its own commit.
+
+### 5. Verify
+
+Confirm the contract held: external behavior unchanged, and **public types
+didn't drift silently**. Diff the emitted `.d.ts` / exported surface
+(`git diff` on declaration output, or `knip`/`api-extractor`) — a structural
+edit can change an inferred return type without touching a single annotation.
+
+**Gate:** behavior preserved; `git diff` of the public surface is empty or
+intended-and-recorded.
+
+### 6. Definition of done
+
+Run the checklist at the end of this file. Record findings and before/after with
+`../assets/refactor-findings-template.md`. Check the result against SKILL.md's
+Mandate and Approval Bar.
+
+### Stop / rollback signals
+
+Abort the current move and revert to the last green commit when:
+
+- **The build won't go green in small steps.** If a "small" step cascades into
+  dozens of unrelated errors, the step was too big or the seam was wrong. Revert,
+  re-plan a smaller cut.
+- **Type-check performance blows up.** A refactor that introduces deep
+  conditional types, large unions, or heavy inference can make `tsc` crawl. If
+  editor responsiveness or `tsc` wall-time degrades sharply, stop: profile with
+  `tsc --generateTrace ./trace` and inspect in Perfetto. The diagnosis-and-fix
+  workflow (sub-apps, breaking the inference chain, `interface` over deep
+  intersections) lives in `dev:typescript` `references/real-world-examples.md` —
+  hand off rather than guessing.
+- **Behavior diverges.** A characterization test goes red on a step that should
+  have been behavior-preserving → you found a latent bug *or* mis-stepped.
+  Revert, isolate, decide (fix-as-separate-commit vs. the step was wrong).
+- **The state space didn't drop.** If the planned move only relocates complexity
+  (Swap test passes, reachable-state count unchanged), it has not earned its
+  diff. Stop and find the move that deletes the model instead.
+
+---
+
+## The top TypeScript refactoring moves
+
+The ~15 that do the most work on real and LLM-generated TS, roughly in order of
+everyday leverage. For each: which **smell** it cures (→ `smell-catalog.md`), the
+**mechanics** (TS-specialized, with the green checkpoint), and a short
+before→after where it sharpens. For the *target shapes* (DU, branded types,
+ports, strategy maps) refer to `paradigms-and-patterns.md` and `dev:typescript`
+`references/design-patterns.md` — this file owns the *moves*, not the targets.
+
+### Extract Function
+
+**Cures:** Long Method; Duplicate Code; Comments (when a comment is really a
+function name waiting to happen). → `smell-catalog.md`.
+
+**Mechanics:**
+1. Find a fragment that hangs together; name it for **intent**, not mechanism
+   (`recalculateTax`, not `processData`).
+2. Free variables read inside become parameters; the single mutated local becomes
+   the return value. *Two or more mutated locals → split the fragment further, or
+   return a small object literal / tuple — don't smuggle out multiple results via
+   parameter mutation.*
+3. Create the function; replace the fragment with a call. **Checkpoint:**
+   `tsc --noEmit` + tests green.
+4. Prefer a free `function` / arrow over a method unless the data is genuinely
+   object-bound. The IDE's "Extract to function" is reliable for the move — but
+   *you* pick the name.
+
+```ts
+// before
+function priceOrder(order: Order) {
+  let total = 0;
+  for (const line of order.lines) total += line.qty * line.unitPrice;
+  // apply discount
+  if (order.coupon) total *= 1 - order.coupon.rate;
+  return total;
+}
+// after
+const subtotal = (lines: readonly Line[]) =>
+  lines.reduce((sum, l) => sum + l.qty * l.unitPrice, 0);
+const applyCoupon = (total: number, c: Coupon | undefined) =>
+  c ? total * (1 - c.rate) : total;
+
+const priceOrder = (order: Order) =>
+  applyCoupon(subtotal(order.lines), order.coupon);
+```
+
+### Replace Nested Conditional with Guard Clauses
+
+**Cures:** Long Method; arrow-shaped nesting; Optional-property soup (the guard
+strips `undefined`). → `smell-catalog.md`.
+
+**Mechanics:**
+1. Identify each special/edge case nested around the happy path.
+2. Pull each to the top as a guard that returns or throws early. **Checkpoint**
+   after each guard: green.
+3. Flatten the remaining body — it now runs on validated, narrowed values.
+4. Consolidate guards that share an outcome.
+
+The TS bonus: `if (!x) return;` doesn't just dedent — it **narrows** the type, so
+the rest of the function sees `x` without `undefined`. Nesting and type-noise
+collapse together.
+
+```ts
+// before
+function pay(user?: User) {
+  if (user) {
+    if (user.active) {
+      if (user.balance > 0) return charge(user);
+    }
+  }
+  return null;
+}
+// after — each guard narrows; body operates on a known-good User
+function pay(user?: User) {
+  if (!user) return null;
+  if (!user.active) return null;
+  if (user.balance <= 0) return null;
+  return charge(user); // user: User, active, positive balance
+}
+```
+
+### Extract Variable (name conditions)
+
+**Cures:** Long Method; opaque expressions; Comments. → `smell-catalog.md`.
+
+**Mechanics:**
+1. Hoist a subexpression into a `const` named for **what it means**
+   (`isPastDue`), never `let`. The `const` proves the extraction is
+   side-effect-free.
+2. Replace the original occurrence; repeat for other parts. **Checkpoint:** green.
+3. **Watch eval semantics:** extracting an operand of `a() || b()` forces both to
+   evaluate — if the operands are effectful or expensive, the short-circuit you
+   removed mattered. Keep predicates pure.
+
+```ts
+// before
+if (order.total > 100 && !order.coupon && order.customer.tier === "gold") { … }
+// after
+const qualifiesForFreeShipping =
+  order.total > 100 && !order.coupon && order.customer.tier === "gold";
+if (qualifiesForFreeShipping) { … }
+```
+
+### Decompose Conditional
+
+**Cures:** Long Method; Switch Statements; dense branching. → `smell-catalog.md`.
+
+**Mechanics:**
+1. Extract the test into a named predicate (`isSummerRate(date)`).
+2. Extract the then-branch and else-branch each into a named function.
+   **Checkpoint:** green after each extraction.
+3. If the predicate distinguishes a *type*, type it as a guard
+   (`x is Foo`) — you get readability **and** narrowing in one move.
+
+```ts
+// before
+if (date.month >= 6 && date.month <= 8) charge = base * summerRate;
+else charge = base * winterRate;
+// after
+const isSummer = (d: Date) => d.month >= 6 && d.month <= 8;
+charge = isSummer(date) ? summerCharge(base) : winterCharge(base);
+```
+
+### Replace Type Code with discriminated union + exhaustive `switch`/`never`
+
+**Cures:** Switch Statements; Primitive Obsession; flag/boolean soup;
+Optional-property soup. *The highest-value conceptual move on branchy code.*
+→ `smell-catalog.md`. For the union shape and exhaustiveness pattern itself, see
+`dev:typescript` `references/design-patterns.md` and the flags→DU /
+union→ADT moves in `dev:typescript` `references/refactoring-patterns.md` —
+coordinate, don't duplicate. Migration mechanics also expand in
+`paradigms-and-patterns.md`.
+
+**Mechanics:**
+1. Name the variants: model the type code (or the cluster of booleans/optionals)
+   as a `type` with a literal discriminant per case, each carrying *only* its
+   own data.
+2. Construct values through the new type at every creation site. **Checkpoint:**
+   green.
+3. Replace each branchy read with a `switch (x.kind)`; in the `default`, assign
+   to a `never` to force exhaustiveness. Adding a future variant now becomes a
+   compile error at every switch — the compiler maintains the branch list.
+4. Delete the now-impossible combinations (the soup that admitted illegal states
+   is gone).
+
+```ts
+// before — three booleans encode one state; illegal combos representable
+interface Job { loading: boolean; error?: string; data?: Result }
+// after — one discriminant; illegal states unrepresentable
+type Job =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "done"; data: Result };
+
+function render(j: Job) {
+  switch (j.kind) {
+    case "loading": return spinner();
+    case "error":   return banner(j.message);
+    case "done":    return view(j.data);
+    default: { const _exhaustive: never = j; return _exhaustive; }
+  }
+}
+```
+
+When the *same* switch is duplicated across many functions, escalate to a
+**strategy map** (`Record<Kind, Handler>`) rather than copying the switch —
+verdict and mechanics in `paradigms-and-patterns.md`.
+
+### Replace Magic Number with named const
+
+**Cures:** Primitive Obsession; Comments. → `smell-catalog.md`.
+
+**Mechanics:**
+1. Declare a `const` carrying the meaning (`const TAX_RATE = 0.2`).
+2. Replace only the occurrences that *truly mean this concept* — not every `0.2`.
+   **Checkpoint:** green.
+3. For a *set* of related literals, prefer an `as const` object + derived union
+   over a numeric `enum` (no runtime enum object, exact literal types):
+
+```ts
+const Role = { Admin: "admin", Editor: "editor", User: "user" } as const;
+type Role = (typeof Role)[keyof typeof Role]; // "admin" | "editor" | "user"
+```
+
+Not every literal is magic — `i < count`, `* 2`, `[0]` are usually fine. A
+literal used as a *type code* belongs in the discriminated-union move above.
+
+### Introduce Branded Type
+
+**Cures:** Primitive Obsession (interchangeable ids/quantities typed as bare
+`string`/`number`). → `smell-catalog.md`. Target shape (nominal/branded types)
+lives in `dev:typescript` `references/design-patterns.md`; this is the safe
+sequence to retrofit one.
+
+**Mechanics:**
+1. Declare the brand and the branded alias. The runtime value is unchanged — the
+   brand exists only in the type system, so this is zero-overhead:
+
+```ts
+declare const brand: unique symbol;
+type Brand<T, B extends string> = T & { readonly [brand]: B };
+type UserId = Brand<string, "UserId">;
+```
+
+2. Add **one** constructor per brand — the single place a raw value becomes a
+   branded one. Confine the `as` cast here. If the source is untrusted, *validate
+   in this constructor* (this is your parse-at-the-boundary seam); if it is
+   already trusted, the cast alone is fine because it is the only one:
+
+```ts
+const toUserId = (raw: string): UserId => {
+  if (raw === "") throw new Error("empty UserId"); // validate when untrusted
+  return raw as UserId;
+};
+```
+
+3. Change the *consuming* signatures from `string` to `UserId` and follow the
+   compiler; every call site that mixed ids now fails to type-check.
+   **Checkpoint:** green — and a deliberately swapped argument is now a red.
+4. Push the constructors to the boundary (parse/DTO layer) so the core never sees
+   a raw `string`. The `as` cast count in the core should drop to zero.
+
+*Why it earns its keep:* it makes "which `string` is this?" a compiler question
+instead of a convention, with no runtime cost. Do not brand every primitive —
+only ones that are semantically distinct and get mixed up.
+
+### Encapsulate Collection (`readonly`)
+
+**Cures:** the "exposed mutable collection" bug; Inappropriate Intimacy.
+→ `smell-catalog.md`.
+
+**Mechanics:**
+1. Store the field `readonly`; type the getter as `readonly T[]` /
+   `ReadonlyArray<T>` (or return a copy).
+2. Add intent-named mutators (`addLine`, `removeLine`); rename any "replace the
+   whole collection" to `replace`.
+3. Follow the compiler errors at call sites that mutated the array directly —
+   each is a real escaped-mutation bug the type now forbids. **Checkpoint:**
+   green once all external mutation routes through the methods.
+
+```ts
+// before — callers can push into internals
+class Cart { items: Item[] = []; }
+// after — the compiler enforces the no-external-mutation contract
+class Cart {
+  readonly #items: Item[] = [];
+  get items(): readonly Item[] { return this.#items; }
+  add(i: Item) { this.#items.push(i); }
+}
+```
+
+### Introduce Parameter Object / Preserve Whole Object (options object)
+
+**Cures:** Long Parameter List; Data Clumps. → `smell-catalog.md`.
+
+**Mechanics (Introduce Parameter Object):**
+1. Define an (often `readonly`) `interface`/`type` for the recurring param clump.
+2. Add it as a single param; replace the individual params with reads from it.
+   **Checkpoint:** green.
+3. Relocate behavior that operates only on that clump onto/near the type if
+   warranted.
+
+**Mechanics (Preserve Whole Object):** when you unpack several fields off an
+object only to pass them separately, pass the object — but choose the **narrowest
+stable type** that still satisfies the callee. Structural typing lets the callee
+accept `{ x: number; y: number }` instead of the whole `Widget`; that keeps the
+dependency minimal and the function testable. Whole-object widens coupling;
+minimal-shape keeps it tight. Pick deliberately.
+
+```ts
+// before
+function createUser(name: string, email: string, age: number, admin: boolean) {}
+// after — named fields kill positional-arg bugs; readonly = no surprise mutation
+interface CreateUserOptions {
+  readonly name: string; readonly email: string;
+  readonly age: number; readonly admin: boolean;
+}
+function createUser(opts: CreateUserOptions) {}
+```
+
+### Replace Parameter with Explicit Methods (kill boolean-flag params)
+
+**Cures:** boolean-flag parameters; Long Parameter List. → `smell-catalog.md`.
+
+**Mechanics:**
+1. For a param whose *value fully selects behavior* (especially a boolean), write
+   one clearly-named function per variant.
+2. Route each caller to the right one; delete the original. **Checkpoint:** green.
+
+```ts
+// before — call site reads as a riddle: setValue(true)? for what?
+function setEnabled(on: boolean) { … }
+setEnabled(true);
+// after
+function enable() { … }
+function disable() { … }
+enable();
+```
+
+Judgment: if the variants share most logic and differ only by *data*, a
+discriminated-union param can beat N near-identical methods. Don't over-split
+rarely-changing variants. The reverse smell — N near-identical methods differing
+by one literal — is cured by **Parameterize Function** (`getAdminUsers` /
+`getEditorUsers` → `getUsersByRole(role)`); just keep the param a union, not a
+boolean mode flag that grows an internal conditional.
+
+### Split Temporary Variable + Remove Assignments to Parameters
+
+**Cures:** Long Method; the reused-`let result`/`temp`/`data` smell.
+→ `smell-catalog.md`.
+
+**Mechanics (Split Temporary Variable):**
+1. Each time a local is reassigned to mean *something new*, introduce a new,
+   well-named variable for that concept.
+2. Make each new variable `const`. If you *can't* make it `const`, that's a
+   signal the fragment wants Extract Function instead. **Checkpoint:** green.
+   (Loop counters are exempt.)
+
+**Mechanics (Remove Assignments to Parameters):**
+1. Reassigning a param? Copy it into a local: `const local = param;` and mutate
+   `local`. **Checkpoint:** green.
+2. Better: treat all params as immutable by convention; mark object/array params
+   `readonly`. Reassigning a param obscures the input contract; mutating a
+   reference-shared object/array param is a genuine foot-gun, not a style nit.
+
+```ts
+// before — one `let` carries two meanings, and mutates the input
+function f(items: number[]) {
+  let temp = items.reduce((a, b) => a + b, 0); // sum
+  temp = temp / items.length;                  // now it's the average
+  items = items.filter((x) => x > temp);       // param reassigned
+  return items;
+}
+// after — one const per concept; param left alone
+function f(items: readonly number[]) {
+  const sum = items.reduce((a, b) => a + b, 0);
+  const average = sum / items.length;
+  return items.filter((x) => x > average);
+}
+```
+
+### Replace Temp with Query / Separate Query from Modifier
+
+**Cures:** Long Method; Duplicate Code; hidden side effects (CQS violation).
+→ `smell-catalog.md`.
+
+**Mechanics (Replace Temp with Query):**
+1. Ensure the temp is assigned exactly once (Split Temporary Variable first if
+   not).
+2. Extract the computing expression into a **pure** helper (Separate Query from
+   Modifier first if it isn't pure).
+3. Replace the temp with the call. **Checkpoint:** green. Keep the temp only for
+   genuinely expensive, memoizable work — and then reach for an explicit memo.
+
+**Mechanics (Separate Query from Modifier):**
+1. A function that both returns a value *and* mutates → create a pure query that
+   returns the value; leave the original holding only the mutation.
+2. At call sites, call the modifier, then the query. **Checkpoint:** green. Pure
+   queries are cacheable and trivially testable; the command isolates the effect.
+   (Exception: returning a value that *is the effect's report* — e.g. a
+   deleted-row count — is fine.)
+
+### Replace Constructor with Factory Method
+
+**Cures:** constructors doing more than field-setting; fallible/async/variant
+creation. → `smell-catalog.md`. For *target* SDK/factory shapes see
+`dev:typescript` `references/design-patterns.md`.
+
+**Mechanics:**
+1. Write a `create*` factory function that wraps the constructor.
+2. Redirect callers to it; make the constructor `private`. **Checkpoint:** green.
+3. Pull non-construction logic (validation, defaulting, async fetch) into the
+   factory. For fallible creation, return a `Result` / discriminated union rather
+   than throwing — failure becomes part of the type signature.
+
+```ts
+// before — a constructor that can't fail gracefully or be async
+class Client { constructor(url: string) { /* validates, throws */ } }
+// after — factory can be async, can return a typed failure
+class Client {
+  private constructor(readonly url: URL) {}
+  static create(raw: string): Result<Client, "bad-url"> {
+    const url = parseUrl(raw);
+    return url ? ok(new Client(url)) : err("bad-url");
+  }
+}
+```
+
+### The deletion moves: Inline Function, Inline Class, Collapse Hierarchy, Remove Parameter
+
+**Cures:** Lazy Class; Middle Man; Speculative Generality; Dead Code; needless
+indirection (the slop LLMs love). → `smell-catalog.md`. *Delete > rearrange — the
+highest-confidence way to drop the state space is to remove a concept.*
+
+**Inline Function:** body is as clear as its name and earns nothing → substitute
+the body at every call site, delete the function. For plain functions there's no
+override chain to check; low-risk. **Checkpoint:** green.
+
+**Inline Class:** a 6-line wrapper module/class that barely does anything → fold
+its members into the sole consumer, redirect references, delete the file.
+**Checkpoint:** green.
+
+**Collapse Hierarchy:** a subclass and superclass have drifted nearly identical →
+pull-up/push-down to consolidate, repoint references, delete the empty layer.
+Watch remaining siblings for LSP breakage. The broader move is "collapse the
+accidental hierarchy into composition or a union" — see
+`paradigms-and-patterns.md`.
+
+**Remove Parameter:** a param no reader needs → confirm unused
+(`noUnusedParameters` + IDE), delete it, fix callers (the compiler lists them).
+Every param is a question in the reader's head; cut the speculative
+"might-need-it-later" ones. **Checkpoint:** green.
+
+### Replace Inheritance with Delegation + Extract Interface
+
+**Cures:** Refused Bequest; inheritance-for-code-reuse; tight is-a coupling that
+isn't really is-a. → `smell-catalog.md`. *Composition over inheritance — the most
+important move in the generalization family.* Target shapes (ports/adapters,
+strategy fields) live in `paradigms-and-patterns.md` and `dev:typescript`
+`references/design-patterns.md`.
+
+**Mechanics (Replace Inheritance with Delegation):**
+1. Hold the former superclass in a field instead of `extends`-ing it.
+2. Add delegating methods for the surface the clients actually use — or, better in
+   TS, expose a focused **interface** rather than re-proxying the whole surface.
+3. Drop `extends`; follow the compiler. **Checkpoint:** green. The endpoint is
+   often a Strategy-style pluggable field.
+
+**Mechanics (Extract Interface) — the one high-value generalization move:**
+1. Name the slice of a type's surface that multiple clients (or a dependency
+   seam, or a test double) actually use, as an `interface`/`type`.
+2. Thanks to **structural typing**, existing types satisfy it with *no*
+   `implements` edits. Depend on the interface at the seam. **Checkpoint:** green.
+   Use freely for ports/adapters and testability. (Its limit: interfaces share
+   *shape*, not *code* — for dedup use Extract Function / Extract Class.)
+
+### Extract Module (split a god module)
+
+**Cures:** Large Class / god-module; Divergent Change (one file edited for many
+unrelated reasons). → `smell-catalog.md`. *Where* the boundaries go is a domain
+question — defer that judgment to `cognition:domain-design`; this is the safe
+mechanical sequence once you know the split.
+
+**Mechanics:**
+1. Identify the axes of change — group functions/types by the *reason they change*
+   (fetching vs validation vs formatting vs caching). Each group is a candidate
+   module.
+2. Move one cohesive group to a new, concept-named file. Keep the moved symbols
+   exported for now so callers still resolve. **Checkpoint:** green.
+3. Fix imports across the original module and follow the compiler. Move one group
+   per step, re-checking between each. **Checkpoint:** green after each group.
+4. **Shrink the public surface:** demote symbols that were only internal
+   implementation (a cache `Map`, a validator) from `export` to module-private.
+   The package should expose only its use-case verbs, not its internals.
+   **Checkpoint:** green; the export count should drop.
+5. Verify no consumer reached into the now-private state; if one did, give it a
+   narrow accessor instead of re-exporting the raw collection (see Encapsulate
+   Collection above).
+
+*The win is measured by export-surface and reasons-to-change, not file count:*
+splitting one 400-line file into four that each still export everything has not
+reduced coupling.
+
+---
+
+## Refactoring without tests
+
+When you must change untested code, make it **safe before you make it clean** —
+write **characterization (golden-master) tests** first. These don't assert what
+the code *should* do; they pin what it *currently does*, so any behavior change
+shows up red.
+
+Briefly, when and how:
+- **When:** the code has no test net, behavior is non-trivial, and a step might
+  change output. Skip only when steps are small enough that `tsc --strict` alone
+  proves them (pure renames, signature-driven moves the compiler fully checks).
+- **How (golden master):** capture the current output for a representative spread
+  of inputs (record real outputs into a snapshot/fixture), then assert future
+  runs match. For wide output, snapshot serialization is the fast path; for a few
+  cases, inline expected values. Run it green *before* the first refactor step —
+  a characterization test that's red at the start is pinning a bug, not behavior.
+- **Then refactor** behind that net, step by step, green between steps. Delete or
+  upgrade the golden master once the design stabilizes and proper tests exist.
+
+Design of the net — risk-proportional coverage, choosing oracles, what *not* to
+test — is owned by `cognition:testing-design`. Hand off for the design; this file
+only says *do it, and do it first*.
+
+---
+
+## Mostly skip in idiomatic TS
+
+The dated family — class-inheritance and association bookkeeping with little
+payoff when you favor modules, composition, unions, and immutability. Skip the
+*technique-as-written*; the underlying goal usually survives via a TS-native
+move. One line each:
+
+- **Pull Up Field / Pull Up Method / Pull Up Constructor Body** — inheritance
+  choreography. → shared function / module / mixin the variants call.
+- **Push Down Field / Push Down Method** — inheritance choreography. → put
+  variant-specific data/behavior directly in the discriminated-union branch.
+- **Extract Subclass** — multi-axis variation dead-ends on inheritance. →
+  composed fields or a discriminated union (the catalog itself routes you here).
+- **Extract Superclass** — single-inheritance ceiling, tight coupling. →
+  **Extract Interface** for shared shape; shared module/function for shared code.
+- **Form Template Method** — base-class skeleton with abstract hooks. →
+  higher-order function / DI: a skeleton function taking the varying steps as
+  callbacks or a strategy object.
+- **Replace Delegation with Inheritance** — pushes the wrong way. → keep
+  composition; expose the delegate directly or via an interface.
+- **Change Unidirectional → Bidirectional Association** — adds coupling, cycles,
+  serialization pain. → keep it one-way and *derive* the reverse via a `Map` /
+  lookup.
+- **Self-Encapsulate Field / Encapsulate Field** — the Java get/set reflex. →
+  `readonly` / `private` / `#`; add accessors only when access needs real logic.
+- **Introduce Foreign Method / Introduce Local Extension** — "foreign method"
+  ceremony / subclassing a 3rd-party type. → a plain standalone utility
+  `fn(x: Foreign, …)` or a thin adapter.
+- **Change Value to Reference** — niche identity/interning. → an explicit
+  `Map`-backed registry, only when you actually need shared identity.
+- **Duplicate Observed Data** (as written) — hand-rolled Observer. → keep the
+  separate-domain-from-view *principle*; implement with reactive state
+  (signals/stores/hooks).
+- **Replace Conditional with Polymorphism** (as a class hierarchy) — for *closed*
+  variant sets, prefer the discriminated-union + exhaustive `switch` move above;
+  escalate to polymorphism/strategy only when the same switch is duplicated
+  across many functions or variants are *open*.
+- **Introduce Null Object** — `isNull()` subclasses. → `strictNullChecks` +
+  explicit `T | undefined` + `?.` / `??`; keep Null Object only for genuine
+  no-op cases (a no-op logger, an empty default strategy).
+
+---
+
+## Definition of done — the refactor checklist
+
+A refactor is done when **all** of these hold. A "no" on any line is a finding
+against the work, not a nit:
+
+- [ ] **State-collapse.** Reachable-state count actually dropped — fewer
+  optionals/flags/`any`, or a discriminated union the compiler now checks. (If
+  it didn't, the diff isn't earned.)
+- [ ] **Deletion over rearrangement.** Incidental complexity a type-level move
+  could delete is gone, not relocated. The Swap test fails for any new
+  abstraction (the opposite choice would *not* be equivalent — i.e. the
+  abstraction is earned).
+- [ ] **Compiler-enforced.** New invariants live in the type system (DU +
+  `never`, `readonly`, branded types, parse-at-boundary) — not in a comment,
+  convention, or runtime guard.
+- [ ] **No new escape hatch.** No added `any` / `as` / `as any` / `!` /
+  `@ts-ignore` / `Record<string, any>` without written justification.
+- [ ] **Reuse, not reinvention.** Nothing reimplements a helper the repo already
+  provides.
+- [ ] **Naming coherence.** File names ↔ export names ↔ concepts line up; no
+  dead scaffolding; no narration comments left behind.
+- [ ] **Size tripwires.** No module pushed toward ~400+ LOC, function past
+  ~40–50 LOC, or cyclomatic ~10 without a structural reason.
+- [ ] **Behavior & contract preserved.** External behavior unchanged; public
+  types didn't drift silently (declaration diff is empty or recorded).
+- [ ] **Green throughout.** `tsc --strict --noEmit` and tests passed after every
+  step; type-check performance did not regress.
+- [ ] **Clean history.** One logical move per commit; refactor commits carry no
+  behavior change; any bug found mid-refactor was deferred to its own commit.
+- [ ] **Recorded.** Findings and before/after captured via
+  `../assets/refactor-findings-template.md`; result checked against SKILL.md's
+  Mandate and Approval Bar.
+
+---
+
+*Source: technique names from the Refactoring.Guru techniques catalog
+(https://refactoring.guru/refactoring/techniques), originating in Martin Fowler's*
+Refactoring*. All mechanics and code are original TypeScript synthesis; no source
+prose is reproduced.*

--- a/.agents/skills/typescript-refactoring/references/smell-catalog.md
+++ b/.agents/skills/typescript-refactoring/references/smell-catalog.md
@@ -1,0 +1,390 @@
+# Smell Catalog — DIAGNOSE
+
+The diagnostic reference. Use it in three moves: **detect** a symptom, **name** the
+smell, **look up the treatment** (which links out — this file never restates mechanics,
+paradigm decisions, or target patterns).
+
+**Spine framing.** A smell is a place where the code admits more **reachable states**
+than the problem needs. A boolean flag doubles the states; a sometimes-set optional
+doubles them again; an `any` blows the count to infinity; a non-exhaustive `switch`
+leaves reachable states unhandled. Every entry is one diagnosis: *this construct
+inflates the reachable-state space; the treatment collapses it, ideally so the compiler
+proves the collapse.* Smells are heuristics, not laws — recognize the smell, diagnose
+the weakness, pick the smallest move that removes the *cause*, verify behavior holds.
+
+**Taxonomy source.** The five classic categories, the 23 classic smells
+(entries 1–23), and the *italicized* refactorings are from
+[refactoring.guru](https://refactoring.guru/refactoring/smells) (Shvets,
+distilling Fowler's *Refactoring* and Beck); entries 24–29 are a TypeScript-native
+group we add (29 smells total). The prose, TypeScript forms, and detection signals
+here are original and TS-native.
+
+**Treatments point to:** mechanics → `refactoring-mechanics.md`; paradigm/pattern
+decisions (functions vs classes, GoF verdicts, indirection audit) →
+`paradigms-and-patterns.md`; target shape (DU, brands, ports, FC/IS, type-state) →
+`dev:typescript` (`references/design-patterns.md`).
+
+---
+
+## The five categories at a glance
+
+| Category | Failure mode | Members | TS detection focus |
+| --- | --- | --- | --- |
+| **Bloaters** | grown too large; nobody removes anything | Long Method · Large Class · Primitive Obsession · Long Parameter List · Data Clumps | `complexity`, `max-lines*`, `max-params`, brands, options objects |
+| **OO Abusers** | OO/polymorphism applied wrong or half-way | Switch Statements · Temporary Field · Refused Bequest · Alternative Classes w/ Different Interfaces | exhaustive-switch lint, DUs, `jscpd` on near-twins |
+| **Change Preventers** | one change forces edits in many places (or vice versa) | Divergent Change · Shotgun Surgery · Parallel Inheritance Hierarchies | git churn, `madge`/`dpdm` fan-in/out |
+| **Dispensables** | their *absence* improves the code | Comments · Duplicate Code · Lazy Class · Data Class · Dead Code · Speculative Generality | `knip`/`ts-prune`, `jscpd`, comment density, generic-arity |
+| **Couplers** | too much coupling, or its over-correction | Feature Envy · Inappropriate Intimacy · Message Chains · Middle Man · Incomplete Library Class | `madge --circular`, chain-depth grep, `as any).` reach-arounds |
+
+---
+
+## Bloaters
+
+### 1. Long Method
+
+- **Signs.** A body you can't hold in your head (questions start past ~10 lines); the urge to write a comment above a block — that block wants to be a named function.
+- **Why it hurts.** Length is the readable proxy for state: more statements/branches/locals in flight at once; long bodies also hide duplication and resist isolated testing.
+- **TypeScript form.** A 200-line React component or Express handler doing validation + business logic + persistence + serialization inline; each `// build the payload` comment marks an unextracted function.
+- **Detection signal.** ESLint `complexity`, `max-lines-per-function`, `max-statements`, `max-depth`, `max-nested-callbacks`; code-intel `get_complexity`/`get_function_hotspots`; long functions cluster low branch coverage.
+- **Treatment.** *Extract Method*; *Decompose Conditional*; *Replace Nested Conditional with Guard Clauses* for arrow-code → `refactoring-mechanics.md`. In components, extract hooks/children.
+
+### 2. Large Class
+
+- **Signs.** A class — or in TS a module/service/store — with too many fields, methods, and lines, "wearing too many hats."
+- **Why it hurts.** SRP violation: unrelated concerns change together and the whole surface stays in your head; the unit's state space is the product of every concern it owns.
+- **TypeScript form.** A 1,500-line `UserService`; a slice owning auth + cart + telemetry; the **god module** — an `index.ts` re-exporting everything until the file *is* the de-facto class.
+- **Detection signal.** ESLint `max-lines`, `max-classes-per-file`; high **fan-in** in `madge`/`dpdm`; LCOM tools flag methods touching disjoint fields; code-intel `get_hotspots`.
+- **Treatment.** *Extract Class* by responsibility; *Extract Interface* for the consumer contract → `refactoring-mechanics.md`. Placement → `cognition:domain-design`; target module shape → `dev:typescript` (`references/design-patterns.md`).
+
+### 3. Primitive Obsession
+
+- **Signs.** Raw primitives for domain concepts (currency, phone, ids, email); constants as type codes (`const ROLE_ADMIN = 1`); string keys as pseudo-fields.
+- **Why it hurts.** The compiler can't stop you passing a `userId` where an `orderId` is wanted — same-typed values are interchangeable and validation scatters; a wide `string` admits ∞ states where the domain has ~3.
+- **TypeScript form.** The canonical TS smell. Stringly-typed values want a union; interchangeable ids want **branded/nominal** types minted by a parser:
+
+  ```ts
+  function suspend(userId: string, status: string) {}        // every string is every other string
+  type UserId = string & { readonly __brand: "UserId" };
+  type Status = "active" | "suspended" | "closed";
+  function suspend(userId: UserId, status: Status) {}        // illegal values unrepresentable
+  ```
+
+- **Detection signal.** `grep -rnE ': (string|number)\b' src` density on domain fields; bare literals in conditionals; `type-coverage` rewards the fix; ESLint `@typescript-eslint/no-magic-numbers`.
+- **Treatment.** *Replace Data Value with Object* / *Replace Type Code with…* → `refactoring-mechanics.md`. Brand/smart-constructor shapes → `dev:typescript` (`references/design-patterns.md`).
+
+### 4. Long Parameter List
+
+- **Signs.** More than ~3–4 params; worse, several booleans or several same-typed params in a row — call sites become positional guessing games.
+- **Why it hurts.** Order-dependence the compiler can't catch (`drawRect(x, y, w, h)`); each param multiplies call-site states; flag soup (`(true, false, true)`) is a state machine smuggled through the signature.
+- **TypeScript form.** The **options object** is the idiomatic fix; booleans become a mode union:
+
+  ```ts
+  function createUser(name: string, email: string, isAdmin: boolean, notify: boolean) {}   // order-fragile, flag-laden
+  function createUser(opts: { name: string; email: string; role: "user" | "admin"; notify?: boolean }) {}
+  ```
+
+- **Detection signal.** ESLint `max-params` (3–4); `grep -rnE '\([^)]*,[^)]*,[^)]*,[^)]*,' src` for 4+-arg calls; consecutive same-type params flagged in review or AST scan.
+- **Treatment.** *Introduce Parameter Object*, *Preserve Whole Object*, *Replace Parameter with Method Call* → `refactoring-mechanics.md`. Boolean→union is a **flags→DU** move; coordinate with `dev:typescript` (`references/refactoring-patterns.md`).
+
+### 5. Data Clumps
+
+- **Signs.** The same group of values travels together repeatedly (`x, y`; `street, city, zip`). Litmus: delete one; if the rest stop making sense, they're a clump.
+- **Why it hurts.** An un-named concept whose members can drift apart, with no cohesive home for group behavior; it's latent Shotgun Surgery — a field change becomes a multi-file edit.
+- **TypeScript form.** A duplicated anonymous object type begging to be one exported `interface`:
+
+  ```ts
+  function ship(street: string, city: string, zip: string) {}   // same clump across 6 sites
+  function tax(street: string, city: string, zip: string) {}
+  interface Address { street: string; city: string; zip: string }
+  function ship(addr: Address) {}                               // one edit propagates
+  ```
+
+- **Detection signal.** `jscpd` on repeated literal shapes; `grep -rnE 'street: string, city: string, zip: string' src` for the ordered triple; structurally identical anonymous types are reviewable.
+- **Treatment.** *Extract Class* / *Introduce Parameter Object* / *Preserve Whole Object*, then migrate group behavior onto the type → `refactoring-mechanics.md`.
+
+---
+
+## Object-Orientation Abusers
+
+### 6. Switch Statements
+
+- **Signs.** A complex `switch`/`if-else if` ladder branching on a type code — and the *same* branching appears in several places, so a new case means hunting every copy.
+- **Why it hurts.** Scattered, non-exhaustive switches are change-amplifiers: a new variant touches N sites and one is always missed; no totality check leaves reachable states silently unhandled.
+- **TypeScript form.** Keep the switch, but make the compiler enforce totality via a **discriminated union + `never` exhaustiveness check**:
+
+  ```ts
+  type Shape = { kind: "circle"; r: number } | { kind: "square"; s: number };
+  function area(sh: Shape): number {
+    switch (sh.kind) {
+      case "circle": return Math.PI * sh.r ** 2;
+      case "square": return sh.s ** 2;
+      default: { const _x: never = sh; return _x; }  // adding a variant breaks compilation here
+    }
+  }
+  ```
+
+- **Detection signal.** ESLint `@typescript-eslint/switch-exhaustiveness-check`, `default-case`, `no-fallthrough`; `grep -rnE '\bswitch\s*\(' src` then check each for a `never` guard; grep the discriminant name to find scattered copies.
+- **Treatment.** *Replace Conditional with Polymorphism* — or its TS-idiomatic inverse, DU + `never` → `refactoring-mechanics.md`. DU vs Strategy-record vs polymorphism → `paradigms-and-patterns.md`; target shape → `dev:typescript` (`references/design-patterns.md`).
+
+### 7. Temporary Field
+
+- **Signs.** A field meaningful only during one operation, empty/`null` the rest of the time — you expect state populated, but it's usually blank.
+- **Why it hurts.** Readers can't tell when the field is valid; the invariant lives in someone's head, not the type, and it admits the illegal state *field-set-but-not-computing*.
+- **TypeScript form.** "Sometimes-set" optionals are the signature. Model states as a DU so impossible combinations are unrepresentable:
+
+  ```ts
+  // before: error? and result? can each be present/absent independently
+  interface Job<T> { status: string; error?: string; result?: T }
+  // after: each field exists only in the variant that owns it
+  type Job<T> =
+    | { status: "pending" }
+    | { status: "done"; result: T }     // result present iff done
+    | { status: "failed"; error: string };
+  ```
+
+- **Detection signal.** Density of optional props on one type (`grep -rnE '\?\s*:' src`), especially mutually-exclusive ones; clusters of `!` or `if (this.x !== undefined)` guards on one field; `exactOptionalPropertyTypes` sharpens it.
+- **Treatment.** *Extract Class* / *Replace Method with Method Object* for scratch fields; make illegal states unrepresentable via DU → `refactoring-mechanics.md`; target shape → `dev:typescript` (`references/design-patterns.md`).
+
+### 8. Refused Bequest
+
+- **Signs.** A subclass uses only part of what it inherits; unused members go dead or are overridden to `throw new Error("unsupported")`.
+- **Why it hurts.** Inheritance chosen for reuse between non-*is-a* classes breaks Liskov — a client holding the base type can call a method the subclass refuses, a reachable crash.
+- **TypeScript form.** Override-to-throw, or an `interface` with stubbed members. Structural typing means you rarely *need* inheritance for reuse — a shared function module or injected dependency is cleaner; prefer **composition** + **narrow interfaces** (ISP).
+- **Detection signal.** `grep -rnE 'throw new (Error|TypeError)\(.*(not |un)support' src` for refusal stubs; review any `extends` where the subclass overrides most methods.
+- **Treatment.** *Replace Inheritance with Delegation*, or *Extract Superclass* if genuine → `refactoring-mechanics.md`. The functions-vs-classes call → `paradigms-and-patterns.md`; FC/IS target → `dev:typescript` (`references/design-patterns.md`).
+
+### 9. Alternative Classes with Different Interfaces
+
+- **Signs.** Two classes/modules do the same job with different method names and signatures, so callers can't treat them interchangeably.
+- **Why it hurts.** Duplicated capability with no shared abstraction; clients hard-code to one and the two drift — two copies of the same state space to keep in sync.
+- **TypeScript form.** Two `HttpClient`s (`get/post` vs `fetchData/send`) that should satisfy one `interface`. Structural typing lets both be used polymorphically once names align — no inheritance. For an unchangeable third-party twin, wrap with an **Adapter** (see Incomplete Library Class).
+- **Detection signal.** `jscpd` / code-intel `find_semantic_clones` on near-identical bodies with different names; `grep -rniE 'class .*Client' src` for duplicated domain nouns.
+- **Treatment.** *Rename/Move/Parameterize Method* to converge, *Extract Superclass*, then delete the redundant class → `refactoring-mechanics.md`. Adapter/port shape → `dev:typescript` (`references/design-patterns.md`).
+
+---
+
+## Change Preventers
+
+### 10. Divergent Change
+
+- **Signs.** One module edited for *many unrelated reasons* — add a product type and you touch find, display, and order code in the same file.
+- **Why it hurts.** Multiple responsibilities in one unit (SRP): every axis of change collides in one place, and the file is a perpetual merge-conflict magnet.
+- **TypeScript form.** A `utils.ts`/`api.ts` touched by every feature; a slice changed by formatting, networking, *and* validation. Split by **reason to change** into domain modules; co-locate type + logic + tests per concern.
+- **Detection signal.** **Git history is the detector:** `git log --format= --name-only | sort | uniq -c | sort -rn | head` — top files change for everything; `madge` fan-out into many domains.
+- **Treatment.** *Extract Class* along the axes of change (each unit = one reason to change) → `refactoring-mechanics.md`. Boundary/ownership → `cognition:domain-design`.
+
+### 11. Shotgun Surgery
+
+- **Signs.** The inverse of Divergent Change: one logical change forces small edits across *many* files (rename a concept → touch 14 files).
+- **Why it hurts.** A single responsibility smeared across many units — tedious, error-prone, easy to miss a site and leave an inconsistency.
+- **TypeScript form.** A status literal duplicated in 14 files instead of one shared union; an env-var read inline everywhere; a DTO redefined per file. **Centralize** into one exported `type`/`const` — a shared union turns a new variant into a *compile error everywhere it must be handled*, making the edit compiler-guided.
+- **Detection signal.** `grep -rn "<literal-or-name>" src | wc -l`; `madge`/`dpdm` showing edits rippling across the graph; review PRs touching many files for one concept.
+- **Treatment.** *Move Method/Field* to consolidate; *Inline Class* the emptied donors → `refactoring-mechanics.md`. Cross-repo graph-safe move → `gitnexus-refactoring`.
+
+### 12. Parallel Inheritance Hierarchies
+
+- **Signs.** Adding a subclass in hierarchy A forces a matching one in B (`Circle`/`Square` ⇒ `CircleRenderer`/`SquareRenderer`).
+- **Why it hurts.** A special case of Shotgun Surgery from mirrored taxonomies, coupled by convention only; forgetting the mirror edit silently breaks things.
+- **TypeScript form.** Mirrored class trees or union+handler trees. Collapse with a **strategy map** keyed by the discriminant: `const handlers: Record<Event, Handler>`. One source-of-truth union removes the second hierarchy; React prefers one config-driven component.
+- **Detection signal.** Mirrored file stems (`diff <(ls a/) <(ls b/)`); recurring "added X, now must add Y" in commits; `madge` clusters that always grow together.
+- **Treatment.** Reference one hierarchy from the other, then collapse the redundant tree (*Move Method/Field*) → `refactoring-mechanics.md`. Strategy-record vs polymorphism → `paradigms-and-patterns.md`.
+
+---
+
+## Dispensables
+
+### 13. Comments
+
+- **Signs.** A body dense with comments narrating *what* the next lines do.
+- **Why it hurts.** "Deodorant over fishy code" — comments compensate for unclear names/structure and drift out of sync (the comment lies after the next edit).
+- **TypeScript form.** `// loop over active users and sum balances` → `const total = sumBalances(activeUsers(users))`. In TS the **type and the name** are the primary docs; a narration comment usually means a missing helper or a too-wide type. **Keep** `// why:` rationale, tricky-algorithm notes, and JSDoc `@deprecated`/`@internal` (tooling reads them).
+- **Detection signal.** Comment density inside a body; `grep -rnE '^\s*//' src | wc -l` trend; comments immediately above a block (vs module top) are the suspect pattern.
+- **Treatment.** *Extract Variable* / *Extract Method* (the comment text is often the method name) / *Rename Method* → `refactoring-mechanics.md`. Narration comments in generated code → `llm-slop-cleanup.md`.
+
+### 14. Duplicate Code
+
+- **Signs.** Two identical or near-identical fragments; subtler, fragments that *look* different but do the same job.
+- **Why it hurts.** Every clone must be edited in lockstep forever — the prime driver of maintenance cost and inconsistency bugs; two copies = two state spaces that can diverge.
+- **TypeScript form.** Copy-pasted validation, mappers, the same `try/catch/log` per handler. Extract a shared function; for varying shape, a **generic** (`function pick<T, K extends keyof T>(…)`); for varying *behavior*, pass a callback. Duplicated *types* → one exported `type`. Beware false DRY — don't merge fragments that change for different reasons.
+- **Detection signal.** **`jscpd`** (token-level; CI threshold) is the standard; code-intel `find_semantic_clones` for non-textual dupes; ESLint `no-duplicate-imports`.
+- **Treatment.** *Extract Method* / *Extract Class* / *Pull Up Method* / *Form Template Method* / *Substitute Algorithm* → `refactoring-mechanics.md`. Repo-wide reuse (don't reimplement) → `llm-slop-cleanup.md`.
+
+### 15. Lazy Class
+
+- **Signs.** A class/module doing too little to justify its cost — often a husk left after refactoring or scaffolding for work that never happened.
+- **Why it hurts.** Every unit carries a fixed cognitive and navigational tax; an under-employed one is pure overhead.
+- **TypeScript form.** A one-method `class` that should be a function; a wrapper module re-exporting one symbol; a single-field interface used once; `type Alias = OtherType` used once. TS favors functions and plain objects — inline trivial classes, delete pass-through barrels.
+- **Detection signal.** `knip`/`ts-prune` flag barely-used exports; `grep -rnE 'export class' src` then check method/field counts; modules with high import cost but ~1 reference.
+- **Treatment.** *Inline Class* / *Collapse Hierarchy* → `refactoring-mechanics.md`. The "is this layer earning its keep" call → `paradigms-and-patterns.md` (indirection audit).
+
+### 16. Data Class
+
+- **Signs.** A *class* that is only fields + getters/setters, no behavior — a dumb container others operate on.
+- **Why it hurts.** If logic about the data lives outside it, that logic duplicates across clients and invariants go unenforced (anemic domain model).
+- **TypeScript form.** **Nuance:** a pure-data **DTO/`interface`** is often *correct* in TS — a wire shape, a Redux slice, a plain return object. The smell is specifically a *class* holding data with related behavior scattered. Cure: move behavior into the type's module (functions taking the type), or demote to `interface`/`Readonly<T>` and stop pretending it has methods.
+- **Detection signal.** `grep -rnE 'get [a-zA-Z]+\(\)|set [a-zA-Z]+\(' src` (getter/setter density); classes with fields but trivial method bodies; review logic over a type living in many call sites.
+- **Treatment.** *Encapsulate Field/Collection*, *Move Method* behavior in, or demote to `interface` → `refactoring-mechanics.md`. Class-vs-data call → `paradigms-and-patterns.md`.
+
+### 17. Dead Code
+
+- **Signs.** A variable, param, field, function, file, or branch never reached or used — usually after a requirement changed and cleanup was skipped.
+- **Why it hurts.** Bloats the codebase, misleads readers ("this must matter"), inflates build/test surface; a dead branch is a reachable-looking state that isn't.
+- **TypeScript form.** Unused exports, unreferenced files, dead union branches, unreachable code after `return`/`throw`, unused generic params, commented-out blocks. TS/lint catch local cases; export-graph cases need dedicated tools.
+- **Detection signal.** **`knip`** and **`ts-prune`** (unused exports/files/deps); tsc `noUnusedLocals`/`noUnusedParameters`; ESLint `no-unreachable`, `@typescript-eslint/no-unused-vars`; code-intel `find_dead_code`/`find_unused_exports`; `grep -rn "^\s*//.*[;{}]" src` for commented-out code.
+- **Treatment.** Delete it (trust version control); *Remove Parameter*; *Inline Class* for dead hierarchy members. Find → confirm → delete safely → `refactoring-mechanics.md`.
+
+### 18. Speculative Generality
+
+- **Signs.** Machinery built for a future that never arrived: an abstract base with one implementation, a strategy interface with one strategy, a config option never set off its default, `<T, U, V>` where callers always pass the same concrete types.
+- **Why it hurts.** YAGNI violation — indirection costs reading and maintenance *now* for flexibility you may never use; the counterweight to the Rule of Three (don't abstract before the third instance).
+- **TypeScript form.** Over-generic signatures, one-impl `interface` + DI container, options objects full of unused flags, an event-bus for one event. **Prefer concrete until duplication demands generic.** Unused type params are dead code at the type level.
+- **Detection signal.** `knip`/`ts-prune`; `grep -rnE '<[A-Z], ?[A-Z], ?[A-Z]' src` for high-arity generics; interfaces with exactly one `implements`; review "added for future use."
+- **Treatment.** *Collapse Hierarchy* / *Inline Class* / *Inline Method* / *Remove Parameter* → `refactoring-mechanics.md`. The earned-abstraction **Swap test** / indirection audit → `paradigms-and-patterns.md`.
+
+---
+
+## Couplers
+
+### 19. Feature Envy
+
+- **Signs.** A function more interested in *another* object's data than its own — it reaches across to pull fields and compute over them.
+- **Why it hurts.** Behavior placed away from the data it uses couples the two units and scatters logic; "things that change together should live together."
+- **TypeScript form.** `function totalPrice(order: Order) { return order.items.reduce(…) }` living in `utils` rather than the order module. In functional TS, "move method" means **co-locate the function in the module that owns the type**. React: a component digging through `props.user.profile.settings.x` wants a selector nearer the data.
+- **Detection signal.** Bodies referencing `other.` far more than own params; code-intel `get_data_flow`/`find_references` showing a function bound to a foreign type; LCOM locality.
+- **Treatment.** *Move Method* (relocate to the data's home); *Extract Method* first if only part envies → `refactoring-mechanics.md`. Correct home → `cognition:domain-design`.
+
+### 20. Inappropriate Intimacy
+
+- **Signs.** One module reaches into another's *internal* fields/methods; bidirectional knowledge of each other's privates.
+- **Why it hurts.** Eroded boundaries mean intimate units can't be changed, tested, or reused independently; cycles couple two state spaces into one.
+- **TypeScript form.** Deep imports into `dist/internal/…`; reaching past a public API via `(obj as any).field` (TS `private` is compile-time only); mutual imports. Cures: a **narrow public interface**, `@internal`/`#private`, import-path lint, broken cycles.
+- **Detection signal.** **`madge --circular`** / `dpdm` / code-intel `find_circular_imports`; `grep -rnE "as any\)\.[a-zA-Z]" src` for reach-arounds; `grep -rnE "from '\.\./\.\./\.\./" src` for deep relative imports; ESLint `import/no-internal-modules`, `no-restricted-imports`, `import/no-cycle`.
+- **Treatment.** *Move Method/Field*, *Hide Delegate*, *Change Bidirectional Association to Unidirectional* → `refactoring-mechanics.md`. Boundary placement → `cognition:domain-design`; module shape → `dev:typescript` (`references/design-patterns.md`).
+
+### 21. Message Chains
+
+- **Signs.** A train of calls/accesses: `a.b().c().d()` or `a.b.c.d.e` — the caller navigates deep through the object graph.
+- **Why it hurts.** The client depends on the *entire path*; any structural change anywhere along it breaks the caller, and it leaks the shape of every intermediate object.
+- **TypeScript form.** `user.getAddress().getCity().getZip()`, `config.server.tls.options.cert`, Redux `state.a.b.c.d`. Cures: a method on the head (`user.zip()`), a **selector**, the Law of Demeter. Note: optional chaining `a?.b?.c?.d` makes a chain *safe* but not *uncoupled* — `?.` papering over depth is the smell, not the fix.
+- **Detection signal.** `grep -rnE '\)\.[a-zA-Z]+\(\)\.[a-zA-Z]+\(' src` for `.x().y()`; `grep -rnE '(\?\.[a-zA-Z]+){3,}' src` for `?.`-chains 3+ deep; `(\.[a-zA-Z]+){4,}` for long property paths.
+- **Treatment.** *Hide Delegate*, or *Extract+Move Method* to the chain's head — but don't over-hide into a Middle Man → `refactoring-mechanics.md`.
+
+### 22. Middle Man
+
+- **Signs.** A class/module whose methods mostly just *delegate* and do nothing else — a pass-through shell.
+- **Why it hurts.** The over-correction of Message Chains: indirection and maintenance with no value, and readers can't find where work actually happens.
+- **TypeScript form.** A "service" whose every method is `return this.repo.x(args)`; a wrapper module re-exporting and forwarding; a React component that only spreads props (`<Child {...props} />`). Remove it unless it's an intentional Adapter/Facade adding a real seam — distinguish from an **anti-corruption layer**, which *transforms*, not forwards.
+- **Detection signal.** `grep -rnE 'return this\.[a-zA-Z]+\.[a-zA-Z]+\(' src`; `knip` showing a thin re-export module; review ≥half the methods being one-line forwards.
+- **Treatment.** *Remove Middle Man* (clients talk to the real object) → `refactoring-mechanics.md`. Is-the-layer-earning-its-keep → `paradigms-and-patterns.md`.
+
+### 23. Incomplete Library Class
+
+- **Signs.** A third-party library almost meets your need but lacks a method/behavior, and you can't edit it.
+- **Why it hurts.** Working around it ad hoc spreads compensating code everywhere the library is used — N copies of the workaround.
+- **TypeScript form.** TS adds options the OO catalog predates: **declaration merging / module augmentation** (`declare module "lib" { interface X { … } }`) for the *types*; an **Adapter/wrapper** for behavior; a standalone helper (`function withRetry(client: LibClient) {…}`) as a Foreign Method; ambient `.d.ts` augmentation for incomplete types. Keep the workaround in **one** local extension module.
+- **Detection signal.** Repeated identical wrappers around the same library call (`jscpd`, or grep the symbol); many `as`/`@ts-ignore` near one import: `grep -rnE "from '(lib-name)'" src` cross-referenced with escape-hatch density; `(libObj as any).x` patterns.
+- **Treatment.** *Introduce Foreign Method* (small gap) / *Introduce Local Extension* (large gap) → `refactoring-mechanics.md`. Adapter/port target → `dev:typescript` (`references/design-patterns.md`).
+
+---
+
+## TypeScript-native smells
+
+No clean entry in the classic OO catalog, but the highest-signal smells in modern
+TS/JS. Each is a hole the type system was meant to close that someone re-opened.
+
+### 24. Escape-hatch density (`as` / `as any` / `as unknown as` / `!`)
+
+- **Signs.** A cast or non-null assertion every few lines; `as unknown as T` forcing incompatible shapes; `!` sprinkled to silence `strictNullChecks`.
+- **Why it hurts.** `as` is the programmer *asserting* a fact the compiler couldn't verify — each one re-admits exactly the states the type was collapsing and goes stale when the real type changes; `!` claims "never null" with zero proof.
+- **TypeScript form.** `const u = (raw as any).user!.profile as Profile;` — three unproven claims in one line. Cure: **parse at the boundary** so the core needs no casts.
+- **Detection signal.** `grep -rnE '\bas any\b|\bas unknown as\b|\bas [A-Z]' src | wc -l`; `grep -rnE '!\.|!\)|!,' src` for non-null assertions; `type-coverage` as the global metric; ESLint `@typescript-eslint/no-explicit-any`, `no-non-null-assertion`, `consistent-type-assertions`.
+- **Treatment.** Parse-don't-validate at the boundary; introduce a brand or DU so the cast vanishes → `refactoring-mechanics.md`. Safety-budget axis + parse-at-boundary target → `dev:typescript` (`references/where-defaults-hide.md`, `references/design-patterns.md`).
+
+### 25. Optional-property soup
+
+- **Signs.** A type with many `?:` fields, several mutually exclusive ("`a` set ⇒ `b` too; `c` only with `d`"); valid combinations are a fraction of what the type permits.
+- **Why it hurts.** `n` optionals admit up to `2ⁿ` shapes where the domain has a few; every consumer must defensively check, and invalid combos are reachable bugs. Temporary Field generalized to plain data.
+- **TypeScript form.**
+
+  ```ts
+  interface Req { loading?: boolean; data?: T; error?: Error; retryCount?: number }   // 2^4 = 16 shapes, ~3 valid
+  type Req<T> =
+    | { state: "loading" }
+    | { state: "success"; data: T }
+    | { state: "error"; error: Error; retryCount: number };                           // exactly the valid states
+  ```
+
+- **Detection signal.** Count `?:` per type (`grep -rnE '\?\s*:' src`); >4–5 optionals is suspect; `exactOptionalPropertyTypes` sharpens; clusters of `!`/`?.` on the fields confirm.
+- **Treatment.** Model states as a DU (flags/optionals → DU) → `refactoring-mechanics.md`; coordinate with `dev:typescript` (`references/refactoring-patterns.md`); target shape → `dev:typescript` (`references/design-patterns.md`).
+
+### 26. `@ts-ignore` / `@ts-expect-error` debt
+
+- **Signs.** Suppression comments accreting over red lines; bare `@ts-ignore` with no reason; stale `@ts-expect-error` left after its error was fixed.
+- **Why it hurts.** Each suppression is an un-checked region — the type system's guarantees stop at that line; bare `@ts-ignore` also hides *new* errors that drift in later. Compounding business-pressure debt.
+- **TypeScript form.** Prefer `@ts-expect-error` (it *fails* once the error is gone, so it self-cleans) over `@ts-ignore`, always with a reason — better, fix the type so neither is needed.
+- **Detection signal.** `grep -rnE '@ts-(ignore|expect-error|nocheck)' src | wc -l` as a debt counter; ESLint `@typescript-eslint/ban-ts-comment` (require a description, ban `@ts-ignore`); track the count in CI.
+- **Treatment.** Resolve the underlying error (often Primitive Obsession or an upstream escape hatch); convert survivors to documented `@ts-expect-error` → `refactoring-mechanics.md`. A **categorical sweep**, not a one-off.
+
+### 27. `Record<string, any>` / index-signature escape hatch
+
+- **Signs.** `Record<string, any>`, `{ [k: string]: any }`, or `object`/`any` as a "bag" type for config, props, or payloads.
+- **Why it hurts.** It defeats the checker on access — every key returns `any`, so the bag is an `any` factory threaded through the program. Primitive Obsession at the object level.
+- **TypeScript form.** Replace with a precise shape, a `Record<KnownKey, V>` over a key union, or a DU of payload variants. If genuinely dynamic, use `Record<string, unknown>` (forces narrowing) and parse at the boundary.
+- **Detection signal.** `grep -rnE 'Record<string, ?any>|\{\s*\[\w+: string\]: ?any' src`; `type-coverage` flags the `any` leakage; ESLint `@typescript-eslint/no-explicit-any`.
+- **Treatment.** Introduce the precise type / key-union; parse dynamic input at the boundary → `refactoring-mechanics.md`. Target shape → `dev:typescript` (`references/design-patterns.md`, `references/where-defaults-hide.md`).
+
+### 28. Overload sprawl
+
+- **Signs.** Many `function f(...)` overload signatures (or stacked interface call signatures) reconciled by internal `typeof`/`as` branching.
+- **Why it hurts.** Each overload is a hand-maintained API corner the implementation must keep consistent by hand — TS does *not* soundly check the impl against the overloads, so they drift; high arity means the function is really several functions or wants a generic/DU input.
+- **TypeScript form.** Replace N overloads with a single generic, a union parameter, or separate named functions (often clearest). Coordinate with the split-overloads move in `dev:typescript` (`references/refactoring-patterns.md`).
+- **Detection signal.** `grep -rnE '^\s*export function (\w+)\b' src` then count repeats per name; ≥3 overloads on one symbol is the threshold; stacked call signatures in one `interface`.
+- **Treatment.** *Parameterize Function* / replace with generic or union / split into named functions → `refactoring-mechanics.md`.
+
+### 29. Barrel / module-boundary cycles
+
+- **Signs.** `index.ts` barrels re-exporting whole subtrees; import cycles surfacing as init-time `undefined`/load-order bugs; a re-export maze where a symbol's real home is three hops away.
+- **Why it hurts.** Barrels create accidental fan-in and **circular imports** (a module importing the barrel that imports it), which break tree-shaking, slow `tsc`, and cause init-order `undefined` bugs no type catches; mazes hide the canonical owner (ties to god module + Inappropriate Intimacy).
+- **TypeScript form.** Import from the **canonical module**, not the barrel, on hot paths; keep barrels thin and acyclic, or drop them; enforce with import-boundary lint.
+- **Detection signal.** **`madge --circular`** / `dpdm --circular` / code-intel `find_circular_imports`; `knip` flags barrel-only re-exports; ESLint `import/no-cycle`, `import/no-internal-modules`.
+- **Treatment.** Break the cycle (move the shared symbol to a leaf module; import direct) → `refactoring-mechanics.md`. Module-organization target → `dev:typescript` (`references/module-organization.md`); ownership → `cognition:domain-design`.
+
+---
+
+## Detection toolkit cheat-sheet
+
+Wire these into CI so smells fail the build rather than accreting as debt.
+
+| Tool / command | What it finds | Smells |
+| --- | --- | --- |
+| ESLint `complexity`, `max-lines-per-function`, `max-statements`, `max-depth`, `max-nested-callbacks` | over-long, over-branched, deeply-nested functions | Long Method |
+| ESLint `max-lines`, `max-classes-per-file` | oversized files/classes | Large Class |
+| ESLint `max-params` (≤3–4) | sprawling signatures | Long Parameter List, Data Clumps |
+| ESLint `@typescript-eslint/switch-exhaustiveness-check`, `default-case`, `no-fallthrough` | non-total switches | Switch Statements, Temporary Field (via DU) |
+| ESLint `@typescript-eslint/no-magic-numbers` | bare literals as type codes | Primitive Obsession |
+| ESLint `@typescript-eslint/no-explicit-any`, `no-non-null-assertion`, `consistent-type-assertions` | escape hatches | Escape-hatch density, `Record<string,any>` |
+| ESLint `@typescript-eslint/ban-ts-comment` | undocumented/banned suppressions | `@ts-ignore` debt |
+| ESLint `import/no-cycle`, `import/no-internal-modules`, `no-restricted-imports` | cycles, boundary breaches | Barrel cycles, Inappropriate Intimacy, Message Chains, Middle Man |
+| ESLint `no-unreachable`, `@typescript-eslint/no-unused-vars`; tsc `noUnusedLocals`/`noUnusedParameters` | local dead code | Dead Code |
+| `tsc --strict` (`strictNullChecks`, `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`) | optional/null holes, index unsafety | Temporary Field, Optional-property soup, Primitive Obsession |
+| **`knip`** / **`ts-prune`** | unused exports, files, deps, types | Dead Code, Lazy Class, Speculative Generality, barrel re-exports |
+| **`jscpd`** | token-level copy-paste | Duplicate Code, Data Clumps, Alternative Classes |
+| **`madge`** / **`dpdm`** (`--circular`, fan-in/out) | cycles, hot modules, mirrored clusters | Inappropriate Intimacy, Divergent Change, Shotgun Surgery, Parallel Inheritance, Barrel cycles |
+| **`type-coverage`** | `any` leakage / wide primitives | Primitive Obsession, Escape-hatch density, `Record<string,any>` |
+| `grep -rnE '\bas any\b\|@ts-(ignore\|expect-error)\|!\.\|: any\b' src \| wc -l` | global type-debt proxy | Escape-hatch density, `@ts-ignore` debt |
+| `grep -rnE '\?\s*:' <type-file>` | optional-prop count per type | Optional-property soup, Temporary Field |
+| `grep -rnE '(\?\.[a-zA-Z]+){3,}\|\)\.[a-z]+\(\)\.[a-z]+\('` src | deep chains | Message Chains |
+| `grep -rnE '^\s*export function (\w+)' src` + count repeats | overload count per symbol (≥3) | Overload sprawl |
+| `git log --format= --name-only \| sort \| uniq -c \| sort -rn` | hot files (many reasons to change) | Divergent Change |
+| code-intel `find_dead_code`, `find_unused_exports`, `find_circular_imports`, `find_semantic_clones`, `get_data_flow`, `get_complexity`, `get_hotspots` | graph-level dead code, cycles, clones, envy, hotspots | Dead Code, Inappropriate Intimacy, Duplicate/Alternative Classes, Feature Envy, Long Method, Large Class |
+
+A detected smell is a **class, not an instance** — when a grep or lint surfaces one,
+sweep the codebase for siblings and fix them together. Treatment mechanics live in
+`refactoring-mechanics.md`; paradigm/pattern choices in `paradigms-and-patterns.md`;
+target shapes in `dev:typescript` (`references/design-patterns.md`).
+
+---
+
+*Synthesis of the [Refactoring.Guru](https://refactoring.guru/refactoring/smells)
+code-smell catalog, re-grounded for TypeScript. Original prose; RG cited as the
+taxonomy source. Named refactorings in italics are RG's.*

--- a/.agents/skills/typescript-refactoring/references/worked-examples.md
+++ b/.agents/skills/typescript-refactoring/references/worked-examples.md
@@ -1,0 +1,571 @@
+# Worked Examples — six refactors, end to end
+
+These are the demonstration. Each one is a complete before→after refactor with a
+single punchline: **the reachable-state count drops, and the compiler proves it.**
+
+How to read each example: the **Smell(s)** name what's wrong (see
+[`smell-catalog.md`](./smell-catalog.md)); **The move** names the refactoring
+technique (see [`refactoring-mechanics.md`](./refactoring-mechanics.md)) and the
+target shape (see [`paradigms-and-patterns.md`](./paradigms-and-patterns.md) or
+the `dev:typescript` skill); the **State-space delta** is the load-bearing
+line — it counts the states you collapsed and states what the type checker now
+enforces. Every "after" block is written to pass `tsc --strict` with no `any`.
+
+---
+
+## 1. Flag/boolean soup → discriminated union
+
+**Smell(s):** [Optional-property soup](./smell-catalog.md#25-optional-property-soup),
+[Switch Statements](./smell-catalog.md#6-switch-statements) (the missing-model kind).
+Three booleans plus two optionals encode one request state machine; nothing stops
+`isLoading && isError`, and `data`/`error` can be present in the wrong phase.
+
+**Before:**
+
+```ts
+interface RequestState<T> {
+  isIdle: boolean;
+  isLoading: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+  data?: T;
+  error?: Error;
+}
+
+function render<T>(state: RequestState<T>): string {
+  if (state.isLoading) return "Loading…";
+  if (state.isError) return `Failed: ${state.error?.message ?? "unknown"}`;
+  if (state.isSuccess) return `Got ${JSON.stringify(state.data)}`;
+  return "Idle";
+}
+
+// Nothing stops these from being constructed:
+const broken: RequestState<number> = {
+  isIdle: false, isLoading: true, isSuccess: true, isError: false,
+  data: 1, error: new Error("???"), // loading AND success AND has an error
+};
+```
+
+**The move:** [Replace Type Code with a discriminated union](./refactoring-mechanics.md#replace-type-code-with-discriminated-union--exhaustive-switchnever):
+the four booleans collapse into one `status` tag, and `data`/`error` move *inside*
+the variant that owns them. Target shape: a tagged union with an exhaustive
+`switch` guarded by a `never` assertion.
+
+**After:**
+
+```ts
+type RequestState<T> =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; data: T }
+  | { status: "error"; error: Error };
+
+function assertNever(x: never): never {
+  throw new Error(`Unhandled request state: ${JSON.stringify(x)}`);
+}
+
+function render<T>(state: RequestState<T>): string {
+  switch (state.status) {
+    case "idle":
+      return "Idle";
+    case "loading":
+      return "Loading…";
+    case "success":
+      return `Got ${JSON.stringify(state.data)}`; // data is in scope, non-optional
+    case "error":
+      return `Failed: ${state.error.message}`; // error is in scope, non-optional
+    default:
+      return assertNever(state); // adding a 5th variant fails the build here
+  }
+}
+
+// The broken object no longer type-checks — there is no such state to build.
+```
+
+**State-space delta:** the type previously admitted `2^4 = 16` boolean
+combinations × the cross-product of two optionals (present/absent) ≈ **64 nominal
+states**, of which only 4 are legal. After, exactly **4 states** exist, the
+illegal combos (`loading + success`, `error` with no `Error`) are
+*unrepresentable*, and `data`/`error` are reachable only in the variant that
+defines them. The compiler now enforces both exhaustiveness (via `never`) and
+field-presence-per-state — no `?.` defensive access survives.
+
+**Why it's better:**
+- The 15 impossible boolean combinations can't be constructed, so no code needs
+  to defend against them.
+- Adding a `"refreshing"` variant turns the `assertNever` line red until every
+  consumer handles it — the compiler becomes your change checklist.
+- `state.data` and `state.error` are non-optional inside their case; the `?.` and
+  `?? "unknown"` ceremony is deleted, not relocated.
+
+---
+
+## 2. Primitive obsession → branded types
+
+**Smell(s):** [Primitive Obsession](./smell-catalog.md#3-primitive-obsession),
+[Data Clumps](./smell-catalog.md#5-data-clumps). Every id is a bare `string`, so
+`userId` and `orderId` are the same type and freely swap at call sites — a bug
+the compiler is blind to.
+
+**Before:**
+
+```ts
+function getOrdersForUser(userId: string): Promise<Order[]> {
+  return db.orders.where("ownerId", userId);
+}
+
+function cancelOrder(userId: string, orderId: string): Promise<void> {
+  return db.orders.update(orderId, { canceledBy: userId });
+}
+
+declare const order: Order;
+declare const session: { userId: string };
+
+// Both compile. The second is a real bug: arguments are swapped.
+await cancelOrder(session.userId, order.id);
+await cancelOrder(order.id, session.userId); // ☠️ accepted by tsc
+```
+
+**The move:** [Introduce Branded Type](./refactoring-mechanics.md#introduce-branded-type)
+(a form of Replace Data Value with Object, but here we keep the runtime value a
+`string` and add a *compile-time* brand). Target shape: nominal/branded types
+(see the `dev:typescript` skill) minted by one smart constructor per id — the
+single place a raw `string` becomes a branded id, and the place to *validate* if
+the source is untrusted.
+
+**After:**
+
+```ts
+declare const __brand: unique symbol;
+type Brand<T, B extends string> = T & { readonly [__brand]: B };
+
+type UserId = Brand<string, "UserId">;
+type OrderId = Brand<string, "OrderId">;
+
+// One constructor per id — the single place a raw string becomes branded.
+// The `as` cast is confined here; validate in this seam when the source is
+// untrusted (e.g. `if (!isUuid(raw)) throw …`). These are trusted, so the
+// confined cast is the whole constructor.
+const UserId = (raw: string): UserId => raw as UserId;
+const OrderId = (raw: string): OrderId => raw as OrderId;
+
+function getOrdersForUser(userId: UserId): Promise<Order[]> {
+  return db.orders.where("ownerId", userId);
+}
+
+function cancelOrder(userId: UserId, orderId: OrderId): Promise<void> {
+  return db.orders.update(orderId, { canceledBy: userId });
+}
+
+declare const order: { id: OrderId };
+declare const session: { userId: UserId };
+
+await cancelOrder(session.userId, order.id); // ok
+// await cancelOrder(order.id, session.userId); // ✗ OrderId is not assignable to UserId
+```
+
+**State-space delta:** before, `UserId` and `OrderId` shared one type, so the set
+of *call shapes the compiler accepts* included every transposition — argument
+order was an unguarded runtime invariant. After, `UserId` and `OrderId` are
+disjoint types; the **two-way mixup states collapse to zero**, and the single
+allowed conversion (raw `string` → branded id) lives only in the two smart
+constructors. The brand is erased at runtime, so the safety costs nothing.
+
+**Why it's better:**
+- The swapped-argument bug becomes a compile error at the call site, not a
+  production incident.
+- "Where does an untrusted string turn into a real id?" has exactly two answers
+  (`UserId`, `OrderId`) instead of "anywhere a `string` is passed."
+- Zero runtime overhead — the `unique symbol` brand exists only in the type
+  system; the value is still a plain `string`.
+
+---
+
+## 3. Long parameter list + boolean flags → options object + explicit functions
+
+**Smell(s):** [Long Parameter List](./smell-catalog.md#4-long-parameter-list),
+plus flag parameters that change *what the function does* (a function doing two
+jobs behind a boolean). Positional `boolean`s at call sites are unreadable
+(`true, false, true`) and silently swappable.
+
+**Before:**
+
+```ts
+function exportReport(
+  rows: Row[],
+  format: string,
+  includeHeader: boolean,
+  compress: boolean,
+  toEmail: boolean,
+  recipient: string,
+): Buffer | void {
+  const body = format === "csv" ? toCsv(rows, includeHeader) : toJson(rows);
+  const payload = compress ? gzip(body) : Buffer.from(body);
+  if (toEmail) {
+    mailer.send(recipient, payload); // recipient only meaningful when toEmail
+    return;
+  }
+  return payload; // …but the return type lies when toEmail is true
+}
+
+// Call site: what do these booleans mean?
+exportReport(rows, "csv", true, false, true, "ops@acme.io");
+```
+
+**The move:** [Introduce Parameter Object](./refactoring-mechanics.md#introduce-parameter-object--preserve-whole-object-options-object)
+for the cohesive options, and
+[Replace Parameter with Explicit Methods](./refactoring-mechanics.md#replace-parameter-with-explicit-methods-kill-boolean-flag-params)
+for the `toEmail` flag that selects between two genuinely different operations
+(one returns a `Buffer`, one sends and returns nothing). Target shape: a typed
+options object plus two named functions with honest return types.
+
+**After:**
+
+```ts
+type ReportFormat = "csv" | "json";
+
+interface ReportOptions {
+  format: ReportFormat;
+  includeHeader?: boolean; // defaulted; only read for csv
+  compress?: boolean;
+}
+
+function buildReport(rows: Row[], options: ReportOptions): Buffer {
+  const { format, includeHeader = true, compress = false } = options;
+  const body = format === "csv" ? toCsv(rows, includeHeader) : toJson(rows);
+  return compress ? gzip(body) : Buffer.from(body);
+}
+
+function emailReport(rows: Row[], recipient: string, options: ReportOptions): void {
+  mailer.send(recipient, buildReport(rows, options));
+}
+
+// Call sites now read themselves, and recipient is required exactly when it matters.
+const csv = buildReport(rows, { format: "csv", compress: true });
+emailReport(rows, "ops@acme.io", { format: "csv" });
+```
+
+**State-space delta:** the original signature accepted `string × 2³ booleans ×
+string` arguments — including the **incoherent states** `toEmail: false` with a
+non-empty `recipient` (ignored), and `toEmail: true` returning a `Buffer | void`
+the caller had to narrow. Splitting on the real fork removes the `toEmail`
+boolean entirely (2 states → 0) and gives each function a single honest return
+type. `format` narrows from `string` (infinite) to a 2-member union. The
+"recipient supplied but unused" and "Buffer returned but discarded" states
+become unreachable.
+
+**Why it's better:**
+- `Buffer | void` is gone: `buildReport` always returns a `Buffer`, `emailReport`
+  always returns `void`. Callers stop narrowing a union the API invented.
+- `recipient` is a required parameter of `emailReport` only — you cannot call the
+  email path without one, and you cannot pass one to the non-email path.
+- Boolean-at-call-site (`true, false, true`) becomes self-documenting keys; adding
+  an option doesn't reshuffle positional arguments.
+
+---
+
+## 4. God module → split by responsibility
+
+**Smell(s):** [Large Class](./smell-catalog.md#2-large-class) /
+[Divergent Change](./smell-catalog.md#10-divergent-change). One `user-service.ts`
+does fetching, validation, formatting, and caching; four unrelated reasons to
+change live in one file, and the export surface leaks internals.
+
+**Before:**
+
+```ts
+// user-service.ts — one file, four jobs, everything exported
+export const cache = new Map<string, User>();
+
+export function isValidEmail(s: string): boolean {
+  return /^[^@]+@[^@]+$/.test(s);
+}
+
+export function formatUser(u: User): string {
+  return `${u.name} <${u.email}>`;
+}
+
+export async function getUser(id: string): Promise<User> {
+  if (cache.has(id)) return cache.get(id)!; // non-null assertion smell
+  const res = await fetch(`/api/users/${id}`);
+  const raw = (await res.json()) as User; // unchecked cast at the boundary
+  if (!isValidEmail(raw.email)) throw new Error("bad email");
+  cache.set(id, raw);
+  return raw;
+}
+```
+
+Where the boundaries go is a domain question — defer that judgment to the
+`cognition:domain-design` skill: cache is infrastructure, validation is a boundary
+parse, formatting is presentation, fetching is the use case that composes them.
+
+**The move:** [Extract Class → Extract Module](./refactoring-mechanics.md#extract-module-split-a-god-module)
+(here Extract Function/Module, since these are free functions), splitting by axis
+of change. Each module owns one job and exports only its public surface; the
+internal `cache` and validator stop being part of the package's API. Target:
+cohesive modules per the `dev:typescript` skill's module organization.
+
+**After:**
+
+```ts
+// user-cache.ts — infrastructure; cache is private to this module
+const store = new Map<string, User>();
+export const getCached = (id: string): User | undefined => store.get(id);
+export const putCached = (id: string, user: User): void => void store.set(id, user);
+
+// user-parse.ts — the boundary parse; returns a typed User or throws once
+export function parseUser(raw: unknown): User {
+  const u = raw as Partial<User>;
+  if (typeof u.email !== "string" || !/^[^@]+@[^@]+$/.test(u.email)) {
+    throw new Error("invalid user payload");
+  }
+  return u as User;
+}
+
+// user-format.ts — presentation only
+export const formatUser = (u: User): string => `${u.name} <${u.email}>`;
+
+// user-service.ts — the use case; composes the others, exposes one verb
+import { getCached, putCached } from "./user-cache";
+import { parseUser } from "./user-parse";
+
+export async function getUser(id: string): Promise<User> {
+  const hit = getCached(id);
+  if (hit) return hit; // no `!` — the type already says "or undefined"
+  const user = parseUser(await (await fetch(`/api/users/${id}`)).json());
+  putCached(id, user);
+  return user;
+}
+```
+
+**State-space delta:** the public surface shrank from **5 exports in 1 file**
+(`cache`, `isValidEmail`, `formatUser`, `getUser`, and the mutable `Map` itself)
+to **1 use-case export** (`getUser`) plus three internal modules that callers
+don't import. The mutable `cache` is no longer a reachable state for the rest of
+the app — it can't be cleared, mutated, or read out of band, because it isn't
+exported. The `cache.get(id)!` non-null assertion is gone: `getCached` returns
+`User | undefined` and the `if (hit)` narrows it, so the unsafe state ("assert
+present when the Map says maybe") is deleted.
+
+**Why it's better:**
+- Each module has one reason to change: swap the cache, tighten validation,
+  restyle formatting, or change the fetch — each edit is local to one file.
+- The cache is encapsulated; the rest of the codebase can no longer reach into
+  shared mutable state, so a whole class of "who cleared the cache?" bugs can't
+  arise.
+- The boundary cast (`as User`) is replaced by a single `parseUser` that *checks*
+  before it trusts — unsafety is confined to one named function.
+
+---
+
+## 5. Class hierarchy → discriminated union + exhaustive dispatch
+
+**Smell(s):** [Refused Bequest](./smell-catalog.md#8-refused-bequest) /
+[Switch Statements](./smell-catalog.md#6-switch-statements) latent in a small
+inheritance tree. The hierarchy buys nothing: each subclass is data + one
+formula, and `abstract` only enforces that `area()` exists — nothing forces a new
+shape to be handled wherever shapes are consumed.
+
+**Before:**
+
+```ts
+abstract class Shape {
+  abstract area(): number;
+}
+
+class Circle extends Shape {
+  constructor(public readonly radius: number) { super(); }
+  area(): number { return Math.PI * this.radius ** 2; }
+}
+
+class Rectangle extends Shape {
+  constructor(public readonly w: number, public readonly h: number) { super(); }
+  area(): number { return this.w * this.h; }
+}
+
+// Consumers must remember every subclass; nothing warns when Triangle is added.
+function describe(shapes: Shape[]): string[] {
+  return shapes.map((s) => {
+    if (s instanceof Circle) return `circle r=${s.radius}`;
+    if (s instanceof Rectangle) return `rect ${s.w}×${s.h}`;
+    return "unknown shape"; // silent fallthrough — a new shape lands here
+  });
+}
+```
+
+**The move:** [collapse the hierarchy into a discriminated union](./paradigms-and-patterns.md#52-inheritance-hierarchy--discriminated-union--dispatch-function),
+replacing polymorphic dispatch with a function over the union (or a
+`Record<Kind, Fn>` lookup). Target shape: a discriminated union with
+`never`-checked exhaustiveness — the exhaustiveness win the class tree could not
+give you. See the
+[functions-vs-classes decision procedure](./paradigms-and-patterns.md#2-the-functions-vs-classes-decision-procedure)
+for when a class still earns its keep.
+
+**After:**
+
+```ts
+type Shape =
+  | { kind: "circle"; radius: number }
+  | { kind: "rectangle"; w: number; h: number };
+
+function assertNever(x: never): never {
+  throw new Error(`Unhandled shape: ${JSON.stringify(x)}`);
+}
+
+// area lives in one place, exhaustively
+function area(shape: Shape): number {
+  switch (shape.kind) {
+    case "circle":
+      return Math.PI * shape.radius ** 2;
+    case "rectangle":
+      return shape.w * shape.h;
+    default:
+      return assertNever(shape);
+  }
+}
+
+function describe(shapes: Shape[]): string[] {
+  return shapes.map((s) => {
+    switch (s.kind) {
+      case "circle":
+        return `circle r=${s.radius}`;
+      case "rectangle":
+        return `rect ${s.w}×${s.h}`;
+      default:
+        return assertNever(s); // adding "triangle" fails the build until handled
+    }
+  });
+}
+```
+
+**State-space delta:** the class version had the same 2 concrete shapes, but the
+*consumer* state space included an unreachable-on-paper-yet-reachable-in-practice
+"unknown shape" branch — the type system permitted a third subclass to flow
+through `describe` and hit the silent fallthrough. After, `Shape` is a closed
+2-member union, the silent default is replaced by `assertNever`, and adding a
+`"triangle"` variant turns **every** non-exhaustive `switch` red. The set of
+"shapes that compile but aren't handled everywhere" drops from *unbounded* to
+**zero**.
+
+**Why it's better:**
+- Adding a shape is compiler-guided: the build lists every site that must handle
+  it, instead of you hoping you found them all.
+- No `instanceof` ladders, no `super()` ceremony, no `abstract` boilerplate —
+  the data is plain and serializable (survives a `JSON.parse` round-trip, which
+  `instanceof` would not).
+- For a *closed* set of variants, exhaustiveness beats polymorphism: the
+  open-for-extension property of inheritance was a liability here, not a feature.
+
+---
+
+## 6. LLM-slop file → cleaned
+
+**Smell(s):** the generated-code cluster from
+[`llm-slop-cleanup.md`](./llm-slop-cleanup.md): arbitrary filename
+([§1](./llm-slop-cleanup.md#1-arbitrary-file--symbol-names)), one-implementation
+interface + factory ([§3 premature abstraction](./llm-slop-cleanup.md#3-premature--speculative-abstraction)),
+an `as any` ([§9 escape-hatch smuggling](./llm-slop-cleanup.md#9-escape-hatch-smuggling)),
+a reimplemented helper ([§4](./llm-slop-cleanup.md#4-reimplementation-of-existing-repo-utilities)),
+narration comments ([§7](./llm-slop-cleanup.md#7-narration-comments)), and a dead
+export ([§6 dead scaffolding](./llm-slop-cleanup.md#6-dead-scaffolding--stubs)).
+
+**Before:**
+
+```ts
+// utils2.ts
+import { clamp } from "./math"; // the repo already has clamp
+
+// Interface for the price calculator service
+export interface IPriceCalculator {
+  calculate(cents: number, discountPct: number): number;
+}
+
+// Factory function to create a price calculator
+export function createPriceCalculator(): IPriceCalculator {
+  // Return an object that implements the interface
+  return {
+    calculate(cents: number, discountPct: number): number {
+      // Clamp the discount between 0 and 100
+      const safePct = Math.min(100, Math.max(0, discountPct));
+      // Apply the discount to the price
+      const result = (cents * (100 - safePct)) / 100;
+      // Round to the nearest integer and return
+      return Math.round(result);
+    },
+  };
+}
+
+// Helper to format the price for display
+export function formatPriceLabel(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+// Exported for future use
+export const DEFAULT_CURRENCY = "USD";
+```
+
+**The move:** the [LLM-slop cleanup pass](./llm-slop-cleanup.md): rename the file
+to its concept, [inline the one-impl interface + factory](./refactoring-mechanics.md#the-deletion-moves-inline-function-inline-class-collapse-hierarchy-remove-parameter)
+into a plain function, replace the reimplemented clamp with the repo's existing
+helper ([reuse, don't reimplement](./smell-catalog.md#14-duplicate-code)), delete
+the `as any` and the narration comments, and drop the dead `DEFAULT_CURRENCY`
+export (no call sites). Target: a small, honestly-named module of plain
+functions.
+
+**After:**
+
+```ts
+// pricing.ts
+import { clamp } from "./math";
+
+/** Apply a percentage discount to a cents amount, rounded to the nearest cent. */
+export function applyDiscount(cents: number, discountPct: number): number {
+  const pct = clamp(discountPct, 0, 100);
+  return Math.round((cents * (100 - pct)) / 100);
+}
+
+export function formatPriceLabel(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+```
+
+(The original `IPriceCalculator`/`createPriceCalculator` had a single
+implementation and a single call site; collapsing the factory to `applyDiscount`
+is the **Swap test** in action — the interface bought nothing.
+There was also an `(config as any)` access in the unshown call site; it's deleted
+because `applyDiscount` takes typed primitives directly.)
+
+**State-space delta:** the export surface drops from **4 exports** (an interface,
+a factory, a formatter, a dead constant) to **2** (`applyDiscount`,
+`formatPriceLabel`). The one-implementation interface meant the factory could
+*in principle* return any conforming object — an open set of implementations
+nobody needed — now collapsed to exactly one named function. The `as any` is
+removed, closing the hole through which arbitrarily-typed values re-entered.
+Reusing `clamp` deletes a divergent second copy of the clamp logic (one source of
+truth instead of two). Net: fewer concepts, one canonical clamp, zero escape
+hatches.
+
+**Why it's better:**
+- The filename names the concept (`pricing.ts`), so the next reader finds it by
+  grep instead of guessing what `utils2` holds.
+- The interface+factory indirection is gone; the Swap test passes (a plain
+  function is equivalent), so the abstraction wasn't earned.
+- The narration comments ("Apply the discount", "Round and return") restated the
+  code; the one surviving doc comment says *what the function guarantees*, which
+  the code does not say for you.
+- The dead `DEFAULT_CURRENCY` and the reimplemented clamp are deleted — less
+  surface to keep in sync, one source of truth for clamping.
+
+---
+
+## The through-line
+
+Every refactor above subtracted reachable states and handed the invariant to the
+compiler: flag soup (64 → 4), interchangeable ids (mixups → 0), flag-driven dual
+returns (`Buffer | void` → honest types), a god module's leaked surface (5 → 1),
+an open class tree (unbounded unhandled shapes → 0), a slop file's speculative
+surface (4 → 2). If your "after" doesn't lower that count — if it only moved the
+mess to new files — it hasn't earned its diff. The state-collapse test and the
+compiler-proof test in
+[The Mandate](../SKILL.md#the-mandate--self-checks-on-your-own-output) are the
+ones that catch a rearrangement masquerading as a refactor.

--- a/docs/projects/typescript-refactoring-skill/DESIGN.md
+++ b/docs/projects/typescript-refactoring-skill/DESIGN.md
@@ -1,0 +1,191 @@
+# Design Lock — `typescript-refactoring` skill
+
+This is the authoring contract. Every file in the skill is built against it. It
+is grounded in the research digests under `./research/` (r1–r5, r4a–r4c).
+
+## 1. Identity
+
+- **Name / dir:** `typescript-refactoring` (kebab, not `civ7-` prefixed — this
+  skill is technology-scoped, not repo-scoped; see r5).
+- **One-liner:** Thermonuclear-grade, first-principles complexity reduction and
+  refactoring for TypeScript.
+- **Sibling:** Tone/approach sibling of the Thermonuclear Code Quality Review
+  skill (r1). It owns the TypeScript substance the Thermonuclear skill omits.
+- **Location:** `.agents/skills/typescript-refactoring/`.
+
+## 2. The Spine (the coined mental model)
+
+**Complexity in TypeScript is the count of reachable states.** Every `any`,
+every optional field, every boolean flag, every non-exhaustive branch multiplies
+the states a reader (and the program) can be in. Refactoring is not tidying —
+it is **collapsing the state space**, ideally so the *compiler* proves the
+collapse.
+
+Three forces (our analog to Thermonuclear's "code judo," r1):
+- **Type-level judo** — the highest-leverage move changes the *types* so whole
+  categories of runtime branches and bugs become impossible, and code deletes
+  itself. The win is *fewer reachable states, not fewer lines.*
+- **Delete > rearrange** — prefer removing complexity over relocating it. A
+  refactor that only moves the mess around has not earned its diff.
+- **A repeated branch is a missing model** — duplicated conditionals/flags are
+  evidence of a type (usually a discriminated union) that wants to exist.
+
+## 3. Voice & Conventions (every file obeys)
+
+From r1 (Thermonuclear) + r2/r5 (dev:typescript + local house style):
+- **Demanding about quality, never rude** (r1). Harshness lives in the *bar*,
+  not in adjectives or theatrics. Sober body, high standards.
+- **Ambition over defect-hunting**: lead with the simpler design that should
+  exist, then close the diff to it.
+- **No rule without a reason** (r3). Every directive states *why*.
+- **Show, don't just tell**: TypeScript before→after pairs (Thermonuclear shows
+  none — this is our differentiator). Bad→good code blocks, `ts` fenced.
+- **Compose, don't duplicate** (r5 local value): when another skill owns a
+  topic, link to it in one line; never restate it as a second spec.
+- **Detection is concrete**: every smell carries a greppable/tooling signal.
+- **Imperative, dense, operator-facing** (local house style).
+- Cross-skill references use the `plugin:skill` form (e.g. `dev:typescript`,
+  `cognition:domain-design`). Own-material references use relative
+  `references/*.md` paths.
+- Lowercase peer-PR-comment voice for the "good phrases" library (r1).
+- End SKILL.md with the skill-usage-disclosure footer pattern used locally.
+
+## 4. Boundary — what we OWN vs LINK (r2 gaps G1–G6, r5 link table)
+
+**We OWN (the gaps dev:typescript leaves):**
+- G1 — a TypeScript code-smell catalog with detection signals.
+- G2 — safe refactoring *mechanics* (step-by-step, compiler-gated).
+- G3 — an end-to-end, gated refactor workflow + definition of done.
+- G4 — cleaning up **LLM-generated slop** (our strongest differentiator).
+- G5 — functional vs class **decision procedure** + bidirectional migration.
+- G6 — over-/under-engineering detection + naming/style cleanup.
+
+**We LINK (never rewrite):**
+| Concern | Hand off to |
+| --- | --- |
+| What good TS looks like; target patterns (DU, brands, ports, FC/IS, type-state) | `dev:typescript` (`references/design-patterns.md`, `philosophy.md`, `axes.md`, `where-defaults-hide.md`, `refactoring-patterns.md`, `module-organization.md`) |
+| Whether to refactor at all / reframing the problem | `cognition:solution-design` |
+| Why complexity recurs; coupling/feedback/second-order effects | `cognition:system-design` |
+| Where boundaries go; module ownership; bounded contexts | `cognition:domain-design` |
+| The safety net before changing behavior (what to test, risk-proportional) | `cognition:testing-design` |
+| Structuring docs the refactor emits | `cognition:information-design` |
+| Target-state SPEC + phased migration/cutover | `dev:architecture` |
+| Refactor crosses a public/exported surface; versioning | `dev:api-design` |
+| Graph-safe mechanical rename/move/extract across the repo | `gitnexus-refactoring` |
+| Quick diff-scoped cleanup / bug-hunt review | `/simplify`, `/code-review` |
+
+**Coordinate (don't duplicate) with dev:typescript `refactoring-patterns.md`:**
+flags→DU, union→ADT, introduce-Result, branded types already live there — we
+reference them and add *mechanics depth* + *detection*, not a second copy.
+
+## 5. File Inventory
+
+### SKILL.md (lean, ~200–260 lines, principle-first)
+Section order (merges r1 Thermonuclear structure + r5 local house style):
+1. Title + 2-sentence mission.
+2. **The Spine** — complexity = reachable states; the three forces.
+3. **Scope / When to use / When not to** (+ one-line hand-offs).
+4. **Before you touch code** — intent-first questions; characterize first;
+   safety net → `cognition:testing-design`.
+5. **The Core Prompt** — a reusable blockquoted seed (TS-flavored).
+6. **Refactor Decision Axes** — table `Axis | Spectrum | What moving it changes`;
+   refactor-specific dials; link to `dev:typescript/axes.md` for design-time
+   dials (don't duplicate those 6).
+7. **Non-Negotiable Standards** — numbered 0–7, rule 0 = meta.
+8. **The Mandate** — named self-checks the agent runs on its own output.
+9. **Default Workflow** — numbered, one line per step (detect → triage/rank →
+   characterize → transform in compiler-green steps → verify → done).
+10. **Reference Map** table.
+11. **Asset Map** table.
+12. **Anti-Patterns / Failure Signals** — short; LLM-slop + over-engineering tells.
+13. **Boundaries — related skills / when to hand off** table.
+14. **Review Tone & Good Phrases** — lowercase PR-comment library.
+15. **Approval Bar / Definition of Done** — presumptive blockers + done criteria.
+16. **Core Invariants** — `<invariants><invariant name="…">…</invariant>` (local).
+17. Quick Start + skill-usage-disclosure footer.
+
+### references/ (depth, on-demand)
+1. `smell-catalog.md` — DIAGNOSE. 5 categories, 23 smells (r4a). Each: signs,
+   why it hurts, TS manifestation, **detection signal**, treatment → links to
+   mechanics/patterns. Closes with the detection-tooling cheat-sheet.
+2. `refactoring-mechanics.md` — TRANSFORM SAFELY. Top TS techniques (r4b) with
+   step-by-step safe mechanics; the compiler-as-safety-net cadence; the gated
+   workflow + definition of done; commit granularity; characterization tests;
+   the "mostly skip in idiomatic TS" list. (G2, G3)
+3. `llm-slop-cleanup.md` — the generated-code triage pass (G4) + naming/style
+   cleanup (part of G6): arbitrarily named files, structureless mega-files,
+   premature abstraction, redundant reimplementation, mixed conventions, dead
+   scaffolding, narration comments, naming incoherence — each detect→fix.
+4. `paradigms-and-patterns.md` — functional vs class decision procedure (G5) +
+   GoF-in-TS verdicts & criticism (r4c) + over-/under-engineering & the
+   indirection audit (G6). Includes the collapse map and bidirectional
+   migration mechanics.
+5. `worked-examples.md` — 5–6 full TS before→after refactors that demonstrate
+   the spine (flag soup → DU; primitive obsession → branded; god module → split;
+   class hierarchy → composition/DU; nested conditionals → guard clauses; an
+   LLM-slop file → cleaned). Each names the smell, the move, and the state-space
+   delta.
+
+### assets/ (copy-forward templates — must be genuinely copied, r3)
+1. `refactor-plan-template.md` — fill before touching code; doubles as execution
+   log + DoD checklist (smell inventory, ranked targets, safety net, per-step
+   plan with verification gates, definition of done).
+2. `refactor-findings-template.md` — review-output template: priority-ranked
+   findings (Thermonuclear 1–7 tiers, TS-flavored), presumptive blockers, and
+   before/after sketches, in the good-phrase voice.
+
+## 6. Refactor Decision Axes (locked content for SKILL.md §6)
+Each passes the decision test (move the dial → the output changes):
+1. **State space** — admits many reachable states (flags/optionals/`any`) ↔
+   illegal states unrepresentable (DU + `never`). *Master dial.*
+2. **Abstraction** — premature indirection/over-generic ↔ inlined concrete ↔
+   abstraction earned by ≥2 real call sites. (over/under-engineering)
+3. **Paradigm** — class + inheritance ↔ functions + data + DU. (when each earns it)
+4. **Cohesion / placement** — scattered or god-module ↔ one canonical owner.
+5. **Type-safety budget** — escape hatches inside the core ↔ sound, parse at the
+   boundary. (full treatment → `dev:typescript/axes.md` Safety Budget)
+6. **Delete vs rearrange** — relocate the mess ↔ delete the model that caused it.
+
+## 7. Non-Negotiable Standards (locked content for SKILL.md §7)
+0. **(meta)** Pursue the simpler *model*, not a tidier version of the same mess.
+   Collapse the state space; prefer deletion over rearrangement.
+1. Don't grow a module toward ~400+ LOC or a function past ~40–50 LOC / cyclomatic
+   ~10 without a structural reason; decompose by responsibility.
+2. No new escape hatch (`any`, `as`, `as any`, `!`, `@ts-ignore`,
+   `Record<string, any>`) without a written justification; push unsafety to a
+   typed boundary (parse, don't validate).
+3. Make illegal states unrepresentable: flag/boolean soup and sometimes-set
+   optionals → discriminated unions; non-exhaustive switch → `never` exhaustiveness.
+4. Prefer boring/explicit over clever/magical: no abstraction without ≥2 real
+   call sites; functions over classes unless a class earns it.
+5. Keep logic in its canonical module; reuse existing repo helpers; never
+   reimplement what the repo already provides.
+6. Behavior- and contract-preserving: `tsc --strict` green and tests passing
+   after EACH step; no silent public-type drift.
+7. Clean the slop you touch: coherent names, no dead scaffolding, no narration
+   comments.
+
+## 8. The Mandate (locked content for SKILL.md §8 — self-checks)
+- **State-collapse test** — did reachable-state count actually drop?
+- **Deletion test** — did I delete complexity or just move it?
+- **Compiler-proof test** — is the invariant now enforced by the type checker,
+  not a comment/convention/runtime guard?
+- **Reuse test** — did I reimplement something the repo already has?
+- **Naming-coherence test** — do file names ↔ export names ↔ concepts line up?
+- **Swap test** — would the opposite choice (class/function, generic/concrete)
+  give an equivalent result? If yes, the abstraction isn't earned.
+- **Behavior-preservation test** — external behavior + public types unchanged
+  (or intentionally changed and recorded)?
+- **Reader test** — fewer concepts to hold in your head than before?
+
+## 9. Quality gates (r3 — definition of done for the skill itself)
+- Frontmatter = `name` + `description` only.
+- Description: ≥8 quoted triggers + capability sentence + negative boundaries
+  naming siblings.
+- SKILL.md lean/navigational; depth in references/; maps accurate; no orphans;
+  all relative paths resolve.
+- Every axis passes the decision test; every standard/mandate item has a reason.
+- Every smell is self-detectable → mapped to a remedy.
+- ≥1 failure mode with symptom→fix.
+- The skill obeys its own mandate (low complexity, no duplication).
+- README Skills table updated with exactly one row.

--- a/docs/projects/typescript-refactoring-skill/research/r1-thermonuclear.md
+++ b/docs/projects/typescript-refactoring-skill/research/r1-thermonuclear.md
@@ -1,0 +1,289 @@
+# R1 — Thermonuclear Code Quality Review: reference synthesis
+
+**Purpose:** Study the "Thermo-Nuclear Code Quality Review" skill as the tone/approach reference
+for our new TypeScript-specific, first-principles complexity-reduction & refactoring skill. This
+document tells us exactly what to emulate, what to quote, and where the white space is.
+
+## Source
+
+- Raw SKILL.md (used):
+  `https://raw.githubusercontent.com/cursor/plugins/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md`
+- GitHub dir listing (confirms single-file skill, no references/assets):
+  `https://api.github.com/repos/cursor/plugins/contents/cursor-team-kit/skills/thermo-nuclear-code-quality-review`
+- HTML view:
+  `https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md`
+
+The skill is **one file, ~12.4 KB**. There are NO reference files, assets, scripts, or subdirectories.
+Everything below is from that single SKILL.md. Frontmatter sets `disable-model-invocation: true`
+(invoked explicitly, never auto-triggered) and the description keys off phrases like "thermo-nuclear
+code quality review", "thermonuclear review", "deep code quality audit", "especially harsh
+maintainability review".
+
+---
+
+## 1. VOICE & TONE
+
+- **Blunt, demanding, unapologetically opinionated** — but explicitly NOT rude. The "Review Tone"
+  section codifies this: *"Be direct, serious, and demanding about quality. Do not be rude, but do
+  not soften major maintainability issues into mild suggestions."*
+- **The "thermonuclear" framing is calibrated severity, not theatrics.** The word "thermo-nuclear"
+  appears in the title/frontmatter to signal *unusually strict*, but the body never leans on
+  explosion metaphors or edgelord posturing. The intensity is delivered through *standards*
+  ("Non-Negotiable", "presumptive blockers", "Approval Bar") rather than through purple prose.
+  Lesson: the harshness lives in the *bar*, not in the adjectives.
+- **Ambition is the dominant emotional register.** The single most-repeated idea is to be
+  *ambitious* about structure — stated in the opening, restated as rule 0, and threaded through
+  "code judo". It reframes review from defect-finding to *aspiration toward an inevitable design*.
+- **Anti-rubber-stamp / anti-"it works".** Recurrent refrain that correctness is not the bar:
+  *"Do not approve merely because behavior seems correct."* / *"Do not rubber-stamp 'it works'
+  implementations that leave the codebase messier."*
+- **Lowercase, peer-to-peer comment voice.** The "Good phrases" are written like real PR comments —
+  lowercase, conversational, ending in a question that proposes the fix. This is a deliberate
+  register: senior engineer leaving a comment, not a linter emitting an error.
+- **Memorable signature device: "code judo".** A coined term for behavior-preserving restructurings
+  that make code *dramatically* simpler by using the existing architecture better. It's the skill's
+  branding hook and recurs ~6 times.
+
+### Verbatim phrases to echo (steal the cadence, not the words)
+
+1. *"Prefer the solution that makes the code feel inevitable in hindsight."*
+2. *"If you see a path to delete complexity rather than rearrange it, push hard for that path."*
+3. *"Do not be satisfied with a merely cleaner version of the same messy idea if there is a
+   plausible path to a much simpler idea."*
+4. *"this refactor moves complexity around, but doesn't really delete it. is there a way to make
+   the model itself simpler?"*
+5. *"Measure twice, cut once."*
+6. (bonus) *"Treat brittle, ad-hoc, or 'magic' behavior as a code-quality problem."*
+
+---
+
+## 2. STRUCTURE (section skeleton)
+
+```
+Frontmatter (name, description, disable-model-invocation: true)
+# Thermo-Nuclear Code Quality Review
+  ── 2-sentence framing: scope + the "be AMBITIOUS / code judo" thesis (the mission, up front)
+## Core Prompt              → a single blockquoted "baseline prompt" the reviewer starts from
+## Non-Negotiable Additional Standards   → 8 numbered rules (0–7), each with sub-bullets
+## Primary Review Questions  → ~13 questions to ask "for every meaningful change"
+## What to Flag Aggressively → ~17-item escalation list (the smell catalog)
+## Preferred Remedies        → ~16-item list of fixes to prefer (mirrors the flags)
+## Review Tone               → how to speak + "Good phrases" (9 verbatim PR comments)
+## Output Expectations       → 7-tier priority ordering of findings + "don't flood with nits"
+## Approval Bar              → the pass criteria + "presumptive blockers" list
+```
+
+**Architecture of the document (worth copying):**
+- **Opens with the mission/thesis, not with rules.** First two paragraphs set ambition + code judo
+  before any procedure. The *why* precedes the *what*.
+- **Core Prompt as a reusable seed.** A literal blockquote the agent can adopt verbatim as its
+  internal instruction. Elegant: gives the model a single dense paragraph to anchor on, then
+  layers structured rules on top.
+- **Rule 0 is the meta-rule** (ambition / code judo); rules 1–7 are concrete smells. Numbering from
+  0 signals "this one governs all the others."
+- **Mirrored lists.** "What to Flag" and "Preferred Remedies" are nearly 1:1 — every smell has a
+  named cure. This pairing is a strong structural pattern to emulate.
+- **Closes with a hard gate.** "Output Expectations" (how to prioritize) then "Approval Bar"
+  (when to block). The doc ends on *decision procedure*, not vibes.
+
+---
+
+## 3. HOW IT MAKES YOU THINK (the first-principles mechanism)
+
+This is the most important part to emulate. The skill does NOT operate as a checklist that you tick.
+It installs a *stance* and a *search procedure*:
+
+1. **Reframe the goal from "find defects" to "find the inevitable design."** The mission line
+   *"Prefer the solution that makes the code feel inevitable in hindsight"* makes the reviewer
+   imagine the ideal end-state first, then measure the diff against it.
+2. **The "code judo" prime.** *"Assume there is often a 'code judo' move available."* By telling the
+   agent to *assume a simplification exists*, it forces active search rather than passive
+   acceptance. This is a cognitive forcing function: the default is "there's a better version,"
+   not "this is fine."
+3. **Delete > rearrange, as a ranked instinct.** Repeatedly insists that removing moving pieces
+   beats redistributing them: *"Strongly prefer simplifications that remove moving pieces altogether
+   over refactors that merely spread the same complexity around."* This gives a *gradient* to
+   optimize along, not a binary pass/fail.
+4. **Questions over rules.** The "Primary Review Questions" section is Socratic — 13 questions the
+   reviewer asks of *every* change ("Is there a code judo move? Can this be reframed so fewer
+   concepts are needed? Is this abstraction actually earning its keep?"). Questions generalize to
+   code the checklist never anticipated.
+5. **Smell → model, not smell → patch.** The remedies push for *changing the model* ("Reframe the
+   state model so conditionals disappear instead of getting centralized") rather than localized
+   cleanup. Repeated conditionals are read as *evidence of a missing abstraction*, not as lines to
+   tidy. First-principles: the symptom points to a structural cause.
+6. **A complexity budget made explicit.** The 1000-line threshold and "concepts a reader must hold
+   in their head" turn vague "maintainability" into a measurable pressure the reviewer can apply.
+
+The mechanism in one sentence: **assume a dramatically simpler design exists, hunt for it, prefer
+deletion over rearrangement, and treat every repeated branch as a missing model.**
+
+---
+
+## 4. RUBRICS / CHECKLISTS / DECISION PROCEDURES (verbatim)
+
+### Core Prompt (the baseline seed — verbatim)
+> Perform a deep code quality audit of the current branch's changes.
+> Rethink how to structure / implement the changes to meaningfully improve code quality without impacting behavior.
+> Work to improve abstractions, modularity, reduce Spaghetti code, improve succinctness and legibility.
+> Be ambitious, if there is a clear path to improving the implementation that involves restructuring some of the codebase, go for it.
+> Be extremely thorough and rigorous. Measure twice, cut once.
+
+### Non-Negotiable Additional Standards (the 8 rules, condensed verbatim headers)
+- **0. Be ambitious about structural simplification.** (look to make whole branches/helpers/modes/
+  conditionals/layers *disappear*; "code judo"; delete complexity rather than rearrange it.)
+- **1. Do not let a PR push a file from under 1k lines to over 1k lines without a very strong
+  reason.** (strong smell by default; extract before sprawling; explicitly ask to decompose at the
+  threshold.)
+- **2. Do not allow random spaghetti growth in existing code.** (suspicious of new ad-hoc
+  conditionals / scattered special cases / one-off branches; "weird if statements in random places"
+  = design problem, not nit.)
+- **3. Bias toward cleaning the design, not just accepting working code.** (don't rubber-stamp "it
+  works"; prefer removing moving pieces.)
+- **4. Prefer direct, boring, maintainable code over hacky or magical code.** (skeptical of generic
+  mechanisms hiding data-shape assumptions; flag thin/identity/pass-through wrappers.)
+- **5. Push hard on type and boundary cleanliness when they affect maintainability.** (question
+  unnecessary optionality, `unknown`, `any`, cast-heavy code; prefer explicit typed models / shared
+  contracts; challenge silent fallbacks papering over invariants.)
+- **6. Keep logic in the canonical layer and reuse existing helpers.** (feature logic leaking into
+  shared paths; reuse canonical utilities; push to the right package/service/module; don't normalize
+  architectural drift.)
+- **7. Treat unnecessary sequential orchestration and non-atomic updates as design smells when the
+  cleaner structure is obvious.** (serialize independent work → consider parallel; half-applied
+  state → push for atomic; don't over-index on micro-opts.)
+
+### Output Expectations — priority ordering of findings (verbatim list)
+1. Structural code-quality regressions
+2. Missed opportunities for dramatic simplification / code-judo restructuring
+3. Spaghetti / branching complexity increases
+4. Boundary / abstraction / type-contract problems that make the code harder to reason about
+5. File-size and decomposition concerns
+6. Modularity and abstraction issues
+7. Legibility and maintainability concerns
+
+Plus: *"Do not flood the review with low-value nits if there are larger structural issues. Prefer a
+smaller number of high-conviction comments over a long list of cosmetic notes."*
+
+### Approval Bar (the gate — verbatim criteria)
+> Do not approve merely because behavior seems correct.
+
+The bar for approval is (all must hold): no clear structural regression; no obvious missed
+opportunity to make the implementation dramatically simpler when such a path is visible; no
+unjustified file-size explosion; no obvious spaghetti-growth from special-case branching; no
+obviously hacky or magical abstraction; no unnecessary wrapper/cast/optionality churn; no clear
+architecture-boundary leak or avoidable canonical-helper duplication; no missed opportunity for an
+obvious decomposition.
+
+**Presumptive blockers** (treated as blockers unless author justifies clearly):
+- preserves a lot of incidental complexity when a plausible code-judo move would delete it
+- pushes a file from below 1000 lines to above 1000 lines
+- adds ad-hoc branching that makes an existing flow more tangled
+- solves a local problem by scattering feature checks across shared code
+- adds an unnecessary abstraction, wrapper, or cast-heavy contract
+- duplicates an existing helper or puts logic in the wrong layer when there's a clear canonical home
+
+### Good phrases (verbatim PR-comment library — note lowercase, question-ending)
+- `this pushes the file past 1k lines. can we decompose this first?`
+- `this adds another special-case branch into an already busy flow. can we move this behind its own abstraction?`
+- `this works, but it makes the surrounding code more spaghetti. let's keep the behavior and restructure the implementation.`
+- `this feels like feature logic leaking into a shared path. can we isolate it?`
+- `this abstraction seems unnecessary. can we just keep the direct flow?`
+- `why does this need a cast / optional here? can we make the boundary more explicit instead?`
+- `this looks like a bespoke helper for something we already have elsewhere. can we reuse the canonical one?`
+- `i think there's a code-judo move here that makes this much simpler. can we reframe this so these branches disappear?`
+- `this refactor moves complexity around, but doesn't really delete it. is there a way to make the model itself simpler?`
+
+**Note on rubrics:** There is **no numeric scoring, no 1–10 scale, no letter grades, no severity
+matrix.** Severity is expressed entirely as (a) the ranked priority list above and (b) the binary
+"presumptive blocker" gate. "Quality" is never defined by a single metric — it's defined by the
+*dimensions* below.
+
+---
+
+## 5. HOW IT DEFINES "QUALITY" (dimensions reviewed)
+
+Quality = maintainability, not correctness. The dimensions, drawn from the rules:
+- **Structural simplicity / number of concepts** a reader must hold in their head (the headline metric).
+- **Abstraction quality** — is it "earning its keep" or a thin/identity/pass-through wrapper?
+- **Spaghetti / branching complexity** — ad-hoc conditionals, scattered special cases, one-off flags.
+- **File/module size & decomposition** — the explicit 1000-line tripwire.
+- **Type & boundary cleanliness** — optionality, `any`/`unknown`, casts, silent fallbacks, explicit
+  contracts.
+- **Layer/ownership correctness** — canonical layer, no leakage, reuse over bespoke duplication.
+- **Orchestration shape** — unnecessary sequencing, non-atomic/half-applied state.
+- **Legibility / directness** — "direct, boring, maintainable" over "magic".
+
+---
+
+## 6. WHAT IT DELIBERATELY DOES NOT DO (the white space)
+
+- **Not language-specific.** TypeScript appears only incidentally (`any`, `unknown`, casts in rule 5).
+  No mention of generics, conditional/mapped types, discriminated unions, `satisfies`, inference,
+  module resolution, declaration files, build/tsconfig, type-level performance, etc.
+- **No concrete code examples.** Zero before/after snippets. It tells you *what* to look for and
+  *how to talk*, never *shows* a transformation. (Big opportunity for us.)
+- **No tooling / mechanics.** Doesn't reference linters, AST tools, codemods, tests-as-safety-net,
+  or *how* to perform a safe refactor without breaking behavior. It's a review/judgment skill, not a
+  do-the-refactor skill.
+- **No scoring system / quantitative rubric.** Deliberately qualitative + gate-based.
+- **Review-time, diff-scoped.** Framed around "the current branch's changes" / "for every meaningful
+  change" — it audits a *diff*, not a greenfield design or a from-scratch implementation.
+- **No process / workflow.** No steps, no phases, no "first do X then Y." It's a stance + catalog,
+  not a procedure.
+- **No correctness / security / performance focus.** Explicitly brackets these out ("without
+  impacting behavior", "do not over-index on micro-optimizations"). Pure maintainability lens.
+
+---
+
+## 7. WHAT TO EMULATE in our TS skill
+
+1. **Lead with mission + a coined mental model.** Open with the thesis before any rules. Adopt our
+   own signature term that plays the role "code judo" plays here (a memorable name for the
+   behavior-preserving, dramatically-simplifying move).
+2. **Provide a "Core Prompt" seed** — one dense blockquoted paragraph the agent adopts as its
+   internal instruction, then layer structured rules on top.
+3. **Numbered Non-Negotiable Standards with a rule-0 meta-rule** (ambition / simplification first),
+   then concrete TS-specific smells as rules 1..n.
+4. **Mirror "What to Flag" ↔ "Preferred Remedies"** — every smell gets a named cure.
+5. **Socratic "Primary Review Questions"** the agent asks of every change — generalizes beyond a
+   checklist.
+6. **A verbatim "Good phrases" library** in lowercase, peer PR-comment voice, each ending in a
+   question that proposes the fix.
+7. **Close with a priority ordering + a hard Approval Bar / presumptive-blocker gate.**
+8. **Make the complexity budget explicit** — the 1000-line tripwire is effective because it's
+   concrete. Give our skill TS-flavored concrete tripwires (e.g., type-arg count, union arm count,
+   conditional-type nesting depth, `as` casts per file, optional-chain depth) so "complexity" is
+   measurable, not vibes.
+9. **Adopt the stance: assume a simpler design exists; prefer deletion over rearrangement; treat
+   repeated branches as a missing model.** Keep the anti-"it works" refrain.
+10. **Tone calibration:** harsh via the *bar*, not via adjectives. Direct, serious, demanding, not
+    rude.
+
+---
+
+## 8. WHAT TO OWN DIFFERENTLY (our opportunity / the white space)
+
+1. **TypeScript-as-design-medium, first principles.** Where Thermonuclear is language-agnostic
+   maintainability, we own *the type system as the primary tool for deleting complexity*: model the
+   domain so illegal states are unrepresentable, push invariants into types so runtime branches
+   disappear, replace boolean/flag soup with discriminated unions, use `satisfies`/inference to
+   delete casts. Our "code judo" is largely *type-level judo*.
+2. **Show, don't just tell — before/after transformations.** Thermonuclear has zero code. We should
+   include concrete TS before/after snippets demonstrating each simplification (flag-arg →
+   discriminated union; `any`/cast chain → typed boundary; nested optionals → `Result`/tagged-error;
+   class hierarchy → tagged union + exhaustive switch).
+3. **Be a do-the-refactor skill, not only a review skill.** Thermonuclear is review/diff-scoped. We
+   can own *the safe-refactoring mechanics*: how to preserve behavior (tests/types as the safety
+   net), incremental migration slices, leaning on the compiler (`tsc --noEmit`), and codemod-style
+   sweeps. Cover both greenfield design and existing-code rescue, not just diff audit.
+4. **TS-specific smell catalog & tripwires.** `any`/`unknown`/`as` density, type assertions hiding
+   invariants, over-generic abstractions ("generics that earn nothing"), barrel-file/module-boundary
+   tangles, enum vs union, `interface` vs `type` boundaries, optionality vs explicit
+   absence, type-check performance (deep conditional/mapped types) as a maintainability cost.
+5. **First-principles framing of TS quality**: types should *encode intent and shrink the state
+   space*; the win is *fewer reachable states*, not just fewer lines. Distinguish "incidental
+   complexity the language forces" from "essential domain complexity."
+6. **Keep correctness/perf out of scope** (same as Thermonuclear) — stay a complexity-reduction /
+   maintainability skill, but specialized to TypeScript. Our differentiation is *depth in one
+   language*, theirs is *breadth across all code*. We are the sibling that goes deep where they go
+   wide.

--- a/docs/projects/typescript-refactoring-skill/research/r2-typescript-skill.md
+++ b/docs/projects/typescript-refactoring-skill/research/r2-typescript-skill.md
@@ -1,0 +1,180 @@
+# R2 — `dev:typescript` Skill: Ownership Map, Overlap → Link Targets, and Gaps
+
+**Research lane:** R2 (existing-skill audit for the new "Thermonuclear-for-TypeScript" complexity-reduction + refactoring skill)
+**Source under review:** `dev:typescript` skill at `~/.claude/plugins/cache/local/dev/0.1.0/skills/typescript/`
+**Files read in full:** `SKILL.md`, `references/{axes, design-patterns, ecosystem, integration-combos, module-organization, philosophy, real-world-examples, refactoring-patterns, sdk-design, where-defaults-hide}.md`
+**Bottom line:** This skill is a *design/architecture-altitude* discipline. It owns the "what good looks like, choose your position, parse at boundaries" layer richly. It is **thin-to-absent** on (a) a named code-smell catalog with detection signals, (b) mechanical step-by-step refactoring recipes, (c) an end-to-end refactor decision procedure with verification gates, (d) cleaning up LLM slop, and (e) a real functional-vs-class decision procedure. Those gaps define what our new skill must own.
+
+---
+
+## 1. OWNERSHIP MAP (per file)
+
+### `SKILL.md` — the router + the mandate
+- Owns the **framing**: "You will write TypeScript like JavaScript with annotations." Defines the core problem (decorating code with types instead of designing with types as material) and "The Spirit of TypeScript" (two programs, types as design material, inference as primary interface, proportional complexity).
+- Owns **"Before Designing Anything"** — the four questions: *What are the boundaries? What must be enforced and where? Who consumes this? How will this grow?*
+- Owns **The Mandate** — six pre-delivery checks: inference test, honesty test, proportionality test, boundary test, swap test, consumer test. Plus **Core Invariants** (`two-programs`, `types-are-api`, `inference-first`, `proportional-complexity`, `parse-at-boundaries`, `one-strategy-per-boundary`, `mandate-before-delivery`).
+- Owns the **workflow index** (design new subsystem / refactor safely / evaluate-critique) and the **Reference Map** table. Note: its "Refactor safely" workflow is only 7 high-level bullets that *point to* `refactoring-patterns.md` — it is a pointer, not a procedure.
+
+### `references/axes.md` — the six decision axes (the crown jewel)
+- Owns the **six independent design dimensions**, each as a spectrum with "when to choose," code for each pole, and "warning sign you've gone too far": **Safety Budget** (minimal ↔ make-illegal-states-unrepresentable), **API Shape** (data-first ↔ builder-first), **Boundary Rigidity** (fluid ↔ enforced `exports`), **Type Origin** (annotation-first ↔ inference-first), **Error Channel** (exceptions ↔ Result/typed unions), **Extension Model** (closed sealed unions ↔ open registries/hooks).
+- Owns the **Decision Framework** with a *default position* + *trigger to move* + *warning-sign-you-overshot* for every axis (e.g. Safety default = "middle ground, strict:true + brands for critical ids"; over-engineering warning = "new members spend days understanding the type system instead of shipping").
+- Owns the **Expression Problem** framing (closed = easy new ops/hard new cases; open = easy new cases/hard new ops) and the "positions shape an architecture" worked example.
+
+### `references/philosophy.md` — the "why," build-from-zero, and when-TS-is-wrong
+- Owns the **two-programs** doctrine in depth (lying types vs honest types; `as` = "you are lying to the compiler"), inference-friendly vs annotation-heavy, **proportional complexity**, **data-first vs class hierarchies**, boundary discipline (the "fortress").
+- Owns **Building from Zero** (a 6-step ordering: identify boundaries → model domain in types → let types tell you the API shape → place effects at the edges → design extension points upfront → choose error strategy upfront).
+- Owns **When TypeScript Is Wrong** (CPU-bound hot paths, systems programming, short-lived scripts, teams-under-time-pressure, type-check-time dominates iteration, when-JS-is-fine) and **The Structural Typing Advantage** + 6 decision principles (Types Are the API; Inference Is the Primary Interface; Proportional Complexity; **Parse, Don't Validate**; One Strategy Per Subsystem; The Compiler Is Your Refactoring Engine).
+
+### `references/where-defaults-hide.md` — the *default* catalog (closest thing to a smell catalog)
+- Owns **8 named structural defaults**, each with "what it looks like / why it happens / what principle it violates / the fix / the rule": (1) `any` as problem-solving, (2) types divorced from values, (3) flat uniform module structure, (4) class-heavy OOP, (5) over-engineered type safety, (6) ignoring the runtime, (7) inconsistent error handling, (8) export everything hide nothing.
+- Owns a **Self-Check** — scan-your-own-output checklist mapping each default to its fix.
+- IMPORTANT for our gap analysis: these are **design/type-honesty defaults**, NOT a general code-smell catalog. They are oriented to "types lying about runtime" and "boundaries not enforced," not to long functions, deep nesting, duplication, dead code, poor naming, feature envy, primitive obsession, etc. (See Gaps.)
+
+### `references/design-patterns.md` — the pattern catalog (runtime + type-level)
+- Owns a **grouped catalog**: (A) model domain invariants — discriminated unions/ADTs, opaque/branded types, type-state, boundary parsing, phantom types; (B) type-driven APIs — accumulating-generic builders, `satisfies` conformance gate, overloads-vs-unions, constraint-first generics, infer-based extractors; (C) coordinate behavior — strategy via function injection, command+handler map, state machine, typed pub/sub event maps, middleware/pipeline; (D) scale architecture — functional core/imperative shell, ports & adapters, CQRS+event sourcing, plugin architecture, monorepo boundary types; (E) type-level power tools — `unique symbol` brands, `as const`+`satisfies`, template-literal DSLs, non-distributive conditionals.
+- Owns **selection heuristics** and a **pitfalls/anti-patterns** list (types-as-truth fallacy, type-level overfitting, union explosion, `any` creep, boolean-flag/optional soup, base-class framework, leaky boundaries, ambient/augmentation abuse, error-channel confusion).
+- Owns a **Symptom (code smell) → Refactoring move → Likely pattern(s)** cross-link table (9 rows; e.g. "Many booleans control behavior → replace flags with tagged union input → A1, C3").
+
+### `references/refactoring-patterns.md` — TS-specific refactoring *moves* (the most relevant existing file)
+- Owns the **mental model** ("the compiler is a change detector / dependency graph / change-impact analyzer / conformance gate") and the **internal-vs-public-API-refactor** distinction ("if downstream consumes it, types are part of the API").
+- Owns a **pre-flight checklist** (define boundary / build is green / record strictness flags / public-surface inventory) and a **core loop** (constrain blast radius → quarantine unknown → refactor behind seams → IDE refactors first → codemods only at 50+ call sites).
+- Owns a **catalog of 8 TS-focused moves**, each with *when to use / TS hazards / safe steps / micro-snippet*: (1) type-façade exports, (2) extract module boundary (ports/adapters), (3) introduce Result/tagged-error, (4) flags-soup → discriminated union input, (5) branded/opaque types, (6) union → ADT + `assertNever`, (7) split overloaded function, (8) dependency inversion via function ports.
+- Owns **architecture refactors** (strangler fig + branch-by-abstraction TS variant; ports/adapters migration steps; DTO/domain separation), **type-check performance refactors** (union explosion, deep generic chains, computed-types-exported-widely, circular imports), and **stop/rollback signals**.
+- NOTE: The "safe steps" are 3-4 bullets per move — they are *sequencing guidance*, not the fully mechanical, test-after-each-step transformations of a Fowler-style recipe.
+
+### `references/module-organization.md` — boundaries, packages, monorepos, DI
+- Owns the **three levels** (Level 1 functions & types: "one file, one reason to change"; Level 2 modules & packages: cohesion/public surface/dependency direction/barrels; Level 3 systems & monorepos: package contracts, project references, team ownership).
+- Owns **boundary enforcement** spectrum (convention → lint `no-restricted-imports` → package boundaries with `exports` + project references) and the **dependency-direction rule** (adapters → application → domain → nothing; acyclic).
+- Owns **monorepo patterns** (shared-types package, project references, workspace protocols, modular monolith), the **"shared dumping ground" anti-pattern** with symptoms + fix, the **barrel-file nuanced take** ("one barrel per package boundary, zero internal barrels"), three **practical organization patterns** (feature-slice / layer-first / modular-monolith-in-packages), **when to split a module into a package**, and **DI in TS** (explicit composition root, function-vs-interface ports, when DI containers make sense).
+
+### `references/sdk-design.md` — library/SDK API surface design
+- Owns **7 SDK principles**: contract-first value tree, inference-friendly surfaces (`satisfies`, prefer DU over overloads, `const` type params), error contracts (typed expected errors vs throw for bugs), schema as single source of truth, middleware as context transformer, curated public surface (`exports`), version evolution (type changes are breaking; `@deprecated`; migration utils; break loudly not silently).
+- Owns **patterns from strong SDKs** (procedure builders, router trees, client-inference-from-server, composable plugins) and an **SDK Design Checklist** + "The Invisible SDK" closing principle.
+
+### `references/ecosystem.md` — tool selection along the type chain
+- Owns the **convergence principle** (whole stack shares one type system → refactors cascade as errors) and runtime selection (Bun / Node 22.6+ strip-types / Deno).
+- Owns **schema-validation selection** (Zod default / Valibot client-heavy / TypeBox JSON-Schema-first / ArkType performance — "don't mix schema libraries"), **data-access selection** (Drizzle code-first / Prisma schema-first / Kysely SQL-first), **API-layer selection** (tRPC / oRPC / Hono / Elysia), testing (Vitest / Bun test), the **full-stack composition** worked example (rename a column → error cascade), and **tool-stack-not-tools** selection principle.
+
+### `references/integration-combos.md` — composing patterns into migratable architectures
+- Owns the **"combo" mindset** (hard systems = implicit boundaries) and **foundation patterns** (hexagonal/clean slices: domain/application/ports/adapters/infra; functional core/imperative shell; typed boundaries DTO pipeline `unknown → InputDTO → DomainCommand → DomainResult → OutputDTO`; Result+tagged-union error contracts; interface-vs-function ports; module boundaries; strangler fig).
+- Owns **7 combo recipes** (problem → target architecture → key patterns → refactor path): "we can't test anything," "we keep rewriting controllers," "service god object," "upstream integrations keep breaking us," "Clean Arch but TS DI is messy," "refactor a live legacy app safely," "monorepo spaghetti."
+- Owns **operational guardrails** (composition root, no-outward-domain-imports, no smart-ORMs-in-domain, DTO parsing near edges, typed errors, fixture libraries).
+
+### `references/real-world-examples.md` — patterns in the wild (tRPC, oRPC, Elysia)
+- Owns **cross-cutting patterns to steal** (contract-first value tree, fluent builder with type-state, context-transforming middleware, runtime schema as source of truth) and per-framework **"build it from scratch" blueprints** (procedure builder + context + middleware + router tree; contract object + typed client + transport proxy; typed route tree + plugins).
+- Owns the **Elysia type-performance debugging workflow** (`tsc --generateTrace` → inspect in Perfetto → split into sub-apps to isolate inference).
+
+---
+
+## 2. PHILOSOPHY & VOICE (so our skill is a coherent sibling)
+
+**Philosophy (the load-bearing axioms):**
+- **Two programs, one design.** Every `.ts` file is a runtime program and a type-time (erased) program; they must be designed together. "A type that claims safety without runtime backing is a lie."
+- **Types are design material, not documentation.** An interface is a structural constraint that shapes what code can be written, a promise to consumers.
+- **Inference is the primary interface.** "Every required annotation is a design smell." If consumers need `<T,U,V>`, the API is leaking.
+- **Proportional complexity.** "If the type is harder to understand than the bug it prevents, simplify." Every type-level construct must earn its cost in readability/compile-time/error quality.
+- **Parse, don't validate; parse at boundaries.** Treat `unknown` as radioactive until parsed; inside the fortress, trust the types.
+- **One strategy per subsystem.** Consistency beats local optimization.
+- **The compiler is your refactoring engine.** Honest types + discriminated unions + `assertNever` make the compiler hunt your bugs during change.
+- **Descriptive, not prescriptive, on the axes.** "There is no universally correct position." Start simple, move conservative only with evidence.
+
+**Voice:**
+- Second person, imperative, confrontational-but-coaching. Opens by predicting the reader's failure ("You will write TypeScript like JavaScript with annotations") and frames craft as the gap between "type-checks" and "well-designed."
+- "Defaults hide" framing: failure modes "feel like the normal way to write TypeScript" — the skill's job is to make you *catch yourself*.
+- Structured for progressive disclosure: a tight `SKILL.md` (problem → spirit → defaults → four questions → six axes → mandate → workflows → reference map) that defers depth to references via an "Open when" table.
+- Test-shaped self-checks ("The inference test," "The swap test," "Self-Check," checklists). Heavy use of bad→good code pairs. Reference files carry **authority-tagged annotated sources** ([PRIMARY]/[PRACTICE]/[BOOK]/[COMMUNITY]) and a "Durable as of <date>" stamp.
+- Honest about limits: an explicit "When TypeScript Is Wrong" / "Boundaries" section. Closes most files with a "Summary"/"The Principles" recap.
+
+**Implication for our skill:** Match the voice (predict-the-failure opener, bad→good pairs, named tests/checklists, authority-tagged sources, "Open when" reference table, Core Invariants block, skill-usage-disclosure footer). Position ours as the *execution/mechanics* sibling to this *design/altitude* skill — and link out, hard, rather than restate the philosophy.
+
+---
+
+## 3. OVERLAP RISK → LINK TARGETS (what NOT to rewrite)
+
+A complexity-reduction + refactoring skill will be *tempted* to re-author each of these. Don't. Link instead.
+
+| Tempting topic in our skill | Already owned by `dev:typescript` | LINK target (don't rewrite) | What to do instead |
+|---|---|---|---|
+| The "why" of good TS / two-programs / parse-at-boundaries / proportional complexity | philosophy.md (full treatment) | `dev:typescript` → `references/philosophy.md` | One-line restatement + link; assume the reader absorbed it. Our skill is mechanics, not mindset. |
+| "Make illegal states unrepresentable," exceptions-vs-Result, data-first-vs-builder tradeoffs | axes.md (six axes + decision framework) | `dev:typescript` → `references/axes.md` | When a refactor *moves a dial* (e.g. flags→DU is a Safety-Budget move), cite the axis; don't re-derive the tradeoff. |
+| The TS pattern vocabulary (DU/ADT, branded types, type-state, phantom, ports/adapters, FC/IS, state machine, middleware, pub/sub) | design-patterns.md (catalog A–E) | `dev:typescript` → `references/design-patterns.md` | Reference the *target* pattern by name (e.g. "A1 discriminated union," "D2 ports & adapters"); our skill says *how to get there safely*, not what the pattern is. |
+| TS-specific refactoring moves (façade exports, ports seam, introduce Result, flags→DU, brands, union→ADT+assertNever, split overloads, function ports) | refactoring-patterns.md (8 moves + core loop + stop/rollback) | `dev:typescript` → `references/refactoring-patterns.md` | **Highest overlap.** Do NOT duplicate these 8 moves. Either (a) link and go deeper *mechanically* on a few high-value ones, or (b) own the moves the existing file omits (see Gaps). Be explicit about the boundary. |
+| Module/package boundaries, barrels, monorepo structure, dependency direction, DI/composition root, shared-dumping-ground | module-organization.md (three levels + enforcement + monorepo) | `dev:typescript` → `references/module-organization.md` | Link for "where should this extracted module live / how to enforce the boundary." Don't re-explain barrels or `exports`. |
+| SDK/public-API discipline, type-as-breaking-change, version evolution, curated surface | sdk-design.md | `dev:typescript` → `references/sdk-design.md` | Link when a refactor crosses a *published* surface. Reuse its "types are part of the API" rule rather than restating. |
+| Schema lib / ORM / API-framework / runtime selection | ecosystem.md | `dev:typescript` → `references/ecosystem.md` | Link for any "which tool" decision. Our skill should be tool-agnostic on selection. |
+| Strangler fig / branch-by-abstraction / "legacy app safely" / "monorepo spaghetti" recipes | integration-combos.md (7 recipes) + refactoring-patterns.md | `dev:typescript` → `references/integration-combos.md` | Link for *architecture-scale* migrations. Our skill owns *unit/module-scale* mechanics; hand off to combos when the refactor is a multi-slice migration. |
+| Type-check performance refactors / `--generateTrace` / split-into-sub-apps | refactoring-patterns.md ("type-check performance refactors") + real-world-examples.md (Elysia trace workflow) | `dev:typescript` → `references/refactoring-patterns.md` and `references/real-world-examples.md` | Link; don't re-author the perf-trace workflow. |
+| Worked patterns from tRPC/oRPC/Elysia | real-world-examples.md | `dev:typescript` → `references/real-world-examples.md` | Link only if illustrating a target shape. |
+
+**One-sentence rule for the new skill:** *`dev:typescript` answers "what good looks like and which pattern to target"; our skill answers "how to detect the bad, and the exact safe sequence to transform it" — and it links to `dev:typescript` for every target it names.*
+
+---
+
+## 4. GAPS — what our new skill must OWN (the most important output)
+
+These are missing or thin in `dev:typescript`. Each is a candidate to own outright.
+
+### G1. A concrete code-smell catalog with detection signals (LARGELY MISSING)
+- `where-defaults-hide.md` is the *only* smell-ish catalog, and it covers exactly 8 **design/type-honesty** defaults (`any`, type-value drift, flat modules, class-heavy OOP, over-engineered types, ignoring runtime, inconsistent errors, export-everything). It is *not* a general code-smell taxonomy.
+- **Absent named smells (with no detection signals anywhere in the skill):** long function / god function, long parameter list, deep nesting / arrow-code, duplicated logic (copy-paste), dead code & unreachable branches, unused exports/vars, primitive obsession, feature envy, data clumps, shotgun surgery, divergent change, message chains / law-of-Demeter violations, speculative generality, temporary fields, comments-as-deodorant, magic numbers/strings, large file / kitchen-sink module, cyclomatic-complexity hotspots.
+- **TS-flavored smells absent or only mentioned in passing:** `as`/`as any`/`as unknown as` chains as a *smell to hunt* (philosophy mentions `as` is lying, but there's no detection-and-sweep procedure), `!` non-null assertion overuse, optional-property soup as invalid-state generator, enum-vs-union misuse, `@ts-ignore`/`@ts-expect-error` accumulation, index-signature `Record<string, any>` escape hatches, overload sprawl (refactoring file has the *move* but no *detection signal/threshold*), barrel-induced import cycles (module-org has the rule, not a detector), re-export mazes.
+- **What to own:** a catalog where each smell = **name + detection signal (concrete, ideally greppable/metric-based: e.g. "function > ~40 lines or cyclomatic > 10," "3+ chained `as`," ">5 optional fields on one type," "two type defs with overlapping fields and separate validators") + why it's costly in TS specifically + pointer to the transformation**. This is the skill's center of gravity.
+
+### G2. Refactoring *mechanics* — step-by-step safe transformations (THIN)
+- `refactoring-patterns.md` gives 8 moves with 3-4 "safe steps" each — *sequencing*, not *mechanics*. There is no Fowler-style "do X, run tests, do Y, run tests" with the compiler/test loop interleaved at each micro-step.
+- **Absent mechanical recipes:** Extract Function / Inline Function, Extract Variable, Extract Type/Interface, Rename Symbol (the safe TS way with tsserver), Move Function/Move Module, Inline Class, Replace Conditional with Polymorphism *or its TS-idiomatic inverse* (replace polymorphism/inheritance with discriminated-union + switch), Decompose Conditional, Replace Nested Conditional with Guard Clauses, Replace Magic Literal with named const, Split Phase, Separate Query from Modifier, Parameterize Function, Remove Dead Code safely (find unused exports → confirm → delete), Consolidate Duplicate Conditional Fragments.
+- The existing file's own framing concedes the gap: it says it "assumes you already know how to refactor in general" and is "**not** refactoring 101."
+- **What to own:** the actual micro-mechanics, TS-specialized — what the compiler/tsserver does for you at each step, where it *won't* catch you (e.g. structural typing means a wrong rename can still type-check; `as` masks breakage; `noUncheckedIndexedAccess` off hides index errors), and the test/compile cadence. Tie each mechanic to the smell(s) in G1.
+
+### G3. An end-to-end refactor decision procedure / workflow with verification gates (THIN)
+- The closest artifacts: `SKILL.md` "Refactor safely" (7 bullets, pure pointer) and `refactoring-patterns.md` "core loop" (5 bullets) + pre-flight checklist. There is **no** decision tree for *"given this code, what do I do first, in what order, and how do I know I'm done."*
+- **Absent:** a triage/prioritization procedure (which smell to attack first — highest leverage vs lowest risk; `SKILL.md` says "identify the highest-leverage fix" but gives no procedure to rank them), a "characterization test before you touch untested code" step, a per-step verification gate (typecheck green + tests green + behavior unchanged + no public-type drift), commit/rollback granularity ("one transformation per commit"), and a **definition of done** / when-to-stop (the existing "stop/rollback signals" are about *type perf blowups*, not about "the refactor is complete and safe").
+- **What to own:** a numbered, gated workflow — Characterize (lock behavior) → Inventory smells → Rank by leverage/risk → Transform one mechanic at a time behind a green build → Verify (typecheck/tests/behavior/public-surface) → Commit → repeat → Done criteria. Make the verification loop explicit and TS-specific (use `tsc --noEmit`, the test runner, `git diff` of `.d.ts`/exports).
+
+### G4. Cleaning up "LLM-generated slop" (ENTIRELY MISSING — strong differentiator)
+- Zero coverage. The existing skill assumes a human-authored codebase that drifted via familiar defaults. It does not address machine-generated tangle.
+- **Absent and high-value to own:** detecting/fixing **arbitrarily named files** (`utils2.ts`, `helpers.ts`, `index-new.ts`, `final_v2`), **structureless tangle** (everything in one mega-file, no boundaries), **over-abstraction** (premature generics, factory-of-factory, interfaces with one implementation, config objects for two call sites, "enterprise" wrappers around one-liners), **redundant re-implementations** (the LLM rebuilt `groupBy`/`pick`/a Result type that already exists in the repo), **inconsistent local conventions** (mixed error channels, mixed `type` vs `interface`, mixed import styles introduced across generated files), **dead scaffolding** (TODO stubs, unused exports, commented-out alternatives, "example" code left in), **comment slop** (narration comments restating the code), and **naming incoherence** (names that don't match the repo's ubiquitous language).
+- **What to own:** a "slop triage" pass — *consolidate duplicate/near-duplicate files, rename to repo conventions, collapse premature abstractions to their single use, delete dead scaffolding, reconcile to one strategy per subsystem* — explicitly framed for code an agent (possibly the same agent) just generated. This is the skill's most distinctive surface and should be a first-class reference.
+
+### G5. Functional vs class-based paradigm — *when* and *how to choose* (BIASED, NOT A DECISION PROCEDURE)
+- The skill has a strong *bias* ("Classes are occasionally useful; they're rarely the right default"; default 4 "class-heavy OOP"; philosophy "prefer discriminated unions and plain objects over class hierarchies") and a worked class→composition fix. But it provides **no decision procedure** for the legitimate cases.
+- **Absent:** an explicit chooser — *when classes genuinely win* (private state with invariants, `Symbol.dispose`/resource lifecycle, instanceof-based ecosystems, errors extending `Error`, framework requirements e.g. Angular/Nest/decorators, hot-path allocation where shape stability matters), vs *when functions+data+closures win* (most app/domain/service logic, testability, serialization, tree-shaking), plus the **migration mechanics** in both directions (class → factory-closure; inheritance tree → discriminated union + dispatch function) as gated recipes. The skill gives the conclusion, not the rule or the move.
+- **What to own:** the decision procedure + bidirectional migration mechanics. Cite axes.md (Safety/Extension) and design-patterns.md (A1/C1/C5) for the targets, but own the *choice* and the *transformation*.
+
+### G6. Over/under-engineering signals & TS-specific style/naming failures (PARTIAL — extend, don't restate)
+- Over-engineering at the *type level* is well covered (where-defaults-hide #5, design-patterns "type-level overfitting," axes warning-signs, refactoring "type-check performance"). **Under-engineering** and **structural** over-engineering are NOT: premature abstraction, needless indirection layers, one-impl interfaces, config-driven everything, wrapper-around-stdlib, "manager/handler/service/util" name-noise, generic parameters that are never varied.
+- **Naming/style failures** are essentially uncovered as a *detect-and-fix* topic: vague names (`data`, `result`, `temp`, `obj`, `handle`), `Manager`/`Helper`/`Util` grab-bags, abbreviations, boolean naming, `type` vs `interface` consistency, file-name ↔ export-name coherence, casing conventions, "stuttering" (`user.userId`). The skill cares about *type honesty*, not *readability craft*.
+- **What to own:** under-engineering signals, structural over-engineering (the "indirection audit": can you delete this layer and lose nothing?), and a TS naming/style cleanup pass with detection signals. (`dev:architecture` has an "indirection audit" concept; coordinate to avoid duplicating that one.)
+
+### Smaller gaps worth a mention
+- **No tooling pipeline for *finding* smells** (knip/ts-prune for unused exports, `madge`/`dpdm` for cycles, ESLint `complexity`/`max-lines`/`max-depth`/`sonarjs`, `tsc --noUnusedLocals`, jscpd for duplication, `ts-morph`/codemods for mechanical sweeps). Refactoring file mentions "codemods at 50+ call sites" and `--generateTrace` but no detection toolchain.
+- **No guidance on refactoring *without* tests** (characterization/approval tests, the "make it safe before you make it clean" step).
+- **No "categorical fix" doctrine** (a pointed-out smell is a *class*, sweep the whole codebase) — strongly aligned with the user's own MEMORY (`fix-issues-categorically`); our skill should own it explicitly.
+
+---
+
+## 5. EXACT LINK TARGETS (concern → file → one-liner)
+
+Use the form: **`dev:typescript` skill, file `references/<x>.md`**.
+
+| Concern (when our skill needs it) | Link target | What that file owns (one line) |
+|---|---|---|
+| Mindset / "what good looks like" / two-programs / parse-at-boundaries | `dev:typescript` → `references/philosophy.md` | The design philosophy, build-from-zero ordering, and when TS is the wrong tool. |
+| Choosing a design position / naming the tradeoff a refactor moves | `dev:typescript` → `references/axes.md` | Six decision axes with default position + trigger-to-move + overshoot warning. |
+| Diagnosing type-honesty/boundary defaults; self-check before delivery | `dev:typescript` → `references/where-defaults-hide.md` | 8 named structural defaults (any, type-value drift, flat modules, class-heavy, over-typed, ignore-runtime, mixed errors, export-everything) + fixes. |
+| The target pattern to refactor *toward* (DU, brands, type-state, ports, FC/IS, state machine, middleware) | `dev:typescript` → `references/design-patterns.md` | Runtime+type-level pattern catalog (A–E) + selection heuristics + symptom→move→pattern table. |
+| TS-specific refactoring moves, blast-radius control, type-perf refactors, stop/rollback | `dev:typescript` → `references/refactoring-patterns.md` | 8 API-safe refactoring moves (façade, ports seam, Result, flags→DU, brands, union→ADT, split overloads, function ports) + core loop. |
+| Where extracted code should live; enforcing boundaries; monorepo/barrels/DI | `dev:typescript` → `references/module-organization.md` | Three design levels, boundary enforcement spectrum, monorepo patterns, composition-root DI. |
+| Refactors that cross a published/library surface; versioning a type change | `dev:typescript` → `references/sdk-design.md` | 7 SDK principles incl. "types are breaking changes," curated `exports`, version evolution. |
+| "Which tool" decisions (schema lib, ORM, API framework, runtime) | `dev:typescript` → `references/ecosystem.md` | Type-chain tool selection (Bun/Node/Deno, Zod/Valibot/TypeBox, Drizzle/Prisma/Kysely, tRPC/oRPC/Hono/Elysia). |
+| Architecture-scale migration (legacy app, monorepo spaghetti, strangler fig) | `dev:typescript` → `references/integration-combos.md` | 7 problem→architecture→refactor-path combo recipes + hexagonal/FC-IS foundations. |
+| Illustrating a target shape from real frameworks; type-perf trace workflow | `dev:typescript` → `references/real-world-examples.md` | tRPC/oRPC/Elysia patterns-to-steal + `tsc --generateTrace`→Perfetto→sub-apps. |
+| Pre-delivery quality gate (reuse, don't reinvent) | `dev:typescript` → `SKILL.md` ("The Mandate" + Core Invariants) | Six mandate checks + 7 core invariants to run before presenting TS code. |
+
+---
+
+## Recommended division of labor (for skill design)
+
+- **`dev:typescript` keeps:** philosophy, the six axes, the pattern catalog, module/SDK/ecosystem design, architecture-scale migration recipes, and its 8 design-level refactoring moves.
+- **Our skill owns:** (G1) a real code-smell catalog with detection signals, (G2) mechanical step-by-step safe transformations, (G3) an end-to-end gated refactor workflow with a definition of done, (G4) LLM-slop cleanup, (G5) the functional-vs-class *decision procedure* + bidirectional migration mechanics, (G6) under-/structural-over-engineering + naming/style cleanup, plus the detection toolchain, refactoring-without-tests, and the categorical-fix doctrine.
+- **Coordinate (don't duplicate):** the flags→DU / union→ADT / introduce-Result / branded-types moves already in `refactoring-patterns.md` — our skill should link to them and only add *mechanics depth* the existing file omits; and the "indirection audit" idea shared with `dev:architecture`.

--- a/docs/projects/typescript-refactoring-skill/research/r3-skill-authoring.md
+++ b/docs/projects/typescript-refactoring-skill/research/r3-skill-authoring.md
@@ -1,0 +1,395 @@
+# R3 — Skill Authoring: The Canonical Method (Synthesis + Blueprint)
+
+**Lane:** Research — extract the canonical METHOD for authoring an excellent skill.
+**Target consumer:** the workstream building a NEW repo-local skill (TypeScript first-principles complexity-reduction & refactoring).
+**Date:** 2026-06-17
+
+## Sources read (fully)
+
+- `dev:resource-skill-builder` — `SKILL.md` + all 6 references (elicitation-playbook, multi-agent-orchestration, research-playbook, skill-doc-template, sync-and-validate, upstream-skill-packs).
+- `cognition:create-principles-skill` command (the principle-first build pipeline).
+- `hq:skill-authoring` — `SKILL.md` + 3 references (progressive-disclosure, quality-patterns, validation-checklist) + `assets/skill-template.md`.
+- **Gold-standard exemplars** (named by create-principles-skill as the structures to absorb): `design:ui-design/SKILL.md` and `cognition:information-design/SKILL.md`.
+
+> Note: `cognition:create-principles-skill` references `references/domain-brief-framework.md` and the `references/principles.md` / `references/critique.md` / `references/axes.md` / `references/where-defaults-hide.md` files of the exemplars. The framework file is not present in the local plugin cache (it lives in the cognition source repo alongside the command), but the command body fully specifies its contents — captured below. The exemplar SKILL.md files themselves were read in full and are the authoritative structural reference.
+
+---
+
+## 0. The three lineages (and which one we follow)
+
+There are three overlapping but distinct skill-authoring doctrines in this toolkit. Knowing which we are building matters because they prescribe different shapes.
+
+| Lineage | Optimizes for | Output shape | Use for our skill? |
+|---|---|---|---|
+| **hq:skill-authoring** | A lean, reliable, navigational **operator manual** | Purpose → workflow → reference map → invariants → anti-patterns → failure modes | YES — this is the baseline convention (frontmatter rules, progressive disclosure, validation gates). |
+| **dev:resource-skill-builder** | Capturing **durable domain knowledge** (a canonical reference doc) | Overview → mental model → patterns → best practices → pitfalls → annotated sources | Partially — borrow the research rigor, authority tagging, and "mental model first" discipline. |
+| **cognition:create-principles-skill** | Teaching agents **how to THINK** about a domain (generative principles, not checklists) | The Problem → Where Defaults Hide → Intent/Before-Anything → Decision Axes → The Mandate → Workflow → Reference Map → Invariants → Anti-Patterns → Failure Modes → Boundaries → Quick Start | **YES — this is the primary doctrine for our skill.** A TS refactoring/complexity-reduction skill is principle-first by nature: it must generate correct decisions across unseen code, not list rules that expire. |
+
+**Verdict for our skill:** Build it as a **principle-first skill** (cognition doctrine) that **obeys the hq operator-manual conventions** (frontmatter, progressive disclosure, validation gates, reference maps) and **uses resource-skill-builder's research method** to ground the principles in real authority. The exemplars `ui-design` and `information-design` are the literal structural templates to adapt.
+
+---
+
+## 1. SKILL.md ANATOMY
+
+### 1.1 Frontmatter (HARD RULE)
+
+Frontmatter contains **only two keys**: `name` and `description`. Nothing else. This is a local convention enforced by the sync validator (`sync-and-validate.md` programmatically asserts `bad = [k for k in keys if k not in ("name","description")]` and fails on extras). No `version`, no `tags`, no `argument-hint` (that's for commands, not skills).
+
+```yaml
+---
+name: <skill-slug>            # kebab-case, matches the directory name
+description: |               # block scalar; see format rules below
+  This skill should be used when the user asks to "<trigger 1>", "<trigger 2>",
+  ... or needs <specific outcome>. <One sentence on what it provides.>
+  Not for <X> — use <other-skill> for that.
+---
+```
+
+- `name`: kebab-case slug, **must equal the folder name**. (Plugin-namespaced skills appear as `plugin:skill` but the `name` field itself is the bare slug.)
+- `description`: a **YAML block scalar** (`|`) so it can span lines. This is the ONLY part of the skill always loaded into context — it is the trigger surface. See §5 for the exact format.
+
+### 1.2 Description format & length (the discovery/trigger engine)
+
+The description is loaded for **every** prompt; the body is loaded only when the skill fires. So the description must do two jobs in a tight budget: **fire at the right time** and **NOT fire at the wrong time**.
+
+Canonical format (from `skill-template.md` + validation-checklist + the exemplars):
+
+```
+This skill should be used when the user asks to "<trigger 1>", "<trigger 2>", "<trigger 3>",
+… or needs <specific outcome>. <1 sentence: what the skill provides / its domain>.
+Not for <adjacent case> — use <other-skill> for that. [repeat boundaries as needed]
+```
+
+Rules:
+- **5–12 concrete trigger phrases** — the literal words users actually type, in quotes. (validation-checklist: "`description` includes 5-12 concrete trigger phrases.")
+- **Lead with quoted trigger phrases**, then a capability sentence, then **explicit negative boundaries** ("Not for X — use Y").
+- **Length:** roughly 1–4 sentences / ~300–600 characters of substance. `ui-design` is deliberately terse (one scope sentence + one negative). `information-design` and `dev:typescript` are long (many quoted triggers + capability + multiple boundaries). For a skill that must **fire precisely and link out heavily**, model on the longer `information-design`/`dev:typescript` style: many triggers + clear negatives.
+- The `dev:typescript` skill already in this repo is the closest sibling — study its description: it enumerates ~15 quoted triggers, states the domain ("design medium, not a language tutorial"), and lists what it covers. Our skill must **carve a boundary against `dev:typescript`** (philosophy/architecture) so the two don't misfire on each other.
+
+### 1.3 Body section structure
+
+Two valid skeletons depending on doctrine. **We use the principle-first skeleton** (below), which is what `create-principles-skill` Stage 4 prescribes and what both exemplars instantiate.
+
+**Principle-first SKILL.md skeleton (adapt; do not copy verbatim):**
+
+1. **Title + one-line essence** — e.g. "Reduce complexity from first principles. Not cleanup — design."
+2. **Scope** — Use for / Not for (with redirects to sibling skills).
+3. **The Problem** — what agents get wrong *by default* in this domain and *why* (the mechanism). This is the hook that justifies the whole skill. (ui-design: "You will generate generic output… intent lives in prose, but code generation pulls from patterns.")
+4. **Where Defaults Hide** — the specific traps, each as: *what it looks like → why the agent does it → what principle it violates*. Summary here; deep version in `references/`.
+5. **Before Doing Anything** — the intent/diagnosis questions to answer *out loud* before acting. (ui-design "Intent First"; info-design "Before Structuring Anything".)
+6. **The Decision Axes** — a **table** of 4–7 axes: `Axis | Spectrum | What It Changes`. Each axis is a dial; moving it changes the output. Depth in `references/axes.md`.
+7. **The Mandate** — named self-checks to run *before delivering* (the "swap test", "logic test", etc.). This is the quality gate the agent applies to its own output.
+8. **Default Workflow** — ordered, actionable steps for the most common case (Assess → Diagnose → Design → Execute → Check).
+9. **Reference Map** — table: `Reference | Path | Open when`. Every reference linked here (one-hop rule).
+10. **Core Invariants** — `<invariants>` block with named `<invariant name="...">` tags (rules worth enforcing in review).
+11. **Anti-Patterns** — named, brief catalog (deep version in references/).
+12. **Failure Modes** — `Symptom → Fix` pairs.
+13. **Boundaries** — explicit "This skill is NOT …" naming adjacent skills.
+14. **Commands** (if any) — assess / reshape / critique trio.
+15. **Quick Start** — minimal steps for the most common entry point.
+
+Not every section is mandatory; but for a principle-first skill, sections 3–8 + 9 + 10 + 13 are the load-bearing bones. Drop sections that don't earn their place rather than padding.
+
+### 1.4 Length discipline (when to split to references/)
+
+- **SKILL.md stays lean and navigational.** It is the always-loaded-when-triggered interface; everything else is on-demand.
+- **The test (progressive-disclosure):** "Read only `SKILL.md`: can you follow the default workflow without guessing?" If yes, depth belongs in references/.
+- **Practical ceiling:** the exemplars run ~150–390 lines. `information-design` (~170 lines) is the better model for *lean* — it pushes all deep treatment to references (`where-defaults-hide.md`, `axes.md`, `principles.md`, `examples.md`). `ui-design` (~390 lines) is on the heavy side because it inlines a lot of craft detail; treat it as the *upper* bound, not the target.
+- **Split trigger:** when a section's depth exceeds what's needed to *follow the workflow*, move the depth to a reference and leave a 2–4 line summary + a link. "If a section grows, move depth into `references/` and keep `SKILL.md` navigational."
+- **Rule of thumb for ours:** aim for SKILL.md ≈ 150–250 lines. The Problem / Where Defaults Hide / Axes / Mandate stay summarized in SKILL.md; full catalogs (every default, every axis explained, before/after code transformations, the complexity-metric playbook) go to references.
+
+---
+
+## 2. PROGRESSIVE DISCLOSURE — what goes where
+
+Three buckets (hq:progressive-disclosure + resource-skill-builder writing workflow):
+
+| Bucket | Contains | Loaded when | Decision rule |
+|---|---|---|---|
+| **`SKILL.md`** | Purpose, when-to-trigger, the principles in summary, decision axes table, the mandate, default workflow, links | Every time the skill triggers | "If it must be read *every time* the skill triggers → SKILL.md." |
+| **`references/*.md`** | Deep treatment of each axis; full default/anti-pattern catalog; before/after worked examples; per-pattern playbooks; troubleshooting; the "theory behind" the principles | On demand, when a branch/variant needs it | "If it's only needed in *some* branches/variants → references/." |
+| **`assets/*`** | Copy-forward templates and skeleton outputs (e.g. a refactor-plan template, a complexity-audit report skeleton) — meant to be **copied into the output**, not read as docs | When producing an artifact | "If it's meant to be *copied into output* → assets/." |
+
+Operating rules:
+- **One-hop rule:** SKILL.md links directly to every reference/asset. No chains (`SKILL.md → ref-a → ref-b`).
+- **No orphans:** every file in references/ and assets/ must be linked from SKILL.md, or delete it. (Validator checks this: `missing = [name for name in ref_files if f"references/{name}" not in text]` must be empty.)
+- **References = documentation to read; assets = templates to copy.** Don't put heavy explanation in assets ("templates as documentation" anti-pattern); don't put copy-forward boilerplate in references.
+- **Split big references** into multiple small files; if a reference is large, add suggested search terms at the top.
+- **Progressive-disclosure test:** open each linked reference — does it earn its existence? If not linked → link or delete.
+
+For our skill specifically, a likely layout:
+- `references/where-defaults-hide.md` — the full catalog of TS complexity defaults (premature abstraction, type gymnastics, boolean-prop proliferation, over-generic generics, etc.).
+- `references/axes.md` — each decision axis explained with how position changes the refactor.
+- `references/principles.md` — the generative principles + the reasoning behind them.
+- `references/examples.md` — before/after worked refactors (the load-bearing proof).
+- `references/critique.md` — the post-refactor craft critique protocol.
+- `assets/refactor-plan-template.md` — copy-forward plan skeleton (only if it earns it).
+
+---
+
+## 3. PRINCIPLE-FIRST DESIGN — the core idea + concrete techniques
+
+**The central thesis** (create-principles-skill): a skill should **activate latent knowledge and teach how to THINK**, not list rules that expire. "Capture the durable thinking of a domain — decision frameworks that produce correct choices across contexts, not checklists that expire. The principles generate decisions; the skill doesn't just describe them."
+
+Why this matters for us: rules ("max 3 params", "no `any`") are brittle and context-blind. A complexity-reduction skill must produce the *right* call on code it has never seen — that requires generative principles + decision procedures, not a lint list.
+
+### Concrete techniques used to achieve "teach how to think":
+
+**(a) Name the failure mechanism, not just the failure.** The Problem section explains *why* the agent defaults ("intent lives in prose, but code generation pulls from patterns; the gap is where defaults win"). Naming the mechanism lets the agent self-detect it.
+
+**(b) "Where Defaults Hide" — make invisible decisions visible.** Defaults disguise themselves as infrastructure ("typography feels like a container"; "bullets feel like structure"). Each entry: *what it looks like → why you do it → what it violates*. For us: "premature abstraction feels like good engineering"; "a generic type parameter feels like flexibility."
+
+**(c) Intent-first / "Before Doing Anything" questions.** Force explicit answers (out loud, to self or user) before acting: who/what/how. For refactoring: *What is this code's actual job? What changes together? What is the simplest thing that could replace this? Who maintains it?* "If you cannot answer these specifically, stop. Ask. Do not default."
+
+**(d) Decision axes (the heart of generativity).** Replace rules with **dials**. A 4–7 row table: `Axis | Spectrum | What It Changes`. The axes are independent. The **decision test** validates each axis: "If I move the dial, does the output actually change in a meaningful way?" Kill any axis that doesn't change the decision; merge axes that always move together. (info-design's six axes are the model.)
+
+**(e) Principles in three tiers** (create-principles-skill Stage 2):
+- **Tier 1 — Universal** (always apply, regardless of axis position).
+- **Tier 2 — Axis-dependent** (apply when a given axis is in play).
+- **Tier 3 — Heuristics** (rules of thumb *with known exceptions*).
+Every principle must pass two tests:
+  - **Decision test:** applied to a concrete scenario, does it tell you to do something *different* than your default?
+  - **Swap test:** could you swap the principle for its opposite and get equivalent results? If yes, it's doing no work — sharpen or kill it.
+
+**(f) The Mandate — self-applied quality gates.** Named tests the agent runs on its *own* output before delivering. The naming makes them referenceable ("the swap test", "the squint test", "the logic test", "the noise test", "the scent test"). For us, invent domain-specific ones, e.g.:
+  - *The deletion test:* could this abstraction be deleted and the code get simpler? Then it's not earning its place.
+  - *The swap test:* if you swapped this refactor for "do nothing", would complexity meaningfully drop? If not, you didn't reduce complexity.
+  - *The reader test:* can someone unfamiliar follow the control flow without jumping between files?
+
+**(g) Principles vs rules — the explicit distinction.** Rules say *what*; principles say *why + how to decide*. The skill must justify every directive with reasoning so the agent can extrapolate. ("Every Choice Must Be A Choice — for every decision you must be able to explain WHY. If your answer is 'it's common' or 'it works' you haven't chosen, you've defaulted.")
+
+**(h) The skill is its own test case.** Apply the domain's principles to the skill's own structure. A complexity-reduction skill must itself be low-complexity and well-factored. If it violates its own mandate, either the mandate is wrong or the skill is.
+
+**(i) Exemplar-driven, not template-driven.** Absorb ui-design/information-design's *bones*, then adapt — don't fill in a template. "These are not templates to fill in. They're exemplars to absorb."
+
+---
+
+## 4. THE skill-doc-template (its shape, summarized)
+
+Two templates exist; pick per doctrine.
+
+**(A) hq `assets/skill-template.md` (operator-manual shape):** frontmatter (name+description) → `## Purpose` → `## When to use` → `## Non-goals / boundaries` → `## Default workflow` (numbered) → `## Reference map` (table) → `## Asset map` (table, optional) → `## Core invariants` (`<invariants>` block) → `## Anti-patterns to avoid` → `## Failure modes (symptom → fix)` → `## Quick start`. Designed to be copied, then trim unused sections.
+
+**(B) resource-skill-builder `references/skill-doc-template.md` (canonical-reference shape):** frontmatter → Subject and scope (+ out of scope) → Version + date context → Overview (1 para: what/why/problems solved) → Key concepts (mental model, optional Mermaid) → Common patterns (minimal snippets) → Best practices → Constraints and pitfalls → **Annotated sources** (grouped by `[Official]/[Maintainer]/[Community]`) → "How this relates to our world" (optional, observational) → Summary (3–5 takeaways + when-to-use + what-next).
+
+**For our skill:** use the **principle-first skeleton from §1.3** (which neither template fully captures — it comes from create-principles-skill Stage 4 and is realized in the exemplars). Borrow from (A) the invariants/failure-modes/reference-map mechanics, and from (B) the "Annotated sources" + version/date discipline if we cite external TS authority.
+
+---
+
+## 5. DESCRIPTION / TRIGGER writing rules
+
+The description is the firing mechanism. Get it right or the skill never runs (or runs constantly and annoys).
+
+**Do:**
+- Open with the canonical stem: `This skill should be used when the user asks to "…", "…", …`.
+- Include **5–12 quoted, literal trigger phrases** — the exact words a user types. For ours: "reduce complexity", "simplify this code", "refactor this", "this is over-engineered", "untangle this", "this file is too complex", "extract this", "flatten this abstraction", "remove this indirection", "first-principles refactor", "this has too many layers".
+- State the **capability/domain** in one sentence after the triggers.
+- Add **explicit negative boundaries** that name the sibling skill: `Not for general TypeScript architecture/philosophy — use the typescript skill. Not for safe-rename/move mechanics — use gitnexus-refactoring.`
+- Keep triggers **specific to this skill's job-to-be-done**; near-misses are fine to *exclude* via the negative boundary.
+
+**Don't:**
+- Trigger soup: a broad keyword dump ("code, refactor, clean, improve, fix, help") → constant misfires.
+- Vague verbs: "help", "stuff", "work with", "improve" *alone*.
+- Omit boundaries when an adjacent skill exists (here `dev:typescript`, `gitnexus-refactoring`, `simplify`/`code-review` slash commands all overlap — disambiguate explicitly).
+
+**Boundary collision check (mandatory for us):** there is already a `dev:typescript` skill and a `/simplify` command and `gitnexus-refactoring`. Our description MUST carve a non-overlapping lane: *first-principles complexity reduction & structural refactoring of TS* vs. typescript=*design philosophy/architecture reference*, /simplify=*apply quick cleanups to the current diff*, gitnexus-refactoring=*mechanical rename/move/extract via the graph*. Validation-checklist: "If the skill is easy to confuse with another, document a boundary ('do not use when …')."
+
+---
+
+## 6. ASSETS vs REFERENCES — distinction + naming
+
+| | `references/` | `assets/` |
+|---|---|---|
+| **Purpose** | Documentation the agent *reads* for depth | Templates/skeletons the agent *copies* into output |
+| **Loaded** | On demand, into context, to inform reasoning | Copied/instantiated, not "read as docs" |
+| **Content** | Variants, deep patterns, checklists, troubleshooting, failure modes, theory, worked examples | Copy-forward templates, skeleton outputs, copy-forward checklists; only minimal embedded guidance (short comments OK) |
+| **Anti-pattern** | "duplicate truth" (copy/pasting canonical docs without a reason) | "templates as documentation" (heavy explanation belongs in references, not assets) |
+| **Invariant** | linked from SKILL.md (no orphans) | "Assets are meant to be copied into outputs, not loaded as docs" + must be copy-ready without hidden context |
+
+**Naming conventions:**
+- Files are kebab-case `.md` (for references). Name by *what they're for / when opened*, not by sequence: `where-defaults-hide.md`, `axes.md`, `principles.md`, `examples.md`, `critique.md`. (resource-skill-builder: "one file per subdomain", e.g. `deployment.md`, `react.md`.)
+- The folder slug = the `name` field = kebab-case.
+- Assets named by the artifact they produce: `refactor-plan-template.md`, `complexity-audit-report.md`.
+- Avoid deep nesting; keep references/ and assets/ flat (one level).
+
+---
+
+## 7. QUALITY GATES / VALIDATION — what makes a skill pass review
+
+Combine three checklists into one definition-of-done.
+
+### 7.1 hq validation-checklist (the 14-gate baseline)
+
+**Frontmatter & triggering**
+- [ ] Frontmatter contains only `name` and `description`.
+- [ ] `description` includes 5–12 concrete trigger phrases (what users actually say).
+- [ ] No vague triggers ("help", "stuff", "work with").
+- [ ] If confusable with another skill, an explicit boundary is documented ("do not use when …").
+
+**SKILL.md body (operator manual)**
+- [ ] Purpose and boundaries are explicit.
+- [ ] Default workflow is ordered and actionable (not prose-only).
+- [ ] SKILL.md is navigational, not encyclopedic.
+- [ ] Reference/asset maps exist and are accurate.
+
+**Progressive disclosure**
+- [ ] Deep detail lives in `references/` (not in SKILL.md).
+- [ ] No orphan references/assets (everything linked from SKILL.md).
+- [ ] Assets are copy-ready without hidden context.
+
+**Failure modes & safety**
+- [ ] At least one failure mode documented (symptom → fix).
+- [ ] High-risk ambiguity requires an explicit "ask and stop" rule.
+
+**Regression guard (for refactors)**
+- [ ] Important content was moved, not silently dropped.
+- [ ] Paths referenced in docs exist and are correct.
+
+### 7.2 Principle-first additional gates (create-principles-skill Stage 6 + process invariants)
+
+- [ ] **Decision test on every axis:** moving the dial changes the output. No dead axes.
+- [ ] **Decision + swap test on every principle:** it changes behavior vs. default; its opposite would NOT give equivalent results.
+- [ ] **Anti-patterns are recognizable, mapped, and remediated:** each is self-detectable, mapped to a specific principle violation, and has a concrete "instead, do this".
+- [ ] **The skill passes its own mandate** (apply the domain's principles to the skill's own structure).
+- [ ] **60-second skim test:** someone skimming SKILL.md knows what it does.
+- [ ] **Reference structure matches how the skill is USED, not how it was researched.**
+- [ ] **The open-ended case works:** if a user says "this code is a mess, fix it", the skill gives enough guidance to act.
+- [ ] **Durability:** would these principles still be correct in 5 years? (Avoid time-bound project status, version-pinned trivia in SKILL.md.)
+- [ ] **Boundary clarity with adjacent skills** (no confusing trigger overlaps).
+- [ ] All cross-references resolve (no broken paths). Run the sync validator.
+
+### 7.3 Common failure modes to AVOID (named, so review can cite them)
+
+- **Trigger soup** — broad keyword dump → constant misfires. (Fix: specific quoted triggers + negative boundaries.)
+- **Wall of text** — everything in SKILL.md, nothing navigable. (Fix: push depth to references/.)
+- **Orphan references** — deep docs exist but SKILL.md never links them. (Fix: link or delete.)
+- **Duplicate truth** — copy/pasting canonical docs without reason. (Fix: synthesize, link, don't mirror.)
+- **Templates as documentation** — heavy explanation in assets. (Fix: explanation → references; assets stay copy-ready.)
+- **Rules without reasoning** — directives with no "why" → agent can't extrapolate. (Fix: every directive earns a principle/justification.)
+- **Frontmatter drift** — any key beyond name/description → sync validator fails.
+- **Decorated, not designed** — formatting (bold/bullets/rules) substituting for actual structure. (Fix: the logic test — remove formatting, does the flow hold?)
+
+### 7.4 Mechanical validation (run before "done")
+
+The sync-and-validate Python check asserts (1) YAML frontmatter exists, (2) top-level keys ⊆ {name, description}, (3) every `references/*.md` is linked in SKILL.md. Run an equivalent check on our skill before shipping even if we don't sync to Codex. Also: confirm every path mentioned in the reference/asset maps actually exists.
+
+---
+
+## 8. CROSS-LINKING to OTHER skills (critical — ours must link out heavily)
+
+This is a first-class concern for our skill, which is meant to be a hub that routes into the broader TS ecosystem.
+
+**How the canon handles cross-linking:**
+- **Boundaries section names siblings explicitly** (information-design's "This skill is not:" lists diataxis, docs-architecture, style guides, data-viz — each with the *distinction* and the *redirect*). Do the same: name `dev:typescript`, `gitnexus-refactoring`, `dev:vercel-composition-patterns`, `/simplify`, `/code-review`, and say when to defer to each.
+- **Scope redirects inline** (ui-design: "Not for … Redirect those to `/frontend-design`").
+- **Commands listed** as a trio at the bottom (`/info:assess`, `/info:reshape`, `/info:critique`) — if we build companion commands, surface them here.
+- **create-principles-skill Stage Pre/Step 2 ("Ground in the domain")** — before authoring, read adjacent skills' SKILL.md and write an `adjacency-map.md` noting concepts to reference, boundaries to respect, handoff points. This is the *input* that makes good cross-links possible.
+- **Reference Map / Asset Map tables** are the in-skill navigation surface; the **Boundaries** + **Commands** sections are the out-of-skill navigation surface.
+- **Cross-reference contract (multi-agent-orchestration "Integration contract"):** "Ensure each reference links to related references (cross-reference map). Resolve conflicts explicitly." If our references cross-cite each other, keep a coherent cross-reference map and avoid contradictions.
+
+**Concrete recommendation for our skill:** add a **"Related skills / when to hand off"** subsection (inside Boundaries) as a table: `Skill | Use instead when | What it owns`. List `dev:typescript` (philosophy/architecture decisions), `gitnexus-refactoring` (graph-safe mechanical rename/move/extract), `dev:vercel-composition-patterns` (React-specific composition), `cognition:information-design` / `cognition:system-design` (for non-code structural reasoning), and the `/simplify` + `/code-review` slash commands (diff-scoped cleanup vs. structural redesign). This both prevents trigger collisions and makes the skill a genuine hub.
+
+---
+
+## 9. THE BLUEPRINT (concrete + prescriptive)
+
+### 9.1 Frontmatter spec (drop-in)
+
+```yaml
+---
+name: <our-slug>            # e.g. typescript-refactoring or reduce-complexity (kebab; = folder name)
+description: |
+  This skill should be used when the user asks to "reduce complexity", "simplify this code",
+  "refactor this", "untangle this", "this is over-engineered", "this file is too complex",
+  "flatten this abstraction", "remove this indirection", "first-principles refactor",
+  "extract this", or needs to redesign TypeScript code to be structurally simpler.
+  Provides generative principles for finding the real shape of a problem, removing premature
+  abstraction and indirection, and reducing complexity from first principles.
+  Not for general TypeScript design/architecture philosophy — use the typescript skill.
+  Not for graph-safe mechanical rename/move/extract — use gitnexus-refactoring.
+  Not for diff-scoped quick cleanups — use the /simplify command.
+---
+```
+
+### 9.2 Section skeleton (use this for SKILL.md)
+
+```
+# <Title — e.g. "Reduce Complexity From First Principles">
+<one-line essence: "Not cleanup — design. Find the real shape, then remove everything else.">
+
+## Scope            (Use for / Not for + redirects)
+
+## The Problem      (what agents do by default in TS + the mechanism — why)
+
+## Where Defaults Hide   (the traps, summarized; → references/where-defaults-hide.md)
+
+## Before Touching Code  (intent/diagnosis questions to answer out loud)
+
+## The Decision Axes     (table: Axis | Spectrum | What It Changes; → references/axes.md)
+
+## The Mandate           (named self-checks: deletion test, swap test, reader test…)
+
+## Default Workflow      (Assess → Diagnose → Design → Refactor → Verify, numbered)
+
+## Reference Map         (table: Reference | Path | Open when)
+
+## Core Invariants       (<invariants> with named tags)
+
+## Anti-Patterns         (named, brief; deep → references/where-defaults-hide.md)
+
+## Failure Modes         (Symptom → Fix)
+
+## Boundaries            ("This skill is NOT…" + Related-skills handoff table)
+
+## Commands              (if we build assess/reshape/critique companions)
+
+## Quick Start           (minimal steps for the most common request)
+```
+
+### 9.3 Progressive-disclosure rules (apply mechanically)
+
+1. SKILL.md target ≈ 150–250 lines, navigational. If a section's depth exceeds "enough to follow the workflow", split it.
+2. Each axis/default/principle: 1-line summary in SKILL.md, full treatment in references/.
+3. Worked before/after refactors → `references/examples.md` (NOT SKILL.md).
+4. Copy-forward artifacts (refactor plan, audit report) → `assets/` only if they'll actually be copied.
+5. One-hop, no-orphans: every reference/asset linked from SKILL.md; every link resolves.
+
+### 9.4 Principle-first techniques to apply (checklist for authoring)
+
+- [ ] Open with The Problem + the *mechanism* of the default.
+- [ ] Build "Where Defaults Hide" as *what it looks like → why → what it violates*.
+- [ ] Force intent questions before action ("ask and stop" if unanswerable).
+- [ ] Express the method as 4–7 **decision axes** (table), each passing the decision test.
+- [ ] Write principles in 3 tiers (universal / axis-dependent / heuristics); each passes decision + swap tests.
+- [ ] Define named **mandate self-checks** the agent runs on its own output.
+- [ ] Justify every directive with a "why" (no rules without reasoning).
+- [ ] Make the skill obey its own mandate (low-complexity, well-factored).
+- [ ] Adapt ui-design / information-design bones; don't fill a template.
+
+### 9.5 Quality-gate checklist (definition of done — run before shipping)
+
+- [ ] Frontmatter = name + description only (mechanical check passes).
+- [ ] Description: 5–12 quoted triggers + capability sentence + explicit negative boundaries naming `dev:typescript`, `gitnexus-refactoring`, `/simplify`.
+- [ ] SKILL.md lean (~150–250 lines), navigational; deep content in references/.
+- [ ] Reference Map + Asset Map present and accurate; no orphans; all paths resolve.
+- [ ] Every decision axis passes the decision test (dial moves → output changes).
+- [ ] Every principle passes decision + swap tests.
+- [ ] Anti-patterns are self-detectable, mapped to a principle, and have a remedy.
+- [ ] ≥1 failure mode (symptom → fix); high-risk ambiguity → explicit "ask and stop".
+- [ ] 60-second skim test passes; open-ended "this is a mess, fix it" case is answerable.
+- [ ] The skill passes its own mandate.
+- [ ] Durable (no time-bound trivia in SKILL.md); would hold in 5 years.
+- [ ] Boundaries clear vs. all adjacent skills (no trigger collision).
+- [ ] Cross-links: Boundaries section has a Related-skills handoff table; references cross-cite coherently.
+
+### 9.6 Authoring process (lift from create-principles-skill, lightweight)
+
+1. **Ground:** read adjacent skills (`dev:typescript`, `gitnexus-refactoring`, `cognition:system-design`, `vercel-composition-patterns`), write an adjacency map (concepts to reference, boundaries, handoffs).
+2. **Research → write before you synthesize:** capture raw source material to file before interpreting (authority-weighted; tag `[Official]/[Maintainer]/[Community]`).
+3. **Axes:** extract 4–7 decision axes; kill dead ones (decision test).
+4. **Principles:** three tiers; decision + swap tests.
+5. **Defaults:** catalog TS complexity anti-patterns (recognizable → mapped → remedy).
+6. **Architecture:** decide SKILL.md vs references vs assets; produce an outline; confirm.
+7. **Write:** SKILL.md first (the interface), then references in reach-for order.
+8. **Validate:** run §9.5; run mechanical frontmatter/link check; run the skill's own mandate against itself; finally run `info:critique` on the SKILL.md.
+```

--- a/docs/projects/typescript-refactoring-skill/research/r4a-smells.md
+++ b/docs/projects/typescript-refactoring-skill/research/r4a-smells.md
@@ -1,0 +1,733 @@
+# r4a — Code Smells: A TypeScript-Oriented Synthesis
+
+> **Primary source.** This document is an original synthesis built on the code-smell
+> catalog and refactoring philosophy of **Refactoring.Guru** (Alexander Shvets,
+> https://refactoring.guru/refactoring/smells), which in turn distills Martin Fowler's
+> *Refactoring* and Kent Beck's "code smell" vocabulary. The taxonomy (5 categories,
+> 23 smells), the per-smell structure (signs / reasons / treatments), and the named
+> refactorings are theirs. Everything below is rewritten in our own words and
+> re-grounded in modern TypeScript/JavaScript: the *prose is original*, the *examples
+> and detection tooling are TS-native*, and the *citations point back to RG*. We do not
+> reproduce RG's text.
+
+---
+
+## Part 1 — Refactoring philosophy (first principles)
+
+### 1.1 What refactoring is
+
+Refactoring is changing the **internal structure** of code without changing its
+**external behavior**. The behavior contract is held fixed — same inputs, same outputs,
+same observable side effects — while the shape of the code underneath is improved. Per
+RG, the purpose is to fight **technical debt**: to transform a mess into clean code and
+a simpler design.
+
+The discipline is the *behavior-preservation* clause. If observable behavior changes,
+that is not refactoring — it is a feature change or a bugfix wearing refactoring's
+clothes. In TypeScript the type system gives you an extra preservation surface: a refactor
+should also leave the **public type signature** of a module/function stable (or strictly
+widen it in a compatible way) unless tightening types *is* the refactor.
+
+### 1.2 What "clean code" means
+
+Synthesizing RG's definition for a TS context, clean code is:
+
+- **Obvious to other readers.** Not clever — clear. Good names beat magic numbers,
+  stringly-typed flags, and bloated functions. In TS this extends to *types as
+  documentation*: a well-named union or branded type explains intent without comments.
+- **Free of duplication.** Every duplicated fragment is a place you must remember to
+  edit in lockstep. Duplication raises cognitive load and is a bug incubator.
+- **Minimal in moving parts.** Fewer classes, functions, and abstractions to hold in
+  your head. *Code is a liability, not an asset* — keep it short and simple. (This is
+  the antidote to Speculative Generality.)
+- **Fully tested / fully type-checked.** RG's bar is "passes all tests." In TS we add:
+  `tsc --noEmit` is green under `strict`, and there are no escape hatches (`any`,
+  `as`, `@ts-ignore`, `!`) silently disabling the checker.
+- **Cheap to maintain.** The payoff of all the above.
+
+### 1.3 The technical-debt metaphor
+
+RG attributes the metaphor to Ward Cunningham. Shipping unclean code is like taking a
+loan: you move faster *now* and pay **interest** later — every future change against the
+messy code is slower and riskier. Skipping tests, leaving kludges to hide unfinished
+work, and deferring refactoring all draw down the principal. The danger is the same as
+real debt: interest can compound until the cost of change exceeds your capacity to
+deliver. RG's catalog of debt causes maps cleanly onto TS teams:
+
+| RG cause | TS-flavored manifestation |
+| --- | --- |
+| Business pressure | `as any` to "make it compile" before a deadline; `// @ts-ignore` on a red line |
+| Not understanding the consequences | treating `strict: false` as permanent rather than a migration waypoint |
+| Tight component coupling | barrel files and god modules that import everything; circular imports |
+| Lack of tests | refactors done blind because there's no green suite to confirm preservation |
+| Lack of documentation | types *are* the docs in TS; weak types = undocumented contracts |
+| Long-lived divergent branches | merge-time type drift between parallel feature branches |
+| Delayed refactoring | a smell left alone accretes dependents that must all move later |
+| No compliance monitoring | no ESLint/`tsc` gate in CI; each author writes "their way" |
+
+### 1.4 When to refactor
+
+RG names four moments. Treat them as triggers, not a scheduled chore:
+
+1. **The Rule of Three.** First time, just write it. Second time, wince but duplicate.
+   Third time, refactor. Two occurrences can be coincidence; three is a pattern that
+   has earned an abstraction. This guards against premature abstraction (the cure for
+   Speculative Generality is *not* abstracting on the first instance).
+2. **When adding a feature.** Refactor first to understand and to make room. It is far
+   cheaper to extend clean code than to bolt onto a mess. Refactoring someone else's
+   dirty code is how you *learn* it.
+3. **When fixing a bug.** Bugs nest in the dirtiest code. Cleaning the area often makes
+   the defect self-evident. In TS, tightening a loose type (e.g., turning a wide
+   `string` into a union) frequently surfaces the bug at compile time.
+4. **During code review.** The last cheap moment to tidy before code goes public. Best
+   done with the author present.
+
+### 1.5 How to refactor safely
+
+RG's safety rules, restated for a TS workflow:
+
+- **Small, behavior-preserving steps.** A refactor is a *sequence* of tiny changes, each
+  leaving the program working. Don't batch a dozen restructurings into one commit — that
+  is how you lose the thread and can't tell which step broke something.
+- **Keep the build and tests green throughout.** After each step: `tsc --noEmit` passes,
+  tests pass, lint passes. If a step breaks tests, either you made an error (fix it) or
+  your tests were too low-level (testing private internals); the latter means the tests,
+  not the refactor, are wrong. Prefer behavior-level (BDD-style) tests so structure can
+  move freely underneath them.
+- **Wear one hat at a time.** *Refactoring* and *adding functionality* are separate
+  activities. Don't create new behavior mid-refactor; isolate the two at least at the
+  commit boundary. In TS this also means: don't sneak a type-tightening that changes
+  runtime behavior into a "pure rename" commit.
+- **Know when to stop — or to rewrite.** If the code is no cleaner after an hour, you
+  either over-batched or the code is past incremental help. Sometimes the right call is
+  a bounded rewrite — but only behind tests and with time budgeted, or you reproduce the
+  original mess.
+
+### 1.6 Why smells matter (the through-line)
+
+A *code smell* is a surface symptom that usually points to a deeper design problem. Smells
+are heuristics, not laws — RG repeatedly lists "When to Ignore." The skill is to (a)
+recognize the smell, (b) diagnose the underlying weakness, (c) pick the smallest
+refactoring that removes the cause, and (d) verify behavior is preserved. The five
+categories below organize the 23 smells by the *kind* of damage they do.
+
+---
+
+## Part 2 — The five smell categories (with TS through-lines)
+
+RG groups the smells into five families by failure mode. Each family has a characteristic
+TypeScript signature:
+
+1. **Bloaters** — code/functions/classes that have grown to unwieldy size. They
+   accumulate; nobody removes anything. *TS through-line:* megafunctions, god modules,
+   primitive-typed everything, sprawling parameter lists, repeated field groups that want
+   to be an `interface`.
+
+2. **Object-Orientation Abusers** — incomplete or wrong application of OO/polymorphism.
+   *TS through-line:* `switch`/`if` ladders that should be discriminated unions with
+   `never` exhaustiveness; optional props that are only sometimes valid; inheritance used
+   where composition belongs; two modules doing the same job with mismatched signatures.
+
+3. **Change Preventers** — structure such that one logical change forces edits in many
+   places (or many unrelated changes land in one place). *TS through-line:* poor module
+   boundaries, leaky cross-cutting concerns, type definitions duplicated across files so a
+   shape change is a multi-file edit.
+
+4. **Dispensables** — things whose *absence* makes the code better: narration comments,
+   duplication, do-nothing classes, anemic data holders, dead code, and "just in case"
+   generality. *TS through-line:* unused exports, unreachable branches, `any`-typed
+   pass-through wrappers, over-parameterized generics nobody instantiates differently.
+
+5. **Couplers** — excessive coupling, or its over-correction into excessive delegation.
+   *TS through-line:* functions reaching deep into another object's fields, `a.b.c.d`
+   chains, modules importing each other's internals, pass-through facades that only
+   forward calls.
+
+| Category | Members | TS detection focus |
+| --- | --- | --- |
+| Bloaters | Long Method · Large Class · Primitive Obsession · Long Parameter List · Data Clumps | `max-lines-per-function`, `max-params`, `complexity`, branded types, options objects |
+| OO Abusers | Switch Statements · Temporary Field · Refused Bequest · Alternative Classes w/ Different Interfaces | exhaustive-switch lint, discriminated unions, `jscpd` on near-twin modules |
+| Change Preventers | Divergent Change · Shotgun Surgery · Parallel Inheritance Hierarchies | `madge`/`dpdm` graph fan-in/out, "edit-count per change" review heuristic |
+| Dispensables | Comments · Duplicate Code · Lazy Class · Data Class · Dead Code · Speculative Generality | `knip`/`ts-prune`, `jscpd`, comment-density grep, generic-arity audit |
+| Couplers | Feature Envy · Inappropriate Intimacy · Message Chains · Middle Man · Incomplete Library Class | LCOM-style locality, `madge --circular`, chain-depth grep, module-`@internal` boundaries |
+
+---
+
+## Part 3 — The 23 smells (TypeScript field guide)
+
+Each entry: **Signs & symptoms** (detect) → **Why it happens / why it hurts** → **Treatment**
+(RG refactorings by name) → **TypeScript manifestation** → **Detection signal**
+(greppable / tooling). Refactoring names in *italics* are RG's named techniques.
+
+---
+
+### Bloaters
+
+#### 1. Long Method
+
+- **Signs & symptoms.** A function whose body is long enough that you can't hold it in
+  your head; RG's rule of thumb: start asking questions past ~10 lines. Telltale: you feel
+  the urge to add a *comment* explaining the next block — that block wants to be its own
+  function.
+- **Why it happens / why it hurts.** It is always easier to append a line than to extract
+  a function ("it's just two lines…"), so methods grow monotonically. Long functions are
+  hard to understand, hard to test in isolation, and are the ideal hiding place for
+  duplicated logic.
+- **Treatment.** *Extract Method* is the workhorse. When locals/params block extraction,
+  *Replace Temp with Query*, *Introduce Parameter Object*, or *Preserve Whole Object*. For
+  conditionals, *Decompose Conditional*; for stubborn cases, *Replace Method with Method
+  Object*; for tangled algorithms, *Substitute Algorithm*.
+- **TypeScript manifestation.** A 200-line React component or an Express handler doing
+  validation + business logic + persistence + serialization inline. Extract pure helper
+  functions; in components, extract custom hooks and child components. A comment like
+  `// build the request payload` above a block is a named-function in disguise.
+- **Detection signal.** ESLint `max-lines-per-function`, `complexity`,
+  `max-statements`, `max-depth`. `grep -rn "// " src | wc -l` correlates with narration
+  blocks. `madge`/coverage: long functions tend to have low branch coverage.
+
+#### 2. Large Class
+
+- **Signs & symptoms.** A class (or, in TS, a module/service/store) with too many fields,
+  methods, and lines — "wearing too many hats."
+- **Why it happens / why it hurts.** Same gravity as Long Method: it is easier to add to
+  an existing class than to create a new one. The result violates Single Responsibility;
+  you must keep a huge surface in your head, and unrelated concerns change together.
+- **Treatment.** *Extract Class* (spin off cohesive behavior), *Extract Subclass* (variant
+  behavior), *Extract Interface* (publish the contract clients use). For UI-bound state,
+  *Duplicate Observed Data* to split presentation from domain.
+- **TypeScript manifestation.** A `UserService` of 1,500 lines, or a Zustand/Redux slice
+  that owns auth + cart + telemetry. Also the **god module**: an `index.ts` re-exporting
+  everything so the file becomes the de-facto class. Split by responsibility into focused
+  modules; expose a narrow `interface` per consumer.
+- **Detection signal.** ESLint `max-lines` (per file), `max-classes-per-file`; method
+  count via a custom rule. High **fan-in** on a single module in `madge`/`dpdm` graphs.
+  LCOM (lack of cohesion) tools flag classes whose methods touch disjoint field sets.
+
+#### 3. Primitive Obsession
+
+- **Signs & symptoms.** Using raw primitives for domain concepts (currency, phone number,
+  user-id, email, ranges); using bare constants as type codes (`const ROLE_ADMIN = 1`);
+  using string keys as pseudo-fields into loose objects/arrays.
+- **Why it happens / why it hurts.** A primitive field is cheaper to type than a class, so
+  it proliferates. Result: validation and behavior tied to the concept are scattered, and
+  unrelated values of the same primitive type are freely (and wrongly) interchangeable —
+  the compiler can't stop you passing a `userId` where an `orderId` is expected.
+- **Treatment.** *Replace Data Value with Object*; for params, *Introduce Parameter Object*
+  / *Preserve Whole Object*; for type codes, *Replace Type Code with Class /
+  Subclasses / State/Strategy*; for array-as-record, *Replace Array with Object*.
+- **TypeScript manifestation.** This is the canonical TS smell. **Stringly-typed code**
+  (`status: string`) should be a **union** (`status: "active" | "suspended" | "closed"`).
+  Interchangeable ids should be **branded/nominal types**:
+  ```ts
+  type UserId = string & { readonly __brand: "UserId" };
+  type OrderId = string & { readonly __brand: "OrderId" };
+  // now fn(userId: UserId) rejects an OrderId at compile time
+  ```
+  Validated primitives (email, positive int) become branded types minted by a parser
+  (Zod `.brand()`, or a `parseEmail(): Email` smart constructor). Magic numbers/strings →
+  `as const` objects or enums-as-unions.
+- **Detection signal.** `grep -rnE ': (string|number)\b' src` density on domain fields;
+  high count of bare string/number literals in conditionals. Type-coverage tools
+  (`type-coverage`) reward replacing wide primitives. Lint: `@typescript-eslint/no-magic-numbers`.
+
+#### 4. Long Parameter List
+
+- **Signs & symptoms.** More than ~3–4 parameters; especially several booleans or several
+  of the same type in a row (call sites become positional guessing games).
+- **Why it happens / why it hurts.** Merging algorithms into one function, or
+  decoupling object creation from use, pushes data in through parameters. Long lists are
+  hard to read, easy to misorder, and resist change.
+- **Treatment.** *Replace Parameter with Method Call* (when an arg is derivable),
+  *Preserve Whole Object* (pass the object, not its fields), *Introduce Parameter Object*
+  (group related args). RG caveat: don't add coupling just to shorten a list.
+- **TypeScript manifestation.** The **options object** is the idiomatic fix:
+  ```ts
+  // smell
+  function createUser(name: string, email: string, isAdmin: boolean, notify: boolean) {}
+  // cure — named, order-free, self-documenting, easily extended
+  function createUser(opts: { name: string; email: string; isAdmin?: boolean; notify?: boolean }) {}
+  ```
+  Multiple same-typed positional params (`drawRect(x, y, w, h)`) are a swap-hazard the
+  compiler can't catch; an object or branded coords fix it. Boolean params are a double
+  smell (also see Switch/flag): prefer a union (`mode: "create" | "update"`).
+- **Detection signal.** ESLint `max-params` (set to 3–4). `grep -rnE '\([^)]*,[^)]*,[^)]*,[^)]*,' src`
+  for 4+ comma call signatures. Consecutive same-type params show up in review; a custom
+  lint or TS AST scan can flag `(a: string, b: string, c: string)`.
+
+#### 5. Data Clumps
+
+- **Signs & symptoms.** The same group of values travels together repeatedly — as
+  parameters (`x, y`), as fields (`street, city, zip`), as the same trio of DB-connection
+  args. RG's litmus test: delete one value; if the rest stop making sense, they're a clump.
+- **Why it happens / why it hurts.** Copy-paste and incremental growth. The clump is an
+  un-named concept; its members can drift apart, and behavior over the group has nowhere
+  cohesive to live.
+- **Treatment.** *Extract Class* (clump-as-fields), *Introduce Parameter Object*
+  (clump-as-params), *Preserve Whole Object* (pass the new object onward). Then migrate
+  behavior onto the new type.
+- **TypeScript manifestation.** Repeated inline shapes begging for a named `interface`/
+  `type`:
+  ```ts
+  // clump appears in 6 signatures
+  function ship(street: string, city: string, zip: string) {}
+  function tax(street: string, city: string, zip: string) {}
+  // extract the concept
+  interface Address { street: string; city: string; zip: string }
+  function ship(addr: Address) {}
+  ```
+  In TS the clump is often *already* a duplicated anonymous object type — DRY it into one
+  exported interface so a field change is one edit (also kills latent Shotgun Surgery).
+- **Detection signal.** `jscpd` flags repeated literal shapes. A grep for the same
+  ordered param triple: `grep -rnE 'street: string, city: string, zip: string' src`.
+  Repeated inline object-type literals across files are reviewable; some AST tools detect
+  structurally identical anonymous types.
+
+---
+
+### Object-Orientation Abusers
+
+#### 6. Switch Statements
+
+- **Signs & symptoms.** A complex `switch`, or an `if/else if` ladder, branching on a
+  type code or mode — and the *same* branching logic appears in several places, so adding
+  a case means hunting down every copy.
+- **Why it happens / why it hurts.** Procedural habits in an OO/typed setting. Scattered
+  switches on the same discriminant are change-amplifiers: a new variant touches N sites,
+  and it's easy to miss one.
+- **Treatment.** RG: "when you see `switch`, think polymorphism." Localize via *Extract
+  Method* + *Move Method*; for type codes, *Replace Type Code with Subclasses* or *…with
+  State/Strategy*; then *Replace Conditional with Polymorphism*. For null branches,
+  *Introduce Null Object*. RG's "ignore" cases: trivial switches, and factory-pattern
+  selection.
+- **TypeScript manifestation.** The signature TS move is the **discriminated union with a
+  `never` exhaustiveness check** — keep the switch but make the compiler enforce
+  totality:
+  ```ts
+  type Shape =
+    | { kind: "circle"; r: number }
+    | { kind: "square"; s: number };
+  function area(sh: Shape): number {
+    switch (sh.kind) {
+      case "circle": return Math.PI * sh.r ** 2;
+      case "square": return sh.s ** 2;
+      default: { const _exhaustive: never = sh; return _exhaustive; } // compile error if a case is added
+    }
+  }
+  ```
+  This converts "scattered, non-exhaustive switch" into "one switch the compiler forces
+  you to complete." Where behavior (not just data) varies, a **Strategy** record
+  (`Record<Kind, () => T>`) or polymorphic classes beat the switch entirely.
+- **Detection signal.** ESLint `@typescript-eslint/switch-exhaustiveness-check`
+  (requires `default` handling / errors on missing union members);
+  `no-fallthrough`; `default-case`. `grep -rnE '\bswitch\s*\(' src` then check each for a
+  `never` guard. Repeated switches on the same discriminant: grep the discriminant name.
+
+#### 7. Temporary Field
+
+- **Signs & symptoms.** A field that holds a meaningful value only during a specific
+  operation and is empty/`null`/`undefined` the rest of the time. You expect object state
+  to be populated, but it's usually blank.
+- **Why it happens / why it hurts.** To avoid a long parameter list, an algorithm's
+  intermediate inputs get parked on instance fields. Readers can't tell when the field is
+  valid; invariants live in the programmer's head, not the type.
+- **Treatment.** *Extract Class* / *Replace Method with Method Object* (move the algorithm
+  and its scratch fields into a dedicated object that lives only for the computation).
+  *Introduce Null Object* to replace existence checks.
+- **TypeScript manifestation.** Optional props that are "sometimes set" are the TS
+  signature: `interface Job { status: string; error?: string; result?: T }`. Model the
+  *states* as a **discriminated union** so impossible combinations are unrepresentable:
+  ```ts
+  type Job<T> =
+    | { status: "pending" }
+    | { status: "done"; result: T }       // result present iff done
+    | { status: "failed"; error: string };// error present iff failed
+  ```
+  This is "make illegal states unrepresentable." Scratch fields on a class become locals
+  in an extracted function or fields on a short-lived helper object.
+- **Detection signal.** `grep -rnE '\?\s*:' src` density of optional props on a single
+  type, especially several that are mutually exclusive. Frequent `if (this.x !== undefined)`
+  guards on a field. `strictNullChecks` makes the optionals visible; clusters of `!`
+  non-null assertions on the same field point here.
+
+#### 8. Refused Bequest
+
+- **Signs & symptoms.** A subclass uses only part of what it inherits; the unused members
+  go dead, or are overridden to throw ("not supported here").
+- **Why it happens / why it hurts.** Inheritance chosen for code reuse alone, between
+  classes that aren't truly an *is-a*. It breaks the Liskov substitution principle: a
+  client holding the base type can call a method the subclass refuses.
+- **Treatment.** If the relationship is bogus, *Replace Inheritance with Delegation*
+  (compose instead). If inheritance is genuine but the base is too fat, *Extract
+  Superclass* — pull the shared parts into a new common parent both classes extend.
+- **TypeScript manifestation.** A subclass overriding to `throw new Error("unsupported")`,
+  or implementing an `interface` with stubbed members. Prefer **composition over
+  inheritance** and **narrow interfaces** (Interface Segregation): split a fat interface so
+  classes implement only what they truly support. TS's structural typing means you rarely
+  *need* inheritance for reuse — a shared module of functions or an injected dependency is
+  usually cleaner.
+- **Detection signal.** `grep -rnE 'throw new (Error|TypeError)\(.*(not |un)support' src`
+  for refusal stubs. Overrides that ignore the parent entirely; methods that `super` is
+  never called from. Review heuristic: any `extends` where the subclass overrides most
+  methods.
+
+#### 9. Alternative Classes with Different Interfaces
+
+- **Signs & symptoms.** Two classes/modules do essentially the same job but expose
+  different method names and signatures, so callers can't treat them interchangeably.
+- **Why it happens / why it hurts.** Whoever wrote the second one didn't know the first
+  existed. You get duplicated capability with no shared abstraction, and clients hard-code
+  to one or the other.
+- **Treatment.** Converge the interfaces: *Rename Method*, *Move Method*, *Add Parameter*,
+  *Parameterize Method* until signatures match; *Extract Superclass* for shared behavior;
+  then delete the redundant class. RG "ignore": when the twins live in third-party libs you
+  can't unify.
+- **TypeScript manifestation.** Two `HttpClient`s — `get()/post()` vs `fetchData()/send()`
+  — that should satisfy one **interface**. Because TS is structurally typed, defining a
+  common `interface` and aligning method names lets both be used polymorphically without an
+  inheritance hierarchy. When you can't change a third-party twin, wrap it with an
+  **Adapter** to the common interface (links to Incomplete Library Class).
+- **Detection signal.** `jscpd` / `find_semantic_clones`-style tools flag two modules with
+  near-identical bodies and different names. Review: two types with the same fields/return
+  shapes but divergent method names. Grep for duplicated domain nouns across modules
+  (`grep -rniE 'class .*Client' src`).
+
+---
+
+### Change Preventers
+
+#### 10. Divergent Change
+
+- **Signs & symptoms.** One class/module must be edited for *many unrelated reasons* — add
+  a product type and you touch find, display, and order methods in the same file.
+- **Why it happens / why it hurts.** Multiple responsibilities crammed into one unit (SRP
+  violation). Every axis of change collides in one place, so unrelated changes risk each
+  other and the file is a perpetual merge-conflict magnet.
+- **Treatment.** *Extract Class* along the axes of change — each resulting unit should have
+  *one reason to change*. If several classes now share behavior, *Extract Superclass* /
+  *Extract Subclass*.
+- **TypeScript manifestation.** A `utils.ts` or `api.ts` touched by every feature; a store
+  slice changed by formatting, networking, *and* validation work. Split by **reason to
+  change** into feature/domain modules with explicit boundaries. Co-locate the type, its
+  logic, and its tests so a single concern is a single directory.
+- **Detection signal.** **Git history is the detector**: `git log --format= --name-only |
+  sort | uniq -c | sort -rn | head` — files at the top change for everything. High
+  authorship/commit churn on one module. `madge` fan-out from one module into many domains.
+
+#### 11. Shotgun Surgery
+
+- **Signs & symptoms.** The opposite of Divergent Change: one logical change forces small
+  edits across *many* files/classes (rename a concept → touch 14 files).
+- **Why it happens / why it hurts.** A single responsibility was smeared across many units.
+  Each change is tedious and error-prone; it's easy to miss a site, leaving an
+  inconsistency the type checker may not catch.
+- **Treatment.** *Move Method* / *Move Field* to consolidate the scattered responsibility
+  into one home; if the donor classes end up empty, *Inline Class* them away.
+- **TypeScript manifestation.** A status string duplicated as a literal in 14 files instead
+  of one shared union; an env-var read inline everywhere instead of one config module; a DTO
+  shape redefined per file. **Centralize**: one exported `type`/`const`, imported
+  everywhere, so the change is one edit and the compiler propagates it. (A shared union also
+  means a new variant *breaks compilation* everywhere it must be handled — turning Shotgun
+  Surgery into compiler-guided edits.)
+- **Detection signal.** `grep -rn "literal-or-name" src | wc -l` — a concept appearing in
+  many files is the smell. `madge`/`dpdm` showing one concept's edits rippling across the
+  graph. Review heuristic: PRs that touch many files for one conceptual change.
+
+#### 12. Parallel Inheritance Hierarchies
+
+- **Signs & symptoms.** Every time you add a subclass in hierarchy A, you must add a
+  matching subclass in hierarchy B (`Shape`→`Circle`/`Square` forces
+  `ShapeRenderer`→`CircleRenderer`/`SquareRenderer`).
+- **Why it happens / why it hurts.** A special case of Shotgun Surgery driven by mirrored
+  taxonomies. The two trees are coupled by convention only; forgetting the mirror edit
+  silently breaks things.
+- **Treatment.** Make instances of one hierarchy *refer to* instances of the other, then
+  collapse the redundant tree via *Move Method* / *Move Field*. RG "ignore": if
+  de-duplication produces uglier code, revert.
+- **TypeScript manifestation.** Mirrored class trees, or mirrored unions —
+  `type Event = "click" | "hover"` paired with a separate `class ClickHandler /
+  HoverHandler` tree. Collapse with a **strategy map** keyed by the discriminant:
+  `const handlers: Record<Event, Handler>`. Composition + a single source-of-truth union
+  removes the second hierarchy. React: prefer one config-driven component over parallel
+  component subtrees.
+- **Detection signal.** Two directories whose file lists mirror each other
+  (`diff <(ls a/) <(ls b/)` shows matching stems). Review: "added X, now must add Y"
+  recurring in commit messages. `madge` showing two cluster shapes that always grow together.
+
+---
+
+### Dispensables
+
+#### 13. Comments
+
+- **Signs & symptoms.** A function dense with explanatory comments narrating *what* the
+  next lines do.
+- **Why it happens / why it hurts.** Comments written to compensate for unclear code —
+  "deodorant over fishy code." They drift out of sync with the code (the comment lies after
+  the next edit), and they signal that names/structure are doing too little work.
+- **Treatment.** *Extract Variable* (name a sub-expression), *Extract Method* (name a block
+  — often the comment text *is* the method name), *Rename Method* (make the name carry the
+  meaning), *Introduce Assertion* (encode a required precondition as a check). RG "keep":
+  comments that explain *why* (rationale, tricky-algorithm notes), not *what*.
+- **TypeScript manifestation.** `// loop over active users and sum balances` →
+  `const total = sumBalances(activeUsers(users))`. In TS, the **type and the name** are the
+  primary documentation; a narration comment usually means a missing well-named helper or a
+  too-wide type. Keep JSDoc that documents public API contracts and `// why:` comments; cut
+  the play-by-play. `@deprecated`/`@internal` JSDoc tags are *useful* comments (tooling reads
+  them).
+- **Detection signal.** Comment density per function (high `// ` count inside a body).
+  `grep -rnE '^\s*//' src | wc -l` trend over time. Comments immediately above a code block
+  (vs at module top) are the suspect pattern. ESLint `capitalized-comments`/custom rules can
+  surface narration.
+
+#### 14. Duplicate Code
+
+- **Signs & symptoms.** Two fragments that are identical or near-identical; subtler:
+  fragments that *look* different but do the same job.
+- **Why it happens / why it hurts.** Parallel work without awareness; copy-paste under
+  deadline pressure. Every clone must be edited in lockstep forever — the prime driver of
+  maintenance cost and inconsistency bugs.
+- **Treatment.** Same class: *Extract Method*. Sibling subclasses: *Extract Method* +
+  *Pull Up Method/Field* (or *Pull Up Constructor Body*); similar-not-identical:
+  *Form Template Method*; different algorithms: *Substitute Algorithm*. Across unrelated
+  classes: *Extract Superclass* or *Extract Class* + reuse. Duplicated conditionals:
+  *Consolidate Conditional Expression* / *Consolidate Duplicate Conditional Fragments*.
+- **TypeScript manifestation.** Copy-pasted validation, mappers, fetch wrappers; the same
+  `try/catch/log` boilerplate in every handler. Extract a shared function/module; for
+  varying-shape data, a **generic** function (`function pick<T, K extends keyof T>(...)`);
+  for varying *behavior*, pass a callback/strategy. Duplicated *types* → one exported
+  `type`/`interface` (ties to Data Clumps + Shotgun Surgery). Beware false DRY: don't merge
+  fragments that merely *look* alike but change for different reasons.
+- **Detection signal.** **`jscpd`** (token-level copy-paste detector) is the standard;
+  set a threshold in CI. `find_semantic_clones` / similarity search for non-textual
+  duplication. ESLint `no-duplicate-imports`. Review: identical diffs landing in two files.
+
+#### 15. Lazy Class
+
+- **Signs & symptoms.** A class/module that does too little to justify the cost of
+  understanding and maintaining it — often a husk left after refactoring, or a placeholder
+  for work that never happened.
+- **Why it happens / why it hurts.** Over-extraction, or speculative scaffolding. Every
+  unit has a fixed cognitive and navigational tax; an under-employed one is pure overhead.
+- **Treatment.** *Inline Class* (fold it into its sole user); for thin subclasses,
+  *Collapse Hierarchy*. RG "ignore": a class deliberately marking a planned extension point.
+- **TypeScript manifestation.** A one-method `class` that should be a plain function; a
+  wrapper module that just re-exports one symbol; a single-field interface used once. TS
+  favors functions and plain objects — inline trivial classes, delete pass-through barrels.
+  A `type Alias = OtherType` used in one place is the type-level version.
+- **Detection signal.** `knip`/`ts-prune` flag barely-used exports; files with one tiny
+  symbol. `grep -rnE 'export class' src` then check method/field counts. Modules with high
+  import cost but ~1 reference.
+
+#### 16. Data Class
+
+- **Signs & symptoms.** A class that is only fields + getters/setters, with no behavior —
+  a dumb container others operate on.
+- **Why it happens / why it hurts.** Fine as a transient stage, but if logic about the data
+  lives *outside* it, that logic gets duplicated across clients and the data's invariants go
+  unenforced (anemic domain model).
+- **Treatment.** *Encapsulate Field* / *Encapsulate Collection* to control access; find
+  behavior in clients that belongs on the data and *Move Method* / *Extract Method* it in;
+  then *Remove Setting Method* / *Hide Method* to tighten the now-rich API. (Note the
+  tension with Feature Envy: behavior should sit with the data it uses.)
+- **TypeScript manifestation.** Nuance: in TS a pure-data **DTO/`interface`** is often
+  *correct and idiomatic* — a wire shape, a Redux state slice, a function's plain return
+  object. The smell is specifically a *class* that holds data but where related behavior is
+  scattered. Cure: either move behavior onto the type's module (functions that take the
+  type), or, if it really is just data, make it an `interface`/`readonly` record and stop
+  pretending it's an object with methods. `class` with only public mutable fields → `interface`
+  or `Readonly<T>`.
+- **Detection signal.** `grep -rnE 'get [a-zA-Z]+\(\)|set [a-zA-Z]+\(' src` (getter/setter
+  density). Classes with fields but trivial method bodies. Review: logic over a type living
+  in many call sites rather than near the type.
+
+#### 17. Dead Code
+
+- **Signs & symptoms.** A variable, parameter, field, function, class, file, or branch that
+  is never reached or never used — often after a requirement changed and cleanup was skipped.
+- **Why it happens / why it hurts.** Nobody removed the obsolete code; or a conditional
+  branch became unreachable. It bloats the codebase, misleads readers ("this must matter"),
+  and inflates build/test surface.
+- **Treatment.** Delete it. For an unused class in a hierarchy, *Inline Class* /
+  *Collapse Hierarchy*; for unused params, *Remove Parameter*. Trust version control — you
+  can always recover deleted code.
+- **TypeScript manifestation.** Unused exports, unreferenced files, dead union branches,
+  unreachable code after `return`/`throw`, unused generic params, commented-out blocks.
+  TS/lint catch the local cases; the *export-graph* cases need dedicated tools.
+- **Detection signal.** **`knip`** and **`ts-prune`** for unused exports/files/deps;
+  TS `noUnusedLocals` / `noUnusedParameters`; ESLint `no-unreachable`,
+  `@typescript-eslint/no-unused-vars`, `no-dead-code`-style rules. `find_dead_code` /
+  `find_unused_exports` (code-intel). `grep -rn "^\s*//.*[;{}]" src` for commented-out code.
+
+#### 18. Speculative Generality
+
+- **Signs & symptoms.** Abstractions, hooks, params, or "framework" machinery built for a
+  future that never arrived: an abstract base with one implementation, a strategy interface
+  with one strategy, a config option never set to anything but its default.
+- **Why it happens / why it hurts.** "We might need it later" / YAGNI violation.
+  Unnecessary indirection makes code harder to follow and maintain *now*, in exchange for
+  flexibility you may never use. (This is the counterweight to the Rule of Three — don't
+  abstract before the third instance.)
+- **Treatment.** *Collapse Hierarchy* (drop the lone abstract layer), *Inline Class*
+  (remove pointless delegation), *Inline Method* (remove unused indirection),
+  *Remove Parameter* (drop unused params), delete unused fields. RG "ignore": genuine
+  library/framework APIs whose extensibility serves external users; and test-only hooks.
+- **TypeScript manifestation.** Over-generic signatures — `function f<T, U, V>()` where
+  callers always pass the same concrete types; a `Strategy` interface with a single impl;
+  options objects full of never-used flags; an event-bus for one event. **Prefer concrete
+  until duplication demands generic.** Remove unused type parameters (they're dead code at
+  the type level). A one-implementation `interface` + DI container is often
+  premature — inline it.
+- **Detection signal.** `knip`/`ts-prune` (unused exports & types). Generic arity audit:
+  `grep -rnE '<[A-Z], ?[A-Z], ?[A-Z]' src` for high-arity generics; check each type param's
+  variance of use. Interfaces with exactly one `implements`. Review: "added for future use"
+  in comments/PRs.
+
+---
+
+### Couplers
+
+#### 19. Feature Envy
+
+- **Signs & symptoms.** A method/function is more interested in *another* object's data
+  than its own — it reaches across to pull fields and compute over them.
+- **Why it happens / why it hurts.** Behavior placed away from the data it operates on
+  (often after fields were moved to a Data Class). It couples the two units and scatters
+  logic that should be co-located; "things that change together should live together."
+- **Treatment.** *Move Method* (relocate it to the data's home); *Extract Method* first if
+  only part of the function envies, then move that part; if it envies several classes, put
+  it where the *majority* of the data lives. RG "ignore": Strategy/Visitor intentionally
+  separate behavior from data.
+- **TypeScript manifestation.** `function totalPrice(order: Order) { return order.items.reduce(...) }`
+  living in a `utils` file rather than as `order.totalPrice()` or in the order module. In a
+  functional TS style, "move method" means **co-locate the function in the module that owns
+  the type** and operates on its internals. React: a component digging through
+  `props.user.profile.settings.x` repeatedly wants a selector/method nearer the data.
+- **Detection signal.** Functions whose body references `other.` far more than `this`/own
+  params: `grep`-count `someObj\.` accesses vs own. Code-intel `get_data_flow` /
+  `find_references` showing a function bound tightly to a foreign type. LCOM-style locality
+  metrics; review heuristic: many dotted accesses into one external object.
+
+#### 20. Inappropriate Intimacy
+
+- **Signs & symptoms.** One class/module reaches into another's *internal* fields and
+  methods; bidirectional knowledge of each other's privates.
+- **Why it happens / why it hurts.** Boundaries eroded over time. Good units know as little
+  about each other as possible; intimate ones can't be changed, tested, or reused
+  independently.
+- **Treatment.** *Move Method* / *Move Field* (relocate what's used into the user);
+  *Extract Class* + *Hide Delegate* (formalize the relationship through a clean interface);
+  *Change Bidirectional Association to Unidirectional* (cut the back-reference); if it's a
+  sub/superclass overreach, *Replace Delegation with Inheritance* (or vice-versa).
+- **TypeScript manifestation.** A module importing another's *non-public* internals (deep
+  import paths into `dist/internal/...`), components mutating each other's state,
+  reaching past a public API into private fields (TS `private` is compile-time only — a
+  determined caller can still `(obj as any).field`). Cures: expose a **narrow public
+  interface**, mark internals with `@internal` / `private` / `#privateFields`, enforce
+  module boundaries with import-path lint, break cycles.
+- **Detection signal.** **`madge --circular`** / `dpdm` / `find_circular_imports` for
+  mutual dependence. `grep -rnE "as any\)\.[a-zA-Z]" src` for private-field reach-arounds.
+  Deep relative imports `grep -rnE "from '\.\./\.\./\.\./" src`. ESLint
+  `import/no-internal-modules`, `no-restricted-imports` to fence boundaries.
+
+#### 21. Message Chains
+
+- **Signs & symptoms.** A train of calls/property accesses: `a.b().c().d()` or
+  `a.b.c.d.e`. The caller is navigating deep through the object graph.
+- **Why it happens / why it hurts.** The client depends on the *entire navigation path*;
+  any structural change anywhere along the chain breaks the caller. It leaks the internal
+  shape of intermediate objects.
+- **Treatment.** *Hide Delegate* (let the first object expose a method that hides the
+  traversal); or, if the chain exists to do something at the end, *Extract Method* +
+  *Move Method* that work to the chain's head. RG caveat: don't over-hide into a Middle Man.
+- **TypeScript manifestation.** `user.getAddress().getCity().getZip()`, or
+  `config.server.tls.options.cert`, or Redux `state.a.b.c.d`. Cures: a method on the head
+  (`user.zip()`), a **selector** function, the **Law of Demeter** ("talk to friends, not
+  strangers"). Note TS **optional chaining** `a?.b?.c?.d` makes chains *safe* but not
+  *uncoupled* — `?.` papering over a deep chain is the smell, not the fix.
+- **Detection signal.** `grep -rnE '\)\.[a-zA-Z]+\(\)\.[a-zA-Z]+\(' src` for `.x().y()`
+  chains; `grep -rnE '(\?\.[a-zA-Z]+){3,}' src` for `?.`-chains 3+ deep; `(\.[a-zA-Z]+){4,}`
+  for long property paths. Review heuristic: any access ≥3 dots deep into a graph.
+
+#### 22. Middle Man
+
+- **Signs & symptoms.** A class/module whose methods mostly just *delegate* to another
+  object and do nothing else — a pass-through shell.
+- **Why it happens / why it hurts.** Over-zealous *Hide Delegate* (the over-correction of
+  Message Chains), or behavior gradually migrating out until only forwarding remains. The
+  middle layer adds indirection and maintenance with no value; readers can't find where work
+  actually happens.
+- **Treatment.** *Remove Middle Man* — let clients talk to the real object directly.
+  RG "ignore": deliberate indirection (Proxy, Decorator, Facade) or middle men that exist to
+  *cut* a dependency.
+- **TypeScript manifestation.** A "service" class every method of which is
+  `return this.repo.x(args)`; a wrapper module that re-exports and forwards with no added
+  logic; a React component that only spreads props to one child (`<Child {...props} />`).
+  Remove the layer unless it's an intentional Adapter/Facade adding a real seam. Distinguish
+  from a legitimate **anti-corruption layer** — that one *transforms*, it doesn't just forward.
+- **Detection signal.** Methods whose bodies are a single `return this.x.method(...args)`:
+  `grep -rnE 'return this\.[a-zA-Z]+\.[a-zA-Z]+\(' src`. `knip` showing a module is a thin
+  re-export. Review: a class where ≥half the methods are one-line forwards.
+
+#### 23. Incomplete Library Class
+
+- **Signs & symptoms.** A third-party library almost meets your need but lacks a method/
+  behavior, and you can't edit it (it's read-only / external).
+- **Why it happens / why it hurts.** Library authors can't anticipate every use; you're
+  stuck between forking and duplicating. Working around it ad hoc spreads compensating code
+  everywhere the library is used.
+- **Treatment.** *Introduce Foreign Method* (a helper function that takes the library object
+  as its first argument, for a small gap); *Introduce Local Extension* (a subclass or wrapper
+  that adds the missing behavior, for larger gaps). RG "ignore": if extending creates more
+  churn than it saves.
+- **TypeScript manifestation.** TS gives extra options the OO catalog predates:
+  **declaration merging / module augmentation** (`declare module "lib" { interface X { ... } }`)
+  to extend third-party *types*; **`Adapter`/wrapper** modules to add behavior; standalone
+  **helper functions** (`function withRetry(client: LibClient) {...}`) as Foreign Methods;
+  and ambient `.d.ts` augmentation when the lib's *types* (not behavior) are incomplete.
+  Prefer a thin local extension module so the workaround lives in one place.
+- **Detection signal.** Repeated identical helper/utility wrappers around the same library
+  call across the codebase (`jscpd`, or grep the library symbol). Many `as`/`@ts-ignore`
+  near a specific import (its types are incomplete): `grep -rnE "from '(lib-name)'" src`
+  cross-referenced with `as`/`@ts-ignore` density. Patterns of `(libObj as any).x`.
+
+---
+
+## Part 4 — TypeScript detection cheat-sheet (cross-smell)
+
+A consolidated tooling map; wire these into CI so smells fail the build rather than
+accreting as debt.
+
+| Tool / signal | Catches (smells) |
+| --- | --- |
+| **ESLint** `complexity`, `max-lines-per-function`, `max-statements`, `max-depth`, `max-nested-callbacks` | Long Method |
+| **ESLint** `max-lines`, `max-classes-per-file` | Large Class |
+| **ESLint** `max-params` (≤3–4) | Long Parameter List, Data Clumps |
+| **ESLint** `@typescript-eslint/switch-exhaustiveness-check`, `default-case`, `no-fallthrough` | Switch Statements, Temporary Field (via DU modeling) |
+| **ESLint** `@typescript-eslint/no-magic-numbers`, `no-magic-strings`-style | Primitive Obsession |
+| **ESLint** `@typescript-eslint/no-unused-vars`, `no-unreachable`; **tsc** `noUnusedLocals`, `noUnusedParameters` | Dead Code |
+| **ESLint** `import/no-internal-modules`, `no-restricted-imports`, `import/no-cycle` | Inappropriate Intimacy, Message Chains, Middle Man |
+| **`knip`** / **`ts-prune`** | Dead Code, Lazy Class, Speculative Generality (unused exports/types/files/deps) |
+| **`jscpd`** | Duplicate Code, Data Clumps, Alternative Classes w/ Different Interfaces |
+| **`madge`** / **`dpdm`** (`--circular`, fan-in/out) | Inappropriate Intimacy, Divergent Change, Shotgun Surgery, Parallel Inheritance |
+| **`type-coverage`** | Primitive Obsession (rewards branded/typed over wide primitives) |
+| **`tsc` `--strict`** (incl. `strictNullChecks`, `exactOptionalPropertyTypes`) | Temporary Field, Primitive Obsession, escape-hatch debt |
+| **grep escape-hatch density**: `grep -rnE 'as any\|@ts-(ignore\|expect-error)\|: any\b\|!\.' src \| wc -l` | global type-debt proxy (correlates with Primitive Obsession, Inappropriate Intimacy, Incomplete Library Class) |
+| **grep chain depth**: `(\?\.[a-zA-Z]+){3,}` / `\)\.[a-z]+\(\)\.[a-z]+\(` | Message Chains |
+| **git churn**: `git log --format= --name-only \| sort \| uniq -c \| sort -rn` | Divergent Change (hot file = many reasons to change) |
+| **code-intel** `find_dead_code`, `find_unused_exports`, `find_circular_imports`, `find_semantic_clones`, `get_data_flow` | Dead Code, cycles/intimacy, Duplicate/Alternative Classes, Feature Envy |
+
+**TS-specific anti-smell techniques referenced throughout:** discriminated unions +
+`never` exhaustiveness (Switch, Temporary Field, Parallel Hierarchies); branded/nominal
+types and smart constructors (Primitive Obsession); options objects (Long Parameter List);
+extracted named `interface`/`type` (Data Clumps, Duplicate Code, Shotgun Surgery);
+composition + narrow interfaces over inheritance (Refused Bequest, Parallel Hierarchies);
+"make illegal states unrepresentable" (Temporary Field, Primitive Obsession); module
+augmentation / Adapter (Incomplete Library Class); selectors + Law of Demeter (Message
+Chains). These connect the smell catalog to the refactoring-technique and design-pattern
+references (see r4b, r4c).
+
+---
+
+*Synthesis of the Refactoring.Guru code-smell catalog (https://refactoring.guru/refactoring/smells)
+and refactoring philosophy pages, re-grounded for TypeScript. Original prose; RG cited as the
+primary external reference.*

--- a/docs/projects/typescript-refactoring-skill/research/r4b-techniques.md
+++ b/docs/projects/typescript-refactoring-skill/research/r4b-techniques.md
@@ -1,0 +1,414 @@
+# r4b — Refactoring Techniques Catalog, TypeScript-Flavored
+
+> **Primary reference:** [Refactoring.Guru / Techniques](https://refactoring.guru/refactoring/techniques) (the Fowler catalog, re-illustrated). All 66 techniques below are grouped into Refactoring Guru's 6 families. Each entry is an **original synthesis** — problem→solution, compressed mechanics, and a modern-TS note. Where a language feature supersedes a technique, or where the technique is OO bookkeeping with little payoff in idiomatic TS, that is flagged.
+>
+> **How to read the TS notes.** "Idiomatic TS" here means: small modules over big class hierarchies, plain functions + data, discriminated unions over runtime type tags, `readonly`/immutability by default, structural typing, and the compiler doing the work a refactoring step used to do by hand. The catalog predates all of this; ~40% of it is timeless, ~25% is "your IDE does this now," and ~35% is OO inheritance/association choreography that idiomatic TS mostly sidesteps.
+>
+> **Legend:** ⭐ core for cleaning real/LLM-generated TS · 🔧 IDE-automated (TS Language Service does it safely) · ⚠️ dated / low-value in idiomatic TS · 🔁 superseded by a language feature
+
+---
+
+## 1. Composing Methods
+
+The family for taming long functions and tangled locals. The most universally useful family in TS — most of it is "make the body readable."
+
+### Extract Method ⭐
+- **What:** A code fragment that hangs together → pull it into a named function/method; replace with a call.
+- **Mechanics:** Name it for *intent*, not mechanism. Free variables read inside become params; a single mutated local becomes the return value; multiple mutated locals are a signal to split or use Replace Method with Method Object.
+- **TS note:** The workhorse. Prefer free `function`s/arrow functions over methods unless the data is genuinely object-bound. Multi-return-value extractions are clean in TS via tuples or a small object literal. IDE "Extract to function" is reliable, but *you* must pick the name.
+
+### Inline Method ⭐
+- **What:** A method whose body is as clear as its name and adds no value → replace calls with the body, delete the method.
+- **Mechanics:** Confirm it isn't overridden anywhere; substitute body at every call site; delete.
+- **TS note:** Used to collapse over-eager indirection (a constant problem in LLM-generated code, which loves one-line wrapper functions). With no subclass-override concern for plain functions, inlining is low-risk. The inverse of Extract Method — reach for it when abstraction earns nothing.
+
+### Extract Variable ⭐
+- **What:** A hard-to-read expression → name its parts in `const`s that explain intent.
+- **Mechanics:** Hoist a subexpression into a `const`; replace the original occurrence; repeat.
+- **TS note:** Use `const` (never `let`) so the extraction is provably side-effect-free. *Caveat from the source:* extracting parts of a short-circuited `a() || b()` forces both to evaluate — watch for changed eval semantics and perf when the operands are effectful. Naming an `if`/ternary condition (`const isEligible = …`) is the highest-leverage version.
+
+### Inline Temp 🔧
+- **What:** A temp assigned a simple expression and used once → replace the temp with the expression.
+- **Mechanics:** Substitute the expression at each use; delete the declaration.
+- **TS note:** Almost never done for its own sake; it's a setup step for Replace Temp with Query or Extract Method. Don't inline a temp that caches an expensive call. Minor cleanup; IDE-assisted.
+
+### Replace Temp with Query ⭐
+- **What:** A local holding a computed value → move the computation into a (pure) function and call it where the temp was used.
+- **Mechanics:** Ensure the temp is assigned exactly once (Split Temporary Variable first if not); Extract Method on the expression (it must be side-effect-free — Separate Query from Modifier if not); replace temp with the call.
+- **TS note:** Enables reuse and shrinks long functions. In TS, prefer a pure helper or a `get` accessor / computed getter. The classic perf objection is mostly moot; keep the temp only for genuinely expensive memoizable work (and then reach for an explicit memo).
+
+### Split Temporary Variable ⭐
+- **What:** One mutable local reused for several unrelated values → one variable per concept, each named.
+- **Mechanics:** At each reassignment that begins a new "meaning," introduce a new well-named variable and update its uses.
+- **TS note:** Highly relevant — LLM code frequently reuses a `let result`/`temp`/`data` for three different things. The TS upgrade: make each new variable a `const`. If you *can't* make them `const`, that's a smell pointing at Extract Method. (Loop counters are exempt.)
+
+### Remove Assignments to Parameters ⭐
+- **What:** Reassigning a parameter inside the body → copy it into a local and mutate that instead.
+- **Mechanics:** `const local = param;` then use `local` everywhere downstream.
+- **TS note:** Still worth doing for clarity, *and* TS gives you a sharper tool: mark params `readonly` (for arrays/objects) or simply treat all params as immutable by convention. Reassigning a param obscures the input contract and breaks the mental model that "params = the inputs." Object/array params are reference-shared, so mutating them is a real foot-gun, not just a style nit.
+
+### Replace Method with Method Object 🔁⚠️
+- **What:** A function so long that its tangled locals defeat Extract Method → promote it to a class whose fields are those locals.
+- **Mechanics:** New class; private field per local + a backref to the original object; constructor takes the locals; copy the body; split it into private methods.
+- **TS note:** Mostly superseded. The modern move is **closures**: a factory function captures the "fields" as closed-over `let`/`const`, and inner functions replace the would-be private methods — no class, no `this`. Reach for the class form only if you already live in a class-heavy codebase. Often a sign you should rethink the data model entirely.
+
+### Substitute Algorithm ⭐ (process, not a mechanical refactor)
+- **What:** An algorithm that's cluttered or obsolete → replace the whole body with a cleaner/standard one.
+- **Mechanics:** Simplify and extract first so the surface is small; write the new algorithm; diff outputs against the old on real inputs; delete the old once tests pass.
+- **TS note:** The "replace with a library / standard method" case is huge in TS — hand-rolled grouping/dedup/sort → `Array` methods, `Map`/`Set`, `Object.groupBy`, or a vetted util. Lean on the type checker + tests as your equivalence oracle.
+
+---
+
+## 2. Moving Features Between Objects
+
+Where responsibilities live. In idiomatic TS this is often "which **module/file** owns this function," not "which class."
+
+### Move Method ⭐ (reframed: move function)
+- **What:** A method that uses another class's data more than its own → move it there.
+- **Mechanics:** Check it isn't part of an override chain; declare it on the recipient; ensure you have a reference to the recipient; turn the old method into a delegating call or delete it.
+- **TS note:** The "Feature Envy" fix. In module-first TS this usually means **moving a function to the module that owns the data it operates on**, or co-locating it with the type it returns. With plain functions there's no override-chain ceremony — just move and update imports (IDE does the import rewrite).
+
+### Move Field 🔧
+- **What:** A field used more by another class than its owner → move it (and redirect accessors).
+- **Mechanics:** Encapsulate first if public; add the field + accessors on the recipient; redirect references; delete the original.
+- **TS note:** For class-based code, IDE-assisted. For idiomatic TS, this is "move a property to the interface/type where it belongs" — a type edit plus follow-the-compiler-errors. Frequently a substep of Extract Class.
+
+### Extract Class ⭐
+- **What:** One class (or module) doing two jobs → split the second job into its own unit.
+- **Mechanics:** Create the new unit; prefer a one-way relationship; Move Field/Move Method the relevant members over a few at a time, testing between.
+- **TS note:** Strongly relevant, but generalize "class" → **module**. The TS version: split a god-module/god-type along a seam (the Single Responsibility cut), often producing a small focused module + a type. The most common real-world structural refactor. Watch for a hidden domain concept wanting to become its own type.
+
+### Inline Class 🔧
+- **What:** A class/module that barely does anything → fold it into its sole consumer.
+- **Mechanics:** Recreate its members on the consumer; redirect references; Move Method/Field everything over; delete.
+- **TS note:** Inverse of Extract Class — kill "Lazy Class"/needless-wrapper modules (LLM code generates these constantly). In TS this is often "delete this 6-line file and inline the function." Low-risk with good imports.
+
+### Hide Delegate 🔧
+- **What:** Client reaches `a.getB().doThing()` → add `a.doThing()` so the client doesn't know about B.
+- **Mechanics:** Add a delegating method on the server for each delegate call the client makes; repoint the client; drop the now-unused accessor.
+- **TS note:** This is the Law-of-Demeter fix. Useful but easy to overdo (→ Middle Man). In TS, often better solved by **passing the right thing in the first place** or exposing a focused interface, rather than accreting delegating methods. Optional chaining (`a.b?.doThing()`) addresses the *null* pain but not the *coupling* pain.
+
+### Remove Middle Man 🔧
+- **What:** A class that's mostly pass-through delegating methods → let clients talk to the delegate directly.
+- **Mechanics:** Expose a getter for the delegate; replace delegating calls with direct calls.
+- **TS note:** Inverse of Hide Delegate; the two are a dial, not a rule. Relevant for trimming anemic "service" wrappers. Judgment call — too far in either direction is a smell.
+
+### Introduce Foreign Method 🔁
+- **What:** You need a method on a type you can't modify (3rd-party) → put it in your code, taking that type as the first arg.
+- **Mechanics:** Write a helper in your class taking the foreign object as a parameter; extract the repeated logic into it; tag it so future readers know it "wants" to live on the foreign type.
+- **TS note:** Just **write a standalone utility function** `fn(x: Foreign, …)`. No ceremony, no "foreign method" tag culture needed. The structural-typing era makes this a non-event. (Avoid prototype/declaration-merging monkey-patching for this — a plain function is clearer and tree-shakeable.)
+
+### Introduce Local Extension 🔁⚠️
+- **What:** You need *several* methods on an unmodifiable type → make a subclass or wrapper that adds them.
+- **Mechanics:** Subclass the utility type (if not `final`/sealed) **or** wrap it, re-delegating its public surface, plus your new methods + a converting constructor.
+- **TS note:** Largely obsolete. Use a **module of free functions** keyed on the foreign type, or a thin adapter object — not a subclass and not a full delegating wrapper. The wrapper variant ("re-expose the whole public interface") is exactly the kind of boilerplate TS lets you skip. Dated.
+
+---
+
+## 3. Organizing Data
+
+Turning primitives and loose data into typed, encapsulated shapes. In TS, **the type system supersedes a large slice of this family** — many "type code" and "value/reference" techniques collapse into "define a union/branded type."
+
+### Self-Encapsulate Field ⚠️
+- **What:** Direct private-field access inside a class → route even internal access through getters/setters.
+- **Mechanics:** Add accessor(s); replace internal direct uses with them.
+- **TS note:** Low value. The original motivation (override accessors in subclasses, lazy-init) is rare in idiomatic TS. Use TS `get`/`set` accessors only when you actually need lazy init, validation, or a computed view — otherwise a plain public `readonly` field is cleaner. Don't pre-encapsulate "just in case."
+
+### Replace Data Value with Object ⭐ (as: give the primitive a type)
+- **What:** A primitive field that has grown its own behavior/associated data → promote it to its own type.
+- **Mechanics:** New class holds the value + behavior; original field becomes that type.
+- **TS note:** The *spirit* is gold — it's the antidote to "Primitive Obsession." The TS form is usually lighter than a class: a **branded type** (`type UserId = string & { readonly __brand: unique symbol }`), a small `interface`/object, or a value object with methods. Don't reach for a full class unless there's real behavior.
+
+### Change Value to Reference ⚠️
+- **What:** Many equal value-objects that should be one shared identity → route creation through a factory/registry returning a canonical instance.
+- **Mechanics:** Replace Constructor with Factory Method; introduce a store/registry; factory returns the shared instance.
+- **TS note:** Niche. This is really an **identity/caching/interning** concern (e.g., entity identity maps in an ORM, flyweight interning). Don't apply broadly. When you need it, model it explicitly as a `Map`-backed registry, not as an OO ritual.
+
+### Change Reference to Value ⭐ (as: make it immutable)
+- **What:** A shared mutable reference object that's small and rarely changes → make it an immutable value with equality-by-content.
+- **Mechanics:** Remove setters (immutable); add a content-equality method; consider making the constructor public.
+- **TS note:** Very aligned with idiomatic TS: prefer **immutable value objects** (`readonly` fields, no setters; copy-on-change). TS lacks value equality, so provide an explicit `equals`/comparator or compare on a normalized key. The "make it immutable" half is mainstream best practice; the equality half needs manual work.
+
+### Replace Array with Object ⭐🔁 (as: replace tuple/array with a typed shape)
+- **What:** An array whose positions mean different things (`[name, …, address]`) → an object/record with named fields.
+- **Mechanics:** New type with a field per element; create access methods; migrate uses; drop the array.
+- **TS note:** Strongly relevant and **type-driven** in TS: replace `any[]`/positional arrays with an `interface`, or at minimum a **named tuple type** (`[name: string, age: number]`) when positional access is intentional. Heterogeneous arrays are a TS smell the compiler can't fully guard — naming the shape gives you real checking.
+
+### Duplicate Observed Data ⚠️🔁
+- **What:** Domain data trapped in GUI classes → split domain from view and sync via Observer.
+- **Mechanics:** Encapsulate the data; create a domain class; wire an Observer so view and domain stay in sync.
+- **TS note:** Dated as written (classic GOF Observer + "doesn't apply to web apps"). The *principle* — separate domain state from presentation — is alive and well, but the modern implementation is **reactive state** (signals, stores, hooks, observables), not a hand-rolled observer with recursion guards. Treat the technique as historical; apply the principle via your framework's state layer.
+
+### Change Unidirectional Association to Bidirectional ⚠️
+- **What:** Two classes that each now need to reach the other, but the link is one-way → add the back-pointer.
+- **Mechanics:** Add the reverse field; pick a "dominant" side that owns updates; add controlled helper(s) to keep both sides consistent.
+- **TS note:** Low-value OO bookkeeping. Bidirectional object graphs create coupling, cycles, and serialization headaches in TS. Prefer: keep it unidirectional and **derive/look up** the reverse direction (e.g., via a `Map` or a query) instead of storing it. Avoid unless a framework (ORM relations) demands it.
+
+### Change Bidirectional Association to Unidirectional ⭐ (as: cut a coupling)
+- **What:** A two-way link where one side no longer uses the other → delete the unused direction.
+- **Mechanics:** Confirm the link is unused (or reconstructable); replace the field with a param/lookup; delete assignments and the field.
+- **TS note:** The useful direction of the association pair — **removing** edges from the object graph reduces coupling, breaks cycles, and helps tree-shaking and serialization. The GC/memory-leak rationale is mostly historical; the decoupling rationale is current.
+
+### Replace Magic Number with Symbolic Constant ⭐
+- **What:** An unexplained literal → a named constant carrying its meaning.
+- **Mechanics:** Declare the constant; find every occurrence; replace only those that truly mean *this* concept.
+- **TS note:** Always-do. In TS: `const TAX_RATE = 0.2` for scalars; for sets of related literals prefer a **`const` object + union** (`const Role = {Admin:'admin',…} as const; type Role = typeof Role[keyof typeof Role]`) over a numeric `enum`. Note the catalog's own pointer: magic numbers used as *type codes* → see the Replace Type Code family. Not every literal is magic (`i < count`, `* 2`).
+
+### Encapsulate Field 🔧⚠️
+- **What:** A public field → make it private + accessors.
+- **Mechanics:** Add getter/setter; redirect external uses; make the field private.
+- **TS note:** Low ceremony in TS and usually unnecessary: use `private`/`#private` + a `readonly` public field, or expose `get` only for a computed/validated view. Don't auto-wrap every field in get/set — that's a Java reflex. Encapsulate only when access needs logic.
+
+### Encapsulate Collection ⭐
+- **What:** A class exposes its collection via plain get/set, letting clients mutate it freely → return a read-only view; provide add/remove methods.
+- **Mechanics:** Add `add`/`remove`; initialize to empty; getter returns a non-mutating view/copy; rename any "set whole collection" to `replace`.
+- **TS note:** Very relevant and a frequent real bug source. TS form: type the getter as `ReadonlyArray<T>`/`readonly T[]` (or return a copy), keep mutation behind intent-named methods, and store the field `readonly`. The compiler then *enforces* the no-external-mutation contract that the original technique could only document.
+
+### Replace Type Code with Class ⭐🔁 (→ branded type / union)
+- **What:** A field holding coded values (`'A'|'E'|'U'`) that don't drive behavior → give it a real type.
+- **Mechanics (classic):** New type class; private value + getter; static instance per code; swap the field's type.
+- **TS note:** **Superseded by the type system.** Use a **string-literal union** (`type Role = 'admin'|'editor'|'user'`) or a `const`-object-derived union. This gives you exactly the IDE type-hinting the technique was straining toward — for free, with zero runtime objects. Reach for an actual class only if the type needs behavior/methods.
+
+### Replace Type Code with Subclasses 🔁
+- **What:** A type code that *does* drive behavior (branches in conditionals) → one subclass per code, behavior pushed down, conditionals → polymorphism.
+- **Mechanics:** Self-encapsulate the code; private constructor + static factory that maps code→subclass; push fields/methods down; finish with Replace Conditional with Polymorphism.
+- **TS note:** Usually **superseded by a discriminated union + exhaustive `switch`** (with a `never` default to force exhaustiveness), or a **strategy map** (`Record<Code, Handler>`). Both give Open/Closed-ish extensibility without an inheritance tree, and the compiler checks you handled every case. Subclasses are the heavier, rarely-warranted option in idiomatic TS.
+
+### Replace Type Code with State/Strategy 🔁
+- **What:** Behavior-driving type code that *changes at runtime* or can't use subclasses → delegate to a swappable state/strategy object.
+- **Mechanics:** Self-encapsulate; state class hierarchy with a factory; original holds a reference and delegates; finish with polymorphism.
+- **TS note:** The legitimate survivor of the type-code trio, but lighten it: a **strategy map of functions/objects keyed by the union tag** beats a State class hierarchy in most TS code. Use it when the variant changes over an object's lifetime or carries variant-specific data. Still: start with a discriminated union; escalate to strategy only if behavior is large or pluggable.
+
+### Replace Subclass with Fields ⭐ (as: collapse trivial subclasses into data)
+- **What:** Subclasses that differ only in constant return values → delete them; store the constants as fields on the parent (set via factory).
+- **Mechanics:** Factory method per subclass; parent fields for the constants; protected constructor; constant methods return the fields; delete subclasses.
+- **TS note:** Excellent guidance, even more so in TS: collapse a needless class hierarchy into **plain data** — a record/lookup table or a config object — and a single function. Subclassing to vary a constant is pure overkill; this technique is the cure. Often the endgame after realizing a "hierarchy" is really a data table.
+
+---
+
+## 4. Simplifying Conditional Expressions
+
+Flattening and clarifying branching logic. After Composing Methods, the **second-most valuable family for real/LLM TS** — generated code is conditional-heavy.
+
+### Decompose Conditional ⭐
+- **What:** A complex `if/else`/`switch` → extract the condition and each branch into named functions.
+- **Mechanics:** Extract the test (`isX()`), the then-body, and the else-body via Extract Method.
+- **TS note:** High leverage. Naming the predicate (`const isPastDue = …` or `function isPastDue(x): boolean`) is the single best readability win on dense conditionals. Pairs with type guards: an extracted predicate typed `x is Foo` also *narrows* — readability and type-safety in one move.
+
+### Consolidate Conditional Expression ⭐
+- **What:** Several separate checks that all lead to the same result → combine into one expression, then name it.
+- **Mechanics:** Join nested conditions with `&&`, consecutive ones with `||`; Extract Method on the combined predicate. **First confirm no branch has side effects.**
+- **TS note:** Solid. The side-effect caveat matters more in TS because `&&`/`||` short-circuit — consolidating effectful branches changes behavior. Keep predicates pure; name the result.
+
+### Consolidate Duplicate Conditional Fragments ⭐
+- **What:** Identical code in every branch of a conditional → hoist it out.
+- **Mechanics:** Common prefix → before the `if`; common suffix → after it; scattered dupes → move to an edge first, then Extract Method if multi-line.
+- **TS note:** Straightforward dedup, common in generated code that repeats a `return`/`log`/`cleanup` in each arm. Always-do.
+
+### Remove Control Flag ⭐
+- **What:** A boolean flag steering loop/exit flow → use `break` / `continue` / `return` / early exit instead.
+- **Mechanics:** Find the flag-assignment that means "stop"; replace with the matching control-flow keyword; delete the flag and its checks.
+- **TS note:** Very relevant — `let done = false; while(!done)…` is a classic LLM pattern. TS/JS additions: `Array.prototype.some`/`every`/`find` often eliminate the loop *and* the flag entirely. Prefer early `return` from an extracted function over deep flag-driven loops.
+
+### Replace Nested Conditional with Guard Clauses ⭐
+- **What:** Arrow-shaped nested `if`s where the happy path is buried → handle special cases up front with early returns.
+- **Mechanics:** Pull each edge case to the top as a guard that returns/throws; flatten; then Consolidate guards with the same outcome.
+- **TS note:** Top-tier technique for TS. Early-return guards + **narrowing** make the rest of the function operate on already-validated, well-typed values (great with `if (!x) return;` to strip `undefined`). Reduces nesting *and* tightens types simultaneously. One of the highest-ROI cleanups on generated code.
+
+### Replace Conditional with Polymorphism 🔁
+- **What:** A conditional that switches on an object's type/field, repeated across methods → push each branch into a subclass method; call polymorphically.
+- **Mechanics:** Ensure/Build a class hierarchy (often via the type-code techniques); override the method per subclass with that branch's body; delete the conditional, make the base abstract.
+- **TS note:** Partially superseded. For *open* sets of variants with rich behavior, polymorphism (or a **strategy map**) wins. But for *closed* variant sets, idiomatic TS prefers a **discriminated union + one exhaustive `switch`** checked by the compiler (`never` in the default). Don't manufacture a class hierarchy just to kill a `switch` — a tagged union + exhaustiveness is often cleaner, more local, and equally safe. Use polymorphism/strategy when the same switch is duplicated across many functions.
+
+### Introduce Null Object 🔁
+- **What:** Pervasive `if (x == null)` checks → return a special object with default/no-op behavior instead of `null`.
+- **Mechanics:** Subclass with `isNull()` + default behaviors; return it where you'd return null; replace null-checks with polymorphic calls.
+- **TS note:** Largely **superseded by the type system + language ergonomics.** With `strictNullChecks`, the compiler *forces* you to handle absence — model it explicitly as `T | undefined` and use optional chaining (`?.`), nullish coalescing (`??`), or an `Option`/`Result` type. The Null Object *pattern* still has niche uses (a no-op logger, an empty collection, a default strategy), but the broad "stop checking for null" goal is better served by explicit-absence types. Don't build `isNull()` subclasses.
+
+### Introduce Assertion ⭐ (reframed: encode invariants in types, assert what types can't)
+- **What:** Code that silently assumes a condition holds → make the assumption explicit and checked.
+- **Mechanics:** Add an assertion where the assumption lives; it must not change behavior when the assumption holds; don't assert things that can legitimately be false.
+- **TS note:** Reframe for TS: **first try to make the invariant unrepresentable-if-false via types** (non-optional fields, narrowed unions, branded types) so no runtime check is needed. For invariants the type system can't express (external input, parsing, "this was validated upstream"), use **assertion functions** (`function assert(x): asserts x`) or schema validation (zod et al.) at the boundary — these both check *and* narrow. The catalog's "use an exception when the user/system can cause it; assertion only for impossible-bug states" distinction maps cleanly onto "validate at boundaries, assert in the core."
+
+---
+
+## 5. Simplifying Method Calls
+
+Cleaner signatures and call sites. A mix of timeless naming/parameter hygiene and a few OO-era items.
+
+### Rename Method ⭐🔧
+- **What:** A name that doesn't describe what it does → rename it.
+- **Mechanics:** Repeat across the override chain; (for public APIs) add a new method delegating to the old, deprecate the old, migrate, then remove.
+- **TS note:** Always-do; IDE rename is safe across a project. The deprecation dance is only for **published** APIs (use `@deprecated` JSDoc — IDEs strike it through). Renaming for intent is the cheapest readability upgrade.
+
+### Add Parameter 🔧⚠️
+- **What:** A method lacks data it now needs → add a parameter.
+- **Mechanics:** (Classically) clone-and-delegate to keep things working, migrate callers, retire the old.
+- **TS note:** Trivial with IDE + compiler (errors flag every caller). But treat the catalog's own warning as the headline: adding params breeds **Long Parameter List**. Prefer an **options object** from the start, and consider whether the data belongs on an existing object instead. The mechanical refactor is a non-event; the *design* caution is the point.
+
+### Remove Parameter ⭐🔧
+- **What:** An unused parameter → delete it.
+- **Mechanics:** Confirm unused across overrides; clone-and-delegate or just delete; fix callers.
+- **TS note:** The compiler finds unused params (`noUnusedParameters`) and IDE refactors callers. Good hygiene — every param is a question in the reader's head. Speculative "might need it later" params are exactly what to cut.
+
+### Separate Query from Modifier ⭐
+- **What:** A method that both returns a value *and* mutates state → split into a pure query and a separate command (CQS).
+- **Mechanics:** New pure query returning the value; original keeps only the mutation; at call sites, call the modifier then the query.
+- **TS note:** Strong fit with functional-leaning TS. Pure queries are referentially transparent, cacheable, and trivially testable; commands isolate effects. Enables Replace Temp with Query and safe predicate extraction. The "but I want the deleted-row count" exception is real — return-from-command is fine when the result *is* the effect's report.
+
+### Parameterize Method ⭐
+- **What:** Several near-identical methods differing only by a literal/value → one method taking that value as a param.
+- **Mechanics:** Extract the common body into a parameterized method; replace the varying literal with the param; redirect and delete the originals.
+- **TS note:** Good dedup, common in generated code (`getAdminUsers`/`getEditorUsers` → `getUsersByRole(role)`). Caution (from the source): don't parameterize into a boolean "mode flag" that grows a big internal conditional — that's the inverse smell (see next). Union-typed params keep it honest.
+
+### Replace Parameter with Explicit Methods ⭐ (the inverse of the above)
+- **What:** A method whose behavior is fully selected by a parameter's value (esp. a boolean flag) → split into one clearly-named method per value.
+- **Mechanics:** A method per variant; route callers to the right one; delete the original.
+- **TS note:** Directly attacks the **boolean-flag-parameter** smell (`setValue('enabled', true)` → `enable()`). Very relevant. *But* if variants share most logic and differ in data, a discriminated-union param may beat N methods — judge by how much branches diverge. Don't over-split rarely-changing variants.
+
+### Preserve Whole Object ⭐
+- **What:** You pull several values off an object just to pass them as separate args → pass the object.
+- **Mechanics:** Add an object param; replace the individual params with reads from it inside; delete the pre-call unpacking.
+- **TS note:** Reduces param lists and future churn. TS caveat: passing the whole object *widens* the dependency — for testability/purity you sometimes *want* to depend only on the two fields you use (and TS structural typing lets you accept a minimal `{x; y}` shape). So it's a real tradeoff: cohesion vs. minimal coupling. Pick the narrowest type that's still stable.
+
+### Replace Parameter with Method Call ⚠️
+- **What:** Caller computes a value via a query then passes it in, but the callee could call that query itself → drop the param, query inside.
+- **Mechanics:** Confirm the value doesn't depend on the caller's locals; move/extract the query into the callee; remove the param.
+- **TS note:** Modest. It trades a smaller signature for **hidden coupling** to the query — the opposite of dependency-injection/testability goals. Idiomatic TS often prefers the *explicit* parameter (easier to test, more pure). Use sparingly, mainly to shrink genuinely redundant params. Mild tension with DI-friendly design.
+
+### Introduce Parameter Object ⭐
+- **What:** The same clump of params recurs across methods → bundle them into one type.
+- **Mechanics:** Create an (immutable) type for the group; add it as a param; replace the individual params with its fields; relocate related behavior onto it if warranted.
+- **TS note:** Very TS-friendly. Use an `interface`/`type` (often `readonly`) — this is also the canonical fix for **Long Parameter List** and a near-cousin of the **options-object** convention. Bonus: named fields kill positional-argument bugs and improve call-site readability. If it ends up pure data with no behavior, that's acceptable in TS (it's a DTO), unlike the OO "Data Class" worry.
+
+### Remove Setting Method ⭐ (as: make it `readonly`)
+- **What:** A field that should only be set at construction → delete its setter.
+- **Mechanics:** Ensure the constructor sets it; redirect any "set right after construct" callers into the constructor; replace internal setter use with direct field access; delete the setter.
+- **TS note:** In TS this is mostly a **declaration change**: mark the field `readonly` (or use a `readonly` property in the type / parameter property `constructor(readonly id: string)`). The compiler then forbids reassignment everywhere — stronger than deleting a setter. Immutability-by-default is idiomatic; this technique is "do that."
+
+### Hide Method 🔧
+- **What:** A method not used outside its class/hierarchy → make it `private`/`protected`.
+- **Mechanics:** Find candidates (unused-export analysis helps); reduce visibility as far as it'll go.
+- **TS note:** Relevant at two scales: class members (`private`/`#`) and — more importantly in module-first TS — **module exports**. Stop `export`ing internals; `noUnusedExports`/dead-export tooling finds them. Shrinking the public surface is a top maintainability lever. (`#private` gives true runtime privacy vs. `private`'s compile-only.)
+
+### Replace Constructor with Factory Method ⭐
+- **What:** A constructor doing more than field-setting, or needing to return subtype/cached/variant instances → use a factory function instead.
+- **Mechanics:** Factory wraps the constructor; redirect callers; make the constructor private; pull non-construction logic into the factory.
+- **TS note:** Idiomatic TS leans on **factory functions** heavily (constructors can't be async, can't fail gracefully without throwing, can't return a union/cached instance). Pair with `Result`/`Option` for fallible creation, or a `create*` returning a discriminated union. A named factory also reads better than `new Thing(…)`. Strong fit.
+
+### Replace Error Code with Exception ⚠️ (TS: often the *reverse* is preferred)
+- **What:** A method returning a sentinel error value → throw an exception.
+- **Mechanics:** Wrap callers in try/catch; throw inside instead of returning the code; document the throw.
+- **TS note:** **Flag as contested in idiomatic TS.** Modern type-safe TS frequently goes the *other way*: return an explicit **`Result<T, E>` / tagged union** so failures are in the type signature and the compiler forces handling — exceptions are invisible to the type system (no checked exceptions). Use exceptions for truly exceptional/unrecoverable cases and at boundaries; prefer `Result` for expected, recoverable failures. So: apply this technique to escape *stringly-typed sentinels*, but consider a typed `Result` rather than `throw` as the destination.
+
+### Replace Exception with Test ⭐
+- **What:** Using try/catch where a cheap precondition check would do → test the condition first.
+- **Mechanics:** Add a guard for the edge case before the try; move the catch body into that guard; verify nothing else throws; drop the try/catch.
+- **TS note:** Solid and common — generated code overuses try/catch for control flow (catching to provide a default, etc.). Prefer `??`/optional chaining/`in`/`Array.includes`/explicit checks over catch-as-flow. Exceptions are for the exceptional; this technique enforces that.
+
+---
+
+## 6. Dealing with Generalization
+
+Inheritance hierarchy maintenance. **The lowest-value family for idiomatic TS** — it's almost entirely class-inheritance bookkeeping. Most of it is "skip; prefer composition / unions / modules." Listed for completeness with honest TS verdicts.
+
+### Pull Up Field ⚠️🔧
+- **What:** Same field in sibling subclasses → move it to the superclass.
+- **TS note:** Only meaningful inside an existing class hierarchy. Idiomatic TS prefers composition / shared interfaces over deepening inheritance. IDE-assisted when you do have the hierarchy. Skip unless you're already committed to inheritance.
+
+### Pull Up Method ⚠️
+- **What:** Identical/near-identical methods in sibling subclasses → unify and move to the superclass.
+- **Mechanics:** Align signatures/bodies; copy up (abstract-out subclass-only deps); delete from subclasses.
+- **TS note:** The dedup goal is valid; the inheritance vehicle usually isn't. In TS, extract the shared logic into a **free function / shared module / mixin** the variants call, rather than a base class. Useful only in class-committed code.
+
+### Pull Up Constructor Body ⚠️
+- **What:** Subclass constructors share opening code → move it to a superclass constructor called via `super`.
+- **TS note:** Niche, inheritance-only. With composition you sidestep constructor-chaining entirely (factories + shared init functions). Skip in idiomatic TS.
+
+### Push Down Field ⚠️🔧
+- **What:** A superclass field used by only some subclasses → move it down to them.
+- **TS note:** Inheritance-only cleanup. The same need in union-modeled TS is just "this field belongs only on these variants" — expressed directly in the discriminated union. Skip unless class-bound.
+
+### Push Down Method ⚠️
+- **What:** A superclass method used by only one/few subclasses → move it down.
+- **TS note:** As above — inheritance bookkeeping. In TS, variant-specific behavior lives in the variant's branch/handler. Substep of the (also-dated) type-code-to-subclasses techniques. Skip.
+
+### Extract Subclass ⚠️🔁
+- **What:** A class with features used only in some cases → push those into a new subclass.
+- **TS note:** The catalog *itself* warns this dead-ends on multiple axes (the "Large + Smooth dog" problem) and steers you to **composition / Strategy**. Take that advice: model the axes as composed fields or a discriminated union, not a subclass. Dated; prefer composition.
+
+### Extract Superclass ⚠️🔁
+- **What:** Two classes sharing fields/methods → hoist commonality into a new shared superclass.
+- **TS note:** For *shared contract*, use **Extract Interface** (below) — structural typing makes it frictionless. For *shared code*, use a shared module/function or mixin. A concrete superclass is rarely the best tool in TS (single-inheritance ceiling, tight coupling). Prefer interface + composition.
+
+### Extract Interface ⭐
+- **What:** Multiple clients use the same slice of a class's surface (or two classes share a sub-interface) → name that slice as an interface.
+- **TS note:** **The one genuinely valuable member of this family.** TS structural typing means you can extract an `interface`/`type` for a role and have existing types satisfy it with no `implements` edits — perfect for ports/adapters, dependency seams, and test doubles. Defines capability contracts ("what this needs") independent of concrete classes. Use freely. (Remember its limit: interfaces share *shape*, not *implementation* — for code dedup use Extract Class/module.)
+
+### Collapse Hierarchy ⭐ (as: delete a needless layer)
+- **What:** A subclass and superclass that have become nearly identical → merge them into one class.
+- **Mechanics:** Pull-up/push-down to consolidate members; repoint references; delete the empty class; watch LSP for remaining siblings.
+- **TS note:** Worth doing — flattening accidental/speculative inheritance layers reduces complexity, and LLM/over-engineered code generates these. The broader idiomatic move is "collapse the hierarchy into composition or a union" when the inheritance never earned its keep.
+
+### Form Template Method ⚠️🔁
+- **What:** Sibling subclasses run the same algorithm skeleton with differing steps → lift the skeleton to the superclass, leave abstract step hooks for subclasses.
+- **TS note:** The Template Method *pattern*. In idiomatic TS, prefer **higher-order functions / dependency injection**: write the skeleton once as a function that takes the varying steps as callbacks (or a strategy object). Same Open/Closed benefit, no inheritance, easier to test. Use the inheritance form only in class-committed code; otherwise HOF.
+
+### Replace Inheritance with Delegation ⭐
+- **What:** A subclass uses only part of its superclass, or inheritance violates LSP (was used just to share code) → hold the former superclass in a field and delegate.
+- **Mechanics:** Add a field for the (ex-)superclass instance; route methods through it; add delegating methods for the surface clients use; drop `extends`.
+- **TS note:** Embodies **"composition over inheritance"** — the most important principle in this whole family. Highly endorsed for TS. The "many tedious delegating methods" drawback is real but often the right trade; and TS lets you expose a focused **interface** instead of re-proxying the entire surface. The endpoint is frequently a Strategy-style pluggable field. Apply whenever inheritance was a code-sharing shortcut rather than a true is-a.
+
+### Replace Delegation with Inheritance ⚠️
+- **What:** A class that delegates to *all* public methods of one other class (and has no parent) → just inherit from it, deleting the forwarders.
+- **Mechanics:** Subclass the delegate; remove the delegating methods; repoint the delegate field to `this`.
+- **TS note:** **Low value / mild anti-pattern in idiomatic TS.** This pushes *toward* inheritance, against the prevailing grain. The boilerplate it removes is better removed by exposing the delegate directly or via an interface. The catalog's own guards (only if delegating to *every* public method, only if no existing parent) make it narrow. Generally skip — prefer keeping composition.
+
+---
+
+## TOP TECHNIQUES FOR MODERN TS
+
+The ~15 that do the most work cleaning up real-world and LLM-generated TypeScript (roughly in order of everyday leverage):
+
+1. **Extract Method / Extract Function** — name behavior; shrink long functions; the universal primitive.
+2. **Replace Nested Conditional with Guard Clauses** — flatten the arrow; early-return + narrowing tightens types as a bonus.
+3. **Extract Variable** (esp. naming conditions) — turn opaque expressions into `const isX = …`.
+4. **Decompose Conditional** — extract predicate + branches; pairs with `x is T` type guards.
+5. **Replace Type Code with Class/Subclasses/State** → in TS: **discriminated unions + exhaustive `switch` (with `never`)**, or a **strategy map** — the highest-value *conceptual* upgrade for branchy code.
+6. **Replace Magic Number with Symbolic Constant** — `const` scalars; `as const` objects + derived unions for related literals.
+7. **Encapsulate Collection** — return `readonly T[]`, mutate only via intent-named methods; the compiler enforces it.
+8. **Introduce Parameter Object / Preserve Whole Object** — kill Long Parameter List; the options-object convention.
+9. **Replace Parameter with Explicit Methods** — kill boolean-flag parameters (`enable()` vs `setEnabled(true)`).
+10. **Split Temporary Variable + Remove Assignments to Parameters** — one `const` per concept; treat params as immutable.
+11. **Replace Temp with Query / Separate Query from Modifier** — pure, reusable, testable reads; CQS.
+12. **Replace Constructor with Factory Method** — async/fallible/variant creation; pairs with `Result`/unions.
+13. **Remove Setting Method** → make it `readonly` (declaration-level immutability).
+14. **Replace Inheritance with Delegation** + **Extract Interface** — composition over inheritance, plus capability contracts for seams/testing.
+15. **Inline Method / Inline Class / Collapse Hierarchy / Remove Parameter** — the *deletion* refactors; remove the speculative indirection LLMs love to generate.
+
+Honorable mentions: **Replace Exception with Test** (stop catch-as-control-flow), **Substitute Algorithm** (replace hand-rolled loops with `Array`/`Map`/`Set` methods or a library), **Introduce Assertion** → encode invariants in types + assertion functions / boundary validation, **Extract Class** → split god-modules.
+
+---
+
+## MOSTLY SKIP IN IDIOMATIC TS
+
+OO/inheritance-and-association bookkeeping with little payoff when you favor modules, composition, unions, and immutability. (Skip the *technique-as-written*; the underlying *goal* often survives via a TS-native move noted inline above.)
+
+- **Pull Up Field / Pull Up Method / Pull Up Constructor Body** — inheritance choreography; prefer shared functions/modules/mixins.
+- **Push Down Field / Push Down Method** — inheritance choreography; variant-specific data/behavior lives in the union branch.
+- **Extract Subclass** — the catalog itself routes you to composition/Strategy; multi-axis variation dead-ends on inheritance.
+- **Extract Superclass** — prefer Extract Interface (shape) + composition/modules (code).
+- **Form Template Method** — prefer higher-order functions / DI over a base-class skeleton with abstract hooks.
+- **Replace Delegation with Inheritance** — pushes the wrong way (toward inheritance); mild anti-pattern; keep composition.
+- **Change Unidirectional → Bidirectional Association** — adds coupling/cycles/serialization pain; derive the reverse via lookup instead.
+- **Introduce Local Extension** — replace wrappers/subclasses of 3rd-party types with free utility functions / thin adapters.
+- **Introduce Foreign Method** — just write a standalone function; no "foreign method" ceremony.
+- **Self-Encapsulate Field / Encapsulate Field** — don't reflexively wrap fields in get/set; use `readonly`/`private`/`#` and add accessors only for real logic.
+- **Duplicate Observed Data** (as written) — the hand-rolled Observer is dated; keep the *separate-domain-from-view* principle via reactive state (signals/stores/hooks).
+- **Change Value to Reference** — niche identity/interning concern; model explicitly with a registry only when actually needed.
+
+**Net:** Families 1 and 4 (Composing Methods, Simplifying Conditionals) are almost entirely high-value in TS. Family 5 (Method Calls) is mostly valuable with a couple of contested items (error-code→exception leans toward `Result` instead; replace-parameter-with-method-call fights DI). Family 3 (Organizing Data) splits cleanly: the "type the primitive / make it immutable / encapsulate the collection" half is core, while the type-code and value/reference machinery is **superseded by the type system** (discriminated unions, branded types). Family 6 (Generalization) is the one to mostly skip — except **Extract Interface**, **Replace Inheritance with Delegation**, and **Collapse Hierarchy**, which actively support a composition-first TS style.
+
+---
+
+*Source: synthesized from the Refactoring.Guru techniques catalog (https://refactoring.guru/refactoring/techniques), originating in Martin Fowler's* Refactoring*. All entries are original paraphrase + TypeScript analysis; no source prose is reproduced.*

--- a/docs/projects/typescript-refactoring-skill/research/r4c-patterns.md
+++ b/docs/projects/typescript-refactoring-skill/research/r4c-patterns.md
@@ -1,0 +1,777 @@
+# R4c — GoF Design Patterns Through a TypeScript Lens
+
+**Research lane:** R4c (design-patterns synthesis for the new TypeScript first-principles
+complexity-reduction & refactoring skill).
+**Mandatory primary reference:** Refactoring Guru — `refactoring.guru/design-patterns`
+(catalog + concept pages), cached locally and read in full for this synthesis.
+**Source pages read:** all 22 pattern articles plus the five concept pages
+(*What's a design pattern?*, *Why learn patterns?*, *Criticism of patterns*,
+*Classification of patterns*, *Design Patterns in TypeScript*).
+**Stance:** This is an **original, opinionated synthesis**, not a copy of RG prose.
+Where I lean on RG's framing (especially its own "Criticism" section), I cite it
+explicitly. The deliverable feeds two downstream concerns of the skill: (1) the
+**over-engineering / cargo-cult** guidance, and (2) the **functional-vs-class
+decision** guidance.
+
+> **One-sentence thesis.** The GoF catalog is a fixed vocabulary for object
+> *collaboration*; in idiomatic TypeScript roughly half of it dissolves into
+> functions, closures, modules, iterables, and discriminated unions — and the
+> patterns that *survive* are the ones that name a **boundary** (Adapter, Facade,
+> Proxy) or a **shape of data/state** (State-as-DU, Composite), not the ones that
+> exist to compensate for a language without first-class functions.
+
+---
+
+## 1. What patterns are — and the criticism that matters most to us
+
+### 1.1 What a pattern actually is
+
+Refactoring Guru frames a design pattern as a **typical solution to a commonly
+occurring design problem** — "like a pre-made blueprint you customize," explicitly
+*not* a copy-pasteable snippet (RG, *What's a design pattern?*). Two distinctions
+from that page are load-bearing for our skill:
+
+- **Pattern ≠ algorithm.** An algorithm is a recipe (fixed steps to a goal); a
+  pattern is a blueprint (you see the result and its properties, but the
+  implementation order is yours). The same pattern looks different in two programs.
+- **Pattern ≠ library.** You can't `npm install` a pattern. It's a *concept*, which
+  is exactly why a pattern can be "implemented" by a language feature instead of by
+  classes — and why, in a sufficiently expressive language, the pattern can vanish
+  as a named artifact while the *problem it solved* still gets solved.
+
+RG also classifies patterns by **scope/altitude** (*Classification*): low-level
+**idioms** (single-language), the three GoF **intent groups** (creational /
+structural / behavioral), and high-level **architectural** patterns. The skill
+should keep this altitude axis: most GoF patterns are *idiom-to-mid* altitude, and
+in TS the idiom layer is where language features do the most replacing.
+
+### 1.2 Why RG says to learn them — the half we keep
+
+RG's defense of patterns (*Why learn patterns?*) reduces to two claims. **One is
+durable, one is contingent.**
+
+- **Durable — shared vocabulary.** "Just use a Strategy for that" communicates an
+  intent in three words. This survives the move to TypeScript completely. Even when
+  the *implementation* is a `Record<string, Fn>`, calling it "a strategy map" tells
+  a reviewer what role it plays. **The names are an asset even when the classes are
+  a liability.** Our skill should teach the vocabulary as *communication*, decoupled
+  from the class machinery.
+- **Contingent — "tried-and-tested OO solutions."** This is the part TS erodes. The
+  value of memorizing a class skeleton drops sharply when the language gives you the
+  collaboration mechanism natively (a closure, an iterable, a module).
+
+### 1.3 The criticism — central to our over-engineering guidance
+
+RG dedicates a whole page to criticism (*Criticism of patterns*), and it is unusually
+candid. The three arguments, in RG's own framing, and why each one anchors a rule in
+our skill:
+
+1. **"Kludges for a weak programming language."** RG attributes this to Paul Graham's
+   *Revenge of the Nerds*: *"Usually the need for patterns arises when people choose
+   a programming language or a technology that lacks the necessary level of
+   abstraction. In this case, patterns become a kludge that gives the language
+   much-needed super-abilities."* RG's own example: **"the Strategy pattern can be
+   implemented with a simple anonymous (lambda) function in most modern programming
+   languages."** This is the single most important sentence for us. TypeScript *is*
+   one of those modern languages — first-class functions, closures, modules,
+   structural typing, generators, union types. So a large fraction of GoF is, by
+   RG's own admission, a workaround for a missing feature TS already has.
+
+2. **"Inefficient solutions" / dogmatic application.** Patterns systematize
+   already-common approaches; treated as dogma and applied "to the letter" without
+   adapting to context, they produce ceremony. Our skill's translation:
+   **implement the *intent*, not the UML.** A 5-class Strategy hierarchy to choose
+   between two functions is the textbook case.
+
+3. **"Unjustified use" — the hammer/nail problem.** RG: novices who just learned
+   patterns "try to apply them everywhere, even in situations where simpler code
+   would do just fine." This is **cargo-culting**, and it is the dominant failure
+   mode in LLM-generated TypeScript specifically: the model has read thousands of
+   pattern tutorials and reaches for a `Factory`/`Manager`/`AbstractBaseStrategy`
+   when a function literal would do.
+
+> **Skill rule derived from §1.3.** *A pattern is justified only when it names a
+> real, present force in your code — a varying axis, a stable boundary, a coupling
+> you must break. If the pattern's machinery (interface + concrete classes +
+> wiring) is larger than the problem, you are paying the "kludge tax" for an
+> abstraction TypeScript already gives you for free. Name the role in plain
+> language; reach for the class skeleton only when the language feature genuinely
+> falls short.*
+
+### 1.4 RG's own TypeScript page — what it does and doesn't say
+
+The *Design Patterns in TypeScript* page (RG) is a **catalog index with one-line
+intents**, not a verdict page. It does not say "this pattern is obsolete in TS."
+That editorial gap is precisely what this lane fills: RG tells you *what* each
+pattern is in TS; we add *whether you should still reach for it*. The one explicit
+language-feature nod RG itself makes is inside the **Strategy** article's Pros/Cons:
+*"A lot of modern programming languages have functional type support that lets you
+implement different versions of an algorithm inside a set of anonymous functions …
+without bloating your code with extra classes and interfaces."* We generalize that
+admission across the catalog.
+
+---
+
+## 2. The three categories (RG classification) with members
+
+Per RG's *Classification*:
+
+- **Creational** — object-creation mechanisms that increase flexibility/reuse:
+  **Factory Method, Abstract Factory, Builder, Prototype, Singleton.**
+- **Structural** — assembling objects/classes into larger structures, kept flexible:
+  **Adapter, Bridge, Composite, Decorator, Facade, Flyweight, Proxy.**
+- **Behavioral** — communication and assignment of responsibilities between objects:
+  **Chain of Responsibility, Command, Iterator, Mediator, Memento, Observer, State,
+  Strategy, Template Method, Visitor.**
+
+Each entry below uses one of three **TS verdicts**:
+
+- **IDIOMATIC** — still pulls its weight in TS; the class form (or a light version of
+  it) is often the right call.
+- **SUPERSEDED-BY-LANGUAGE** — a TS/JS feature does the job better; the named pattern
+  becomes a description of a one-liner, not a structure you build.
+- **OVER-ENGINEERING-RISK** — solves a real but *rare* problem; defaults to ceremony.
+  Worth it only when a specific, present force justifies it.
+
+---
+
+## 3. Creational patterns
+
+### Factory Method
+- **Intent.** Define an interface for creating an object, but let subclasses decide
+  which concrete type to instantiate (RG).
+- **Real problem it solves.** Decouple client code from `new ConcreteThing()` so new
+  product types don't force edits across the codebase; give framework users an
+  extension seam to override which component class is built.
+- **TS verdict: SUPERSEDED-BY-LANGUAGE (mostly) → a factory *function* / DI.** The
+  "subclass overrides the creation method" mechanism is inheritance ceremony. In TS
+  the idiom is a plain function returning the interface type, or passing a creator
+  function as a parameter:
+  ```ts
+  type Transport = { deliver(): void };
+  const makeTransport = (kind: "road" | "sea"): Transport =>
+    kind === "road" ? roadTransport() : seaTransport();
+  ```
+  Returning an interface (structural type) gives you the decoupling Factory Method
+  promises without a `Creator` hierarchy.
+- **Worth it when.** You're authoring a library/framework and want a documented,
+  overridable creation hook on a class consumers already subclass — i.e. the
+  inheritance is *already there for other reasons* (RG's own "best case scenario").
+- **Smell when.** A `Factory` class wrapping a single `switch` that a function would
+  hold; or `*Factory` classes created reflexively for objects that have one variant.
+
+### Abstract Factory
+- **Intent.** Produce *families* of related objects without naming their concrete
+  classes (RG).
+- **Real problem it solves.** Guarantee that objects used together are
+  **compatible** (all "Modern" furniture, all "macOS" widgets) and swap the whole
+  family by swapping one factory.
+- **TS verdict: OVER-ENGINEERING-RISK → an object of factory functions, or a config
+  record.** The genuine value (family consistency) is real but narrow. The
+  lightweight TS form is a single object literal whose methods return the interfaces:
+  ```ts
+  type UIKit = { button(): Button; checkbox(): Checkbox };
+  const macKit: UIKit = { button: makeMacButton, checkbox: makeMacCheckbox };
+  ```
+  No `AbstractFactory` interface + N concrete classes needed; the object *is* the
+  factory, and TS structurally checks `macKit` against `UIKit`.
+- **Worth it when.** Multiple product *families* × multiple product *types* form a
+  real matrix (RG's "map out a matrix"), variants are swapped wholesale, and
+  cross-family mixing must be statically prevented (cross-platform UI, theming
+  engines, multi-backend drivers).
+- **Smell when.** One family, or a family that never changes — then it's just five
+  interfaces guarding a constructor call (RG lists this exact downside: "a lot of
+  new interfaces and classes").
+
+### Builder
+- **Intent.** Construct a complex object step by step; reuse the construction code to
+  produce different representations (RG).
+- **Real problem it solves.** Kill the **telescoping constructor** (RG's named
+  trigger) and the explosion of config subclasses; allow partial/optional
+  configuration without a 10-arg constructor.
+- **TS verdict: SUPERSEDED-BY-LANGUAGE (for config) → options object;
+  IDIOMATIC (narrowly) for fluent/typed staged builders.** TypeScript's
+  **optional properties on an options object** solve the telescoping-constructor
+  problem directly and idiomatically:
+  ```ts
+  function makeHouse(opts: { walls: number; pool?: boolean; garage?: boolean }) { … }
+  ```
+  The *Director* role almost always collapses into a named factory function. The
+  Builder *class* re-earns its place only when you want a **fluent, type-state API**
+  where the accumulating generic forbids `.build()` until required steps ran — a TS
+  *type-level* win that the plain options object can't express (see R2's
+  "accumulating-generic builder").
+- **Worth it when.** Public SDK ergonomics where chaining + compile-time "you forgot
+  a required step" matters; or genuinely building *different representations* from
+  one sequence (RG's car + manual example).
+- **Smell when.** A builder for a 3-field record. Use an options object.
+
+### Prototype
+- **Intent.** Copy existing objects without coupling to their concrete classes (RG).
+- **Real problem it solves.** Clone configured instances (including private state)
+  when you only hold an interface; avoid re-running expensive init; use pre-built
+  presets instead of init-only subclasses.
+- **TS verdict: SUPERSEDED-BY-LANGUAGE → `structuredClone`, spread, immutable
+  updates.** The cloning problem RG describes (private fields invisible from
+  outside) is solved natively:
+  ```ts
+  const copy = structuredClone(original);          // deep, handles cycles
+  const tweaked = { ...original, color: "red" };    // shallow override
+  ```
+  `structuredClone` even handles RG's "circular references" caveat. A `clone()`
+  method per class is rarely needed.
+- **Worth it when.** A class encapsulates clone semantics that structural copy can't
+  capture (reattaching live handles, custom deep-copy invariants, registry of named
+  prototypes). Then a `clone()` method is a legitimate domain operation, not a
+  pattern.
+- **Smell when.** Hand-rolled `clone()` that copies each field — that's
+  `structuredClone`/spread reinvented.
+
+### Singleton
+- **Intent.** One instance, globally accessible (RG).
+- **Real problem it solves.** Control a single shared resource (a connection pool, a
+  config) and provide one access point.
+- **TS verdict: SUPERSEDED-BY-LANGUAGE → ES modules.** A module is a singleton: it
+  evaluates once, and its exports are the single shared instances. No private
+  constructor, no `getInstance`, no double-checked locking (RG's multithreading
+  caveat doesn't even apply to single-threaded JS).
+  ```ts
+  // db.ts — imported anywhere, evaluated once
+  export const db = createConnection(config);
+  ```
+  RG *itself* lists the Singleton's downsides: SRP violation, masks bad design,
+  hard to unit-test ("Or just don't use the Singleton pattern."). The module form
+  inherits the **same testability problem** (hidden global coupling), so the real
+  upgrade is **dependency injection**: pass the dependency in, default it to the
+  module instance.
+- **Worth it when.** Truly never — as a *class pattern*. The legitimate need (one
+  shared instance) is met by a module export; the legitimate *concern* (testability)
+  pushes you toward DI.
+- **Smell when.** A `class X { static getInstance() }` in TS. It's a module wearing a
+  costume, and it imports the hardest-to-test property of globals.
+
+---
+
+## 4. Structural patterns
+
+### Adapter
+- **Intent.** Let objects with incompatible interfaces collaborate (RG).
+- **Real problem it solves.** Use a 3rd-party/legacy thing whose shape doesn't match
+  your code, *without* editing it (you may not own it).
+- **TS verdict: IDIOMATIC.** This is one of the patterns that **fully survives** —
+  but the TS form is usually a **function or a small wrapper object**, not a class
+  hierarchy. The pattern is fundamentally "a boundary translation," and boundaries
+  are exactly where TS wants explicit code (parse-at-the-edges).
+  ```ts
+  // wrap a JSON-only lib for an XML-shaped caller
+  const xmlToJsonAdapter = (svc: JsonAnalytics): XmlAnalytics => ({
+    analyze: (xml) => svc.analyze(xmlToJson(xml)),
+  });
+  ```
+- **Worth it when.** Integrating any external/legacy API; isolating your domain from
+  a vendor's shape so swapping vendors touches one file. (This is the same instinct
+  as ports-and-adapters.)
+- **Smell when.** "Adapting" code you own and could just change (RG: "sometimes it's
+  simpler just to change the service class"); or a class with one delegating method
+  that should be a function.
+
+### Bridge
+- **Intent.** Split a class into two independent hierarchies — *abstraction* and
+  *implementation* — that vary separately (RG).
+- **Real problem it solves.** Prevent the **combinatorial subclass explosion** when
+  a type varies along two orthogonal axes (Shape × Color; GUI × OS API).
+- **TS verdict: OVER-ENGINEERING-RISK → composition / inject the implementation.**
+  The *insight* is excellent and timeless: **prefer composition over a 2-D
+  inheritance grid.** But the named "abstraction/implementation hierarchy" framing
+  (which RG admits "sound too academic") is heavier than TS needs. In TS you just
+  give the high-level object a field of an interface type and inject the
+  implementation — which is also how Strategy and State look (RG notes all three
+  share a structure).
+  ```ts
+  type Renderer = { drawCircle(r: number): void };       // "implementation"
+  class Circle { constructor(private r: Renderer) {} … }   // "abstraction"
+  ```
+- **Worth it when.** Two axes that *both* genuinely grow over time and must ship
+  independently (e.g. N device drivers × M frontends), decided up-front (RG: "Bridge
+  is usually designed up-front").
+- **Smell when.** Applied to a "highly cohesive class" (RG's own warning) or when one
+  axis is actually fixed. Then it's indirection with no payoff.
+
+### Composite
+- **Intent.** Compose objects into trees and treat individual objects and
+  compositions uniformly (RG).
+- **Real problem it solves.** Run an operation recursively over a part-whole
+  hierarchy (file system, UI tree, order-of-boxes) without the client knowing
+  leaf-vs-container.
+- **TS verdict: IDIOMATIC — best expressed as a recursive discriminated union +
+  fold.** The pattern's intent is sound and common. But the *idiomatic TS* shape is
+  **data + a function**, not a class tree:
+  ```ts
+  type Node =
+    | { kind: "leaf"; price: number }
+    | { kind: "box"; children: Node[]; packaging: number };
+
+  const total = (n: Node): number =>
+    n.kind === "leaf" ? n.price : n.packaging + n.children.reduce((s, c) => s + total(c), 0);
+  ```
+  The DU gives exhaustiveness checking the class form lacks; the recursive function
+  *is* the "uniform treatment." Use classes only when nodes carry real behavior +
+  identity.
+- **Worth it when.** Your core model genuinely is a tree (RG: "makes sense only when
+  the core model can be represented as a tree").
+- **Smell when.** Forcing a tree onto flat data, or "overgeneralizing the component
+  interface" (RG's stated downside) so leaves carry meaningless `add()/remove()`.
+
+### Decorator
+- **Intent.** Attach new behavior by wrapping objects in interface-compatible
+  wrappers; stackable at runtime (RG).
+- **Real problem it solves.** Add responsibilities (logging, compression, formatting,
+  extra notification channels) *combinatorially* without a subclass per combination,
+  and at runtime.
+- **TS verdict: SUPERSEDED-BY-LANGUAGE → higher-order functions / function
+  composition.** ⚠️ **Distinct from TS `@decorators`** — those are a metadata/AOP
+  annotation feature, *not* this pattern. The GoF Decorator's "wrap-and-delegate,
+  stack the wrappers" is exactly function composition:
+  ```ts
+  type Notify = (msg: string) => void;
+  const withSlack = (next: Notify): Notify => (m) => { sendSlack(m); next(m); };
+  const withSms   = (next: Notify): Notify => (m) => { sendSms(m); next(m); };
+  const notify = withSlack(withSms(emailNotify));   // stacked decorators
+  ```
+  For object-shaped services, a wrapper object spreading the original
+  (`{ ...inner, method: … }`) is the equivalent. RG's own downsides ("hard to remove
+  a specific wrapper," "behavior depends on stack order," "config code looks ugly")
+  apply to HOFs too, but with far less boilerplate.
+- **Worth it when.** You need the *object* interface preserved across many stacked
+  layers and the wrappers carry state. Otherwise compose functions.
+- **Smell when.** A `BaseDecorator` abstract class + N subclasses to add behaviors
+  that are one-line wrappers.
+
+### Facade
+- **Intent.** Provide a simplified interface to a complex subsystem (RG).
+- **Real problem it solves.** Shield clients from a sprawling library's
+  initialization order/dependencies; define a clean entry point per subsystem layer.
+- **TS verdict: IDIOMATIC — usually a module, sometimes a function.** Survives
+  cleanly; the TS form is **a module that exports a few well-named functions** which
+  internally orchestrate the messy subsystem. No `Facade` class required.
+  ```ts
+  // videoFacade.ts
+  export function encode(file: string, format: string): Blob { /* hides 12 classes */ }
+  ```
+- **Worth it when.** Wrapping any complex dependency you want to use a slice of, or
+  decoupling subsystems so they talk only through facades (RG's layering use).
+- **Smell when.** The facade grows into a **god object** coupled to everything (RG's
+  explicit warning) — the sign it should be split into several smaller facades/modules.
+
+### Flyweight
+- **Intent.** Share common (intrinsic) state across many objects to fit more in RAM;
+  pass per-instance (extrinsic) state in as arguments (RG).
+- **Real problem it solves.** Millions of near-identical objects exhausting memory
+  (RG's particle-system example).
+- **TS verdict: OVER-ENGINEERING-RISK → only under a measured memory ceiling.** This
+  is a genuine *optimization* pattern, not a design pattern; its value "depends
+  heavily on how and where it's used" (RG). In TS the lightweight expression is an
+  **intern pool / memoized factory** (`Map<key, shared>`) returning shared immutable
+  objects — no `Flyweight` class hierarchy.
+- **Worth it when.** You have *measured* that a huge number of objects with shared
+  immutable state is blowing the heap (RG: "only when your program must support a
+  huge number of objects which barely fit into available RAM").
+- **Smell when.** Applied speculatively. RG's own downside: "the code becomes much
+  more complicated; new team members will always be wondering why the state was
+  separated." Don't pay that without a profiler reading.
+
+### Proxy
+- **Intent.** A stand-in with the **same interface** that controls access to the real
+  object — for lazy init, access control, caching, logging, remoting, smart refs (RG).
+- **Real problem it solves.** Insert cross-cutting behavior *before/after* calls
+  without changing the real object or its clients (it can't tell the difference).
+- **TS verdict: IDIOMATIC — and JS has a literal `Proxy` built-in.** Survives; two
+  TS forms. (1) A **wrapper object/function** with the same shape (most cases —
+  caching, logging, lazy init via a getter). (2) The runtime **`Proxy`** object for
+  truly dynamic interception (`get`/`set`/`apply` traps) — e.g. reactive state, ORMs.
+  ```ts
+  const lazyDb: Db = new Proxy({} as Db, { get: (_, k) => (realDb ??= connect())[k] });
+  ```
+- **Worth it when.** Lazy/expensive resources, caching layers, access guards, remote
+  stubs, reactive frameworks. The "same interface" constraint (vs Adapter's
+  *different* interface, vs Decorator's *enhanced* one) is the discriminator (RG).
+- **Smell when.** A proxy that only forwards with no added control — that's dead
+  indirection; or hand-written interception that the native `Proxy` would do.
+
+---
+
+## 5. Behavioral patterns
+
+### Chain of Responsibility
+- **Intent.** Pass a request along a chain of handlers; each handles or forwards (RG).
+- **Real problem it solves.** Decouple sender from the (dynamic, reorderable) set of
+  processors; run ordered checks/filters where any link may stop the flow
+  (auth → sanitize → rate-limit → cache → handle).
+- **TS verdict: IDIOMATIC (as a concept) → an array of handler *functions* /
+  middleware.** The pattern is alive and everywhere — but the linked-list-of-handler-
+  *classes* form is superseded by the **middleware array** idiom (Express/Koa/
+  oRPC-style):
+  ```ts
+  type Handler = (req: Req, next: () => Res) => Res;
+  const run = (hs: Handler[], req: Req): Res =>
+    (function go(i): Res { return i < hs.length ? hs[i](req, () => go(i + 1)) : final(req); })(0);
+  ```
+  Handlers as functions are reorderable at runtime (RG's key requirement) without a
+  `setNext` field.
+- **Worth it when.** Pluggable, runtime-configurable pipelines where order matters and
+  short-circuiting is real (middleware, validation chains, event bubbling).
+- **Smell when.** A fixed two-step check modeled as a handler hierarchy. RG's own
+  downside — "some requests may end up unhandled" — is a real failure mode to guard.
+
+### Command
+- **Intent.** Turn a request into a standalone object holding all call info; enables
+  queueing, logging, undo (RG).
+- **Real problem it solves.** Parameterize objects with operations; defer/queue/
+  serialize/log/undo invocations; decouple invoker from receiver.
+- **TS verdict: SUPERSEDED-BY-LANGUAGE → closures (and tagged unions for
+  serializable commands).** "A request as an object with an `execute()`" is a
+  **closure** that captures its args:
+  ```ts
+  const copy = () => editor.copy();        // a command
+  history.push(copy);                       // queue / store / replay
+  ```
+  When commands must be **serialized** (sent over the wire, persisted, replayed —
+  RG's queue/log use), model them as a **discriminated union of plain data** + one
+  interpreter function; that's better than command classes because it's
+  exhaustively typed and trivially JSON-able.
+- **Worth it when.** Undo/redo with state mementos, event sourcing, job queues — i.e.
+  commands need *identity and data*, not just behavior. Then the DU-of-data form wins.
+- **Smell when.** A `Command` interface + N classes each wrapping one function call.
+  RG even pairs Command with Memento for undo — in TS that's "a data record + a
+  reducer," not two class hierarchies.
+
+### Iterator
+- **Intent.** Traverse a collection's elements without exposing its representation
+  (RG).
+- **TS verdict: SUPERSEDED-BY-LANGUAGE → iteration protocol + generators +
+  `for…of`.** This is the cleanest "the language already has it" case. JS/TS have a
+  built-in iteration protocol (`Symbol.iterator`), **generators** for custom
+  traversal, and `for…of`/spread that consume any iterable:
+  ```ts
+  function* inOrder(t: Tree): Iterable<number> {
+    if (t.left) yield* inOrder(t.left);
+    yield t.value;
+    if (t.right) yield* inOrder(t.right);
+  }
+  for (const v of inOrder(tree)) { … }
+  ```
+  Multiple independent traversals, lazy iteration, pause/resume (all RG benefits)
+  come for free, with lazy evaluation as a bonus the classic pattern lacks.
+- **Worth it when.** Effectively never as a hand-built `Iterator` class. Implement
+  `[Symbol.iterator]` / write a generator instead.
+- **Smell when.** A `hasNext()`/`next()` class in TS. That's the iteration protocol,
+  reinvented and incompatible with `for…of`.
+
+### Mediator
+- **Intent.** Centralize chaotic many-to-many object communication behind one
+  mediator; components talk only to it (RG).
+- **Real problem it solves.** Untangle N components that each know about the others
+  (a form where every field reacts to every other) so they depend on one hub.
+- **TS verdict: OVER-ENGINEERING-RISK → an event bus / store / reducer.** The intent
+  (kill direct component-to-component coupling) is sound, and it's the basis of real
+  architectures (Redux-style stores, `EventTarget` buses, parent-coordinator
+  components). But a bespoke `Mediator` class/interface is heavy; reach for an
+  existing coordination mechanism first. RG itself notes a Mediator "can evolve into
+  a God Object," and that an Observer-based mediator "may look very similar to
+  Observer."
+- **Worth it when.** A real web of mutual dependencies among UI/components that you
+  must decouple and reuse independently (RG's dialog example), *and* an off-the-shelf
+  store/bus doesn't fit.
+- **Smell when.** A "Manager/Coordinator" hub that accretes every interaction until
+  it's the god object RG warns about.
+
+### Memento
+- **Intent.** Capture and restore an object's state without breaking encapsulation
+  (RG).
+- **Real problem it solves.** Undo/redo and transactional rollback while keeping
+  snapshot internals private to the originator.
+- **TS verdict: SUPERSEDED-BY-LANGUAGE (largely) → immutable snapshots /
+  `structuredClone` / readonly state.** With immutable data, a "memento" is just a
+  previous value you kept:
+  ```ts
+  const history: readonly State[] = [];
+  const snapshot = structuredClone(state);   // or state is already immutable
+  ```
+  RG's whole motivating problem — "how to copy private fields without exposing them"
+  — is mostly an OO artifact; with plain immutable state objects there's nothing to
+  hide and nothing to clone-by-hand. RG even concedes dynamic languages "can't
+  guarantee" memento immutability — so lean on `readonly`/`Readonly<T>` + discipline.
+- **Worth it when.** A class with genuinely private, complex internals must control
+  exactly what's snapshotted/restored (custom serialization, partial state). Then a
+  real memento method is justified.
+- **Smell when.** A `Memento` + `Caretaker` + `Originator` trio guarding a value you
+  could have cloned.
+
+### Observer
+- **Intent.** Define a subscription so many subscribers are notified of a subject's
+  state changes (RG).
+- **Real problem it solves.** One-to-many dynamic notification without the publisher
+  knowing concrete subscriber classes.
+- **TS verdict: SUPERSEDED-BY-LANGUAGE / ECOSYSTEM → `EventTarget`, signals, RxJS,
+  framework reactivity.** The mechanism RG describes (a subscriber list + add/remove
+  + notify) is provided natively and by standard libraries:
+  - **`EventTarget`** (built into browsers and Node) — `addEventListener` /
+    `dispatchEvent` *is* Observer.
+  - **Signals / reactive primitives** (Solid, Vue refs, Preact/Angular signals,
+    the TC39 signals proposal) — fine-grained auto-subscription.
+  - **RxJS `Observable`** — Observer at scale, with operators.
+  - A typed micro-emitter (`Map<event, Set<handler>>`) when you want zero deps.
+  ```ts
+  const bus = new EventTarget();
+  bus.addEventListener("restock", (e) => render(e));   // subscribe
+  bus.dispatchEvent(new CustomEvent("restock"));        // notify
+  ```
+- **Worth it when.** Effectively always *use* the pattern — but via these tools, not
+  a hand-rolled `Subject`/`Observer` interface pair. Roll your own only for a tiny,
+  dependency-free, strongly-typed emitter.
+- **Smell when.** A `Publisher`/`Subscriber` interface hierarchy reimplementing
+  `EventTarget`. RG's "subscribers notified in random order" caveat is yours to own.
+
+### State
+- **Intent.** Let an object change behavior when its internal state changes — "as if
+  it changed its class" (RG).
+- **Real problem it solves.** Replace the sprawling `switch(state)` repeated across
+  every method (RG's exact motivation) with per-state behavior, and make transitions
+  explicit.
+- **TS verdict: IDIOMATIC — as a discriminated union + transition function (a typed
+  FSM).** This is the flagship "the pattern is real, the *class* form isn't" case.
+  RG's own problem statement is a `switch` on a `state: string`; the TS answer isn't
+  N state classes — it's a **DU of states** + a transition function with
+  **exhaustiveness checking**:
+  ```ts
+  type Doc =
+    | { status: "draft" }
+    | { status: "moderation" }
+    | { status: "published" };
+
+  const publish = (d: Doc, user: User): Doc => {
+    switch (d.status) {
+      case "draft":      return { status: "moderation" };
+      case "moderation": return user.isAdmin ? { status: "published" } : d;
+      case "published":  return d;
+      default:           return assertNever(d);   // compiler enforces totality
+    }
+  };
+  ```
+  This keeps RG's win (no scattered conditionals, easy to add states) and adds
+  compile-time guarantees that the class form can't give. For complex state +
+  side-effects, a library FSM (XState) is the scaled form. (This directly feeds the
+  skill's "State-as-DU" guidance.)
+- **Worth it when.** A real finite-state machine with many states / frequent change
+  (RG). DU for logic-heavy; XState for orchestration/side-effects.
+- **Smell when.** A class-per-state hierarchy where states share most behavior, or a
+  2-state toggle dressed as an FSM (RG: "overkill if a state machine has only a few
+  states").
+
+### Strategy
+- **Intent.** Define a family of interchangeable algorithms; swap them at runtime
+  (RG).
+- **Real problem it solves.** Stop a class from ballooning with every algorithm
+  variant; pick behavior at runtime; isolate algorithm internals from the caller.
+- **TS verdict: SUPERSEDED-BY-LANGUAGE → first-class functions (and a `Record` of
+  them).** This is the pattern RG *itself* uses as the headline example of the
+  "kludge for a weak language" criticism, and repeats in the Strategy Pros/Cons. A
+  strategy is **a function**:
+  ```ts
+  type RouteFn = (from: Point, to: Point) => Point[];
+  const strategies: Record<Mode, RouteFn> = { car: drive, walk: walkRoute, bus: transit };
+  const route = strategies[mode](a, b);
+  ```
+  Pass the function as a parameter, or look it up in a map keyed by a union. No
+  `Strategy` interface, no concrete classes.
+- **Worth it when.** A strategy needs **multiple methods or its own state** — then an
+  object (still not necessarily a class) earns its keep. A single-method strategy is
+  always a function.
+- **Smell when.** `interface Strategy { execute() }` + N one-method classes. That's
+  the literal kludge RG describes.
+
+### Template Method
+- **Intent.** Define an algorithm's skeleton in a base class; let subclasses override
+  specific steps without changing the structure (RG).
+- **Real problem it solves.** Remove duplication across near-identical algorithms by
+  hoisting the shared shape and varying only the differing steps (parse → analyze →
+  report, where only parsing differs).
+- **TS verdict: SUPERSEDED-BY-LANGUAGE → higher-order function taking step
+  functions.** The "skeleton + overridable steps" is a function that accepts the
+  varying steps as parameters/callbacks:
+  ```ts
+  const mine = (steps: { open(): Raw; parse(r: Raw): Data }) => {
+    const raw = steps.open();
+    const data = steps.parse(raw);
+    return analyze(data);          // shared skeleton
+  };
+  ```
+  This sidesteps RG's stated downsides: the inheritance form risks **Liskov
+  violations** (suppressing a default step) and gets "harder to maintain the more
+  steps they have." Passing steps as data has neither problem.
+- **Worth it when.** You already have an inheritance hierarchy and the skeleton truly
+  belongs to a base class consumers extend (framework lifecycle hooks). RG notes
+  Factory Method is a specialization of Template Method — same caveats.
+- **Smell when.** A new abstract base class created *just* to host a template method,
+  when an HOF would do.
+
+### Visitor
+- **Intent.** Separate algorithms from the object structure they operate on; add new
+  operations without changing the element classes (RG).
+- **Real problem it solves.** Add operations (export-to-XML, then export-to-JSON, …)
+  over a fixed set of element types you can't/won't keep editing; uses **double
+  dispatch** to route to the right method.
+- **TS verdict: OVER-ENGINEERING-RISK → discriminated union + a `switch` function.**
+  Visitor exists to fake the dispatch and open/closed properties that TS gives you
+  natively. The double-dispatch + `accept()` ceremony is unnecessary: with a DU,
+  "add an operation" is just "write another function" — no element changes:
+  ```ts
+  type Node = City | Industry | Sightseeing;       // closed set
+  const toXml = (n: Node): string => {              // a "visitor" = a function
+    switch (n.kind) {
+      case "city":        return …;
+      case "industry":    return …;
+      case "sightseeing": return …;
+    }                                               // exhaustiveness checked
+  };
+  const toJson = (n: Node): string => { … };        // new op, zero element edits
+  ```
+  This wins on RG's own axis (new behavior without touching elements) *and* adds
+  exhaustiveness, *and* removes the `accept()` boilerplate.
+- **Worth it when.** The classic Visitor still has a niche: when **element types are
+  stable but operations grow** AND you cannot use a DU because the element set is an
+  *open class hierarchy you don't control*. RG's own downside ("update all visitors
+  each time a class is added") is the **expression-problem** tradeoff — DU/`switch`
+  makes adding *operations* free but adding *cases* costly; Visitor/classes are the
+  inverse. Choose by which axis actually changes. (See R2's "expression problem"
+  framing.)
+- **Smell when.** A `Visitor` interface + `accept()` over a closed set you *do* own —
+  that's a DU and a function, with worse ergonomics.
+
+---
+
+## 6. Synthesis — patterns as a functional-vs-class lens
+
+This is the section that feeds the skill's functional-vs-class decision guidance. The
+GoF catalog, run through TypeScript, sorts cleanly into **what collapses into plain
+language constructs** and **what legitimately wants an object/class (or a tree of
+data).** The collapse target is the discriminator.
+
+### 6.1 The collapse map
+
+| GoF pattern | TS verdict | Collapses into (idiomatic TS) | Wants a class/object when… |
+|---|---|---|---|
+| **Strategy** | SUPERSEDED | a **function** / `Record<K, Fn>` | strategy has multiple methods or own state |
+| **Command** | SUPERSEDED | a **closure**; DU-of-data if serializable | undo/event-sourcing needs identity + data |
+| **Template Method** | SUPERSEDED | **HOF** taking step functions | a real base-class lifecycle consumers extend |
+| **Iterator** | SUPERSEDED | **generator** / `[Symbol.iterator]` / `for…of` | ~never (use the protocol) |
+| **Observer** | SUPERSEDED | `EventTarget` / **signals** / RxJS / tiny emitter | a tiny typed dependency-free emitter |
+| **Decorator** | SUPERSEDED | **HOF composition** (≠ TS `@decorators`) | stacked wrappers must preserve an object interface + state |
+| **Prototype** | SUPERSEDED | `structuredClone` / **spread** | custom clone semantics (reattach handles) |
+| **Singleton** | SUPERSEDED | an **ES module** export (prefer DI) | ~never (module + DI) |
+| **Memento** | SUPERSEDED | **immutable snapshot** / `structuredClone` | private complex internals control snapshot |
+| **Factory Method** | SUPERSEDED | a **factory function** / injected creator | overridable hook on an existing class hierarchy |
+| **Adapter** | IDIOMATIC | a **wrapper fn/object** at a boundary | wrapping a stateful multi-method service |
+| **Facade** | IDIOMATIC | a **module** of named functions | (rarely) a stateful subsystem handle |
+| **Proxy** | IDIOMATIC | a **wrapper** or native **`Proxy`** | access control / lazy / caching / reactivity |
+| **Composite** | IDIOMATIC | a **recursive DU + fold function** | nodes carry real behavior + identity |
+| **State** | IDIOMATIC | a **DU + transition fn** (FSM; XState at scale) | complex orchestration + side-effects |
+| **Chain of Resp.** | IDIOMATIC | an **array of middleware functions** | handlers are stateful objects |
+| **Abstract Factory** | OVER-ENG | an **object of factory functions** | real family × type matrix, swapped wholesale |
+| **Builder** | OVER-ENG | an **options object** (optional props) | fluent type-state SDK; multiple representations |
+| **Bridge** | OVER-ENG | **inject an implementation** (composition) | two axes both grow + ship independently |
+| **Flyweight** | OVER-ENG | an **intern pool / memoized factory** | measured memory ceiling, huge object counts |
+| **Mediator** | OVER-ENG | an **event bus / store / reducer** | genuine N×N coupling no store fits |
+| **Visitor** | OVER-ENG | a **DU + `switch` function** | open hierarchy you don't own + growing ops |
+
+### 6.2 The three collapse targets (what "becomes a function" really means)
+
+1. **Single-method patterns → a function or `Record<K, Fn>`.** Strategy, Command,
+   Template Method, Factory Method, and Visitor-over-a-closed-set all reduce to "pass
+   behavior as a value." If a pattern's interface has exactly one method, it is a
+   function type in TS. **Rule: one-method interface ⇒ use a function.** This is the
+   direct cash-out of RG's "Strategy = a lambda" criticism, generalized.
+
+2. **"One shared instance / shared state" patterns → modules and data.** Singleton →
+   module export. Prototype/Memento → `structuredClone`/immutable values. Flyweight →
+   an intern `Map`. The OO ceremony existed to manage *access to shared/copied state*;
+   modules and value semantics handle that without classes.
+
+3. **Iteration & notification patterns → built-in protocols & platform APIs.**
+   Iterator → the iteration protocol/generators; Observer → `EventTarget`/signals/
+   RxJS. The platform *is* the pattern. Reimplementing it by hand is the purest
+   cargo-cult.
+
+### 6.3 What legitimately wants a class — or at least a stateful object
+
+A class (or a stateful object — TS lets you have encapsulated state without `class`)
+earns its place when **all three** of these hold; otherwise prefer functions + data:
+
+- **Identity + lifecycle.** The thing has its own mutable state evolving over time
+  that callers reference by identity (a connection, a parser cursor, a live
+  subscription, a game entity). Functions are stateless; this is the strongest
+  pro-object signal.
+- **Multiple methods that share that state.** A *cohesive* cluster of operations over
+  the same private data. One method ⇒ function. Many methods over shared mutable
+  state ⇒ object.
+- **A boundary worth naming/enforcing.** Adapter, Facade, Proxy all wrap a *boundary*
+  (vendor edge, subsystem, access control). Encapsulating that boundary in one
+  named unit is a real design win, not ceremony.
+
+Conversely, the **data-shaped** patterns (Composite, State, serializable Command,
+Visitor-over-closed-set) want a **discriminated union + functions**, not classes.
+These are the cases where the "pattern" is really *"model the shape as a tagged union
+and fold over it,"* and TS's exhaustiveness checking makes the functional form
+strictly safer than the polymorphic class form.
+
+### 6.4 The decision rule (for the skill)
+
+> **When you reach for a GoF pattern in TypeScript, first ask which collapse target
+> it has.** If the pattern's interface is **one method**, write a function (or a
+> `Record` of functions). If it manages a **single shared instance or copied state**,
+> use a module or value semantics (`structuredClone`/immutability). If it's
+> **iteration or notification**, use the built-in protocol / platform API
+> (`for…of`/generators, `EventTarget`/signals). If it models a **closed set of
+> shapes** with operations over them, use a **discriminated union + a `switch`
+> function** (with `assertNever` for exhaustiveness). Reach for a **class/stateful
+> object only** when there is genuine identity + lifecycle + multiple methods over
+> shared state, or a **boundary** worth naming (Adapter / Facade / Proxy). Reach for
+> the **full multi-class pattern** (Abstract Factory, Bridge, Mediator, Visitor,
+> Flyweight) only when a specific, present, *measured* force — a real variant matrix,
+> two independently-growing axes, true N×N coupling, an open foreign hierarchy, a
+> profiler-confirmed memory ceiling — justifies the ceremony. Absent that force, the
+> pattern is the "kludge tax" RG warns about, paid for an abstraction TypeScript
+> already gives you.**
+
+### 6.5 The cargo-cult tells (for LLM-slop cleanup)
+
+The patterns most over-applied in generated TS, with the one-line fix:
+
+- `class FooStrategy implements Strategy` → a function.
+- `class FooFactory` wrapping one `switch` → a factory function.
+- `class FooManager` / `FooMediator` coordinating two things → direct calls or a store.
+- `getInstance()` singleton → a module export (or inject it).
+- hand-written `hasNext()/next()` iterator → a generator / `for…of`.
+- `Subject`/`Observer` interface pair → `EventTarget` or a typed emitter.
+- `Visitor` + `accept()` over a closed, owned set → a DU + `switch`.
+- `AbstractBaseX` whose only job is one template method → an HOF.
+
+Each of these is "the pattern's *name* survives, its *class machinery* should not."
+
+---
+
+## 7. Cross-references for the skill
+
+- **R2** (`dev:typescript` audit) already owns the *positive* TS pattern catalog
+  (DUs/ADTs, branded types, type-state builders, strategy-via-function-injection,
+  command+handler map, FSM, typed pub/sub, ports & adapters, the **expression
+  problem**). This lane is the **deciding-against** companion: it maps each GoF
+  pattern to *when not to* and *what it collapses into*. The skill should link the
+  two so "don't build Visitor" lands next to "here's the DU you build instead."
+- The **§1.3 criticism → §6.4 decision rule** path is the spine of the
+  over-engineering guidance; the **§6.1 collapse map** is the spine of the
+  functional-vs-class guidance.
+- Citations throughout are to **refactoring.guru/design-patterns** (catalog +
+  *What's a design pattern?*, *Why learn patterns?*, *Criticism of patterns*,
+  *Classification of patterns*, *Design Patterns in TypeScript*). All prose here is
+  original synthesis; RG's wording is quoted only where explicitly marked.

--- a/docs/projects/typescript-refactoring-skill/research/r5-linkouts-and-conventions.md
+++ b/docs/projects/typescript-refactoring-skill/research/r5-linkouts-and-conventions.md
@@ -1,0 +1,327 @@
+# R5 — Link-Outs and Local Skill Conventions
+
+Research lane output for the new repo-local skill: a **TypeScript first-principles
+complexity-reduction & refactoring skill**. This skill must (a) **link out** to the
+existing cognition/dev design skills rather than re-deriving their content, and
+(b) **match the local repo skill conventions** under `.agents/skills/`.
+
+Two parts:
+
+- **Part A — Link-out table.** Where our skill should hand off, what each target
+  skill owns, and the exact trigger that forces the handoff.
+- **Part B — Local conventions** our skill must conform to (frontmatter, layout,
+  tone, cross-references, README registration, operating rules).
+
+---
+
+## Part A — Design Skills to Link Out To
+
+### A.0 Naming convention for link-outs (verified)
+
+Local repo skills reference plugin design skills with the **`plugin:skill`**
+prefix form — confirmed by grepping `.agents/skills/`: `cognition:system-design`,
+`cognition:framing-design`, `cognition:team-design`, `cognition:inquiry-design`,
+`cognition:investigation-design`, `mapgen:placement`, `mapgen:foundation`. The dev
+plugin equivalents are written `dev:architecture` and `dev:api-design` (as in the
+prompt and the system skill list). **Our skill must use these prefixed names when
+linking out.** Bare `system-design` / `architecture` are the internal `name:` of
+the skill files; the *callable* reference form in this repo is the namespaced one.
+
+Note on the cognition skill set: the SKILL.md files in
+`.../cognition/1.0.0/skills/` declare bare `name:` values (`system-design`,
+`domain-design`, …). The repo invokes them as `cognition:<name>`. There is a small
+naming gap: some local skills reference cognition skills that are *not* in the read
+set (`framing-design`, `inquiry-design`, `investigation-design`) — these exist in
+the plugin but were out of scope for this lane. Our skill should only link out to
+skills it has actually located.
+
+### A.1 What each target skill OWNS (from frontmatter + opening + reference map)
+
+**`cognition:solution-design`** — `name: solution-design`
+Owns judgment about **WHAT to solve, WHETHER to solve, at WHAT LEVEL, and HOW to
+navigate solution spaces.** Problem reframing, stakeholder incentive mapping,
+solution-space topology (smooth↔rugged), reversibility-calibrated depth,
+satisficing vs optimizing. Six axes (Problem Character, Solution Space Topology,
+Stakeholder Complexity, Intervention Type, Commitment Reversibility, Knowledge
+State). Explicitly upstream of system-design. **Medium-agnostic** (product, org,
+policy, technical). Its own boundary note: "Development Architecture is
+software-specific patterns. Solution design is medium-agnostic."
+
+**`cognition:system-design`** — `name: system-design`
+Owns **applied systems thinking for real-world systems** — feedback loops, stocks
+& flows, delays, second-order effects, leverage points (9-level hierarchy),
+incentive structures, boundary-as-choice. Six axes (Agency, Complexity Domain,
+Observability, Coupling, Feedback Speed, Boundary Permeability). Has a **software
+systems leaflet**. Boundary note: "dev:architecture is about software structure
+patterns… Architecture is a substrate-specific application of system design
+principles."
+
+**`cognition:domain-design`** — `name: domain-design`
+Owns **drawing boundaries** — decomposing a system into domains/bounded contexts,
+**single-authority ownership**, ubiquitous language as a boundary signal, seams of
+weak interaction (Simon), encapsulation, ambiguity-as-cost. Seven axes (Boundary
+Permeability, Authority Distribution, Domain Stability, Decomposition Granularity,
+Domain Formality, Membership Model, Coupling Topology). Has **software-services and
+software-data leaflets**. This is the closest cognition skill to "module
+boundaries / where should this code live" at the *conceptual* level.
+
+**`cognition:testing-design`** — `name: testing-design`
+Owns **what to test, how rigorously, and where failure is most likely** —
+adversarial/falsification testing, oracles, risk-proportional effort, boundary
+analysis, testability-as-design. Six axes (Assurance Target, Cognitive Mode,
+System Legibility, Discovery Method, Evidence Standard, Feedback Speed). Has a
+software-testing leaflet. Explicitly **NOT** for writing test code (defers to
+language/framework skills — which is exactly where *our* TS skill could provide the
+"how to keep refactors safe" hook, while testing-design provides the "what to
+probe" judgment).
+
+**`cognition:information-design`** — `name: information-design`
+Owns **shaping content/structure for a reader** — information hierarchy,
+progressive disclosure, chunking, signal-to-noise, information scent. Six axes
+(Purpose, Density, Linearity, Audience, Scope, Temporality). This is the skill we
+use **on our own SKILL.md** (and on any docs the refactor produces), not on code.
+
+**`cognition:ontology-design`** (frontmatter only) — `name: ontology-design`
+Owns **operational semantic models for inference/validation** (RDF vs JSON schema,
+SPARQL/SHACL, knowledge-graph ontologies). Out of scope for a refactoring skill;
+no handoff expected.
+
+**`cognition:disambiguation`** (frontmatter only) — `name: disambiguation`
+Owns **detecting ambiguity in a request and asking minimal high-leverage
+questions**, presenting options with tradeoffs, preserving context. Handoff when
+the *refactoring request itself* is ambiguous (which module? what outcome?).
+
+**`cognition:mental-map`** (frontmatter only) — `name: mental-map`
+Owns **orientation across many steps** — mapping terrain, breadcrumbs, "already
+checked", injecting accumulated context. Handoff when a large refactor spans many
+files and the agent risks re-discovering / getting lost.
+
+**`dev:architecture`** — `name: architecture`
+Owns **target-state software architecture and migration**: turning exploration/
+spikes into a **pure SPEC**, **decision packets** (this-or-this ambiguity →
+accept/reject), **migration slices** (prepare → cutover → cleanup, every bridge
+has a deletion target), dependency ordering (spine → boundaries → domain),
+current/target/transition separation, cutover validation ("no legacy left"). This
+is the skill our refactoring skill hands off to when a refactor is large enough to
+need a *durable target spec and a phased migration plan* rather than an in-place
+edit.
+
+**`dev:api-design`** — `name: api-design`
+Owns **the design of any programmatic interface** — network APIs, **SDKs, local
+libraries, CLI tools, AI/MCP tool interfaces.** Consumer-model-first, explicit
+contracts, consistency, encapsulation-preserves-freedom, versioning/evolution. Six
+axes including a **Substrate axis (network ↔ in-process/local)** and an **SDK/Local
+APIs leaflet** — directly relevant when a TS refactor changes a module's public
+surface / exported types. Boundary note: "Not for system architecture (use
+architecture skill)."
+
+### A.2 LINK-OUT TABLE
+
+For each concern, the **exact reference name** to use in our SKILL.md, what it
+owns, and the **trigger phrase** that should make our skill hand off.
+
+| Concern | Reference name (use this exact form) | What it owns (1 line) | Trigger that hands off to it |
+|---|---|---|---|
+| **Solution design** | `cognition:solution-design` | Whether/what to solve, problem reframing, depth calibration by reversibility, solution-space navigation | "Should we even refactor this?", "is the complexity the real problem or a symptom?", "is this worth the risk?" — i.e. the request is about *whether/what*, not *how* |
+| **System design** | `cognition:system-design` | System dynamics: feedback loops, second-order effects, leverage points, coupling, incentives | "Why does this complexity keep coming back?", "what breaks two steps downstream if I change this?", reasoning about coupling/feedback rather than local code shape |
+| **Domain design** | `cognition:domain-design` | Where boundaries go, single-authority ownership, bounded contexts, language seams, encapsulation | "Where should this code live?", "what's the right module boundary?", "who owns this concept?", "split this into bounded contexts" |
+| **Testing design** | `cognition:testing-design` | What to test, how hard, where failure is likely; falsification, oracles, risk-proportional effort | "What could break if I refactor this?", "how do I make this refactor safe?", "design the test net before I change behavior" (the *strategy*, not the test code) |
+| **Information design** | `cognition:information-design` | Structuring content for a reader; hierarchy, progressive disclosure, scent | Authoring/restructuring our SKILL.md, references/, or any doc the refactor emits — "make this doc clearer / shape this for the reader" |
+| **Architecture** | `dev:architecture` | Target-state SPEC, decision packets, migration slices, current→target cutover, dependency ordering | "This refactor is big enough to need a target spec + phased migration", "plan the cutover", "decision packet for this-or-this", "no legacy left" |
+| **API design** | `dev:api-design` | Interface/contract design for libraries, SDKs, CLIs, MCP tools; consumer model, explicit contracts, versioning | "The refactor changes a public/exported surface", "redesign this module's exports/types", "this is an SDK/CLI/library boundary", "versioning/evolution of the interface" |
+| *(supporting)* **Disambiguation** | `cognition:disambiguation` | Detect ambiguity, ask minimal high-leverage questions | The refactoring *request* is unclear (which target? what success looks like?) before any work begins |
+| *(supporting)* **Mental map** | `cognition:mental-map` | Orientation/breadcrumbs across many-step navigation | A refactor spans many files and the agent risks re-discovery or getting lost |
+
+**Self-positioning for the new skill (the seam it must NOT cross):** our skill
+owns the **TypeScript-specific, code-level craft of reducing complexity and
+executing safe refactors** — type-driven simplification, module-boundary
+*mechanics in TS*, in-place safe-refactor moves, dead-code/indirection removal,
+keeping the type-checker green. It **defers the judgment of whether/what** to
+`cognition:solution-design`, **systemic why** to `cognition:system-design`,
+**conceptual boundary placement** to `cognition:domain-design`, **the safety-net
+strategy** to `cognition:testing-design`, **large target-spec + migration** to
+`dev:architecture`, and **public-surface/contract redesign** to `dev:api-design`.
+The existing `dev:typescript` skill (in the system skill list) is the nearest
+neighbor and the most important to differentiate against — note it in design.
+
+---
+
+## Part B — Local Repo Skill Conventions to Match
+
+Source files:
+`/.agents/skills/README.md`,
+`/.agents/skills/civ7-systematic-workstream/SKILL.md`,
+`/.agents/skills/civ7-architecture-authority/SKILL.md`,
+`/.agents/skills/civ7-mapgen-workstream/SKILL.md`.
+
+### B.1 Frontmatter spec
+
+Local skills use **YAML frontmatter with exactly two keys**, same as the cognition
+plugin skills:
+
+```yaml
+---
+name: <kebab-case-skill-name>
+description: |
+  Use in the Civ7 Modding Tools repo when <situation>. Trigger phrases include
+  "<phrase>", "<phrase>", ... . Do not use for <explicit non-goals / sibling skills>.
+---
+```
+
+Observed rules (all three local skills conform):
+- **`name:`** — kebab-case, matches the directory name (`civ7-systematic-workstream`
+  in dir `civ7-systematic-workstream/`). No `civ7-` prefix is *required* by the
+  format, but every current local skill carries a repo/domain prefix; our skill is
+  *not* civ7-specific, so it should still be kebab-case and self-descriptive
+  (e.g. `typescript-refactoring` or `typescript-complexity-reduction`).
+- **`description:`** — block scalar (`|`), multi-line. **Three-part shape**:
+  (1) "Use … when <situations>", (2) **explicit "Trigger phrases include …"** list
+  of quoted natural-language phrases, (3) **"Do not use for …" / non-goals** that
+  name the sibling skills it defers to. Local skills additionally scope with
+  **"Use in the Civ7 Modding Tools repo when …"** — our skill should scope by
+  *technology/condition* instead ("Use when refactoring or reducing complexity in
+  TypeScript code …") since it is not repo-specific.
+- **No extra frontmatter fields.** Local skills do **not** use `version`,
+  `author`, `tags`, `allowed-tools`, etc. Only `name` + `description`. (This
+  matches the cognition plugin skills, which also use only `name` + `description`.)
+
+### B.2 Directory layout
+
+Confirmed identical across all three local skills (`ls` verified):
+
+```
+.agents/skills/<skill-name>/
+  SKILL.md          # lean entry point — routing, invariants, quick start
+  references/       # deeper rules, method loops, axis detail, failure patterns
+  assets/           # copy-forward templates (ledgers, checklists, preflights)
+```
+
+So our skill must be `.agents/skills/typescript-refactoring/` (final name TBD) with
+`SKILL.md` + `references/` + `assets/`. This mirrors the cognition/dev plugin layout
+too (`references/`, `assets/`), so the patterns transfer cleanly.
+
+### B.3 SKILL.md internal structure (the local house style)
+
+Local SKILL.md files follow a recurring section skeleton (not all sections in every
+file, but this is the union and the common spine):
+
+- `# <Title>` then `## Purpose` (what the skill owns + that it **composes** with
+  other skills and **does not replace** them).
+- `## When To Use` / `## When Not To Use` (or `## Non-Goals`) — explicit routing in
+  and out.
+- A **routing / companion-skill section** that names sibling skills and *when to
+  load them* (e.g. systematic-workstream's "Companion Skill Routing";
+  mapgen-workstream's "Routing Table" + "Reference Graph (compose, do not
+  duplicate)").
+- `## Default Workflow` — a numbered, **one-line-per-step** loop. (systematic =
+  "12 gates, one line each"; mapgen = "11-step loop"; architecture = 9 steps.)
+- `## Reference Map` — a table `| Reference | Path | Open When |`.
+- `## Asset Map` — a table `| Asset | Path | Use When |`.
+- `## Core Invariants` — wrapped in **`<invariants>` … `<invariant name="...">`**
+  XML tags (identical mechanism to the cognition skills). This is a load-bearing
+  convention: invariants are tagged, named, one sentence each.
+- `## Anti-Patterns` / `## Failure Signals` / `## Failure Modes` — what drift looks
+  like.
+- `## Quick Start` — a short numbered "do this first" recap.
+
+Our skill should adopt this spine: Purpose → When/When-Not → Companion routing →
+Default Workflow (numbered, terse) → Reference Map (table) → Asset Map (table) →
+`<invariants>` block → Anti-Patterns/Failure Signals → Quick Start.
+
+### B.4 Tone / voice
+
+- **Imperative, operator-facing, dense.** Second-person/agent-directed ("Use this
+  skill before…", "Do not tune before…"). No marketing voice.
+- **Strong invariant language**: short declarative rules ("Core stays pure.",
+  "Generated output is read-only.", "Proof classes stay separate.").
+- **Compose-don't-duplicate is an explicit value** in the local skills — they
+  repeatedly say *route to the owner, never restate it as a second spec*
+  (README lines 7-9; mapgen `compose-not-duplicate` invariant; systematic "it does
+  not replace them"). Our link-out skill must echo this posture explicitly.
+- **Evidence/proof discipline & honesty** is a recurring theme even outside
+  mapgen — keep claims scoped to what was actually verified. For a refactoring
+  skill this maps to: keep the type-checker/test claims separate, don't claim a
+  refactor is "safe" beyond what was actually run.
+- Cross-skill references are written inline as **`cognition:system-design`-style
+  prefixed names**, and longer pointers use the Reference Map table with relative
+  `references/<file>.md` paths.
+
+### B.5 How they reference other skills
+
+- **Sibling/plugin skills** → prefixed name inline (`cognition:system-design`,
+  `civ7-architecture-authority`, `dev:architecture`, `mapgen:placement`).
+- **Own deeper material** → relative paths in Reference/Asset Map tables
+  (`references/method-loop.md`, `assets/closure-checklist.md`).
+- mapgen-workstream models the gold standard for a **router skill that links out**:
+  a "Reference Graph (compose, do not duplicate)" ASCII map + a CURRENCY BANNER
+  classifying which referenced skills are authoritative vs philosophy-only. Our
+  skill is also a "thinking-spine-plus-links" skill, so this pattern is the closest
+  precedent to imitate.
+
+### B.6 README registration (REQUIRED — exact format)
+
+The README at `.agents/skills/README.md` has a **`## Skills` table** that every
+skill must appear in. The table has **exactly two columns**: `Skill` and `Use
+When`. The header/separator and an example data row, verbatim:
+
+```markdown
+## Skills
+
+| Skill | Use When |
+|---|---|
+| `civ7-architecture-authority` | Placing code, moving boundaries, changing MapGen stage/step/domain shape, separating core/mod/adapter/generated concerns, or reviewing architecture drift. |
+```
+
+Rules to match when we add our row:
+- **Skill name in backticks** in column 1 (e.g. `` `typescript-refactoring` ``).
+- Column 2 is a **single "Use When" sentence/fragment**, capitalized, ending with a
+  period, describing the triggering situation (longer entries — e.g. the
+  `civ7-mapgen-workstream` row — run several clauses but stay one cell).
+- Separator row is `|---|---|`.
+- Add exactly one new row; do not restructure the table.
+
+Draft row for our skill (adjust final name):
+
+```markdown
+| `typescript-refactoring` | Reducing complexity or executing safe refactors in TypeScript code from first principles — simplifying types, tightening module boundaries in TS, removing indirection/dead code, and keeping the type-checker green; routes whether/what to `cognition:solution-design`, conceptual boundaries to `cognition:domain-design`, the safety-net strategy to `cognition:testing-design`, large target-spec + migration to `dev:architecture`, and public-surface/contract redesign to `dev:api-design`. |
+```
+
+### B.7 Operating Rules (from README "## Operating Rules" — our skill must comply)
+
+Verbatim list the README states:
+
+- Read the root `AGENTS.md` first, then the closest subtree `AGENTS.md` for files
+  being touched.
+- Load the smallest skill set that covers the work.
+- **Keep `SKILL.md` files lean. Put deeper rules in `references/` and copy-forward
+  templates in `assets/`.**
+- **Do not store temporary workstream state in these skills.** Use
+  `docs/projects/<project>/...` for project state and phase artifacts.
+- Use `openspec/` for implementation change records once a project slice becomes an
+  OpenSpec workstream.
+- **Update a skill only when durable authority changes.**
+
+Implications for the new skill:
+- SKILL.md is the **lean router**; depth → `references/`, templates → `assets/`.
+- **No project status / migration notes / chat carry-forward in the skill** (README
+  preamble: "They are not project status, migration notes, or chat
+  carry-forward.").
+- It must **encode durable operating guidance only** and **link out** to the design
+  skills rather than duplicating them — same posture the README sets for the mapgen
+  skills routing to the normalization packet.
+
+---
+
+## Summary (for the workstream)
+
+1. **Link out, prefixed.** Use `cognition:*` and `dev:*` names exactly. Map the
+   seven concerns per the Part A table; our skill owns TS code-level craft only.
+2. **Frontmatter = `name` + `description` (block scalar)** with a "Trigger phrases
+   include …" list and a "Do not use for …" non-goals clause. No extra fields.
+3. **Layout = `SKILL.md` + `references/` + `assets/`.**
+4. **House style = imperative + `<invariants>` block + Reference/Asset Map tables +
+   numbered terse workflow + compose-don't-duplicate + scoped proof claims.**
+5. **Register in README's two-column `| Skill | Use When |` table** (name in
+   backticks, one capitalized "Use When" sentence ending in a period).
+6. **Obey the Operating Rules**: lean SKILL.md, no temp state, deeper rules in
+   references, durable authority only.

--- a/docs/projects/typescript-refactoring-skill/workstream-record.md
+++ b/docs/projects/typescript-refactoring-skill/workstream-record.md
@@ -1,0 +1,97 @@
+# Workstream Record — `typescript-refactoring` skill
+
+## Objective
+Build a repo-local skill: a TypeScript-specific, first-principles complexity
+reduction and refactoring skill ("Thermonuclear Code Quality Review, but deeply
+layered for TypeScript"). An agent handed it must be able to read it + linked
+references/assets, look at TS code, and execute a thorough refactor — detecting
+smells, designing a solution, and cleaning up LLM-generated slop.
+
+## Containment boundary
+- All edits in worktree `wt-codex-skill-typescript-refactoring`, Graphite branch
+  `codex/skill-typescript-refactoring`, stacked on
+  `codex/habitat-toolkit-reference-docs` (top of the active stack).
+- Skill lives at `.agents/skills/typescript-refactoring/`.
+- Workstream state (research, design, this record) under
+  `docs/projects/typescript-refactoring-skill/`.
+- Refactoring Guru raw scrape cached OUTSIDE the repo
+  (`…/worktrees/.refactoring-guru-cache/`); copyrighted — never committed.
+
+## Non-goals
+- Not a TypeScript language tutorial; not a rewrite of `dev:typescript`.
+- No code in the civ7 product is refactored as part of this workstream.
+- No PR submission / push unless the user asks.
+
+## Authority order
+1. User instructions in this session.
+2. Local skill conventions (`.agents/skills/README.md`, house style).
+3. Research digests (`./research/`) and `./DESIGN.md` (authoring contract).
+4. Primary external source: refactoring.guru (synthesized, never copied).
+
+## Phases
+- [x] P0 Ground & frame — stack, worktree, tracked branch.
+- [x] P1 Research wave — r1 thermonuclear, r2 typescript boundary, r3 authoring,
+      r4a/b/c refactoring.guru, r5 link-outs + local conventions.
+- [x] P2 Design lock — `DESIGN.md`.
+- [x] P3 Build — SKILL.md (host) + 5 references (agent wave) + 2 assets (host).
+- [x] P4 Review & repair — two adversarial lanes (skill-conventions + TS-principal);
+      all blockers/majors repaired, minors dispositioned.
+- [x] P5 Close — README registration, gates, Next Packet.
+
+## Closure
+**Outputs (skill at `.agents/skills/typescript-refactoring/`):**
+- `SKILL.md` (266→269 ln) — spine, axes, standards, mandate, workflow, boundaries,
+  good-phrases, approval bar, invariants.
+- `references/`: smell-catalog (29 smells, 5 classic + TS-native), refactoring-mechanics
+  (gated workflow + 17 moves + DoD), llm-slop-cleanup (10 slop patterns + indirection
+  audit), paradigms-and-patterns (functions-vs-classes rule + GoF-in-TS verdicts +
+  collapse map + migration mechanics), worked-examples (6 before→after refactors).
+- `assets/`: refactor-plan-template, refactor-findings-template.
+- `.agents/skills/README.md` — one Skills-table row added.
+
+**Gates:**
+- Frontmatter: `name`+`description` only ✓ (12 quoted triggers + negative boundaries).
+- Cross-links: 50/50 internal links + anchors resolve ✓ (GitHub-slug validator).
+- Code fences balanced across all 8 files ✓.
+- New branded-type snippet typechecks clean under `tsc --strict` ✓ (reviewer also
+  compiled the worked-example after-blocks clean).
+- No `23 smells` / no `](plugin:skill)` residue ✓.
+
+**Review disposition:** both lanes GO-WITH-FIXES. Repaired: B1 (9 broken anchors +
+2 missing mechanics added: Introduce Branded Type, Extract Module), M1-TS (relabeled
+an `as`-cast falsely called "parse"), markdown-link-as-URL ×7, B3 (smell count 23→29),
+structuredClone caveat (Prototype/Memento), axis deferral, bare path prefix, before/
+after markers, grep "candidates-not-verdicts" caveat. Accepted as-authored: M2-skill
+(verdict column is decision content; shape is explicitly deferred to dev:typescript).
+Won't-fix (acceptable): reference line counts over soft target (single-responsibility);
+"review this TS for quality" trigger (negative boundary disclaims /code-review overlap).
+
+**Repo/Graphite state:** branch `codex/skill-typescript-refactoring` tracked on
+`codex/habitat-toolkit-reference-docs`; worktree `wt-codex-skill-typescript-refactoring`.
+Refactoring Guru raw cache kept outside the repo (uncommitted, copyrighted).
+
+**Deferred inventory:** none blocking. Optional future: a CI markdown link-checker for
+`.agents/skills/**` to prevent anchor regressions; optional companion `/ts-refactor`
+command if invocation ergonomics are wanted.
+
+**Next Packet:** to use the skill, an agent reads `SKILL.md`, inventories smells via
+`references/smell-catalog.md` + the detection toolkit, copies
+`assets/refactor-plan-template.md`, and transforms via `references/refactoring-mechanics.md`
+keeping `tsc --strict` green per step. To extend it, add moves to refactoring-mechanics
+or examples to worked-examples; keep SKILL.md lean and link out per DESIGN §4.
+
+## Evidence inputs
+- `research/r1-thermonuclear.md` … `research/r5-linkouts-and-conventions.md`
+- `.refactoring-guru-cache/` (23 smells, 66 techniques, 22 patterns, 10 concept).
+
+## Stop conditions
+- If a reference would duplicate `dev:typescript`, stop and link instead.
+- If a naming/scope decision can't be inferred, surface to user.
+
+## Closure (filled at P5)
+- Outputs:
+- Gates:
+- Review disposition:
+- Repo/Graphite state:
+- Deferred inventory:
+- Next Packet:


### PR DESCRIPTION
A repo-local, TypeScript-deep sibling of the Thermonuclear Code Quality Review:
detect smells, execute safe compiler-gated refactors, collapse the reachable-state
space, choose functions vs classes, judge over-/under-engineering, and clean up
LLM-generated slop.

- SKILL.md: spine (complexity = reachable states), refactor decision axes,
  non-negotiable standards, the mandate (self-checks), gated workflow, boundaries
  with hand-off table, good-phrases, approval bar, invariants.
- references/: smell-catalog (29 smells incl. TS-native, detection signals),
  refactoring-mechanics (gated workflow + 17 moves + DoD), llm-slop-cleanup
  (10 slop patterns + indirection audit), paradigms-and-patterns (functions-vs-
  classes + GoF-in-TS verdicts + collapse map + migration mechanics),
  worked-examples (6 before→after refactors).
- assets/: refactor-plan-template, refactor-findings-template.
- Links out to dev:typescript, cognition:{solution,system,domain,testing,
  information}-design, dev:architecture, dev:api-design (compose, don't duplicate).
- Primary external source: refactoring.guru (synthesized originally, not copied).
- README Skills table updated; design/research provenance under
  docs/projects/typescript-refactoring-skill/.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>