### PR TITLE
fix(studio): retire placement.discoveries from loaded configs (heal disconnected presets)

### DIFF
--- a/apps/mapgen-studio/src/features/configMigrations/pipelineConfig.ts
+++ b/apps/mapgen-studio/src/features/configMigrations/pipelineConfig.ts
@@ -54,6 +54,23 @@ function migrateMapRiversKnobs(root: unknown): void {
   delete knobs.riverDensity;
 }
 
+function migratePlacementDiscoveries(root: unknown): void {
+  if (!isPlainObject(root)) return;
+  const placement = root.placement;
+  if (!isPlainObject(placement)) return;
+  if (!hasOwn(placement, "discoveries")) return;
+
+  // `placement.discoveries` was retired: discoveries are placed by Civ7's official
+  // discovery generator (run through the adapter at the place-discoveries step), which
+  // owns density/spacing/type — there is no authored knob anymore. Old presets and
+  // persisted authoring state still carry the block, and because the recipe placement
+  // schema is `additionalProperties: false`, it surfaces as an unknown-key validation
+  // failure (the preset silently fails to apply). Drop it so legacy configs heal to the
+  // current shape instead of falling back to a disconnected config. There is no
+  // replacement key, so this is a straight removal (unlike the map-rivers density alias).
+  delete placement.discoveries;
+}
+
 export function migratePipelineConfig(value: PipelineConfig): PipelineConfig {
   return migratePipelineConfigUnknown(value) as PipelineConfig;
 }
