### PR TITLE
docs(habitat): add D0 public contract inventory for deep refactor

### DIFF
--- a/docs/projects/habitat-harness/deep-refactor/D0-public-contract-inventory.md
+++ b/docs/projects/habitat-harness/deep-refactor/D0-public-contract-inventory.md
@@ -1,0 +1,242 @@
+# D0 Public Contract Inventory
+
+**Status:** active compatibility ledger for Phase 3 implementation
+**Packet:** `D0-scenario-public-contract-inventory`
+**OpenSpec change:** `deep-habitat-d0-public-contract-inventory`
+**Owner:** Command/API Contract
+**Scope:** current Habitat command, JSON, package export, root script, Nx target,
+generator, and hook surfaces
+
+## Purpose
+
+D0 records the compatibility surface that later Deep Habitat packets must
+preserve, intentionally version, or deliberately retire. It is not a behavior
+change packet. It is the ledger that prevents internal refactors from hardening
+or breaking accidental contracts without naming the compatibility decision.
+
+The product scenario is an agent or human using Habitat before, during, and
+after a repo edit without guessing command shape, JSON shape, package export,
+root script, Nx target, generator, or hook behavior.
+
+## Contract States
+
+| State | Meaning | Later packet handling |
+| --- | --- | --- |
+| Public stable | Intended current user-facing behavior. Preserve unless an accepted packet explicitly changes it. | Tests and docs must stay aligned. |
+| Public versioned | Public or machine-facing surface whose schema/shape may evolve only with explicit versioning or migration notes. | Preserve current shape or add a versioned replacement. |
+| Package-internal | Exported or reachable for in-repo implementation convenience, but not a stable package API. | May move after local imports/tests are realigned and the packet records the move. |
+| Command-only DTO | Machine shape emitted or consumed by commands/receipts. The DTO, not the helper implementation, is the contract. | Preserve JSON fields or version the command DTO. |
+| Test-only | Exists for tests, probes, parity checks, or fixture control. | May move with tests; must not be documented as user/product API. |
+| Generated/derived | Loaded by tools or generated from another source of truth. | Edit the source/generator, not generated output by hand. |
+| Deprecated | Existing surface retained only for compatibility until a named removal/migration packet. | Keep compatibility notes and removal trigger. |
+| Refused | Deliberately unsupported invocation, shape, generator kind, receipt substitution, or workflow. | Fail with a useful reason; do not silently accept. |
+
+## CLI Command Surface
+
+Canonical local invocation is `bun run habitat <command> ...`, which routes to
+the repo-local Habitat source runner. The production bin is `habitat` after the
+package is built.
+
+| Verb | Arguments and flags | Human output contract | Machine output contract | State | Stability notes |
+| --- | --- | --- | --- | --- | --- |
+| `check` | Flags: `--json`, `--output <file>`, `--owner <project>`, `--rule <id>`, `--tool <tool>`, `--staged`, `--expand-baseline`, `--base <ref>` defaulting to `main`. | `renderReport(CheckReport)` summary and diagnostics. Exact prose is not stable beyond useful failure/remediation content. | `CheckReport` schema version 1 via `--json` or `--output`. Selector failures also return schema version 1 with `rule-selection-integrity`. | Public stable command; `CheckReport` is command-only DTO. | Canonical JSON invocation is `bun run habitat check --json`. `bun run habitat check -- --json` is an argument-forwarding ambiguity and is not a stable example. |
+| `classify` | Required `path` argument: repo-relative path, absolute path, literal diff, or `.diff`/`.patch` file. No flags today. | None; command prints formatted JSON. | `Classification` for a single path or `DiffClassification` schema version 1 for diffs. | Public stable command; output is command-only DTO and public versioned. | `Classification` currently has no top-level `schemaVersion`; D4 must preserve or explicitly version the classify DTO before changing fields. |
+| `verify` | Flags: `--base <ref>`, `--json`. | Runs `check`; when check passes, runs affected Nx verification and streams output. | `VerifyProof` schema version 1 with check summary, affected status, post-state, and non-claims. | Public stable command; `VerifyProof` is command-only receipt DTO. | Current behavior skips the affected Nx receipt when check fails and records `habitat-check-failed` in JSON mode. |
+| `fix` | Flag: `--dry-run`. | Streams approved Grit apply transaction output and formatter/gate output. | Direct CLI JSON is not implemented. Underlying transaction receipt is `GritApplyTransactionProof`. | Public stable command; receipt DTO is public versioned for D9. | Live writes require clean worktree unless the transaction path provides isolated-copy receipt data. |
+| `graph` | Flag: `--json`. | Prints Nx graph JSON, pretty by default. | Compact JSON when `--json` is supplied. | Public stable command. | This is a graph introspection command, not a receipt that all graph tasks pass. |
+| `hook` | Optional `name` argument, valid values `pre-commit` and `pre-push`; flag `--base <ref>` for pre-push probes. | Local hook feedback with explicit local-only receipt language. | `HookTrace` is available to hook runtime/tests, but the CLI does not emit trace JSON by default. | Public stable command; `HookTrace` is command-only/test DTO. | Unknown or missing hook names are refused with exit 2 and a named expected set. |
+
+### Invocation Ambiguity
+
+Use `bun run habitat check --json`, not `bun run habitat check -- --json`, in
+docs, tests, and future packets. If a future packet changes root script or Bun
+forwarding behavior, it must treat the `--` mismatch as a product command
+compatibility issue, not a typo.
+
+This does not make every double-dash form non-canonical. Root alias scripts
+such as `bun run habitat:check -- --json` are a separate public compatibility
+surface because they depend on Bun forwarding through a root script that already
+contains the Habitat subcommand.
+
+## Command-Entrypoint Grounding Note
+
+D0 found that command receipts are sensitive to generated command artifact and
+workspace dependency state. Before dependency/build grounding, stale or missing
+`tools/habitat-harness/dist/**` output produced false command-surface results:
+unknown selectors either appeared to pass against old generated code or failed
+because commands were unavailable. After `bun install --frozen-lockfile` and
+`bun run --cwd tools/habitat-harness build`, the command-entrypoint suite passed
+without source changes.
+
+Compatibility expectation: unknown `--owner`, `--rule`, and `--tool` selectors
+refuse before rule execution and return the `rule-selection-integrity`
+`CheckReport` receipt. Later packets must ground command receipts against a
+coherent dependency/build state before claiming command behavior.
+
+## Command DTO Compatibility
+
+Some current DTOs and helper names are proof/artifact-shaped because that is
+the present code surface. D0 records those names as compatibility facts only. It
+does not bless proof/artifact generation as Habitat's target domain model.
+Downstream packets should simplify these surfaces into minimal command receipts
+only where a real classify/check/maintain/evolve/scaffold/guard/refuse/recover
+scenario needs them, and should remove or collapse artifact-generation concepts
+that do not carry product value.
+
+| DTO | Source | Current producer | Current consumer | State | Compatibility rule |
+| --- | --- | --- | --- | --- | --- |
+| `CheckReport` | `tools/habitat-harness/src/lib/diagnostics.ts` | `check`, `verify`, tests | agents, tests, `VerifyProof`, report renderer | Command-only DTO; public versioned | Preserve `schemaVersion: 1`, `command`, `startedAt`, `ok`, and `rules` fields unless a versioned DTO is introduced. |
+| `RuleReport` | `diagnostics.ts` | rule execution/check report | agents/tests/report renderer | Command-only DTO | Preserve rule id, owner tool, lane, status, locked, diagnostics, detect, message, and remediation semantics or version `CheckReport`. |
+| `HabitatDiagnostic` | `diagnostics.ts` | rules and built-ins | report/JSON consumers | Command-only DTO | Preserve normalized diagnostic shape `{ ruleId, path, line?, message, severity, baselined }`. |
+| `Classification` | `command-engine.ts` | `classify` | agents/tests/future routing packets | Command-only DTO; public versioned | Preserve existing fields or introduce schema versioning in D4 before removing/renaming fields. |
+| `DiffClassification` | `command-engine.ts` | `classify` for literal/file diffs | agents/tests | Command-only DTO; public versioned | Preserve `schemaVersion: 1`, `inputKind: "diff"`, and sorted `paths`. |
+| `ClassifiedTarget` | `command-engine.ts` | `classify` | agents/tests | Command-only DTO | Preserve distinction between project, workspace, and Habitat-owned targets. |
+| `UnavailableClassifiedTarget` | `command-engine.ts` | `classify` | agents/tests | Command-only DTO | Missing targets are routing facts, not commands to run. |
+| `ScopedRule` | `command-engine.ts` | `classify` | agents/tests | Command-only DTO | Preserve exact-path, project-owner, workspace-gate, and unresolved-metadata distinction. |
+| `VerifyProof` | `command-engine.ts` | `verify --json` | agents/review handoff/tests | Command-only DTO; public versioned current surface | Preserve `schemaVersion: 1`, explicit affected executed/skipped states, bounded streams, post-state, and non-claims until D12 reassesses whether the proof-shaped DTO should become a minimal verify receipt. |
+| `GritApplyTransactionProof` | `grit-apply.ts` | `fix` internals/tests/receipt artifacts | D9 transaction consumers | Current transaction DTO; downstream reassessment required | D9 must decide which fields are product-bearing transaction receipts and collapse artifact-generation concepts that do not serve guarded maintenance/evolution workflows. |
+| `HookTrace` | `hooks.ts` | hook runtime/tests | local feedback tests/future D11 | Command-only/test DTO | D11 owns trace stabilization; do not claim CLI trace output until implemented, and keep hook receipts local-feedback scoped. |
+
+## Package Export Surface
+
+The package is private, but `exports` and `src/index.ts` still create
+reachable TypeScript surfaces for in-repo consumers and tests. Later packets
+must not move, remove, or narrow these names without either preserving the
+import path, replacing it with a deliberate facade, or recording a compatibility
+decision in the packet.
+
+| Package export | Target | State | Compatibility rule |
+| --- | --- | --- | --- |
+| `@internal/habitat-harness` / `.` | `./src/index.ts` | Public versioned envelope over mixed internals | Keep import path until a curated public facade replaces it. Individual names below decide stability. |
+| `main` | `dist/index.js` | Generated/derived build surface | Production build artifact path. Do not hand-edit generated `dist`; regenerate through the owning build target when build repair is in scope. |
+| `@internal/habitat-harness/plugin` / `./plugin` | `./src/plugin.js` | Generated/derived graph integration surface | Nx loads this as workspace plugin. Keep path stable or update `nx.json` and graph receipt checks together. |
+| `@internal/habitat-harness/rules` / `./rules` | `./src/rules/rules.json` | Generated/derived rule manifest surface | Treat `rules.json` as rule registry data, not hand-authored package API. |
+| `bin.habitat` | `./bin/run.js` | Public stable production command bin after build | Preserve `habitat` command name unless a command-surface packet changes it. |
+| `generators` | `./generators.json` | Public stable Nx generator surface | Preserve generator names or version/refuse with Nx generator docs. |
+| `migrations` | `./migrations.json` | Public versioned Nx migration surface | Current no-op records wiring only; convention migrations require separate receipt criteria. |
+| Package-local scripts | `build`, `dev`, `check`, `test`, `clean`, `build:*` | Package-internal developer surface | Useful for local debugging/building; root Nx scripts remain the repo-level handoff surface. |
+| Package Nx targets | `build:tsc`, `build:manifest`, `build:bin-mode`, `build` | Generated/build orchestration surface | Build target contract belongs to package build ownership and Graph/Nx packets, not the command DTO contract. |
+| `files` allowlist | `bin`, `dist`, manifests, source generator/migration/plugin/rules/baselines | Generated/derived package publication shape | Private repo-local package surface; update only with package build/generator ownership. |
+
+## `src/index.ts` Export Matrix
+
+| Export(s) | Source module | State | Compatibility handling |
+| --- | --- | --- | --- |
+| `BaselineContractFailure`, `BaselineContractFailureReason`, `BaselineContractValidation`, `BaselineState`, `RuleIntroductionBaselineManifest` | `./lib/baseline.js` | Package-internal | D5 may replace with a baseline authority facade. Preserve local consumers until then. |
+| `applyBaseline`, `baselineFailureDiagnostic`, `checkBaselineIntegrity`, `guardBaselineExpansion`, `isBaselineLocked`, `loadBaseline`, `loadBaselineState`, `mergeBase`, `validateBaselineContract`, `violationKey` | `./lib/baseline.js` | Package-internal | Baseline mechanics are not a stable package API. D5 owns extraction and any public facade. |
+| `Classification`, `ClassifiedTarget`, `DiffClassification`, `RuleScopeKind`, `ScopedRule`, `UnavailableClassifiedTarget` | `./lib/command-engine.js` | Command-only DTO | Preserve classify JSON compatibility or explicitly version in D4. |
+| `ClassifyOptions` | `./lib/command-engine.js` | Package-internal | Test/control injection shape, not classify JSON. D4 may replace it while preserving command output. |
+| `buildHabitatCommand`, `commandSummary`, `selectRules` | `./lib/command-engine.js` | Package-internal | Internal helpers. Later packets may move after imports/tests are realigned. |
+| `classifyPath`, `classifyTarget` | `./lib/command-engine.js` | Package-internal | Callable helpers used by the command/tests. D4 may introduce a deliberate facade before treating callable classify APIs as public. |
+| `createCheckReport`, `renderCheckReport`, `stringifyCheckReport` | `./lib/command-engine.js` | Command-only DTO helpers | Structural Enforcement may move helpers in D7 only if `CheckReport` JSON compatibility is preserved. |
+| `expandBaselines` | `./lib/command-engine.js` | Package-internal | Authoring-only baseline expansion helper. D5 owns future authority and refusal behavior. |
+| `resolveVerifyBase`, `runAffectedVerification` | `./lib/command-engine.js` | Package-internal | D12 owns verify receipt assembly; direct helper API is not stable. |
+| `runFix`, `runGraph`, `runHook` | `./lib/command-engine.js` / `./lib/hooks.js` | Package-internal command runners | CLI behavior is public; direct function shape may change in D9/D11 after local imports/tests update. |
+| `CheckReport`, `HabitatDiagnostic`, `HabitatSeverity`, `RuleReport` | `./lib/diagnostics.js` | Command-only DTO | Preserve schema version 1 JSON contract or version it. |
+| `validateCheckReport` | `./lib/diagnostics.js` | Command-only DTO helper | Keep while tests/probes consume it; D7 may move behind report facade. |
+| `effectParityProbeProgram`, `runEffectParityProbe` | `./lib/effect-parity.js` | Test-only | Effect parity probes are not product APIs. |
+| `runHabitatEffect` | `./lib/effect-runtime.js` | Package-internal | Effect substrate helper; D15 trigger governs broader provenance decisions. |
+| `readGitState` | `./lib/git-state.js` | Package-internal | Used by transaction/receipt internals; not a stable package API. |
+| `injectedProbeRoot` | `./lib/grit.js` | Test-only | Probe fixture root. Do not expose as product command contract. |
+| `GritApplyTransactionProof` | `./lib/grit-apply.js` | Current transaction DTO; downstream reassessment required | D9 must keep only product-bearing transaction receipt fields and collapse artifact-generation concepts that do not serve guarded maintenance/evolution workflows. |
+| `GritApplyRewriteInventoryEntry`, `GritApplyTransactionOptions`, `GritApplyTransactionResult` | `./lib/grit-apply.js` | Package-internal | Transaction implementation/control shapes until D9 decides a facade. |
+| `classifyApplyRewriteInventory`, `parseApplyRewriteInventory`, `runGritApplyTransaction` | `./lib/grit-apply.js` | Package-internal | D9 owns transaction extraction. Preserve tests or provide a D9 facade before moving. |
+| `GritAdapterFailure`, `GritAdapterFailureTag`, `createGritAdapterFailure`, `gritAdapterFailureTags`, `isGritAdapterFailureTag`, `renderGritAdapterFailure` | `./lib/grit-failures.js` | Package-internal | D6 owns diagnostic adapter failure model. |
+| `InjectedGritProbeFailure`, `InjectedGritProbeInput`, `InjectedGritProbeResult`, `InjectedProbeScope`, `injectedGritProbeProgram`, `runInjectedGritProbe` | `./lib/grit-injected-probe.js` | Test-only / package-internal receipt helpers | D6 may preserve as receipt fixtures or move behind diagnostic catalog tests. |
+| `CommandCachePolicy`, `GritParseStatus`, `HabitatCommandKind`, `HabitatCommandResult`, `HabitatProcessRequest`, `GritToolUnavailable`, `HabitatProcess`, `HabitatProcessLive`, `makeFakeHabitatProcessLayer`, `makeHabitatCommandResult` | `./lib/habitat-process.js` | Package-internal; `makeFakeHabitatProcessLayer` is test-only | D6/D9/D11/D15 own process/provenance boundaries. Not a public command API. |
+| `AdapterProofArtifact`, `AdapterProofClass`, `WriteAdapterProofArtifactInput`, `adapterProofArtifactPath`, `buildAdapterProofArtifact`, `ProofArtifactWriteFailure`, `ProofArtifactWriter`, `ProofArtifactWriterLive`, `writeAdapterProofArtifact` | `./lib/proof-artifact.js` | Package-internal proof/artifact-shaped current surface | D1 must reassess whether artifact writing serves a concrete repo-maintenance workflow. Preserve current consumers until then, but do not treat artifact generation as target-domain authority. |
+| `HabitatToolExecutionPlane`, `MaterializedHabitatCommand`, `materializeHabitatCommand` | `./lib/workspace-tools.js` | Package-internal | Workspace tool materialization is not a user API; D3/D12 may realign. |
+| `executeRule`, `HarnessRule`, `ruleById`, `rules` | `./rules/architecture.js` | Package-internal / generated-derived registry | D2 owns rule registry metadata. `rules` is registry data, not a generic API. |
+| `CandidatePatternAuthorityManifest`, `PatternAuthorityManifest`, `PatternAuthorityRuleReference`, `PatternAuthorityValidationFailureReason`, `PatternAuthorityValidationIssue`, `PatternAuthorityValidationOptions`, `PatternAuthorityValidationResult`, `RegisteredPatternAuthorityManifest` | `./rules/pattern-authority/manifest.js` | Public versioned Pattern Governance contract | D8 owns future manifest changes. Preserve versioned manifest compatibility or add migration/refusal behavior. |
+| `patternAuthorityManifestSchemaVersion`, `validatePatternAuthorityManifest` | `./rules/pattern-authority/manifest.js` | Public versioned Pattern Governance contract | Schema version and validation remain stable or migrate through D8 governance. |
+| `patternAuthorityCandidateRoot`, `patternAuthorityManifestPath`, `patternAuthorityManifestRoot` | `./rules/pattern-authority/manifest.js` | Package-internal | Path helpers may move only with generator/manifest realignment. |
+
+## Root Script Surface
+
+| Root script | Current command | State | Compatibility rule |
+| --- | --- | --- | --- |
+| `habitat` | repo-local Habitat CLI source runner | Public stable | Canonical agent entrypoint for command examples. |
+| `habitat:check` | `bun run habitat check` | Public stable | Root alias for diagnostic full Habitat rule aggregate. Preserve `bun run habitat:check -- <flags>` forwarding as a distinct root-alias surface from nested `bun run habitat check -- --<flag>`. |
+| `habitat:fix` | `bun run habitat fix` | Public stable | Preserve dry-run forwarding examples through command-surface tests. |
+| `biome:format`, `biome:check`, `biome:ci` | root Biome hygiene scripts | Public stable workspace scripts | Root script contract for Biome-owned formatting/check/CI surfaces; target names are also present in the Nx target matrix. |
+| `lint` | `nx run @internal/habitat-harness:biome:ci` | Public stable workspace gate | May use Nx cache when inputs match; not just style lint. |
+| `verify` | `nx run-many --targets=verify` | Public stable graph aggregate | Graph-owned verifier aggregate, separate from `habitat verify`. |
+| `check` | `nx run-many --targets=build,check,lint,test,verify` | Public stable graph aggregate | Full root aggregate; not a replacement for command DTO receipts. |
+| Legacy or package-local scripts | package-local commands | Package-internal or project-local | Use only after Habitat classify/graph tells the agent the target exists. |
+
+## Nx Target Surface
+
+Habitat is loaded as an Nx inference plugin from `nx.json` through
+`./tools/habitat-harness/src/plugin.js`.
+
+| Target family | Owner | State | Compatibility rule |
+| --- | --- | --- | --- |
+| `boundaries` | `@internal/habitat-harness` | Public stable workspace target | Project-plane import boundary gate. |
+| `biome:format`, `biome:check`, `biome:ci` | `@internal/habitat-harness` | Public stable workspace targets | Biome owns formatting/hygiene; target names are intentionally namespaced. |
+| `grit:check` | `@internal/habitat-harness` | Public stable workspace target | Diagnostic Grit catalog gate, not apply approval. |
+| `generated:check` | `@internal/habitat-harness` | Public stable workspace target name/role | Stable contract is the workspace target name and generated/protected-zone drift-gate role. Current Civ7/MapGen policy details are not generic Habitat API; D10 owns the host-policy boundary. |
+| `habitat:check:all` | `@internal/habitat-harness` | Public stable aggregate target | Runs broad Habitat rule check once. |
+| `habitat:check` | each rule owner with registered rules | Public stable owner target | Runs rules owned by that project; D2/D7 may refine after registry metadata. |
+| `habitat:rule:<rule-id>` | each rule owner with registered rule | Public versioned generated target | Alias target generated from rule registry. Target existence depends on registry metadata. |
+
+Known D0 compatibility risk: plugin alias dependency parsing for colon-bearing
+target names remains current behavior record, not a D0 repair. D3 owns graph
+integration fixes and false-green target alias reduction.
+
+## Generator Surface
+
+| Generator | Schema surface | State | Compatibility rule |
+| --- | --- | --- | --- |
+| `@internal/habitat-harness:project` | `name`, `kind`, optional `packageName`, optional `directory`; kind enum includes uniform and refused non-uniform kinds, with optional `kind:` prefixes. | Public stable generator with refused states | Supported kinds are `foundation`, `kind:foundation`, `plugin`, `kind:plugin`, `app`, and `kind:app`. Non-uniform `mod`, `engine`, `control`, `adapter`, `sdk`, `tooling`, and their `kind:*` forms remain refused until owning domains define uniform generator contracts. |
+| `@internal/habitat-harness:pattern` | `ruleId`, `ownerProject`, `patternName`, `lifecycle`, `openspecChangeId`, `manifestPath`, `hookScope`; lifecycle values are `candidate`, `registered-advisory`, and `registered-enforced`. | Public versioned Pattern Governance generator | Candidate generation writes a non-active draft. Registered advisory/enforced modes may write active Grit patterns and rule-pack entries only after Pattern Authority Manifest, baseline, current-tree, fixture, false-positive, and hook-scope gates pass. D8 owns future governance changes. |
+
+Unsupported scenario fixture for D0 receipt: invoking the project generator with
+`--kind=mod` must refuse before writes with the owning-domain/non-uniform-kind
+reason.
+
+## Hook Surface
+
+| Hook file | Delegation | State | Compatibility rule |
+| --- | --- | --- | --- |
+| `.husky/pre-commit` | `bun run habitat hook pre-commit` | Public stable local feedback entrypoint | Hook remains local feedback only. It may format/restage eligible staged files but must not claim a CI receipt. |
+| `.husky/pre-push` | `bun run habitat hook pre-push` | Public stable local feedback entrypoint | Uses affected verification for the local branch slice. CI and explicit verification remain authoritative. |
+
+`HookTrace` is a runtime/test receipt shape for D11. The hook CLI does not yet
+promise trace JSON output.
+
+Current stale command help: `tools/habitat-harness/src/commands/hook.ts` still
+describes hook wiring as deferred even though Husky delegation is implemented.
+D0 records this as stale human output text; a command-surface/docs packet should
+align help text without changing hook behavior.
+
+## Stability Requirements For Later Packets
+
+No later packet may:
+
+- move or narrow `src/index.ts` exports without a facade, import realignment, or
+  explicit compatibility disposition;
+- change command JSON fields without preserving the current DTO or adding a
+  versioned replacement;
+- treat `Classification` as schema-versioned until D4 adds that contract;
+- treat direct command helper functions as public user API merely because they
+  are exported today;
+- treat generated/derived rule and Nx surfaces as hand-editable contracts;
+- document `bun run habitat check -- --json` as canonical before resolving the
+  forwarding ambiguity;
+- collapse unsupported generator kinds into best-effort scaffolds;
+- claim hook, verify, Grit apply, or graph output establishes product/runtime
+  behavior unless the owning packet adds that receipt.
+
+## D0 Done Criteria
+
+D0 is done when:
+
+- this matrix exists and classifies the current command/API contract surface;
+- the OpenSpec change records D0 requirements and non-claims;
+- Habitat implemented-surface docs point future readers to this ledger;
+- command entrypoint tests, representative classify, OpenSpec validation, lint,
+  and unsupported generator refusal receipt have been run and explicitly
+  recorded;
+- review lanes have no unresolved accepted P1/P2 findings;
+- the Graphite branch is clean and submitted;
+- supervisor/product authority approves advancing to D1.

