### PR TITLE
docs(habitat): add phase 2 workstream packet suite

### DIFF
--- a/docs/projects/habitat-harness/domain-refactor-prep/domino-candidate-ledger.md
+++ b/docs/projects/habitat-harness/domain-refactor-prep/domino-candidate-ledger.md
@@ -61,16 +61,16 @@ Consumers should receive projections, not the whole registry object, unless a pa
    - D3 Workspace Graph Integration Boundary -> D4 Orientation and Routing.
    - D5 Baseline Authority.
    - D6 Diagnostic Pattern Catalog.
-   - D10 Generated/Protected Zone Authority.
-5. D7 Structural Enforcement Pipeline after D5 and D6.
-6. D8 Pattern Governance after D5 and D6.
-7. D9 Transformation Transaction after D8.
-8. D11 Local Feedback after D7, D9, and D10.
-9. D12 Proof/Handoff Verify Command after D1, D3, and D7.
-10. D13 Scaffolding and Refusal Contracts after D0, D2, and D8.
-11. D14 Authoring Topology Fence after D4, D12, and D13.
-12. D15 Execution Provenance Substrate Trigger activates only inside packets where typed failures/provenance require it.
-13. G-HOST Host Policy Boundary Gate must be satisfied before D9, D10, or D13 claims generic closure over host-specific policy.
+   - G-HOST Host Policy Boundary Gate.
+5. D10 Generated/Protected Zone Authority after D2 and G-HOST.
+6. D7 Structural Enforcement Pipeline after D5, D6, and D10.
+7. D8 Pattern Governance after D5 and D6.
+8. D9 Transformation Transaction after D8, D6, and D10.
+9. D11 Local Feedback after D7, D9, and D10.
+10. D12 Proof/Handoff Verify Command after D1, D3, and D7.
+11. D13 Scaffolding and Refusal Contracts after D0, D2, D8, and G-HOST.
+12. D14 Authoring Topology Fence after D4, D12, and D13.
+13. D15 Execution Provenance Substrate Trigger activates only inside packets where typed failures/provenance require it.
 
 ## Dominoes
 
@@ -83,11 +83,11 @@ Consumers should receive projections, not the whole registry object, unless a pa
 | D4 | Orientation and Routing | Orientation owner | Agents and humans before editing | `habitat classify` path/diff output, owner, scoped rules, targets, unavailable facts | Classification uses optional-heavy shapes and prose-derived scope | D2, D3 | D14, scenario handoff packets | Command behavior, classify tests, malformed/refusal tests | Scenario corpus, classify examples |
 | D5 | Baseline Authority | Baseline owner | Structural Enforcement, Pattern Governance | explicit empty/debt/external-exception states, shrink-only guard, introduction manifest | Strong current state machine is applied inline with check and pattern admission | D2 | D7, D8 | Baseline contract tests, baseline-integrity current-tree check | Baseline contract record |
 | D6 | Diagnostic Pattern Catalog | Grit diagnostics owner | Structural Enforcement, Pattern Governance, Local Feedback | Grit acquisition/projection, scan roots, adapter failure projection, injected-probe proof | Grit diagnostics, pattern admission, and apply patterns share terms but not authority | D1, D2 | D7, D8, D9, D11 | Native sample, current-tree wrapper, injected violation, adapter failure tests | Grit proof matrix |
-| D7 | Structural Enforcement Pipeline | Enforcement owner | `check`, `verify`, hooks, Nx targets | Rule selection, execution, normalized CheckReport, baseline application, staged mode | `createCheckReport` mixes selection, execution, baselines, built-ins, status, and rendering | D1, D2, D5, D6 | D11, D12 | CheckReport schema, command behavior, selector tests | Enforcement compatibility matrix |
+| D7 | Structural Enforcement Pipeline | Enforcement owner | `check`, `verify`, hooks, Nx targets | Rule selection, execution, normalized CheckReport, baseline application, staged mode | `createCheckReport` mixes selection, execution, baselines, built-ins, status, and rendering | D1, D2, D5, D6, D10 | D11, D12 | CheckReport schema, command behavior, selector tests | Enforcement compatibility matrix |
 | D8 | Pattern Governance | Pattern Authority owner | Pattern authors, DRA, Structural Enforcement | Candidate vs registered lifecycle, manifest, baseline contract, hook-scope decision, fixture/proof sources | Generator, manifest validator, registration, Grit rows, and baselines jointly define admission | D1, D2, D5, D6 | D9, D13 | Manifest tests, registration tests, baseline proof | Pattern Authority ledger |
-| D9 | Transformation Transaction | Apply owner | `habitat fix`, future approved apply packets | dry-run inventory, isolated-copy proof, approved roots/paths, rollback, Biome handoff, per-pattern gates | Generic transaction currently embeds one pattern and MapGen-specific export validation | D1, D6, D8 | D11, future apply packets | Safe-write, transaction-copy, rollback, formatter handoff | Apply safety matrix |
+| D9 | Transformation Transaction | Apply owner | `habitat fix`, future approved apply packets | dry-run inventory, isolated-copy proof, approved roots/paths, rollback, Biome handoff, per-pattern gates | Generic transaction currently embeds one pattern and MapGen-specific export validation | D1, D6, D8, D10 | D11, future apply packets | Safe-write, transaction-copy, rollback, formatter handoff | Apply safety matrix |
 | D10 | Generated/Protected Zone Authority | Generated-zone owner | Structural Enforcement, hooks, apply, agents avoiding hand edits | Generated/protected zone declarations, staged mutation guard, drift check | Host-specific zones are encoded in generic modules and scripts | D1, D2, G-HOST | D7, D9, D11 | Staged file-layer tests, generated-check proof | Protected-zone authority record |
-| G-HOST | Host Policy Boundary Gate | Host policy owner | Generated/Protected Zone Authority, Transformation Transaction, Scaffolding | Host declaration/refusal contract for generated zones and pattern-specific gates | MapGen and Civ-specific policy currently appears inside generic modules | D0, D1 | D9, D10, D13 closure | Host declaration/refusal tests, command behavior, non-claims | Host policy boundary record |
+| G-HOST | Host Policy Boundary Gate | Host policy owner | Generated/Protected Zone Authority, Transformation Transaction, Scaffolding | Host declaration/refusal contract for generated zones and pattern-specific gates | MapGen and Civ-specific policy currently appears inside generic modules | D0, D1 | D10, D13, D9 host-policy consumption | Host declaration/refusal tests, command behavior, non-claims | Host policy boundary record |
 | D11 | Local Feedback | Hook owner | Developers and agents using Git hooks | local-only hook behavior, staged path policy, Graphite base detection, resource state guards | Hooks orchestrate many proof owners and can be mistaken for verification authority | D1, D6, D7, D9, D10 | Clean Graphite handoff ergonomics | Hook trace tests, staged mutation tests, pre-push base tests | Hook contract doc |
 | D12 | Proof/Handoff Verify Command | Proof owner | DRA, reviewers, agents handing off work | `habitat verify` runs check then affected Nx and emits non-claims | Verify depends on check shape, graph target list, post-state, stream parsing, and proof labels | D1, D3, D7 | Phase 2 closure model | VerifyProof schema/tests and command behavior | Verification contract |
 | D13 | Scaffolding and Refusal Contracts | Scaffolding owner | Agents creating supported uniform structures | supported project generator, pattern candidate generation, explicit unsupported-kind refusal | Project and pattern generators share Nx mechanics but answer different product questions | D0, D2, D8 | D14 | Generator tests, refusal tests, Nx discovery proof | Scaffolding matrix |
@@ -96,23 +96,28 @@ Consumers should receive projections, not the whole registry object, unless a pa
 
 ## Parallelism Model
 
-Safe parallel work after D0, D1, and D2:
+Safe parallel work:
 
+- G-HOST can start after D0 and D1. It may proceed while D2-D6 continue, but
+  D10 cannot close until both G-HOST and D2 are stable.
 - D3 then D4 can proceed as the graph/orientation lane.
 - D5 can proceed as the baseline lane.
 - D6 can proceed as the diagnostic Grit lane.
-- D10 can proceed as generated/protected zone lane.
+- D10 may investigate current generated-zone evidence in parallel, but it
+  cannot design or close generic generated/protected-zone authority until
+  G-HOST defines the host declaration/refusal boundary and D2 defines the
+  metadata facets it consumes.
 
 Sequential blockers:
 
-- D7 must wait for D5 and D6.
+- D10 must wait for G-HOST before claiming generic closure.
+- D7 must wait for D5, D6, and D10.
 - D8 must wait for D5 and D6.
-- D9 must wait for D8.
+- D9 must wait for D8, D6, and D10.
 - D11 must wait for D7, D9, and D10.
 - D12 must wait for D1, D3, and D7.
-- D13 must wait for D0, D2, and D8.
+- D13 must wait for D0, D2, D8, and G-HOST.
 - D14 must wait for D4, D12, and D13.
-- G-HOST must be satisfied before D9, D10, or D13 claim generic closure over host-specific policy.
 
 ## Anti-Dominoes
 

--- a/docs/projects/habitat-harness/domain-refactor-prep/review-disposition-ledger.md
+++ b/docs/projects/habitat-harness/domain-refactor-prep/review-disposition-ledger.md
@@ -20,7 +20,7 @@ Accepted P1/P2 findings block goal attachment until dispositioned. Disposition r
 | R0-003 | P1 | Generic Habitat could be justified by Civ7/MapGen-only behavior. | Guarded. MapGen-specific apply and generated-zone behavior are marked as host/pattern policy boundaries. | `scenario-corpus.md`; `domain-responsibility-map.md`; `domino-candidate-ledger.md`. |
 | R0-004 | P1 | Current full-suite Habitat test reliability is a proof risk. | Converted to Phase 2 stop condition and validation result. It does not block attaching the design goal, but blocks any packet proof closure that depends on Habitat tests until fixed or explicitly non-claimed. | `validation-results.md`; `domino-candidate-ledger.md`. |
 | R0-005 | P1 | `habitat:rule:biome-ci` alias may report false green due to colon target parsing. | Converted to Phase 2 stop condition and validation result. It does not block attaching the design goal, but blocks graph/alias proof closure until fixed or explicitly dispositioned. | `validation-results.md`; `domino-candidate-ledger.md`. |
-| R0-006 | P2 | Broad `src/index.ts` exports may harden internals as public API. | Tracked. D0 and Command/API Contract require export policy before internal movement. | `domain-responsibility-map.md`; `domino-candidate-ledger.md`. |
+| R0-006 | P2 | Broad `src/index.ts` exports may harden internals as public API. | Converted to Phase 2 stop condition. D0 must produce an explicit public/private/export-state matrix before any packet moves internals or narrows package exports. | `domain-responsibility-map.md`; `domino-candidate-ledger.md`; `phase2-workstream-packets/D0-scenario-public-contract-inventory.md`. |
 
 ## Wave 3 Findings
 