@@ -61,5 +78,6 @@ export function migratePipelineConfig(value: PipelineConfig): PipelineConfig {
 export function migratePipelineConfigUnknown(value: unknown): unknown {
   const next = cloneConfigValue(value);
   migrateMapRiversKnobs(next);
+  migratePlacementDiscoveries(next);
   return next;
 }

--- a/apps/mapgen-studio/test/config/defaultConfigSchema.test.ts
+++ b/apps/mapgen-studio/test/config/defaultConfigSchema.test.ts
@@ -506,7 +506,7 @@ describe("Studio default config", () => {
   });
 
   it("exposes semantic Placement authoring keys instead of runtime step/op envelopes", () => {
-    const expected = ["knobs", "naturalWonders", "discoveries", "resources", "starts", "support"];
+    const expected = ["knobs", "naturalWonders", "resources", "starts", "support"];
     const schemaProps =
       (
         getSchemaAtPath(STANDARD_RECIPE_CONFIG_SCHEMA, ["placement"]) as {
@@ -557,7 +557,9 @@ describe("Studio default config", () => {
   it("exposes documented and bounded Placement public controls to Studio", () => {
     // S7 knob surface: the S3 resources, S4 starts, and S5 support groups all
     // reach Studio through the generated schema (no hand-maintained shadow).
-    const publicKeys = ["knobs", "naturalWonders", "discoveries", "resources", "starts", "support"];
+    // Discoveries were retired from the public surface in #1796 (placed by the
+    // official generator), so they are not part of the authored placement keys.
+    const publicKeys = ["knobs", "naturalWonders", "resources", "starts", "support"];
 
     expectPublicStageDescription(STANDARD_RECIPE_CONFIG_SCHEMA, "placement");
     for (const key of publicKeys) {

--- a/apps/mapgen-studio/test/config/pipelineConfigMigration.test.ts
+++ b/apps/mapgen-studio/test/config/pipelineConfigMigration.test.ts
@@ -64,6 +64,41 @@ describe("migratePipelineConfigUnknown", () => {
       })
     ).toThrow(PipelineConfigMigrationError);
   });
+
+  it("drops retired placement.discoveries while preserving sibling placement keys", () => {
+    const input = {
+      placement: {
+        knobs: {},
+        naturalWonders: { minSpacingTiles: 6 },
+        discoveries: { densityPer100Tiles: 3, minSpacingTiles: 3 },
+        resources: { density: 1 },
+        starts: { fertilityWeight: 3 },
+      },
+    };
+
+    const migrated = migratePipelineConfigUnknown(input) as any;
+
+    expect(migrated.placement).toEqual({
+      knobs: {},
+      naturalWonders: { minSpacingTiles: 6 },
+      resources: { density: 1 },
+      starts: { fertilityWeight: 3 },
+    });
+    expect("discoveries" in migrated.placement).toBe(false);
+    // input is cloned, not mutated in place
+    expect("discoveries" in input.placement).toBe(true);
+  });
+
+  it("leaves placement untouched when it carries no retired discoveries block", () => {
+    const migrated = migratePipelineConfigUnknown({
+      placement: { resources: { density: 1 }, starts: { fertilityWeight: 3 } },
+    }) as any;
+
+    expect(migrated.placement).toEqual({
+      resources: { density: 1 },
+      starts: { fertilityWeight: 3 },
+    });
+  });
 });
 
 describe("resolveImportedPreset migration conflicts", () => {

--- a/mods/mod-swooper-maps/test/config/standard-authoring-surface-guards.test.ts
+++ b/mods/mod-swooper-maps/test/config/standard-authoring-surface-guards.test.ts
@@ -91,7 +91,7 @@ const STANDARD_PUBLIC_KEYS: Record<string, readonly string[]> = {
     "plotEffectCoverage",
   ],
   "map-ecology": ["knobs", "biomeBindings"],
-  placement: ["knobs", "naturalWonders", "discoveries", "resources", "starts", "support"],
+  placement: ["knobs", "naturalWonders", "resources", "starts", "support"],
 };
 
 function isObject(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Problem

Selecting a map config/preset in MapGen Studio that still carries `placement.discoveries` silently fails: the preset appears selected, but map size / plate count and other parameters stop responding — the UI is "disconnected" from generation.

## Root cause

`placement.discoveries` was retired from the recipe schema in #1796 (discoveries are now placed by Civ7's official generator — no authored knob). `PlacementPublicSchema` is `additionalProperties: false`, so any config still carrying the block fails `normalizeStrict` as an unknown key. In Studio, `applyPresetConfig` returns `{ value: null }` and `StudioShell` toasts "Preset invalid" and returns **without** calling `setPipelineConfig` — so the new config is never adopted and edits act on a stale config.

Accumulated saved/imported presets, persisted authoring state, and the (gitignored) `studio-current` scratchpad all predate the retirement, so from the user's seat "all the configs" are affected.

## Fix

**1. Durable migration (`fix` commit).** Add `migratePlacementDiscoveries` to `migratePipelineConfigUnknown` — the single choke point every client config-load path runs through (presets, `storage`, `importFlow`, `persistence`, the browser runner, and run-in-game via `clientState`). It mirrors the existing retired `map-rivers` `riverDensity` migration; with no replacement key it is a straight drop. Legacy configs now heal to the current shape on load instead of disconnecting, and run-in-game rewrites `studio-current.config.json` clean for `gen:maps`.

**2. Test-debt sweep (`test` commit).** #1796 removed `discoveries` from the schema but left three placement public-key expectations that have **failed since it merged** (the Studio `defaultConfigSchema` key-list + control guard, and the mod `standard-authoring-surface-guards` key set). Dropped the stale key so the guards match the retired surface — the same cleanup #1799 applied to `maps-schema-valid`. The internal `place-discoveries` step is unchanged.

## Verification

- `mapgen-studio` `test/config` → **47 passed** (incl. 2 new migration cases proving the strip + 2 previously-failing schema guards now green)
- mod `standard-authoring-surface-guards.test.ts` → **3 pass / 0 fail** (was 1 fail)
- `nx run mapgen-studio:check` and `nx run mod-swooper-maps:check` → pass
- biome clean on all changed files
- The user's local gitignored `studio-current.config.json` was also cleaned of the stale block (immediate relief; not part of this diff since it's gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