--- a/openspec/changes/deep-habitat-d0-public-contract-inventory/design.md
+++ b/openspec/changes/deep-habitat-d0-public-contract-inventory/design.md
@@ -1,0 +1,108 @@
+# Design
+
+## Responsibility
+
+D0 belongs to the Command/API Contract owner. It inventories the current public
+and internal-facing surface so later owner packets can reduce state without
+breaking compatibility by accident.
+
+Forbidden owners:
+
+- Structural Enforcement must not define command compatibility while refactoring
+  check/report internals.
+- Workspace Graph Integration must not define root script compatibility while
+  repairing target aliases.
+- Local Feedback must not define hook receipt language outside the public hook
+  contract.
+
+## Sources
+
+- `docs/projects/habitat-harness/phase2-workstream-packets/D0-scenario-public-contract-inventory.md`
+- `docs/projects/habitat-harness/deep-refactor/implementation-reference-frame.md`
+- `tools/habitat-harness/src/commands/**`
+- `tools/habitat-harness/src/lib/command-engine.ts`
+- `tools/habitat-harness/src/lib/diagnostics.ts`
+- `tools/habitat-harness/src/lib/grit-apply.ts`
+- `tools/habitat-harness/src/lib/hooks.ts`
+- `tools/habitat-harness/src/index.ts`
+- `tools/habitat-harness/package.json`
+- `tools/habitat-harness/generators.json`
+- `tools/habitat-harness/src/generators/**/schema.json`
+- `tools/habitat-harness/src/plugin.js`
+- `nx.json`
+- root `package.json`
+- `.husky/pre-commit`
+- `.husky/pre-push`
+
+## Contract State Model
+
+Every inventoried surface is classified into one of:
+
+- public stable;
+- public versioned;
+- package-internal;
+- command-only DTO;
+- test-only;
+- generated/derived;
+- deprecated;
+- refused.
+
+This model lets later packets distinguish current compatibility promises from
+mere reachability through broad exports.
+
+## Public Export Handling
+
+`tools/habitat-harness/src/index.ts` currently exports command DTOs, command
+helpers, baseline internals, Grit adapter internals, transaction helpers,
+process abstractions, receipt artifact helpers, rule registry data, and Pattern
+Authority manifest contracts. The D0 matrix does not make all of these stable.
+It records which are command DTOs, which are public versioned governance
+contracts, and which are package-internal surfaces that can move only after
+local consumers and tests are realigned.
+
+Later facade work is expected. D0 does not implement the facade because its
+packet outcome is inventory and compatibility framing.
+
+## Command Invocation Handling
+
+The canonical local command form is:
+
+```bash
+bun run habitat <command> ...
+```
+
+For JSON check output, the canonical form is:
+
+```bash
+bun run habitat check --json
+```
+
+The `bun run habitat check -- --json` shape is an observed argument-forwarding
+ambiguity and remains non-canonical until a command-surface packet explicitly
+changes or refuses it. D0 records the issue as product compatibility risk.
+
+## Non-Claims
+
+D0 does not establish:
+
+- command correctness beyond the existing command-entrypoint test run;
+- current-tree structural cleanliness;
+- internal module extraction safety;
+- future public facade design;
+- runtime or product Civ7 behavior;
+- CI receipts;
+- Grit apply safety beyond existing command/receipt surfaces.
+
+## Review Lanes
+
+D0 requires:
+
+- API/CLI contract review;
+- TypeScript public-surface review;
+- Product scenario review;
+- stale docs/downstream review;
+- receipt/workstream review;
+- Graphite hygiene review.
+
+Accepted P1/P2 findings block D0 closure until repaired, rejected with source records,
+or superseded by explicit authority.