--- a/docs/projects/habitat-harness/domain-refactor-prep/source-authority.md
+++ b/docs/projects/habitat-harness/domain-refactor-prep/source-authority.md
@@ -5,9 +5,16 @@ This register records the authority order for Phase 2 Deep Habitat Toolkit packe
 ## Worktree
 
 - Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame`
-- Branch: `codex/habitat-fast-lint-checks`
+- Preparation validation branch: `codex/habitat-fast-lint-checks`
+- Phase 2 packet-suite branch: `codex/deep-habitat-phase2-prep`
 - Original checkout excluded as repo evidence: `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools`
 - Allowed non-worktree inputs: skill files under `/Users/mateicanavra/.codex/skills`, `/Users/mateicanavra/.agents/skills`, `/Users/mateicanavra/.codex/plugins/cache`, and `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills`.
+
+Phase 2 packet-suite drafting occurs on `codex/deep-habitat-phase2-prep`, which
+is a Graphite child of the preparation commit. Validation rows captured on
+`codex/habitat-fast-lint-checks` remain preparation evidence only. Packet-suite
+closure must record fresh current-state commands from
+`codex/deep-habitat-phase2-prep` before claiming completion.
 
 ## Authority Order
 
@@ -110,6 +117,9 @@ Agent read claims are accepted only where a scratch file or final report records
 - If current docs conflict with source, source and commands define current behavior while docs become downstream realignment candidates.
 - If an OpenSpec or archive record conflicts with the frame, it is historical evidence only.
 - If an agent finding came from a bad checkout, it is invalid. Only findings from the mandated worktree and branch can be used.
+- If validation evidence names `codex/habitat-fast-lint-checks`, treat it as
+  preparation baseline evidence and rerun or relabel it before using it as
+  packet-suite completion proof on `codex/deep-habitat-phase2-prep`.
 - If a future packet cannot name owner, consumer, contract, state-space reduction, dependency order, proof class, and downstream record, it must stop and reframe.
 - If a future packet cites Wave 1, cite the consolidated corpus rather than the raw agent claim unless an auditable Wave 1 scratch file is later produced.
 

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D0-scenario-public-contract-inventory.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D0-scenario-public-contract-inventory.md
@@ -1,0 +1,196 @@
+# D0 Scenario/Public Contract Inventory
+
+## Intent
+
+Create the compatibility ledger that all later refactor packets must preserve or
+intentionally change. This packet prevents Phase 3 from moving internals before
+Habitat knows what agents, humans, tests, scripts, Nx, generators, hooks, and
+package consumers currently depend on.
+
+## Product Scenario
+
+An agent needs to use Habitat before, during, and after a repo edit without
+guessing which command shape, JSON shape, package export, Nx target, generator,
+or hook output is stable.
+
+## Domain Owner
+
+Command/API Contract owner.
+
+Forbidden owners:
+
+- Structural Enforcement may not define public command compatibility while
+  refactoring `createCheckReport`.
+- Workspace Graph Integration may not define root script compatibility while
+  fixing target aliases.
+- Local Feedback may not define hook proof language outside the public hook
+  contract.
+
+## Consumers
+
+Agents, humans, package tests, root scripts, Nx inferred targets, Oclif command
+entrypoints, generators, hooks, and future packet authors.
+
+## Contract
+
+Inventory and classify:
+
+- CLI verbs: `check`, `classify`, `verify`, `fix`, `graph`, `hook`.
+- CLI flags and argument forwarding, including the observed mismatch between
+  `bun run habitat check -- --json` and `bun run habitat check --json`.
+- JSON schemas and human output for `CheckReport`, `Classification`,
+  `DiffClassification`, `VerifyProof`, `GritApplyTransactionProof`, and
+  `HookTrace`.
+- package exports from `/tools/habitat-harness/src/index.ts` and
+  `/tools/habitat-harness/package.json`.
+- root scripts and Habitat script entrypoints.
+- inferred Nx targets from `/tools/habitat-harness/src/plugin.js` and
+  `/nx.json`.
+- generator surfaces under `/tools/habitat-harness/src/generators/`.
+- Husky delegators and `habitat hook` behavior.
+
+The output must include an export matrix for
+`/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame/tools/habitat-harness/src/index.ts`
+and
+`/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame/tools/habitat-harness/package.json`.
+Each export must be classified as public stable, public versioned,
+package-internal, command-only DTO, test-only, generated/derived, deprecated, or
+refused. No later packet may move or remove exported internals until this matrix
+states compatibility handling.
+
+## Dependency Order
+
+Blocked by: fresh checkout, source-authority register, current command evidence.
+
+Unblocks: D1-D14. No later packet may move or narrow a public surface before D0
+states whether that surface is public, internal, deprecated, or unstable.
+
+Parallelism: none. D0 is the suite entrance.
+
+## Current State-Space Problem
+
+Public and internal surfaces are mixed. `/tools/habitat-harness/src/index.ts`
+exports broad internals from `command-engine.ts`, `baseline.ts`, `grit-apply.ts`,
+`hooks.ts`, and pattern authority. The TypeScript state space is too large
+because every exported inferred type can become an accidental public contract.
+
+D0 reduces state by producing a contract matrix with explicit states:
+
+- public stable,
+- public but intentionally versioned,
+- package-internal,
+- command-only,
+- test-only,
+- generated/derived,
+- deprecated or refused.
+
+## Solution Design
+
+1. Build a public-surface matrix from source, tests, root scripts, package
+   exports, Oclif manifest expectations, Nx inferred targets, generator schemas,
+   and hook delegators.
+2. Assign every surface one contract state from the explicit set above.
+3. Record exact compatibility examples for command JSON and human output.
+4. Record surfaces that Phase 3 must stabilize with type facades before any
+   extraction.
+5. Mark any command invocation ambiguity as a product contract issue, not a doc
+   typo.
+
+## TypeScript State-Space Reduction
+
+The implementation packet should plan a public facade before extraction:
+
+- package public exports become an explicit `public.ts` or curated `index.ts`;
+- command JSON DTOs are separate from internal domain types;
+- internal helpers stop leaking through broad exports;
+- accidental inferred return types become named contracts only where consumers
+  exist.
+
+The simpler alternative, "just move internals and fix imports," is rejected
+because it lets inferred types drift silently and hardens implementation details
+through current exports.
+
+## Public Surface Impact
+
+No public behavior changes in this packet. It may identify future intentional
+changes, but it must not implement them. Any future public change must name
+compatibility, versioning, migration, or refusal behavior.
+
+## Proof Classes
+
+Required design proof:
+
+- command inventory from source and tests;
+- package export inventory;
+- Nx target inventory;
+- generator schema inventory;
+- hook command inventory.
+
+Later implementation proof:
+
+- command behavior tests for every stable CLI shape;
+- package export compatibility check or declaration diff;
+- root script smoke checks;
+- Nx metadata checks;
+- generator schema tests;
+- hook trace tests.
+
+Non-claims:
+
+- D0 does not prove command correctness.
+- D0 does not prove current-tree structural cleanliness.
+- D0 does not prove runtime or product behavior.
+
+## Review Lanes
+
+- API/CLI contract review.
+- Product scenario review.
+- TypeScript public-surface review.
+- Stale docs review.
+- Graphite stack review.
+
+## Downstream Realignment
+
+Update or create:
+
+- command/API compatibility matrix;
+- README command examples;
+- `tools/habitat-harness/docs/IMPLEMENTED-SURFACE.md`;
+- generator surface notes;
+- root script documentation;
+- OpenSpec packet prerequisites for D1-D14.
+
+## Validation Commands / Proof Template
+
+- `git status --short --branch`: expected exit 0; records clean Graphite state
+  before and after packet implementation.
+- `bun run --cwd tools/habitat-harness test -- test/commands/habitat-entrypoints.test.ts`:
+  expected exit 0; command behavior proof for public CLI compatibility.
+- `bun run habitat classify /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame/tools/habitat-harness/src/plugin.js`:
+  expected exit 0; command behavior proof for a stable representative path.
+- `bun run lint`: expected exit 0; hygiene proof, cache acceptable only if Nx
+  reports matching inputs.
+- Cache stance: `git status`, command entrypoint tests, and `classify` must run
+  fresh from the current worktree; `bun run lint` may use Nx cache only when the
+  output records matching inputs.
+- Fixture requirement: include one unsupported scenario fixture and prove it
+  refuses with a named product reason.
+- Non-claim: this packet does not prove internal module extraction, only the
+  public contract inventory that later extraction must preserve or version.
+
+## Graphite/OpenSpec Closure
+
+Phase 3 implementation should be one docs/spec layer if it only inventories, or
+one code+tests layer if it introduces a public facade. Use OpenSpec if any
+public command or package export behavior changes.
+
+## Stop Conditions
+
+Stop if:
+
+- any later packet needs a public surface that D0 has not classified;
+- command examples still disagree on `--` forwarding;
+- package exports are treated as internal without a compatibility decision;
+- the matrix cannot distinguish stable JSON DTOs from internal types.
+- `src/index.ts` broad exports remain only "tracked" risk rather than a hard
+  packet stop condition.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D1-proof-contract-boundary.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D1-proof-contract-boundary.md
@@ -1,0 +1,163 @@
+# D1 Proof Contract Boundary
+
+## Intent
+
+Define Habitat's proof vocabulary and proof DTO boundaries before check, verify,
+hooks, Grit, apply, and Graphite handoff refactors start sharing or reshaping
+evidence.
+
+## Product Scenario
+
+A DRA owner hands work to a reviewer and needs Habitat output to say what was
+checked, observed, skipped, refused, and not claimed without implying CI,
+runtime, OpenSpec, apply safety, or product proof.
+
+## Domain Owner
+
+Proof Contract owner.
+
+Forbidden owners:
+
+- `check` may not define proof semantics beyond structural diagnostics.
+- hooks may not define proof semantics beyond local feedback.
+- apply may not define current-tree diagnostic proof.
+- Graphite state may not be collapsed into command proof.
+
+## Consumers
+
+`habitat verify`, `habitat check`, hooks, Grit adapter, apply transaction,
+review ledgers, DRA handoffs, OpenSpec workstream records.
+
+## Contract
+
+Define proof labels, non-claim labels, bounded command stream fields, post-state
+fields, failure/refusal shape, and compatibility rules for:
+
+- `VerifyProof`,
+- `CheckReport` proof summary,
+- `GritApplyTransactionProof`,
+- `HookTrace`,
+- `AdapterProofArtifact`,
+- Graphite state records in docs and handoffs.
+
+## Dependency Order
+
+Blocked by: D0.
+
+Unblocks: D6, D7, D8, D9, D10, D11, D12, D13, D14.
+
+Parallelism: can run after D0 and before D2 implementation, but D2 must consume
+the proof labels rather than invent its own.
+
+## Current State-Space Problem
+
+Proof-like shapes use different status encodings:
+
+- `CheckReport.ok` is correlated with rule statuses by convention.
+- `VerifyProof` contains check summary, Nx affected state, streams, and
+  post-state in one object.
+- `GritApplyTransactionResult` uses `ok: boolean` while transaction proof has
+  separate fields.
+- `HookTrace` records local events but can be misread as verification proof.
+
+The reachable state problem is proof substitution: a value can be structurally
+present but semantically weaker than the caller assumes.
+
+## Solution Design
+
+1. Define a closed proof-label vocabulary and non-claim vocabulary.
+2. Define proof DTO boundaries around command-facing evidence, not around
+   implementation modules.
+3. Add constructors or validators that prevent contradictory proof states, such
+   as "affected Nx executed" when Habitat check failed.
+4. Require every proof DTO to carry `proofClass`, `scope`, `nonClaims`, and
+   bounded command evidence where applicable.
+5. Keep proof DTOs shallow and projection-specific; reject a generic proof
+   supertype unless it demonstrably removes contradictory states.
+
+## TypeScript State-Space Reduction
+
+Refactor boolean/correlation contracts into discriminated states:
+
+- `CheckReport` result summary derived by constructor from rule reports.
+- `VerifyProof.nxAffected` remains an explicit union of executed/skipped/failed
+  with reason.
+- apply proof separates dry-run, live-apply, rollback, and formatter handoff.
+- hook proof is tagged as `local-feedback`.
+
+The simpler alternative, a shared `Proof<T>` wrapper, is rejected because it
+would hide proof-class differences and create a mega-framework.
+
+## Public Surface Impact
+
+Likely affects JSON schema names and exact proof fields. Must preserve
+`schemaVersion: 1` unless a deliberate version bump is designed through D0.
+Human output must keep the same proof/non-claim truth as JSON output.
+
+## Proof Classes
+
+Required design proof:
+
+- schema inventory for existing proof shapes;
+- non-claim inventory from prep and current docs;
+- current tests that assert proof output.
+
+Later implementation proof:
+
+- schema validation tests;
+- verify proof tests;
+- hook trace tests;
+- Grit/apply proof tests;
+- command behavior for `habitat verify --json` and `habitat check --json`.
+
+Non-claims:
+
+- D1 does not prove rule execution.
+- D1 does not prove current-tree cleanliness.
+- D1 does not prove apply safety.
+
+## Review Lanes
+
+- Proof-class adversarial review.
+- API compatibility review.
+- Operations review for command stream bounding.
+- Stale-record review for docs and handoff examples.
+
+## Downstream Realignment
+
+Update:
+
+- proof-class ledger;
+- `tools/habitat-harness/docs/IMPLEMENTED-SURFACE.md`;
+- `tools/habitat-harness/docs/SCENARIOS.md`;
+- OpenSpec workstream templates if they cite Habitat proof;
+- command examples in project records.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/proof-artifact.test.ts test/lib/verify-proof.test.ts`:
+  expected exit 0; schema/test proof for proof DTO boundaries.
+- `bun run habitat check --json`: expected exit 0 only after current-tree
+  proof risks are fixed or explicitly non-claimed by this packet.
+- `git status --short --branch`: expected exit 0; records proof artifacts do
+  not create untracked generated state.
+- Cache stance: schema tests may use normal Vitest execution; command proof
+  must record whether Nx cache was used.
+- Injected bad case: include one malformed proof payload and one command failure
+  projection that cannot be reported as a passing proof.
+- Non-claim: this packet does not prove any individual rule is correct.
+
+## Graphite/OpenSpec Closure
+
+Use OpenSpec if schema or command JSON changes. Commit as one proof-contract
+layer before packets that consume proof DTOs. Do not submit/claim Graphite
+readiness while downstack `needs restack` remains unresolved.
+
+## Stop Conditions
+
+Stop if:
+
+- proof labels collapse separate proof classes;
+- a proof DTO can represent impossible states;
+- command JSON changes without D0 compatibility disposition;
+- tests assert only snapshots without semantic proof/non-claim checks.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D10-generated-protected-zone-authority.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D10-generated-protected-zone-authority.md
@@ -1,0 +1,144 @@
+# D10 Generated/Protected Zone Authority
+
+## Intent
+
+Move generated/protected zone protection behind generic declarations and staged
+mutation guards so Habitat prevents hand edits without owning host-specific
+regeneration semantics.
+
+## Product Scenario
+
+An agent stages a generated file edit. Habitat must refuse the hand edit, name
+the owning generated/protected zone, provide the next safe regeneration action,
+and avoid claiming runtime or product proof.
+
+## Domain Owner
+
+Generated/Protected Zone Authority owner.
+
+Forbidden owners:
+
+- Host Policy Boundary owns host-specific zone data.
+- Local Feedback invokes staged guards but does not own zone authority.
+- Transformation Transaction may consume zone approvals but does not define
+  generated state.
+
+## Consumers
+
+Structural Enforcement, hooks, apply transaction, agents avoiding hand edits,
+generated drift scripts.
+
+## Contract
+
+Define:
+
+- generated zone declarations;
+- protected zone declarations;
+- staged mutation guard;
+- drift check surface;
+- regeneration/remediation hint;
+- host-policy missing refusal.
+
+## Dependency Order
+
+Blocked by: D1, D2, and G-HOST.
+
+Unblocks: D7, D9, and D11.
+
+Parallelism: can proceed after G-HOST contract and D2 metadata facets stabilize.
+
+## Current State-Space Problem
+
+`generated-zones.ts` contains generated zones for Swooper map entrypoints, Civ7
+types, Civ7 map policy tables, and pnpm artifacts in one generic library. The
+rule registry also has generated-zone references. Hooks invoke staged checks but
+do not own zone truth.
+
+## Solution Design
+
+1. Consume host declarations from G-HOST instead of inline host-specific arrays.
+2. Define zone states: generated, protected, forbidden artifact, missing host
+   declaration.
+3. Build staged guard output as a command-facing refusal with next safe action.
+4. Keep generated drift check separate from staged guard.
+5. Align rule metadata generated-zone facet with zone declarations.
+
+## TypeScript State-Space Reduction
+
+Replace generic `GeneratedZone[]` constants with typed declarations where each
+zone variant owns required fields. Prevent a zone from lacking remediation or
+host owner when command output needs them.
+
+The rejected alternative is moving current constants to another file without
+changing ownership.
+
+## Public Surface Impact
+
+Command messages for file-layer rules and hooks may change. D0 must classify
+stable fields and examples. Root command names should not change.
+
+## Proof Classes
+
+Required design proof:
+
+- current zone inventory;
+- host declaration mapping;
+- staged mutation scenarios.
+
+Later implementation proof:
+
+- generated-zone schema tests;
+- staged file-layer tests;
+- missing host declaration refusal tests;
+- generated-check command proof;
+- hook pre-commit staged mutation tests.
+
+Non-claims:
+
+- generated-zone proof does not regenerate files.
+- generated-zone proof does not prove runtime/product behavior.
+
+## Review Lanes
+
+- Host boundary review.
+- Generated-zone authority review.
+- Hook consumer review.
+- Apply consumer review.
+
+## Downstream Realignment
+
+Update:
+
+- protected-zone authority record;
+- AGENTS generated-output guidance if command examples change;
+- `docs/process/resources-submodule.md` references if Civ7 resources remain host
+  declarations;
+- rule metadata generated-zone facets.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/generated-zones.test.ts test/lib/hooks.test.ts`:
+  expected exit 0 after the packet creates or updates generated-zone fixtures.
+- `nx run @internal/habitat-harness:generated:check`: expected exit 0; current
+  generated-zone freshness proof.
+- `bun run habitat check --staged --tool file-layer --json`: expected exit 0
+  for clean staged state and nonzero for injected protected-zone mutation.
+- Cache stance: staged file-layer proof must run fresh; generated-check must
+  record whether dependency targets were cached.
+- Injected bad case: stage one protected generated file mutation and prove it is
+  refused with the owning remediation.
+- Non-claim: this packet does not define host policy; it consumes G-HOST.
+
+## Graphite/OpenSpec Closure
+
+Use OpenSpec if command output or host declaration surface is public. Commit
+before D11 hook closure.
+
+## Stop Conditions
+
+Stop if:
+
+- host paths remain embedded as generic Habitat truth;
+- staged guard omits next safe action;
+- protected/generated/refused states are represented by optional fields;
+- hook success is used as generated-zone proof beyond staged local feedback.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md
@@ -1,0 +1,157 @@
+# D11 Local Feedback
+
+## Intent
+
+Refactor hooks as local feedback consumers of published Habitat contracts,
+without letting pre-commit or pre-push become proof authority.
+
+## Product Scenario
+
+A developer commits or pushes. Habitat hooks quickly catch staged generated-zone
+edits, formatting drift, staged Grit findings, resource submodule issues, and
+affected-target failures while clearly stating that hook success is local
+feedback only.
+
+## Domain Owner
+
+Local Feedback owner.
+
+Forbidden owners:
+
+- Structural Enforcement owns check truth.
+- Generated/Protected Zone Authority owns staged generated-zone rules.
+- Diagnostic Pattern Catalog owns staged Grit diagnostics.
+- Transformation Transaction owns apply/write safety.
+- Workspace Graph Integration owns affected target truth.
+
+## Consumers
+
+Husky hooks, local developers, agents preparing commits, Graphite handoff
+records.
+
+## Contract
+
+Define:
+
+- `habitat hook pre-commit`;
+- `habitat hook pre-push`;
+- `HookTrace`;
+- resource state variants;
+- staged path policy;
+- partial staging refusal;
+- local-feedback non-claims;
+- Graphite-aware pre-push base resolution.
+
+## Dependency Order
+
+Blocked by: D1, D6, D7, D9, D10.
+
+Unblocks: clean local ergonomics and Phase 3 handoff reliability.
+
+Parallelism: cannot close before consumers are stable. Can design against
+contracts while D7/D9/D10 are in review.
+
+## Current State-Space Problem
+
+`hooks.ts` orchestrates resource state, staged paths, file-layer checks, Biome,
+Grit, restaging, Graphite base resolution, affected targets, reporting, and
+trace capture. `ResourceState.kind` and `allowPreCommit` can contradict if not
+constructed centrally.
+
+## Solution Design
+
+1. Define hook orchestration as a pipeline of local-feedback stages.
+2. Consume published command contracts from D7, D10, and D6 rather than
+   duplicating proof semantics.
+3. Model resource state as a union where allowed/disallowed is derived from
+   variant.
+4. Keep partial staging refusal explicit.
+5. Label every hook result as local feedback, not verification/CI/product proof.
+6. Evaluate D15 only if hook command provenance cannot be represented locally.
+
+## TypeScript State-Space Reduction
+
+Replace `ResourceState` boolean correlation with constructors or discriminated
+states:
+
+- clean,
+- not configured,
+- staged gitlink allowed,
+- dirty submodule refused,
+- unstaged gitlink refused,
+- inspection failure refused.
+
+The rejected alternative is to add comments around `allowPreCommit`; the
+compiler should derive the allowed state.
+
+## Public Surface Impact
+
+Hook human output may change. JSON trace compatibility depends on D0. Husky
+delegator command path should remain stable.
+
+## Proof Classes
+
+Required design proof:
+
+- current hook stage inventory;
+- resource state scenarios;
+- staged path and partial staging scenarios.
+
+Later implementation proof:
+
+- hook trace tests;
+- resource state tests;
+- staged mutation tests;
+- partial staging refusal tests;
+- pre-push base tests;
+- command behavior for pre-commit/pre-push representative cases.
+
+Non-claims:
+
+- hook pass is not CI.
+- hook pass is not review proof.
+- hook pass is not runtime/product proof.
+- hook pass is not full apply safety proof.
+
+## Review Lanes
+
+- Local feedback product review.
+- Proof-class review.
+- Generated-zone/Grit/check consumer review.
+- Graphite operations review.
+
+## Downstream Realignment
+
+Update:
+
+- hook contract doc;
+- AGENTS hook guidance if behavior changes;
+- Graphite handoff docs;
+- command examples.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/hooks.test.ts`:
+  expected exit 0; hook orchestration and staged-path proof.
+- `bun run habitat hook pre-commit --dry-run`: expected exit 0 for clean staged
+  state after D7/D9/D10 contracts are stable.
+- `bun run habitat hook pre-push --dry-run`: expected exit 0 and must record
+  Graphite base detection.
+- Cache stance: hook dry-runs must run fresh because they depend on Git state.
+- Injected bad case: include a staged generated-zone mutation and a failing
+  wrapped check; prove hooks report local feedback without claiming CI proof.
+- Non-claim: hooks are not authoritative verification and do not replace D12.
+
+## Graphite/OpenSpec Closure
+
+Use OpenSpec if hook behavior or trace schema changes. Commit after dependent
+consumers are stable and tests prove local-feedback boundaries.
+
+## Stop Conditions
+
+Stop if:
+
+- hook code owns proof semantics instead of consuming published contracts;
+- resource state can contradict allowed commit behavior;
+- hooks restage or rewrite outside explicit policy;
+- hook success is described as CI or product proof.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D12-proof-handoff-verify-command.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D12-proof-handoff-verify-command.md
@@ -1,0 +1,148 @@
+# D12 Proof/Handoff Verify Command
+
+## Intent
+
+Refactor `habitat verify` into a handoff proof assembler that runs Habitat
+check, conditionally runs affected Nx proof, records post-state, and states
+non-claims without owning check or graph internals.
+
+## Product Scenario
+
+A DRA owner needs a bounded, current command proof for handoff. If Habitat check
+fails, affected Nx proof is skipped with reason. If check passes, affected proof
+runs against the correct base and records cache/stream/post-state evidence.
+
+## Domain Owner
+
+Proof Contract owner with Workspace Graph Integration as graph dependency.
+
+Forbidden owners:
+
+- Verify does not own structural diagnostics.
+- Verify does not own Nx graph construction.
+- Verify does not own Graphite submit/PR state.
+
+## Consumers
+
+DRA owners, reviewers, handoff packets, agents before final response, project
+records.
+
+## Contract
+
+`habitat verify` emits `VerifyProof` with:
+
+- proof class;
+- Habitat check summary;
+- selected base;
+- affected target plan/result/skipped reason;
+- bounded stdout/stderr streams;
+- cache state by task where observable;
+- git/resource post-state;
+- non-claims.
+
+## Dependency Order
+
+Blocked by: D1, D3, and D7.
+
+Unblocks: D14 and Phase 3 closure model.
+
+Parallelism: can design before D7 implementation if CheckReport contract is
+stable, but cannot close before D7.
+
+## Current State-Space Problem
+
+`createVerifyProof` combines check summary, affected Nx states, stream bounding,
+cache parsing, git/resource state, and non-claims. `VerifyProof.habitatCheck.requestedSelectors`
+currently emits `{}` because verify has no selector flags.
+
+## Solution Design
+
+1. Consume `CheckReport` constructor output from D7.
+2. Consume graph/target facts from D3.
+3. Make requested selector state explicit: none, inherited, unsupported, or
+   requested.
+4. Keep affected Nx states as executed/skipped/failed with required reasons.
+5. Record Graphite state as a separate non-claim field if included at all.
+
+## TypeScript State-Space Reduction
+
+Replace `{}` selector placeholders and optional affected fields with explicit
+variants. Prevent affected proof from executing when check failed unless a
+future public contract intentionally supports forced mode.
+
+The rejected alternative is to keep `VerifyProof` as a broad output bag and fix
+individual fields.
+
+## Public Surface Impact
+
+Likely affects `VerifyProof` JSON. D0/D1 must version or preserve stable fields.
+Human output must keep non-claims visible.
+
+## Proof Classes
+
+Required design proof:
+
+- current verify proof field inventory;
+- affected command behavior;
+- check-failure skip scenario.
+
+Later implementation proof:
+
+- verify proof schema tests;
+- check-failure skip tests;
+- affected-executed tests;
+- stream bounding tests;
+- cache parsing tests;
+- command behavior for `habitat verify --json`.
+
+Non-claims:
+
+- verify is not CI.
+- verify is not runtime/product proof.
+- verify is not Graphite submit/PR proof.
+- verify does not prove apply safety.
+
+## Review Lanes
+
+- Proof/handoff review.
+- Graph consumer review.
+- API/JSON compatibility review.
+- Operations stream-boundary review.
+
+## Downstream Realignment
+
+Update:
+
+- verification contract;
+- handoff templates;
+- validation stop conditions;
+- docs that compare root `bun run verify` and `habitat verify`.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/verify-proof.test.ts test/lib/proof-artifact.test.ts`:
+  expected exit 0; verify proof schema and artifact proof.
+- `bun run habitat verify --json`: expected exit 0 only after D7 current-tree
+  proof and D3 graph metadata are stable.
+- `git status --short --branch`: expected exit 0; verify must not mutate the
+  worktree except explicit proof-output paths.
+- Cache stance: verify must record each delegated command and whether it was
+  cached, fresh, skipped, or explicitly non-claimed.
+- Injected bad case: include one failing delegated command and prove verify
+  emits a failing proof with bounded stdout/stderr.
+- Non-claim: verify assembles handoff proof; it does not make local hooks or CI
+  redundant.
+
+## Graphite/OpenSpec Closure
+
+Use OpenSpec for any verify schema or command behavior change. Commit after D7
+and D3 are stable.
+
+## Stop Conditions
+
+Stop if:
+
+- affected targets run after failed check without explicit contract;
+- `{}` or absent fields hide unsupported selector state;
+- Graphite state is reported as behavior proof;
+- verify output omits non-claims.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D13-scaffolding-and-refusal-contracts.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D13-scaffolding-and-refusal-contracts.md
@@ -1,0 +1,149 @@
+# D13 Scaffolding and Refusal Contracts
+
+## Intent
+
+Separate supported generic scaffolding from unsupported domain authoring so
+Habitat creates uniform structures only when it owns the shape and otherwise
+returns designed refusals.
+
+## Product Scenario
+
+An agent asks Habitat to scaffold a project or pattern. Habitat creates
+supported app/foundation/plugin projects and candidate patterns, while refusing
+unsupported kinds and MapGen Authoring Topology requests with next safe action.
+
+## Domain Owner
+
+Scaffolding owner.
+
+Forbidden owners:
+
+- Pattern Governance owns registration, not candidate file writing.
+- Host Policy Boundary owns host-specific unsupported kinds.
+- Authoring Topology owns future MapGen domain/op/stage/step/recipe generation.
+
+## Consumers
+
+Nx generators, agents creating structures, pattern authors, future Authoring
+Topology investigators.
+
+## Contract
+
+Define:
+
+- supported project kinds;
+- project generator preflight/refusal states;
+- candidate pattern generator output state;
+- registered pattern handoff to D8;
+- unsupported-kind refusal;
+- Authoring Topology refusal/future trigger;
+- host-policy missing refusal.
+
+## Dependency Order
+
+Blocked by: D0, D2, D8, and G-HOST.
+
+Unblocks: D14.
+
+Parallelism: project generator refusal design can proceed after D0/D2; pattern
+candidate semantics wait for D8.
+
+## Current State-Space Problem
+
+Project and pattern generators share Nx mechanics but answer different product
+questions. Candidate pattern output can be mistaken for registered enforcement.
+Unsupported Authoring Topology has doc-level warnings but needs command-facing
+refusal semantics.
+
+## Solution Design
+
+1. Model project generator supported kinds as a closed union.
+2. Model pattern generator output as candidate-only until D8 registration.
+3. Define refusal DTO/message with blocked action, reason, owner, next safe
+   action, proof class, and non-claims.
+4. Add unsupported host/domain authoring refusals, including MapGen topology.
+5. Keep generator tests scenario-based rather than implementation-folder based.
+
+## TypeScript State-Space Reduction
+
+Replace stringly kind/options handling with discriminated scaffolding requests:
+
+- supported project request,
+- candidate pattern request,
+- unsupported kind refusal,
+- authoring topology refusal,
+- preflight conflict refusal.
+
+The rejected alternative is merging project and pattern generators because they
+both use Nx. That preserves product ambiguity.
+
+## Public Surface Impact
+
+Generator schema and error messages may change. D0 must classify whether
+generator options are stable. Unsupported kinds should fail deliberately.
+
+## Proof Classes
+
+Required design proof:
+
+- generator schema inventory;
+- supported/unsupported scenario inventory;
+- Pattern Governance handoff contract.
+
+Later implementation proof:
+
+- generator tests for supported kinds;
+- refusal tests for unsupported kinds;
+- candidate pattern generation tests;
+- registration handoff tests;
+- classify/check after generated supported project when feasible.
+
+Non-claims:
+
+- project scaffolding does not prove app/product behavior.
+- candidate pattern generation does not register a rule.
+- scaffold refusal does not implement Authoring Topology.
+
+## Review Lanes
+
+- Product/scenario review.
+- Refusal contract review.
+- Pattern Governance review.
+- Host boundary review.
+- API/generator compatibility review.
+
+## Downstream Realignment
+
+Update:
+
+- scaffolding matrix;
+- `tools/habitat-harness/docs/SCENARIOS.md`;
+- `tools/habitat-harness/docs/AUTHORING-NEXT.md`;
+- AGENTS scaffold guidance if command examples change.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/generators/project-generator.test.ts test/generators/pattern-generator.test.ts`:
+  expected exit 0; supported scaffold and pattern candidate proof.
+- `nx g @internal/habitat-harness:project habitat-scratch --kind=plugin --dry-run`:
+  expected exit 0; supported project dry-run proof.
+- `nx g @internal/habitat-harness:project unsupported-scratch --kind=host-specific --dry-run`:
+  expected nonzero; unsupported-kind refusal proof.
+- Cache stance: generator dry-runs must run fresh and must not rely on Nx cache.
+- Injected bad case: include unsupported kind, registered-pattern-without-manifest,
+  and host-specific scaffold request; all must refuse before writes.
+- Non-claim: this packet does not implement unsupported project kinds.
+
+## Graphite/OpenSpec Closure
+
+Use OpenSpec for generator schema/behavior changes. Commit after D8 and G-HOST
+are stable.
+
+## Stop Conditions
+
+Stop if:
+
+- unsupported kinds fall through to generic generation;
+- candidate pattern output is described as registered enforcement;
+- Authoring Topology implementation enters scope;
+- refusal lacks next safe action or non-claim.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D14-authoring-topology-fence.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D14-authoring-topology-fence.md
@@ -1,0 +1,142 @@
+# D14 Authoring Topology Fence
+
+## Intent
+
+Make future Authoring Topology an explicit product boundary and refusal/future
+trigger, preventing Phase 3 from implementing MapGen domain/op/stage/step/recipe
+generation as part of the structural substrate refactor.
+
+## Product Scenario
+
+An agent asks Habitat to create MapGen authoring topology. Habitat refuses or
+routes to future investigation because current Habitat owns structural
+orientation, enforcement, proof, guarded repair, and narrow scaffolding, not
+domain-specific authoring workflows.
+
+## Domain Owner
+
+Future Authoring Topology owner.
+
+Forbidden owners:
+
+- Scaffolding cannot absorb domain authoring because it can create generic
+  project shells.
+- Orientation cannot imply authoring support because it can classify paths.
+- Pattern Governance cannot imply full authoring because it admits structural
+  rules.
+
+## Consumers
+
+DRA owners, future product investigators, agents requesting generators, docs.
+
+## Contract
+
+Define:
+
+- explicit unsupported authoring actions;
+- future acceptance criteria;
+- required investigation/proof for authoring;
+- refusal output;
+- downstream deferral record.
+
+## Dependency Order
+
+Blocked by: D4, D12, and D13.
+
+Unblocks: future investigation only. It does not unblock Phase 3 structural
+implementation except by keeping scope clean.
+
+Parallelism: design after classify, verify, and scaffolding contracts are known.
+
+## Current State-Space Problem
+
+Current docs identify Authoring Topology as a gap, but without a command-facing
+fence agents can conflate supported project/pattern scaffolding with domain
+authoring. The invalid state is "Habitat can scaffold generic structures, so it
+can also invent MapGen domain topology."
+
+## Solution Design
+
+1. List unsupported authoring actions explicitly.
+2. Define future acceptance criteria: product convention, target topology,
+   generator proof, classify/check proof, compile proof, and product acceptance.
+3. Connect unsupported requests to D13 refusal shape.
+4. Record deferral with trigger rather than implementation tasks.
+5. Ensure no Phase 3 packet adds authoring generators.
+
+## TypeScript State-Space Reduction
+
+No direct implementation refactor is planned unless D13 needs an unsupported
+request variant. The state-space reduction is product-level: unsupported
+authoring requests become a closed refusal state instead of falling into generic
+scaffolding options.
+
+The rejected alternative is to leave authoring as a prose gap in docs only.
+
+## Public Surface Impact
+
+May affect generator refusal output and docs. No authoring command is added.
+
+## Proof Classes
+
+Required design proof:
+
+- unsupported action inventory;
+- future acceptance criteria;
+- refusal examples.
+
+Later implementation proof:
+
+- refusal tests through D13;
+- docs/deferral record truth proof;
+- classify/verify examples that state non-support.
+
+Non-claims:
+
+- D14 does not implement Authoring Topology.
+- D14 does not prove MapGen product behavior.
+- D14 does not create generators.
+
+## Review Lanes
+
+- Product boundary review.
+- Scope-control review.
+- Refusal review.
+- Stale-record review.
+
+## Downstream Realignment
+
+Update:
+
+- Authoring Topology deferral row with trigger;
+- `tools/habitat-harness/docs/AUTHORING-NEXT.md`;
+- scenario corpus if future criteria change;
+- AGENTS guidance only if durable generic guidance changes.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/generators/project-generator.test.ts test/lib/classify.test.ts`:
+  expected exit 0; refusal and orientation proof for out-of-scope authoring
+  topology requests.
+- `bun run habitat classify /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame/docs/projects/habitat-harness/domain-mapping/domain-design-packet.md`:
+  expected exit 0; docs orientation proof for future-trigger records.
+- `git status --short --branch`: expected exit 0; fence records must be docs or
+  explicit OpenSpec changes only.
+- Cache stance: refusal tests must run fresh.
+- Injected bad case: include a MapGen Authoring Topology implementation request
+  and prove Habitat answers with a future-work boundary, not a scaffold.
+- Non-claim: this packet does not implement Authoring Topology.
+
+## Graphite/OpenSpec Closure
+
+Docs/refusal-only closure unless D13 command behavior changes. No
+implementation packet for authoring topology in Phase 3.
+
+## Stop Conditions
+
+Stop if:
+
+- any packet adds MapGen domain/op/stage/step/recipe generator implementation;
+- future acceptance criteria are vague;
+- unsupported authoring request has no command-facing refusal path;
+- Civ7/MapGen specifics become generic Habitat authority.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D15-execution-provenance-substrate-trigger.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D15-execution-provenance-substrate-trigger.md
@@ -1,0 +1,163 @@
+# D15 Execution Provenance Substrate Trigger
+
+## Intent
+
+Define the narrow condition under which a packet may introduce a typed execution
+provenance substrate. D15 is not a default standalone migration to Effect or any
+other process framework.
+
+## Product Scenario
+
+A packet needs to prove command provenance, cwd/env/git state/cache policy/output
+digests, or typed process failures and cannot do so with the local DTOs in that
+packet without creating contradictory states.
+
+## Domain Owner
+
+Process/proof substrate owner.
+
+Forbidden owners:
+
+- Individual packet owners may not introduce broad substrate migrations because
+  command execution feels messy.
+- Proof Contract may define labels but not force an Effect migration by default.
+
+## Consumers
+
+Primarily D6, D9, and optionally D7/D11 if their command provenance states cannot
+be represented locally.
+
+## Contract
+
+D15 is a trigger protocol. A consuming packet must record:
+
+- concrete scenario requiring typed provenance;
+- current contradictory state;
+- local DTO alternative rejected;
+- runtime command fields required;
+- public output impact;
+- proof class;
+- rollback/escape plan;
+- type-check and test performance risk.
+
+## Dependency Order
+
+Blocked by: D1 and a packet-specific need.
+
+Unblocks: only the packet that triggered it. It does not reorder the whole suite.
+
+Parallelism: none as a standalone implementation. Triggered work must stay
+inside the consuming packet or become a separately reviewed OpenSpec slice only
+after packet-minimization passes.
+
+## Current State-Space Problem
+
+Habitat already has command/process-related code (`habitat-process.ts`,
+`effect-runtime.ts`, `effect-parity.ts`, Grit/apply proof fields), but a broad
+substrate migration would add state before proving which state it removes.
+
+## Solution Design
+
+1. Treat D15 as a decision checklist embedded in D6, D7, D9, or D11.
+2. Require proof that local discriminated DTOs are insufficient.
+3. If triggered, design the smallest typed provenance layer for the consuming
+   packet's command family.
+4. Preserve behavior and public types unless explicitly versioned.
+5. Reject broad framework migration without measured state-space reduction and
+   green proof.
+
+## TypeScript State-Space Reduction
+
+A valid D15 activation must remove at least one contradictory state, such as:
+
+- success result without cwd/argv provenance;
+- cache status assumed when unobservable;
+- output digest absent for write proof;
+- git state stale or untied to command execution;
+- failure tag string not tied to command family.
+
+The rejected default is "move all Habitat internals to Effect." Effect is only
+valid when it is the smallest way to model the needed provenance.
+
+## Public Surface Impact
+
+Should be internal unless proof DTOs expose provenance fields. D0/D1 classify
+and version any public proof fields.
+
+## Proof Classes
+
+Required design proof:
+
+- trigger scenario;
+- current contradictory state;
+- local alternative rejected;
+- type-check/build risk analysis.
+
+Later implementation proof if triggered:
+
+- typed command result tests;
+- failure injection tests;
+- command behavior;
+- performance/build sanity;
+- parity tests if replacing existing execution path.
+
+Non-claims:
+
+- D15 does not authorize broad substrate migration.
+- D15 does not improve product behavior by itself.
+- D15 does not replace proof-class labels.
+
+## Review Lanes
+
+- TypeScript overengineering review.
+- Operations proof review.
+- Public API impact review.
+- Performance/build review.
+
+## Downstream Realignment
+
+Update only the consuming packet's decision row unless D15 becomes a standalone
+OpenSpec change. If it becomes standalone, update the packet suite index with
+the exact trigger and dependency impact.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/habitat-process.test.ts test/lib/effect-parity.test.ts`:
+  expected exit 0; typed command-result and substrate parity proof.
+- `git status --short --branch`: expected exit 0; provenance capture must not
+  create hidden output files.
+- `bun run habitat check --tool grit-check --json`: expected status follows D6;
+  when used as a D15 trigger, record argv, cwd, env subset, duration,
+  stdout/stderr bounds, cache/freshness, and git state.
+- `bun run habitat check --json`: expected status follows D7; when used as a
+  D15 trigger, record delegated command provenance for each rule/tool segment.
+- `bun run habitat fix --dry-run --json`: expected status follows D9; when used
+  as a D15 trigger, record isolated-copy path, approved write roots, formatter
+  handoff, and git state.
+- `bun run habitat hook pre-commit --dry-run`: expected status follows D11; when
+  used as a D15 trigger, record staged paths, Graphite base, and local-only
+  non-claim.
+- Consuming-packet note: D6, D7, D9, and D11 still own whether these commands
+  are required for their closure; D15 only defines the substrate trigger
+  evidence shape when one of those exact commands exposes untyped provenance.
+- Cache stance: process/provenance tests run fresh; delegated command cache use
+  must be captured rather than hidden.
+- Injected bad case: include one missing binary, one nonzero command, and one
+  oversized output case; all must preserve typed failure state.
+- Non-claim: D15 does not authorize broad Effect/substrate migration unless a
+  consuming packet passes minimization.
+
+## Graphite/OpenSpec Closure
+
+No standalone commit by default. If triggered into an implementation slice, it
+must be one focused Graphite layer with OpenSpec only when public proof behavior
+changes.
+
+## Stop Conditions
+
+Stop if:
+
+- the packet cannot name a contradictory state removed by typed provenance;
+- the proposal is framework migration language rather than product proof need;
+- type-check performance or readability risk is unmeasured;
+- public proof fields change without D0/D1 compatibility.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D2-rule-registry-metadata-contract.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D2-rule-registry-metadata-contract.md
@@ -1,0 +1,169 @@
+# D2 Rule Registry Metadata Contract
+
+## Intent
+
+Turn the rule registry from a prose-heavy shared object into typed metadata
+facets consumed by graph, classify, check, baseline, Pattern Governance, hooks,
+and generated-zone guards.
+
+## Product Scenario
+
+An agent classifies a path or runs a rule selector and gets precise rule scope,
+owner, tool, hook scope, baseline, manifest, and generated-zone facts without
+Habitat guessing from prose.
+
+## Domain Owner
+
+Rule Registry Metadata owner.
+
+Forbidden owners:
+
+- `plugin.js` may not hard-code owner roots as registry truth.
+- `classify` may not parse prose `scope` as semantic routing authority.
+- baseline and Pattern Governance may not infer admission state from file
+  presence alone.
+
+## Consumers
+
+Structural Enforcement, Orientation and Routing, Workspace Graph Integration,
+Baseline Authority, Diagnostic Pattern Catalog, Pattern Governance,
+Generated/Protected Zone Authority, Local Feedback.
+
+## Contract
+
+Define minimal typed facets:
+
+- identity facet: `id`, `ownerProject`, `ownerTool`, `lane`;
+- selector facet: owner/tool/rule selector vocabulary;
+- scope/routing facet: structured path globs or owning surfaces;
+- graph facet: owning project root, target alias policy, dependency target;
+- baseline facet: baseline state contract and introduction manifest relation;
+- Grit facet: `gritPattern`, scan root, hook scope;
+- generated-zone facet: `generatedZone` and host declaration link;
+- governance facet: Pattern Authority manifest status.
+
+Consumers receive projections. They do not consume the whole registry unless a
+packet proves that is the smaller state.
+
+## Dependency Order
+
+Blocked by: D0 and D1.
+
+Unblocks: D3, D4, D5, D6, D7, D8, D10, D13.
+
+Parallelism: after the contract is drafted, projections for D3/D5/D6 can be
+implemented in parallel if their write sets do not overlap.
+
+## Current State-Space Problem
+
+`/tools/habitat-harness/src/rules/rules.json` mixes stable fields, prose fields,
+tool-specific fields, hook fields, generated-zone fields, and wrapped-test
+fields. `plugin.js` separately encodes owner roots and alias construction.
+`classifyRuleScope` uses string scope heuristics.
+
+The reachable state problem is missing metadata: each consumer creates its own
+interpretation, so the same rule can be simultaneously routable, unroutable,
+hook-scoped, baseline-owned, or graph-owned depending on which module reads it.
+
+## Solution Design
+
+1. Define a versioned registry schema with typed optional facets, not a single
+   mega-record.
+2. Add projection functions with consumer-specific return types:
+   `ruleSelectorFacts`, `ruleRoutingFacts`, `ruleGraphFacts`,
+   `ruleBaselineFacts`, `ruleGritFacts`, `ruleGeneratedZoneFacts`.
+3. Move owner-root truth into graph metadata or an explicit registry graph facet.
+4. Preserve human `why`, `message`, and `remediate` fields as command output,
+   not routing authority.
+5. Add malformed-rule refusal states for missing facet fields where a consumer
+   requires them.
+
+## TypeScript State-Space Reduction
+
+Replace optional soup with discriminated facet states:
+
+- `ownerTool: "grit-check"` requires `gritPattern`;
+- `ownerTool: "file-layer"` requires `generatedZone` or a declared file-layer
+  rule kind;
+- wrapped Nx rules require `nxTarget`;
+- target aliases are generated from a typed graph facet, not target-name string
+  parsing.
+
+The rejected alternative is "add more optional fields to rules.json." It would
+increase invalid combinations and keep routing logic scattered.
+
+## Public Surface Impact
+
+Internal registry shape changes are possible. Public command output may gain
+more precise facts but must preserve D0-classified stable fields. Package export
+impact depends on whether registry types are public or internal after D0.
+
+## Proof Classes
+
+Required design proof:
+
+- registry field inventory;
+- consumer projection matrix;
+- malformed rule scenarios.
+
+Later implementation proof:
+
+- schema validation tests;
+- projection tests per consumer;
+- classify scope tests;
+- Nx target alias metadata tests;
+- baseline and Pattern Authority tests that consume facets;
+- command behavior for selector errors.
+
+Non-claims:
+
+- D2 does not execute rules.
+- D2 does not prove target aliases run.
+- D2 does not admit new patterns.
+
+## Review Lanes
+
+- Metadata minimization review.
+- API/schema compatibility review.
+- Graph consumer review.
+- Pattern Governance review.
+- TypeScript state-space review.
+
+## Downstream Realignment
+
+Update:
+
+- rule-pack contract record;
+- `tools/habitat-harness/docs/DOMAIN-MAPPING.md`;
+- taxonomy references if owner roots change;
+- OpenSpec packets that cite rule metadata;
+- tests that fixture registry records.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/rule-selection.test.ts test/rules/pattern-authority-manifest.test.ts`:
+  expected exit 0; schema and selector proof for registry facets.
+- `bun run habitat classify /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame/tools/habitat-harness/src/rules/rules.json`:
+  expected exit 0; command behavior proof that registry ownership remains
+  discoverable.
+- `nx show project @internal/habitat-harness`: expected exit 0; graph metadata
+  proof that registry-derived targets remain visible.
+- Cache stance: graph metadata may be cached, but the packet must record the
+  exact JSON target metadata used.
+- Injected bad case: include one rule row missing owner/tool/lane metadata and
+  prove it fails before command execution.
+- Non-claim: this packet does not admit new rules or change baseline debt.
+
+## Graphite/OpenSpec Closure
+
+Use OpenSpec if registry schema or generated target behavior changes. Commit
+schema/projection work before consumer refactors.
+
+## Stop Conditions
+
+Stop if:
+
+- consumers still parse prose scope for authoritative routing;
+- a whole-rule object is passed where a smaller projection is enough;
+- malformed metadata silently disables a rule;
+- target aliases depend on colon-string parsing instead of structured facts.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D3-workspace-graph-integration-boundary.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D3-workspace-graph-integration-boundary.md
@@ -1,0 +1,153 @@
+# D3 Workspace Graph Integration Boundary
+
+## Intent
+
+Make Nx project and target truth a single Habitat boundary that `classify`,
+`verify`, root scripts, and inferred targets consume without duplicating graph
+knowledge.
+
+## Product Scenario
+
+An agent classifies a file and receives target facts that are true according to
+the current Nx graph, including unavailable targets as routing facts rather than
+commands to run.
+
+## Domain Owner
+
+Workspace Graph Integration owner.
+
+Forbidden owners:
+
+- Orientation and Routing may present graph facts but not infer target truth.
+- Proof Contract may record target execution but not construct the graph.
+- Rule Registry may declare intended graph facets but not read Nx metadata.
+
+## Consumers
+
+`habitat classify`, `habitat verify`, root Nx scripts, inferred Habitat targets,
+rule-target aliases, packet proof commands.
+
+## Contract
+
+Define a graph service contract for:
+
+- project metadata read;
+- owning project lookup by repo-relative path;
+- available/unavailable target facts;
+- inferred Habitat aggregate, owner, and rule targets;
+- alias dependency normalization;
+- graph error/refusal states.
+
+## Dependency Order
+
+Blocked by: D2.
+
+Unblocks: D4 and D12.
+
+Parallelism: can proceed in parallel with D5/D6 after D2 because write set is
+graph/plugin focused.
+
+## Current State-Space Problem
+
+`/tools/habitat-harness/src/plugin.js` builds inferred targets and owner roots,
+while `/tools/habitat-harness/src/lib/nx-projects.ts` reads project metadata for
+classification. Validation found a false-green risk where an inferred
+`habitat:rule:biome-ci` alias depends on `{"projects":["biome"],"target":"ci"}`
+even though `biome` is not a project.
+
+The reachable state problem is target-name string parsing and duplicate graph
+truth. A target can exist as a display fact, an alias, a dependency, or a command
+without a shared type saying which state it is in.
+
+## Solution Design
+
+1. Define `HabitatGraphFact` and `HabitatTargetFact` as discriminated states:
+   available target, unavailable target, alias target, broad aggregate target,
+   graph-error.
+2. Centralize owner-root and target alias construction behind graph functions
+   consumed by both plugin and classify.
+3. Make alias dependency resolution structured, not colon-split.
+4. Preserve unavailable target facts in classify output without encouraging
+   execution.
+5. Add graph error handling that distinguishes Nx daemon errors, malformed
+   graph JSON, and missing target/project states.
+
+## TypeScript State-Space Reduction
+
+Remove target ambiguity by replacing string target facts with typed graph facts.
+The compiler should prevent a missing-project alias from being represented as an
+executable target.
+
+The rejected alternative is "fix the biome alias special case." That would leave
+the string parsing state space open for the next rule.
+
+## Public Surface Impact
+
+`classify` output may become more precise. D0 must decide whether new target
+fact fields are additive under `schemaVersion: 1` or require schema versioning.
+Nx inferred target names should remain stable unless explicitly versioned.
+
+## Proof Classes
+
+Required design proof:
+
+- current plugin target inventory;
+- current classify target output inventory;
+- failing alias risk documented.
+
+Later implementation proof:
+
+- `nx show project @internal/habitat-harness --json`;
+- plugin unit tests for inferred targets;
+- classify tests for available/unavailable targets;
+- injected missing-project alias test;
+- command behavior for representative path classification.
+
+Non-claims:
+
+- D3 graph metadata does not execute targets.
+- A valid target fact does not prove target success.
+
+## Review Lanes
+
+- Nx/tooling review.
+- Public classify contract review.
+- TypeScript graph-state review.
+- Operations proof review.
+
+## Downstream Realignment
+
+Update:
+
+- Nx/Habitat graph contract doc;
+- `tools/habitat-harness/docs/CAPABILITIES.md`;
+- classify examples;
+- validation stop conditions related to false-green aliases.
+
+## Validation Commands / Proof Template
+
+- `nx show project @internal/habitat-harness`: expected exit 0; graph metadata
+  proof for Habitat project targets and package exports.
+- `nx run @internal/habitat-harness:habitat:rule:biome-ci`: expected exit 0
+  only when the alias proves its dependency ran rather than a false green.
+- `nx run @internal/habitat-harness:boundaries`: expected exit 0 after current
+  graph-file ENOENT risks are fixed or explicitly non-claimed.
+- Cache stance: target-alias proof must run with cache disabled or include
+  dependency execution evidence.
+- Injected bad case: include one intentionally broken target alias and prove it
+  cannot pass through `node -e ""`.
+- Non-claim: this packet does not prove individual Habitat rule semantics.
+
+## Graphite/OpenSpec Closure
+
+Use a dedicated Graphite layer because plugin target inference affects many
+commands. Use OpenSpec if target names or classify JSON change.
+
+## Stop Conditions
+
+Stop if:
+
+- alias dependencies are still parsed from colon-delimited strings;
+- classify can display a target as executable when Nx metadata says it is not;
+- plugin and classify retain separate owner-root maps;
+- graph errors collapse into generic command failure without target facts.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D4-orientation-and-routing.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D4-orientation-and-routing.md
@@ -1,0 +1,150 @@
+# D4 Orientation and Routing
+
+## Intent
+
+Refactor `habitat classify` around explicit path/diff states, owner facts, rule
+scope projections, and target facts so agents can orient before editing without
+Habitat overclaiming precision.
+
+## Product Scenario
+
+An agent receives a path or diff and needs to know the owning project, tags,
+applicable rules, runnable proof targets, unavailable targets, and unresolved
+facts before making a change.
+
+## Domain Owner
+
+Orientation and Routing owner.
+
+Forbidden owners:
+
+- Workspace Graph Integration owns Nx truth.
+- Rule Registry Metadata owns rule scope facts.
+- Structural Enforcement owns rule execution.
+
+## Consumers
+
+Agents, humans, docs, handoff packets, DRA owners, `habitat classify` command
+tests.
+
+## Contract
+
+`habitat classify <path-or-diff>` returns a versioned classification DTO with
+explicit variants:
+
+- workspace path,
+- project path,
+- diff with classified paths,
+- malformed/pathless diff,
+- unresolved owner,
+- graph error.
+
+Each variant states owner, scoped rules, targets, unavailable targets, unresolved
+facts, and non-claims where applicable.
+
+## Dependency Order
+
+Blocked by: D2 and D3.
+
+Unblocks: D14 and scenario handoff examples.
+
+Parallelism: can run after D3 while D5/D6/D8 continue if shared public DTOs are
+coordinated through D0.
+
+## Current State-Space Problem
+
+`Classification` in `command-engine.ts` is an optional-heavy shape. Diff
+classification, workspace fallback, project owner, scoped rules, targets, and
+unavailable targets can coexist in combinations that do not match product
+states. Rule scope is partly derived from prose.
+
+## Solution Design
+
+1. Design classification as a discriminated union of scenario states.
+2. Consume graph target facts from D3 and rule routing projections from D2.
+3. Make malformed/pathless diff an explicit refusal-like state with next safe
+   action.
+4. Preserve non-claims in both human and JSON output.
+5. Add examples for path, diff, workspace fallback, unresolved owner, and graph
+   failure.
+
+## TypeScript State-Space Reduction
+
+Replace optional fields with explicit variants so a diff result cannot also be
+treated as a single project path, and an unresolved graph state cannot carry
+executable target facts.
+
+The rejected alternative is adding optional `kind?: string` to the existing
+interface. That would not remove invalid combinations.
+
+## Public Surface Impact
+
+Likely affects `Classification` and `DiffClassification` JSON. D0 must version
+or preserve fields. Human output may change to include unresolved facts and
+non-claims.
+
+## Proof Classes
+
+Required design proof:
+
+- current classify command examples;
+- DTO field inventory;
+- scenario examples from prep.
+
+Later implementation proof:
+
+- classify unit tests for every variant;
+- command behavior tests for path and diff;
+- graph error fixture;
+- rule-scope projection tests;
+- docs examples regenerated from real command output when feasible.
+
+Non-claims:
+
+- classify does not run targets.
+- classify does not prove rule correctness or apply safety.
+
+## Review Lanes
+
+- Product ergonomics review.
+- API/JSON compatibility review.
+- Graph/rule projection review.
+- Refusal contract review.
+
+## Downstream Realignment
+
+Update:
+
+- `tools/habitat-harness/docs/SCENARIOS.md`;
+- classify examples in README/docs;
+- scenario corpus if new states appear;
+- D14 Authoring Topology fence examples.
+
+## Validation Commands / Proof Template
+
+- `bun run habitat classify /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame/tools/habitat-harness/src/plugin.js`:
+  expected exit 0; representative supported-path classification proof.
+- `bun run habitat classify /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame/docs/projects/habitat-harness/phase2-workstream-packets/README.md`:
+  expected exit 0; representative docs-path classification proof.
+- `bun run --cwd tools/habitat-harness test -- test/lib/classify.test.ts`:
+  expected exit 0; JSON and refusal contract proof.
+- Cache stance: classify command proof must be current process output, not only
+  cached Nx metadata.
+- Injected bad case: include one unsupported path or malformed diff and prove
+  the command refuses with a stable reason.
+- Non-claim: this packet does not prove targets are fresh; it only proves
+  routing and orientation.
+
+## Graphite/OpenSpec Closure
+
+Use OpenSpec for JSON/human command contract changes. Commit D4 after D3 and D2
+contracts are available.
+
+## Stop Conditions
+
+Stop if:
+
+- classify still relies on prose `scope` as authority;
+- malformed diff and unresolved owner are indistinguishable;
+- unavailable targets are presented as runnable commands;
+- output omits what classify does not prove.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D5-baseline-authority.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D5-baseline-authority.md
@@ -1,0 +1,153 @@
+# D5 Baseline Authority
+
+## Intent
+
+Separate baseline debt authority from structural enforcement execution and
+Pattern Governance admission so baselines remain explicit, shrink-only, and
+reviewable.
+
+## Product Scenario
+
+A rule reports existing debt. Habitat must say whether the baseline is explicit
+empty, explicit debt, external exception, malformed, missing, or a valid rule
+introduction, and it must refuse accidental debt growth.
+
+## Domain Owner
+
+Baseline Authority owner.
+
+Forbidden owners:
+
+- Structural Enforcement consumes baseline states but does not define debt
+  authority.
+- Pattern Governance consumes baseline contracts but does not bypass them.
+- Grit diagnostics reports findings but does not decide baseline growth.
+
+## Consumers
+
+`habitat check`, Pattern Governance, rule introduction workflows, baseline JSON
+files, tests, review ledgers.
+
+## Contract
+
+Define baseline state and guard contracts:
+
+- explicit empty baseline,
+- explicit debt baseline,
+- external exception baseline,
+- malformed baseline,
+- missing baseline,
+- orphan baseline,
+- introduced-rule baseline expansion,
+- shrink-only failure.
+
+## Dependency Order
+
+Blocked by: D2.
+
+Unblocks: D7 and D8.
+
+Parallelism: can run in parallel with D3 and D6 after D2.
+
+## Current State-Space Problem
+
+`baseline.ts` already contains several useful discriminated states, but
+`BaselineExpansionGuardResult` remains `{ ok: boolean; message: string;
+reason?: ... }`, and external exception source models use optional projection
+and validation paths. Enforcement currently applies baselines inline inside
+`createCheckReport`.
+
+The reachable state problem is incomplete baseline authority: baseline state,
+rule introduction, external exception validation, and enforcement report
+construction can drift.
+
+## Solution Design
+
+1. Tighten baseline guard outputs into discriminated states.
+2. Separate baseline state loading/validation from enforcement report assembly.
+3. Define external exception source variants so incomplete projection/validation
+   combinations cannot exist.
+4. Add a baseline contract projection consumed by Pattern Governance.
+5. Keep `--expand-baseline` behavior behind a typed introduction guard.
+
+## TypeScript State-Space Reduction
+
+Collapse boolean guard results and optional exception models into unions with
+variant-owned fields. The compiler should prevent `ok: true` with a failure
+reason or an external exception state missing its projection contract.
+
+The rejected alternative is to leave baseline logic inline and add more tests
+around `createCheckReport`; that preserves mixed authority.
+
+## Public Surface Impact
+
+Baseline JSON contract and command failure messages may become more explicit.
+D0 must classify whether baseline error JSON is stable. No arbitrary baseline
+growth is permitted.
+
+## Proof Classes
+
+Required design proof:
+
+- baseline file inventory;
+- current baseline contract tests;
+- external exception models.
+
+Later implementation proof:
+
+- baseline contract tests;
+- baseline expansion guard tests;
+- malformed/orphan/missing baseline tests;
+- current-tree baseline integrity check;
+- Pattern Governance baseline-consumer tests.
+
+Non-claims:
+
+- D5 does not execute Grit.
+- D5 does not prove all structural rules pass.
+- D5 does not admit new rules.
+
+## Review Lanes
+
+- Baseline authority review.
+- TypeScript state-space review.
+- Pattern Governance consumer review.
+- Proof/non-claim review.
+
+## Downstream Realignment
+
+Update:
+
+- baseline contract record;
+- `recovery-claim-ledger.md` rows that cite baseline state;
+- Pattern Authority docs;
+- check command examples that show baseline failures.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/baseline.test.ts`:
+  expected exit 0; baseline state-machine proof.
+- `bun run habitat check --rule baseline-integrity --json`: expected exit 0;
+  current-tree baseline-integrity command proof.
+- `git status --short --branch`: expected exit 0; proves baseline edits are
+  intentional tracked changes only.
+- Cache stance: baseline tests are uncached Vitest proof; command proof must
+  record whether the Habitat check used any wrapped target cache.
+- Injected bad case: include missing, malformed, orphaned, and expanded
+  baseline rows; prove additions are rejected unless the rule itself is new.
+- Non-claim: this packet does not prove a diagnostic is correct, only how debt
+  is represented and allowed to shrink.
+
+## Graphite/OpenSpec Closure
+
+Use OpenSpec if baseline file contract or command output changes. Commit before
+D7 and D8 implementation.
+
+## Stop Conditions
+
+Stop if:
+
+- baseline guard can represent contradictory ok/failure states;
+- baseline expansion can run without introduction manifest proof;
+- Pattern Governance has a second baseline contract;
+- current-tree baseline integrity is unverified or non-claimed incorrectly.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D6-diagnostic-pattern-catalog.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D6-diagnostic-pattern-catalog.md
@@ -1,0 +1,158 @@
+# D6 Diagnostic Pattern Catalog
+
+## Intent
+
+Separate Grit diagnostic acquisition and projection from Pattern Governance and
+Transformation Transaction so diagnostics are trustworthy without implying rule
+admission or apply safety.
+
+## Product Scenario
+
+An agent runs `habitat check --tool grit-check` and receives normalized Grit
+findings, scan-root facts, adapter failures, and injected-violation proof
+without assuming the pattern is registered for governance or safe to apply.
+
+## Domain Owner
+
+Diagnostic Pattern Catalog owner.
+
+Forbidden owners:
+
+- Pattern Governance owns candidate/registered lifecycle.
+- Transformation Transaction owns writes.
+- Structural Enforcement owns report assembly after diagnostics are projected.
+
+## Consumers
+
+Structural Enforcement, Pattern Governance, Local Feedback, Transformation
+Transaction, Grit tests, DRA proof matrices.
+
+## Contract
+
+Define:
+
+- Grit pattern diagnostic catalog entries;
+- scan-root validation;
+- native Grit command request;
+- adapter failure projection;
+- current-tree diagnostic projection;
+- injected probe input/result;
+- cache/freshness policy where command provenance requires it.
+
+## Dependency Order
+
+Blocked by: D1 and D2.
+
+Unblocks: D7, D8, D9, D11.
+
+Parallelism: can run in parallel with D5 after D2.
+
+## Current State-Space Problem
+
+`grit.ts` owns Grit acquisition, output parsing, scan-root validation, result
+projection, and cache observations. Pattern Authority, apply, and hooks also use
+Grit terms. The same pattern can be a diagnostic, a governed candidate, a
+registered rule, a hook-scoped rule, or an apply candidate.
+
+## Solution Design
+
+1. Define diagnostic catalog states separate from governance and apply states.
+2. Make Grit adapter failures a first-class proof class and command output
+   projection.
+3. Separate scan-root derivation from selected-rule execution.
+4. Preserve native sample proof, current-tree wrapper proof, and injected
+   violation proof as separate rows.
+5. Evaluate D15 only if command cache/freshness/provenance cannot be represented
+   locally in the D6 DTOs.
+
+## TypeScript State-Space Reduction
+
+Model Grit diagnostic states as a union:
+
+- unavailable tool,
+- parse failure,
+- scan-root refusal,
+- clean result,
+- findings result,
+- cache/freshness unobservable,
+- injected-probe failure.
+
+Do not use a generic `ok: boolean` plus optional error fields where the variant
+can own the necessary fields.
+
+The rejected alternative is to let Pattern Governance own all Grit metadata. It
+would make diagnostics depend on human admission workflow.
+
+## Public Surface Impact
+
+May affect Grit failure messages and `CheckReport` diagnostic details. Must
+preserve D0-classified JSON fields or version them. Native Grit fixture output
+is not Habitat public API.
+
+## Proof Classes
+
+Required design proof:
+
+- current Grit rule inventory;
+- scan-root validation scenarios;
+- adapter failure scenarios;
+- injected probe coverage.
+
+Later implementation proof:
+
+- native Grit sample proof;
+- current-tree wrapper proof;
+- injected violation tests;
+- adapter failure tests;
+- command behavior for selected Grit checks;
+- hook staged Grit tests after D11 consumes D6.
+
+Non-claims:
+
+- D6 does not admit a pattern.
+- D6 does not prove apply safety.
+- D6 does not prove full current-tree structural cleanliness.
+
+## Review Lanes
+
+- Grit diagnostic review.
+- Proof-class review.
+- Pattern Governance boundary review.
+- TypeScript state-space review.
+
+## Downstream Realignment
+
+Update:
+
+- Grit proof matrix;
+- Pattern Authority ledger references to diagnostic proof;
+- hook contract docs;
+- `tools/habitat-harness/docs/CAPABILITIES.md`.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/grit-adapter.test.ts test/lib/grit-injected-probe.test.ts test/grit/grit-patterns.test.ts`:
+  expected exit 0; adapter, injected-probe, and native Grit sample proof.
+- `bun run habitat check --tool grit-check --json`: expected exit 0 after the
+  current `GritMalformedJson` projection risk is fixed or explicitly non-claimed.
+- `git status --short --branch`: expected exit 0; proves probe cleanup leaves no
+  source-tree residue.
+- Cache stance: injected probes must run fresh; native Grit sample proof may
+  record tool cache only if output includes exact pattern provenance.
+- Injected bad case: include one scoped probe that should match exactly one row
+  and one malformed wrapper output that must be projected as adapter failure.
+- Non-claim: this packet does not admit or govern patterns; D8 owns admission.
+
+## Graphite/OpenSpec Closure
+
+Use a dedicated layer because many downstream packets consume Grit states. Use
+OpenSpec if command JSON changes.
+
+## Stop Conditions
+
+Stop if:
+
+- native Grit proof is reported as Habitat wrapper proof;
+- a diagnostic rule is treated as an apply pattern;
+- scan-root failures become generic command failures;
+- D15 broad Effect/provenance migration is introduced without trigger proof.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D7-structural-enforcement-pipeline.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D7-structural-enforcement-pipeline.md
@@ -1,0 +1,158 @@
+# D7 Structural Enforcement Pipeline
+
+## Intent
+
+Refactor structural checking into a pipeline with clear rule selection,
+execution, diagnostics, baseline application, report construction, and rendering
+without changing public check behavior accidentally.
+
+## Product Scenario
+
+An agent runs `habitat check` or a selector such as `--owner`, `--rule`, or
+`--tool` and receives a trustworthy structural report with selector failures,
+baseline state, enforced/advisory separation, and explicit non-claims.
+
+## Domain Owner
+
+Structural Enforcement owner.
+
+Forbidden owners:
+
+- Baseline Authority owns baseline state and growth rules.
+- Diagnostic Pattern Catalog owns Grit acquisition.
+- Rule Registry Metadata owns selector and scope facts.
+- Proof Contract owns proof labels.
+
+## Consumers
+
+`habitat check`, `habitat verify`, hooks, Nx targets, tests, DRA handoff proof.
+
+## Contract
+
+Define:
+
+- selector input and selector failure states;
+- selected rule set;
+- rule execution result;
+- normalized diagnostic;
+- baseline application result;
+- `CheckReport` constructor;
+- renderer/stringifier.
+
+## Dependency Order
+
+Blocked by: D1, D2, D5, D6, D10.
+
+Unblocks: D11 and D12.
+
+Parallelism: cannot implement before D5/D6; can be designed while those are in
+review if their public contracts are stable.
+
+## Current State-Space Problem
+
+`createCheckReport` in `command-engine.ts` mixes rule selection, rule execution,
+Grit/native/wrapped/file-layer execution, baseline load/apply/integrity, status
+derivation, report validation, and rendering support. `CheckReport.ok` is a
+boolean correlated by convention with rule reports.
+
+## Solution Design
+
+1. Extract pipeline stages by responsibility after D0 preserves public contracts.
+2. Use constructors to derive `CheckReport.ok` and rule status from diagnostics
+   and lane semantics.
+3. Consume baseline and Grit projections rather than reading their internals.
+4. Keep selector failures as explicit rule reports with command behavior tests.
+5. Preserve human and JSON output truth equivalence.
+
+## TypeScript State-Space Reduction
+
+Replace broad `CheckOptions` optionals with stage-specific inputs:
+
+- selector request,
+- execution request,
+- baseline request,
+- staged check request,
+- report render request.
+
+The compiler should prevent staged paths from appearing in non-staged execution
+and prevent selector failure reports from being treated as successful rule
+execution.
+
+The rejected alternative is "split command-engine.ts by file size." The split
+must follow pipeline authority and proof boundaries.
+
+## Public Surface Impact
+
+`habitat check` behavior should be preserved unless D0/D1 explicitly versions
+schema changes. Report field ordering can change only if tests and docs treat it
+as non-contractual.
+
+## Proof Classes
+
+Required design proof:
+
+- current `CheckReport` field inventory;
+- selector scenarios;
+- baseline and Grit consumer boundaries.
+
+Later implementation proof:
+
+- rule selection tests;
+- CheckReport schema tests;
+- command behavior for clean, failing, advisory, selector failure, staged modes;
+- baseline integrity current-tree check;
+- injected violation proof for representative rule paths.
+
+Non-claims:
+
+- check does not prove affected Nx targets.
+- check does not prove runtime/product behavior.
+- check does not prove apply safety.
+
+## Review Lanes
+
+- Enforcement pipeline review.
+- API/JSON compatibility review.
+- Baseline consumer review.
+- Grit consumer review.
+- Proof/non-claim review.
+
+## Downstream Realignment
+
+Update:
+
+- enforcement compatibility matrix;
+- command examples;
+- verify packet assumptions;
+- hook packet assumptions;
+- recovery claim ledger rows that cite check behavior.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/commands/habitat-entrypoints.test.ts test/lib/enforcement-surface.test.ts test/lib/rule-selection.test.ts`:
+  expected exit 0; command, report-shape, and selector proof.
+- `bun run habitat check --json`: expected exit 0 after current-tree proof risks
+  are fixed or explicitly non-claimed.
+- `bun run habitat check --rule workspace-entrypoints --json`: expected exit 0;
+  exact single-rule command behavior proof.
+- Cache stance: command proof must record whether wrapped Nx targets were
+  cached and whether current-tree checks ran fresh.
+- Injected bad case: include invalid selector JSON and a staged generated-zone
+  violation from D10; prove neither can pass as baseline-only proof.
+- Non-claim: this packet does not own baselines, diagnostics, or generated-zone
+  policy; it consumes D5, D6, and D10.
+
+## Graphite/OpenSpec Closure
+
+Use OpenSpec for any check schema or command behavior change. Commit as one
+pipeline layer or split into facade-preserving sublayers only if each sublayer
+is independently green and behavior-preserving.
+
+## Stop Conditions
+
+Stop if:
+
+- `CheckReport.ok` can contradict rule statuses;
+- selector failures are indistinguishable from rule failures;
+- baseline or Grit internals leak into enforcement stages;
+- command behavior changes without D0/D1 compatibility disposition.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md
@@ -1,0 +1,153 @@
+# D8 Pattern Governance
+
+## Intent
+
+Separate Pattern Authority lifecycle from Grit diagnostics, baselines, and apply
+transactions so candidate and registered patterns cannot be confused.
+
+## Product Scenario
+
+A human or DRA creates a candidate structural pattern and later registers it
+only after manifest, fixture, baseline, hook-scope, false-positive, and proof
+decisions are explicit.
+
+## Domain Owner
+
+Pattern Authority owner.
+
+Forbidden owners:
+
+- Diagnostic Pattern Catalog does not admit patterns.
+- Baseline Authority does not decide pattern lifecycle.
+- Scaffolding may create candidates but not register enforced rules by
+  implication.
+- Transformation Transaction may only consume approved apply patterns.
+
+## Consumers
+
+Pattern generator, pattern registration script, Structural Enforcement,
+Diagnostic Pattern Catalog, Transformation Transaction, Local Feedback,
+recovery ledgers.
+
+## Contract
+
+Define lifecycle states:
+
+- candidate draft,
+- manifest-invalid candidate,
+- registered diagnostic pattern,
+- registered hook-scoped pattern,
+- registered apply-approved pattern,
+- refused pattern,
+- retired pattern.
+
+Each state names required sources, fixtures, proof classes, baseline contract,
+hook-scope decision, and apply-safety decision.
+
+## Dependency Order
+
+Blocked by: D1, D2, D5, D6.
+
+Unblocks: D9 and D13.
+
+Parallelism: after D5/D6 contracts stabilize, can proceed before D7 finishes if
+it does not modify enforcement execution.
+
+## Current State-Space Problem
+
+Pattern candidate generation, manifest validation, rule registration, Grit rows,
+baseline files, and hook scope currently combine to define admission. Candidate
+output can be mistaken for an active rule, baseline authority, or hook-scoped
+check.
+
+## Solution Design
+
+1. Model Pattern Authority lifecycle as discriminated states.
+2. Make candidate generation produce an explicit non-registered state.
+3. Make registration consume D2 metadata facets, D5 baseline contract, and D6
+   diagnostic proof.
+4. Add refusal states for missing manifest, missing fixtures, missing baseline
+   contract, missing hook-scope decision, and apply-safety absence.
+5. Ensure apply approval is a separate decision, not implied by Grit diagnostic
+   registration.
+
+## TypeScript State-Space Reduction
+
+Replace implicit lifecycle through file presence with a typed lifecycle union.
+The compiler and tests should prevent a candidate pattern from being treated as
+registered and prevent a registered diagnostic from being treated as apply-safe.
+
+The rejected alternative is to document candidate/registered differences only in
+README text. The product requires refusals and proof gates.
+
+## Public Surface Impact
+
+Pattern generator output and registration messages may change. Any generator
+schema or output behavior change must be handled with D0 and D13 compatibility.
+
+## Proof Classes
+
+Required design proof:
+
+- candidate/registered lifecycle inventory;
+- manifest schema inventory;
+- baseline and Grit dependencies.
+
+Later implementation proof:
+
+- manifest validation tests;
+- candidate generator tests;
+- registration tests;
+- baseline contract proof;
+- diagnostic proof linkage tests;
+- refusal tests for missing gates.
+
+Non-claims:
+
+- registered diagnostic pattern is not apply-safe.
+- candidate output is not an active rule.
+- manifest validation does not prove current-tree wrapper behavior.
+
+## Review Lanes
+
+- Product lifecycle review.
+- Proof-class review.
+- Baseline/Grit dependency review.
+- Scaffolding handoff review.
+
+## Downstream Realignment
+
+Update:
+
+- Pattern Authority ledger;
+- `grit-pattern-corpus-ledger.md`;
+- pattern generator docs;
+- command examples and AGENTS guidance if candidate semantics change.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/generators/pattern-generator.test.ts test/rules/pattern-authority-manifest.test.ts`:
+  expected exit 0; candidate generation and manifest proof.
+- `bun run habitat check --rule baseline-integrity --json`: expected exit 0;
+  baseline contract proof for registered patterns.
+- `git status --short --branch`: expected exit 0; proves candidate generation
+  and manifest updates are tracked intentionally.
+- Cache stance: generator/manifest tests must run fresh; baseline command may
+  use normal command execution if exact output is recorded.
+- Injected bad case: include a candidate without accepted manifest, fixture
+  proof, or hook-scope decision and prove it cannot become registered.
+- Non-claim: this packet does not own Grit acquisition or apply transactions.
+
+## Graphite/OpenSpec Closure
+
+Use OpenSpec if generator or registration behavior changes. Commit after D5 and
+D6 proof contracts are available.
+
+## Stop Conditions
+
+Stop if:
+
+- file presence still implies lifecycle;
+- candidate and registered states share one unconstrained type;
+- apply approval is implied by diagnostic registration;
+- baseline or hook-scope decisions are optional prose only.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/D9-transformation-transaction.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/D9-transformation-transaction.md
@@ -1,0 +1,167 @@
+# D9 Transformation Transaction
+
+## Intent
+
+Refactor guarded structural writes so `habitat fix` can apply only approved
+patterns with dry-run inventory, isolated-copy proof, path approval, rollback,
+formatter handoff, and per-pattern gates.
+
+## Product Scenario
+
+An agent wants Habitat to apply a known structural repair. Habitat must show
+what would change, refuse unsafe or unapproved writes, apply only inside approved
+paths, run handoff gates, and leave rollback/non-claim proof.
+
+## Domain Owner
+
+Apply transaction owner.
+
+Forbidden owners:
+
+- Diagnostic Pattern Catalog owns findings, not writes.
+- Pattern Governance owns apply admission decisions.
+- Host Policy Boundary owns host-specific gates.
+- Biome owns formatting, not transaction safety.
+
+## Consumers
+
+`habitat fix`, future approved apply packets, DRA owners, Pattern Governance,
+Local Feedback.
+
+## Contract
+
+Define transaction states:
+
+- dry-run inventory clean/no matches;
+- dry-run inventory with approved changes;
+- dry-run parse failure;
+- dirty worktree refusal;
+- unapproved path refusal;
+- live apply success;
+- live apply mismatch/refusal;
+- formatter handoff success/failure;
+- gate success/failure;
+- rollback success/failure.
+
+## Dependency Order
+
+Blocked by: D1, D6, D8, and D10.
+
+Unblocks: D11 and future apply packets.
+
+Parallelism: no implementation until D8 and D10 are stable. G-HOST is consumed
+through D10 for generated/protected-zone policy and directly for host-specific
+pattern gates.
+
+## Current State-Space Problem
+
+`grit-apply.ts` combines generic transaction mechanics, one approved pattern,
+inventory parsing, copy proof, changed path approval, MapGen-specific public ops
+validation, Biome handoff, optional gates, and rollback. `GritApplyTransactionOptions`
+can combine modes that do not represent user scenarios unless construction is
+centralized.
+
+## Solution Design
+
+1. Separate transaction lifecycle from pattern-specific gates.
+2. Consume Pattern Governance apply approval and Host Policy gate declarations.
+3. Model transaction state as a union rather than `ok: boolean` plus optional
+   proof fields.
+4. Preserve dry-run before live apply as a public product path.
+5. Keep Biome and other gates as handoffs with proof/non-claim labels.
+6. Evaluate D15 only if command provenance/cwd/env/cache fields cannot be
+   represented inside D9 transaction states.
+
+## TypeScript State-Space Reduction
+
+Introduce typed constructors for apply request modes:
+
+- dry-run only,
+- live approved transaction,
+- rollback-capable transaction,
+- gate handoff.
+
+Prevent invalid combinations such as live apply without approved pattern,
+MapGen-specific gate without host declaration, or success proof with failed
+formatter handoff.
+
+The rejected alternative is to generalize `runGritApplyTransaction` while
+leaving pattern-specific validation inline.
+
+## Public Surface Impact
+
+`habitat fix` JSON/human output may change. D0 must version or preserve stable
+fields. The command must remain narrow; this packet must not turn fix into a
+general auto-repair engine.
+
+## Proof Classes
+
+Required design proof:
+
+- current apply transaction flow inventory;
+- current approved pattern inventory;
+- host-specific gate inventory;
+- safe-write proof shape.
+
+Later implementation proof:
+
+- dry-run tests;
+- isolated-copy tests;
+- unapproved path injected tests;
+- dirty worktree refusal tests;
+- rollback tests;
+- formatter handoff tests;
+- host gate tests;
+- command behavior for `habitat fix --dry-run`.
+
+Non-claims:
+
+- apply success does not prove current-tree diagnostics are clean unless check
+  runs separately.
+- apply success does not prove product/runtime behavior.
+- dry-run inventory does not prove live apply success.
+
+## Review Lanes
+
+- Apply safety review.
+- Pattern Governance admission review.
+- Host boundary review.
+- Operations proof review.
+- TypeScript state-space review.
+
+## Downstream Realignment
+
+Update:
+
+- apply safety matrix;
+- Pattern Authority ledger rows for apply-approved patterns;
+- command docs;
+- hook docs if hooks consume apply recovery guidance.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/grit-apply.test.ts`:
+  expected exit 0; isolated-copy, rollback, and safe-write proof.
+- `bun run habitat fix --dry-run --json`: expected exit 0 after approved apply
+  patterns have stable dry-run inventory output.
+- `git status --short --branch`: expected exit 0 before and after dry-run; for
+  write-mode fixture proof, only expected fixture files may change.
+- Cache stance: dry-run and isolated-copy proof must run fresh, not from Nx cache.
+- Injected bad case: include one apply pattern that would write outside approved
+  roots and one generated-zone write blocked by D10.
+- Non-claim: this packet does not admit apply patterns or prove host semantics;
+  D8 and G-HOST own those inputs.
+
+## Graphite/OpenSpec Closure
+
+Use OpenSpec for any command output, transaction contract, or apply behavior
+change. Commit only with clean worktree and rollback proof.
+
+## Stop Conditions
+
+Stop if:
+
+- `habitat fix` can apply an unapproved diagnostic pattern;
+- host-specific gates remain in generic transaction code;
+- rollback failure is not represented distinctly;
+- Biome/gate success is reported as apply safety or product proof.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/G-HOST-host-policy-boundary-gate.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/G-HOST-host-policy-boundary-gate.md
@@ -1,0 +1,158 @@
+# G-HOST Host Policy Boundary Gate
+
+## Intent
+
+Create a generic host-policy boundary so Habitat can remain repo-agnostic while
+still consuming host-specific generated zones, protected paths, and
+pattern-specific validation gates.
+
+## Product Scenario
+
+Habitat protects generated/protected zones and apply gates in this repository
+without turning Civ7 or MapGen policy into generic Habitat core behavior.
+
+## Domain Owner
+
+Host Policy Boundary owner.
+
+Forbidden owners:
+
+- Generated/Protected Zone Authority may consume host declarations but not bake
+  Civ7/MapGen paths into generic code.
+- Transformation Transaction may run pattern-specific gates but not own host
+  policy.
+- Scaffolding may refuse unsupported host shapes but not infer host semantics.
+
+## Consumers
+
+D9 Transformation Transaction, D10 Generated/Protected Zone Authority, D13
+Scaffolding and Refusal Contracts, D14 Authoring Topology Fence.
+
+## Contract
+
+Define host declaration/refusal contract for:
+
+- generated/protected zones;
+- host-specific regeneration commands;
+- pattern-specific apply gates;
+- unsupported host-owned scaffold kinds;
+- future authoring topology triggers;
+- non-claims when host policy is missing.
+
+## Dependency Order
+
+Blocked by: D0 and D1.
+
+Unblocks: D10, D13, and D9 host-policy consumption. D9 still depends on D10
+for generated/protected-zone authority before generic apply closure.
+
+Parallelism: can run after D0/D1 while D2-D6 proceed, but D10/D9/D13 cannot
+claim generic closure until this gate is satisfied.
+
+## Current State-Space Problem
+
+`generated-zones.ts` embeds Swooper/Civ7 generated paths. `grit-apply.ts`
+contains MapGen-specific public ops target validation inside a generic
+transaction. Generator docs and AGENTS guidance mention MapGen authoring gaps
+inside generic Habitat usage.
+
+The reachable state problem is host coupling: generic Habitat can represent
+host-specific checks as universal toolkit behavior.
+
+## Solution Design
+
+1. Define a minimal host declaration shape for generated/protected zones and
+   apply gates.
+2. Move host-specific path/gate data behind declarations consumed by generic
+   Habitat modules.
+3. Add explicit refusal when required host policy is absent.
+4. Keep generic modules responsible for enforcing declarations, not knowing
+   host semantics.
+5. Record where Civ7/MapGen remains current-repo host data rather than generic
+   Habitat model.
+
+## TypeScript State-Space Reduction
+
+Replace host-specific inline constants with typed host-policy variants:
+
+- declared generated zone,
+- declared protected zone,
+- declared apply gate,
+- unsupported/missing declaration refusal,
+- host policy unavailable.
+
+The rejected alternative is "rename generated-zones to make it look generic."
+Without declarations, the generic core still carries host-specific state.
+
+## Public Surface Impact
+
+May affect command messages for generated-zone and apply refusals. Should not
+change generic command verbs. Host declaration file location becomes a new
+internal or public config surface; D0 must classify it.
+
+## Proof Classes
+
+Required design proof:
+
+- current host-specific path/gate inventory;
+- declaration/refusal shape;
+- D9/D10/D13 consumer matrix.
+
+Later implementation proof:
+
+- host declaration schema tests;
+- missing declaration refusal tests;
+- generated-zone command behavior;
+- apply gate behavior;
+- non-claim tests for unsupported host shapes.
+
+Non-claims:
+
+- G-HOST does not prove generated files are current.
+- G-HOST does not prove MapGen runtime/product behavior.
+- G-HOST does not implement Authoring Topology.
+
+## Review Lanes
+
+- Generic Habitat boundary review.
+- Product refusal review.
+- Generated-zone consumer review.
+- Apply transaction consumer review.
+
+## Downstream Realignment
+
+Update:
+
+- host policy boundary record;
+- generated-zone docs;
+- apply safety matrix;
+- scaffolding matrix;
+- Authoring Topology deferral.
+
+## Validation Commands / Proof Template
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/generated-zones.test.ts test/lib/grit-apply.test.ts`:
+  expected exit 0 after the packet creates or updates the host-policy fixtures.
+- `bun run habitat classify /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame/mods/mod-swooper-maps/src/maps/generated/swooper-earthlike.ts`:
+  expected exit 0; representative host-owned generated path classification.
+- `git status --short --branch`: expected exit 0; proves host declarations are
+  tracked data, not hidden generated state.
+- Cache stance: host declaration/refusal tests must run fresh.
+- Injected bad case: include one unregistered host policy and prove generic
+  Habitat refuses to interpret it as built-in truth.
+- Non-claim: this packet does not prove generated files are current, MapGen
+  runtime behavior, or Authoring Topology.
+
+## Graphite/OpenSpec Closure
+
+Use OpenSpec if host declaration location or command behavior is public. Commit
+before D9/D10/D13 claim closure.
+
+## Stop Conditions
+
+Stop if:
+
+- Civ7/MapGen path literals remain generic source truth after D10/D9;
+- apply gates cannot identify host-specific ownership;
+- missing host policy silently disables protection;
+- host policy is over-generalized beyond observed product need.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/README.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/README.md
@@ -1,0 +1,133 @@
+# Deep Habitat Phase 2 Workstream Packet Suite
+
+This directory is the Phase 2 design suite for the Deep Habitat Toolkit refactor.
+It is architecture and workstream design only. It does not authorize TypeScript
+implementation.
+
+The suite is grounded in:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame/docs/projects/habitat-harness/domain-refactor-prep/`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame/docs/projects/habitat-harness/domain-mapping/domain-design-packet.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame/docs/projects/habitat-harness/domain-refactor-frame.md`
+- current source under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame/tools/habitat-harness/`
+
+## Suite Objective
+
+Design the full Phase 2 Deep Habitat Toolkit refactor workstream packet suite,
+domino by domino, from the prepared source-authority register, scenario corpus,
+code topology map, domain-responsibility map, and reviewed domino ledger. For
+every domino, the packet states product scenario, domain owner, consumer,
+contract, dependency order, TypeScript state-space reduction, public surface
+impact, proof classes, review lanes, downstream realignment, Graphite/OpenSpec
+closure, and stop conditions. Habitat remains a generic repo-local structural
+toolkit. Implementation waits until this suite is reviewed.
+
+## Suite Rules
+
+- Current code is present-behavior evidence, not target-domain authority.
+- Public command, package export, root script, Nx target, generator, and hook
+  contracts are stabilized before internal extraction.
+- A packet is valid only when it reduces reachable TypeScript state or deletes
+  an accidental authority overlap.
+- Proof classes stay separate: command behavior, schema tests, current-tree
+  checks, native Grit behavior, injected violation proof, hook feedback, graph
+  metadata, Graphite state, and OpenSpec validation are different claims.
+- No packet may justify generic Habitat boundaries from Civ7 or MapGen-only
+  behavior without the host-policy boundary.
+- D15 is a trigger protocol, not a default substrate migration.
+
+## Critical Sequence
+
+1. D0 Scenario/Public Contract Inventory.
+2. D1 Proof Contract Boundary.
+3. D2 Rule Registry Metadata Contract.
+4. Parallel lanes after D0/D1: G-HOST Host Policy Boundary can start while D2
+   proceeds. After D2, D3 Workspace Graph Integration Boundary, D5 Baseline
+   Authority, and D6 Diagnostic Pattern Catalog can proceed.
+5. D4 Orientation and Routing after D3.
+6. D10 Generated/Protected Zone Authority after G-HOST and D2.
+7. D7 Structural Enforcement Pipeline after D5, D6, and D10.
+8. D8 Pattern Governance after D5 and D6.
+9. D9 Transformation Transaction after D8, D6, and D10.
+10. D11 Local Feedback after D7, D9, and D10.
+11. D12 Proof/Handoff Verify Command after D1, D3, and D7.
+12. D13 Scaffolding and Refusal Contracts after D0, D2, D8, and G-HOST.
+13. D14 Authoring Topology Fence after D4, D12, and D13.
+14. D15 Execution Provenance Substrate Trigger is evaluated inside D6, D7, D9,
+    and D11 only when typed command provenance is otherwise impossible.
+
+## Packets
+
+- [D0 Scenario/Public Contract Inventory](./D0-scenario-public-contract-inventory.md)
+- [D1 Proof Contract Boundary](./D1-proof-contract-boundary.md)
+- [D2 Rule Registry Metadata Contract](./D2-rule-registry-metadata-contract.md)
+- [D3 Workspace Graph Integration Boundary](./D3-workspace-graph-integration-boundary.md)
+- [D4 Orientation and Routing](./D4-orientation-and-routing.md)
+- [D5 Baseline Authority](./D5-baseline-authority.md)
+- [D6 Diagnostic Pattern Catalog](./D6-diagnostic-pattern-catalog.md)
+- [D7 Structural Enforcement Pipeline](./D7-structural-enforcement-pipeline.md)
+- [D8 Pattern Governance](./D8-pattern-governance.md)
+- [G-HOST Host Policy Boundary Gate](./G-HOST-host-policy-boundary-gate.md)
+- [D9 Transformation Transaction](./D9-transformation-transaction.md)
+- [D10 Generated/Protected Zone Authority](./D10-generated-protected-zone-authority.md)
+- [D11 Local Feedback](./D11-local-feedback.md)
+- [D12 Proof/Handoff Verify Command](./D12-proof-handoff-verify-command.md)
+- [D13 Scaffolding and Refusal Contracts](./D13-scaffolding-and-refusal-contracts.md)
+- [D14 Authoring Topology Fence](./D14-authoring-topology-fence.md)
+- [D15 Execution Provenance Substrate Trigger](./D15-execution-provenance-substrate-trigger.md)
+- [Review Disposition Ledger](./review-disposition-ledger.md)
+- [Validation Results](./validation-results.md)
+
+## Packetization Decision Table
+
+| ID | Standalone Status | Why It Is Separate |
+| --- | --- | --- |
+| D0 | Standalone packet | Every other packet depends on public command/API/export compatibility. Folding it into D1 would let proof terminology hide public surface drift. |
+| D1 | Standalone packet | Proof-class boundaries are consumed by most later packets and must be stable before proof DTOs are reshaped. |
+| D2 | Standalone packet | Registry metadata is the typed source for graph, classify, baseline, diagnostics, governance, zones, and scaffolding; a section in one consumer would recreate duplicated interpretations. |
+| D3 | Standalone packet | Workspace graph truth has separate Nx/plugin proof and fixes the false-green target-alias risk before classify/verify consume targets. |
+| D4 | Standalone packet | Orientation is the primary user/agent entry scenario and needs its own public JSON/refusal contract. |
+| D5 | Standalone packet | Baseline debt authority has shrink-only behavior and Pattern Governance dependency separate from enforcement execution. |
+| D6 | Standalone packet | Grit diagnostic acquisition/projection must stay separate from governance and apply. |
+| D7 | Standalone packet | Structural enforcement is the main check pipeline and must consume D5/D6 rather than owning them. |
+| D8 | Standalone packet | Pattern lifecycle admission is a product gate distinct from diagnostics and scaffolding. |
+| G-HOST | Standalone gate packet | Host-specific paths and gates currently exist in generic code; D9/D10/D13 cannot claim generic closure without this boundary. |
+| D9 | Standalone packet | Safe write/apply transaction has rollback and proof obligations that cannot be a Grit or governance subsection. |
+| D10 | Standalone packet | Generated/protected zone authority is a structural guard consumed by hooks/apply/check and blocked by host policy. |
+| D11 | Standalone packet | Hooks orchestrate many owners but own only local feedback, requiring explicit proof non-claims. |
+| D12 | Standalone packet | Verify is a handoff proof assembler with public proof JSON and graph/check dependencies. |
+| D13 | Standalone packet | Scaffolding/refusal is a generator-facing product contract distinct from Pattern Governance registration. |
+| D14 | Standalone fence packet | Kept separate because it is a scope-control and future-trigger artifact; implementation remains outside Phase 3 unless D13 refusal tests require a small variant. |
+| D15 | Trigger packet, not default implementation | Kept as a decision record so packet-local provenance needs are governed. It does not authorize a standalone substrate migration unless a consuming packet passes minimization. |
+
+## Shared Closure Requirements
+
+Every implementation phase derived from these packets must:
+
+- open or update an OpenSpec change before code when a public behavior or
+  implementation contract changes;
+- preserve or explicitly version public CLI JSON, package export, Nx target,
+  generator, and hook surfaces;
+- run packet-specific tests and exact command proof recorded with proof class
+  labels and non-claims;
+- update downstream docs, ledgers, generated records, and scenario examples
+  named in the packet;
+- commit one logical Graphite layer with a clean worktree;
+- avoid Graphite submit/PR readiness claims while a downstack branch reports
+  `needs restack`.
+- include exact command strings, expected exit status, cache/freshness stance,
+  injected-bad-case requirement where relevant, and explicit non-claims.
+
+## Completion Gate
+
+The suite is ready for Phase 3 execution only after adversarial review finds no
+accepted P1/P2 issue in:
+
+- sequence and dependency order,
+- public contract preservation,
+- domain ownership,
+- state-space reduction value,
+- proof sufficiency and non-claims,
+- generic Habitat boundary,
+- downstream realignment,
+- Graphite/OpenSpec closure.

