### PR TITLE
docs(habitat): accept D7 structural enforcement packet

### DIFF
--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-code-topology-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-code-topology-investigation.md
@@ -1,0 +1,188 @@
+# D7 Code/Topology Investigation
+
+Status: BLOCKING
+
+## Blocking Reason
+
+The current code is traceable enough to describe present `habitat check` behavior, but it does not support a complete D7 implementation packet, write set, and validation matrix yet.
+
+Missing evidence:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/design.md` is still requires the executor to first provide the concrete write set, protected path list, verification gates, and D0 compatibility disposition.
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/tasks.md` still has the design intake tasks open, including recording the concrete write set and protected paths.
+- D7 says it consumes D0/D1/D2/D3/D5/D6/D10 authority, but the current D6 diagnostic-projection and D10 generated/protected-zone authority are not present as accepted source contracts in code. Current code has present behavior, not the target consumer projection that D7 says it must consume.
+- Current report validation checks structural presence and does not enforce `CheckReport.ok`/rule-status consistency, which is one of the D7 packet stop-condition risks.
+
+This report therefore records current topology and a candidate D7 write set, but D7 should remain blocked until the missing authority and validation matrix are made explicit.
+
+## Current `habitat check` Path
+
+`habitat check` enters through `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/commands/check.ts`.
+
+The command parses these flags today: `--json`, `--output`, `--owner`, `--rule`, `--tool`, `--staged`, `--expand-baseline`, and `--base`. `--expand-baseline` bypasses report generation and calls baseline expansion. Normal execution calls `createCheckReport`, renders with `renderCheckReport`, logs or writes the result, and exits `0` when `report.ok` is true and `1` otherwise.
+
+`createCheckReport` in `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts` currently owns the full orchestration:
+
+1. Select rules with `selectRules`.
+2. Return a synthetic `rule-selection-integrity` failure report on invalid selectors.
+3. Reduce selected rules for staged execution with `rulesForExecution`.
+4. Execute selected rules with `executeSelectedRules`.
+5. Load and apply baselines per rule.
+6. Convert diagnostics and baseline failures into `RuleReport.status`.
+7. Append a built-in `baseline-integrity` report.
+8. Construct `CheckReport.ok` from `reports.every((report) => report.status !== "fail")`.
+
+Rule execution branches today:
+
+- `grit-check` rules are grouped and executed by `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/grit.ts`.
+- `file-layer` rules are executed by `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/generated-zones.ts`.
+- Other native/wrapped rules run through `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/rules/architecture.ts`.
+
+Baseline application is in `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/baseline.ts`. It mutates matching diagnostics with `baselined: true`, rejects parser-owned baselining for explicit baseline files, returns contract-failure diagnostics, and checks baseline integrity against the base registry.
+
+Human output is rendered by `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/rules/messages.ts`. JSON output is `JSON.stringify(report, null, 2)` after `validateCheckReport`.
+
+Graph/Nx facts exist in `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/plugin.js` and related classify/verify paths. They are not currently consumed by `createCheckReport` when assembling `CheckReport`.
+
+## Current-State Inventory
+
+| Surface | Owner today | Source paths | Side effects | Output fields | Tests |
+| --- | --- | --- | --- | --- | --- |
+| Check CLI | Oclif command wrapper | `tools/habitat-harness/src/commands/check.ts` | Writes `--output`; exits 0/1; `--expand-baseline` can write baseline files | command flags forwarded into `CheckOptions`; rendered human/JSON output | `tools/habitat-harness/test/commands/habitat-commands.test.ts`; `tools/habitat-harness/test/commands/habitat-entrypoints.test.ts` |
+| Report orchestration | `command-engine.ts` | `tools/habitat-harness/src/lib/command-engine.ts` | Runs rule commands; reads baselines; reads git state; invokes Grit/file-layer/native execution | `CheckReport.schemaVersion`, `command`, `startedAt`, `ok`, `rules[]` | `tools/habitat-harness/test/lib/rule-selection.test.ts`; command entrypoint tests |
+| Rule selection | `selectRules` and selector failure report | `tools/habitat-harness/src/lib/command-engine.ts`; `tools/habitat-harness/src/rules/architecture.ts`; `tools/habitat-harness/src/rules/rules.json` | No external command on selection failure | selected `HarnessRule[]`, selector failures, synthetic `rule-selection-integrity` report | `tools/habitat-harness/test/lib/rule-selection.test.ts`; `tools/habitat-harness/test/commands/habitat-entrypoints.test.ts` |
+| Rule registry metadata | Registry JSON and architecture loader | `tools/habitat-harness/src/rules/rules.json`; `tools/habitat-harness/src/rules/architecture.ts` | None when loaded | `HarnessRule` fields: `id`, `ownerTool`, `ownerProject`, `lane`, `scope`, `forbids`, `why`, `detect`, `remediate`, optional Grit/generated/hook fields | `tools/habitat-harness/test/lib/enforcement-surface.test.ts` |
+| Native/wrapped execution | Architecture rule adapter | `tools/habitat-harness/src/rules/architecture.ts` | Spawns `rule.detect` commands from repo root | `RuleRunResult.diagnostics`, duration, coarse or parsed diagnostic messages | `tools/habitat-harness/test/lib/enforcement-surface.test.ts` |
+| Grit diagnostics | Grit adapter | `tools/habitat-harness/src/lib/grit.ts`; `tools/habitat-harness/src/lib/grit-failures.ts`; `tools/habitat-harness/src/lib/grit-injected-probe.ts` | Runs `grit`; creates/uses `.grit/cache`; may create temp cache dirs; reads scan roots | Grit diagnostics projected into `HabitatDiagnostic[]`; infrastructure failure diagnostics | `tools/habitat-harness/test/lib/grit-adapter.test.ts`; `tools/habitat-harness/test/lib/grit-injected-probe.test.ts`; `tools/habitat-harness/test/lib/grit-patterns.test.ts` |
+| Baseline application | Baseline module | `tools/habitat-harness/src/lib/baseline.ts`; `tools/habitat-harness/baselines/**` | Reads baseline files; reads git base/current registry; `expandBaselines` writes baseline files | diagnostic `baselined` mutation; baseline failure diagnostics; `baseline-integrity` rule report | `tools/habitat-harness/test/lib/baseline.test.ts`; baseline cases in command entrypoint tests |
+| Generated/protected file-layer | Generated-zone module | `tools/habitat-harness/src/lib/generated-zones.ts` | Reads real staged paths with `git diff --cached --name-status -z` | file-layer diagnostics for generated zones and forbidden file names | Hook tests exercise staged command behavior; no dedicated generated-zone unit test found |
+| Human/JSON rendering | Messages and report validator | `tools/habitat-harness/src/rules/messages.ts`; `tools/habitat-harness/src/lib/diagnostics.ts`; `tools/habitat-harness/src/lib/command-engine.ts` | Writes `--output`; logs to stdout/stderr via command wrapper | human summary/counts/details or serialized `CheckReport` | `tools/habitat-harness/test/lib/rule-selection.test.ts`; `tools/habitat-harness/test/commands/habitat-entrypoints.test.ts` |
+| Graph facts | Nx plugin/classify/verify topology | `tools/habitat-harness/src/plugin.js`; `tools/habitat-harness/src/lib/classify.ts`; verify code in `command-engine.ts` | Nx target inference; verify target execution | project targets, owner targets, aggregate targets, verify proof facts | `tools/habitat-harness/test/lib/enforcement-surface.test.ts`; classify/verify command tests |
+| Public exports | Package facade | `tools/habitat-harness/src/index.ts` | None | exports `createCheckReport`, `selectRules`, `renderCheckReport`, `stringifyCheckReport`, `CheckReport`, `RuleReport`, `HabitatDiagnostic`, baseline/Grit/rule types | Export changes require D0 compatibility coverage; no dedicated export compatibility test found in this pass |
+
+## Candidate D7 Write Set
+
+This is a candidate write set supported by current topology, not an acceptance-ready D7 write set. It needs D0/D1/D2/D3/D5/D6/D10 authority before implementation.
+
+| Candidate path | Rationale |
+| --- | --- |
+| `tools/habitat-harness/src/lib/command-engine.ts` | Current `createCheckReport` mixes selector validation, staged rule filtering, execution grouping, baseline application, status derivation, baseline integrity, and report construction. D7's central refactor almost certainly starts here while preserving the public facade. |
+| New `tools/habitat-harness/src/lib/check*.ts` or `tools/habitat-harness/src/lib/check/**` modules | D7 needs explicit pipeline boundaries for selection, execution result collection, baseline projection/application, report construction, and rendering/serialization contracts. |
+| `tools/habitat-harness/src/lib/diagnostics.ts` | Current `validateCheckReport` is shape-based. D7 likely needs report constructors or invariant validation for `ok`, rule statuses, diagnostics, and selector/baseline failure semantics. Any public shape change requires D0 compatibility disposition. |
+| `tools/habitat-harness/src/commands/check.ts` | Edit when command request construction changes. Existing flags and exit behavior are public CLI surface and should stay stable unless D0 says otherwise. |
+| `tools/habitat-harness/src/index.ts` | Edit when D7 adds public pipeline exports or replaces existing exported symbols. This is public package surface and requires D0 compatibility coverage. |
+| `tools/habitat-harness/test/lib/rule-selection.test.ts` | Existing selector behavior is already pinned here and should remain the first regression surface. |
+| `tools/habitat-harness/test/lib/check-pipeline.test.ts` or equivalent new file | Missing focused home for D7 stage and invariant tests. |
+| `tools/habitat-harness/test/lib/generated-zones.test.ts` or equivalent new file | D7 needs file-layer/generated-zone validation, but no dedicated unit test exists today. |
+| `tools/habitat-harness/test/commands/habitat-entrypoints.test.ts` | Existing JSON/human command behavior and selector/baseline report shape are pinned here. |
+| `tools/habitat-harness/test/lib/enforcement-surface.test.ts` | Current owner-tool inventory and graph target inference are pinned here. D7 should avoid changing these without D2/D3 authority. |
+
+## Protected Paths For D7
+
+| Protected path | Rationale |
+| --- | --- |
+| `tools/habitat-harness/dist/**` | Generated artifact; root AGENTS says generated artifacts are read-only and should be regenerated, not hand-edited. |
+| `tools/habitat-harness/baselines/**` | D5 baseline authority. D7 should consume baseline state/application results, not rewrite baseline data except through existing baseline-expansion behavior when explicitly requested. |
+| `tools/habitat-harness/src/rules/rules.json` | D2 registry metadata authority. D7 should consume registry facts, not redefine registry schema or rule ownership. |
+| `.grit/**` and `.grit/patterns/**` | D6/D8/D9-adjacent diagnostic/pattern authority. D7 should consume diagnostic projections rather than authoring Grit rules or pattern files. |
+| `tools/habitat-harness/src/lib/grit.ts`, `tools/habitat-harness/src/lib/grit-failures.ts`, `tools/habitat-harness/src/lib/grit-injected-probe.ts` | Current Grit acquisition/projection internals. D7 should not redefine diagnostic catalog behavior unless D6 exposes the needed consumer surface. |
+| `tools/habitat-harness/src/lib/baseline.ts` | D5-owned baseline semantics. D7 can call a stable projection/application API, but should not move baseline authority into the enforcement pipeline. |
+| `tools/habitat-harness/src/lib/generated-zones.ts` | D10-owned generated/protected-zone semantics. Current behavior can be documented, but D7 should not hard-code new protected-zone authority before D10 is accepted. |
+| `tools/habitat-harness/src/plugin.js` | D3 graph/Nx topology. D7 may consume graph facts if a contract exists, but should not change plugin target topology as part of pipeline separation. |
+| Root package scripts, Nx config, public exports | D0 public compatibility surfaces. Any change needs explicit compatibility-matrix disposition. |
+| Lockfiles and generated mod/resource outputs | Repo policy treats lockfiles/generated outputs as protected from hand edits. |
+
+## Current False-Green And Ambiguity Paths
+
+### Report invariant weakness
+
+`$HABITAT_TOOL/src/lib/diagnostics.ts` validates structural report fields but not semantic consistency. It checks that `schemaVersion` is `1`, `command` and `startedAt` are strings, `ok` is boolean, `rules` is an array, and each rule has basic `ruleId`, `status`, and `diagnostics` shape.
+
+It does not validate:
+
+- `report.ok === report.rules.every((rule) => rule.status !== "fail")`.
+- Advisory lanes cannot produce enforced failures by accident.
+- Enforced lanes with unbaselined error diagnostics must fail.
+- Baseline failure diagnostics must fail the rule/report.
+- `RuleReport` fields such as `ownerTool`, `lane`, `locked`, `durationMs`, `detect`, `message`, and `remediate`.
+
+`createCheckReport` currently computes `RuleReport.status` and `CheckReport.ok` in the same function, but no constructor or validator prevents future contradictions.
+
+### Grit pattern projection can ignore unexpected native output
+
+`/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/grit.ts` projects findings with `rule.gritPattern ?? rule.id` and only rejects unexpected `patternIdentity` when `rejectUnexpectedPatternIdentity` is explicitly requested.
+
+`/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/grit-adapter.test.ts` pins the current permissive behavior: findings outside the selected pattern set are ignored by default. This can be false-green for D7/D6 target semantics if all native Grit output is unexpected or if a rule is missing explicit pattern identity.
+
+### Generated-zone checks are staged-mode and internally source staged paths
+
+`/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/generated-zones.ts` returns pass with no diagnostics when `context.staged` is false. It reads staged files internally through `git diff --cached --name-status -z`.
+
+`CheckOptions.stagedPaths` affects staged Grit scan roots but does not inject file-layer staged paths, because non-Grit execution only receives `{ staged }`. That makes file-layer behavior harder to test and leaves D7 without a clean stage input model for generated/protected-zone decisions.
+
+No dedicated generated-zone unit test was found in this pass.
+
+### Baseline authority leaks into orchestration
+
+`createCheckReport` directly calls `loadBaselineState`, `applyBaseline`, `isBaselineLocked`, `baselineFailureDiagnostic`, and `checkBaselineIntegrity`. This works today, but D7's stated direction is a pipeline that consumes baseline authority rather than recomputing or owning it. Current topology does not yet expose a D5-shaped projection boundary for D7 to consume.
+
+### Grit acquisition/projection leaks into orchestration
+
+`executeSelectedRules` in `command-engine.ts` directly groups Grit rules, computes staged scan roots, and calls `runGritRules`. D7 wants a structural pipeline over diagnostic outcomes, but the current code consumes Grit internals rather than a D6 diagnostic run outcome.
+
+### Graph facts are not part of `habitat check`
+
+`tools/habitat-harness/src/plugin.js` defines aggregate targets, owner targets, rule alias targets, and generated-zone targets, and tests pin parts of that topology. `createCheckReport` does not consume graph facts while constructing a report. If D7's target behavior claims graph facts participate in structural enforcement, the consumer contract is missing.
+
+### Verify summary loses selector request facts
+
+`summarizeVerifyCheckReport` in `command-engine.ts` sets `requestedSelectors: {}` unconditionally. This is not necessarily D7-owned, but it is an adjacent ambiguity for verification proof consumers that need to know what selector context produced a check report.
+
+### Current-tree check is not uniformly green
+
+A direct command probe in this worktree showed:
+
+- `bun run habitat:check -- --json --rule definitely-not-a-rule` exits `1` with a synthetic `rule-selection-integrity` failure report.
+- `bun run habitat:check -- --json --rule workspace-entrypoints` exits `1` because `mods/mod-swooper-maps/package.json` currently has a package-local script violation for `migrate:configs`.
+- `bun run habitat:check -- --staged --json --tool file-layer` exits `0` with four file-layer pass reports plus `baseline-integrity`.
+
+D7 validation gates that assume broad `habitat check --json` is green need a current-tree failure disposition.
+
+## Existing Tests Relevant To D7
+
+| Test path | Current coverage |
+| --- | --- |
+| `tools/habitat-harness/test/commands/habitat-commands.test.ts` | Flag forwarding into `createCheckReport`; `renderCheckReport` options; `--expand-baseline`; verify command invocation shape. |
+| `tools/habitat-harness/test/commands/habitat-entrypoints.test.ts` | CLI help; invalid selector JSON/human output; selector failure report shape; baseline contract failure reports; invalid baseline expansion selectors. |
+| `tools/habitat-harness/test/lib/rule-selection.test.ts` | Owner/rule/tool selector behavior; wrong namespace; unknown selector; empty intersection; selector failure render; staged Grit filtering. |
+| `tools/habitat-harness/test/lib/enforcement-surface.test.ts` | Owner-tool inventory; root structural script policy; wrapper dispositions; direct wrapped-script parser policy; plugin target inference. |
+| `tools/habitat-harness/test/lib/baseline.test.ts` | Explicit-empty/debt baselines; missing/malformed/duplicate/unsorted/orphan baselines; external exception mismatch; parser-owned baseline bypass rejection; baseline growth refusal. |
+| `tools/habitat-harness/test/lib/grit-adapter.test.ts` | Grit JSON/text parsing; infrastructure failure projection; selected-pattern projection; permissive unexpected-pattern default; strict proof modes; scan-root refusals; command request construction; docs apply dry-run. |
+| `tools/habitat-harness/test/lib/hooks.test.ts` | Pre-commit staged file-layer command; file-layer failure blocks; staged Grit command behavior; parse/finding failures fail closed. |
+| `tools/habitat-harness/test/lib/grit-injected-probe.test.ts` and `tools/habitat-harness/test/lib/grit-patterns.test.ts` | Grit probe/pattern-adjacent behavior relevant to D6 inputs consumed by D7. |
+
+## Missing Tests For D7 Validation
+
+- A report-construction invariant test that proves `CheckReport.ok`, rule statuses, lanes, diagnostics, and baseline failures cannot contradict each other.
+- Focused pipeline-stage tests for selection, execution outcome collection, baseline projection/application, report construction, and rendering.
+- JSON compatibility tests for the complete `CheckReport` shape, not only structural presence fields.
+- Human/JSON equivalence tests for clean, failing, advisory, baselined, selector-failure, and baseline-integrity cases.
+- End-to-end tests for mixed `--owner`, `--rule`, `--tool`, and `--staged` selectors with explicit baseline-integrity inclusion/exclusion expectations.
+- A generated-zone unit test suite covering staged generated paths, non-staged non-claim/pass behavior, unknown generated-zone metadata, forbidden pnpm filenames, and injectable staged path inputs.
+- A Grit projection test at `createCheckReport` level proving unexpected pattern identity and missing `gritPattern` behavior under D6 target semantics.
+- A graph-fact test or explicit non-claim test: either `habitat check` consumes graph facts through a stable projection, or D7 must say graph facts are outside current check report construction.
+- A public export compatibility test if D7 adds or changes exported pipeline/report types.
+
+## D7 Stop Condition Disposition
+
+The D7 source packet says to stop if the topology does not support a complete packet write set and validation matrix. That stop condition is met.
+
+The current source topology can support a careful refactor of present behavior, but D7's target dependencies are not acceptance-ready:
+
+- Baseline behavior is present but still consumed through D5 internals.
+- Grit behavior is present but still consumed through D6 internals, and current projection has known permissive paths.
+- Generated/protected-zone behavior is present but staged-mode, internally sourced, and not backed by D10 target authority or dedicated tests.
+- Graph facts exist but are not part of `habitat check` report construction.
+- Report invariants are conventionally maintained in `createCheckReport`, not enforced by the report schema or constructors.
+
+D7 should remain BLOCKING until the phase record supplies the concrete accepted write set, protected paths, D0 compatibility disposition, D6 diagnostic projection contract, D10 generated/protected-zone contract, and the validation matrix above.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-cross-domino-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-cross-domino-investigation.md
@@ -1,0 +1,135 @@
+# D7 Cross-Domino Investigation
+
+Status: BLOCKING
+
+## Finding
+
+D7 is not acceptable input yet. The source packet has the right intent, but the
+OpenSpec packet lacks executable cross-domino contracts: it says D7 consumes
+D2/D3/D5/D6/D10 and unblocks D11/D12, yet it does not define the exact consumed
+projections, state families, false-green refusal states, public-surface
+blockers, or downstream consumer contracts.
+
+The blocking failure is not that D7 explicitly takes ownership of every adjacent
+domain. The failure is that it leaves implementation agents and downstream D11
+and D12 packets to infer report semantics from `command-engine.ts` and from
+adjacent packets. That violates the stop condition for this review. D7 must make
+the enforcement pipeline a published-language boundary: adjacent domains publish
+facts/results; D7 composes them into check outcomes; D11/D12 consume those
+check outcomes without reinterpreting internals.
+
+## Dependency Ledger
+
+| Consumed contract | Source packet/change | D7 use | Source implementation blocker | Downstream effect |
+| --- | --- | --- | --- | --- |
+| D0 public-surface rows for `habitat check`, `CheckReport`, `RuleReport`, diagnostics, package exports, Nx target outputs, hooks/docs examples touched by check behavior | D0 `deep-habitat-d0-command-surface-inventory` | Gate any JSON, human output, package export, script/Nx target output, field order, exit behavior, selector behavior, or docs/example change | D0 is accepted for design/specification only; concrete matrix rows must exist before source implementation can change public/durable surfaces | Without explicit rows, D11/D12 cannot know whether check JSON/human semantics are preserved, versioned, facaded, or refused |
+| D1 check outcome, rule status, diagnostic, refusal, non-claim, and check-report consistency rules | D1 `deep-habitat-d1-receipt-contract-boundary` | Construct/validate `CheckReport` so `ok`, rule statuses, selector failures, refusals, command failures, advisory-only, no-rules-selected, and non-claims cannot contradict | D1 implementation is blocked until D0 rows exist; D7 must cite the D1 output family for every new failure/refusal shape | D12 needs a stable check summary and non-claims; D11 needs local-only hook output that does not claim CI/verify authority |
+| `ruleSelectorFacts`, `ruleReportFacts`, and `ruleExecutionFacts` | D2 `deep-habitat-d2-rule-registry-metadata-contract` | Select rules, render rule report facts, execute through adapter facts, and distinguish selector failure from zero selected rules | Live D2 projection implementation is required; D7 must not consume whole `RuleRegistryRecord`, legacy `HarnessRule`, prose `scope`, or local substitute metadata | D11 hook selection and D12 verify check summary cannot infer selector semantics from whole registry rows |
+| `ruleBaselineFacts` and D5 baseline application/integrity results | D2 plus D5 `deep-habitat-d5-baseline-authority` | Apply baseline coverage to executed diagnostics; consume baseline-integrity result for built-in rule; surface D5 refusals as check diagnostics | D5 source implementation requires D0 rows and live D2 baseline projections; D7 must not load baseline internals or decide shrink/growth/manifest/external exception policy | D11 must report baseline-related local feedback as check output only; D12 must skip/execute affected targets based on D7 check result without re-deciding baseline status |
+| `ruleGritFacts` and D6 `DiagnosticRunOutcome` / diagnostic consumer projection | D2 plus D6 `deep-habitat-d6-diagnostic-pattern-catalog` | Run/acquire diagnostics, normalize findings/advisory/failure outcomes, and prevent adapter failures from becoming structural pass | D6 implementation requires D0 rows, D1 output-family citations, and live D2 Grit projections; D7 must not parse raw `GritReport`, whole `HabitatCommandResult`, or derive pattern identity from `gritPattern ?? ruleId` | D11 staged/local Grit feedback must consume D7/D6 published outcomes; D12 check summary must distinguish findings from diagnostic acquisition failure |
+| D3 graph target facts for Nx-inferred `habitat:check` / `habitat:rule:*` invocation surfaces, not direct check evaluation | D3 `deep-habitat-d3-workspace-graph-boundary` | Respect graph-backed invocation availability and false-green alias prevention for check-related Nx targets | D3 source implementation is blocked until D0 rows and live D2 graph projections exist | D12 consumes D3 target plan facts separately; D7 must not make verify infer graph truth from check internals |
+| D10 generated/protected-zone guard/refusal result | D10 `deep-habitat-d10-protected-zone-authority` packet | Treat protected-zone violations/refusals as structural check outcomes without defining host policy or staged guard authority | D10 remains draft/blocking; G-HOST and D2 inputs are unresolved for source implementation | D11 pre-commit generated-zone feedback depends on stable D10 + D7 semantics; D9 apply must not infer generated-zone permission from check pass |
+| D7 check outcome state model and report projection | D7 packet itself | Publish the composed enforcement outcome consumed by D11/D12 | Missing today: no closed outcome union, no selector-failure/no-rules/refused/command-failed/advisory-only model, no exact JSON/human compatibility map, no exit semantics | D11/D12 are currently forced to infer report semantics, which is blocking |
+
+## D7 Contracts That Must Be Published
+
+D7 must publish a closed pipeline model before acceptance:
+
+- `CheckRequest` / selector request state: none, requested rule, requested owner,
+  requested tool, staged mode, invalid/unknown selector, and unsupported
+  selector combination. Invalid selector must be a report/refusal state, not
+  zero executed rules.
+- `SelectedRuleSet`: selected rule facts from D2, empty-by-valid-selection,
+  refused-by-metadata-failure, and blocked-by-unavailable dependency facts.
+- `RuleExecutionOutcome`: not-run/refused, command-failed, diagnostic-failed,
+  findings, advisory-findings, clean, and protected-zone/baseline refusal
+  outcomes. It must carry source owner references without exposing adjacent
+  internals.
+- `BaselineAppliedRuleOutcome`: result of D5 application, with covered debt,
+  new diagnostics, and baseline contract diagnostics distinguishable.
+- `CheckOutcome`: pass, fail, advisory-only, no-rules-selected, refused,
+  command-failed, blocked-input-authority, and selector-failed. `CheckReport.ok`
+  must be derived from this state and rule statuses.
+- `CheckReport` construction contract: field inventory, D0/D1 compatibility
+  handling, human/JSON truth equivalence, non-claims, exit-code mapping, and
+  renderer/stringifier boundaries.
+- `D15 trigger decision`: dormant unless D7 can name a command-provenance
+  contradictory state that local D7 DTOs cannot encode.
+
+## D11 Consumer Contract Required From D7
+
+D11 must not infer hook semantics from `command-engine.ts` or current check JSON.
+D7 must publish:
+
+- the local-feedback-safe check projection D11 may consume;
+- which check outcomes stop later hook stages;
+- how staged mode maps to D7 without D7 owning D10 staged guard policy;
+- selector failure and diagnostic acquisition failure rendering rules for hooks;
+- non-claims D11 must preserve: local feedback only, not CI, not verify, not
+  product/runtime proof, not apply safety;
+- cache/freshness stance for hook-invoked check segments, or a D15 trigger if
+  D7 cannot represent it locally.
+
+## D12 Consumer Contract Required From D7
+
+D12 needs a stable check summary, not raw rule reports. D7 must publish:
+
+- `VerifyCheckSummary` or equivalent projection from `CheckReport`;
+- exact check outcomes that allow affected Nx execution versus require skipped
+  affected state;
+- selector-request state, including the replacement for current `{}` placeholder
+  behavior;
+- bounded diagnostic/count/status summary sufficient for handoff without
+  reinterpreting D2/D5/D6/D10 internals;
+- non-claims to carry into verify: check does not prove CI, runtime/product
+  behavior, apply safety, Graphite readiness, or OpenSpec acceptance;
+- exit-code and command-failure mapping so D12 can distinguish failed check from
+  failed verify assembly.
+
+## Other Downstream Effects
+
+- D8 may cite D7 check behavior as enforcement/report output. Pattern
+  lifecycle and baseline/diagnostic admission remain D8/D5/D6.
+- D9 must not use a D7 pass as write approval. Apply approval remains D8/D10/G-HOST
+  plus D9 transaction authority.
+- D13/D14 should consume D7 through command examples or refusal/handoff
+  docs after D7 output compatibility is settled.
+- D15 remains dormant unless D7 records a concrete local-state contradiction
+  around delegated command provenance, cache freshness, cwd/env, or bounded
+  output that cannot be represented inside D7.
+
+## Packet Index And Control Record Updates Needed
+
+Before D7 can be accepted, update the control records as follows:
+
+- `openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/design.md`:
+  replace the incomplete target contract with the dependency ledger, closed state
+  model, pipeline stages, D0/D1 compatibility blockers, D11/D12 published
+  contracts, D15 trigger decision, write set, protected paths, and falsifying
+  validation gates.
+- `openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/tasks.md`:
+  split implementation into prerequisites, characterization, model/projection,
+  consumer migration, deletion, validation, and downstream realignment tasks.
+  Add explicit blockers for concrete D0 rows, live D2/D3/D5/D6 projections, and
+  accepted D10 contract state.
+- `openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/specs/habitat-harness/spec.md`:
+  add normative requirements for check outcome states, selector failure
+  distinction, baseline/diagnostic/protected-zone refusal propagation, false
+  green prevention, report validation, and downstream projections.
+- `openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/workstream/downstream-realignment-ledger.md`:
+  replace the generic "later domino packets" row with exact D11, D12, D8, D9,
+  D13/D14, and D15 rows.
+- `openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/workstream/review-disposition-ledger.md`:
+  record this cross-domino finding as accepted P1/blocking unless a later
+  reviewer rejects it with source evidence.
+- `docs/projects/habitat-harness/openspec-remediation/packet-index.md`:
+  keep D7 as BLOCKING until the above repairs land and the per-domino review
+  ledger records no unresolved accepted P1/P2 findings. Do not mark D7 accepted
+  merely because the packet exists.
+
+## Acceptance Bar
+
+D7 becomes acceptable input when a downstream agent can implement D11 or
+D12 by reading D7's published projections and non-claims, without opening
+`command-engine.ts` to infer check semantics and without re-deciding D2, D3,
+D5, D6, or D10 authority.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-domain-ontology-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-domain-ontology-investigation.md
@@ -1,0 +1,187 @@
+# D7 Structural Enforcement Pipeline Domain/Ontology Investigation
+
+Status: BLOCKING
+
+Fresh D7 adversarial review. I treated the D7 source domino and accepted D0/D1/D2/D3/D5/D6 packets as controlling inputs, D10 as draft protected-zone dependency input, and current Habitat code/tests as evidence rather than authority.
+
+## Findings
+
+### P1: D7 packet does not define the Structural Enforcement Pipeline ontology it claims to settle
+
+Evidence:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D7-structural-enforcement-pipeline.md:32` requires D7 to define selector input/failure states, selected rule set, rule execution result, normalized diagnostic, baseline application result, `CheckReport` constructor, and renderer/stringifier.
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/design.md:22` says "Define check pipeline ownership and inputs from D2/D3/D5/D6/D10"; lines 24-26 are bullets, not a domain model, state model, transition model, or ownership contract.
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/specs/habitat-harness/spec.md:5` has one broad SHALL and two scenarios; it does not enumerate selector refusal, selected-empty, execution-not-run, adapter failure, baseline refusal, graph refusal, protected-zone refusal, advisory-only, rendering, or exit-status derivation.
+- Current implementation evidence shows why this must be explicit: `createCheckReport` in `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts:273` through `:342` currently performs selection, staged filtering, rule execution, baseline load/application, integrity, report-row construction, and `ok` derivation inline.
+
+Required packet repair:
+
+D7 must replace the incomplete packet with a closed target state model and transition contract. The complete repair defines these D7-owned stages and their exact inputs/outputs:
+
+- `SelectorRequest`
+- `RuleSelectionResult`
+- `SelectorRefusal`
+- `SelectedRuleSet`
+- `StructuralCheckDependencyAvailability`
+- `RuleExecutionPlan`
+- `RuleExecutionObservation`
+- `DiagnosticProjectionInput`
+- `NormalizedRuleDiagnostic`
+- `BaselineApplicationOutcome`
+- `RuleReportConstructionResult`
+- `CheckReportConstructionResult`
+- `RenderedCheckReport`
+- `CheckExitDecision`
+
+Each stage must state its single owner, accepted upstream projections, refusal/failure states, non-claims, and transition rules. The packet must make impossible the current broad "do everything in `createCheckReport`" shape without merely splitting by file size.
+
+### P1: D7 does not specify how it consumes adjacent domain authority, so it leaves owner confusion and local recomputation routes open
+
+Evidence:
+
+- D2 defines consumer projections and forbids passing whole registry records: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d2-rule-registry-metadata-contract/design.md:180` through `:195`.
+- D3 owns graph read status, target availability, and graph refusals; `command-engine.ts` may not hard-code project targets or verify affected targets outside the graph module after D3: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d3-workspace-graph-boundary/design.md:50` through `:85`.
+- D5 says D7 consumes `BaselineApplicationResult`, `BaselineIntegrityResult`, and D5 command diagnostics, and may not load untyped baseline internals after D5 publishes target results: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d5-baseline-authority/design.md:164` through `:172`.
+- D6 says D7 receives `DiagnosticRunOutcome`, finding projections, and adapter failure projections, and must not infer raw Grit internals or pattern/apply authority: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d6-diagnostic-pattern-catalog/design.md:441` through `:450`.
+- D7 design says "inputs from D2/D3/D5/D6/D10" at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/design.md:24`, without naming the projections, availability/refusal states, or protected owner boundaries.
+- Current code evidence shows the hazardous local-authority pattern: `command-engine.ts:281` loads baseline state directly, `:285` applies it directly, `:315` checks integrity directly, and `:423` through `:438` invokes Grit from selected whole rules. `generated-zones.ts:17` through `:37` has a local generated-zone table, while D2/D10 require protected-zone authority to be consumed through explicit contracts.
+
+Required packet repair:
+
+D7 must include a dependency-consumption matrix with exact accepted inputs and refused inputs:
+
+- D2: consume `ruleSelectorFacts`, `ruleReportFacts`, `ruleExecutionFacts`, and the D2-owned metadata projections D7 is allowed to see.
+- D3: consume graph target/check invocation availability and graph refusal projections; do not derive graph truth from local arrays, colon strings, or Nx output text.
+- D5: consume `BaselineApplicationResult`, `BaselineIntegrityResult`, and D5 diagnostic/refusal projections.
+- D6: consume `DiagnosticRunOutcome` and `DiagnosticConsumerProjection` variants; adapter failures must become failed/refused report rows, never pass.
+- D10/G-HOST: consume protected-zone guard/refusal results; do not define protected-zone policy or generated-zone authority locally.
+
+The packet must state that D7 owns aggregation and report-row construction, not the upstream truth of registry, graph, baseline, diagnostic acquisition, or protected-zone policy.
+
+### P1: False-green state coverage is incomplete, especially not-run/dropped execution paths and unavailable dependency states
+
+Evidence:
+
+- The source packet says D7 must avoid selector failures, baseline/Grit leakage, and `CheckReport.ok` contradictions; stop conditions include selector failures indistinguishable from rule failures and baseline/Grit internals leaking into enforcement stages: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D7-structural-enforcement-pipeline.md:90` through `:96`.
+- D6 explicitly states adapter failure can never produce a structural pass: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d6-diagnostic-pattern-catalog/design.md:336` through `:347`.
+- D3 explicitly rejects no-op wrappers and missing dependency resolution as runnable target success: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d3-workspace-graph-boundary/design.md:11` through `:13`, and defines graph refusal states at `:154` through `:165`.
+- Current D7-relevant code can drop staged Grit execution: `rulesForExecution` filters Grit rules in staged mode when there are no staged Grit roots at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts:398` through `:409`; `createCheckReport` then derives `ok` from emitted report rows at `:336` through `:342`.
+- D7 spec says unavailable inputs report "blocked or failed state" at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/specs/habitat-harness/spec.md:11` through `:13`; it does not define which unavailable states are blocked, failed, refused, skipped, advisory-only, or non-claim-bearing.
+
+Required packet repair:
+
+D7 must define a closed `RuleExecutionObservation` / `RuleExecutionDisposition` model that distinguishes:
+
+- `executed-clean`
+- `executed-findings`
+- `execution-failed`
+- `dependency-unavailable`
+- `selector-refused`
+- `diagnostic-adapter-failed`
+- `diagnostic-scan-refused`
+- `graph-refused`
+- `baseline-refused`
+- `protected-zone-refused`
+- `not-run-not-applicable`
+- `not-run-due-to-staged-scope`
+- `not-run-due-to-upstream-refusal`
+
+Explicitly modeled non-applicability may avoid failure, and it must carry a report row/non-claim when the user selected that rule/tool/owner. A selected rule disappearing from the selected rule set or execution plan must be impossible unless D7 emits a named skipped/refused report state with exit-status semantics.
+
+### P2: `CheckReport`, renderer, and exit status derivation are not treated as one truth-preserving contract
+
+Evidence:
+
+- D1 says `CheckReport` is selected rules, rule statuses, diagnostics, and baseline/check command outcome, not a receipt or current-tree proof: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d1-receipt-contract-boundary/design.md:20`.
+- D1 requires `CheckReport.ok` to be derived from rule statuses or for validation to reject contradictions: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d1-receipt-contract-boundary/design.md:177`.
+- Current structural validation checks shape, not `ok`/rule-status consistency: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/diagnostics.ts:44` through `:66`.
+- Current command exit derives from `report.ok`: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/commands/check.ts:46` through `:53`.
+- Current human renderer derives its summary from `report.ok`, `fail` rows, and advisory rows: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/rules/messages.ts:27` through `:39`.
+- D7 source packet requires preserving human and JSON output truth equivalence at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D7-structural-enforcement-pipeline.md:63`.
+
+Required packet repair:
+
+D7 must define one `CheckReportConstructionResult` that derives:
+
+- every `RuleReport.status`;
+- `CheckReport.ok`;
+- renderer summary facts;
+- JSON report facts;
+- `CheckExitDecision`.
+
+The renderer/stringifier should consume the constructed report, but may not invent status, suppress refusal states, or derive a divergent command outcome. Validation must include semantic consistency, not just field shape.
+
+### P2: D7 names "failure/refusal states" but does not define selector request/result/refusal identity or selected-rule-set identity
+
+Evidence:
+
+- Current selector model exists in code as `RuleSelection`, `RuleSelectionResult`, `RuleSelectorFact`, and `RuleSelectionFailureReason` at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts:34` through `:68`.
+- Current selector failures are encoded as a synthetic rule report with `ruleId: "rule-selection-integrity"` at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts:569` through `:603`.
+- D2 defines selector facts as a projection and says selector failures must not become zero executed rules: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d2-rule-registry-metadata-contract/design.md:184`.
+- D7 design does not mention selector vocabulary, selector fact identity, selected-rule-set identity, synthetic report-row policy, or whether selector refusal is a rule report, command refusal, or check report construction refusal.
+
+Required packet repair:
+
+D7 must define:
+
+- `SelectorRequest`: user intent over `owner`, `rule`, `tool`, and later staged/command scope when relevant.
+- `RuleSelectorFact`: D2-owned projection consumed by D7, not reconstructed from whole registry rows.
+- `RuleSelectionResult`: accepted selected set or `SelectorRefusal`.
+- `SelectedRuleSet`: stable identity containing selected rule ids plus the selector facts that produced them.
+- `SelectorRefusalReport`: explicit D7 report construction for unknown selector, wrong namespace, and empty intersection.
+
+The packet must decide whether selector refusals are represented as a synthetic `RuleReport`, a command-level refusal row, or a new check outcome. Current synthetic row may be preserved for D0/D1 compatibility, but target meaning cannot remain implicit.
+
+### P3: D7 validation gates are too broad and do not falsify the ontology failures above
+
+Evidence:
+
+- D7 tasks list `test/commands/habitat-commands.test.ts`, broad `habitat check --json`, OpenSpec validation, and `git diff --check`: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/tasks.md:18` through `:24`.
+- The D7 source packet required rule selection tests, CheckReport schema tests, clean/failing/advisory/selector-failure/staged command behavior, baseline integrity current-tree check, and injected violation proof: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D7-structural-enforcement-pipeline.md:72` through `:84`.
+- D5 explicitly says `habitat check --rule baseline-integrity --json` is the D5 command outcome and broad `habitat check --json` cannot replace it: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d5-baseline-authority/design.md:234` through `:239`.
+
+Required packet repair:
+
+The D7 packet should replace broad validation with falsifying gates for each state family: selector refusal, empty selected set, diagnostic adapter failure, D6 scan-root refusal, baseline application refusal, baseline integrity refusal, graph refusal, protected-zone refusal, advisory-only, staged not-applicable, renderer/JSON equivalence, and exit-status derivation.
+
+## Proposed Accepted D7 Ontology Vocabulary
+
+Use these as target D7 language:
+
+- `StructuralCheckRequest`: the requested check operation, including command invocation context and selector request.
+- `SelectorRequest`: user selector intent over owner/rule/tool and check scope.
+- `RuleSelectorFact`: D2-owned selector projection consumed by D7.
+- `RuleSelectionResult`: accepted selected rules or a selector refusal.
+- `SelectorRefusal`: unknown selector, wrong selector namespace, or empty selector intersection.
+- `SelectedRuleSet`: accepted rule ids and selector facts; not whole registry rows.
+- `StructuralCheckDependencyAvailability`: availability/refusal of D2, D3, D5, D6, and D10 inputs for this check.
+- `RuleExecutionPlan`: the D7-owned plan for which selected rules will execute and which upstream projections each rule requires.
+- `RuleExecutionObservation`: D7 observation of executed, failed, refused, skipped, or not-applicable rule execution.
+- `DiagnosticProjectionInput`: D6-owned diagnostic run outcome or native/wrapped diagnostic output ready for D7 aggregation.
+- `NormalizedRuleDiagnostic`: report-ready diagnostic after D6 projection and before/after D5 baseline application, with D5 baseline state explicit.
+- `BaselineApplicationOutcome`: D5-owned result consumed by D7 for one rule.
+- `ReportRowInput`: D7 aggregation input combining rule report facts, execution observation, diagnostic projection, baseline application, and dependency availability.
+- `RuleReportConstructionResult`: pass/fail/advisory/refused/skipped row construction with diagnostics and non-claims.
+- `CheckReportConstructionResult`: constructed `CheckReport` plus semantic consistency proof inputs.
+- `RenderedCheckReport`: JSON/human output projection from the same constructed report.
+- `CheckExitDecision`: exit code derived from `CheckReportConstructionResult`, never independently from renderer text.
+
+## Rejected Terms Or Usages
+
+- `pipeline ownership and inputs` as a substitute for a state model.
+- `failure/refusal states` without closed reason values and owner.
+- `result aggregation` without named aggregation inputs and output invariants.
+- `baseline decision` without `BaselineApplicationResult`, `BaselineIntegrityResult`, `BaselineExpansionDecision`, or `BaselineAuthorityProjection`.
+- `Grit result` as D7 input when the correct D7 input is D6 `DiagnosticRunOutcome` or `DiagnosticConsumerProjection`.
+- `graph facts` without D3 availability/refusal state.
+- `generated-zone guard` as D7-owned policy; D7 consumes D10/G-HOST guard/refusal results.
+- `rule execution result` when it conflates process exit, diagnostic projection, adapter failure, and rule report status.
+- `selected rules` if it means whole `HarnessRule` rows rather than D2 projections and selected rule ids.
+- `skip`, `silent skip`, `not applicable`, or `no staged roots` unless modeled as an explicit D7 execution disposition with report and exit semantics.
+- `CheckReport.ok` as a settable boolean; it must be derived or semantically validated.
+- `proof` / `evidence` as D7 target language except compatibility citations classified by D0/D1.
+
+## Stop-Condition Assessment
+
+D7 remains ambiguous in domain model, naming, scenario coverage, and artifact structure. The current D7 OpenSpec packet does not yet settle the Structural Enforcement Pipeline; it leaves the implementation agent to invent the core ontology while editing `command-engine.ts`. That is blocking.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-final-code-topology-cross-domino-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-final-code-topology-cross-domino-review.md
@@ -1,0 +1,73 @@
+Status: ACCEPTED
+
+## Review Scope
+
+Final D7 code-topology/cross-domino rereview of the repaired packet at `$D7_CHANGE`.
+This review is design/specification-only. It does not approve source implementation.
+
+Inputs read:
+
+- Required skills: Domain Design, Information Design, Solution Design, TypeScript Refactoring, and all TypeScript refactoring references.
+- Repaired D7 packet: `proposal.md`, `design.md`, `specs/habitat-harness/spec.md`, `tasks.md`, and workstream ledgers.
+- Shared context: `$REMEDIATION_DIR/context.md`.
+- Current topology: `$HABITAT_TOOL/src/lib/command-engine.ts`, `$HABITAT_TOOL/src/lib/diagnostics.ts`, `$HABITAT_TOOL/src/rules/messages.ts`, `$HABITAT_TOOL/src/commands/check.ts`, `$HABITAT_TOOL/src/commands/verify.ts`, `$HABITAT_TOOL/src/rules/architecture.ts`, `$HABITAT_TOOL/src/plugin.js`, and packet-referenced tests.
+- First-wave D7 code/topology and cross-domino scratch files as negative-control input only.
+
+## Decision
+
+No unresolved P1/P2 remain for D7 design/specification acceptance from current code topology, vendor/native behavior, or cross-domino dependency standpoint.
+
+The repaired packet is acceptable because it no longer asks implementation to discover the core structural pipeline. It now records the live current-state inventory, the D7-owned state model, consumed upstream projections, public-surface blockers, downstream D11/D12 projections, write set/protected paths, and falsifying validation gates with enough precision to prevent broad source movement or adjacent-domain reownership.
+
+## Evidence
+
+Current live topology matches the repaired inventory:
+
+- `CheckOptions`, selector state, report orchestration, baseline/Grit/native execution, and final `ok` derivation currently sit inside `createCheckReport` in `$HABITAT_TOOL/src/lib/command-engine.ts` lines 219-343. D7 records this in `design.md` Current Enforcement Inventory and treats it as the state space to collapse, not as target authority.
+- `validateCheckReport` is shape-only in `$HABITAT_TOOL/src/lib/diagnostics.ts` lines 44-66. D7 now explicitly requires construction/semantic rejection for `ok`/status contradictions in `design.md` lines 177-190 and `spec.md` lines 139-154.
+- `habitat check` still forwards flags into `createCheckReport` and exits from `report.ok` in `$HABITAT_TOOL/src/commands/check.ts` lines 36-53. D7 captures this as public command behavior requiring D0 rows before source changes.
+- `verify` still derives affected execution from raw `report.ok` in `$HABITAT_TOOL/src/commands/verify.ts` lines 29-64. D7 now publishes `VerifyCheckSummaryProjection` instead of leaving D12 to infer semantics from `CheckReport`.
+- Nx alias targets use `node -e ""` plus `dependsOn` in `$HABITAT_TOOL/src/plugin.js` lines 190-238. D7 now scopes D3 consumption to check-related Nx invocation surfaces and false-green alias prevention, not direct `habitat check` report truth.
+
+The write/protected set is concrete enough:
+
+- `design.md` lines 246-264 limits the design packet write set and later implementation areas.
+- `design.md` lines 266-276 protects baseline, registry, Grit, generated-zone, plugin, `.grit`, generated artifact, lockfile, and non-Habitat product domains.
+- `tasks.md` lines 17-33 blocks source implementation on D0/D1/D2/D3/D5/D6/D10 prerequisites before deleting current coupling.
+
+Cross-domino dependencies are precise enough:
+
+- `design.md` lines 33-45 assigns D0/D1/D2/D3/D5/D6/D10/D11/D12 owners and D7 use.
+- `design.md` lines 87-95 records the consumed contract matrix and the adjacent-domain actions D7 must not perform.
+- `spec.md` lines 3-31 normatively requires upstream projection consumption without recomputing registry, graph, baseline, diagnostic, or protected-zone authority.
+- `spec.md` lines 203-216 blocks public-surface changes until concrete D0 rows exist and touched rows are no longer `blocked-pending-d0-row`.
+
+D11/D12 handoffs are no longer dependent on current JSON/human parsing:
+
+- `design.md` lines 214-244 defines `LocalFeedbackCheckProjection` and `VerifyCheckSummaryProjection`.
+- `spec.md` lines 175-201 requires D11 and D12 to consume those projections and preserves non-claims/skip behavior.
+- The downstream ledger records D11/D12 consumer actions and prevents inference from current raw JSON/human output.
+
+The validation matrix falsifies the live risks it claims to cover:
+
+- `design.md` lines 278-298 includes current selector tests, entrypoint tests, enforcement-surface tests, baseline tests, Grit adapter/probe/native tests, plus new D7 report, lane, render, protected-zone, D11, and D12 projection tests.
+- The matrix explicitly records current red/drift facts for command help and inventory as repair/disposition prerequisites instead of treating them as green source proof.
+- The packet correctly rejects `bun run habitat:check -- --json --rule baseline-integrity` as a current valid gate because `baseline-integrity` is a built-in row today, not a selectable rule.
+
+Design-time validation run in this review:
+
+- `bun run openspec -- validate deep-habitat-d7-structural-enforcement-pipeline --strict` exited 0.
+- `bun run openspec:validate` exited 0, 249/249 passed.
+- `git diff --check` exited 0.
+
+## P3 Polish
+
+- `spec.md` D12 blocking scenario names `diagnostic-refused`, `baseline-refused`, and `protected-zone-refused` alongside `dependency-refused`; the state model represents those through diagnostic/baseline/D10 dispositions and dependency/refusal projections. This is acceptable, but later implementation docs could make that projection mapping explicit in one sentence.
+- `tasks.md` validation items remain unchecked even after this rereview ran the design-time gates. That is consistent with the packet's closure process, but the owner who updates packet index/closure records should record the validation results rather than infer them from this scratch file.
+
+## Non-Claims
+
+- This review does not approve source implementation.
+- This review does not prove current-tree structural cleanliness.
+- This review does not prove CI, runtime/product behavior, apply safety, Graphite readiness, OpenSpec acceptance for downstream packets, or D10 protected-zone closure.
+- D7 implementation remains blocked until concrete D0 rows, D1 output-family handling, live D2/D3/D5/D6 projections, and accepted D10 guard/refusal contracts exist wherever touched.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-final-domain-ontology-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-final-domain-ontology-review.md
@@ -1,0 +1,87 @@
+Status: ACCEPTED
+
+# D7 Final Domain/Ontology Review
+
+Final rereview scope: design/specification acceptance only for
+`$D7_CHANGE` after the repaired disk state. I treated the first-wave D7
+domain/ontology and cross-domino scratch files as negative-control inputs only,
+not authority.
+
+## Acceptance Finding
+
+No unresolved P1/P2 domain or ontology blockers remain for D7
+design/specification acceptance.
+
+D7 now has a coherent bounded-context role: Structural Enforcement owns the
+composition of accepted upstream projections into a finalized `habitat check`
+outcome, public `CheckReport`, rendering, and exit decision. It explicitly does
+not own public-surface classification, receipt semantics, rule registry
+metadata, graph truth, baseline authority, diagnostic acquisition, protected
+zone policy, hook sequencing, or verify handoff receipt schema
+(`proposal.md` lines 5-13, 55-69; `design.md` lines 5-15, 33-45).
+
+The repaired ontology is complete enough to prevent implementation agents from
+inventing the core domain while editing source code. `design.md` defines the
+accepted D7 terms for request normalization, selector outcomes, dependency
+availability, execution disposition, diagnostic consumption, baseline
+application, structural rule outcome, report construction, check outcome, and
+D11/D12 projections (`design.md` lines 47-68). The closed state sketch and
+construction rules make the important false-green states explicit: selector
+refusal cannot enter execution planning, selected rules cannot disappear without
+not-applicable/refused disposition, findings variants are non-empty,
+`CheckReport.ok` is derived, and covered diagnostics remain visible
+(`design.md` lines 97-155).
+
+The rejected language is strong enough for design/specification acceptance.
+It blocks generic "result" language where it conflates process exit,
+diagnostic projection, adapter failure, report status, and baseline result;
+blocks whole mutable `HarnessRule` rows as selected-rule meaning; blocks raw
+`Grit result`; blocks unqualified `graph facts`; blocks D7-owned generated-zone
+policy; blocks silent skip; and blocks free settable `CheckReport.ok`
+(`design.md` lines 70-85). This directly repairs the first-wave naming failure.
+
+The adjacent-domain contracts are now consumed as projections/refusals rather
+than recomputed locally. The consumed-contract matrix says D7 consumes D2
+selector/report/execution/baseline/Grit/generated-zone facts, D3 availability
+and `GraphRefusal`, D5 baseline application/integrity results, D6 diagnostic
+outcomes/projections, and D10 guard accepted/refused states, while forbidding
+whole registry authority, local graph truth, local baseline policy, raw Grit
+parsing, and local protected-zone policy (`design.md` lines 87-95). The same
+boundary is repeated normatively in the spec (`specs/habitat-harness/spec.md`
+lines 3-31).
+
+D11 and D12 output contracts are precise enough and do not overclaim. D11 gets
+`LocalFeedbackCheckProjection` with local-feedback-only non-claims and is barred
+from parsing human output for semantics (`design.md` lines 214-228;
+`specs/habitat-harness/spec.md` lines 175-187). D12 gets
+`VerifyCheckSummaryProjection` with requested selectors, selected real/built-in
+ids, status/refusal/not-applicable counts, an `allowsAffectedExecution` signal
+derived from `CheckOutcome`, skipped-affected reason, and bounded non-claims
+(`design.md` lines 230-244; `specs/habitat-harness/spec.md` lines 189-201).
+The downstream ledger preserves the same ownership split for D11/D12 and
+prevents them from inferring check semantics from current raw JSON or human
+output (`workstream/downstream-realignment-ledger.md` lines 17-18).
+
+Implementation remains correctly blocked behind concrete D0 rows, D1
+output-family handling, live D2/D3/D5/D6 projections, and accepted D10 guard
+contracts where those surfaces are touched (`proposal.md` lines 71-81;
+`tasks.md` lines 17-33; `workstream/phase-record.md` lines 40-50). Those are
+source implementation prerequisites, not unresolved design/ontology blockers
+for this acceptance lane.
+
+## P3 Polish
+
+- Align refusal naming between the core `CheckOutcome` model and downstream
+  projection prose before implementation. `CheckOutcome` currently groups
+  owner-specific refusals under `dependency-refused` (`design.md` lines
+  135-141), while D11/D12 projection text names `diagnostic-unavailable`,
+  `baseline-refused`, `protected-zone-refused`, and `diagnostic-refused`
+  separately (`design.md` lines 216-220; `specs/habitat-harness/spec.md` lines
+  198-200). This is not blocking because the design already carries owner and
+  refusal reason through dependency/refusal states, but tightening the naming
+  would reduce translation ambiguity for implementation.
+
+## Validation Notes
+
+- `bun run openspec -- validate deep-habitat-d7-structural-enforcement-pipeline --strict` passed.
+- `git diff --check` passed.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-final-openspec-information-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-final-openspec-information-review.md
@@ -1,0 +1,68 @@
+Status: ACCEPTED
+
+# D7 Final OpenSpec / Information Review
+
+## Scope
+
+Reviewed the repaired D7 packet at `$D7_CHANGE` for design/specification acceptance from the OpenSpec and information-design standpoint only:
+
+- `proposal.md`
+- `design.md`
+- `specs/habitat-harness/spec.md`
+- `tasks.md`
+- `workstream/phase-record.md`
+- `workstream/review-disposition-ledger.md`
+- `workstream/downstream-realignment-ledger.md`
+- `workstream/closure-checklist.md`
+
+I also read the first-wave D7 OpenSpec/information investigation as negative-control input, not authority.
+
+## Acceptance Decision
+
+No unresolved P1/P2 remain for D7 design/specification acceptance from the OpenSpec/information-design lane.
+
+The repaired packet is now executable by a later implementation agent without requiring that agent to decide domain/product trade-offs during implementation. It does not claim source implementation is complete, and it correctly blocks source work behind concrete D0 rows, D1 output-family handling, live D2/D3/D5/D6 projections, and accepted/live D10 protected-zone guard results where those surfaces are touched.
+
+## Evidence
+
+- `proposal.md` now frames D7 as the Structural Enforcement owner for check outcome/report/rendering/exit decisions, while preserving upstream ownership boundaries and source blockers.
+- `design.md` contains the missing implementation-control information: current enforcement inventory, D7/domain owner map, target ontology, rejected terms, consumed-contract matrix, closed target state model, pipeline stages, false-green invariant matrix, D0 public-surface compatibility inventory, D11/D12 consumer contracts, write set/protected paths, validation matrix, and refactor sequence.
+- `specs/habitat-harness/spec.md` now has falsifiable requirements and scenarios for projection consumption, selector refusal, execution disposition, diagnostic failure, baseline preservation/refusal, lane/status derivation, semantic `CheckReport` validation, rendering truth, D11/D12 projections, and D0 blocker behavior.
+- `tasks.md` now separates packet-readiness work, source prerequisites, characterization, state-model introduction, pipeline migration, consumer projections, validation, downstream realignment, and closure. The remaining unchecked tasks are implementation or final-review workflow tasks, not unresolved design questions.
+- The workstream ledgers are no longer stale control records. They record repaired first-wave findings, source blockers, downstream consumed/provided contracts, design-time validation state, non-claims, and closure gates.
+
+## Design-Time / Implementation-Time Split
+
+The split is now correct:
+
+- Design/spec acceptance is about the packet being coherent and implementation-ready.
+- Source implementation remains explicitly blocked until prerequisite concrete inputs exist.
+- Current red source tests and missing live dependency projections are treated as implementation closure blockers, not as reasons to reject the repaired design packet.
+- `blocked-pending-d0-row` is used as a stop condition for source edits, not as an unresolved design placeholder.
+
+## Validation Run
+
+Design-time checks passed from the repaired worktree:
+
+- `bun run openspec -- validate deep-habitat-d7-structural-enforcement-pipeline --strict`: passed.
+- `bun run openspec:validate`: passed, 249 items valid.
+- `git diff --check`: passed.
+
+Shortcut/complete-standard wording scan found only provenance or explicit rejected-language/blocked-state usage:
+
+- negative-control scratch says the old packet lacked executable information architecture;
+- review ledger records that finding as repaired pending rereview;
+- proposal/tasks say the incomplete packet was replaced;
+- downstream/phase records mention downstream D10 draft/blocking status;
+- design rejects `silent skip` as target language.
+
+None of these hits authorize reduced-standard implementation strategy or generated-output hand editing.
+
+## P3 Polish
+
+- `design.md` names `RuleExecutionPlan` in the ontology and pipeline stages but does not include a separate pseudocode type for it in the target state-model code block. This is acceptable because the stage contract, selected-rule requirement, and `RuleExecutionDisposition` union are explicit, but a later cleanup could add a small `RuleExecutionPlan` pseudotype for symmetry.
+- The phase record and closure checklist should be updated by the workstream owner after the remaining final rereview lanes complete, so this lane's accepted status is reflected alongside domain/ontology, TypeScript/validation, and code/topology/cross-domino results.
+
+## Final OpenSpec / Information Finding
+
+ACCEPTED for design/specification from this lane. No P1/P2 OpenSpec or information-design blockers remain.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-final-typescript-validation-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-final-typescript-validation-review.md
@@ -1,0 +1,52 @@
+Status: ACCEPTED
+
+# D7 Final TypeScript/Validation Review
+
+No unresolved P1/P2 remain for D7 design/specification acceptance from a TypeScript state-space and validation standpoint.
+
+This acceptance is design/specification-only. It does not approve source implementation. D7 source work remains blocked behind the prerequisites already stated in the packet: concrete D0 public-surface rows, D1-compatible output-family handling, live D2/D3/D5/D6 projections where consumed, and accepted D10 protected-zone guard/refusal contracts where protected-zone outcomes are implemented.
+
+## Acceptance Basis
+
+The repaired packet now gives implementation agents enough closed state and validation structure to collapse the current `createCheckReport` option/result/status soup without deciding product/domain policy while coding.
+
+- `$D7_CHANGE/design.md` section `Target State Model` defines discriminated state families for `StructuralCheckRequest`, `RuleSelectionOutcome`, `RuleExecutionDisposition`, `DiagnosticConsumptionOutcome`, `BaselineApplicationOutcome`, `StructuralRuleOutcome`, and `CheckOutcome`.
+- `$D7_CHANGE/design.md` section `Target State Model` uses `NonEmptyReadonlyArray<T>` for selected rule sets, findings, advisory findings, refusals, failing reports, and refusal reports where emptiness would create false-green ambiguity.
+- `$D7_CHANGE/design.md` section `Construction rules` explicitly forbids free internal `CheckReport.ok`, derives public `ok` from `CheckOutcome`, preserves covered diagnostics, and gives nonzero exit semantics for selector/dependency/enforced-failure outcomes.
+- `$D7_CHANGE/specs/habitat-harness/spec.md` requirements `Selector Outcomes Are Closed Before Execution`, `Execution Dispositions Cannot Disappear`, `Diagnostic Failures Cannot Become Pass`, `Baseline Application Preserves Diagnostics`, `Lane And Status Derivation Is Centralized`, and `CheckReport Is Derived Or Semantically Rejected` provide normative scenarios for the key illegal states.
+- `$D7_CHANGE/design.md` section `Public Surface Compatibility Inventory` and `$D7_CHANGE/specs/habitat-harness/spec.md` requirement `Public Surface Changes Wait For D0 Rows` correctly name public DTO/export/command/hook/verify/Nx/docs compatibility traps behind D0/D1 blockers instead of treating them as internal-only refactors.
+
+## False-Green Coverage
+
+The validation matrix is now falsifying enough for design/spec acceptance.
+
+- Selector refusal: covered by `$D7_CHANGE/specs/habitat-harness/spec.md` requirement `Selector Outcomes Are Closed Before Execution` and `$D7_CHANGE/design.md` gate `D7-SELECTOR`.
+- Dependency unavailable / graph false green: covered by `$D7_CHANGE/design.md` sections `Consumed Contract Matrix`, `False-Green Invariant Matrix`, and validation gate `D7-COMMAND-CURRENT`/D3 dependency notes.
+- Adapter failure: covered by `$D7_CHANGE/specs/habitat-harness/spec.md` requirement `Diagnostic Failures Cannot Become Pass` and `$D7_CHANGE/design.md` gate `D7-DIAGNOSTIC`.
+- Baseline covered/uncovered/refused: covered by `$D7_CHANGE/specs/habitat-harness/spec.md` requirement `Baseline Application Preserves Diagnostics` and `$D7_CHANGE/design.md` gate `D7-BASELINE`.
+- Advisory lane: covered by `$D7_CHANGE/specs/habitat-harness/spec.md` requirement `Lane And Status Derivation Is Centralized` and `$D7_CHANGE/design.md` gate `D7-LANE`.
+- Staged not-applicable: covered by `$D7_CHANGE/specs/habitat-harness/spec.md` requirement `Execution Dispositions Cannot Disappear`.
+- Protected-zone refusal: covered as D10-owned consumption in `$D7_CHANGE/specs/habitat-harness/spec.md` requirement `Structural Enforcement Consumes Upstream Projections Only`, `$D7_CHANGE/design.md` consumed contract matrix, and validation gate `D7-PROTECTED`.
+- Rendering and exit semantics: covered by `$D7_CHANGE/specs/habitat-harness/spec.md` requirement `Rendering Preserves Structured Truth`, `$D7_CHANGE/design.md` pipeline stages 7-9, and validation gate `D7-RENDER`.
+
+## Negative-Control Findings Disposition
+
+The first-wave TypeScript and validation scratch records remain useful as negative controls, but their design/spec blockers are repaired on disk.
+
+- The previous missing concrete state families are addressed by `$D7_CHANGE/design.md` section `Target State Model`.
+- The previous missing semantic report constructor/validator oracle is addressed by `$D7_CHANGE/specs/habitat-harness/spec.md` requirement `CheckReport Is Derived Or Semantically Rejected` and `$D7_CHANGE/design.md` gate `D7-REPORT-SEMANTIC`.
+- The previous invalid `--rule baseline-integrity` proof is corrected in `$D7_CHANGE/proposal.md` section `Verification Gates`, `$D7_CHANGE/design.md` section `Validation Matrix`, and `$D7_CHANGE/specs/habitat-harness/spec.md` scenario `Built-in baseline integrity is reported`.
+- The previous generic public compatibility blocker is now a concrete placeholder inventory in `$D7_CHANGE/design.md` section `Public Surface Compatibility Inventory`; source implementation remains blocked while rows are `blocked-pending-d0-row`.
+
+## Validation Run
+
+- `bun run openspec -- validate deep-habitat-d7-structural-enforcement-pipeline --strict`: passed.
+- `bun run openspec:validate`: passed, 249 items passed and 0 failed.
+- `git diff --check`: passed.
+
+## P3 Polish
+
+- `$D7_CHANGE/design.md` validation gate `D7-COMMAND-CURRENT` is necessarily broad because exact command cases depend on later implementation slices. This is acceptable for design/spec acceptance because the focused falsifying gates above name the actual state families, but implementation should split that gate into concrete per-surface tests as soon as the first source slice exists.
+- `$D7_CHANGE/workstream/closure-checklist.md` still shows final rereview lanes and packet-index update as pending. That is process state, not a D7 TypeScript/validation design blocker; update it only after all final lanes complete.
+
+Skills used: domain-design, information-design, solution-design, testing-design, typescript-refactoring.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-openspec-information-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-openspec-information-investigation.md
@@ -1,0 +1,227 @@
+# D7 OpenSpec / Information Design Investigation
+
+Status: BLOCKING
+
+## Review Frame
+
+This is a fresh adversarial review of:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D7-structural-enforcement-pipeline.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/`
+
+I treated prior agent findings as non-authoritative. The acceptance bar is whether the D7 OpenSpec packet leaves a later execution agent with no product/domain trade-off to invent. It does not.
+
+The current D7 packet has topic labels without executable information architecture. It names categories such as registry facts, graph facts, diagnostic projections, baselines, generated-zone guards, `CheckReport`, consumers, validation, and stop conditions without defining the state model, inventories, tables, scenarios, or artifact contracts that make those labels executable.
+
+## Blocking Findings
+
+### P1: `design.md` does not contain the current-state inventory required to refactor `createCheckReport`
+
+The source D7 packet explicitly requires current `CheckReport` field inventory, selector scenarios, and baseline/Grit consumer boundaries. The OpenSpec `design.md` does not inventory the current enforcement state at all. It never enumerates the current responsibilities mixed in `tools/habitat-harness/src/lib/command-engine.ts`: selector validation, selected rule set construction, staged Grit filtering, Grit/native/file-layer execution, baseline load/application, baseline integrity, status derivation, report construction, JSON validation, rendering, output writing, and verify consumption.
+
+Missing artifact contract: add a "Current Enforcement Inventory" table with columns for current symbol/path, current role, public/D0 surface impact, source authority today, target owner, target D7 stage, consumed upstream contract, false-green risk, and required deletion/migration. This must include at least `CheckOptions`, `RuleSelectionResult`, `rulesForExecution`, `executeSelectedRules`, `createRuleSelectionFailureReport`, `createCheckReport`, `RuleReport`, `CheckReport`, `validateCheckReport`, `renderCheckReport`, `stringifyCheckReport`, staged/file-layer behavior, and verify's current `createCheckReport` call.
+
+Without this table, an implementer must decide which existing shapes are compatibility facades, which are target names, and which code paths are deleted.
+
+### P1: D7 has no target state model for enforcement outcomes
+
+The D7 design says "Specify result aggregation and failure/refusal states" but does not specify them. There is no discriminated union or equivalent closed model for:
+
+- selector request, selector failure, empty selection, and selected rule set;
+- execution planning vs execution result;
+- skipped/staged/not-run rule states;
+- D6 diagnostic outcomes consumed by enforcement;
+- D5 baseline application and integrity outcomes consumed by enforcement;
+- D10 protected-zone guard outcomes consumed by enforcement;
+- D7-owned rule status derivation;
+- `CheckReport.ok` derivation;
+- command/report refusal state.
+
+This violates the TypeScript state-space bar. The current code already has an `ok: boolean` report field correlated by convention with rule statuses. D1 states that `CheckReport.ok` must be derived from rule statuses or validation must reject contradictions. D7 must define the constructor/validator contract that makes that impossible.
+
+Missing artifact contract: add a "Target Enforcement State Model" section with concrete type-shape pseudocode or tables. It needs `CheckRequest`, `RuleSelectionOutcome`, `RuleExecutionPlan`, `RuleExecutionOutcome`, `RuleAggregationInput`, `RuleAggregationOutcome`, `CheckReportConstructionResult`, and `CheckRenderRequest`. Each state needs selected-when conditions and forbidden combinations.
+
+### P1: consumed upstream contracts are named but not integrated
+
+The proposal lists D2/D3/D5/D6/D10 as inputs, but the packet never says exactly what D7 consumes from each or what D7 may not recompute.
+
+Required consumed-contract table is missing:
+
+| Upstream | D7 must consume | D7 must not do |
+| --- | --- | --- |
+| D2 | `ruleSelectorFacts`, `ruleReportFacts`, `ruleExecutionFacts`, `ruleBaselineFacts`, `ruleGritFacts`, `ruleGeneratedZoneFacts` as applicable | read whole `RuleRegistryRecord`/legacy `HarnessRule` as authority or parse prose `scope`, `detect`, `message`, `remediate` |
+| D3 | available target, aggregate target, dependency declaration, resolved dependency, graph refusal facts for check invocation surfaces | treat Nx wrapper exit 0 or `node -e ""` alias as structural success |
+| D5 | `BaselineApplicationResult`, `BaselineIntegrityResult`, D5 refusal reasons | load/apply baseline internals or decide shrink-only integrity locally |
+| D6 | `DiagnosticRunOutcome` or discriminated consumer projection with non-empty findings, adapter failure, projection miss, cache/freshness failure | consume raw Grit reports/process records or infer Pattern Governance/apply safety |
+| D10 | protected-zone guard decisions/refusals and recovery guidance | hard-code generated zones or downgrade protected-zone violations to advisory warnings |
+
+Without this table, D7 remains a broad orchestration bucket and implementers decide owner boundaries while coding.
+
+### P1: D0/D1 public-surface blockers are not actionable
+
+D7 says "Check JSON may change through D0 compatibility and D1 receipt/non-claim decisions" and "D0 compatibility disposition" is needed, but it does not list the specific D0 rows or row classes D7 must cite before source implementation.
+
+Missing artifact contract: add a public-surface compatibility inventory with one row per touched plane: `habitat check` flags/exit behavior, `--json` schemaVersion 1 report shape, invalid selector JSON/human behavior, `--output`, `--staged`, `--expand-baseline` interaction boundaries if touched, `CheckReport`/`RuleReport`/`HabitatDiagnostic`/`validateCheckReport` package exports, `renderCheckReport`/`stringifyCheckReport` exports, verify's check summary consumption, hook parse expectations, docs examples, and Nx `habitat:check`/`habitat:rule:*` surfaces where D3 projects invocation.
+
+D1-specific blockers are also missing: D7 must adopt the D1 distinction that `CheckReport` is check output, not receipt/proof; diagnostics are findings inside reports; refusals and recovery are explicit; canonical non-claims bound the report. The D7 packet does not list the D1 non-claims it inherits or the D1 bad case `ok: true` with a failing rule.
+
+### P1: D11/D12 consumer contracts are missing
+
+D7 claims it unblocks D11 and D12, but it does not define what they receive.
+
+Missing D11 contract: a hook-local projection for structural check outcome that distinguishes pass, fail, advisory-only, refused/blocked, malformed/unavailable diagnostic input, baseline refusal, protected-zone refusal, and non-claims. D11 must be able to consume this without parsing human output or recreating check semantics.
+
+Missing D12 contract: a verify-handoff projection that summarizes selected rules, selected real rules, built-in rules, status counts, advisory/failing counts, blocked/refused state, graph-related non-claims, and check-report validity without letting verify create new check authority. D12 must know whether a blocked upstream check prevents affected target execution and how to report skipped state.
+
+The current downstream ledger row "Later domino packets | pending" is not a consumer contract.
+
+### P1: spec delta is too thin to control implementation
+
+`specs/habitat-harness/spec.md` contains one requirement and two scenarios. It does not cover:
+
+- selector unknown, wrong namespace, empty intersection, and invalid selector human/JSON behavior;
+- selected rule set and no-rule/refused states;
+- clean enforced rule, failing enforced rule, advisory findings, and advisory-only check result;
+- D6 adapter failure, scan-root refusal, projection miss, unexpected identity, and cache-observation-missing;
+- D5 explicit-empty, explicit-debt, external-exception, baseline refusal, and baseline-integrity refusal handling;
+- D10 protected-zone refusal during staged check;
+- missing upstream authority/refusal states from D2/D3/D5/D6/D10;
+- `CheckReport.ok` contradiction rejection;
+- render/stringify truth equivalence;
+- D11/D12 consumer projection scenarios;
+- D0/D1 compatibility blocker scenarios.
+
+The current scenarios "all inputs are available" and "an input authority is unavailable" are too broad to falsify a wrong implementation.
+
+### P2: tasks remain design questions instead of implementation steps
+
+Tasks 2.1-2.3 are:
+
+- "Define check pipeline ownership and inputs from D2/D3/D5/D6/D10."
+- "Specify result aggregation and failure/refusal states."
+- "Separate enforcement result from orientation and receipts."
+
+These are the core design deliverables, not source implementation steps. Under the OpenSpec workstream contract, tasks must be implementation steps after design is resolved.
+
+Repair expectation: move design work into `design.md` and `spec.md`; rewrite tasks as ordered implementation slices with files, tests, deletion requirements, public-surface citations, and gates. Example task shape: "Introduce `RuleSelectionOutcome` from D2 `ruleSelectorFacts` in `<path>`; preserve invalid-selector JSON behavior covered by `<test>`; delete local selector namespace inference after projection tests pass."
+
+### P2: validation matrix is not falsifying enough
+
+The D7 proposal and phase record list green commands, but not expected statuses, bad cases, cache/freshness stance, proof oracle, non-claims, or which state each gate falsifies. The source packet required exact command behavior for clean, failing, advisory, selector failure, staged modes, baseline integrity current-tree check, representative injected violation proof, and cache stance.
+
+Missing artifact contract: a validation matrix with columns: gate id, command/test, expected status, states covered, required bad case, cache/freshness stance, D0/D1 surface covered, non-claims, and closure owner. It should include separate rows for invalid selector JSON/human, stale selector cannot pass as baseline-covered proof, baseline refusal, D6 adapter failure/projection miss, staged generated-zone violation, advisory-only result, report contradiction rejection, `renderCheckReport`/`stringifyCheckReport`, and D11/D12 projection consumers.
+
+### P2: workstream ledgers cannot support closure
+
+The D7 review ledger records global constraints and a pending per-domino gate. The downstream realignment ledger has generic `pending` rows. The closure checklist has unchecked generic statements that could be satisfied by headings rather than content.
+
+Missing ledger repairs:
+
+- Review ledger needs rows for this investigation's accepted/rejected findings and concrete repair evidence paths.
+- Downstream ledger needs named D0, D1, D2, D3, D5, D6, D10, D11, D12 rows with exact consumed/provided contract and patch/no-patch disposition.
+- Closure checklist must require current-state inventory, target state model, false-green invariant matrix, consumed contract matrix, D11/D12 projection contracts, validation matrix, task rewrite, and no unresolved P1/P2 review findings.
+
+## Wording That Lowers The Bar
+
+The following current wording delegates design to implementation:
+
+- `proposal.md`: "Define check pipeline ownership and inputs from D2/D3/D5/D6/D10." This says a design must happen later; it does not define the inputs.
+- `proposal.md`: "Specify result aggregation and failure/refusal states." This is the central D7 state model, currently an unresolved task.
+- `proposal.md`: "Check JSON may change through D0 compatibility and D1 receipt/non-claim decisions." This is true but insufficient; it lacks D0 row inventory and D1 non-claim adoption.
+- `design.md`: "Target Contract" repeats the proposal bullets without adding design content.
+- `design.md`: "Implementation Readiness" says the executor must have D0 disposition, write set, tests, and review findings, but the packet does not provide the D7-specific inventory needed to obtain them.
+- `design.md`: "Use standard engineering terms..." is generic. It does not choose D7's target ontology or dispose current terms like `RuleSelectionResult`, `CheckOptions`, `RuleReport`, `RuleStatus`, `baselined`, `locked`, `detect`, `message`, `remediate`, `VerifyProof`, and `proof`.
+- `tasks.md`: "Re-run or cite the required dependency gates" leaves dependency acceptance criteria open. D7 needs concrete accepted-design vs live-implementation blockers for each dependency.
+- `spec.md`: "aggregate typed registry, graph, diagnostic, baseline, and protected-zone decisions" hides the actual aggregation rules. "Reports blocked or failed state" leaves the blocked-vs-failed trade-off to implementation.
+
+## Proposed Information Architecture For The Rewrite
+
+### `proposal.md`
+
+1. Summary: D7 as Structural Enforcement report constructor and command outcome authority.
+2. Product scenario: check command returns reliable structural result without false-green paths.
+3. Authority and inputs: source D7 packet, remediation frame, accepted D0/D1/D2/D3/D5/D6, D10 status explicitly classified.
+4. What changes: exact D7-owned responsibilities.
+5. What does not change: registry, graph, diagnostic acquisition, baseline authority, protected-zone authority, hook local feedback, verify handoff.
+6. Requires/enables with accepted-design vs live-implementation blockers.
+7. Public-surface impact summary with pointer to detailed D0/D1 table in `design.md`.
+8. Stop conditions as false-green invariants, not generic prose.
+9. Validation gate summary with pointer to the full matrix.
+
+### `design.md`
+
+1. Frame and acceptance threshold.
+2. Current Enforcement Inventory.
+3. Domain boundary and single-authority owner map.
+4. Target ontology and term disposition.
+5. Consumed Contract Matrix for D2/D3/D5/D6/D10.
+6. Target Enforcement State Model with closed states.
+7. Pipeline stage design:
+   - request normalization;
+   - selector resolution;
+   - execution planning;
+   - diagnostic acquisition consumption;
+   - baseline application;
+   - protected-zone guard consumption;
+   - rule aggregation/status derivation;
+   - `CheckReport` construction/validation;
+   - rendering/stringifying;
+   - consumer projections.
+8. False-Green Invariant Matrix: impossible state, current risk, target prevention, test/gate.
+9. D0/D1 Public Surface Compatibility Blockers.
+10. D11/D12 Consumer Contracts.
+11. Implementation write set and protected paths.
+12. Safe refactor sequence: characterize -> introduce closed states -> facades -> migrate consumers -> delete invalid paths.
+13. Validation matrix with bad cases and non-claims.
+14. Rejected alternatives.
+
+### `specs/habitat-harness/spec.md`
+
+Split the single broad requirement into scenario-specific requirements:
+
+1. Structural Enforcement consumes named upstream projections.
+2. Selector outcomes are closed and cannot execute as rule results.
+3. Rule execution outcomes distinguish clean, findings, advisory, skipped, refused, and adapter-failed states.
+4. Baseline application and integrity are D5 results rendered by D7.
+5. Diagnostic acquisition failures cannot become pass.
+6. Protected-zone guard refusals cannot become advisory/pass.
+7. `CheckReport.ok` is derived or contradiction-rejected.
+8. Human/JSON rendering preserve the same truth.
+9. D11 consumes local-feedback-safe check projections.
+10. D12 consumes verify-handoff-safe check projections.
+11. Public surface changes wait for D0 rows and D1 non-claim/receipt boundaries.
+
+Each requirement needs concrete scenarios for the bad cases named in the source D7 packet.
+
+### `tasks.md`
+
+Tasks should become implementation slices, not design placeholders:
+
+1. Grounding and D0/D1/D2/D3/D5/D6/D10 live blocker citation.
+2. Characterization tests for current selector/report behavior.
+3. State model introduction.
+4. Selector projection migration.
+5. Diagnostic outcome consumption migration.
+6. Baseline result consumption migration.
+7. Protected-zone guard consumption migration.
+8. Report constructor and validator hardening.
+9. Renderer/stringifier truth equivalence.
+10. D11/D12 consumer projection additions.
+11. Deletion of local recomputation and substitute-authority paths.
+12. Validation and downstream realignment.
+
+### Workstream ledgers
+
+The phase record should name acceptance threshold, dependency status, write/protected paths, and validation matrix. The review ledger should track this review and repairs. The downstream ledger should have one row per upstream consumed contract and downstream consumer. The closure checklist should fail if any design table, scenario set, validation row, or ledger disposition is absent.
+
+## Stop Condition Applied
+
+An execution agent would still have to guess multiple product/domain trade-offs:
+
+- what exact D7 closed state model replaces the current boolean/optional report construction;
+- whether blocked upstream input is a failed rule, a refused check, a command failure, or a separate report state;
+- how to map every D5/D6/D10 failure family into `RuleReport.status`, diagnostics, and `CheckReport.ok`;
+- what D11 and D12 may consume without parsing the full check report;
+- which D0/D1 surfaces must be preserved, facaded, versioned, or refused before source edits.
+
+Therefore D7 is BLOCKING until those artifact contracts are written into the OpenSpec packet.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-testing-validation-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-testing-validation-investigation.md
@@ -1,0 +1,99 @@
+# D7 Testing/Validation Investigation
+
+Status: BLOCKING
+
+## Blocking Finding
+
+D7 should not proceed as acceptable input yet. The missing oracle is a semantic `CheckReport` constructor/validator that proves:
+
+- `CheckReport.ok === rules.every(rule.status !== "fail")`;
+- enforced unbaselined error diagnostics always produce `status: "fail"`;
+- advisory findings never make the whole report fail;
+- selector refusal reports cannot be represented as successful rule execution;
+- built-in report rows such as `baseline-integrity` are selectable or explicitly non-selectable with packet-compatible command proof.
+
+Current `validateCheckReport` validates field shape but not semantic consistency. A hand-built report with `ok: true` and a failing rule can still satisfy the schema validator, so false green states can survive unless every report is constructed through a trusted path and the constructor is itself tested adversarially.
+
+Additional current blockers from fresh command proof:
+
+- `bun run --cwd tools/habitat-harness test -- test/commands/habitat-entrypoints.test.ts test/lib/enforcement-surface.test.ts test/lib/rule-selection.test.ts` exits 1. Failures: `check --help` exits 2 for both root and dev runners; current rule inventory expects 31 `grit-check` rules but the registry has 32.
+- `bun run habitat:check -- --json --rule baseline-integrity` exits 1 with `rule-selection-integrity`. D5 lists `bun run habitat check --rule baseline-integrity --json` as baseline-integrity proof, but `baseline-integrity` is appended as a built-in row, not a registry-selectable rule.
+
+## Existing Test Inventory
+
+Command/public surface:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/commands/habitat-entrypoints.test.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/commands/habitat-commands.test.ts`
+
+Structural enforcement and selection:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/enforcement-surface.test.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/rule-selection.test.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/verify-proof.test.ts`
+
+Baseline authority:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/baseline.test.ts`
+
+Grit/vendor diagnostics:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/grit-adapter.test.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/grit-injected-probe.test.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/grit/grit-patterns.test.ts`
+
+Generated/protected and local feedback neighbors:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/hooks.test.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/scripts/verify-generated-zones.mjs`
+
+Graph/classification neighbors:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/classify.test.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/workspace-tools.test.ts`
+
+## D7 Validation Matrix
+
+| Scenario | Command/test | Expected status/output | Non-claim |
+|---|---|---|---|
+| Report invariant falsification | Add a unit test near `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/rule-selection.test.ts` or a new `check-report.test.ts` that constructs one report with `ok: true` plus a `fail` rule and one with `ok: false` plus only pass/advisory rules. | Current expected outcome: should fail today because `validateCheckReport` does not enforce semantic consistency. Required D7 outcome: constructor/validator rejects both contradictory reports before rendering. | Does not prove any rule diagnostic is correct; proves report-state consistency. |
+| Clean structural report | `bun run habitat:check -- --json --tool file-layer --staged` with no staged files. | Exit 0. JSON `ok: true`; all file-layer rules `status: "pass"`; `baseline-integrity` present and pass; no diagnostics. Observed fresh outcome matches this. | Does not prove current-tree Grit, Biome, Nx, wrapped tests, or generated freshness. |
+| Current failing enforced rule | `bun run habitat:check -- --json --rule workspace-entrypoints` | Exit 1 while current repo has the package-script sequencing violation. JSON `ok: false`; selected rule status `fail`; diagnostic severity `error`, `baselined: false`; `baseline-integrity` also present and pass. Observed fresh outcome matches this. | Does not prove the workspace-entrypoints rule is complete; proves enforced failure projects into report failure. |
+| Advisory findings | Add or run command proof with an advisory rule that emits diagnostics, e.g. `bun run habitat:check -- --json --rule docs-local-checkout-paths` if current tree has advisory findings, or a unit-injected advisory rule if current tree is clean. | Exit 0 when only advisory findings exist. JSON `ok: true`; advisory rule `status: "advisory-findings"`; diagnostics severity `advisory`; human output must not label command as FAIL. | Does not prove advisory content is correct or complete. |
+| Selector refusal: unknown/wrong namespace/empty intersection | Existing: `bun run --cwd tools/habitat-harness test -- test/lib/rule-selection.test.ts`; command: `bun run habitat:check -- --json --rule definitely-not-a-rule`; `bun run habitat:check -- --json --rule grit-check`; `bun run habitat:check -- --json --owner @civ7/control-orpc --tool biome`. | Unit tests exit 0. Commands exit 1 with exactly one `rule-selection-integrity` row, `ok: false`, diagnostic path `.`, and no `baseline-integrity` row. Observed selector command tests pass. | Does not prove command execution or selected-rule diagnostics. |
+| Dependency unavailable: Grit executable | Add a command-engine or Grit adapter test using a fake `HabitatProcess`/PATH that makes `grit` unavailable, then run selected Grit rule through D7 report construction. | Exit/report failure is explicit: affected selected Grit rules get infrastructure diagnostics containing `GritToolUnavailable`; report `ok: false`; no silent pass when the dependency is absent. Existing lower-level `habitat-process`/Grit failure modeling exists, but D7 command-level projection is not pinned. | Does not prove Grit pattern correctness or cache freshness. |
+| Dependency unavailable: Biome executable | Add a command-level test that runs `--tool biome` with `PATH` excluding Biome or with injected spawn result. | Exit 1; `biome-ci` status `fail`; diagnostic explains tool execution failure; no `ok: true` from missing executable. Current command path is not dependency-injectable enough for a clean unit proof without refactor. | Does not prove Biome diagnostics or formatting correctness. |
+| Baseline-covered finding | Existing lower-level proof: `bun run --cwd tools/habitat-harness test -- test/lib/baseline.test.ts`. Add D7 report test where a selected enforced rule emits only baseline-covered errors. | Existing tests exit 0 for baseline state machine. Required D7 report outcome: rule `status: "pass"` when all enforced errors are baselined, diagnostics remain present with `baselined: true`, and report `ok: true`. | Does not prove baseline growth is allowed; D5 owns baseline authority. |
+| Baseline contract failure | Existing command test mutates baseline fixtures: `bun run --cwd tools/habitat-harness test -- test/commands/habitat-entrypoints.test.ts` | Required exit 0 for the test; command cases inside exit 1 for missing, malformed, and orphan baselines. Current full file is blocked by unrelated help failures, but the baseline contract cases pass inside the failing file. | Does not prove diagnostic correctness; proves malformed baseline state cannot be hidden. |
+| Baseline-integrity current-tree proof | D5 proposed `bun run habitat check --rule baseline-integrity --json`; current equivalent is missing. | BLOCKING. Current command exits 1 as unknown selector. D7 must either make `baseline-integrity` selectable, add a supported `--built-in baseline-integrity` style proof, or update D5/D7 proof commands with authority. | Does not prove all baselines shrink; proves the built-in integrity row has an executable oracle. |
+| Generated-zone staged clean | `bun run habitat:check -- --json --tool file-layer --staged` with no staged generated/protected files. | Exit 0; all file-layer rules pass. Observed fresh outcome matches this. | Does not prove generated artifacts are fresh; proves staged protected-zone guard. |
+| Generated-zone staged violation | In a disposable test, modify and stage a tracked file under `mods/mod-swooper-maps/src/maps/generated/`, run `bun run habitat:check -- --json --tool file-layer --staged`, then restore index and worktree. Prefer a Vitest fixture around `runGeneratedZoneRule` with mocked staged paths if D10 has not provided disposable command harness. | Exit 1; `file-layer-swooper-map-generated` status `fail`; diagnostic path is the staged generated file; report `ok: false`; cleanup leaves `git status` exactly as before. | Does not prove map generation freshness; D10/generated authority owns policy. |
+| Staged path Grit selector | Existing: `bun run --cwd tools/habitat-harness test -- test/lib/rule-selection.test.ts` | Exit 0. Unit tests prove staged execution includes hook-scoped Grit only for approved staged source roots and excludes Grit rules outside approved roots. | Does not prove hook command behavior; D11 owns hook packet. |
+| Report rendering JSON/human equivalence | Add tests around `renderCheckReport`/`stringifyCheckReport` that parse JSON and inspect human output for the same pass/fail/advisory/selector states. Existing selector JSON rendering coverage does not establish the complete D7 rendering contract. | JSON and human rendering must agree on `PASS`/`FAIL`, selected rule ids, advisory wording, and non-claims. Rendering must throw on semantic-invalid reports after D7 constructor/validator exists. | Does not prove rule execution; proves rendering truth equivalence. |
+| Root command help | Existing: `bun run --cwd tools/habitat-harness test -- test/commands/habitat-entrypoints.test.ts` | BLOCKING current outcome: exits 1 because `check --help` exits 2 for root and dev runners. Required D7 outcome: command help exits 0 and lists stable flags from D0. | Does not prove structural enforcement; proves public command surface is usable. |
+| Rule inventory drift | Existing: `bun run --cwd tools/habitat-harness test -- test/lib/enforcement-surface.test.ts` | BLOCKING current outcome: exits 1 because expected `grit-check: 31`, actual `grit-check: 32`. Required D7 outcome: inventory updated or registry change dispositioned, with no silent rule admission. | Does not prove the new Grit rule is correct; proves registry/test inventory cannot drift silently. |
+| Nx target/cache proof | `nx show project @internal/habitat-harness --json`; for command proof with cache-sensitive claims use `nx run @internal/habitat-harness:habitat:check:all --skip-nx-cache` or record cache-hit/fresh state from Nx output. | Graph metadata command exits 0 and contains Habitat target aliases. Cache-sensitive proof either runs fresh or records whether Nx replayed cached terminal output. | Does not prove target success from metadata inspection; D3 owns graph target truth. |
+
+## Existing Proof Run During This Investigation
+
+- `bun run --cwd tools/habitat-harness test -- test/commands/habitat-entrypoints.test.ts test/lib/enforcement-surface.test.ts test/lib/rule-selection.test.ts`: exit 1. Selector tests passed; command entrypoint help and enforcement inventory failed as described above.
+- `bun run --cwd tools/habitat-harness test -- test/lib/baseline.test.ts test/lib/grit-adapter.test.ts test/lib/grit-injected-probe.test.ts test/grit/grit-patterns.test.ts`: exit 0, 44 tests passed.
+- `bun run habitat:check -- --json --rule workspace-entrypoints`: exit 1 with enforced unbaselined error and `ok: false`.
+- `bun run habitat:check -- --json --rule baseline-integrity`: exit 1 with selector refusal, proving the packet proof command is not currently valid.
+- `bun run habitat:check -- --json --tool biome`: exit 1 with `biome-ci` failure and `ok: false`.
+- `bun run habitat:check -- --json --tool file-layer --staged`: exit 0 with file-layer pass rows and `baseline-integrity` pass.
+
+## Vendor Behavior Assumptions
+
+- Grit CLI: D6/D7 may rely on `grit check [PATHS]...` accepting target paths and Grit exposing `--json`, `--no-cache`, and `--refresh-cache` options for check-like command proof. Primary source: [Grit CLI Reference](https://docs.grit.io/cli/reference).
+- Biome CLI: D7 should treat Biome warnings/errors through Biome's command exit/reporting contract, not by parsing incidental colored text. The official CLI documents `--error-on-warnings` and reporter choices including `json`/`json-pretty`. Primary source: [Biome CLI Reference](https://biomejs.dev/reference/cli/).
+- Nx cache: D7 proof cannot claim fresh execution from a cache replay. Nx documents that cacheable tasks store and replay terminal output and artifacts when the computation hash matches, and `--skip-nx-cache` bypasses local/remote cache for a task. Primary sources: [Nx How Caching Works](https://nx.dev/docs/concepts/how-caching-works), [Nx Configure Outputs for Task Caching](https://nx.dev/docs/guides/tasks--caching/configure-outputs), and [Nx Skip Task Caching](https://nx.dev/docs/guides/tasks--caching/skipping-cache).
+
+## Non-Claims For This Report
+
+- This report does not approve D7 implementation.
+- This report does not claim current-tree structural cleanliness.
+- This report does not claim Grit pattern correctness, Pattern Governance admission, apply safety, runtime/product behavior, or affected Nx target success.
+- This report does not rely on prior agent scratch findings as authority; cited inputs are the D7 packet, dependency packets, current source/tests, observed commands, and primary vendor docs.
+
+Skills used: domain-design, information-design, solution-design, testing-design, civ7-open-spec-workstream, typescript-refactoring.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-typescript-state-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-typescript-state-investigation.md
@@ -1,0 +1,136 @@
+# D7 TypeScript State-Space Investigation
+
+Status: BLOCKING
+
+D7 is not acceptable input yet. The packet says "pipeline" and "typed decisions", but it still leaves the concrete state model, public compatibility strategy, write set, and falsifying oracle for the implementation agent to invent. That violates the D7 stop condition: if implementation could still decide the concrete state model, write set, public compatibility, or validation oracle later, this report must block.
+
+## Controlling Finding
+
+The live check path is a state-space compression failure concentrated in `createCheckReport`, but the D7 packet has not yet specified the replacement type-state families tightly enough to prevent the known false-green paths.
+
+Evidence:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts:273` starts `createCheckReport(options: CheckOptions = {})`, where one broad options object carries selector fields, baseline base, command rendering args, staged mode, and staged paths.
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts:274-342` mixes selection, staged filtering, rule execution, baseline load/apply, mutation of diagnostics, status derivation, built-in baseline-integrity insertion, and final `CheckReport.ok` derivation.
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/diagnostics.ts:36-42` exports `CheckReport` with `ok: boolean` and `rules: RuleReport[]`; `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/diagnostics.ts:45-66` validates shape but not the invariant that `ok` must equal "no failing rule reports".
+- D1 already requires either validator rejection or construction-level impossibility for `ok: true` with a failing rule at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d1-receipt-contract-boundary/specs/habitat-harness/spec.md:36-39`. Current validation does not satisfy that.
+
+## Current TypeScript Smell Inventory
+
+1. Optional/flag soup in check entry input.
+   `CheckOptions` extends `RuleSelection` and adds optional `base`, `commandArgs`, `staged`, and `stagedPaths` at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts:70-75`. This admits incoherent states: render-only args during rule execution, `stagedPaths` without `staged`, staged execution for current-tree-only rules, and baseline-base concerns on selection-only paths.
+
+2. Boolean-correlated result state.
+   `CheckReport.ok` is a free boolean at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/diagnostics.ts:36-42`, and construction derives it by convention at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts:336-342`. Any caller can still construct contradictory reports because the public type allows it.
+
+3. Selector failure encoded as a fake rule execution.
+   `RuleSelectionResult` is a real DU at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts:59-68`, but `createRuleSelectionFailureReport` converts it to a synthetic `RuleReport` with `ruleId: "rule-selection-integrity"` at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts:569-603`. That preserves current JSON compatibility, but the target model must keep "selector failed before execution" distinct from "a selected structural rule failed" internally.
+
+4. Baseline application mutates diagnostics in place.
+   `applyBaseline` mutates `d.baselined` at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/baseline.ts:153-209`, and `createCheckReport` then appends baseline contract diagnostics to the same array at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts:284-289`. D5 says D7 should consume `BaselineApplicationResult` and `BaselineIntegrityResult`, not decide D5 internals, at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d5-baseline-authority/specs/habitat-harness/spec.md:169-184`.
+
+5. Advisory/enforced lanes collapse through shared status strings.
+   `RuleReport.status` is only `"pass" | "fail" | "advisory-findings"` at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/diagnostics.ts:19-25`. Status derivation at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts:289-299` treats advisory findings as non-failing by convention. The target must make "advisory finding does not fail check" a constructor rule, not a renderer convention.
+
+6. Diagnostic adapter failures are downgraded into ordinary diagnostics.
+   D6 models Grit acquisition failure families explicitly, including tool unavailable not becoming pass at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d6-diagnostic-pattern-catalog/specs/habitat-harness/spec.md:98-104` and adapter outcomes at `:105-141`. Live Grit code has `GritCheckParseResult` as a DU at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/grit.ts:45-58`, but `runGritRules` projects failures to `{ exitCode, diagnostics }` at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/grit.ts:203-212` and `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/grit.ts:772-780`. D7 must not lose the family when aggregating.
+
+7. Dependency unavailable can still be modeled as "nothing ran, nothing failed" unless D7 consumes D3 states.
+   D3 requires unavailable/missing graph targets and alias dependency failures to refuse before runnable commands at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d3-workspace-graph-boundary/specs/habitat-harness/spec.md:22-43` and `:44-93`; D7 specifically may not treat wrapper exit 0 as success without dependency resolution at `:147-160`. Current direct `executeRule` just runs `rule.detect` for non-Grit/non-file-layer rules at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/rules/architecture.ts:109-121`.
+
+8. Rendering can invent semantics from fields.
+   Human rendering decides PASS/FAIL from `report.ok` and counts statuses directly at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/rules/messages.ts:27-39`. If a malformed report has `ok: true` and a failing rule, rendering reports PASS while listing a failing rule count. `renderCheckReport` only validates shape before JSON/string rendering at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts:462-475`.
+
+9. Public exports make this a compatibility change, not an internal refactor.
+   `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/index.ts:29-50` exports `createCheckReport`, `renderCheckReport`, `stringifyCheckReport`, `CheckReport`, and `RuleReport`. D0 requires rows before changing command JSON, DTOs, exports, examples, or hooks at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d0-command-surface-inventory/specs/habitat-harness/spec.md:3-28`. The named D0 matrix path is absent in this worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/public-surface-compatibility-matrix.md`.
+
+## Target Discriminated Unions And Type-State Families
+
+D7 should specify these families before implementation:
+
+1. `CheckRequest`
+   Collapse broad `CheckOptions` into:
+   - `{ kind: "current-tree-check"; selectors: SelectorRequest; baseline: BaselineIntegrityRequest; command: CommandRenderInput }`
+   - `{ kind: "staged-check"; selectors: SelectorRequest; stagedPaths: NonEmptyReadonlyArray<RepoPath> | { kind: "no-staged-paths" }; command: CommandRenderInput }`
+   - `{ kind: "baseline-authoring"; selectors: SelectorRequest; baselineExpansion: BaselineExpansionRequest }`
+   This eliminates `stagedPaths` without `staged`, baseline authoring flowing through report emission, and command args leaking into execution stages.
+
+2. `RuleSelectionOutcome`
+   Keep selector result separate from execution:
+   - `{ kind: "selected"; requested: SelectorRequest; selectedRules: NonEmptyReadonlyArray<RuleExecutionPlan>; selectorFacts: SelectorFact[] }`
+   - `{ kind: "selection-refused"; reason: "unknown-selector" | "wrong-selector-namespace" | "empty-selection"; selectorFacts: SelectorFact[]; reportProjection: SelectorFailureProjection }`
+   Compatibility can still project `selection-refused` to `rule-selection-integrity`, but execution APIs must not accept it as selected rules.
+
+3. `RuleExecutionPlan`
+   Consume D2/D3/D6/D10 projections instead of `HarnessRule`:
+   - `{ kind: "grit-diagnostic"; rule: RuleIdentity; lane: EnforcementLane; diagnosticEntry: DiagnosticCatalogEntry; scanDecision: DiagnosticScanRootDecision }`
+   - `{ kind: "wrapped-target"; rule: RuleIdentity; lane: EnforcementLane; graphTarget: AvailableTarget | GraphRefusal }`
+   - `{ kind: "file-layer-guard"; rule: RuleIdentity; lane: EnforcementLane; protectedZoneDecision: GuardDecision }`
+   - `{ kind: "native-diagnostic"; rule: RuleIdentity; lane: EnforcementLane; diagnosticEntry: NativeDiagnosticEntry }`
+   This collapses optional fields like `gritPattern?`, `generatedZone?`, `forbiddenFileNames?`, `hookScope?`, and `nxTarget?` on `HarnessRule`.
+
+4. `DiagnosticRunOutcome`
+   Collapse `{ exitCode, diagnostics }` into:
+   - `{ kind: "clean"; commandObservation?: BoundedCommandObservation }`
+   - `{ kind: "findings"; diagnostics: NonEmptyReadonlyArray<NormalizedDiagnostic>; commandObservation?: BoundedCommandObservation }`
+   - `{ kind: "adapter-refused"; failure: DiagnosticAdapterFailure }`
+   - `{ kind: "projection-refused"; reason: "projection-missed" | "unexpected-diagnostic-identity" | "cache-observation-missing"; failureDiagnostic: NormalizedDiagnostic }`
+   This prevents tool unavailable, malformed JSON, projection miss, empty roots, and cache provenance gaps from being mistaken for a clean run.
+
+5. `BaselineApplicationOutcome`
+   D7 should consume, not recompute:
+   - `{ kind: "baseline-applied"; covered: DiagnosticKey[]; uncovered: NormalizedDiagnostic[]; locked: boolean }`
+   - `{ kind: "baseline-refused"; refusal: BaselineContractFailure; diagnostic: NormalizedDiagnostic }`
+   - `{ kind: "integrity-accepted"; result: BaselineIntegrityResult }`
+   - `{ kind: "integrity-refused"; refusal: BaselineIntegrityRefusal; diagnostic: NormalizedDiagnostic }`
+   This prevents "baseline-covered findings erase diagnostics"; covered diagnostics remain observable as covered debt, while uncovered/current and contract diagnostics remain distinct.
+
+6. `RuleReportDraft -> RuleReport`
+   Make report construction staged:
+   - `ExecutedRuleReportDraft` contains selected rule identity, lane, diagnostic outcome, baseline outcome, and duration.
+   - `SelectorFailureReportDraft` contains selector failure only.
+   - `BuiltInReportDraft` contains baseline-integrity or other D7-owned built-ins.
+   A single `finalizeRuleReport(draft): RuleReport` derives status. Callers cannot set `status` directly.
+
+7. `CheckOutcome -> CheckReport`
+   Build the public schema at the boundary:
+   - `{ kind: "check-passed"; reports: RuleReport[] }`
+   - `{ kind: "check-failed"; failures: NonEmptyReadonlyArray<FailingReport>; reports: RuleReport[] }`
+   - `{ kind: "check-refused"; refusal: SelectorFailure | MetadataFailure | GraphRefusal | DiagnosticAdapterFailure | BaselineRefusal; reports: NonEmptyReadonlyArray<RuleReport> }`
+   Then `toCheckReport(outcome)` derives `ok`. No internal code should accept raw `CheckReport` construction except compatibility/test factories.
+
+## Public Type And Export Compatibility Traps
+
+- `CheckReport`, `RuleReport`, `HabitatDiagnostic`, `createCheckReport`, `renderCheckReport`, and `stringifyCheckReport` are package exports. A D7 source change that narrows, renames, versions, or stops exporting them requires concrete D0 rows. The D0 matrix file is absent, so D7 implementation is blocked if it changes those surfaces.
+- `habitat check --json` is command JSON. D1 says it remains a `CheckReport` with `ok` matching rule statuses and invalid selector JSON still returns schemaVersion 1 `CheckReport` without claiming rule execution. D7 may use internal unions, but public JSON must be preserved, versioned, or facaded through D0.
+- `validateCheckReport` is exported and currently shape-based. Changing it to reject contradictory reports is behaviorally correct per D1, but still a public validator behavior change; D7 needs D0 compatibility disposition.
+- Hooks parse `CheckReport` and regex Grit adapter failure text at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/hooks.ts:802-823`. If D7 changes diagnostic message text or adds structured failure fields, hook compatibility must be handled explicitly.
+- Tests currently mock `createCheckReport` with `ok: true, rules: []` at `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/commands/habitat-commands.test.ts:3-9`. If D7 requires non-empty reports or a constructor-only report type, command tests need compatibility factories rather than raw objects.
+
+## Required Validation Gates That Would Falsify D7 Risks
+
+D7 should not proceed until these gates are exact in the packet/tasks:
+
+- Type-level gate: a `tsc --noEmit` or package typecheck includes negative compile-time fixtures, or equivalent `tsd`/`expectTypeOf` tests, proving raw contradictory `CheckReport` construction is unavailable through the new internal constructor path.
+- Runtime validator gate: unit test `validateCheckReport({ ok: true, rules: [{ status: "fail", ... }] })` rejects, or a constructor test proves that state cannot be created.
+- Selector gate: JSON and human invalid selector tests assert `selection-refused` projects to `rule-selection-integrity`, exits nonzero, and records no ordinary selected rule execution.
+- Dependency-unavailable gate: injected D3 graph-refusal fixture for a wrapped target proves wrapper `exitCode: 0` cannot produce a passing rule report unless dependency resolution was accepted.
+- Diagnostic adapter gate: Grit tool unavailable, no JSON, malformed JSON, schema drift, unexpected shape, projection miss, unexpected identity, and cache-provenance-missing each produce a failed/refused D7 outcome, not a clean diagnostic run.
+- Lane gate: an advisory rule with findings yields `advisory-findings` and does not fail check, while an enforced rule with the same uncovered error diagnostic fails check; both paths are constructed by the same status finalizer.
+- Baseline gate: covered diagnostics remain present and marked covered; uncovered diagnostics fail enforced rules; baseline contract refusals become separate command diagnostics and cannot be erased by baseline coverage.
+- Rendering truth-equivalence gate: for a synthetic report with every status family, JSON and human output agree on pass/fail, failing rule IDs, advisory counts, covered diagnostics, and refusal states. Rendering must not derive semantics not present in the finalized outcome.
+- Public compatibility gate: before source edits, list the exact D0 `surface_id` rows for package exports, command JSON, command human output, hooks, docs examples, and tests touched by D7, with the closed compatibility handling action.
+- OpenSpec gate: `bun run openspec -- validate deep-habitat-d7-structural-enforcement-pipeline --strict` must pass only after the D7 spec names the concrete state families above or an equivalent closed model.
+
+## Complete Repair Required To Make D7 Acceptable Input
+
+The D7 OpenSpec packet must be repaired before implementation. The repaired packet must:
+
+- Add a normative spec requirement for `CheckOutcome` and `RuleReportDraft` constructors deriving `ok` and `status`.
+- Add a requirement that D7 consumes D2 selector/execution projections, D3 graph target/refusal states, D5 baseline application/integrity results, D6 diagnostic outcomes, and D10 guard decisions without reading whole `HarnessRule` or recomputing adjacent authority.
+- Add D0 compatibility rows or cite existing concrete rows for every public check/report/export/hook surface D7 changes.
+- Replace generic validation bullets with the falsifying gates above, including negative contradiction tests and injected unavailable-dependency/adapter-failure cases.
+
+Until those are present, D7 remains BLOCKING.
+
+Skills used: domain-design, information-design, solution-design, civ7-open-spec-workstream, typescript-refactoring.

--- a/docs/projects/habitat-harness/openspec-remediation/context.md
+++ b/docs/projects/habitat-harness/openspec-remediation/context.md
@@ -13,7 +13,7 @@ variables below.
 | Variable | Value |
 | --- | --- |
 | `$ACTIVE_REMEDIATION_WORKTREE` | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation` |
-| `$ACTIVE_REMEDIATION_BRANCH` | `codex/d6-diagnostic-pattern-packet-repair` |
+| `$ACTIVE_REMEDIATION_BRANCH` | `codex/d7-structural-enforcement-packet` |
 
 ## Path Variables
 
@@ -105,6 +105,27 @@ variables below.
 | `$D6_PHASE_RECORD` | `$D6_CHANGE/workstream/phase-record.md`. |
 | `$D6_DOWNSTREAM_LEDGER` | `$D6_CHANGE/workstream/downstream-realignment-ledger.md`. |
 | `$D6_CLOSURE_CHECKLIST` | `$D6_CHANGE/workstream/closure-checklist.md`. |
+
+## D7 Variables
+
+| Variable | Meaning |
+| --- | --- |
+| `$D7_CHANGE` | `$OPENSPEC_CHANGES/deep-habitat-d7-structural-enforcement-pipeline`. |
+| `$D7_SOURCE_PACKET` | `$PHASE2_PACKET_DIR/D7-structural-enforcement-pipeline.md`. |
+| `$D7_DOMAIN_REVIEW` | `$AGENT_SCRATCH/domino-D7-domain-ontology-investigation.md`. |
+| `$D7_TYPESCRIPT_REVIEW` | `$AGENT_SCRATCH/domino-D7-typescript-state-investigation.md`. |
+| `$D7_TOPOLOGY_REVIEW` | `$AGENT_SCRATCH/domino-D7-code-topology-investigation.md`. |
+| `$D7_INFORMATION_REVIEW` | `$AGENT_SCRATCH/domino-D7-openspec-information-investigation.md`. |
+| `$D7_VALIDATION_REVIEW` | `$AGENT_SCRATCH/domino-D7-testing-validation-investigation.md`. |
+| `$D7_CROSS_DOMINO_REVIEW` | `$AGENT_SCRATCH/domino-D7-cross-domino-investigation.md`. |
+| `$D7_FINAL_DOMAIN_REVIEW` | `$AGENT_SCRATCH/domino-D7-final-domain-ontology-review.md`. |
+| `$D7_FINAL_TYPESCRIPT_VALIDATION_REVIEW` | `$AGENT_SCRATCH/domino-D7-final-typescript-validation-review.md`. |
+| `$D7_FINAL_OPENSPEC_INFORMATION_REVIEW` | `$AGENT_SCRATCH/domino-D7-final-openspec-information-review.md`. |
+| `$D7_FINAL_TOPOLOGY_CROSS_DOMINO_REVIEW` | `$AGENT_SCRATCH/domino-D7-final-code-topology-cross-domino-review.md`. |
+| `$D7_REVIEW_LEDGER` | `$D7_CHANGE/workstream/review-disposition-ledger.md`. |
+| `$D7_PHASE_RECORD` | `$D7_CHANGE/workstream/phase-record.md`. |
+| `$D7_DOWNSTREAM_LEDGER` | `$D7_CHANGE/workstream/downstream-realignment-ledger.md`. |
+| `$D7_CLOSURE_CHECKLIST` | `$D7_CHANGE/workstream/closure-checklist.md`. |
 
 ## Path Templates
 

--- a/docs/projects/habitat-harness/openspec-remediation/packet-index.md
+++ b/docs/projects/habitat-harness/openspec-remediation/packet-index.md
@@ -5,10 +5,10 @@ change packets. It is part of the remediation frame, not an implementation
 commitment. Most rows remain draft scaffolding: global review findings have
 been converted into shared constraints, but each domino remains blocking until
 its own per-domino adversarial review has run and all accepted P1/P2 findings
-are repaired. D0, D1, D2, D3, D4, D5, and D6 are the current exceptions: they are
+are repaired. D0, D1, D2, D3, D4, D5, D6, and D7 are the current exceptions: they are
 accepted for design/specification after their per-domino final reviews found no
-unresolved P1/P2 blockers. D0-D6 are not implementation-complete, and
-D7-D15/G-HOST remain blocking unless their own status rows say otherwise.
+unresolved P1/P2 blockers. D0-D7 are not implementation-complete, and
+D8-D15/G-HOST remain blocking unless their own status rows say otherwise.
 
 Path variables and operational checkout fixtures are defined in
 `$REMEDIATION_DIR/context.md`. This index records packet identity and sequencing;
@@ -23,7 +23,7 @@ it does not repeat local worktree paths or branch names.
 | D4 | D4 Classify Orientation And Routing | `deep-habitat-d4-orientation-routing` | D0, D1 vocabulary, D2, D3; concrete D0 rows plus live D2/D3 implementation facts required before source implementation | D14 | accepted for design/specification; final domain/ontology, OpenSpec/testing, and topology/cross-domino rereviews found no unresolved P1/P2 blockers; not implementation-complete |
 | D5 | D5 Baseline Authority | `deep-habitat-d5-baseline-authority` | D0, D2; concrete D0 rows and live D2 `ruleBaselineFacts`/baseline projections required before source implementation | D7, D8 | accepted for design/specification; final domain/ontology, OpenSpec/testing, and topology/TypeScript/cross-domino rereviews found no unresolved P1/P2 blockers; not implementation-complete |
 | D6 | D6 Diagnostic Pattern Catalog | `deep-habitat-d6-diagnostic-pattern-catalog` | D0, D1, D2; concrete D0 rows, D1 output-family decisions where touched, and live D2 `ruleGritFacts` required before source implementation | D7, D8, D9, D11, D15 evaluation | accepted for design/specification; final after-observed-identity domain/ontology, TypeScript/validation, OpenSpec/information, and code/vendor topology rereviews found no unresolved P1/P2 blockers; not implementation-complete |
-| D7 | D7 Structural Enforcement Pipeline | `deep-habitat-d7-structural-enforcement-pipeline` | D0, D1, D2, D3, D5, D6, D10 | D11, D12 | draft scaffold; global constraints applied; per-domino adversarial gate BLOCKING |
+| D7 | D7 Structural Enforcement Pipeline | `deep-habitat-d7-structural-enforcement-pipeline` | D0, D1, D2, D3, D5, D6, D10; concrete D0 rows, D1 output-family handling, live D2/D3/D5/D6 projections, and accepted D10 guard contract required before source implementation where touched | D11, D12 | accepted for design/specification; final domain/ontology, TypeScript/validation, OpenSpec/information, and code/topology/cross-domino rereviews found no unresolved P1/P2 blockers; not implementation-complete |
 | D8 | D8 Pattern Governance | `deep-habitat-d8-pattern-governance` | D0, D2, D5, D6 | D9, D13 | draft scaffold; global constraints applied; per-domino adversarial gate BLOCKING |
 | G-HOST | Host Policy Boundary Gate | `deep-habitat-host-policy-boundary-gate` | D0, D1 | D10, D13 | draft scaffold; global constraints applied; per-domino adversarial gate BLOCKING |
 | D9 | D9 Transformation Transaction | `deep-habitat-d9-transformation-transaction` | D0, D1, D6, D8, D10 | D11 | draft scaffold; global constraints applied; per-domino adversarial gate BLOCKING |

--- a/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/design.md
+++ b/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/design.md
@@ -2,71 +2,328 @@
 
 ## Frame
 
-D7 Structural Enforcement Pipeline is a downstream implementation-control packet derived from
-`D7-structural-enforcement-pipeline.md`. The packet is complete only when it leaves the later execution
-agent with no product, domain, naming, sequencing, public-surface, or validation
-decision to invent.
+D7 is the Structural Enforcement owner for `habitat check`: it composes accepted
+upstream results into a finalized check outcome, public report, rendering, and
+exit decision. It does not decide registry metadata, graph truth, baseline
+authority, diagnostic acquisition, or protected-zone policy. It makes those
+inputs explicit enough that implementation can collapse the current broad
+`createCheckReport` state space without inventing product/domain decisions.
 
-The existing packet is input, not output. Current Habitat code is
-present-behavior evidence. This design chooses target language from Habitat's
-generic repo-maintenance product scenarios rather than preserving accidental
-module or DTO names.
+Acceptance threshold: the packet is acceptable for design/specification only
+when an implementation agent can name every D7-owned state, consumed upstream
+projection, public-surface blocker, validation oracle, and downstream consumer
+contract without opening chat history.
+
+## Current Enforcement Inventory
+
+| Current surface | Current role | Public/D0 plane | Target owner | Target D7 stage | False-green risk |
+| --- | --- | --- | --- | --- | --- |
+| `CheckOptions` in `$HABITAT_TOOL/src/lib/command-engine.ts` | One optional object for selectors, base, command args, staged mode, and staged paths. | package-export if exposed through `createCheckReport`; command behavior through CLI flags. | D7 for check request normalization; D11 for hook invocation policy later. | `StructuralCheckRequest` construction. | `stagedPaths` without staged mode, baseline authoring mixed with report emission, and command rendering args leaking into execution planning. |
+| `selectRules` / `RuleSelectionResult` | Selects whole `HarnessRule` rows or returns selector failure. | package-export, command-json/human through selector failures. | D2 owns selector facts; D7 owns check-level selector outcome projection. | `RuleSelectionOutcome`. | Selector failure can be projected as a fake executed rule without internal distinction. |
+| `rulesForExecution` | Drops staged Grit rules when no approved staged roots exist. | command behavior and hook behavior. | D7 for execution disposition; D11 owns hook sequencing. | `RuleExecutionPlan` and `RuleExecutionDisposition`. | Selected rules can disappear from reports without a not-run/refused state when user selected a scoped check. |
+| `executeSelectedRules` | Groups Grit, computes scan roots, runs Grit, and runs native/file-layer rules. | command behavior, package-internal. | D6 owns diagnostic acquisition; D7 owns orchestration over consumer projections. | `RuleExecutionObservation`. | Adapter failure or scan-root refusal can collapse into ordinary diagnostics or absence of diagnostics. |
+| `executeRule` in `$HABITAT_TOOL/src/rules/architecture.ts` | Runs non-Grit detect commands or file-layer rules from whole registry rows. | package-export and command behavior. | D2/D3/D6/D10 inputs; D7 aggregation. | Execution observation over accepted projections. | Wrapper exit 0 can be treated as structural pass without D3 dependency resolution. |
+| `loadBaselineState` / `applyBaseline` / `checkBaselineIntegrity` | Loads baseline files, mutates diagnostics, emits baseline failures and built-in integrity row. | command-json/human, durable baseline data, package exports. | D5. D7 consumes D5 results. | `BaselineApplicationOutcome` and built-in report row construction. | Baseline-covered diagnostics can disappear or baseline refusals can be folded into ordinary findings. |
+| `RuleReport` / `CheckReport` in `$HABITAT_TOOL/src/lib/diagnostics.ts` | Public report DTOs with settable `ok`, status strings, diagnostics. | package-export, command-json, docs examples. | D7 for check report construction; D1 constrains boundary. | `CheckReportConstructionResult`. | Structurally valid report can say `ok: true` while containing a failing rule. |
+| `validateCheckReport` | Shape-only validation. | package-export, command-json guard. | D7 with D1 compatibility. | Semantic report validator or constructor gate. | Contradictory reports survive validation and rendering. |
+| `renderCheckReport` / `stringifyCheckReport` / `$HABITAT_TOOL/src/rules/messages.ts` | Renders JSON/human output from `CheckReport`. | command-json, human-output, package-export. | D7. | `RenderedCheckReport` and `CheckExitDecision`. | Renderer can present PASS from `report.ok` while counts show failing reports. |
+| `verify` command check summary | Calls `createCheckReport` and summarizes rule status counts. | command-json for verify. | D12 consumes D7 projection; D7 publishes check summary. | `VerifyCheckSummaryProjection`. | Verify currently loses selector request facts and must infer skipped affected target semantics from `report.ok`. |
+| hooks parsing check JSON | Reads check reports and Grit adapter failures for local feedback. | hook and human-output. | D11 consumes D7 projection. | `LocalFeedbackCheckProjection`. | Hook semantics can be inferred from current JSON or message text instead of D7/D11 contracts. |
 
 ## Domain Boundary
 
-- Owner: Structural Enforcement.
-- Primary scenario: An agent runs Habitat check and receives a reliable structural result that composes registry metadata, diagnostics, baselines, generated-zone guards, and graph facts without false green paths.
-- Adjacent domains consume this packet through explicit contracts and may not
-  recreate its authority locally.
+| Concern | Owner | D7 use |
+| --- | --- | --- |
+| Public compatibility plane, row ids, and handling action. | D0 | D7 blocks source changes until concrete rows exist. |
+| Check report family limits, non-claims, refusal/receipt boundary. | D1 | D7 inherits report/diagnostic/refusal boundaries and does not call a `CheckReport` a receipt. |
+| Selector facts, rule report facts, rule execution facts, rule facet projections. | D2 | D7 consumes projections and selected rule ids; D7 does not parse whole registry rows as authority. |
+| Graph target availability, alias dependency resolution, graph refusals. | D3 | D7 consumes graph invocation availability/refusal for check-related target surfaces. |
+| Baseline application, baseline integrity, baseline refusals. | D5 | D7 renders D5 results into check rows. |
+| Diagnostic acquisition, adapter outcomes, diagnostic projections. | D6 | D7 consumes D6 outcomes and maps them to enforcement rows. |
+| Protected/generated-zone guard decisions and refusals. | D10 | D7 renders D10 guard results; D7 does not own protected-zone policy. |
+| Hook sequencing and local feedback trace. | D11 | D7 publishes a local-feedback-safe check projection. |
+| Verify handoff receipt and affected-target execution. | D12 | D7 publishes a verify-check summary projection. |
 
-## Target Contract
+## Target Ontology
 
-- Define check pipeline ownership and inputs from D2/D3/D5/D6/D10.
-- Specify result aggregation and failure/refusal states.
-- Separate enforcement result from orientation and receipts.
+Accepted D7 target terms:
 
-## Non-Goals
+| Term | Meaning |
+| --- | --- |
+| `StructuralCheckRequest` | Normalized check operation: command context, selector request, check mode, base request, staged request when present. |
+| `SelectorRequest` | User selector intent over owner, rule, tool, and command scope. |
+| `RuleSelectionOutcome` | Accepted selected rule set or selector refusal. |
+| `SelectorRefusal` | Unknown selector, wrong selector namespace, or empty selector intersection. |
+| `SelectedRuleSet` | Non-empty selected rule identities plus D2 selector facts. |
+| `StructuralDependencyAvailability` | Per-check availability/refusal of D2, D3, D5, D6, and D10 inputs. |
+| `RuleExecutionPlan` | D7-owned plan for each selected rule using accepted upstream projections. |
+| `RuleExecutionDisposition` | Executed, not applicable, refused by upstream dependency, or failed before diagnostics. |
+| `DiagnosticConsumptionOutcome` | D6 diagnostic consumer projection as consumed by D7. |
+| `BaselineApplicationOutcome` | D5 baseline application/integrity result as consumed by D7. |
+| `StructuralRuleOutcome` | D7 aggregation of rule identity, lane, execution disposition, diagnostic outcome, baseline outcome, and dependency state. |
+| `RuleReportDraft` | Internal constructor input for one public `RuleReport`; not exported as current public DTO unless D0 versions/facades it. |
+| `CheckOutcome` | Final D7 state: passed, failed, advisory-only, selector-refused, dependency-refused, or no-applicable-rules. |
+| `CheckReportConstructionResult` | Constructed public `CheckReport` plus semantic consistency state. |
+| `LocalFeedbackCheckProjection` | D11-safe projection that preserves local-only non-claims. |
+| `VerifyCheckSummaryProjection` | D12-safe projection for affected-target skip/execute decisions. |
 
-- No rule registry schema ownership.
-- No baseline admission ownership.
-- No hook-specific local feedback ownership.
+Rejected target language:
 
-## Naming And Language Decisions
+- `pipeline ownership and inputs` without a state model.
+- `rule execution result` when it conflates process exit, diagnostic projection,
+  adapter failure, rule report status, and baseline result.
+- `selected rules` when it means whole mutable `HarnessRule` rows.
+- `baseline decision` without specifying application, integrity, expansion, or
+  projection context.
+- `Grit result` as D7 input; D7 consumes D6 outcomes/projections.
+- `graph facts` without D3 availability/refusal state.
+- `generated-zone guard` as D7-owned policy; D7 consumes D10 decisions.
+- `skip` or `silent skip`; use an explicit `not-applicable` or
+  `dependency-refused` disposition with report/exit semantics.
+- `CheckReport.ok` as a free settable boolean inside core D7 code.
+- proof/evidence-shaped names as target language; current public names remain
+  compatibility facts where D0/D1 require them.
 
-- Use standard engineering terms that name the actual workflow object:
-  receipts, checks, diagnostics, guard decisions, transactions, refusals,
-  recovery instructions, metadata projections, command outcomes, and handoff
-  records.
-- Treat legacy proof/evidence-shaped code names as compatibility facts unless
-  this packet explicitly accepts them as target language.
-- Do not create generic artifact machinery when a smaller command result,
-  receipt, or diagnostic contract serves the scenario.
+## Consumed Contract Matrix
 
-## Implementation Readiness
+| Upstream | D7 consumes | D7 must not do |
+| --- | --- | --- |
+| D2 | `ruleSelectorFacts`, `ruleReportFacts`, `ruleExecutionFacts`, `ruleBaselineFacts`, `ruleGritFacts`, and `ruleGeneratedZoneFacts` as relevant to selected rules. | Consume whole registry rows as target authority, parse prose `scope`, or treat optional `gritPattern`, `generatedZone`, `nxTarget`, `hookScope`, or `detect` fields as a replacement for D2 projections. |
+| D3 | Available project target, unavailable target, alias target dependency resolution, aggregate/workspace target state, and `GraphRefusal` states for check-related Nx invocation surfaces. | Treat wrapper exit 0, `node -e ""`, or missing dependency execution as structural success. |
+| D5 | `BaselineApplicationResult`, `BaselineIntegrityResult`, D5 refusal reasons, and command diagnostics generated from D5 refusals. | Load/apply baseline internals, decide shrink-only growth, accept rule-introduction manifests, or validate external exception projection locally. |
+| D6 | `DiagnosticRunOutcome` or `DiagnosticConsumerProjection`: clean, non-empty findings, scan-root refused, adapter failed, projection missed, unexpected identity, cache observation missing. | Parse raw Grit JSON/text/process records, infer Pattern Governance, infer apply safety, or downgrade adapter failure to pass. |
+| D10 | Protected-zone guard accepted/refused states and recovery guidance. | Define generated/protected-zone policy, downgrade protected-zone refusal to advisory, or infer write approval. |
 
-Before implementation starts, the executor must have:
+## Target State Model
 
-- D0 compatibility disposition for every public command, JSON, export, script,
-  target, generator, and hook surface touched by this packet.
-- A concrete write set and protected path list.
-- Tests and command gates from this packet copied into the phase record.
-- Review findings dispositioned with accepted P1/P2 repaired.
+```ts
+type NonEmptyReadonlyArray<T> = readonly [T, ...T[]];
 
-## Review Lanes
+type StructuralCheckRequest =
+  | { kind: "current-tree-check"; selectors: SelectorRequest; base: BaselineComparisonRequest; command: CommandContext }
+  | { kind: "staged-check"; selectors: SelectorRequest; staged: StagedCheckScope; base: BaselineComparisonRequest; command: CommandContext }
+  | { kind: "baseline-authoring"; selectors: SelectorRequest; expansion: BaselineExpansionRequest; command: CommandContext };
 
-- Domain-language adversary: names, owner, authority, and inherited terminology.
-- OpenSpec packet review: proposal/design/tasks/spec consistency and shortcut
-  language.
-- TypeScript state-space review: invalid states removed without type machinery
-  that exceeds the product need.
-- Testing/validation review: gates are falsifying, scenario-grounded, and have
-  exact command expectations.
-- Cross-domino review: dependencies, public-surface compatibility, and
-  downstream realignment.
+type RuleSelectionOutcome =
+  | { kind: "selected"; selector: SelectorRequest; facts: readonly RuleSelectorFact[]; selected: NonEmptyReadonlyArray<SelectedRuleIdentity> }
+  | { kind: "selector-refused"; selector: SelectorRequest; refusal: SelectorRefusal; facts: readonly RuleSelectorFact[] };
 
-## Structural Alternative Rejected
+type RuleExecutionDisposition =
+  | { kind: "executed"; durationMs: number; observation: CommandObservation }
+  | { kind: "not-applicable"; reason: "staged-scope-no-approved-roots" | "rule-not-in-requested-scope" }
+  | { kind: "dependency-refused"; owner: "D2" | "D3" | "D5" | "D6" | "D10"; refusal: UpstreamRefusal }
+  | { kind: "execution-failed"; failure: RuleExecutionFailure };
 
-The rejected alternative is to implement the existing domino packet directly
-and let the execution agent create missing proposal, design, spec, task, and
-ledger details while coding. That path already caused design drift. This
-OpenSpec packet resolves the execution-control layer before implementation.
+type DiagnosticConsumptionOutcome =
+  | { kind: "clean"; diagnostics: readonly [] }
+  | { kind: "findings"; diagnostics: NonEmptyReadonlyArray<NormalizedRuleDiagnostic> }
+  | { kind: "diagnostic-refused"; reason: DiagnosticRefusalReason; diagnostic: NormalizedRuleDiagnostic };
+
+type BaselineApplicationOutcome =
+  | { kind: "baseline-applied"; covered: readonly DiagnosticKey[]; uncovered: readonly NormalizedRuleDiagnostic[]; locked: boolean }
+  | { kind: "baseline-refused"; refusal: BaselineRefusal; diagnostic: NormalizedRuleDiagnostic }
+  | { kind: "integrity-accepted"; result: BaselineIntegrityResult }
+  | { kind: "integrity-refused"; refusal: BaselineIntegrityRefusal; diagnostic: NormalizedRuleDiagnostic };
+
+type StructuralRuleOutcome =
+  | { kind: "rule-passed"; lane: "enforced"; diagnostics: readonly NormalizedRuleDiagnostic[]; covered: readonly DiagnosticKey[] }
+  | { kind: "rule-failed"; lane: "enforced"; failingDiagnostics: NonEmptyReadonlyArray<NormalizedRuleDiagnostic>; covered: readonly DiagnosticKey[] }
+  | { kind: "rule-advisory-findings"; lane: "advisory"; diagnostics: NonEmptyReadonlyArray<NormalizedRuleDiagnostic> }
+  | { kind: "rule-refused"; lane: "enforced" | "advisory"; refusal: RuleRefusal; diagnostics: NonEmptyReadonlyArray<NormalizedRuleDiagnostic> }
+  | { kind: "rule-not-applicable"; lane: "enforced" | "advisory"; reason: "staged-scope-no-approved-roots" };
+
+type CheckOutcome =
+  | { kind: "passed"; reports: readonly FinalizedRuleReport[] }
+  | { kind: "failed"; failingReports: NonEmptyReadonlyArray<FinalizedRuleReport>; reports: NonEmptyReadonlyArray<FinalizedRuleReport> }
+  | { kind: "advisory-only"; advisoryReports: NonEmptyReadonlyArray<FinalizedRuleReport>; reports: NonEmptyReadonlyArray<FinalizedRuleReport> }
+  | { kind: "selector-refused"; refusalReport: FinalizedRuleReport }
+  | { kind: "dependency-refused"; refusalReports: NonEmptyReadonlyArray<FinalizedRuleReport>; reports: NonEmptyReadonlyArray<FinalizedRuleReport> }
+  | { kind: "no-applicable-rules"; selector: SelectorRequest; report: FinalizedRuleReport };
+```
+
+Construction rules:
+
+- `findings` variants use non-empty arrays.
+- `CheckOutcome.kind == "passed"` cannot contain a report with status `fail`.
+- `CheckOutcome.kind == "advisory-only"` exits 0 but must carry advisory report
+  rows.
+- `selector-refused`, `dependency-refused`, and enforced `rule-failed` outcomes
+  exit nonzero.
+- Public `CheckReport.ok` is derived from `CheckOutcome`; core D7 code does not
+  accept a raw `ok` boolean except inside D0/D1 compatibility facades and tests.
+- Covered diagnostics remain in report rows with covered/baselined state; D7
+  does not erase them to make a rule look clean.
+- Owner-specific refusals such as diagnostic acquisition refusal, baseline
+  refusal, graph refusal, and protected-zone refusal remain attached to their
+  owning upstream state and are projected through D7 as dependency/refusal
+  outcomes with explicit owner and reason fields. D11 and D12 may expose
+  audience-specific refusal labels, but they do not create new D7-owned refusal
+  domains.
+
+## Pipeline Stages
+
+1. Request normalization constructs `StructuralCheckRequest` from CLI/package
+   inputs and rejects impossible option combinations before execution planning.
+2. Selector resolution consumes D2 selector facts and produces
+   `RuleSelectionOutcome`.
+3. Execution planning consumes D2 execution facets plus D3/D6/D10 availability
+   facts and creates one `RuleExecutionPlan` per selected rule.
+4. Diagnostic consumption consumes D6 projections and refuses adapter/projection
+   failure states.
+5. Baseline application consumes D5 application/integrity results and preserves
+   covered, uncovered, and refusal diagnostics.
+6. Rule aggregation derives `StructuralRuleOutcome` from lane, diagnostics,
+   baseline state, and dependency disposition.
+7. Report construction converts rule outcomes into public-compatible
+   `RuleReport` rows and derives `CheckOutcome`.
+8. Rendering/stringifying consumes only the finalized report outcome and cannot
+   derive independent status.
+9. Exit decision derives only from `CheckOutcome`.
+
+## False-Green Invariant Matrix
+
+| Risk | Target prevention | Required later oracle |
+| --- | --- | --- |
+| `ok: true` with failing rule. | Constructor derives `ok`; semantic validator rejects contradictions. | Unit test with contradictory report plus constructor tests. |
+| Selector failure treated as selected-rule pass. | `selector-refused` outcome cannot enter execution planning. | JSON/human invalid selector tests. |
+| Selected staged Grit rule disappears silently. | `not-applicable` or `dependency-refused` disposition with explicit selected-rule relation. | Staged selected-rule tests with no approved roots and approved roots. |
+| Adapter failure becomes clean. | D6 adapter/projection failure maps to `rule-refused` or `dependency-refused`. | Grit tool unavailable/no JSON/malformed JSON/projection miss fixtures. |
+| Wrapper/Nx alias false green. | D3 graph availability/refusal required for check-related target invocation surfaces. | Injected missing-project alias or cache-disabled dependency-execution gate after D3 source exists. |
+| Baseline-covered diagnostics erased. | Covered diagnostics remain visible; only uncovered enforced errors fail. | Baseline-covered report-construction test. |
+| Baseline contract failure hidden. | D5 baseline refusal maps to failing diagnostic row. | Missing/malformed/orphan/growth/manifest fixture tests. |
+| Protected-zone violation downgraded. | D10 guard refusal maps to failing/refused check outcome. | Staged generated-zone violation test after D10 acceptance. |
+| Human and JSON disagree. | Renderer consumes finalized report only; no independent status derivation. | Render/stringify equivalence tests. |
+| Verify/hook infer semantics from raw fields. | D7 publishes projections for D11/D12. | Projection consumer tests in D11/D12 implementation. |
+
+## Public Surface Compatibility Inventory
+
+Rows use `blocked-pending-d0-row` until the concrete D0 matrix exists. Source
+implementation cannot start while touched public rows remain placeholders.
+
+| Surface | Plane | D0 surface id | Required handling before source edits |
+| --- | --- | --- | --- |
+| `habitat check` flags and selector behavior | command-behavior | `blocked-pending-d0-row` | Preserve, facade, version, or refuse explicitly. |
+| `habitat check --json` schemaVersion 1 `CheckReport` | command-json | `blocked-pending-d0-row` | Preserve unless D0 versions; semantic consistency may tighten through facade/validator decision. |
+| `habitat check` human output | human-output | `blocked-pending-d0-row` | Preserve/facade/version summary and refusal wording. |
+| `habitat check --output` | command-behavior | `blocked-pending-d0-row` | Preserve write semantics or version through D0. |
+| `habitat check --staged` | command-behavior/hook | `blocked-pending-d0-row` | Preserve staged behavior while adding explicit not-applicable/refusal states. |
+| `habitat check --expand-baseline` | command-behavior | `blocked-pending-d0-row` | D5 owns expansion; D7 preserves command separation. |
+| `baseline-integrity` built-in row | command-json/human-output | `blocked-pending-d0-row` | Decide whether it remains built-in only or becomes selectable; current `--rule baseline-integrity` fails. |
+| `CheckReport`, `RuleReport`, `HabitatDiagnostic`, `RuleStatus` | package-export/command-json | `blocked-pending-d0-row` | Preserve/facade/version names and schema. |
+| `validateCheckReport` | package-export | `blocked-pending-d0-row` | Tighten semantics only through D0/D1-compatible handling. |
+| `createCheckReport`, `renderCheckReport`, `stringifyCheckReport` | package-export | `blocked-pending-d0-row` | Preserve public call shape or version/facade. |
+| Hook parsing of check output | hook/human-output | `blocked-pending-d0-row` | Preserve D11 compatibility until D11 consumes projection. |
+| Verify check summary | command-json | `blocked-pending-d0-row` | D12 consumes D7 projection; current `{}` selector summary is compatibility fact. |
+| Nx `habitat:check` and `habitat:rule:*` outputs | script/Nx target output | `blocked-pending-d0-row` | Preserve or version target output semantics with D3 dependency facts. |
+| Docs/examples/generated help | docs-example/generated-only | `blocked-pending-d0-row` | Document-only or generated-only changes after source behavior is settled. |
+
+## D11 Consumer Contract
+
+D7 must publish `LocalFeedbackCheckProjection` for D11 with:
+
+- `kind`: `pass`, `fail`, `advisory-only`, `selector-refused`,
+  `dependency-refused`, `diagnostic-unavailable`, `baseline-refused`,
+  `protected-zone-refused`, or `not-applicable`;
+- selected rule ids and status counts;
+- failed/advisory rule ids;
+- local rendering message and recovery hint when present;
+- non-claims: local feedback only, not CI, not verify, not product/runtime
+  behavior, not apply safety, not Graphite/OpenSpec readiness.
+
+D11 may decide hook sequencing and staged-file behavior. It may not parse D7
+human output to discover structural semantics.
+
+The diagnostic, baseline, and protected-zone projection labels above are
+audience-facing labels for D6, D5, and D10 owner-specific refusal states carried
+through D7; they are not separate D7 policy domains.
+
+## D12 Consumer Contract
+
+D7 must publish `VerifyCheckSummaryProjection` for D12 with:
+
+- requested selectors and check mode;
+- selected real rule ids and built-in row ids;
+- status counts, advisory count, failing count, refused count, and
+  not-applicable count;
+- `allowsAffectedExecution: boolean`, derived from `CheckOutcome`;
+- skipped-affected reason when check failed/refused;
+- bounded non-claims: check does not prove CI, runtime/product behavior, apply
+  safety, Graphite readiness, OpenSpec acceptance, or graph target execution.
+
+D12 owns verify receipt schema and affected-target execution. D7 only supplies
+the check summary and skip/allow signal.
+
+Skipped-affected reasons may name diagnostic, baseline, graph, or protected-zone
+refusals when those owner-specific states are present, but D12 receives them as
+D7 check-summary projections, not as permission to recompute upstream authority.
+
+## Write Set And Protected Paths
+
+This design packet may edit only `$D7_CHANGE/**`, `$REMEDIATION_DIR/context.md`,
+`$REMEDIATION_DIR/packet-index.md` when D7 status changes, and D7 scratch/final
+review files under `$AGENT_SCRATCH`.
+
+Later source implementation may edit only after D7 acceptance and prerequisites:
+
+| Area | Purpose |
+| --- | --- |
+| `$HABITAT_TOOL/src/lib/command-engine.ts` | Keep public facade while delegating to D7 pipeline stages. |
+| New `$HABITAT_TOOL/src/lib/check/**` or equivalent | D7-owned state model, report construction, selector projection, execution aggregation, consumer projections. |
+| `$HABITAT_TOOL/src/lib/diagnostics.ts` | Semantic `CheckReport` construction/validation while preserving public compatibility. |
+| `$HABITAT_TOOL/src/rules/messages.ts` | Truth-preserving human rendering only from finalized outcome. |
+| `$HABITAT_TOOL/src/commands/check.ts` | Request normalization/exit handling only if public flags stay D0-compatible. |
+| `$HABITAT_TOOL/src/commands/verify.ts` and verify summary helpers | Consume D7 verify summary projection without owning check semantics. |
+| `$HABITAT_TOOL/src/lib/hooks.ts` | Only compatibility bridge until D11 consumes D7 projection. |
+| `$HABITAT_TOOL/src/index.ts` | Export facades or versioned public symbols only with D0 rows. |
+| Focused tests under `$HABITAT_TOOL/test/commands/**` and `$HABITAT_TOOL/test/lib/**` | Characterization and D7 state/consumer validation. |
+
+Protected paths:
+
+- `$HABITAT_TOOL/baselines/**` except fixture-controlled tests owned by D5;
+- `$HABITAT_TOOL/src/rules/rules.json` and registry generators unless D2 owns
+  the change;
+- `$HABITAT_TOOL/src/lib/baseline.ts` D5 semantics;
+- `$HABITAT_TOOL/src/lib/grit.ts`, `grit-failures.ts`, and
+  `grit-injected-probe.ts` D6 semantics;
+- `$HABITAT_TOOL/src/lib/generated-zones.ts` D10 semantics until D10 acceptance;
+- `$HABITAT_TOOL/src/plugin.js` D3 graph topology unless D3 owns the change;
+- `.grit/**`, generated artifacts, lockfiles, and non-Habitat product domains.
+
+## Validation Matrix
+
+| Gate | Command/test | Expected outcome | Covers | Non-claim |
+| --- | --- | --- | --- | --- |
+| D7-OPEN | `bun run openspec -- validate deep-habitat-d7-structural-enforcement-pipeline --strict` | exit 0 | OpenSpec shape | Not source behavior |
+| D7-ALL-OPEN | `bun run openspec:validate` | exit 0 | Cross-change OpenSpec consistency | Not source behavior |
+| D7-DIFF | `git diff --check` | exit 0 | Patch hygiene | Not semantic correctness |
+| D7-SELECTOR | `bun run --cwd tools/habitat-harness test -- test/lib/rule-selection.test.ts` | exit 0 | Selector facts/refusals and staged Grit filtering | Not command output |
+| D7-ENTRY | `bun run --cwd tools/habitat-harness test -- test/commands/habitat-entrypoints.test.ts` | exit 0 after current help failure repaired/dispositioned | Public command behavior, invalid selector JSON/human, baseline contract JSON | Not current-tree cleanliness |
+| D7-SURFACE | `bun run --cwd tools/habitat-harness test -- test/lib/enforcement-surface.test.ts` | exit 0 after registry inventory drift repaired/dispositioned | Enforcement inventory and Nx target surface | Not rule correctness |
+| D7-REPORT-SEMANTIC | new focused report-construction test | contradictory `ok`/status report rejected or unconstructable | False-green report invariant | Not diagnostic correctness |
+| D7-LANE | new focused lane/status tests | advisory findings exit/pass; enforced uncovered errors fail | Lane separation | Not advisory completeness |
+| D7-BASELINE | `bun run --cwd tools/habitat-harness test -- test/lib/baseline.test.ts` plus D7 report tests | D5 states project into D7 rows without erasure | Baseline application/integrity consumption | Not baseline policy ownership |
+| D7-DIAGNOSTIC | `bun run --cwd tools/habitat-harness test -- test/lib/grit-adapter.test.ts test/lib/grit-injected-probe.test.ts test/grit/grit-patterns.test.ts` plus D7 adapter-failure tests | D6 adapter/refusal states cannot pass | Diagnostic consumption | Not Pattern Governance or apply safety |
+| D7-PROTECTED | staged generated-zone fixture after D10 acceptance | protected-zone refusal exits nonzero and remains D10-owned | D10 guard consumption | Not write approval |
+| D7-RENDER | new render/stringify equivalence tests | JSON/human/exit agree for pass/fail/advisory/refusal states | Rendering truth equivalence | Not rule correctness |
+| D7-COMMAND-CURRENT | focused `habitat check` commands selected by implemented surfaces | expected status recorded per current tree | Public command integration | Not CI/runtime/product behavior |
+
+Do not cite `bun run habitat:check -- --json --rule baseline-integrity` as a
+current valid gate. Today it is an invalid selector. Making built-in rows
+selectable is a D0/D7 public behavior decision.
+
+## Refactor Pattern
+
+D7 implementation must follow the TypeScript Refactoring bar:
+
+1. Characterize current public behavior before structural moves.
+2. Introduce closed discriminated states before splitting files.
+3. Keep public DTOs behind D0/D1-compatible facades while internal state space
+   collapses.
+4. Migrate consumers stage by stage.
+5. Delete local recomputation and invalid state constructors.
+6. Run compiler/tests after each logical move.
+
+The rejected alternative is splitting `command-engine.ts` by file size. The
+target is lower reachable state space: no broad option object, no settable
+`ok`, no whole-row registry authority, no erased baseline-covered diagnostics,
+and no adapter/graph/protected-zone failure represented as pass.

--- a/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/proposal.md
+++ b/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/proposal.md
@@ -2,82 +2,139 @@
 
 ## Summary
 
-Open the D7 Structural Enforcement Pipeline OpenSpec packet for Deep Habitat Phase 2 remediation. This
-change converts the existing D7 domino packet into a review-gated
-OpenSpec packet scaffold. It resolves scope, owner, public surface impact,
-validation gates, downstream realignment, and stop conditions before any
-TypeScript implementation resumes.
+D7 specifies the Structural Enforcement Pipeline for Habitat `check`. It turns
+selected rule metadata, graph invocation facts, diagnostic outcomes, baseline
+application results, and protected-zone guard decisions into one coherent check
+outcome, public `CheckReport`, human rendering, and command exit decision.
 
-## Authority
-
-- Current user decision to restart OpenSpec packet preparation from square one.
-- Remediation frame: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation-frame.md.
-- Phase 2 packet suite: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets.
-- Root AGENTS.md Graphite/OpenSpec workflow guidance.
-- Domain Design and Information Design skills as mandatory language and artifact gates.
-- Current Habitat Toolkit code and tests as present-behavior evidence only.
-- Source domino packet: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D7-structural-enforcement-pipeline.md.
+This packet replaces the prior incomplete packet with design/specification
+content. It is not implementation-complete. Source edits remain blocked until
+concrete D0 compatibility rows, live D2/D3/D5/D6 projections, and an accepted
+D10 protected-zone contract exist for every touched surface.
 
 ## Product Scenario
 
-An agent runs Habitat check and receives a reliable structural result that composes registry metadata, diagnostics, baselines, generated-zone guards, and graph facts without false green paths.
+An agent or human runs `habitat check`, `habitat check --json`, or a selector
+such as `--owner`, `--rule`, `--tool`, or `--staged`. Habitat returns a
+trustworthy structural result where:
+
+- selector refusals are not confused with rule execution;
+- advisory findings do not fail the check;
+- enforced uncovered findings do fail the check;
+- dependency, baseline, diagnostic, graph, or protected-zone refusals cannot
+  become pass;
+- baseline-covered findings remain visible as covered debt;
+- JSON, human output, and process exit state are derived from the same
+  finalized check outcome.
+
+## Authority
+
+- Direct user D7 entry gate and remediation restart decisions.
+- `$REMEDIATION_DIR/context.md` for path variables.
+- `$D7_SOURCE_PACKET` as controlling domino input.
+- Accepted design/specification packets D0, D1, D2, D3, D5, and D6.
+- D10 as a required protected-zone dependency, currently still draft/blocking.
+- Current Habitat code/tests as current-behavior evidence, not target authority.
+- Domain Design, Ontology Design, Information Design, Solution Design,
+  TypeScript Refactoring, Testing Design, and Civ7 OpenSpec Workstream skills.
 
 ## What Changes
 
-- Define check pipeline ownership and inputs from D2/D3/D5/D6/D10.
-- Specify result aggregation and failure/refusal states.
-- Separate enforcement result from orientation and receipts.
+- D7 defines the check pipeline owner boundary and target state model.
+- D7 defines how upstream projections are consumed without recomputing adjacent
+  domain authority.
+- D7 defines false-green prevention invariants for selector, execution,
+  diagnostic, baseline, graph, protected-zone, report, rendering, and exit
+  states.
+- D7 defines D11 and D12 consumer projections so later packets do not infer
+  check semantics from current `command-engine.ts`.
+- D7 defines a validation matrix that falsifies real check risks.
 
 ## What Does Not Change
 
-- No rule registry schema ownership.
-- No baseline admission ownership.
-- No hook-specific local feedback ownership.
+- D7 does not own D0 public-surface classification or concrete compatibility
+  rows.
+- D7 does not own D1 command receipt, verify receipt, hook trace, refusal record,
+  or non-claim family definitions.
+- D7 does not own D2 rule registry metadata, selector facts, or rule facet
+  projections.
+- D7 does not own D3 graph truth, target availability, alias dependency
+  resolution, or Nx graph refusal reasons.
+- D7 does not own D5 baseline state, shrink-only integrity, expansion decisions,
+  external exception projection, or rule-introduction manifests.
+- D7 does not own D6 diagnostic acquisition, Grit/native catalog identity,
+  injected probes, adapter failure taxonomy, or cache/freshness observations.
+- D7 does not own D10 protected-zone or generated-zone policy.
+- D7 does not own D11 hook sequencing/local feedback or D12 verify handoff
+  receipt schema.
 
 ## Requires
 
-- D0
-- D1
-- D2
-- D3
-- D5
-- D6
-- D10
+| Dependency | D7 design use | Source implementation blocker |
+| --- | --- | --- |
+| D0 | Public-surface planes and closed compatibility handling. | Concrete D0 rows are required before changing command JSON, human output, package exports, hook parsing, docs examples, script/Nx outputs, generated help, or exit behavior. |
+| D1 | Check report boundary, refusal/non-claim discipline, and receipt/trace separation. | D1 implementation and output-family decisions must exist wherever D7 touches D1-governed public compatibility names. |
+| D2 | Selector facts, rule report facts, rule execution facts, baseline/Grit/generated-zone projections. | Live D2 projections must replace whole-row registry authority before source implementation removes current `HarnessRule` coupling. |
+| D3 | Graph target/check invocation availability and graph-refusal states. | Live D3 graph projections must exist before D7 can prevent check-related Nx wrapper false greens in source. |
+| D5 | `BaselineApplicationResult`, `BaselineIntegrityResult`, and D5 refusal diagnostics. | Live D5 baseline application/integrity results must exist before D7 deletes local baseline loading/application. |
+| D6 | `DiagnosticRunOutcome` or diagnostic consumer projection. | Live D6 diagnostic projections must exist before D7 deletes local Grit/native diagnostic coupling. |
+| D10 | Protected-zone guard decision/refusal consumed by staged/file-layer check. | D10 is still draft; source implementation of protected-zone report outcomes is blocked until D10 acceptance and live guard results. |
 
 ## Enables
 
-- D11
-- D12
+- D11 Local Feedback can consume D7's local-feedback-safe check projection
+  instead of parsing current human output or reinterpreting `CheckReport`.
+- D12 Verify Handoff Receipt can consume D7's verify-check summary and skip/allow
+  affected-target execution without redefining check semantics.
 
-## Affected Owners
+## Public Surface Impact
 
-- Domain owner: Structural Enforcement.
-- OpenSpec change path: `openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/**`.
-- Expected Habitat implementation write set named in `design.md`; no code is
-  authorized by this remediation packet itself.
+D7 is public-surface heavy. Source implementation must cite concrete D0 rows
+before touching:
 
-## Forbidden Owners
+- `habitat check` flags, selector behavior, `--json`, `--output`, `--staged`,
+  `--expand-baseline`, process exit behavior, and human output;
+- `CheckReport`, `RuleReport`, `HabitatDiagnostic`, `RuleStatus`,
+  `validateCheckReport`, `createCheckReport`, `renderCheckReport`, and
+  `stringifyCheckReport` package exports;
+- hook parsing/feedback that reads check JSON or messages;
+- verify summary fields derived from check reports;
+- Nx `habitat:check` / `habitat:rule:*` command surfaces;
+- docs/examples and generated help/manifests that show check output.
 
-- Adjacent dominoes may not redefine Structural Enforcement authority.
-- Current code names may not become target-domain language without this packet
-  accepting the term.
-- Implementation agents may not add shims, fallbacks, dual paths, silent skips,
-  optional target shape, or generated-output hand edits.
-
-## Consumer Impact
-
-Check JSON may change only through D0 compatibility and D1 receipt/non-claim decisions.
+Allowed D0 handling values remain exactly `preserve`, `version`, `facade`,
+`deprecate`, `refuse`, `document-only`, and `generated-only`.
 
 ## Stop Conditions
 
-- A diagnostic failure is reported as pass.
-- Baseline/generated-zone/graph decisions are recomputed locally instead of consumed.
-- Check owns hook or verify handoff semantics.
+Stop D7 if any artifact permits:
+
+- `CheckReport.ok` to contradict finalized rule statuses;
+- a selector refusal to be represented as ordinary successful rule execution;
+- selected rules to disappear without an explicit not-run/refused disposition;
+- diagnostic adapter failure, graph refusal, baseline refusal, or protected-zone
+  refusal to become pass;
+- advisory and enforced lanes to share status derivation by convention only;
+- baseline-covered diagnostics to disappear from the report;
+- renderer/stringifier/output code to invent semantics absent from the finalized
+  structured outcome;
+- D7 to read whole registry, baseline, Grit, graph, or protected-zone internals
+  after the owning upstream projection exists.
 
 ## Verification Gates
 
-- bun run --cwd tools/habitat-harness test -- test/commands/habitat-commands.test.ts
-- bun run habitat check --json
-- bun run openspec -- validate deep-habitat-d7-structural-enforcement-pipeline --strict
+Design-time gates:
+
+- `bun run openspec -- validate deep-habitat-d7-structural-enforcement-pipeline --strict`
 - `bun run openspec:validate`
 - `git diff --check`
+- D7 complete-standard wording audit across `$D7_CHANGE/**` and D7 scratch/final
+  review records.
+
+Later implementation gates are defined in `design.md` and `tasks.md`. Current
+known evidence from fresh review:
+
+- `baseline-integrity` is a built-in report row today, not a selectable rule.
+  Any selectable built-in command behavior is a D0/D7 design change.
+- Current entrypoint/enforcement inventory tests are red for help/inventory
+  drift and must be repaired or explicitly dispositioned before source closure.

--- a/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/specs/habitat-harness/spec.md
+++ b/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/specs/habitat-harness/spec.md
@@ -1,13 +1,217 @@
 ## ADDED Requirements
 
-### Requirement: D7 Structural Enforcement Pipeline Is Resolved Before Implementation
+### Requirement: Structural Enforcement Consumes Upstream Projections Only
 
-Habitat structural enforcement SHALL aggregate typed registry, graph, diagnostic, baseline, and protected-zone decisions into a check result without recomputing adjacent domain authority or reporting unavailable checks as passing.
+D7 Structural Enforcement SHALL compose accepted upstream projections into check
+outcomes without recomputing adjacent domain authority.
 
-#### Scenario: All required inputs are available
-- **WHEN** Habitat check runs for a supported repo state
-- **THEN** the result reports structural pass/fail from consumed domain decisions
+#### Scenario: D7 consumes rule metadata
+- **WHEN** a check request selects registered rules
+- **THEN** D7 consumes D2 selector, report, execution, baseline, Grit, and generated-zone facts
+- **AND** D7 SHALL NOT treat whole registry rows, prose scope strings, or optional legacy rule fields as target authority after D2 projections exist
 
-#### Scenario: An input authority is unavailable
-- **WHEN** registry, graph, diagnostic, baseline, or protected-zone facts cannot be resolved
-- **THEN** the check reports blocked or failed state rather than false green
+#### Scenario: D7 consumes graph availability
+- **WHEN** a check-related Nx target, alias target, or wrapper target is part of the check invocation surface
+- **THEN** D7 consumes D3 target availability or `GraphRefusal`
+- **AND** D7 SHALL NOT treat wrapper exit 0 as structural success unless D3 dependency resolution is accepted
+
+#### Scenario: D7 consumes baseline authority
+- **WHEN** rule diagnostics need baseline application or baseline integrity is reported
+- **THEN** D7 consumes D5 `BaselineApplicationResult` or `BaselineIntegrityResult`
+- **AND** D7 SHALL NOT decide shrink-only integrity, baseline growth, external exception projection, or rule-introduction manifest acceptance
+
+#### Scenario: D7 consumes diagnostic outcomes
+- **WHEN** a selected diagnostic rule runs
+- **THEN** D7 consumes D6 `DiagnosticRunOutcome` or diagnostic consumer projection
+- **AND** D7 SHALL NOT parse raw Grit reports, raw process records, or infer Pattern Governance or apply safety
+
+#### Scenario: D7 consumes protected-zone decisions
+- **WHEN** staged/file-layer check encounters generated or protected-zone surfaces
+- **THEN** D7 consumes D10 protected-zone guard decisions and refusals
+- **AND** D7 SHALL NOT define generated/protected-zone policy or write approval
+
+### Requirement: Selector Outcomes Are Closed Before Execution
+
+D7 SHALL distinguish selector refusal from selected rule execution.
+
+#### Scenario: Selector request is accepted
+- **WHEN** D2 selector facts resolve to one or more selected rules
+- **THEN** D7 creates a `SelectedRuleSet`
+- **AND** every selected rule has an execution plan or explicit not-applicable/refused disposition
+
+#### Scenario: Selector value is unknown
+- **WHEN** a selector requests an unknown owner, rule, or tool
+- **THEN** D7 creates a `SelectorRefusal`
+- **AND** no ordinary rule execution is planned
+- **AND** the public compatibility projection may preserve the `rule-selection-integrity` row only through D0/D1-compatible handling
+
+#### Scenario: Selector value belongs to another selector namespace
+- **WHEN** a selector requests a value that is known under another selector kind
+- **THEN** D7 creates a wrong-namespace `SelectorRefusal`
+- **AND** the check exits nonzero
+
+#### Scenario: Valid selector intersection is empty
+- **WHEN** multiple valid selectors have no overlapping rules
+- **THEN** D7 creates an empty-intersection `SelectorRefusal`
+- **AND** D7 SHALL NOT report zero executed rules as pass
+
+### Requirement: Execution Dispositions Cannot Disappear
+
+D7 SHALL give every selected rule an explicit execution disposition.
+
+#### Scenario: Rule executes and reports clean
+- **WHEN** a selected rule has accepted dependencies and D6 or native execution returns a clean outcome
+- **THEN** D7 may construct a passing rule outcome for an enforced rule
+
+#### Scenario: Rule executes and reports findings
+- **WHEN** a selected rule has a non-empty diagnostic finding set
+- **THEN** D7 preserves the diagnostics through report construction
+- **AND** D7 distinguishes advisory findings from enforced uncovered findings
+
+#### Scenario: Rule is not applicable to staged scope
+- **WHEN** a selected staged rule has no approved staged roots or is not applicable to the staged request
+- **THEN** D7 records a `not-applicable` disposition
+- **AND** D7 SHALL NOT silently drop the selected rule from the check outcome
+
+#### Scenario: Rule dependency is refused
+- **WHEN** D2, D3, D5, D6, or D10 refuses a required dependency for a selected rule
+- **THEN** D7 records a dependency-refused disposition
+- **AND** the rule or check outcome cannot be pass
+
+### Requirement: Diagnostic Failures Cannot Become Pass
+
+D7 SHALL map D6 diagnostic failures to non-passing check outcomes.
+
+#### Scenario: Adapter fails
+- **WHEN** D6 reports tool unavailable, command failed, interrupted command, no JSON, malformed JSON, schema drift, unexpected shape, empty scan roots, projection miss, unexpected identity, or missing cache observation
+- **THEN** D7 constructs a failed or refused rule outcome
+- **AND** the check cannot exit as pass because of that selected rule
+
+#### Scenario: Findings projection is empty
+- **WHEN** D6 reports a findings variant
+- **THEN** D7 requires a non-empty diagnostic set
+- **AND** an empty findings variant is rejected before report construction
+
+### Requirement: Baseline Application Preserves Diagnostics
+
+D7 SHALL consume D5 baseline application without erasing structural findings.
+
+#### Scenario: Diagnostics are covered by baseline debt
+- **WHEN** D5 marks diagnostics as covered by explicit debt or modeled external exception projection
+- **THEN** D7 keeps those diagnostics visible as covered debt
+- **AND** D7 may derive pass for an enforced rule only when no uncovered enforced diagnostics remain
+
+#### Scenario: Enforced diagnostics are uncovered
+- **WHEN** D5 returns uncovered error diagnostics for an enforced rule
+- **THEN** D7 derives a failing rule outcome
+- **AND** `CheckReport.ok` is false
+
+#### Scenario: Baseline authority refuses
+- **WHEN** D5 returns a baseline application refusal or baseline integrity refusal
+- **THEN** D7 renders D5's refusal as a command diagnostic
+- **AND** D7 does not redefine the D5 refusal reason
+- **AND** the check cannot pass
+
+#### Scenario: Built-in baseline integrity is reported
+- **WHEN** D7 includes the built-in baseline-integrity row
+- **THEN** the row is derived from D5 `BaselineIntegrityResult`
+- **AND** D7 SHALL NOT claim `--rule baseline-integrity` is selectable unless D0/D7 intentionally design that public command behavior
+
+### Requirement: Lane And Status Derivation Is Centralized
+
+D7 SHALL derive rule status from lane, diagnostics, baseline state, and refusal
+state through one constructor.
+
+#### Scenario: Advisory rule has findings
+- **WHEN** an advisory rule reports one or more advisory diagnostics
+- **THEN** D7 derives `advisory-findings`
+- **AND** the check may exit 0 when no enforced failures/refusals exist
+
+#### Scenario: Enforced rule has uncovered error diagnostics
+- **WHEN** an enforced rule reports uncovered error diagnostics
+- **THEN** D7 derives `fail`
+- **AND** the check exits nonzero
+
+#### Scenario: Rule has no diagnostics and no refusals
+- **WHEN** a selected rule executes cleanly with accepted dependencies
+- **THEN** D7 derives `pass`
+
+### Requirement: CheckReport Is Derived Or Semantically Rejected
+
+D7 SHALL make contradictory public reports unrepresentable through construction
+or rejected through validation.
+
+#### Scenario: Failing rule is present
+- **WHEN** a finalized report contains any rule with status `fail`
+- **THEN** `CheckReport.ok` is false
+
+#### Scenario: No failing rule is present
+- **WHEN** a finalized report contains only pass and advisory-findings statuses
+- **THEN** `CheckReport.ok` is true unless the check outcome is an explicit selector/dependency refusal projected through a D0-compatible failure row
+
+#### Scenario: Contradictory report is supplied to validation
+- **WHEN** a structurally valid `CheckReport` says `ok: true` while containing a failing rule
+- **THEN** D7 validation rejects the report or the report cannot be constructed through public constructors
+
+### Requirement: Rendering Preserves Structured Truth
+
+D7 SHALL render JSON, human output, output files, and exit codes from the same
+finalized check outcome.
+
+#### Scenario: Human rendering summarizes failure
+- **WHEN** the finalized check outcome is failed or refused
+- **THEN** human output says FAIL
+- **AND** the listed failing/refused rule ids match the structured report
+
+#### Scenario: JSON rendering serializes report
+- **WHEN** JSON output is requested
+- **THEN** the serialized `CheckReport` matches the finalized check outcome
+- **AND** renderer code does not invent independent status or exit semantics
+
+#### Scenario: Output path is requested
+- **WHEN** `--output` is provided
+- **THEN** D7 writes the same JSON report that stdout would render for `--json`
+
+### Requirement: D11 Receives Local Feedback Projection
+
+D7 SHALL publish a local-feedback-safe check projection for D11.
+
+#### Scenario: Hook consumes check outcome
+- **WHEN** D11 needs local hook feedback
+- **THEN** it consumes D7 `LocalFeedbackCheckProjection`
+- **AND** it does not parse D7 human output to infer structural semantics
+
+#### Scenario: Hook reports non-claims
+- **WHEN** D11 renders local feedback from D7
+- **THEN** it preserves local-feedback-only non-claims
+- **AND** it does not imply CI, verify, apply safety, runtime/product behavior, Graphite readiness, or OpenSpec acceptance
+
+### Requirement: D12 Receives Verify Check Summary
+
+D7 SHALL publish a verify-check summary projection for D12.
+
+#### Scenario: Check permits affected verification
+- **WHEN** D7's check outcome has no enforced failures or dependency refusals
+- **THEN** D12 may treat the check summary as allowing affected-target execution
+- **AND** D12 still owns verify receipt schema and affected-target behavior
+
+#### Scenario: Check blocks affected verification
+- **WHEN** D7's check outcome is failed, selector-refused, dependency-refused, diagnostic-refused, baseline-refused, or protected-zone-refused
+- **THEN** D12 receives a skipped-affected reason
+- **AND** D12 does not run affected targets as if check passed
+- **AND** diagnostic-refused, baseline-refused, and protected-zone-refused are D7 projections of D6, D5, and D10 owner-specific refusal states, not new D7-owned authority domains
+
+### Requirement: Public Surface Changes Wait For D0 Rows
+
+D7 source implementation SHALL stop before public-surface changes when concrete
+D0 rows are absent.
+
+#### Scenario: D7 touches command JSON or human output
+- **WHEN** D7 implementation would change `habitat check` JSON, human output, output files, flags, selector behavior, built-in row selectability, or exit behavior
+- **THEN** the implementation cites concrete D0 rows
+- **AND** every row uses one closed handling value: `preserve`, `version`, `facade`, `deprecate`, `refuse`, `document-only`, or `generated-only`
+
+#### Scenario: D7 touches package exports
+- **WHEN** D7 implementation changes `CheckReport`, `RuleReport`, `HabitatDiagnostic`, `RuleStatus`, `validateCheckReport`, `createCheckReport`, `renderCheckReport`, or `stringifyCheckReport`
+- **THEN** the implementation cites concrete D0 rows
+- **AND** source implementation stops while any touched row remains `blocked-pending-d0-row`

--- a/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/tasks.md
+++ b/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/tasks.md
@@ -1,33 +1,100 @@
 # Tasks
 
-## 1. Pre-Implementation Grounding
+## 1. Packet Readiness Before Source Implementation
 
-- [ ] 1.1 Read `D7-structural-enforcement-pipeline.md`, the remediation frame, D0 compatibility records,
-  and this OpenSpec packet.
-- [ ] 1.2 Confirm the branch/worktree starts from the approved implementation
-  stack and is clean before source edits.
-- [ ] 1.3 Record the concrete write set and protected paths in the phase record.
-- [ ] 1.4 Re-run or cite the required dependency gates: D0, D1, D2, D3, D5, D6, D10.
+- [x] 1.1 Import fresh D7 domain/ontology, TypeScript state-space, code/topology,
+  OpenSpec/information, testing/validation, and cross-domino investigation
+  findings into the review ledger.
+- [x] 1.2 Replace the incomplete proposal/design/spec/tasks with a complete D7
+  Structural Enforcement design/specification packet.
+- [x] 1.3 Record D7 write set, protected paths, upstream blockers, downstream
+  contracts, and validation matrix in workstream records.
+- [x] 1.4 Run fresh final D7 rereview lanes against the repaired disk state.
+- [x] 1.5 Repair accepted P1/P2 final-rereview findings.
+- [x] 1.6 Update packet index only after final rereviews record no unresolved
+  P1/P2 findings.
 
-## 2. Implementation
+## 2. Source Implementation Prerequisites
 
-- [ ] 2.1 Define check pipeline ownership and inputs from D2/D3/D5/D6/D10.
-- [ ] 2.2 Specify result aggregation and failure/refusal states.
-- [ ] 2.3 Separate enforcement result from orientation and receipts.
+- [ ] 2.1 Cite concrete D0 rows for every touched command JSON, human output,
+  command behavior, package export, hook, verify, docs-example, script/Nx output,
+  and generated/help surface.
+- [ ] 2.2 Confirm D1 output-family handling for check report, diagnostics,
+  refusals, local feedback, verify summary, and non-claims.
+- [ ] 2.3 Confirm live D2 selector/report/execution/baseline/Grit/generated-zone
+  projections exist; do not migrate from whole registry rows until they do.
+- [ ] 2.4 Confirm live D3 graph invocation availability/refusal projections exist
+  for check-related Nx surfaces before removing wrapper false-green paths.
+- [ ] 2.5 Confirm live D5 baseline application/integrity results exist before
+  deleting local baseline loading/application in D7 code.
+- [ ] 2.6 Confirm live D6 diagnostic consumer projections exist before deleting
+  local Grit/native diagnostic coupling.
+- [ ] 2.7 Confirm D10 accepted protected-zone guard/refusal contract exists before
+  implementing protected-zone report outcomes.
 
-## 3. Validation
+## 3. Characterization And State Model
 
-- [ ] 3.1 Run `bun run --cwd tools/habitat-harness test -- test/commands/habitat-commands.test.ts`.
-- [ ] 3.2 Run `bun run habitat check --json`.
-- [ ] 3.3 Run `bun run openspec -- validate deep-habitat-d7-structural-enforcement-pipeline --strict`.
-- [ ] 3.4 Run `bun run openspec:validate`.
-- [ ] 3.5 Run `git diff --check`.
+- [ ] 3.1 Characterize current public command behavior for invalid selectors,
+  JSON/human rendering, `--output`, `--staged`, `--expand-baseline`, current
+  built-in `baseline-integrity` row behavior, and current non-selectability of
+  `--rule baseline-integrity`.
+- [ ] 3.2 Add semantic report-construction tests that reject or prevent
+  contradictory `CheckReport.ok` and rule status combinations.
+- [ ] 3.3 Introduce internal D7 closed states for `StructuralCheckRequest`,
+  `RuleSelectionOutcome`, `RuleExecutionPlan`, `RuleExecutionDisposition`,
+  `DiagnosticConsumptionOutcome`, `BaselineApplicationOutcome`,
+  `StructuralRuleOutcome`, and `CheckOutcome`.
+- [ ] 3.4 Preserve public `CheckReport`/`RuleReport` compatibility through
+  D0/D1-approved facades while the internal state model becomes authoritative.
 
-## 4. Review And Realignment
+## 4. Pipeline Migration
 
-- [ ] 4.1 Run domain-language, OpenSpec, TypeScript, validation, and
-  cross-domino review lanes.
-- [ ] 4.2 Repair accepted P1/P2 findings before packet closure.
-- [ ] 4.3 Update downstream docs, examples, specs, tests, and packet index rows
-  affected by implementation facts.
-- [ ] 4.4 Leave the worktree clean or write a zero-context next packet.
+- [ ] 4.1 Migrate selector resolution to consume D2 selector facts and project
+  selector refusals before execution planning.
+- [ ] 4.2 Migrate execution planning to consume D2 execution facts and D3 graph
+  availability/refusal facts.
+- [ ] 4.3 Migrate diagnostic consumption to consume D6 diagnostic projections and
+  preserve adapter/projection/cache refusal states.
+- [ ] 4.4 Migrate baseline application and baseline-integrity reporting to
+  consume D5 results without mutating diagnostics in the D7 stage.
+- [ ] 4.5 Migrate protected-zone/file-layer outcomes to consume D10 guard
+  decisions after D10 acceptance.
+- [ ] 4.6 Centralize rule status, check outcome, public report, rendering, and
+  exit derivation in D7-owned constructors.
+- [ ] 4.7 Delete local recomputation paths after each owning upstream projection
+  is live and covered by tests.
+
+## 5. Consumer Projections
+
+- [ ] 5.1 Publish `LocalFeedbackCheckProjection` for D11 and migrate hook
+  compatibility code only through D0/D1-approved handling.
+- [ ] 5.2 Publish `VerifyCheckSummaryProjection` for D12 and replace current
+  verify summary inference once D12 accepts the contract.
+- [ ] 5.3 Preserve D7 non-claims in both projections: no CI, runtime/product,
+  apply safety, Graphite readiness, OpenSpec acceptance, or graph execution
+  authority.
+
+## 6. Validation
+
+- [ ] 6.1 Run `bun run --cwd tools/habitat-harness test -- test/lib/rule-selection.test.ts`.
+- [ ] 6.2 Run `bun run --cwd tools/habitat-harness test -- test/commands/habitat-entrypoints.test.ts`.
+- [ ] 6.3 Run `bun run --cwd tools/habitat-harness test -- test/lib/enforcement-surface.test.ts`.
+- [ ] 6.4 Run focused D7 report-construction, lane/status, rendering, baseline
+  consumption, diagnostic-refusal, staged protected-zone, D11 projection, and D12
+  projection tests added by implementation.
+- [ ] 6.5 Run focused command proofs for implemented current-tree/staged
+  scenarios and record expected exit/status/non-claims.
+- [x] 6.6 Run `bun run openspec -- validate deep-habitat-d7-structural-enforcement-pipeline --strict`.
+- [x] 6.7 Run `bun run openspec:validate`.
+- [x] 6.8 Run `git diff --check`.
+
+## 7. Downstream Realignment And Closure
+
+- [ ] 7.1 Update D11 and D12 packet assumptions only after D7 acceptance records
+  the final projection contracts.
+- [ ] 7.2 Update D8/D9/D13/D14/D15 downstream assumptions where D7 check outcome
+  non-claims or trigger decisions affect them.
+- [ ] 7.3 Keep D7 accepted for design/specification only until source
+  implementation completes in a later layer.
+- [ ] 7.4 Commit the D7 design/specification layer through Graphite with a clean
+  subject/body commit message.

--- a/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/workstream/closure-checklist.md
+++ b/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/workstream/closure-checklist.md
@@ -1,20 +1,42 @@
 # Closure Checklist: D7 Structural Enforcement Pipeline
 
-## Design Readiness
+## Design/Specification Acceptance
 
-- [ ] Proposal cites controlling authority and source packet.
-- [ ] Design resolves naming, domain owner, forbidden owners, and non-goals.
-- [ ] Tasks are implementation steps, not unresolved design questions.
-- [ ] Spec delta uses normative SHALL language with scenarios.
-- [ ] Review ledger has no accepted unresolved P1/P2 findings.
-- [ ] Downstream realignment is recorded.
-- [ ] OpenSpec validation passes for `deep-habitat-d7-structural-enforcement-pipeline`.
+- [x] Proposal frames D7 as Structural Enforcement report/outcome authority.
+- [x] Proposal states D0/D1/D2/D3/D5/D6/D10 dependencies and source blockers.
+- [x] Design includes current enforcement inventory.
+- [x] Design includes target ontology and rejected terms.
+- [x] Design includes consumed-contract matrix for D2/D3/D5/D6/D10.
+- [x] Design includes closed target state model and pipeline stages.
+- [x] Design includes false-green invariant matrix.
+- [x] Design includes D0/D1 public-surface compatibility inventory.
+- [x] Design includes D11 and D12 consumer contracts.
+- [x] Tasks are implementation slices, not unresolved design questions.
+- [x] Spec delta includes normative scenarios for selector, execution,
+  diagnostic, baseline, lane/status, report, rendering, D11, D12, and D0
+  blocker behavior.
+- [x] First D7 investigation findings are imported into the review ledger.
+- [x] Fresh final rereview lanes have no unresolved P1/P2 findings against the
+  repaired disk state.
+- [x] D7 strict OpenSpec validation passes.
+- [x] Full OpenSpec validation passes.
+- [x] `git diff --check` passes.
+- [x] D7 wording audit is clean or remaining hits are explicitly non-guidance
+  provenance.
+- [x] Packet index row is updated only after acceptance evidence exists.
 
 ## Implementation Closure (Later)
 
-- [ ] Source changes stay inside the approved write set.
-- [ ] Validation gates pass with exact command output recorded.
-- [ ] Public-surface changes are dispositioned through D0 compatibility.
+- [ ] Concrete D0 rows cited for all touched public/durable surfaces.
+- [ ] Live D2/D3/D5/D6 projections and accepted D10 guard contract exist where
+  source implementation depends on them.
+- [ ] Source changes stay inside the approved D7 write set.
+- [ ] Public compatibility facades preserve or version D0-classified surfaces.
+- [ ] `CheckReport.ok` contradiction is unconstructable or rejected.
+- [ ] Selector refusals, dependency refusals, diagnostic failures, baseline
+  refusals, protected-zone refusals, advisory findings, and staged
+  not-applicable states have focused tests.
+- [ ] Human/JSON/output/exit behavior derives from one finalized outcome.
+- [ ] D11 and D12 consumer projections are implemented and tested.
 - [ ] Downstream docs/tests/specs are realigned.
-- [ ] Graphite layer is clean, reviewable, and does not proceed past unresolved
-  packet approval.
+- [ ] Graphite layer is clean and reviewable.

--- a/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/workstream/downstream-realignment-ledger.md
@@ -1,9 +1,27 @@
 # Downstream Realignment Ledger: D7 Structural Enforcement Pipeline
 
-| Downstream Surface | Disposition | Required Action |
+## Status
+
+D7 is accepted for design/specification after fresh final rereview found no
+unresolved P1/P2 blockers. Downstream rows below are design contracts, not
+implementation-complete claims. Source edits remain gated by concrete D0 rows,
+D1 output-family handling where touched, live D2/D3/D5/D6 projections, and an
+accepted D10 protected-zone guard/refusal contract where D7 consumes protected
+zone outcomes.
+
+| Surface | D7 disposition | Required downstream action |
 | --- | --- | --- |
-| Phase 2 packet suite | pending | Mark D7 as OpenSpec-packetized after review. |
-| D0 compatibility matrix | pending | Confirm public surfaces touched by D7 are classified before implementation. |
-| Habitat docs/examples | pending | Update only when implementation facts change or public guidance must be clarified. |
-| Tests and command fixtures | pending | Add or update during implementation according to tasks.md. |
-| Later domino packets | pending | Update dependency assumptions if review changes D7 contract. |
+| D0 public-surface matrix | D7 requires concrete rows for all touched check/report/export/hook/verify/Nx/docs/generated surfaces. | Do not start source edits while touched rows remain `blocked-pending-d0-row`. |
+| D1 receipt/refusal/non-claim boundary | D7 inherits check report and non-claim limits; `CheckReport` remains check output, not a receipt. | D11/D12 must preserve D1 non-claims when consuming D7 projections. |
+| D2 rule metadata projections | D7 consumes selector/report/execution/baseline/Grit/generated-zone facts. | D2 implementation must provide live projections before D7 deletes whole-row registry coupling. |
+| D3 graph boundary | D7 consumes graph target availability/refusal for check-related Nx invocation surfaces. | D12 continues to consume D3 verify target plans separately; D7 cannot be used as graph truth. |
+| D5 baseline authority | D7 consumes `BaselineApplicationResult` and `BaselineIntegrityResult`. | D5 remains the only owner of baseline state, expansion, integrity, external projection, and manifest acceptance. |
+| D6 diagnostic catalog | D7 consumes `DiagnosticRunOutcome` / diagnostic consumer projection. | D6 remains owner of Grit/native diagnostic identity, adapter failures, and probe outcomes. |
+| D10 protected-zone authority | D7 consumes D10 guard/refusal results. | D10 remains blocking; D7 protected-zone source work waits for D10 acceptance and live guard results. |
+| D11 Local Feedback | D7 publishes `LocalFeedbackCheckProjection`. | D11 must consume this projection for hook/local feedback and cannot infer check semantics from human output or current raw JSON. |
+| D12 Verify Handoff Receipt | D7 publishes `VerifyCheckSummaryProjection`. | D12 uses D7's allow/skip affected-execution signal but owns verify receipt schema and affected-target execution. |
+| D8 Pattern Governance | D7 check behavior is enforcement/report output only. | D8 may cite D7 outcomes as structural enforcement context but owns pattern lifecycle/admission. |
+| D9 Transformation Transaction | D7 pass does not approve writes. | D9 must require D8/D10/G-HOST/D9 transaction authority for apply safety. |
+| D13/D14 docs, generators, and topology | D7 affects examples and refusal/handoff wording only after D7 public surfaces are D0-classified. | Later packets must consume the accepted D7 design/specification contract without inferring implementation readiness. |
+| D15 trigger | D7 does not currently trigger D15. | D15 is triggered only if D7 implementation finds a concrete command-provenance/cache/cwd/env/output state that local D7 DTOs cannot encode. |
+| Packet index | D7 row is accepted for design/specification after final rereview and validation evidence. | Keep D7 marked not implementation-complete; D8-D15/G-HOST remain blocking unless their own rows say otherwise. |

--- a/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/workstream/phase-record.md
+++ b/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/workstream/phase-record.md
@@ -2,35 +2,94 @@
 
 ## State
 
-- Status: OpenSpec packet drafted for remediation review; implementation not
-  started.
-- Worktree: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation.
-- Branch: codex/deep-habitat-openspec-remediation.
-- Source packet: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D7-structural-enforcement-pipeline.md.
-- OpenSpec change: openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/.
+- Status: accepted for design/specification after fresh final rereview found no
+  unresolved P1/P2 blockers. Not implementation-complete.
+- Worktree: `$ACTIVE_REMEDIATION_WORKTREE`.
+- Branch: `$ACTIVE_REMEDIATION_BRANCH`.
+- Source packet: `$D7_SOURCE_PACKET`.
+- OpenSpec change: `$D7_CHANGE`.
+- D7 source implementation remains blocked behind concrete D0 rows, D1
+  output-family handling, live D2/D3/D5/D6 projections, and accepted D10 guard
+  contract wherever those surfaces are touched.
 
 ## Objective
 
-Convert D7 into a review-gated OpenSpec packet scaffold for Structural Enforcement
-without reopening implementation or carrying forward lazy domain language.
+Specify the Structural Enforcement Pipeline so implementation can collapse the
+current check path into explicit stage outcomes without inventing product/domain
+trade-offs while coding.
 
 ## Current Gate
 
-Design/preparation gate. The packet can authorize later implementation only
-after review ledgers contain no accepted unresolved P1/P2 findings.
+Final D7 rereview gate is closed for design/specification acceptance. The first
+investigation wave found P1/P2 blockers, the packet was rewritten to repair
+them, and fresh final domain/ontology, TypeScript/validation,
+OpenSpec/information, and code/topology/cross-domino lanes read the repaired
+disk and recorded no unresolved P1/P2 findings.
 
-## Exact Validation Gates
+## First Investigation Inputs
 
-- bun run --cwd tools/habitat-harness test -- test/commands/habitat-commands.test.ts
-- bun run habitat check --json
-- bun run openspec -- validate deep-habitat-d7-structural-enforcement-pipeline --strict
-- bun run openspec:validate
-- git diff --check
+| Lane | Scratch record | Status |
+| --- | --- | --- |
+| Domain/ontology | `$D7_DOMAIN_REVIEW` | BLOCKING; imported as repair input |
+| TypeScript state-space | `$D7_TYPESCRIPT_REVIEW` | BLOCKING; imported as repair input |
+| Code/topology | `$D7_TOPOLOGY_REVIEW` | BLOCKING; imported as repair input |
+| OpenSpec/information | `$D7_INFORMATION_REVIEW` | BLOCKING; imported as repair input |
+| Testing/validation | `$D7_VALIDATION_REVIEW` | BLOCKING; imported as repair input |
+| Cross-domino | `$D7_CROSS_DOMINO_REVIEW` | BLOCKING; imported as repair input |
+
+## Final Rereview Evidence
+
+| Lane | Scratch record | Result |
+| --- | --- | --- |
+| Domain/ontology | `$D7_FINAL_DOMAIN_REVIEW` | ACCEPTED; no unresolved P1/P2 |
+| TypeScript/validation | `$D7_FINAL_TYPESCRIPT_VALIDATION_REVIEW` | ACCEPTED; no unresolved P1/P2 |
+| OpenSpec/information | `$D7_FINAL_OPENSPEC_INFORMATION_REVIEW` | ACCEPTED; no unresolved P1/P2 |
+| Code/topology/cross-domino | `$D7_FINAL_TOPOLOGY_CROSS_DOMINO_REVIEW` | ACCEPTED; no unresolved P1/P2 |
+
+## Dependency State
+
+| Dependency | Design status | D7 implementation status |
+| --- | --- | --- |
+| D0 | accepted for design/specification | concrete matrix rows required before public-surface edits |
+| D1 | accepted for design/specification | output-family handling required where D7 touches D1-governed surfaces |
+| D2 | accepted for design/specification | live selector/report/execution/baseline/Grit/generated-zone projections required before deleting whole-row registry coupling |
+| D3 | accepted for design/specification | live graph target/refusal projections required before D7 closes wrapper false-green paths |
+| D5 | accepted for design/specification | live baseline application/integrity results required before D7 deletes baseline internals |
+| D6 | accepted for design/specification | live diagnostic consumer projections required before D7 deletes Grit/native coupling |
+| D10 | draft/blocking | accepted protected-zone guard/refusal contract required before D7 implements protected-zone outcomes |
+
+## Validation Matrix
+
+Design-time validation after this repair:
+
+| Gate | Command | Expected | Result |
+| --- | --- | --- | --- |
+| D7-OPEN | `bun run openspec -- validate deep-habitat-d7-structural-enforcement-pipeline --strict` | exit 0 | passed |
+| D7-ALL-OPEN | `bun run openspec:validate` | exit 0 | passed; 249 items valid |
+| D7-DIFF | `git diff --check` | exit 0 | passed |
+| D7-WORDING | complete-standard wording audit over `$D7_CHANGE/**` and D7 scratch/final review records | no active reduced-standard guidance | passed |
+
+Later implementation gates are listed in `design.md` and `tasks.md`. Fresh
+validation investigation recorded current red behavior for command help and rule
+inventory drift; implementation closure must repair or disposition those facts.
+
+## Write Set
+
+Current design/specification layer may edit:
+
+- `$D7_CHANGE/**`;
+- `$REMEDIATION_DIR/context.md`;
+- `$REMEDIATION_DIR/packet-index.md` only after acceptance status changes;
+- D7 scratch/final review files under `$AGENT_SCRATCH`.
+
+Source implementation write set is listed in `design.md` and remains blocked.
 
 ## Non-Claims
 
-- This remediation packet does not implement Habitat source changes.
-- This packet does not prove runtime behavior.
-- This packet does not approve Graphite submission for later implementation.
-- Legacy code names remain compatibility facts unless design.md accepts them as
-  target language.
+- D7 repair does not implement Habitat source changes.
+- D7 repair does not prove current-tree structural cleanliness.
+- D7 repair does not prove CI, runtime/product behavior, apply safety, Graphite
+  readiness, OpenSpec acceptance for later packets, or D10 protected-zone
+  closure.
+- D7 accepted design/specification, when achieved, will not mean
+  implementation-complete.

--- a/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/workstream/review-disposition-ledger.md
+++ b/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/workstream/review-disposition-ledger.md
@@ -1,10 +1,42 @@
 # Review Disposition Ledger: deep-habitat-d7-structural-enforcement-pipeline
 
+## Status
+
+D7 is accepted for design/specification after fresh final rereview found no
+unresolved P1/P2 blockers. It is not implementation-complete. All first-wave
+P1/P2 findings were accepted as repair input and repaired in the packet.
+
+## Findings
+
 | Finding | Severity | Disposition | Repair Evidence |
 | --- | --- | --- | --- |
-| Global domain-language concern catalog applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-domain-adversary.md and docs/projects/habitat-harness/openspec-remediation/review-disposition-ledger.md. Per-domino domain-language review remains blocking. |
-| Global OpenSpec artifact-shape constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-openspec-architect.md and packet traceability index. Per-domino OpenSpec review remains blocking. |
-| Global information-design constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-information-design-reviewer.md and traceability/evidence policy repairs. Per-domino information-design review remains blocking. |
-| Global validation-design constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-testing-validation-designer.md and packet validation gates. Per-domino validation review remains blocking. |
-| Global cross-domino sequencing constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-cross-domino-sequencer.md and dependency/trigger repairs. Per-domino sequencing compatibility review remains blocking. |
-| Per-domino adversarial review gate required before packet acceptance or source edits. | P1 | blocking, pending design-time review | Fresh per-domino domain, OpenSpec, topology, validation, information-design, and cross-domino reviewers must disposition findings before this packet can be accepted or used for implementation. |
+| Global domain-language concern catalog applies to D7 but is not acceptance evidence. | Global constraint | applied | Rewritten packet defines D7 target ontology and rejected terms; final D7 domain rereview remains required. |
+| Global OpenSpec artifact-shape constraints apply to D7 but are not acceptance evidence. | Global constraint | applied | Proposal/design/spec/tasks/control records were expanded; final D7 OpenSpec/information rereview remains required. |
+| Global validation-design constraints apply to D7 but are not acceptance evidence. | Global constraint | applied | `design.md`, `tasks.md`, and phase record now split design-time and later implementation gates. |
+| Global cross-domino sequencing constraints apply to D7 but are not acceptance evidence. | Global constraint | applied | D7 dependencies and downstream consumer contracts are recorded; final cross-domino rereview remains required. |
+| D7 packet lacked executable information architecture and did not define the Structural Enforcement ontology. | P1 | accepted and repaired | `design.md` now defines target terms, rejected terms, state model, pipeline stages, and false-green invariants; `$D7_FINAL_DOMAIN_REVIEW` accepted with no unresolved P1/P2. |
+| D7 did not specify consumed adjacent-domain contracts and left local recomputation paths open. | P1 | accepted and repaired | `proposal.md` and `design.md` now define D2/D3/D5/D6/D10 consumed-contract matrices and source blockers; final cross-domino review accepted with no unresolved P1/P2. |
+| False-green not-run/refusal states were incomplete. | P1 | accepted and repaired | `design.md` and `spec.md` now require explicit `RuleExecutionDisposition`, dependency-refused states, not-applicable states, and non-passing adapter/graph/baseline/protected-zone refusals; final TypeScript/validation review accepted with no unresolved P1/P2. |
+| `CheckReport`, rendering, and exit status were not one truth-preserving contract. | P2 | accepted and repaired | `design.md` defines `CheckOutcome`, `CheckReportConstructionResult`, rendering/exit derivation, and semantic validation; `spec.md` adds contradiction rejection and rendering truth requirements; final TypeScript/validation review accepted with no unresolved P1/P2. |
+| Selector request/result/refusal identity was underspecified. | P2 | accepted and repaired | `design.md` and `spec.md` now define `SelectorRequest`, `RuleSelectionOutcome`, `SelectorRefusal`, and selected-set rules; final domain/ontology and TypeScript/validation reviews accepted with no unresolved P1/P2. |
+| Validation gates were broad and cited invalid current command for `--rule baseline-integrity`. | P2 | accepted and repaired | `design.md`, `proposal.md`, `tasks.md`, and phase record now state `baseline-integrity` is currently a built-in row, not a selectable rule, and require D0/D7 decision before citing a selectable command gate; final validation review accepted with no unresolved P1/P2. |
+| Public compatibility blockers were generic. | P1 | accepted and repaired | `design.md` now lists D7 public-surface inventory with `blocked-pending-d0-row` placeholders and closed D0 handling values; source implementation remains blocked while touched rows are placeholders. |
+| D11/D12 consumer contracts were missing. | P1 | accepted and repaired | `design.md`, `spec.md`, and downstream ledger now define `LocalFeedbackCheckProjection` and `VerifyCheckSummaryProjection` contracts; final domain/ontology and cross-domino reviews accepted with no unresolved P1/P2. |
+| Tasks were unresolved design questions. | P2 | accepted and repaired | `tasks.md` now separates packet readiness, prerequisites, characterization, state model, pipeline migration, consumer projections, validation, and downstream closure; final OpenSpec/information review accepted with no unresolved P1/P2. |
+| Workstream ledgers were generic and could not support closure. | P2 | accepted and repaired | Phase record, review ledger, downstream ledger, and closure checklist now record D7-specific state, blockers, validations, and acceptance gates; final OpenSpec/information review accepted with no unresolved P1/P2. |
+| Final domain/ontology rereview found one P3 refusal-label alignment polish item. | P3 | accepted and repaired | `design.md` and `spec.md` now state diagnostic, baseline, graph, and protected-zone labels are owner-specific upstream refusals projected through D7, not new D7 policy domains. |
+
+## Final Rereview Evidence
+
+Fresh final rereview records against the repaired disk state found no unresolved
+P1/P2 across:
+
+| Lane | Scratch record | Result |
+| --- | --- | --- |
+| Domain/ontology | `$D7_FINAL_DOMAIN_REVIEW` | ACCEPTED; no unresolved P1/P2 |
+| TypeScript state-space and validation | `$D7_FINAL_TYPESCRIPT_VALIDATION_REVIEW` | ACCEPTED; no unresolved P1/P2 |
+| OpenSpec/information design | `$D7_FINAL_OPENSPEC_INFORMATION_REVIEW` | ACCEPTED; no unresolved P1/P2 |
+| Code/topology and cross-domino sequencing | `$D7_FINAL_TOPOLOGY_CROSS_DOMINO_REVIEW` | ACCEPTED; no unresolved P1/P2 |
+
+Accepted design/specification will not authorize source implementation until the
+source blockers in `phase-record.md` are satisfied.


### PR DESCRIPTION
Specify the D7 Structural Enforcement Pipeline OpenSpec packet as accepted for design/specification only. The packet defines current check-path inventory, target enforcement state families, upstream projection consumption from D2/D3/D5/D6/D10, D11/D12 consumer projections, D0/D1 public-surface blockers, validation gates, and review/control records. Adds first-wave investigation and final rereview scratch records with no unresolved P1/P2 findings.

Validation: D7 complete-standard wording audit; bun run openspec -- validate deep-habitat-d7-structural-enforcement-pipeline --strict; bun run openspec:validate; git diff --check.