--- a/openspec/changes/deep-habitat-d0-public-contract-inventory/proposal.md
+++ b/openspec/changes/deep-habitat-d0-public-contract-inventory/proposal.md
@@ -1,0 +1,52 @@
+# Why
+
+The Deep Habitat refactor starts by stabilizing the compatibility frame.
+Habitat currently exposes a useful but mixed surface: Oclif commands, command
+JSON DTOs, root scripts, inferred Nx targets, Nx generators, Husky delegators,
+and broad `src/index.ts` exports that include internal helpers. Later packets
+will move responsibilities into clearer owners. Without D0, those moves can
+accidentally break agent-facing behavior or harden implementation details as
+public API.
+
+D0 creates the contract inventory that every later packet must consult before
+moving, narrowing, deleting, or versioning a surface.
+
+## What Changes
+
+- Add a durable public contract matrix at
+  `docs/projects/habitat-harness/deep-refactor/D0-public-contract-inventory.md`.
+- Classify command verbs, flags, invocation examples, JSON DTOs, package
+  exports, `src/index.ts` exports, root scripts, inferred Nx targets,
+  generators, and hook delegators.
+- Record the `bun run habitat check --json` versus
+  `bun run habitat check -- --json` forwarding ambiguity as a product contract
+  issue.
+- Add OpenSpec requirements that make the D0 matrix a prerequisite for later
+  refactor packet closure.
+- Link the matrix from Habitat's implemented-surface reference.
+
+## What Does Not Change
+
+- No command behavior changes.
+- No package export moves.
+- No new public facade implementation.
+- No generator, hook, graph, Grit, baseline, or verify behavior changes.
+- No Civ7- or MapGen-specific policy is added to generic Habitat.
+
+## Product Impact
+
+Agents and humans get a durable compatibility map before the refactor starts.
+Later packets can simplify TypeScript state and move internals without guessing
+whether a symbol, command shape, or DTO is stable, versioned, internal,
+generated, test-only, deprecated, or refused.
+
+## Verification
+
+- `bun run openspec -- validate deep-habitat-d0-public-contract-inventory --strict`
+- `bun run openspec:validate`
+- `bun run --cwd tools/habitat-harness test -- test/commands/habitat-entrypoints.test.ts`
+- `bun run habitat classify tools/habitat-harness/src/plugin.js`
+- unsupported generator refusal receipt:
+  `bun run nx g @internal/habitat-harness:project unsupported-d0-probe --kind=mod --dry-run`
+- `bun run lint`
+- `git diff --check`