--- a/docs/projects/habitat-harness/phase2-workstream-packets/review-disposition-ledger.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/review-disposition-ledger.md
@@ -1,0 +1,28 @@
+# Phase 2 Packet Suite Review Disposition Ledger
+
+This ledger records review findings against the packet suite itself. Accepted
+P1/P2 findings block Phase 3 execution until repaired, source-rejected, or moved
+outside the closure claim with owner and trigger.
+
+## Fresh Review Findings
+
+Reviewer:
+`019ed800-7f16-7d72-a5d4-41bf7dec88b5`
+
+Worktree:
+`/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame`
+
+Branch:
+`codex/deep-habitat-phase2-prep`
+
+| ID | Severity | Finding | Disposition | Repair Evidence |
+| --- | --- | --- | --- | --- |
+| PH2-REV-001 | P1 | Preparation provenance named `codex/habitat-fast-lint-checks` while packet drafting is on `codex/deep-habitat-phase2-prep`. | Accepted and repaired. Prep validation is now labeled as preparation evidence only; packet closure must record current-state validation from the packet branch. | `source-authority.md`; this ledger; current-state validation to be recorded before closure. |
+| PH2-REV-002 | P1 | G-HOST/D10/D7/D9 ordering was contradictory: D10 appeared as an unblocker for D7/D9 while D7/D9 did not consistently block on D10. | Accepted and repaired. The authoritative DAG is now G-HOST -> D10 -> D7/D9 for generated/protected-zone claims; only evidence investigation may happen before the blocker is satisfied. | `domain-refactor-prep/domino-candidate-ledger.md`; `README.md`; `D7-structural-enforcement-pipeline.md`; `D9-transformation-transaction.md`; `D10-generated-protected-zone-authority.md`; `G-HOST-host-policy-boundary-gate.md`. |
+| PH2-REV-003 | P1 | Export policy was dispositioned as "Tracked" despite review rules requiring a real disposition. | Accepted and repaired. R0-006 is now a Phase 2 stop condition; D0 requires an export matrix before internal movement. | `domain-refactor-prep/review-disposition-ledger.md`; `D0-scenario-public-contract-inventory.md`. |
+| PH2-REV-004 | P2 | Automatic packetization conflicts with packet minimization, especially D14 and D15. | Accepted and repaired. The suite now has a packetization decision table and D15 is explicitly trigger-only. | `README.md`; `D15-execution-provenance-substrate-trigger.md`. |
+| PH2-REV-005 | P2 | CLI proof commands are easy to misuse because `-- --json` fails while direct `--json` is accepted. | Accepted and repaired in packet requirements. D0 requires root-script vs direct-Oclif invocation matrix; shared closure requires exact commands and expected exits. | `D0-scenario-public-contract-inventory.md`; `README.md`. |
+| PH2-REV-006 | P2 | Packet proof cells need sharper command/proof templates, including exact commands, expected exit status, fixture or injected-bad-case shape, cache/freshness stance, proof labels, and non-claims. | Accepted and repaired. Every packet now has a `Validation Commands / Proof Template` section and the shared closure requirement remains in the suite index. | `D0-scenario-public-contract-inventory.md` through `D15-execution-provenance-substrate-trigger.md`; `G-HOST-host-policy-boundary-gate.md`; `README.md`. |
+| PH2-REV-007 | P1 | G-HOST's D2 dependency was inconsistent: some records implied G-HOST starts after D0-D2 while G-HOST itself was blocked only by D0/D1. | Accepted and repaired. G-HOST consistently starts after D0/D1 while D2 proceeds in parallel; D10 is the packet that waits for both G-HOST and D2. | `domain-refactor-prep/domino-candidate-ledger.md`; `README.md`; `G-HOST-host-policy-boundary-gate.md`. |
+| PH2-REV-008 | P2 | D0 lacked a packet-level cache/freshness stance covering every command in its proof template. | Accepted and repaired. D0 now states fresh execution requirements for git status, entrypoint tests, and classify, with Nx cache allowed only for lint when matching inputs are recorded. | `D0-scenario-public-contract-inventory.md`. |
+| PH2-REV-009 | P2 | D15 used a placeholder consuming-packet command instead of exact commands and expected statuses. | Accepted and repaired. D15 now names the D6/D7/D9/D11 trigger commands and makes consuming-packet ownership a note rather than a command row. | `D15-execution-provenance-substrate-trigger.md`. |

