### PR TITLE
docs(habitat): add D8 domain ontology investigation

### DIFF
--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-code-vendor-topology-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-code-vendor-topology-investigation.md
@@ -1,0 +1,449 @@
+# D8 Code/Vendor Topology Investigation
+
+Status: BLOCKING
+
+## Blocking Reason
+
+The current D8 disk packet is a draft scaffold, not a complete executable
+Pattern Governance topology contract. The current source tree contains partial
+Pattern Authority implementation facts, but those facts are present-behavior
+evidence only. They do not satisfy the Phase 2 D8 source packet as a complete
+OpenSpec target.
+
+The packet remains blocking because it does not yet normatively specify the full
+D8 lifecycle state model, current code topology, public surfaces, write set,
+protected paths, vendor ownership split, upstream/downstream contracts, stale
+outputs, or validation gates that a later implementation agent must follow
+without inventing product or domain decisions.
+
+## Sources Read
+
+Mandatory skill anchors:
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/source-map.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/validation-checks.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/artifact-contracts.md`
+
+Repo and OpenSpec sources:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/AGENTS.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/process/GRAPHITE.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md`
+- All current files under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d8-pattern-governance/`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+- Relevant upstream/downstream OpenSpec packet files for D0-D7, D9, D11, and D13.
+
+Current code, tests, and docs:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/rules/pattern-authority/manifest.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/generators/pattern/generator.cjs`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/generators/pattern/registration.cjs`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/generators/pattern/schema.json`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/rules/rules.json`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/plugin.js`
+- Relevant slices of `tools/habitat-harness/src/lib/command-engine.ts`, `tools/habitat-harness/src/lib/hooks.ts`, `tools/habitat-harness/src/lib/grit.ts`, `tools/habitat-harness/src/lib/grit-apply.ts`, and `tools/habitat-harness/src/lib/baseline.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/rules/pattern-authority-manifest.test.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/generators/pattern-generator.test.ts`
+- Grit check/apply pattern inventory under `.grit/patterns/habitat/**`
+- Baseline inventory under `tools/habitat-harness/baselines/**`
+- `tools/habitat-harness/README.md`, `tools/habitat-harness/docs/CAPABILITIES.md`, and `tools/habitat-harness/docs/SCENARIOS.md`
+
+## Vendor Docs Consulted
+
+- Grit CLI Reference: https://docs.grit.io/cli/reference
+- Grit authoring guide: https://docs.grit.io/guides/authoring
+- GritQL testing guide: https://docs.grit.io/guides/testing
+- Grit target languages: https://docs.grit.io/language/target-languages
+- Grit configuration and Markdown pattern rules: https://docs.grit.io/guides/config
+- Biome CLI reference: https://biomejs.dev/reference/cli/
+- Biome Continuous Integration recipe: https://biomejs.dev/recipes/continuous-integration/
+- Nx Local Generators: https://nx.dev/docs/extending-nx/local-generators
+- Nx Project Graph Plugins: https://nx.dev/docs/extending-nx/project-graph-plugins
+- Nx CreateNodesV2 reference: https://nx.dev/docs/reference/devkit/CreateNodesV2
+- Nx inferred tasks: https://nx.dev/docs/concepts/inferred-tasks
+- Nx run tasks: https://nx.dev/docs/features/run-tasks
+
+Vendor ownership facts D8 must respect:
+
+- Grit owns GritQL syntax, target-language declarations, Markdown pattern
+  loading, pattern frontmatter interpretation, native fixture execution through
+  `grit patterns test`, diagnostic observation through `grit check`, and write
+  transforms through `grit apply`.
+- Grit documentation makes Markdown pattern filename/title/body/frontmatter/test
+  conventions native Grit facts. Habitat may require additional Pattern
+  Authority metadata, but it must not pretend Grit frontmatter or prose is
+  Habitat authority.
+- `grit check` and `grit apply` are different vendor commands. Diagnostic
+  registration must not imply apply approval.
+- Biome owns `biome check`, `biome ci`, formatter/linter/import sorting
+  behavior, and CI-oriented no-write command semantics. D8 should not treat
+  Biome hygiene as Pattern Governance.
+- Nx owns generator mechanics, generator schema/default conventions, project
+  graph plugin `createNodesV2` mechanics, inferred task creation, target
+  inputs/outputs/cache metadata, and task running. Habitat owns which generator
+  requests it supports and which generated candidate states are non-enforcing.
+
+## Current Code Topology
+
+### Pattern Authority Manifest
+
+`tools/habitat-harness/src/rules/pattern-authority/manifest.ts` is the current
+core Pattern Authority surface.
+
+Current exported model:
+
+- `PatternAuthorityLifecycle` is only
+  `candidate | registered-advisory | registered-enforced`.
+- `PatternAuthorityOwnerTool` is `grit-check | grit-apply`.
+- Registered manifests require normative sources, proving sources, language,
+  scan roots, fixture strategy, false-positive model, current-tree scan,
+  baseline contract, hook scope, and apply safety.
+- `PatternAuthorityApplySafety` already separates `not-apply` from `apply`
+  proof fields, but apply approval is not a lifecycle state.
+- Candidate manifests contain candidate artifact paths, rejected registration,
+  and required registration items.
+- Validation reasons include missing, malformed, placeholder, contradiction,
+  orphan, Grit-metadata-only, and Nx-options-only reasons.
+
+Current validator behavior:
+
+- `validatePatternAuthorityManifest(undefined)` reports `missing-manifest`.
+- Candidate manifests can be valid drafts while `authorityAccepted` is false.
+- Registered manifests are accepted only when structured fields pass and, when
+  requested, the rule-pack reference matches rule id, pattern name, manifest
+  path, owner tool, lane, and hook scope.
+- Registered manifests outside the canonical `pattern-authority/<rule-id>.json`
+  path are rejected.
+- Candidate manifests outside the candidate root are rejected when a manifest
+  path is provided.
+- Grit frontmatter/prose and Nx generator options are rejected as standalone
+  Habitat authority metadata.
+
+D8 gap:
+
+- The Phase 2 D8 source packet requires a complete lifecycle including candidate
+  draft, manifest-invalid candidate, registered diagnostic pattern, registered
+  hook-scoped pattern, registered apply-approved pattern, refused pattern, and
+  retired pattern. Current code has three lifecycle strings plus validation
+  failure reasons. The current union does not model refused or retired patterns
+  as durable states, and it does not model manifest-invalid candidate or
+  apply-approved registered pattern as lifecycle states.
+
+### Pattern Generator And Promotion
+
+`tools/habitat-harness/src/generators/pattern/generator.cjs` is the current Nx
+generator entrypoint for pattern work.
+
+Current candidate generation:
+
+- Normalizes `ruleId`, `patternName`, lifecycle, owner project, OpenSpec change
+  id, manifest path, and hook scope.
+- Defaults lifecycle to `candidate`.
+- Refuses active rule collisions in `.grit/patterns/habitat/checks`, baseline
+  collisions under `tools/habitat-harness/baselines`, and duplicate `rules.json`
+  ids.
+- Writes candidate pattern and candidate manifest under
+  `tools/habitat-harness/src/rules/pattern-authority/candidates`.
+- Candidate output explicitly says it is not an active Grit check, not a
+  `rules.json` entry, not baselined, and not hook-scoped.
+
+Current registered promotion:
+
+- Non-candidate lifecycle routes into `registration.cjs`.
+- Registered promotion requires `--manifestPath`.
+- Reads and validates the manifest with a required rule-pack reference.
+- Requires an explicit baseline file and rule-introduction baseline manifest
+  before writing registered output.
+- Refuses active pattern collisions and candidate-artifact collisions.
+- Writes `.grit/patterns/habitat/checks/<pattern>.md`.
+- Appends a rule entry to `tools/habitat-harness/src/rules/rules.json`.
+- Records `hookScope: "pre-commit"` only when the accepted manifest and
+  invocation agree.
+
+D8 gap:
+
+- The generator currently performs both candidate scaffolding and registered
+  promotion. D8 must decide whether this remains one generator surface with
+  lifecycle states or becomes separated by D13 scaffolding/refusal and D8
+  Pattern Governance. D13 consumes D8 and explicitly says project scaffolding
+  must be separated from Pattern Governance candidate generation.
+
+### Rule Registry And Active Grit Catalog
+
+`tools/habitat-harness/src/rules/rules.json` is the current Habitat rule pack.
+Current disk inventory:
+
+- 52 total registered Habitat rules.
+- 32 rules with `ownerTool: "grit-check"`.
+- 31 `grit-check` rules are enforced and hook-scoped to `pre-commit`.
+- `docs-local-checkout-paths` is the advisory `grit-check` rule and is not
+  hook-scoped.
+- Current Grit check pattern directory contains 32 Markdown files under
+  `.grit/patterns/habitat/checks`.
+- Current Grit apply pattern directory contains 3 Markdown files under
+  `.grit/patterns/habitat/apply`.
+- No committed candidate files currently exist under
+  `tools/habitat-harness/src/rules/pattern-authority/candidates`.
+- No committed registered Pattern Authority JSON manifests currently exist
+  under `tools/habitat-harness/src/rules/pattern-authority/*.json`.
+
+D8 gap:
+
+- Active rule rows generally have `gritPattern` and `hookScope`, but they do not
+  have `manifestPath`. Existing registered Grit rules therefore predate the
+  target Pattern Authority Manifest contract. D8 must specify whether and how
+  legacy registered rules are represented, grandfathered, refused, migrated, or
+  retired without confusing current enforcement with complete Pattern Authority
+  admission.
+
+### Execution Consumers
+
+Current consumers of D8-adjacent state:
+
+- `tools/habitat-harness/src/lib/grit.ts` consumes `rules.json` Grit facts and
+  `.grit` patterns to run/project diagnostics.
+- `tools/habitat-harness/src/lib/baseline.ts` consumes registered rule ids and
+  baseline JSON files, and enforces rule-introduction baseline manifests for
+  seeded new-rule baselines.
+- `tools/habitat-harness/src/lib/command-engine.ts` selects rules, reduces
+  staged Grit execution to hook-scoped rules, executes rule owners, applies
+  baselines, and assembles `CheckReport`.
+- `tools/habitat-harness/src/lib/hooks.ts` uses `hookScope` and staged Grit
+  roots for pre-commit local feedback.
+- `tools/habitat-harness/src/plugin.js` uses `rules.json` to infer
+  `habitat:check`, `habitat:rule:*`, `grit:check`, `generated:check`, and
+  owner-specific targets.
+- `tools/habitat-harness/src/lib/grit-apply.ts` consumes apply patterns for fix
+  transactions. D9 owns transaction safety, rollback, and recovery states.
+
+D8 does not own final report assembly, baseline application, diagnostic
+projection, hook-local sequencing, Nx target inference, or apply transaction
+execution. It owns the admission/lifecycle contract that these consumers may
+trust.
+
+## Public/Durable Surfaces
+
+### Public Or Durable D8-Adjacent Surfaces
+
+- Package exports from `tools/habitat-harness/src/index.ts`:
+  `CandidatePatternAuthorityManifest`, `RegisteredPatternAuthorityManifest`,
+  `PatternAuthorityManifest`, `PatternAuthorityRuleReference`,
+  `PatternAuthorityValidationFailureReason`,
+  `PatternAuthorityValidationIssue`,
+  `PatternAuthorityValidationOptions`, `PatternAuthorityValidationResult`,
+  `patternAuthorityCandidateRoot`, `patternAuthorityManifestPath`,
+  `patternAuthorityManifestRoot`, `patternAuthorityManifestSchemaVersion`,
+  `patternAuthorityRuleReferenceFromRule`, and
+  `validatePatternAuthorityManifest`.
+- Nx generator surface from `tools/habitat-harness/generators.json`:
+  `@internal/habitat-harness:pattern`, its schema, and its factory.
+- Generator schema fields in
+  `tools/habitat-harness/src/generators/pattern/schema.json`: `ruleId`,
+  `ownerProject`, `patternName`, `lifecycle`, `openspecChangeId`,
+  `manifestPath`, and `hookScope`.
+- Current active rule registry fields in `rules.json`: `id`, `ownerTool`,
+  `ownerProject`, `lane`, `scope`, `forbids`, `why`, `detect`, `remediate`,
+  `message`, `exceptionPath`, `gritPattern`, `manifestPath`, and `hookScope`.
+- Grit pattern file paths under `.grit/patterns/habitat/checks/**` and
+  `.grit/patterns/habitat/apply/**`.
+- Baseline JSON files under `tools/habitat-harness/baselines/<rule-id>.json`.
+- Human guidance in `tools/habitat-harness/README.md`,
+  `tools/habitat-harness/docs/SCENARIOS.md`, and
+  `tools/habitat-harness/docs/CAPABILITIES.md`.
+- OpenSpec D8 artifacts under
+  `openspec/changes/deep-habitat-d8-pattern-governance/**`.
+
+Any D8 implementation that changes these surfaces needs D0 public-surface
+compatibility rows and compatibility handling before source edits.
+
+### Upstream Contracts Consumed By D8
+
+- D0 Public Surface Compatibility: D8 must cite D0 rows before changing command
+  behavior, command JSON, exports, root scripts, Nx target metadata, generator
+  schema/behavior, hook output, or public examples.
+- D1 Receipt Contract Boundary: D8 must not reuse proof/receipt/handoff
+  language for Pattern Governance unless D1 makes that output family explicit.
+- D2 Rule Registry Metadata: D8 consumes rule identity, owner tool, owner
+  project, lane, Grit facts, baseline facts, hook-scope facts, and generated
+  registry projections. D8 must not parse whole `rules.json` rows as target
+  authority if D2 provides narrower projections.
+- D3 Workspace Graph Boundary: D8 should treat Nx project/target facts as graph
+  metadata owned by D3, especially when generator or plugin targets appear in
+  validation gates.
+- D4 Classify Orientation And Routing: D8 can be routed by classification but
+  does not own classify output semantics.
+- D5 Baseline Authority: D8 consumes explicit baseline contract, shrink-only
+  rules, rule-introduction manifests, and baseline-integrity gates. D8 does not
+  own baseline JSON semantics.
+- D6 Diagnostic Pattern Catalog: D8 consumes diagnostic pattern identity,
+  native Grit fixture/probe evidence, Grit command/projection facts, and
+  diagnostic non-claims. D8 does not own diagnostic acquisition or projection.
+- D7 Structural Enforcement Pipeline: D8 supplies admitted pattern state to
+  enforcement but does not own final check report construction, exit policy, or
+  enforcement report invariants.
+
+### Downstream Consumers
+
+- D9 Transformation Transaction consumes D8 apply-safety decisions. D9 requires
+  D8 and must not infer write safety from diagnostic registration.
+- D11 Local Feedback consumes D7/D9/D10 decisions and hook-scoped rule facts. It
+  will observe D8 hook-scope admission through enforcement outputs, but it must
+  not decide pattern lifecycle locally.
+- D13 Scaffolding And Refusal consumes D8 candidate semantics. It must keep
+  scaffolding/refusal separate from Pattern Governance and must not register
+  generated pattern candidates automatically.
+
+## D8 Write Set
+
+This investigation writes only this scratch document. It does not authorize
+source refactor code.
+
+Candidate later D8 implementation write set, after packet acceptance:
+
+- `openspec/changes/deep-habitat-d8-pattern-governance/**` for packet repair,
+  phase records, review disposition, downstream realignment, and closure
+  evidence.
+- `tools/habitat-harness/src/rules/pattern-authority/manifest.ts` for the
+  lifecycle union, manifest validation, refusal-state shape, retired-state
+  shape, and rule-reference projection.
+- `tools/habitat-harness/src/generators/pattern/generator.cjs` only for
+  generator behavior that creates candidate states or routes promotion through
+  accepted D8 governance.
+- `tools/habitat-harness/src/generators/pattern/registration.cjs` only for
+  registered promotion admission gates, refusal output, and baseline/manifest
+  consumption.
+- `tools/habitat-harness/src/generators/pattern/schema.json` only if D0/D13
+  compatibility allows generator schema changes.
+- `tools/habitat-harness/src/index.ts` only for explicit public export
+  additions/versioning approved through D0.
+- `tools/habitat-harness/test/rules/pattern-authority-manifest.test.ts` for
+  lifecycle, refusal, retired-state, manifest-invalid candidate, hook-scope,
+  apply-safety, and rule-reference tests.
+- `tools/habitat-harness/test/generators/pattern-generator.test.ts` for
+  candidate and promotion write/refusal tests.
+- A new focused D8 test file may be justified if lifecycle state explosion makes
+  the two existing test files too broad.
+- `tools/habitat-harness/README.md`,
+  `tools/habitat-harness/docs/SCENARIOS.md`, and
+  `tools/habitat-harness/docs/CAPABILITIES.md` only for public guidance
+  updates caused by accepted D8 semantics.
+- `docs/projects/habitat-harness/openspec-remediation/packet-index.md` and
+  D8 downstream ledgers only after D8 review/repair facts change packet status.
+
+Conditional write set requiring extra authority:
+
+- `tools/habitat-harness/src/rules/rules.json` only when D2 registry facts,
+  D5 baseline contract, and D8 admission state explicitly authorize a rule
+  registration or migration.
+- `.grit/patterns/habitat/checks/**` only when D6 diagnostic catalog and D8
+  admission both authorize active pattern creation or migration.
+- `.grit/patterns/habitat/apply/**` only when D9 apply-safety authority
+  authorizes a transformation pattern; D8 alone cannot approve apply writes.
+- `tools/habitat-harness/baselines/**` only through D5-approved
+  rule-introduction or baseline-integrity paths.
+
+## Protected Paths
+
+D8 must protect these paths from direct edits unless the named owner contract
+explicitly authorizes the change:
+
+- `tools/habitat-harness/dist/**` and
+  `tools/habitat-harness/oclif.manifest.json`: generated build artifacts.
+- `node_modules/**`, `.nx/**`, `.grit/cache/**`, and `.grit/.gritmodules/**`:
+  vendor/cache output.
+- Root lockfiles and package manager generated state.
+- `tools/habitat-harness/baselines/**`: D5 baseline authority. Do not edit
+  baseline JSON as a side effect of Pattern Governance design.
+- Existing `.grit/patterns/habitat/checks/**`: D6 diagnostic catalog and
+  current enforcement state. D8 must not treat file presence as lifecycle
+  authority.
+- Existing `.grit/patterns/habitat/apply/**`: D9 transformation authority.
+  Diagnostic registration does not imply apply approval.
+- `tools/habitat-harness/src/rules/rules.json`: D2 rule registry metadata.
+  D8 may consume and reference registry facts, but schema/row changes need D2
+  and D0 compatibility.
+- `tools/habitat-harness/src/plugin.js`, `nx.json`, and root Nx target
+  configuration: D3 graph/Nx topology and D0 public surfaces.
+- `tools/habitat-harness/src/lib/command-engine.ts`,
+  `tools/habitat-harness/src/lib/hooks.ts`,
+  `tools/habitat-harness/src/lib/grit.ts`,
+  `tools/habitat-harness/src/lib/grit-apply.ts`, and
+  `tools/habitat-harness/src/lib/baseline.ts`: owned primarily by D7, D11, D6,
+  D9, and D5 respectively.
+- Generated or protected product outputs outside Habitat, including `mod/**`,
+  `dist/**`, `mods/mod-swooper-maps/src/maps/generated/**`, and
+  `packages/civ7-map-policy/src/civ7-tables.gen.ts`.
+
+Stale/generated-output concerns:
+
+- `tools/habitat-harness/docs/CAPABILITIES.md` says there are 31 active
+  `grit-check` rules and 2 apply patterns, while current disk inventory shows
+  32 `grit-check` rules and 3 apply pattern files. D8 must treat that as stale
+  guidance evidence, not a source of truth, and should repair docs only if D8
+  implementation changes public guidance.
+- Candidate and registered generated pattern files are generated by the pattern
+  generator. A later D8 implementation must prove generated output through the
+  generator/tests, not by hand-editing candidate or active pattern output.
+
+## Validation Gates
+
+Current D8 scaffold gates:
+
+- `bun run --cwd tools/habitat-harness test -- test/rules/pattern-authority-manifest.test.ts`
+- `bun run habitat classify tools/habitat-harness/src/rules/rules.json`
+- `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict`
+- `bun run openspec:validate`
+- `git diff --check`
+
+Required D8 topology gates before implementation readiness:
+
+- `bun run --cwd tools/habitat-harness test -- test/rules/pattern-authority-manifest.test.ts test/generators/pattern-generator.test.ts`: must cover candidate draft, manifest-invalid candidate, registered diagnostic, hook-scoped registered, apply-approved registered, refused, retired, missing manifest, missing fixtures, missing baseline contract, missing hook decision, apply-safety absence, and no-write refusal cases.
+- `bun run habitat check --rule baseline-integrity --json`: must prove D5
+  baseline contract state for any registered pattern touched by D8. Broad
+  `habitat check --json` is not a substitute for the D5-focused gate.
+- `GRIT_TELEMETRY_DISABLED=true bunx --no-install grit patterns test --verbose`
+  or a narrowed accepted equivalent: must prove native Grit fixture behavior
+  for pattern files touched by D8. This proves pattern fixture syntax/behavior,
+  not Pattern Governance admission.
+- `bun run habitat classify tools/habitat-harness/src/rules/rules.json` and
+  `bun run habitat classify tools/habitat-harness/src/rules/pattern-authority/manifest.ts`: must record path routing facts and available targets.
+- `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict`
+- `bun run openspec:validate`
+- `git diff --check`
+- `git status --short --branch`
+- `gt status`
+
+Required non-claims:
+
+- Passing native Grit pattern tests does not prove current-tree enforcement,
+  baseline acceptance, hook scope, or apply safety.
+- Passing manifest validation does not prove the active Grit catalog, baseline
+  contract, or current-tree diagnostic behavior unless those gates are also
+  present.
+- Candidate generation does not prove registration, hook scope, baseline state,
+  or apply approval.
+- Registered diagnostic state does not prove apply approval.
+- Hook-scoped state does not prove CI authority or D11 local feedback closure.
+
+## P1/P2 Blockers
+
+| ID | Severity | Finding | Required Repair |
+| --- | --- | --- | --- |
+| D8-P1-001 | P1 | The D8 OpenSpec spec has only broad candidate/registered scenarios and does not encode the full Phase 2 lifecycle state set. | Add normative lifecycle requirements and scenarios for candidate draft, manifest-invalid candidate, registered diagnostic pattern, registered hook-scoped pattern, registered apply-approved pattern, refused pattern, and retired pattern. |
+| D8-P1-002 | P1 | The current packet does not declare a concrete D8 write set and protected path list. | Move the write/protected set from investigation into `design.md` and `phase-record.md`, including conditional owners for `rules.json`, `.grit` patterns, baselines, and generator schema changes. |
+| D8-P1-003 | P1 | Current implementation topology has partial Pattern Authority code, but the packet does not classify which parts are target contract versus compatibility facts. | Add current topology inventory to the packet and explicitly mark existing three-state lifecycle, current generated messages, and legacy rule rows as present behavior until accepted as target. |
+| D8-P1-004 | P1 | The packet does not name the vendor ownership split. | Record Grit, Biome, and Nx ownership boundaries with exact official URLs and state what D8 owns around those vendor tools. |
+| D8-P1-005 | P1 | Validation gates omit `pattern-generator.test.ts`, the D5 `baseline-integrity` focused gate, native Grit fixture proof, and bad-case refusal coverage required by the source packet. | Repair proposal/tasks/phase record gates and require exact command expectations plus non-claims. |
+| D8-P1-006 | P1 | Existing active Grit rules generally have no `manifestPath`, while current code can require one for registered promotion. The packet does not define legacy registered-rule disposition. | Specify legacy active pattern disposition: grandfathered compatibility, migration, refused, retired, or accepted manifest path. Do not let file presence imply lifecycle. |
+| D8-P1-007 | P1 | D8 dependencies are underspecified. The source packet says blocked by D1, D2, D5, and D6, while current OpenSpec proposal says D0, D2, D5, and D6. | Reconcile consumed upstream contracts explicitly: D0 for public surfaces, D1 for receipt/output language, D2 for registry facts, D5 for baseline contracts, D6 for diagnostic pattern facts, and D7 as enforcement consumer boundary. |
+| D8-P1-008 | P1 | The D8 phase record records branch `codex/deep-habitat-openspec-remediation`, but the active requested branch is `codex/d8-pattern-governance-packet`. | Update phase record state before claiming review/implementation readiness. |
+| D8-P2-001 | P2 | Docs guidance appears stale against current inventory counts: current disk has 32 `grit-check` rules and 3 apply pattern files, while `CAPABILITIES.md` records 31 and 2. | Decide whether D8 or a docs realignment pass repairs the counts; until then, treat docs counts as stale guidance, not topology truth. |
+| D8-P2-002 | P2 | The current generator description says it scaffolds a Grit pattern and matching rule-pack entry, but candidate behavior does not write `rules.json`. | Repair public docs/schema/description through D0/D13 compatibility so candidate generation is described as non-registering unless promotion is explicitly requested and accepted. |
+| D8-P2-003 | P2 | The packet does not yet name D9, D11, and D13 consumer non-claims in one place. | Add downstream consumer section: D9 consumes apply-safety only, D11 consumes hook-scoped enforcement facts only through D7/D9/D10, and D13 consumes candidate/refusal semantics without automatic registration. |
+| D8-P2-004 | P2 | Refusal reasons exist as validator issues but not as durable lifecycle/output states. | Decide target shape for refused states and require tests that prove missing manifest, malformed manifest, placeholder manifest, missing baseline, missing hook-scope decision, missing fixtures, and apply-safety absence fail closed before writes. |
+

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-domain-ontology-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-domain-ontology-investigation.md
@@ -1,0 +1,203 @@
+# D8 Domain/Ontology Investigation
+
+Status: BLOCKING.
+
+Current disk does not satisfy the complete D8 domain contract. The Phase 2 D8 source packet is strong controlling input, but the current OpenSpec packet still leaves lifecycle states, decision inputs, refusal reasons, owner boundaries, naming, and consumer projections for a later execution agent to invent.
+
+## Sources Read
+
+- `git status --short --branch --untracked-files=all`; worktree was clean on `codex/d8-pattern-governance-packet` before authoring.
+- `gt status`; Graphite delegates to Git in this checkout and reported a clean worktree.
+- Root `AGENTS.md`.
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`.
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`.
+- `/Users/mateicanavra/.agents/skills/ontology-design/SKILL.md`.
+- All directly referenced Ontology Design reference files: `axes.md`, `principles.md`, `where-defaults-hide.md`, `representation-choices.md`, `operationalization.md`, `maintenance.md`, `examples.md`, and `source-map.md`.
+- Relevant context from `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`.
+- Relevant context from `.agents/skills/civ7-open-spec-workstream/SKILL.md`, including `references/source-map.md` and `references/phase-loop.md`.
+- `docs/projects/habitat-harness/openspec-remediation-frame.md`.
+- `docs/projects/habitat-harness/openspec-remediation/context.md`.
+- `docs/projects/habitat-harness/phase2-workstream-packets/README.md`.
+- `docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md`.
+- Current D8 OpenSpec packet files under `openspec/changes/deep-habitat-d8-pattern-governance/`: `proposal.md`, `design.md`, `tasks.md`, `specs/habitat-harness/spec.md`, and workstream ledger/checklist files.
+- D0, D1, D2, D5, D6, and D7 OpenSpec spec deltas where they define consumed contracts.
+- Accepted review records for D0, D2, D5, D6, and D7 domain/ontology acceptance, plus D1 domain/ontology status as non-accepted input.
+- Boundary packets for D9 apply transactions, D11 local feedback, and D13 generator/refusal behavior, including Phase 2 source packets and current OpenSpec spec/design files.
+
+## Frame
+
+D8 is the Pattern Governance domain. It owns admission and lifecycle decisions for structural patterns. It does not own rule registry metadata, diagnostic acquisition, baseline truth, enforcement report construction, apply transaction safety, hook behavior, or generator file creation.
+
+The standard engineering ontology is admission control plus lifecycle governance:
+
+- Pattern Governance is the bounded context and policy model.
+- Pattern Authority is the decision authority and durable decision record inside that context.
+- A Pattern Authority decision admits, refuses, retires, or changes the capability admission of one pattern.
+- A pattern candidate is source evidence or a proposed work item until Pattern Authority admits it.
+- Registry rows, baseline files, Grit diagnostics, fixture runs, hook eligibility, and apply requests are inputs or consumers. None of them are admission authority by existence.
+
+The remediation frame requires complete OpenSpec implementation-control packets. The D8 OpenSpec packet therefore must do more than restate the Phase 2 packet. It must define enough domain language, state, input contracts, projections, refusals, and validation gates that implementation cannot create new lifecycle semantics while editing TypeScript.
+
+## Domain/Ontology Findings
+
+The Phase 2 D8 source packet correctly identifies the state-space defect: pattern candidate generation, manifest validation, rule registration, Grit rows, baseline files, and hook scope currently combine to imply admission. That is the right problem.
+
+The current disk packet has not yet converted that problem into a complete ontology. `design.md` names the owner and scenario, then repeats three target bullets: define lifecycle states, separate generated candidates from registered enforcement, and connect governance to D2/D5. `spec.md` has one requirement with two scenarios. That is not enough to define identity, state transitions, input evidence, refusal states, decision records, maintenance behavior, or consumer projections.
+
+The current packet also omits D6 from the target contract even though D6 is a listed prerequisite and is essential to D8. D8 cannot admit a diagnostic pattern without consuming D6 diagnostic capability, fixture result, injected probe outcome, observed diagnostic identity limitations, and diagnostic non-claims. D2 can tell D8 which rule and pattern identity relation exists; D6 tells D8 whether there is an accepted diagnostic capability and what validation evidence exists.
+
+Pattern Governance and Pattern Authority are not yet separated. The design says the owner is Pattern Governance and the product scenario uses Pattern Authority, but it does not define whether Pattern Authority is a ledger, manifest authority, approval board, command contract, package module, or decision record. That ambiguity matters because D2 publishes `ruleGovernanceFacts`, D5 publishes baseline authority projections, D6 publishes diagnostic capabilities, D9 consumes apply admission, and D13 writes candidates. These consumers need stable endpoints.
+
+The packet also carries inherited terms that have not earned their place. The source packet's states `registered diagnostic pattern`, `registered hook-scoped pattern`, and `registered apply-approved pattern` combine registry membership, diagnostic capability, hook eligibility, and apply admission into state names. The better model is a lifecycle state plus separate capability admission decisions. Registration is a registry concept owned by D2; diagnostic capability is D6; local feedback consumption is D11; apply transaction execution is D9. D8 owns admission, not those adjacent operations.
+
+## Required D8 State Model
+
+D8 should define a closed `PatternAuthorityDecision` model with stable pattern identity, decision identity, decision author/owner, source evidence, accepted inputs, lifecycle state, capability admissions, refusals, supersession, and consumer projections.
+
+Lifecycle states:
+
+- `candidate-draft`: a proposed pattern exists. It is non-enforcing, not admitted, not apply-approved, and not local-feedback-approved.
+- `candidate-under-review`: Pattern Authority has accepted the candidate for review and is evaluating required decision inputs. This state still has no enforcement or apply authority.
+- `admitted`: Pattern Authority accepts the pattern identity and at least one capability admission. The admitted lifecycle state must point to each accepted capability decision.
+- `refused`: Pattern Authority rejects admission for a closed refusal reason. A refused pattern may retain source evidence and recovery guidance, but it is not enforcement authority.
+- `retired`: Pattern Authority withdraws current admission. Retired records preserve historical identity, replacement/supersession where present, and consumer migration guidance.
+
+Capability admission states:
+
+- `diagnostic-admitted`: D8 accepts a pattern for diagnostic use after D2 identity/governance facts, D6 diagnostic capability, fixture/probe evidence, false-positive assessment, and D5 baseline projection/refusal disposition are all resolved.
+- `local-feedback-admitted`: D8 accepts that the diagnostic pattern may be surfaced to local feedback consumers. D11 still owns hook orchestration, output, and non-claims.
+- `apply-admitted`: D8 accepts that this pattern may be offered to D9 as an apply-capable pattern. D9 still owns dry-run, live mutation, path approval, rollback, formatter handoff, gate outcomes, and recovery instructions.
+
+Refusal states:
+
+- `manifest-missing`.
+- `manifest-invalid`.
+- `pattern-identity-missing`.
+- `pattern-identity-conflicted`.
+- `d2-governance-reference-missing`.
+- `d2-governance-reference-contradicted`.
+- `d6-diagnostic-capability-missing`.
+- `diagnostic-fixture-missing`.
+- `diagnostic-fixture-insufficient`.
+- `injected-probe-missing`.
+- `injected-probe-rejected`.
+- `false-positive-assessment-missing`.
+- `false-positive-assessment-rejected`.
+- `baseline-authority-missing`.
+- `baseline-authority-refused`.
+- `local-feedback-admission-rejected`.
+- `apply-admission-rejected`.
+- `retirement-target-missing`.
+- `public-surface-compatibility-missing`.
+
+Decision inputs:
+
+- D0 public surface rows for every command, JSON, package export, generator, hook, docs example, and durable schema touched by D8.
+- D1 command/report/refusal family where D8 reports malformed admission input or public command output.
+- D2 `ruleGovernanceFacts`, `ruleGritFacts`, and `ruleBaselineFacts`; D8 must not read whole registry rows as authority.
+- D5 baseline authority projection or baseline refusal result; D8 must not decide baseline truth, shrink-only policy, external exception projection, or rule-introduction baseline acceptance.
+- D6 diagnostic capability, accepted diagnostic identity, fixture outcome, injected probe outcome, limitations, and diagnostic non-claims; D8 must not parse raw Grit output or turn diagnostic success into admission by itself.
+- D13 candidate handoff when the input came from generation. D13 writes candidate files; D8 decides admission.
+- Human or maintainer decision input: owner, reason, reviewer, decision time, accepted sources, recovery guidance, supersession, and non-claims.
+
+Consumer projections:
+
+- `PatternAuthorityProjection`: durable D8 projection for D2/D13 that names pattern id, manifest path, lifecycle state, admitted capabilities, refusal reason where present, and supersession.
+- `DiagnosticAdmissionProjection`: D8-to-D7 context that says whether a selected diagnostic pattern is admitted for enforcement consumption. D7 still builds check outcomes from D2/D5/D6 projections.
+- `ApplyAdmissionProjection`: D8-to-D9 context that says whether a pattern is admitted for apply consideration. D9 still proves transaction safety.
+- `LocalFeedbackAdmissionProjection`: D8-to-D11 context that says whether local feedback may present the pattern. D11 still owns hook-local behavior and non-claims.
+- `CandidateHandoffProjection`: D8-to-D13 context that keeps generated pattern output candidate-only and states the exact next admission requirements.
+- `PatternRecoveryProjection`: recovery guidance for refused or retired patterns, including owner, reason, next allowed action, and superseded decision if present.
+
+## Boundary Decisions
+
+D8 owns:
+
+- Pattern identity admission as Pattern Authority decision.
+- Lifecycle state and capability admission state.
+- Refusal reason taxonomy for admission.
+- Manifest acceptance as an admission input, not as D2 registry truth.
+- Fixture sufficiency and false-positive assessment for pattern admission.
+- Whether a diagnostic pattern may be admitted for local feedback or apply consideration.
+- Consumer projections that prevent D2, D7, D9, D11, and D13 from inferring admission from nearby facts.
+
+D8 does not own:
+
+- D2 registry schema, row identity, ownerTool compatibility, execution adapter, path coverage, graph facts, baseline facts, Grit facts, local feedback facts, or whole-row public compatibility.
+- D5 baseline acceptance, baseline integrity, external exception projection, shrink-only behavior, baseline application, or seeded baseline expansion.
+- D6 diagnostic catalog identity, Grit command acquisition, observed diagnostic identity handling, adapter failures, scan root decisions, diagnostic projection, cache/freshness states, or injected probe cleanup semantics.
+- D7 structural enforcement selection, execution disposition, diagnostic/baseline application, report rendering, `CheckReport.ok`, exit status, D11 projection, or D12 projection.
+- D9 dry-run inventory, live write execution, rollback, path approval, formatter handoff, gate execution, or transaction recovery.
+- D11 hook orchestration, hook trace schema, local output, Graphite base resolution, or hook non-claims.
+- D13 project generation, candidate file writing, unsupported generator refusals, or host-specific generation refusal.
+
+## Naming Repairs
+
+Use `Pattern Governance` for the bounded context and `Pattern Authority` for the decision authority/decision record. Do not use them as interchangeable labels.
+
+Replace `registered diagnostic pattern` with `diagnostic-admitted pattern` unless the text is explicitly discussing a D2 registry row. Registration is D2 vocabulary; admission is D8 vocabulary.
+
+Replace `registered hook-scoped pattern` with `local-feedback-admitted pattern`. Hook execution and output belong to D11; D8 decides only admission for local feedback presentation.
+
+Replace `registered apply-approved pattern` with `apply-admitted pattern`. Apply transaction safety belongs to D9; D8 decides only admission for apply consideration.
+
+Replace `baseline policy` in D8 target language with `D5 baseline authority projection` or `D5 baseline refusal result`. D8 consumes D5; it does not define baseline policy.
+
+Replace `reviewed` as a standalone lifecycle state unless the packet defines who reviewed what, which input set was reviewed, what decision was produced, and what consumers may infer. Use `candidate-under-review` for pre-decision work and `admitted` or `refused` for decisions.
+
+Current disk uses the historical phrase "OpenSpec packet scaffold" in D8 proposal and phase record. That wording is superseded for this pass. D8 must be described as a complete OpenSpec packet or incomplete OpenSpec packet; the historical phrase must not become acceptance language.
+
+## P1/P2 Blockers
+
+### P1: Current D8 packet does not define the lifecycle ontology it requires
+
+`design.md` only says D8 will define lifecycle states and admission gates. `spec.md` names candidate, reviewed, registered, refused, and retired states, but does not define closed states, transitions, required inputs, invariants, refusal reasons, or state-specific consumer meaning. This leaves the most important D8 design decision for implementation.
+
+### P1: Pattern Governance and Pattern Authority boundary is undefined
+
+The packet names Pattern Governance as owner and Pattern Authority as the promotion/rejection mechanism, but does not define Pattern Authority as a decision record, manifest authority, approval process, or projection source. Adjacent packets cannot consume a stable authority endpoint from the current text.
+
+### P1: D8 consumed-contract matrix is missing
+
+D8 must consume exact D2, D5, and D6 projections. The current packet says D8 connects to D2 facets and D5 baselines, but it does not name `ruleGovernanceFacts`, `ruleGritFacts`, `ruleBaselineFacts`, `BaselineAuthorityProjection`, baseline refusal result, D6 diagnostic capability, injected probe outcome, or D6 limitations. It also does not explicitly forbid whole registry row reads, raw baseline reads, or raw Grit parsing.
+
+### P1: Refusal taxonomy is absent
+
+The source packet requires refusal states for missing manifest, fixtures, baseline contract, hook-scope decision, and apply-safety absence. Current disk collapses refusal into one unnamed state and has no normative refusal scenarios. Without closed refusal reasons, generated candidates, contradicted registry references, missing diagnostic capability, refused baseline authority, and apply admission rejection remain implementation-time judgments.
+
+### P1: Consumer projections are absent
+
+D8 must publish bounded projections for D2/D13, D7, D9, D11, and recovery ledgers. Current disk does not define any D8 projection. That omission lets downstream domains infer admission from file presence, D2 registry state, D5 baseline state, D6 diagnostic success, D7 check behavior, or D13 generation output.
+
+### P2: Current naming preserves domain conflation
+
+The source packet state names combine registration, diagnostics, hook scope, and apply approval. The OpenSpec packet has not repaired that naming. D8 should use admission vocabulary and keep D2 registration, D6 diagnostics, D11 local feedback, and D9 transaction safety separate.
+
+### P2: D6 prerequisite is underrepresented
+
+The proposal lists D6 under `Requires`, but the `What Changes` and design target contract omit D6. D8 admission cannot be complete without D6 diagnostic capability, fixture/probe outcomes, and limitation inputs.
+
+### P2: Validation gates do not prove the D8 state model
+
+The current gates include manifest test, classify, OpenSpec validation, and whitespace checks. They do not require a negative admission fixture proving candidate output cannot become admitted, diagnostic admission cannot imply apply admission, D5 refusal blocks admission, D6 diagnostic capability absence blocks diagnostic admission, or consumer projections reject contradictory states.
+
+### P2: Remediation context branch fixture is stale
+
+`docs/projects/habitat-harness/openspec-remediation/context.md` records `$ACTIVE_REMEDIATION_BRANCH` as `codex/d7-structural-enforcement-packet`, while this checkout is on `codex/d8-pattern-governance-packet`. This does not change D8 ontology, but it is packet hygiene risk for durable path references in the current remediation pass.
+
+## Acceptance Bar
+
+D8 can move out of BLOCKING only when the disk packet defines, normatively and consistently:
+
+- Pattern Governance versus Pattern Authority boundary.
+- Closed lifecycle states, capability admission states, transitions, and non-claims.
+- Closed refusal taxonomy with scenarios for every required missing or contradicted input.
+- Exact D2, D5, and D6 consumed projections and forbidden adjacent-domain reads.
+- Exact consumer projections for D2/D13, D7, D9, D11, and recovery records.
+- Naming repairs that replace registration/hook/apply conflation with admission vocabulary.
+- D0/D1 public-surface compatibility gates for every D8-touched command, JSON, package export, generator, hook, docs example, and durable manifest surface.
+- Validation gates with injected bad cases for candidate-only output, contradicted D2 governance facts, D5 baseline refusal, D6 diagnostic capability absence, local-feedback admission rejection, apply admission rejection, and retired/superseded pattern consumption.
+
+Until those conditions are met, the current D8 OpenSpec packet is not accepted for design/specification and must not authorize source refactor implementation.
+
+Skills used: domain-design, information-design, ontology-design, solution-design, civ7-open-spec-workstream.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-typescript-state-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-typescript-state-investigation.md
@@ -1,0 +1,373 @@
+# D8 TypeScript State-Space Investigation
+
+Status: BLOCKING
+
+D8 is not acceptable implementation input yet. The source packet correctly requires Pattern Authority lifecycle separation, but the current OpenSpec scaffold does not yet specify the complete type model, consumer projections, exact write set, protected paths, or falsifying TypeScript gates required to prevent candidate/registered/apply-safe conflation.
+
+The current disk state partially prevents bad promotion by runtime tests and manifest validation. It does not fully prevent conflation at the packet level: the scaffold still leaves the concrete state model and implementation boundaries for a later agent to invent, and the live rule registry contains optional Pattern Authority fields without any checked-in `manifestPath` entries proving active Pattern Authority admission.
+
+## Sources Read
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/smell-catalog.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/refactoring-mechanics.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/llm-slop-cleanup.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/paradigms-and-patterns.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/worked-examples.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/assets/refactor-plan-template.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/assets/refactor-findings-template.md`
+- `AGENTS.md`
+- `docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md`
+- `openspec/changes/deep-habitat-d8-pattern-governance/proposal.md`
+- `openspec/changes/deep-habitat-d8-pattern-governance/design.md`
+- `openspec/changes/deep-habitat-d8-pattern-governance/tasks.md`
+- `openspec/changes/deep-habitat-d8-pattern-governance/specs/habitat-harness/spec.md`
+- `openspec/changes/deep-habitat-d8-pattern-governance/workstream/phase-record.md`
+- `openspec/changes/deep-habitat-d8-pattern-governance/workstream/closure-checklist.md`
+- `openspec/changes/deep-habitat-d8-pattern-governance/workstream/review-disposition-ledger.md`
+- `tools/habitat-harness/src/rules/pattern-authority/manifest.ts`
+- `tools/habitat-harness/src/generators/pattern/generator.cjs`
+- `tools/habitat-harness/src/generators/pattern/registration.cjs`
+- `tools/habitat-harness/src/generators/pattern/schema.json`
+- `tools/habitat-harness/src/rules/architecture.ts`
+- `tools/habitat-harness/src/rules/rules.json`
+- `tools/habitat-harness/src/plugin.js`
+- `tools/habitat-harness/src/lib/baseline.ts`
+- `tools/habitat-harness/src/lib/grit-apply.ts`
+- `tools/habitat-harness/test/rules/pattern-authority-manifest.test.ts`
+- `tools/habitat-harness/test/generators/pattern-generator.test.ts`
+- `tools/habitat-harness/test/lib/grit-apply.test.ts`
+- `tools/habitat-harness/test/lib/grit-adapter.test.ts`
+- `tools/habitat-harness/test/lib/hooks.test.ts`
+- `tools/habitat-harness/test/lib/rule-selection.test.ts`
+
+## Current Type/Code Inventory
+
+The current manifest layer already contains a useful discriminant, but it is not the complete Pattern Authority state machine D8 needs.
+
+- `PatternAuthorityLifecycle` is `"candidate" | "registered-advisory" | "registered-enforced"` in `tools/habitat-harness/src/rules/pattern-authority/manifest.ts:5`.
+- `CandidatePatternAuthorityManifest` owns `candidateArtifacts`, `registration.accepted: false`, and `requiredForRegistration` at `manifest.ts:67-78`.
+- `RegisteredPatternAuthorityManifest` owns normative/proving sources, language, scan roots, fixture strategy, false-positive model, current-tree scan, baseline contract, hook scope, and apply safety at `manifest.ts:80-122`.
+- `PatternAuthorityApplySafety` separates `{ kind: "not-apply" }` from `{ kind: "apply"; dryRunCommand; noWriteProof; appliedDiffProof; rollbackProof; typeAndTestProof }` at `manifest.ts:34-43`.
+- `PatternAuthorityValidationResult` returns `ok: true`, a broad `manifest`, `state`, and `authorityAccepted: boolean`, or `ok: false` issues at `manifest.ts:176-186`.
+
+The validator catches many contradictions, but the current result shape still leaks a broad manifest and a boolean acceptance flag instead of projecting lifecycle-specific admission states.
+
+- Missing manifest returns `"missing-manifest"` at `manifest.ts:225-236`.
+- Candidate manifests are accepted as drafts, with `authorityAccepted: false`, at `manifest.ts:271-285`.
+- Registered manifest storage must be canonical at `manifest.ts:288-318`.
+- Registered fields are validated as independent sections at `manifest.ts:366-381`.
+- Registered contradictions reject pre-commit scope outside enforced lifecycle, blocked current-tree scans, blocked baseline actions, and grit-check/apply-safety conflicts at `manifest.ts:597-645`.
+- Rule-pack reference validation rejects orphan or contradictory registered metadata at `manifest.ts:647-758`.
+
+The generator path is still driven by string lifecycle options and file-presence checks.
+
+- `patternGenerator()` normalizes options, validates collisions, then branches on `options.lifecycle !== "candidate"` at `tools/habitat-harness/src/generators/pattern/generator.cjs:3-10`.
+- `normalizeOptions()` builds one broad options record with `lifecycle`, `manifestPath`, and optional `hookScope` at `generator.cjs:26-38`.
+- `normalizeLifecycle()` validates raw strings at `generator.cjs:41-51`.
+- Candidate generation writes a candidate pattern markdown and candidate manifest at `generator.cjs:12-24`.
+- `validateNoActiveRegistrationCollision()` uses active Grit pattern path, baseline path, and `rules.json` presence as lifecycle collision checks at `generator.cjs:76-91`.
+
+The registration program correctly fail-closes before promotion writes in several cases, but it does so as runtime sequencing over a broad input record.
+
+- `registeredPatternPromotionProgram(input)` refuses missing `manifestPath` at `tools/habitat-harness/src/generators/pattern/registration.cjs:32-37`.
+- It reads and validates the manifest with an invocation-shaped rule reference at `registration.cjs:39-63`.
+- It validates baseline contract before active writes at `registration.cjs:64-65` and `registration.cjs:148-223`.
+- It rejects existing active pattern/candidate artifacts before writes at `registration.cjs:67-85`.
+- It writes only the active Grit pattern and `rules.json` after all checks at `registration.cjs:87-102`.
+- It projects a rule-pack entry with `manifestPath` and optional `hookScope` at `registration.cjs:106-123`.
+
+The rule registry and Nx plugin still represent Pattern Authority as optional metadata on a general-purpose rule record.
+
+- `HarnessRule` includes optional `gritPattern?`, `manifestPath?`, `hookScope?`, `generatedZone?`, `forbiddenFileNames?`, and `nxTarget?` at `tools/habitat-harness/src/rules/architecture.ts:16-34`.
+- `rules.json` is the shared rule-pack source, but the current file has no `"manifestPath"` entries.
+- `plugin.js` treats `ownerTool === "grit-check"` as an alias to the canonical Grit target at `tools/habitat-harness/src/plugin.js:213-217`, regardless of Pattern Authority lifecycle.
+
+Baseline and apply code already define adjacent authority states that D8 should consume through projections instead of re-owning.
+
+- Baseline states are a real union: explicit empty, explicit debt, external exception source, or contract failure at `tools/habitat-harness/src/lib/baseline.ts:53-83`.
+- Baseline growth for new rules requires an accepted rule-introduction manifest at `baseline.ts:330-338`, `baseline.ts:423-467`, and `baseline.ts:799-830`.
+- Grit apply transaction proof has changed paths, diff evidence, inventory, rollback, gate commands, and non-claims at `tools/habitat-harness/src/lib/grit-apply.ts:74-91`.
+- Apply inventory and diff evidence classify pre-approved versus blocked writes at `grit-apply.ts:576-633`.
+- Apply request non-claims explicitly do not prove current-tree Grit, baseline shrink, or product runtime at `grit-apply.ts:665-703` and `grit-apply.ts:1081-1119`.
+
+Current tests prove important behavior but not the full D8 packet target.
+
+- Manifest tests accept registered advisory with matching rule reference and candidate drafts without authority acceptance at `tools/habitat-harness/test/rules/pattern-authority-manifest.test.ts:10-60`.
+- Manifest tests reject missing, malformed, placeholder, contradicted, orphan, wrong-path, sparse-reference, hook-mismatch, Grit-only, Nx-options-only, and placeholder-baseline states at `pattern-authority-manifest.test.ts:62-263`.
+- Generator tests prove candidate writes do not register active enforcement at `tools/habitat-harness/test/generators/pattern-generator.test.ts:20-55`.
+- Generator tests prove missing manifest, placeholder manifest, hook mismatch, and missing baseline refuse before promotion writes at `pattern-generator.test.ts:57-207`.
+- Generator tests prove registered advisory/enforced/hook-scoped writes after accepted manifest and baseline contract at `pattern-generator.test.ts:139-237`.
+- Generator tests assert no candidate or promotion writes for collision/refusal cases at `pattern-generator.test.ts:310-385`.
+- Apply tests block unapproved inventory, outside roots, create evidence, and delete evidence; they pre-approve only modification evidence inside approved roots at `tools/habitat-harness/test/lib/grit-apply.test.ts:173-298`.
+- Grit adapter and hook tests reject protected scan roots and avoid staged Grit outside approved roots at `tools/habitat-harness/test/lib/grit-adapter.test.ts:221-233`, `tools/habitat-harness/test/lib/hooks.test.ts:315-331`, and `tools/habitat-harness/test/lib/rule-selection.test.ts:121-160`.
+
+## State-Space Smells
+
+1. File-presence lifecycle.
+   Candidate/registered distinction is partly enforced by path collisions: candidate artifacts under `tools/habitat-harness/src/rules/pattern-authority/candidates/**`, active patterns under `.grit/patterns/habitat/checks/**`, baseline files under `tools/habitat-harness/baselines/**`, and rule-pack entries in `rules.json`. The checks are important, but they are symptoms of state, not the state model. D8 must make file presence a projection of `PatternAuthorityState`, never the authority source.
+
+2. Optional/flag soup in generator input.
+   One broad options object carries `lifecycle`, `manifestPath?`, and `hookScope?`. Invalid combinations are representable: registered lifecycle without manifest path, hook scope without enforced lifecycle, candidate with manifest path, candidate with hook scope, or registered apply semantics through a check-owned generator path.
+
+3. Stringly lifecycle and lane translation.
+   `registered-enforced` becomes `lane: "enforced"` by repeated string checks in generator and registration code. The D8 packet must specify a single lifecycle-to-consumer projection, not repeated ad hoc translation.
+
+4. Whole-record leakage.
+   Registered promotion consumes and passes broad `RegisteredPatternAuthorityManifest` into rule-entry and markdown builders. Consumers should receive smaller projections: rule-pack registration projection, diagnostic catalog projection, baseline introduction projection, hook projection, and apply-safety projection. Whole manifest access lets downstream code accidentally depend on authority fields outside its owner boundary.
+
+5. Candidate/registered conflation.
+   Candidate and registered manifests share `PatternAuthorityManifestBase` and a `PatternAuthorityManifest` union, which is fine internally, but `PatternAuthorityValidationResult` exposes both through one `manifest` property plus `authorityAccepted: boolean`. A downstream consumer can forget to narrow and treat "valid draft" as "accepted authority" if the packet does not specify projection-only APIs.
+
+6. Diagnostic/apply safety conflation.
+   `applySafety` is present on registered manifests, and the validator rejects `grit-check` with `apply`, but the packet does not yet define separate registered diagnostic and registered apply-approved states. D8 must make "registered diagnostic" and "apply-approved pattern" different variants. A Grit diagnostic catalog entry must not imply apply safety.
+
+7. Runtime refusal instead of typed refusal.
+   Promotion refusal is represented by thrown/failed `PatternPromotionFailure` reasons such as missing manifest path, manifest rejected, baseline contract rejected, and unexpected collision. D8 should specify typed refusal results so implementation can test them directly and consumers do not parse error text.
+
+8. Rule-pack optional metadata as authority.
+   `HarnessRule.manifestPath?` and `hookScope?` are optional. The current `rules.json` contains Grit rules with `gritPattern` and hook scope, but no `manifestPath`. D8 must prevent "registered by rule-pack row only" from being a valid accepted Pattern Authority state.
+
+9. Protected write set is implicit.
+   Promotion currently writes active pattern markdown and `rules.json`; tests also assert it does not write candidate manifests, candidate patterns, or baselines. The packet needs an explicit write/protected path contract before implementation.
+
+10. Apply write safety lives in D9-adjacent mechanics, not Pattern Authority.
+   Grit apply has roots, inventory approval, diff evidence, changed paths, rollback, and non-claims. D8 must require an apply-safety admission receipt for apply patterns, but it must not own apply transaction mechanics.
+
+## Target Type Model
+
+D8 should specify these target families or an equivalent closed model before source implementation.
+
+### PatternAuthorityState
+
+```ts
+type PatternAuthorityState =
+  | CandidatePatternDraft
+  | CandidateManifestInvalid
+  | RegisteredDiagnosticPattern
+  | RegisteredHookScopedPattern
+  | RegisteredApplyApprovedPattern
+  | RefusedPattern
+  | RetiredPattern;
+```
+
+Required invariants:
+
+- `CandidatePatternDraft` has candidate artifacts, candidate manifest path, draft source, and `registration: { accepted: false }`. It has no active rule id projection, no baseline projection, no hook projection, and no apply projection.
+- `CandidateManifestInvalid` preserves candidate identity and validation issues. It has no write permission beyond candidate artifact repair.
+- `RegisteredDiagnosticPattern` has accepted manifest receipt, rule-pack projection, diagnostic catalog projection, current-tree scan decision, fixture strategy, false-positive model, and baseline contract. It has `applySafety: { kind: "not-apply" }`.
+- `RegisteredHookScopedPattern` extends registered diagnostic with `hookScope: { decision: "pre-commit"; acceptedCostAndScopeEvidence: ... }` and is only reachable for enforced lifecycle.
+- `RegisteredApplyApprovedPattern` is distinct from registered diagnostic/hook states. It requires `ownerTool: "grit-apply"`, apply safety receipt, protected write set, dry-run result, isolated diff evidence, rollback result, formatter/type/test gates, and explicit non-claims.
+- `RefusedPattern` is a typed result, not an exception string. It carries one refusal reason family and the protected paths that remained unwritten.
+- `RetiredPattern` records prior registered identity, retirement authority, replacement/disposition, and guarantee that enforcement no longer consumes the rule unless explicitly preserved as historical baseline context.
+
+### PatternAdmissionInput
+
+```ts
+type PatternAdmissionInput =
+  | { kind: "candidate-generation-request"; ruleId: RuleId; patternName: PatternName; ownerProject: ProjectName; openspecChangeId: ChangeId }
+  | { kind: "registered-diagnostic-admission"; manifestPath: CanonicalManifestPath; ruleReference: ExpectedRulePackReference; baseline: BaselineIntroductionProjection; diagnostics: DiagnosticProofProjection }
+  | { kind: "registered-hook-admission"; manifestPath: CanonicalManifestPath; ruleReference: ExpectedRulePackReference & { hookScope: "pre-commit" }; baseline: BaselineIntroductionProjection; diagnostics: DiagnosticProofProjection; hook: HookScopeReceipt }
+  | { kind: "apply-approval-admission"; manifestPath: CanonicalManifestPath; apply: ApplySafetyReceipt; protectedWriteSet: ProtectedWriteSet };
+```
+
+This removes optional `manifestPath?` and `hookScope?` from admission call sites. A caller must choose the lifecycle-specific constructor before promotion can run.
+
+### PatternAdmissionResult
+
+```ts
+type PatternAdmissionResult =
+  | { kind: "candidate-created"; state: CandidatePatternDraft; writes: CandidateWriteSet }
+  | { kind: "registered-admitted"; state: RegisteredDiagnosticPattern | RegisteredHookScopedPattern; writes: RegisteredDiagnosticWriteSet }
+  | { kind: "apply-approved"; state: RegisteredApplyApprovedPattern; writes: ApplyAuthorityWriteSet }
+  | { kind: "admission-refused"; refusal: PatternAdmissionRefusal; protectedPaths: readonly RepoPath[] };
+```
+
+Refusal reasons must be typed:
+
+```ts
+type PatternAdmissionRefusalReason =
+  | "missing-manifest-path"
+  | "manifest-unreadable"
+  | "manifest-malformed"
+  | "manifest-placeholder"
+  | "manifest-contradicted"
+  | "manifest-orphan"
+  | "candidate-active-collision"
+  | "registered-candidate-collision"
+  | "rule-pack-collision"
+  | "baseline-contract-missing"
+  | "baseline-contract-mismatch"
+  | "baseline-action-blocked"
+  | "fixture-strategy-missing"
+  | "false-positive-model-missing"
+  | "current-tree-blocks-registration"
+  | "hook-scope-mismatch"
+  | "apply-safety-missing"
+  | "apply-safety-forbidden-for-diagnostic"
+  | "apply-protected-write-set-rejected";
+```
+
+### Consumer Projections
+
+D8 must specify that consumers receive projections, not the whole manifest.
+
+- Pattern generator receives `CandidateGenerationProjection`: candidate paths, draft markdown fields, candidate manifest fields.
+- Registration writer receives `RegisteredRulePackProjection`: rule id, owner project, lane, diagnostic pattern name, manifest path, hook scope if accepted, message text source, and baseline reference.
+- Diagnostic Pattern Catalog receives `DiagnosticPatternProjection`: pattern name, language, scan roots, fixture strategy, false-positive model, current-tree scan class, and non-claims. It does not receive apply safety fields.
+- Baseline Authority receives `BaselineIntroductionProjection`: rule id, baseline path, action, initial keys, comparison base, owner tool/project, and rule-introduction manifest path.
+- Local Feedback receives `HookScopeProjection`: only accepted pre-commit hook-scoped enforced rules and approved staged roots.
+- Transformation Transaction receives `ApplyPatternProjection`: apply pattern paths, protected write set, apply safety receipt, rollback/type/test/formatter gates, and non-claims. It does not receive diagnostic-only manifest state.
+- Recovery/ledger consumers receive `AdmissionReceiptProjection`: accepted/refused/retired state, authoritative sources, proving sources, validation commands, and protected paths.
+
+## Safe Refactor Moves
+
+These are behavior-preserving moves for the later implementation packet. They should be specified in D8 before source edits and executed in small compiler-gated steps.
+
+1. Introduce lifecycle state constructors next to `manifest.ts`.
+   Add functions that return `PatternAuthorityState` variants from validated manifests and admission inputs. Keep existing manifest JSON shape initially. Do not change public generator behavior in the same step.
+
+2. Replace `authorityAccepted: boolean` with state-owned acceptance.
+   Keep compatibility projection if needed, but internal consumers should switch on `state.kind`. Candidate valid draft, registered diagnostic, hook-scoped, apply-approved, refused, and retired states must not share a boolean acceptance convention.
+
+3. Introduce lifecycle-specific admission inputs.
+   Replace broad generator promotion calls with `registered-diagnostic-admission` and `registered-hook-admission` constructors. Missing manifest path becomes unrepresentable for registered constructors.
+
+4. Convert promotion failures to typed refusal results.
+   Keep thrown errors only at the Nx generator boundary if D0 compatibility requires it. Internally return `PatternAdmissionResult` with `kind: "admission-refused"` and exact refusal reason.
+
+5. Extract consumer projection builders.
+   Move rule-entry construction, Grit markdown construction, baseline contract checks, and hook-scope projection behind small functions that accept projections. This removes whole-record manifest leakage from consumers.
+
+6. Split diagnostic registration from apply approval.
+   Add a separate apply-approved state and projection. `grit-check` registered states must only construct `RegisteredDiagnosticPattern` or `RegisteredHookScopedPattern` with `not-apply`. `grit-apply` must require apply safety receipt and protected write set.
+
+7. Make write sets explicit.
+   Have candidate generation and registered admission return a typed write set before applying writes. Tests can assert exact intended writes and protected paths before any write is performed.
+
+8. Preserve public behavior at the boundary.
+   Existing generator CLI/schema behavior, error text expectations, and JSON manifest shape may remain as compatibility projections until D0 authorizes public changes. The internal state model should still collapse first.
+
+9. Keep baselines and apply transactions owned by adjacent domains.
+   D8 should consume D5 baseline projection and D9 apply safety projection. It should not duplicate baseline expansion logic or apply transaction mechanics.
+
+## Write/Protected Set
+
+Later implementation must stay inside this write set unless the D8 packet is explicitly expanded and re-reviewed.
+
+Allowed source write set:
+
+- `tools/habitat-harness/src/rules/pattern-authority/manifest.ts`
+- `tools/habitat-harness/src/generators/pattern/generator.cjs`
+- `tools/habitat-harness/src/generators/pattern/registration.cjs`
+- `tools/habitat-harness/src/generators/pattern/schema.json` only if D0 compatibility disposition covers generator option changes.
+- `tools/habitat-harness/src/rules/architecture.ts` only for typed projection consumption, not unrelated rule execution behavior.
+- `tools/habitat-harness/src/rules/rules.json` only for adding `manifestPath` metadata required by an accepted registered fixture or test case; no broad registry churn.
+- `tools/habitat-harness/test/rules/pattern-authority-manifest.test.ts`
+- `tools/habitat-harness/test/generators/pattern-generator.test.ts`
+- New narrowly-scoped tests under `tools/habitat-harness/test/rules/` or `tools/habitat-harness/test/generators/` for Pattern Authority admission state and negative type/runtime cases.
+- D8 OpenSpec packet files under `openspec/changes/deep-habitat-d8-pattern-governance/**`.
+- D8 scratch/phase records under `docs/projects/habitat-harness/openspec-remediation/**`.
+- Pattern Authority docs or ledgers explicitly named by the repaired D8 packet.
+
+Allowed runtime write projections for the generator:
+
+- Candidate generation may write:
+  - `tools/habitat-harness/src/rules/pattern-authority/candidates/<rule-id>.json`
+  - `tools/habitat-harness/src/rules/pattern-authority/candidates/<pattern-name>.md`
+- Registered diagnostic/hook admission may write:
+  - `.grit/patterns/habitat/checks/<pattern-name>.md`
+  - `tools/habitat-harness/src/rules/rules.json`
+- Registered diagnostic/hook admission may require existing, prewritten:
+  - `tools/habitat-harness/src/rules/pattern-authority/<rule-id>.json`
+  - `tools/habitat-harness/baselines/<rule-id>.json`
+  - the manifest's rule-introduction baseline manifest path under `openspec/changes/<change-id>/workstream/**`
+
+Protected paths:
+
+- `tools/habitat-harness/baselines/**` must not be created, expanded, or edited as a side effect of Pattern Authority admission. Baseline files are D5-owned inputs to D8 admission.
+- `.grit/patterns/habitat/apply/**` must not be edited by diagnostic registration. Apply patterns require a separate apply-approved state.
+- `.grit/grit.yaml`, `.gritignore`, `.gitignore`, and Grit acquisition configuration must not be changed by D8 admission.
+- `tools/habitat-harness/src/lib/grit-apply.ts` and Grit apply transaction tests are protected from D8 implementation unless the packet explicitly invokes the D9/apply workstream.
+- `tools/habitat-harness/src/lib/baseline.ts` is protected from D8 implementation unless D5 contract changes are explicitly accepted.
+- Product source roots (`apps/**`, `packages/**`, `mods/**`) are protected from D8 implementation except for test fixtures explicitly approved by the packet.
+- Generated artifacts (`dist/**`, `mod/**`, generated zones, `.civ7/**`, lockfiles) are protected.
+- Existing active Grit pattern files unrelated to the admitted test fixture are protected.
+- Existing rule-pack rows unrelated to the admitted pattern fixture are protected.
+
+## Validation Matrix
+
+| Gate | State collapse proved | Required expectation |
+| --- | --- | --- |
+| Manifest state constructor tests | Candidate, invalid candidate, registered diagnostic, hook-scoped, apply-approved, refused, and retired states are distinct variants | Valid candidate cannot project to registered; registered diagnostic cannot project to apply-safe |
+| Negative TypeScript fixture or equivalent `expectTypeOf` test | Illegal admission inputs are unrepresentable | Registered admission without manifest path, hook admission without pre-commit hook, and apply approval without apply receipt fail at compile time |
+| `pattern-authority-manifest.test.ts` | Manifest parsing and contradiction checks preserve current behavior | Existing missing/malformed/placeholder/orphan/contradicted tests pass, with new refusal reasons if public-compatible |
+| `pattern-generator.test.ts` no-write refusals | Refused admission protects candidate, active pattern, baseline, and rule-pack paths | Missing manifest, placeholder manifest, hook mismatch, baseline missing/mismatch, current-tree blocked, and apply-for-diagnostic all leave protected paths unchanged |
+| Candidate generation test | Candidate draft has no enforcement projection | Candidate writes only candidate paths, not active pattern, baseline, `rules.json`, hook scope, or apply projection |
+| Registered diagnostic admission test | Accepted manifest plus baseline contract admits only diagnostic enforcement | Active check pattern and `rules.json` row are written; baseline and manifest remain unchanged; rule row has manifest path |
+| Hook-scoped admission test | Hook scope is accepted only for enforced registered state | Advisory plus pre-commit refuses; enforced plus matching manifest/invocation projects hook scope |
+| Apply safety test | Diagnostic and apply safety are separate states | `grit-check` plus apply safety refuses; `grit-apply` plus missing apply proof refuses; apply-approved state requires protected write set |
+| Whole-record leakage test | Consumer projections are narrower than the full manifest | Rule-pack builder, diagnostic builder, baseline projection, hook projection, and apply projection do not accept `RegisteredPatternAuthorityManifest` directly |
+| Baseline integration gate | D8 consumes D5 baseline contract without owning expansion | `bun run habitat check --rule baseline-integrity --json` exits 0 or records exact accepted failure; D8 tests do not edit baseline files |
+| Protected root gate | D8 does not expand Grit scan/apply roots | Existing protected-root tests for `.civ7`, generated zones, docs root approval, staged roots, and apply diff evidence continue to pass |
+| OpenSpec gate | Packet itself names the closed model and write/protected set | `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict` passes after spec/tasks/design include these requirements |
+| Repo hygiene gate | Only the intended scratch/spec files changed for this investigation | `git diff --check` passes and `git status --short --branch` shows no source edits from this design pass |
+
+Suggested exact later command set:
+
+- `bun run --cwd tools/habitat-harness test -- test/rules/pattern-authority-manifest.test.ts test/generators/pattern-generator.test.ts`
+- `bun run --cwd tools/habitat-harness test -- test/lib/grit-apply.test.ts test/lib/grit-adapter.test.ts test/lib/hooks.test.ts test/lib/rule-selection.test.ts`
+- `bun run habitat check --rule baseline-integrity --json`
+- `bun run habitat classify tools/habitat-harness/src/rules/rules.json`
+- `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict`
+- `bun run openspec:validate`
+- `git diff --check`
+
+## P1/P2 Blockers
+
+### P1: Packet does not yet specify the complete Pattern Authority state model
+
+The OpenSpec scaffold says lifecycle states must exist, but the spec requirement only names "candidate, reviewed, registered, refused, and retired" at `openspec/changes/deep-habitat-d8-pattern-governance/specs/habitat-harness/spec.md:3-13`. It does not specify diagnostic registered versus hook-scoped versus apply-approved variants, nor the required fields/projections per state.
+
+Required repair: add normative requirements for `PatternAuthorityState`, lifecycle-specific admission inputs, typed refusal results, and consumer projections.
+
+### P1: Packet does not yet prevent diagnostic/apply-safe conflation
+
+The source packet explicitly says registered diagnostic pattern is not apply-safe at `D8-pattern-governance.md:105-109`, and current manifest validation rejects `grit-check` plus `applySafety.kind === "apply"` at `manifest.ts:628-645`. The OpenSpec scaffold does not carry that into a complete spec requirement. A later implementation agent could preserve the runtime check but still expose a registered manifest projection that implies apply safety by whole-record leakage.
+
+Required repair: add a distinct `RegisteredApplyApprovedPattern` state and state that diagnostic consumers never receive apply safety fields.
+
+### P1: Packet lacks exact write set and protected paths
+
+`tasks.md:9` says to record a concrete write set later, but D8 cannot authorize implementation while the implementation write/protected set is unresolved. The source packet stop conditions include file-presence lifecycle and optional baseline/hook decisions, so the packet must own this before source edits.
+
+Required repair: copy the write/protected set above into `design.md`, `tasks.md`, and/or `phase-record.md` with no reduced-scope language.
+
+### P1: Current active rule registry does not prove registered Pattern Authority admission
+
+`HarnessRule` can carry `manifestPath?`, but current `rules.json` has no `manifestPath` entries. Existing active Grit rows with `gritPattern` and hook scope therefore cannot be treated as Pattern Authority-registered by current disk state. D8 must not claim current disk already prevents candidate/registered/apply-safe conflation.
+
+Required repair: state that current rule-pack metadata is present-behavior evidence only; later admission must add or validate `manifestPath` through explicit accepted manifests.
+
+### P2: Validation gates are too generic
+
+The current D8 scaffold validation gates include the manifest test, classify, OpenSpec validation, and `git diff --check`, but they do not include negative type-state gates, whole-record leakage gates, apply safety separation gates, or protected write-set tests.
+
+Required repair: add a validation matrix tied to TypeScript state collapse, not only runtime smoke tests.
+
+### P2: Refusal states remain error-message-driven
+
+Promotion currently surfaces failures through `PatternPromotionFailure` messages. Tests assert message substrings such as `requires --manifestPath`, `placeholder-manifest`, and hook mismatch. This is acceptable as an outer compatibility projection, but not as the internal D8 model.
+
+Required repair: specify typed refusal results and require compatibility error messages to be generated from refusal state, not parsed as authority.
+
+### P2: Whole-manifest access is not bounded by consumer projections
+
+Rule-entry and pattern markdown builders currently accept the full registered manifest. That can remain temporarily, but D8 must specify the replacement projections before implementation.
+
+Required repair: require projection builders and tests proving consumers do not accept whole manifests where a narrower projection exists.
+
+Skills used: domain-design, information-design, solution-design, typescript-refactoring.


### PR DESCRIPTION
docs(habitat): add D8 domain ontology investigation

Define the D8 Pattern Governance ontology target, including lifecycle states, admission capabilities, refusal reasons, owner boundaries, and consumer projections.

Record current D8 OpenSpec packet blockers as BLOCKING so later packet repair does not infer Pattern Authority semantics from registry, baseline, diagnostic, enforcement, apply, hook, or generator surfaces.

References:
- Project: Deep Habitat OpenSpec remediation
- Source: docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md

docs(habitat): add D8 TypeScript state investigation

Add the D8 TypeScript state-space investigation scratch document for the Deep Habitat OpenSpec remediation pass. The investigation maps current Pattern Authority manifest, generator, rule registration, baseline, and apply-adjacent states, then records the target lifecycle model, write/protected set, validation matrix, and blocking packet repairs.

References:
- Project: Deep Habitat OpenSpec remediation
- Docs: docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md
- OpenSpec: openspec/changes/deep-habitat-d8-pattern-governance

docs(habitat): add D8 code vendor topology investigation

Add the D8 Pattern Governance code/vendor topology scratch document with current topology, vendor boundaries, public surfaces, write set, protected paths, validation gates, and P1/P2 blockers.

References:
- Project: Deep Habitat OpenSpec remediation
- Docs: docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-code-vendor-topology-investigation.md