--- a/openspec/changes/deep-habitat-d0-public-contract-inventory/specs/habitat-harness/spec.md
+++ b/openspec/changes/deep-habitat-d0-public-contract-inventory/specs/habitat-harness/spec.md
@@ -1,0 +1,105 @@
+## ADDED Requirements
+
+### Requirement: Public Contract Inventory Gates Deep Refactor Packets
+
+Deep Habitat refactor packets SHALL consult the D0 public contract inventory
+before moving, narrowing, removing, or versioning Habitat command, JSON,
+package export, root script, Nx target, generator, or hook surfaces.
+
+#### Scenario: Later packet changes a public surface
+- **WHEN** a later packet changes an inventoried public stable, public
+  versioned, or command-only DTO surface
+- **THEN** the packet records whether compatibility is preserved, versioned,
+  migrated, deprecated, or refused
+
+#### Scenario: Later packet moves an internal export
+- **WHEN** a later packet moves an inventoried package-internal export
+- **THEN** the packet realigns in-repo imports and tests or introduces an
+  explicit facade before claiming closure
+
+### Requirement: Command Invocation Compatibility Is Explicit
+
+Habitat SHALL distinguish canonical command invocations from unsupported or
+ambiguous argument-forwarding forms.
+
+#### Scenario: Canonical JSON check invocation
+- **WHEN** docs, tests, or packets need JSON check output
+- **THEN** they use `bun run habitat check --json` unless a later accepted
+  command-surface packet changes the canonical invocation
+
+#### Scenario: Double-dash forwarding ambiguity
+- **WHEN** `bun run habitat check -- --json` is discussed or encountered
+- **THEN** it is treated as a product command-compatibility issue rather than a
+  harmless documentation typo
+
+### Requirement: Command DTOs Are Distinct From Internal Helpers
+
+Habitat SHALL classify command JSON/receipt DTOs separately from implementation
+helpers exported through the package index.
+
+#### Scenario: Current command JSON shape is consumed by agents
+- **WHEN** an agent consumes current command JSON such as `CheckReport`,
+  `Classification`, `DiffClassification`, or `VerifyProof`
+- **THEN** the owning packet preserves the current DTO shape or introduces an
+  explicit versioned replacement
+
+#### Scenario: Future or internal receipt shape is inventoried
+- **WHEN** D0 records future or internal surfaces such as
+  `GritApplyTransactionProof` or `HookTrace`
+- **THEN** the matrix distinguishes them from current CLI JSON output and names
+  the downstream owner before treating them as public agent-facing contracts
+
+#### Scenario: Proof-shaped surface lacks product value
+- **WHEN** a downstream packet evaluates a proof/artifact-shaped current surface
+- **THEN** it simplifies the surface into the smallest command receipt required
+  by a real repo-maintenance scenario or removes/collapses the artifact concept
+  instead of preserving proof generation as target-domain authority
+
+#### Scenario: Helper function is exported through `src/index.ts`
+- **WHEN** a helper function is exported only for in-repo implementation or
+  tests
+- **THEN** broad export reachability alone does not make the helper a stable
+  user-facing API
+
+### Requirement: Package Exports Have Compatibility Dispositions
+
+Habitat SHALL classify package export paths and `src/index.ts` symbols as
+public stable, public versioned, package-internal, command-only DTO, test-only,
+generated/derived, deprecated, or refused.
+
+#### Scenario: Package export path is consumed by tooling
+- **WHEN** Nx, commands, tests, or local code consume a package export path
+- **THEN** the D0 matrix records the surface state and later packets preserve
+  the path or realign consumers with receipt checks
+
+#### Scenario: Rule or plugin data is generated or derived
+- **WHEN** a later packet changes generated or derived surfaces such as the Nx
+  plugin target surface or rule manifest
+- **THEN** it changes the owning source/generator and records regenerated receipts
+  rather than hand-editing generated output
+
+### Requirement: Root Scripts, Nx Targets, Generators, And Hooks Are Inventoried
+
+Habitat SHALL include root scripts, inferred Nx targets, generator schema
+surfaces, and Husky hook delegators in the D0 compatibility ledger.
+
+#### Scenario: Agent follows Habitat handoff guidance
+- **WHEN** an agent reads the inventory before authoring or verifying
+- **THEN** it can distinguish root script gates, project-local targets,
+  workspace/Habitat targets, generator refusals, and local hook feedback
+
+#### Scenario: Unsupported generator kind is requested
+- **WHEN** a non-uniform project kind such as `mod` is passed to the Habitat
+  project generator
+- **THEN** the generator refuses before writes with a named product/domain
+  reason
+
+### Requirement: D0 Does Not Change Behavior
+
+D0 SHALL create compatibility records without changing command, generator,
+hook, graph, baseline, Grit, or package export behavior.
+
+#### Scenario: D0 closes
+- **WHEN** D0 is closed
+- **THEN** its closure receipt is inventory, review, and existing behavior smoke
+  verification, not an implementation claim for later refactor behavior