--- a/docs/projects/habitat-harness/phase2-workstream-packets/validation-results.md
+++ b/docs/projects/habitat-harness/phase2-workstream-packets/validation-results.md
@@ -1,0 +1,64 @@
+# Phase 2 Packet Suite Validation Results
+
+This record captures current-branch evidence for the Phase 2 packet-suite
+artifact set. It supersedes neither the preparation corpus nor implementation
+proof. It exists to make the packet-suite closure provenance explicit.
+
+## Context
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame`
+- Branch: `codex/deep-habitat-phase2-prep`
+- Objective: design the full Phase 2 Deep Habitat Toolkit refactor workstream
+  packet suite; no implementation.
+- Date: 2026-06-17.
+
+## Command Evidence
+
+| Command | Result | Proof Class | Notes |
+| --- | --- | --- | --- |
+| `git status --short --branch` | Current branch with docs-only packet-suite changes | Graphite/git state | No source or generated-output edits were present after build. |
+| `gt status` | Reported the same unstaged docs changes before commit | Graphite state | Ancestor `06-13-keep_things` still reports `needs restack`; not introduced by this packet suite. |
+| `gt log --no-interactive` | Current branch `codex/deep-habitat-phase2-prep` on top of `codex/habitat-fast-lint-checks` | Graphite state | Confirms packet-suite branch is a child of the preparation commit. |
+| `git diff --check` | Passed | Docs hygiene | No whitespace errors in the current diff. |
+| `bun install` | Passed in 65 ms; no dependency changes | Dependency state | Checked 1699 installs across 1805 packages. |
+| `bun run build` | Passed | Build proof | Ran root Nx build; Nx read 30 of 47 tasks from local cache. |
+| `bun run lint` | Passed | Hygiene proof | Runs `nx run @internal/habitat-harness:biome:ci`; Biome checked 2475 files. |
+| `nx show project @internal/habitat-harness` | Passed | Workspace graph metadata | Project metadata exposes Habitat targets and package exports for Phase 2 packet design. |
+| `bun run habitat classify /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-habitat-toolkit-domain-refactor-frame/tools/habitat-harness/src/plugin.js` | Passed | Command behavior evidence | Classified `tools/habitat-harness/src/plugin.js` as `@internal/habitat-harness`; required targets were `nx run @internal/habitat-harness:check`, `nx run @internal/habitat-harness:test`, and `bun run lint`. |
+| `bun run --cwd tools/habitat-harness test` | Failed | Current proof risk | 210 tests passed; `test/lib/boundary-taxonomy.test.ts` failed because `audit.ok` was false. This is current behavior evidence and remains a Phase 2 proof risk, not packet-suite implementation closure. |
+| `bun run habitat check --json` | Failed | Current-tree Habitat proof risk | Failed on current-tree issues: `workspace-entrypoints`, Grit adapter `GritMalformedJson` projections, `nx-boundaries` ENOENT for `apps/hr-scratch-discovery-app/src/index.ts`, and advisory `doc-ambiguity`. This is current behavior evidence, not a packet-suite docs regression. |
+
+## Post-Repair Rerun
+
+After repairing the final adversarial review findings for dependency order and
+packet-local proof templates:
+
+- `git diff --check` passed.
+- `bun run lint` passed.
+- `bun run build` passed; Nx again reported successful root build with 30 of 47
+  tasks read from local cache.
+
+After repairing the final G-HOST/D2 sequencing, D0 cache/freshness, and D15
+exact-trigger-command findings:
+
+- `git diff --check` passed.
+- `bun run lint` passed.
+- `bun run build` passed; Nx reported successful root build with 30 of 47 tasks
+  read from local cache.
+
+## Non-Claims
+
+- These commands do not prove any Phase 2 implementation packet.
+- The successful build/lint results do not override failed Habitat current-tree
+  proof.
+- Failed Habitat proof does not invalidate the packet-suite artifact by itself;
+  each affected packet must carry the relevant proof-risk stop condition forward.
+- Cache-backed build results are acceptable for docs-only packet-suite closure,
+  but implementation packets must state their own cache/freshness stance.
+
+## Closure Use
+
+Use this record only for packet-suite closure provenance. Implementation work in
+Phase 3 must rerun the proof commands required by each packet and must not cite
+this record as behavior closure.


### PR DESCRIPTION
This PR establishes the full Phase 2 Deep Habitat Toolkit refactor workstream packet suite as a design-only artifact set on `codex/deep-habitat-phase2-prep`.

**Packet suite added** (`docs/projects/habitat-harness/phase2-workstream-packets/`):

Each domino from the candidate ledger now has a standalone packet specifying product scenario, domain owner, forbidden owners, consumers, contract, dependency order, TypeScript state-space reduction, public surface impact, proof classes with exact validation commands and injected-bad-case requirements, review lanes, downstream realignment, Graphite/OpenSpec closure, and stop conditions:

- **D0** – Scenario/Public Contract Inventory: entrance gate requiring an explicit public/private/export-state matrix before any packet moves or narrows internals
- **D1** – Proof Contract Boundary: closed proof-label and non-claim vocabulary consumed by all downstream packets
- **D2** – Rule Registry Metadata Contract: typed facet projections replacing prose-heavy shared registry consumption
- **D3** – Workspace Graph Integration Boundary: single graph service contract fixing the false-green `habitat:rule:biome-ci` alias risk
- **D4** – Orientation and Routing: discriminated classification DTO replacing optional-heavy `Classification` shape
- **D5** – Baseline Authority: shrink-only baseline guard with discriminated states separated from enforcement execution
- **D6** – Diagnostic Pattern Catalog: Grit acquisition/projection separated from governance and apply
- **D7** – Structural Enforcement Pipeline: pipeline stages by responsibility consuming D5, D6, and D10
- **D8** – Pattern Governance: typed lifecycle union preventing candidate/registered confusion
- **G-HOST** – Host Policy Boundary Gate: generic host-declaration contract moving Civ7/MapGen-specific paths and gates out of generic modules
- **D9** – Transformation Transaction: typed apply transaction states consuming D8, D6, and D10
- **D10** – Generated/Protected Zone Authority: zone declarations and staged mutation guards consuming G-HOST
- **D11** – Local Feedback: hook orchestration as local-feedback consumer of published contracts
- **D12** – Proof/Handoff Verify Command: handoff proof assembler consuming D7 and D3
- **D13** – Scaffolding and Refusal Contracts: closed supported-kind union with explicit unsupported and host-policy refusals, now also blocked by G-HOST
- **D14** – Authoring Topology Fence: explicit product boundary and future-trigger record preventing Phase 3 from absorbing MapGen domain authoring
- **D15** – Execution Provenance Substrate Trigger: trigger-only decision checklist, not a default substrate migration

**Dependency order corrections** (`domino-candidate-ledger.md`):

- G-HOST is promoted into the parallel wave after D0/D1 rather than being a late gate
- D10 now explicitly waits for both G-HOST and D2 before claiming generic closure
- D7 and D9 add D10 as a blocker
- D13 adds G-HOST as a blocker
- Parallelism model rewritten to reflect that D10 investigation may proceed early but design/closure cannot

**Review disposition updates** (`domain-refactor-prep/review-disposition-ledger.md`):

- R0-006 (`src/index.ts` broad exports) escalated from "Tracked" to a Phase 2 stop condition requiring D0 to produce an explicit export matrix before any internal movement

**Source authority register** (`source-authority.md`):

- Phase 2 packet-suite branch `codex/deep-habitat-phase2-prep` recorded alongside the preparation branch
- Validation evidence from `codex/habitat-fast-lint-checks` labeled as preparation baseline only; packet closure must rerun from the packet branch

**Suite-level artifacts**:

- `README.md` with critical sequence, packetization decision table, shared closure requirements, and completion gate
- `review-disposition-ledger.md` recording nine accepted P1/P2 findings from adversarial review and their repairs
- `validation-results.md` capturing current-branch command evidence and explicit non-claims scoping its use to packet-suite closure provenance only