--- a/openspec/changes/deep-habitat-d0-public-contract-inventory/tasks.md
+++ b/openspec/changes/deep-habitat-d0-public-contract-inventory/tasks.md
@@ -1,0 +1,45 @@
+# Tasks
+
+## 1. Source And Contract Inventory
+
+- [x] 1.1 Re-check repo state, Graphite stack, and live watcher/control artifacts.
+- [x] 1.2 Inventory CLI verbs, flags, output modes, and invocation examples.
+- [x] 1.3 Inventory command JSON/receipt DTOs.
+- [x] 1.4 Inventory `package.json` exports and `src/index.ts` exports.
+- [x] 1.5 Inventory root scripts, inferred Nx targets, generator schemas, and Husky hook delegators.
+
+## 2. D0 Artifacts
+
+- [x] 2.1 Add the D0 public contract matrix.
+- [x] 2.2 Add OpenSpec proposal, design, spec delta, tasks, phase record, review ledger, and downstream realignment ledger.
+- [x] 2.3 Link the matrix from Habitat implemented-surface docs.
+- [x] 2.4 Record the `--` forwarding ambiguity as a product contract issue.
+
+## 3. Review
+
+- [x] 3.1 Run API/CLI contract review.
+- [x] 3.2 Run TypeScript public-surface review.
+- [x] 3.3 Run product scenario review.
+- [x] 3.4 Run stale docs/downstream review.
+- [x] 3.5 Disposition every accepted P1/P2 finding.
+
+## 4. Verification
+
+- [x] 4.1 `bun run openspec -- validate deep-habitat-d0-public-contract-inventory --strict`
+- [x] 4.2 `bun run openspec:validate`
+- [x] 4.3 `bun run --cwd tools/habitat-harness test -- test/commands/habitat-entrypoints.test.ts`
+  - Result after dependency/build grounding: exit 0.
+- [x] 4.4 `bun run habitat classify tools/habitat-harness/src/plugin.js`
+- [x] 4.5 Unsupported generator refusal receipt:
+  `bun run nx g @internal/habitat-harness:project unsupported-d0-probe --kind=mod --dry-run`
+- [x] 4.6 `bun run lint`
+- [x] 4.7 `git diff --check`
+
+## 5. Closure
+
+- [x] 5.1 Update verification results in `workstream/phase-record.md`.
+- [x] 5.2 Ensure review ledger has no unresolved accepted P1/P2 findings.
+- [x] 5.3 Ensure downstream realignment ledger is accurate.
+- [x] 5.4 Commit through Graphite with clean worktree.
+- [x] 5.5 Submit the D0 Graphite branch.
+- [x] 5.6 Ask supervisor/product authority for D0 approval before starting D1.

--- a/openspec/changes/deep-habitat-d0-public-contract-inventory/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/deep-habitat-d0-public-contract-inventory/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,24 @@
+# Downstream Realignment Ledger
+
+**Change:** `deep-habitat-d0-public-contract-inventory`
+**Owner:** directly responsible implementation agent
+
+| Downstream artifact | Current risk | Required disposition | Status |
+| --- | --- | --- | --- |
+| Command dependency/build grounding | Stale or missing ignored `tools/habitat-harness/dist/**` command artifacts can produce false command-surface receipts. | Later command packets must run dependency/build grounding before claiming command behavior. No source repair is required from D0. | watched |
+| D1 receipt-contract packet | Proof/artifact-shaped surfaces could be preserved as target authority merely because they exist today. | D1 must consume the D0 DTO matrix, reassess proof/artifact-shaped code through concrete repo-maintenance scenarios, and collapse/remove artifact-generation concepts that do not carry product value. | watched |
+| D2 Rule Registry Metadata Contract | Rule registry exports and generated per-rule targets could be treated as public API by accident. | D2 must consume the package export and Nx target matrix. | watched |
+| D3 Workspace Graph Integration Boundary | Graph plugin aliases and root script targets could be repaired without preserving command guidance. | D3 must consume root script and Nx target compatibility notes. | watched |
+| D4 Orientation and Routing | `Classification` currently lacks top-level schema versioning. | D4 must preserve current classify DTO fields or introduce a versioned replacement. | watched |
+| D5 Baseline Authority | Baseline internals are broadly exported through `src/index.ts`. | D5 may move them only after import/test realignment or facade introduction. | watched |
+| D6 Diagnostic Pattern Catalog | Grit adapter and injected-probe exports are mixed public/internal surfaces. | D6 must preserve receipt/test consumers or move them behind diagnostic catalog APIs. | watched |
+| D7 Structural Enforcement Pipeline | `CheckReport` helpers and diagnostics are mixed with enforcement internals. | D7 must preserve schema version 1 JSON or version it. | watched |
+| D8 Pattern Governance | Pattern Authority manifest exports are public versioned governance contracts. | D8 must version or migrate manifest changes explicitly. | watched |
+| D9 Transformation Transaction | `GritApplyTransactionProof` is the current transaction DTO, but proof/artifact-shaped transaction logic may exceed Habitat's product value. | D9 must keep only receipt fields needed for guarded structural writes, rollback, formatter handoff, and maintenance/evolution decisions; collapse artifact-generation concepts that do not serve those workflows. | watched |
+| D10 Generated/Protected Zone Authority | `generated:check` is a public graph target but host policy remains separate. | D10 must not hard-code Civ7 policy into generic Habitat. | watched |
+| D11 Local Feedback | Hook CLI is public; `HookTrace` is runtime/test DTO only today. | D11 must not claim hook trace JSON CLI output unless it implements and tests it. | watched |
+| Command help/documentation alignment | `habitat hook` help still says hook wiring is deferred although Husky delegation is implemented. | Align command help under a command-surface/docs packet without changing hook behavior. | open |
+| D12 Receipt/Handoff Verify Command | `VerifyProof` schema version 1 is current handoff DTO, but its proof-shaped name/model is not automatically target-domain authority. | D12 must preserve compatibility until it deliberately versions/replaces the DTO, and should simplify toward the smallest verify receipt that supports handoff, non-claims, and maintenance decisions. | watched |
+| D13 Scaffolding and Refusal Contracts | Project and pattern generator surfaces are already public. | D13 must preserve supported/refused kinds or record versioned refusal changes. | watched |
+| D14 Authoring Topology Fence | Unsupported authoring generators must remain refused. | D14 must consume generator refusal notes before adding future topology triggers. | watched |
+| Habitat implemented-surface docs | Future agents may miss the D0 matrix. | Link implemented-surface docs to the D0 compatibility ledger. | realigned |

--- a/openspec/changes/deep-habitat-d0-public-contract-inventory/workstream/phase-record.md
+++ b/openspec/changes/deep-habitat-d0-public-contract-inventory/workstream/phase-record.md
@@ -1,0 +1,115 @@
+# Phase Record
+
+## Phase
+
+- Project: Habitat Harness
+- Phase: D0 scenario/public contract inventory /
+  `deep-habitat-d0-public-contract-inventory`
+- Owner: directly responsible implementation agent
+- Branch/Graphite stack: `codex/deep-habitat-d0-public-contract-inventory`
+- Status: implementation complete; awaiting supervisor/product approval before D1
+
+## Objective
+
+Create the compatibility ledger that later Deep Habitat packets must preserve,
+version, migrate, deprecate, or refuse before moving internals.
+
+## Authority
+
+- User implementation takeover instructions.
+- Root `AGENTS.md` and Graphite workflow.
+- `docs/projects/habitat-harness/deep-refactor/implementation-reference-frame.md`
+- `docs/projects/habitat-harness/phase2-workstream-packets/D0-scenario-public-contract-inventory.md`
+- Current Habitat command/source/docs surfaces.
+
+## Scope
+
+Expected writes:
+
+- `docs/projects/habitat-harness/deep-refactor/D0-public-contract-inventory.md`
+- `openspec/changes/deep-habitat-d0-public-contract-inventory/**`
+- small discoverability links from Habitat docs.
+
+Forbidden writes:
+
+- command behavior changes;
+- package export moves;
+- generator behavior changes;
+- hook behavior changes;
+- generated artifacts;
+- lockfiles.
+
+## Current State Synthesis
+
+- Habitat exposes six Oclif verbs: `check`, `classify`, `verify`, `fix`,
+  `graph`, and `hook`.
+- `CheckReport`, `Classification`, `DiffClassification`, `VerifyProof`,
+  `GritApplyTransactionProof`, and `HookTrace` are the primary command/receipt
+  DTOs D0 must distinguish from internal helpers.
+- `src/index.ts` broadly exports baseline, command-engine, Grit, hook/process,
+  receipt, registry, and Pattern Authority surfaces.
+- `package.json` exposes the root index, Nx plugin, rules manifest, command
+  bin, generators, and migrations.
+- `nx.json` loads Habitat's inference plugin, which creates graph targets for
+  boundaries, Biome, Grit, generated-zone checks, aggregate Habitat checks,
+  owner checks, and per-rule aliases.
+- Root scripts expose both command entrypoints and graph-owned gates.
+- Husky hook files delegate to `bun run habitat hook pre-commit` and
+  `bun run habitat hook pre-push`.
+- The `bun run habitat check --json` versus `bun run habitat check -- --json`
+  shape is a command compatibility issue that D0 records but does not repair.
+- Root aliases such as `bun run habitat:check -- --json` are separate public
+  script-forwarding surfaces because the root script already includes the
+  Habitat subcommand.
+- Command-entrypoint grounding: stale or missing ignored
+  `tools/habitat-harness/dist/**` output produced false command-surface
+  results during D0. Running `bun install --frozen-lockfile` and
+  `bun run --cwd tools/habitat-harness build` restored coherent generated
+  command artifacts without source changes, after which entrypoint tests passed.
+- Current hook help text still says hook wiring is deferred; D0 records it as
+  stale human command output for downstream command-surface/docs alignment.
+- Proof/artifact-shaped code names such as `VerifyProof`,
+  `GritApplyTransactionProof`, and `ProofArtifactWriter` are current
+  compatibility facts, not target-domain authority. Downstream packets should
+  simplify them into minimal command receipts only where real repo-design,
+  construction, maintenance, evolution, linting, guarding, refusal, or recovery
+  workflows need them.
+
+## Review
+
+Required lanes:
+
+- API/CLI contract review.
+- TypeScript public-surface review.
+- Product scenario review.
+- stale docs/downstream review.
+- receipt/workstream review.
+- Graphite hygiene review.
+
+Review artifacts:
+
+- `workstream/review-disposition-ledger.md`
+
+## Verification
+
+- `git status --short --branch`: ran; D0 docs/spec edits only.
+- `bun run openspec -- validate deep-habitat-d0-public-contract-inventory --strict`:
+  exit 0.
+- `bun run openspec:validate`: reported by workstream reviewer as exit 0.
+- `bun install --frozen-lockfile`: exit 0; restored missing workspace
+  dependency links for Habitat package dependencies.
+- `bun run --cwd tools/habitat-harness build`: exit 0 after dependency
+  grounding; regenerated ignored command artifacts.
+- `bun run --cwd tools/habitat-harness test -- test/commands/habitat-entrypoints.test.ts`:
+  exit 0 after dependency/build grounding.
+- `bun run habitat classify tools/habitat-harness/src/plugin.js`: exit 0.
+- `bun run nx g @internal/habitat-harness:project unsupported-d0-probe --kind=mod --dry-run`:
+  exit 1 with expected unsupported uniform-kind refusal reason.
+- `bun run lint`: exit 0; Nx reported cache hit with matching outputs.
+- `git diff --check`: exit 0.
+
+## Non-Claims
+
+D0 does not establish command correctness, current-tree structural cleanliness,
+internal extraction safety, future facade design, CI proof, Grit apply safety,
+or product/runtime behavior.

--- a/openspec/changes/deep-habitat-d0-public-contract-inventory/workstream/review-disposition-ledger.md
+++ b/openspec/changes/deep-habitat-d0-public-contract-inventory/workstream/review-disposition-ledger.md
@@ -1,0 +1,25 @@
+# Review Disposition Ledger
+
+**Change:** `deep-habitat-d0-public-contract-inventory`
+**Status:** accepted P1/P2 findings dispositioned and final validation complete;
+awaiting supervisor/product approval before D1
+**Owner:** directly responsible implementation agent
+
+Accepted P1/P2 findings block D0 closure until repaired, rejected with source
+records, invalidated with later records, or superseded by explicit authority.
+
+## Findings
+
+| ID | Lane | Severity | Finding | Disposition | Required repair | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| D0-SUP-P2-001 | scope/product-language control | P2 | Supervisor noted that D0 must remain the public contract inventory/compatibility gate unless an explicit packet authority supersedes the no-public-behavior-change constraint. The command-entrypoint failure must be recorded as current command-surface state, not automatically repaired in D0. Product contract naming should prefer receipt vocabulary for new names, while broad existing docs should not be churned. | accepted; later invalidated as current source failure | The apparent command failure was invalidated by dependency/build grounding, not source repair: `bun install --frozen-lockfile` plus `bun run --cwd tools/habitat-harness build` restored coherent generated command artifacts and the command-entrypoint test passed. D0 now records the generated-artifact grounding requirement and retains the no-public-behavior-change boundary. | patched |
+| D0-REV-P1-001 | workstream closure | P1 | Required command-entrypoint validation failed and was not recorded in closure artifacts. | accepted; later invalidated as current source failure | Phase record and tasks now record the final passing command-entrypoint test after dependency/build grounding, plus the artifact-state issue that caused false failures. | patched |
+| D0-REV-P2-001 | TypeScript public surface | P2 | `classifyPath`/`classifyTarget` were classified as public versioned command APIs, accidentally hardening direct helper exports. | accepted | Reclassified callable classify helpers as package-internal and left the classify JSON DTOs as the versioned command contract. | patched |
+| D0-REV-P2-002 | TypeScript public surface | P2 | Several export rows mixed public DTOs with package-internal options/helpers, making individual dispositions ambiguous. | accepted | Split `ClassifyOptions`, `GritApplyTransactionProof`, Grit transaction internals, Pattern Authority schema/validation, and Pattern Authority path helpers into separate rows. | patched |
+| D0-REV-P2-003 | package export surface | P2 | Package `main`, package-local scripts, package Nx targets, and package files allowlist were omitted from the package export inventory. | accepted | Added those package-level surfaces with generated/build or package-internal dispositions. | patched |
+| D0-REV-P2-004 | product/domain contract | P2 | Spec treated `HookTrace` and `GritApplyTransactionProof` as current agent-consumed CLI DTOs, risking hardening internal/future surfaces. | accepted | Spec now separates current command JSON DTOs from future/internal receipt shapes and requires matrix ownership before public CLI treatment. | patched |
+| D0-REV-P2-005 | workstream closure | P2 | Tasks, phase status, review ledger, downstream ledger, and all-record OpenSpec validation were not closure-ready. | accepted | Tasks and ledgers now record review dispositions, validation status, all-record OpenSpec validation, and remaining final validation/Graphite/approval gates. | patched |
+| D0-REV-P2-006 | API/CLI contract | P2 | Root alias forwarding (`bun run habitat:check -- --json`) was not distinguished from non-canonical nested forwarding (`bun run habitat check -- --json`). | accepted | Matrix and phase record now distinguish root alias forwarding as a separate public script surface. | patched |
+| D0-REV-P2-007 | root script inventory | P2 | Root `biome:format`, `biome:check`, and `biome:ci` scripts were missing from the root script inventory. | accepted | Added root Biome scripts to the root script table. | patched |
+| D0-REV-P2-008 | generator contract | P2 | Pattern generator row underclassified implemented registered advisory/enforced modes as candidate-only. | accepted | Pattern generator row now records candidate and registered lifecycle modes and their governance gates. | patched |
+| D0-SUP-P2-002 | product/domain control | P2 | Supervisor clarified that proof/evidence-shaped Habitat code and artifact logic are likely a code smell unless they directly serve repo-design, construction, maintenance, evolution, linting, guarding, refusal, or recovery workflows. D0 must not rename current code, but also must not bless proof/artifact concepts as target-domain authority. | accepted | D0 now records `VerifyProof`, `GritApplyTransactionProof`, and `ProofArtifact*` surfaces as current compatibility facts requiring downstream reassessment and simplification into minimal command receipts only where product scenarios justify them. | patched |

--- a/tools/habitat-harness/README.md
+++ b/tools/habitat-harness/README.md
@@ -16,6 +16,8 @@ Current toolkit reference:
 - `docs/GAPS.md` names unsupported product and authoring gaps.
 - `docs/SCENARIOS.md` separates supported and unsupported usage scenarios.
 - `docs/AUTHORING-NEXT.md` frames the next generator/apply product loop.
+- `../../docs/projects/habitat-harness/deep-refactor/D0-public-contract-inventory.md`
+  records the Deep Habitat command/API compatibility ledger.
 
 The command shell is oclif, matching the repo's `@mateicanavra/civ7-cli`
 pattern: command classes live under `src/commands/**`, local repo scripts run

--- a/tools/habitat-harness/docs/IMPLEMENTED-SURFACE.md
+++ b/tools/habitat-harness/docs/IMPLEMENTED-SURFACE.md
@@ -54,6 +54,12 @@ Implemented command qualities:
   runtime artifacts;
 - command tests cover command argument forwarding and output behavior.
 
+Deep Habitat Phase 3 compatibility is recorded in
+`docs/projects/habitat-harness/deep-refactor/D0-public-contract-inventory.md`.
+Later refactor packets must consult that ledger before moving or narrowing
+command, DTO, package export, root script, Nx target, generator, or hook
+surfaces.
+
 ## Nx Graph Ownership
 
 Implemented graph integration:


### PR DESCRIPTION
This PR establishes the D0 public contract inventory for the Deep Habitat refactor, creating a durable compatibility ledger that all later refactor packets (D1–D14) must consult before moving, narrowing, removing, or versioning any Habitat surface.

The core artifact is `docs/projects/habitat-harness/deep-refactor/D0-public-contract-inventory.md`, which classifies every current Habitat surface into one of eight contract states: public stable, public versioned, package-internal, command-only DTO, test-only, generated/derived, deprecated, or refused. Coverage includes:

- **CLI verbs** (`check`, `classify`, `verify`, `fix`, `graph`, `hook`) with their flags, human output contracts, and machine JSON/receipt DTO contracts
- **Command DTOs** (`CheckReport`, `Classification`, `DiffClassification`, `VerifyProof`, `GritApplyTransactionProof`, `HookTrace`) distinguished from internal helpers that happen to be exported
- **`src/index.ts` export matrix** classifying every exported symbol across baseline, command-engine, Grit, hooks, process, receipt artifact, rule registry, and Pattern Authority modules
- **Package export paths**, root scripts, inferred Nx targets, generator schemas, and Husky hook delegators

Key compatibility decisions recorded:

- `bun run habitat check --json` is canonical; `bun run habitat check -- --json` is a product compatibility issue, not a typo
- Root alias forwarding (`bun run habitat:check -- --json`) is a separate public surface from nested forwarding
- Proof/artifact-shaped surfaces (`VerifyProof`, `GritApplyTransactionProof`, `ProofArtifactWriter`) are current compatibility facts only — downstream packets must simplify them into minimal command receipts where product scenarios justify them, not treat artifact generation as target-domain authority
- `Classification` currently lacks top-level schema versioning; D4 must preserve or explicitly version it before changing fields
- Command-entrypoint tests require dependency/build grounding (`bun install --frozen-lockfile` + `bun run --cwd tools/habitat-harness build`) before claiming command behavior, as stale `dist/**` artifacts produce false results

The accompanying OpenSpec change (`deep-habitat-d0-public-contract-inventory`) adds requirements that gate all later refactor packet closure on consulting this ledger. The downstream realignment ledger tracks watched obligations for D1 through D14. No command behavior, package exports, generators, hooks, or generated artifacts are changed.