### PR TITLE
docs(habitat): accept D8 pattern governance packet

### DIFF
--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-code-vendor-topology-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-code-vendor-topology-investigation.md
@@ -4,8 +4,8 @@ Status: BLOCKING
 
 ## Blocking Reason
 
-The current D8 disk packet is a draft scaffold, not a complete executable
-Pattern Governance topology contract. The current source tree contains partial
+The current D8 disk packet is an incomplete packet, not a complete executable
+Pattern Governance topology contract. The current source tree contains incomplete
 Pattern Authority implementation facts, but those facts are present-behavior
 evidence only. They do not satisfy the Phase 2 D8 source packet as a complete
 OpenSpec target.
@@ -167,10 +167,10 @@ Current registered promotion:
 
 D8 gap:
 
-- The generator currently performs both candidate scaffolding and registered
+- The generator currently performs both candidate starter packeting and registered
   promotion. D8 must decide whether this remains one generator surface with
-  lifecycle states or becomes separated by D13 scaffolding/refusal and D8
-  Pattern Governance. D13 consumes D8 and explicitly says project scaffolding
+  lifecycle states or becomes separated by D13 generator/refusal and D8
+  Pattern Governance. D13 consumes D8 and explicitly says project starter packeting
   must be separated from Pattern Governance candidate generation.
 
 ### Rule Registry And Active Grit Catalog
@@ -294,8 +294,8 @@ compatibility rows and compatibility handling before source edits.
 - D11 Local Feedback consumes D7/D9/D10 decisions and hook-scoped rule facts. It
   will observe D8 hook-scope admission through enforcement outputs, but it must
   not decide pattern lifecycle locally.
-- D13 Scaffolding And Refusal consumes D8 candidate semantics. It must keep
-  scaffolding/refusal separate from Pattern Governance and must not register
+- D13 Generator And Refusal consumes D8 candidate semantics. It must keep
+  generator/refusal separate from Pattern Governance and must not register
   generated pattern candidates automatically.
 
 ## D8 Write Set
@@ -392,7 +392,7 @@ Stale/generated-output concerns:
 
 ## Validation Gates
 
-Current D8 scaffold gates:
+Current D8 validation gates:
 
 - `bun run --cwd tools/habitat-harness test -- test/rules/pattern-authority-manifest.test.ts`
 - `bun run habitat classify tools/habitat-harness/src/rules/rules.json`
@@ -436,14 +436,13 @@ Required non-claims:
 | --- | --- | --- | --- |
 | D8-P1-001 | P1 | The D8 OpenSpec spec has only broad candidate/registered scenarios and does not encode the full Phase 2 lifecycle state set. | Add normative lifecycle requirements and scenarios for candidate draft, manifest-invalid candidate, registered diagnostic pattern, registered hook-scoped pattern, registered apply-approved pattern, refused pattern, and retired pattern. |
 | D8-P1-002 | P1 | The current packet does not declare a concrete D8 write set and protected path list. | Move the write/protected set from investigation into `design.md` and `phase-record.md`, including conditional owners for `rules.json`, `.grit` patterns, baselines, and generator schema changes. |
-| D8-P1-003 | P1 | Current implementation topology has partial Pattern Authority code, but the packet does not classify which parts are target contract versus compatibility facts. | Add current topology inventory to the packet and explicitly mark existing three-state lifecycle, current generated messages, and legacy rule rows as present behavior until accepted as target. |
+| D8-P1-003 | P1 | Current implementation topology has incomplete Pattern Authority code, but the packet does not classify which parts are target contract versus compatibility facts. | Add current topology inventory to the packet and explicitly mark existing three-state lifecycle, current generated messages, and legacy rule rows as present behavior until accepted as target. |
 | D8-P1-004 | P1 | The packet does not name the vendor ownership split. | Record Grit, Biome, and Nx ownership boundaries with exact official URLs and state what D8 owns around those vendor tools. |
 | D8-P1-005 | P1 | Validation gates omit `pattern-generator.test.ts`, the D5 `baseline-integrity` focused gate, native Grit fixture proof, and bad-case refusal coverage required by the source packet. | Repair proposal/tasks/phase record gates and require exact command expectations plus non-claims. |
 | D8-P1-006 | P1 | Existing active Grit rules generally have no `manifestPath`, while current code can require one for registered promotion. The packet does not define legacy registered-rule disposition. | Specify legacy active pattern disposition: grandfathered compatibility, migration, refused, retired, or accepted manifest path. Do not let file presence imply lifecycle. |
 | D8-P1-007 | P1 | D8 dependencies are underspecified. The source packet says blocked by D1, D2, D5, and D6, while current OpenSpec proposal says D0, D2, D5, and D6. | Reconcile consumed upstream contracts explicitly: D0 for public surfaces, D1 for receipt/output language, D2 for registry facts, D5 for baseline contracts, D6 for diagnostic pattern facts, and D7 as enforcement consumer boundary. |
 | D8-P1-008 | P1 | The D8 phase record records branch `codex/deep-habitat-openspec-remediation`, but the active requested branch is `codex/d8-pattern-governance-packet`. | Update phase record state before claiming review/implementation readiness. |
 | D8-P2-001 | P2 | Docs guidance appears stale against current inventory counts: current disk has 32 `grit-check` rules and 3 apply pattern files, while `CAPABILITIES.md` records 31 and 2. | Decide whether D8 or a docs realignment pass repairs the counts; until then, treat docs counts as stale guidance, not topology truth. |
-| D8-P2-002 | P2 | The current generator description says it scaffolds a Grit pattern and matching rule-pack entry, but candidate behavior does not write `rules.json`. | Repair public docs/schema/description through D0/D13 compatibility so candidate generation is described as non-registering unless promotion is explicitly requested and accepted. |
+| D8-P2-002 | P2 | The current generator description says it starter packets a Grit pattern and matching rule-pack entry, but candidate behavior does not write `rules.json`. | Repair public docs/schema/description through D0/D13 compatibility so candidate generation is described as non-registering unless promotion is explicitly requested and accepted. |
 | D8-P2-003 | P2 | The packet does not yet name D9, D11, and D13 consumer non-claims in one place. | Add downstream consumer section: D9 consumes apply-safety only, D11 consumes hook-scoped enforcement facts only through D7/D9/D10, and D13 consumes candidate/refusal semantics without automatic registration. |
 | D8-P2-004 | P2 | Refusal reasons exist as validator issues but not as durable lifecycle/output states. | Decide target shape for refused states and require tests that prove missing manifest, malformed manifest, placeholder manifest, missing baseline, missing hook-scope decision, missing fixtures, and apply-safety absence fail closed before writes. |
-

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-cross-domino-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-cross-domino-investigation.md
@@ -1,0 +1,310 @@
+# D8 Cross-Domino Investigation
+
+Status: BLOCKING
+
+## Finding
+
+D8 is not complete cross-domino input yet. The source packet correctly assigns
+Pattern Governance as the exclusive owner of pattern lifecycle and admission,
+but the current OpenSpec packet does not publish enough state, sequencing,
+source-blocker, or downstream handoff detail for D9, D11, D13, and G-HOST to
+consume D8 without inventing governance semantics later.
+
+The blocking risk is not that D8 lacks any present implementation evidence.
+Current code already has useful Pattern Authority manifest and generator
+behavior. The risk is that current source names and tests are narrower than the
+complete-standard D8 source packet: source code currently centers
+`candidate`, `registered-advisory`, and `registered-enforced`, while the D8
+source packet requires candidate draft, manifest-invalid candidate, registered
+diagnostic pattern, registered hook-scoped pattern, registered apply-approved
+pattern, refused pattern, and retired pattern states with explicit manifest,
+fixture, baseline, hook-scope, false-positive, proof, and apply-safety
+decisions.
+
+D8 must become the complete published-language boundary for lifecycle and
+admission before downstream packets proceed. D9 must not decide what
+apply-approved means. D13 must not decide what generated candidate or registered
+means. D11 must not infer hook-scoped pattern admission from rule-pack fields or
+manifest strings. G-HOST must not receive host-specific pattern gates through
+generic Pattern Governance prose.
+
+## Sources Read
+
+Skills and workflow authorities:
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/system-design/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/source-map.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/phase-loop.md`
+- `AGENTS.md`
+
+D8 packet and starter packet:
+
+- `docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md`
+- `openspec/changes/deep-habitat-d8-pattern-governance/proposal.md`
+- `openspec/changes/deep-habitat-d8-pattern-governance/design.md`
+- `openspec/changes/deep-habitat-d8-pattern-governance/tasks.md`
+
+Accepted upstream design/spec packets and control records:
+
+- `docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+- `docs/projects/habitat-harness/openspec-remediation/review-disposition-ledger.md`
+- `openspec/changes/deep-habitat-d0-command-surface-inventory/design.md`
+- `openspec/changes/deep-habitat-d1-receipt-contract-boundary/design.md`
+- `openspec/changes/deep-habitat-d2-rule-registry-metadata-contract/design.md`
+- `openspec/changes/deep-habitat-d5-baseline-authority/design.md`
+- `openspec/changes/deep-habitat-d6-diagnostic-pattern-catalog/design.md`
+- `openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/design.md`
+
+Downstream and adjacent source packets:
+
+- `docs/projects/habitat-harness/phase2-workstream-packets/D9-transformation-transaction.md`
+- `docs/projects/habitat-harness/phase2-workstream-packets/D10-generated-protected-zone-authority.md`
+- `docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md`
+- `docs/projects/habitat-harness/phase2-workstream-packets/D13-starter packeting-and-refusal-contracts.md`
+- `docs/projects/habitat-harness/phase2-workstream-packets/G-HOST-host-policy-boundary-gate.md`
+
+Downstream OpenSpec starter packets:
+
+- `openspec/changes/deep-habitat-d9-transformation-transaction/{proposal.md,design.md,tasks.md}`
+- `openspec/changes/deep-habitat-d10-protected-zone-authority/{proposal.md,design.md,tasks.md}`
+- `openspec/changes/deep-habitat-d11-local-feedback/{proposal.md,design.md,tasks.md}`
+- `openspec/changes/deep-habitat-d13-starter packeting-refusal-contracts/{proposal.md,design.md,tasks.md}`
+- `openspec/changes/deep-habitat-host-policy-boundary-gate/{proposal.md,design.md,tasks.md}`
+
+Present-behavior evidence only:
+
+- `tools/habitat-harness/src/rules/pattern-authority/manifest.ts`
+- `tools/habitat-harness/src/generators/pattern/generator.cjs`
+- `tools/habitat-harness/src/generators/pattern/registration.cjs`
+- `tools/habitat-harness/test/rules/pattern-authority-manifest.test.ts`
+- `tools/habitat-harness/test/generators/pattern-generator.test.ts`
+- `docs/projects/habitat-harness/grit-pattern-corpus-ledger.md`
+- `docs/projects/habitat-harness/recovery-claim-ledger.md`
+
+## Dependency Map
+
+| Dependency | D8 use | Current status | Source blocker | Downstream effect if missing |
+| --- | --- | --- | --- | --- |
+| D0 Command Surface Inventory | Public compatibility rows for generator options/output, manifest durable schema, rule-pack fields, command JSON/human messages, package exports, docs examples, and any generated/help surfaces touched by Pattern Governance | Accepted for design/specification only; not implementation-complete | D8 source implementation cannot change any public/durable surface until concrete D0 rows say preserve, version, facade, deprecate, refuse, document-only, or generated-only | D13 cannot know whether candidate generator output/schema is compatible; D9 cannot know whether apply-admission fields are public-compatible |
+| D1 Receipt Contract Boundary | Refusal, command outcome, diagnostic, non-claim, and protected downstream-owned terminology families for missing manifest, manifest-invalid, baseline-refused, diagnostic-refused, hook-scope-refused, apply-safety-refused, and registration-refused states | Accepted for design/specification only; not implementation-complete | D8 starter packet currently omits D1 from `Requires`; source implementation must cite D1 output families and D0 rows before adding or changing refusals/messages | Downstream packets are forced to invent "proof" or error language for Pattern Governance failures |
+| D2 Rule Registry Metadata Contract | `ruleGovernanceFacts`, `ruleGritFacts`, `ruleBaselineFacts`, and rule-pack references tying rule id, pattern identity, manifest path, lifecycle expectation, hook eligibility, and governance relation to D8 | Accepted for design/specification only; source implementation still waits for live projections | D8 may design against D2 projection contracts, but source implementation cannot parse whole `RuleRegistryRecord`, legacy `HarnessRule`, `lane`, `gritPattern`, `hookScope`, `manifestPath`, or prose `scope` as target authority after D2 projections exist | D13 and D9 can otherwise infer registration/apply approval from broad rule rows instead of D8 lifecycle |
+| D5 Baseline Authority | `BaselineAuthorityProjection` and baseline refusal state consumed by D8 admission; D8 decides what lifecycle does with D5 result, not whether baseline debt/source/growth is valid | Accepted for design/specification only; not implementation-complete | D8 source implementation for registered states waits for D5 projection/refusal where baseline authority is required; D8 must not validate baseline files, expansion, external projections, or seeded debt locally | D9/D13 can otherwise treat baseline files or manifest strings as enough for apply/registration |
+| D6 Diagnostic Pattern Catalog | Diagnostic capability, diagnostic identity, fixture/native sample result, injected probe outcome, current-tree diagnostic limitations, and non-claims | Accepted for design/specification only; not implementation-complete | D8 source implementation for registered diagnostic states waits for D6 diagnostic projections where diagnostic proof is required; D8 must not infer diagnostic identity from `gritPattern ?? ruleId` or Grit prose | D9 can otherwise mistake diagnostics for write safety; D11 can mistake staged Grit findings for hook admission |
+| D7 Structural Enforcement Pipeline | Current-tree check outcome and structural report semantics for admission evidence when D8 requires Habitat wrapper current-tree proof or hook-scoped enforcement readiness | Accepted for design/specification only; not implementation-complete | D8 can define lifecycle state requirements now, but source acceptance of current-tree check evidence that depends on D7 must wait for D7's check outcome projection and non-claims | D11/D9 can otherwise reinterpret check pass/fail as hook or apply approval |
+| D10 Generated/Protected Zone Authority | Protected/generated-zone guard decisions for pattern scan roots, candidate/probe roots, apply paths, and protected-zone write refusals when lifecycle or apply admission touches host-owned generated/protected areas | Draft/blocking; not accepted | D8 must not accept apply-approved or hook-scoped lifecycle claims for paths requiring generated/protected-zone authority until D10 has an accepted contract; D8 must consume D10, not define protected-zone policy | D9 can otherwise approve writes into protected zones; D11 can otherwise localize protected-zone failures without owner/recovery guidance |
+
+The current D8 starter packet lists D0/D2/D5/D6 but not D1, D7, or D10. That is
+insufficient. D1 is mandatory for complete refusal/output semantics. D7 is
+mandatory wherever D8 treats Habitat check/current-tree results as admission
+evidence. D10 is mandatory wherever lifecycle, probes, scan roots, or apply
+approval touch generated/protected zones.
+
+## Downstream Handoff Model
+
+D8 must publish a closed Pattern Governance state model. Downstream packets may
+consume D8 projections; they may not inspect current manifest code, rule-pack
+rows, Grit markdown, baseline files, hook fields, or generator options to
+recreate lifecycle semantics.
+
+Required D8 state families:
+
+- `candidate-draft`: generated draft only; not an active rule, not a Grit
+  diagnostic catalog entry, not hook-scoped, not baselined, not apply-approved.
+- `manifest-invalid-candidate`: candidate with malformed, placeholder,
+  contradicted, orphan, Grit-only, Nx-options-only, missing-source, or
+  missing-proof state; cannot be promoted.
+- `registered-diagnostic-pattern`: registered as diagnostic/check only with
+  accepted manifest, D2 governance/Grit relation, D5 baseline projection, D6
+  diagnostic capability/proof, fixture strategy, false-positive model,
+  current-tree disposition, and `not-apply` apply-safety decision.
+- `registered-hook-scoped-pattern`: registered enforced diagnostic pattern plus
+  explicit hook-scope decision, D6 staged diagnostic capability as applicable,
+  D7 check projection where hook-scoped enforcement depends on structural check
+  outcome, and D11-owned local-feedback non-claims preserved.
+- `registered-apply-approved-pattern`: registered apply pattern with explicit
+  apply-safety decision and D9 handoff inputs; diagnostic registration never
+  implies apply safety.
+- `refused-pattern`: refusal with owner, reason, failed dependency result, next
+  safe action, public-surface handling, and non-claims.
+- `retired-pattern`: no longer admitted for new enforcement/apply/hook use,
+  with replacement or removal guidance and downstream cleanup owner.
+
+Required downstream ledger rows:
+
+| Downstream surface | Disposition | Required D8 handoff row |
+| --- | --- | --- |
+| D9 Transformation Transaction | Blocked until D8 publishes apply-admission projection | Add a D9 row stating: D9 consumes only `registered-apply-approved-pattern` or explicit apply-refusal from D8, plus pattern id, manifest path, approved apply pattern identity, D8 apply-safety proof fields, D10/G-HOST path/gate references when applicable, and non-claims. D9 may not promote diagnostics to writes, approve apply roots, decide fixture sufficiency, or accept a `grit-check` manifest as apply-safe. |
+| D11 Local Feedback | Indirect consumer through D7/D9/D10, with a direct hook-scope admission guard where D8 marks a pattern hook-scoped | Add a D11 row stating: D11 consumes D8 hook-scope admission only as a published eligibility projection and still owns hook sequencing, staged-file policy, local output, and local-feedback non-claims. D11 may not infer hook eligibility from `hookScope`, rule lane, manifest strings, or current generator options. |
+| D13 Generator And Refusal Contracts | Blocked for pattern candidate semantics and registration handoff until D8 publishes candidate/registration contract | Add a D13 row stating: D13 may create `candidate-draft` artifacts only through the D8 candidate contract and must hand registration requests to D8. D13 must preserve candidate-only output, refuse registered-without-manifest or candidate-with-active-rule collisions before writes, and must not write active `.grit`, `rules.json`, baseline, hook, or apply states by implication. |
+| G-HOST Host Policy Boundary Gate | Adjacent authority, not governed by D8; D8 consumes host declarations for host-specific apply gates and protected/generated-zone references | Add a G-HOST row stating: G-HOST owns host declarations, generated/protected-zone ownership, host-specific apply gates, unsupported host starter packet kinds, and host-policy missing refusals. D8 may reference host-policy declarations in lifecycle/apply decisions but may not encode Civ/MapGen host semantics inside Pattern Governance. Missing host policy yields a D8 refusal only after naming G-HOST as the owner. |
+| D7 Structural Enforcement Pipeline | Upstream evidence source and downstream enforcement consumer, depending on state | Add a D7 row stating: D8 consumes D7 check outcomes only as current-tree evidence/non-claims for admission; D7 may consume only D8's registered/hook-scoped eligibility projection when selecting active pattern-related rules. D7 may not decide lifecycle, fixture sufficiency, false-positive model, hook scope, or apply approval. |
+| D2/D5/D6 upstream packets | Source-blocking prerequisites, not downstream design owners | Add rows stating that D8 consumes D2/D5/D6 projections and never reimplements registry, baseline, or diagnostic authority locally. |
+| Packet index | Pending D8 final rereviews | Keep D8 BLOCKING until D8 repairs proposal/design/tasks/spec/downstream ledger and final per-domino reviews find no unresolved accepted P1/P2 blockers. |
+
+## Source Blockers
+
+D8 source implementation must not start until these blockers are represented in
+the packet and satisfied by the later implementation phase:
+
+| Blocker | Required before D8 source edits |
+| --- | --- |
+| Public/durable compatibility | Concrete D0 rows for every touched generator option/output, manifest schema/location, rule-pack field, command message, command JSON, package export, docs example, and generated/help surface. |
+| Refusal/output semantics | D1 output-family citations for missing manifest, malformed manifest, placeholder manifest, contradicted manifest, orphan manifest, baseline refusal, diagnostic refusal, hook-scope refusal, apply-safety refusal, retired pattern use, and registration refusal. |
+| Registry projection availability | Live D2 `ruleGovernanceFacts` and `ruleGritFacts` where D8 reads rule-pack relation; D8 must not read whole registry rows or use legacy field presence as target lifecycle authority. |
+| Baseline projection availability | Live D5 `BaselineAuthorityProjection` or baseline refusal where registration depends on baseline contract. D8 must not decide baseline load, shrink-only, external exception, or seeded-debt validity. |
+| Diagnostic projection availability | Live D6 diagnostic capability, native fixture/sample, current-tree diagnostic, injected probe, limitation, and non-claim projections where diagnostic admission depends on them. D8 must not use native Grit or Grit markdown alone as admission proof. |
+| Current-tree check evidence | Accepted D7 check outcome projection where D8 treats Habitat wrapper current-tree result as admission evidence. D8 must not infer structural pass/fail from `CheckReport.ok` or current command strings. |
+| Protected/generated-zone authority | Accepted D10 guard/refusal contract, backed by G-HOST, where scan roots, probe paths, candidate paths, or apply paths touch generated/protected zones. |
+| Lifecycle model mismatch | The D8 packet must either adopt current `candidate`, `registered-advisory`, and `registered-enforced` names as compatibility projections or supersede them with complete-standard state names before source changes. Current code does not by itself satisfy `registered diagnostic`, `registered hook-scoped`, `registered apply-approved`, `manifest-invalid`, `refused`, and `retired` state requirements. |
+| Apply admission | D8 must publish `not-apply`, `apply-refused`, and `apply-approved` states separately from diagnostic registration. A `grit-check` diagnostic manifest cannot claim apply safety; a `grit-apply` manifest cannot rely on D6 diagnostic proof alone. |
+| Hook admission | D8 must publish hook-scope admission/refusal separately from D11 local hook execution. A rule-pack `hookScope` field is not enough without D8 lifecycle acceptance and D11 consumer non-claims. |
+
+Present source evidence:
+
+- `manifest.ts` validates `candidate`, `registered-advisory`, and
+  `registered-enforced`, rejects several invalid manifest shapes, and carries
+  baseline, hook, and apply fields. This is useful evidence but not the complete
+  OpenSpec contract.
+- `generator.cjs` creates candidate-only artifacts and refuses registered
+  generation without a manifest. This supports D13 handoff but does not replace
+  D8 packet language.
+- `registration.cjs` can promote a registered check pattern after manifest and
+  baseline checks. This is present behavior; D8 still needs complete lifecycle,
+  downstream handoff, D0/D1 compatibility, and D2/D5/D6/D7/D10 blocker language
+  before implementation closure.
+
+## Packet Index/Status Requirements
+
+Current D8 packet-index status must remain:
+
+`incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING`
+
+D8 may update the packet index only after final rereviews pass and all accepted
+P1/P2 findings are repaired. The acceptable post-repair row language is:
+
+`accepted for design/specification; final domain/ontology, OpenSpec/information, TypeScript/validation, code/topology, and cross-domino rereviews found no unresolved P1/P2 blockers; not implementation-complete; source implementation requires concrete D0 rows, D1 output-family citations, live D2 ruleGovernanceFacts/ruleGritFacts, D5 BaselineAuthorityProjection, D6 diagnostic projections, accepted D7 check outcome projection where current-tree admission evidence is consumed, and accepted D10/G-HOST protected-zone/host-policy contracts where scan roots, probes, apply paths, or host gates are touched`
+
+Required index effects:
+
+- Keep D8 `Requires` expanded to D0, D1, D2, D5, D6, D7 where current-tree
+  check admission is consumed, and D10 where generated/protected-zone or apply
+  path authority is consumed. If D7/D10 are conditional for a specific lifecycle
+  state, state the condition directly in the row or a note; do not omit them.
+- Keep D8 `Enables` as D9 and D13, and add a note that D11 consumes D8 only
+  through hook-scope eligibility and D7/D9/D10 projections.
+- Do not mark D9 or D13 implementation-ready until their rows cite the accepted
+  D8 handoff records.
+- Do not use current source tests as packet-index acceptance evidence. They are
+  implementation evidence only after packet review acceptance and current gates.
+
+## P1/P2 Blockers
+
+### P1-D8-XD-01: D8 lifecycle is not complete-standard
+
+The source packet requires lifecycle states for candidate draft,
+manifest-invalid candidate, registered diagnostic pattern, registered
+hook-scoped pattern, registered apply-approved pattern, refused pattern, and
+retired pattern. The current OpenSpec packet only says "define pattern
+lifecycle states and admission gates" and current code only exposes a narrower
+three-state lifecycle plus field-level validation.
+
+Required repair: D8 design/spec/tasks/downstream ledger must define the full
+state family, each state's required sources, D2/D5/D6/D7/D10 dependencies,
+refusal reasons, public-surface blockers, tests, non-claims, and downstream
+projection.
+
+### P1-D8-XD-02: D1/D7/D10 dependencies are missing or under-specified
+
+D8 cannot be a complete packet without D1 refusal/output semantics. D8 also
+depends on D7 wherever current-tree check outcomes are admission evidence and
+on D10 wherever lifecycle/apply admission touches generated/protected zones.
+The current packet omits those dependencies.
+
+Required repair: D8 proposal/design/tasks must add D1 as a required upstream
+packet. D7 and D10 must be modeled as required source blockers for the specific
+D8 state families they affect, or as explicit non-consumed dependencies if D8
+chooses not to claim those evidence classes in the packet.
+
+### P1-D8-XD-03: D9 is still forced to decide apply admission
+
+D9 source says Pattern Governance owns apply admission decisions, but the D8
+starter packet does not publish the exact `registered-apply-approved-pattern`
+projection. D9 would have to decide whether an accepted diagnostic manifest,
+`ownerTool`, `applySafety.kind`, or Grit apply row is enough for writes.
+
+Required repair: D8 must define apply-admission states and the exact D9 handoff:
+pattern identity, manifest path, accepted apply proof fields, D10/G-HOST path
+or gate references when applicable, refusal reasons, and non-claims.
+
+### P1-D8-XD-04: D13 is still forced to decide candidate and registration semantics
+
+D13 source says Pattern Governance owns registration, not candidate file
+writing. The D8 starter packet does not publish the candidate artifact contract,
+manifest-invalid state, registration request/refusal shape, or promotion
+handoff. D13 would have to decide when candidate output is only a draft and
+when a generator request is trying to register enforcement.
+
+Required repair: D8 must publish candidate-only output semantics and
+registration handoff/refusal states. D13 may write candidate artifacts only
+through that contract and must not create active Grit patterns, rule-pack rows,
+baseline files, hook-scope decisions, or apply approval by implication.
+
+### P1-D8-XD-05: D8 can still leak baseline and diagnostic ownership
+
+Current D8 language says registration consumes D2 metadata, D5 baseline
+contract, and D6 diagnostic proof, but does not name the exact projections or
+forbidden local decisions. That leaves implementation room to validate
+baseline files or diagnostic identity inside Pattern Governance.
+
+Required repair: D8 must state that D5 owns baseline authority and D6 owns
+diagnostic catalog/projection. D8 consumes their published accepted/refused
+states and decides lifecycle/admission only.
+
+### P2-D8-XD-01: Downstream ledger rows are not exact enough
+
+D8 has no durable per-downstream ledger rows for D9, D11, D13, G-HOST, D7, and
+packet-index status. Generic "downstream docs/examples/specs/tests" language is
+not enough for a high-fanout governance packet.
+
+Required repair: Add the ledger rows listed in this investigation with allowed
+facts, forbidden decisions, source-blocking status, and non-claims.
+
+### P2-D8-XD-02: Validation gates do not cover lifecycle-state false positives
+
+The current D8 validation gates are useful but incomplete. They do not name
+bad cases for manifest-invalid candidate, retired pattern use, diagnostic-only
+pattern used as apply-safe, hook-scoped state without D11-compatible admission,
+baseline-refused registration, D6 diagnostic-refused registration, D7
+current-tree failure evidence, or D10 protected-zone apply refusal.
+
+Required repair: D8 tasks must include focused manifest/generator/registration
+tests for each lifecycle/refusal family plus D0/D1 public-surface
+characterization where output/schema changes.
+
+### P2-D8-XD-03: Current code names can become accidental target language
+
+Current source names such as `registered-advisory`, `registered-enforced`,
+`authorityAccepted`, `baselineContract`, `hookScope`, and `applySafety` are
+useful evidence, but the packet must decide whether they are target terms,
+compatibility projections, or superseded historical wording.
+
+Required repair: Add a D8 term-disposition table that maps current code fields
+to complete-standard target terms and forbidden interpretations.
+
+## Acceptance Bar
+
+D8 becomes acceptable design/specification input only when a downstream agent
+can implement D9, D11, D13, or G-HOST consumption by reading D8's OpenSpec
+packet and downstream ledger, without opening current Pattern Authority source
+to infer lifecycle semantics and without re-deciding D0 public compatibility,
+D1 refusal/output families, D2 registry projections, D5 baseline authority, D6
+diagnostic authority, D7 check evidence, D10 generated/protected-zone authority,
+or G-HOST host policy.
+
+The repaired D8 packet must leave no product, domain, naming, sequencing,
+public-surface, testing, or downstream handoff decision for source
+implementation agents to invent.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-domain-ontology-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-domain-ontology-investigation.md
@@ -145,7 +145,7 @@ Replace `baseline policy` in D8 target language with `D5 baseline authority proj
 
 Replace `reviewed` as a standalone lifecycle state unless the packet defines who reviewed what, which input set was reviewed, what decision was produced, and what consumers may infer. Use `candidate-under-review` for pre-decision work and `admitted` or `refused` for decisions.
 
-Current disk uses the historical phrase "OpenSpec packet scaffold" in D8 proposal and phase record. That wording is superseded for this pass. D8 must be described as a complete OpenSpec packet or incomplete OpenSpec packet; the historical phrase must not become acceptance language.
+Current disk uses the historical phrase "incomplete OpenSpec packet" in D8 proposal and phase record. That wording is superseded for this pass. D8 must be described as a complete OpenSpec packet or incomplete OpenSpec packet; the historical phrase must not become acceptance language.
 
 ## P1/P2 Blockers
 

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-final-code-vendor-topology-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-final-code-vendor-topology-review.md
@@ -1,0 +1,230 @@
+# D8 Final Code / Vendor Topology Rereview
+
+Status: ACCEPTED FOR DESIGN/SPECIFICATION ONLY
+
+No unresolved P1/P2 code, vendor, public-surface, write-path, protected-path,
+stale-output, or validation-gate blockers remain in the repaired D8 Pattern
+Governance packet. This acceptance is limited to design/specification review.
+It does not authorize source refactor implementation, does not mark D8
+implementation-complete, and does not override the packet's source blockers for
+D0, D1, D2, D5, D6, D7, D10/G-HOST, D9, D11, and D13 inputs.
+
+## Scope
+
+Reviewed:
+
+- `openspec/changes/deep-habitat-d8-pattern-governance/**`.
+- D8 first-wave and final scratch records under
+  `docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-*.md`.
+- Current Pattern Authority, generator, registry, Grit, baseline, command,
+  hook, apply, plugin, and public-doc topology:
+  - `tools/habitat-harness/src/rules/pattern-authority/manifest.ts`
+  - `tools/habitat-harness/src/generators/pattern/generator.cjs`
+  - `tools/habitat-harness/src/generators/pattern/registration.cjs`
+  - `tools/habitat-harness/src/generators/pattern/schema.json`
+  - `tools/habitat-harness/generators.json`
+  - `tools/habitat-harness/src/rules/architecture.ts`
+  - `tools/habitat-harness/src/rules/rules.json`
+  - `tools/habitat-harness/src/plugin.js`
+  - `tools/habitat-harness/src/lib/grit.ts`
+  - `tools/habitat-harness/src/lib/baseline.ts`
+  - `tools/habitat-harness/src/lib/command-engine.ts`
+  - `tools/habitat-harness/src/lib/hooks.ts`
+  - `tools/habitat-harness/src/lib/grit-apply.ts`
+  - `.grit/patterns/habitat/checks/**`
+  - `.grit/patterns/habitat/apply/**`
+  - `tools/habitat-harness/baselines/**`
+  - `tools/habitat-harness/README.md`
+  - `tools/habitat-harness/docs/CAPABILITIES.md`
+  - `tools/habitat-harness/docs/SCENARIOS.md`
+
+Skill anchors read before review:
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/SKILL.md`
+- `.agents/skills/civ7-open-spec-workstream/SKILL.md`
+- `.agents/skills/civ7-habitat-dra-workstream/SKILL.md`
+- `.agents/skills/civ7-systematic-workstream/SKILL.md`
+
+Official vendor docs consulted where vendor behavior matters:
+
+- Grit CLI Reference: https://docs.grit.io/cli/reference
+- Grit Authoring Guide: https://docs.grit.io/guides/authoring
+- Biome CLI Reference: https://biomejs.dev/reference/cli/
+- Nx Local Generators: https://nx.dev/docs/extending-nx/local-generators
+- Nx Project Graph Plugins: https://nx.dev/docs/extending-nx/project-graph-plugins
+
+## Review Result
+
+The repaired packet now maps actual topology well enough for a later
+implementation agent to proceed without deciding topology, vendor ownership,
+public surfaces, write paths, protected paths, stale outputs, or validation
+gates while editing source.
+
+The key repair is that current source is explicitly treated as present-state
+evidence, not target authority. `proposal.md:11` says the current source has
+useful Pattern Authority behavior but the D8 packet must decide the target
+domain model before source implementation resumes. `design.md:15` then
+characterizes the real source topology: three current lifecycle strings,
+candidate generation, registered promotion, active rules without
+`manifestPath`, and incomplete test coverage. That matches current source:
+
+- `manifest.ts:5` exposes only `candidate`, `registered-advisory`, and
+  `registered-enforced`.
+- `manifest.ts:176` returns a broad validation result with a whole manifest and
+  `authorityAccepted`.
+- `generator.cjs:7` branches registered promotion from candidate generation by
+  string lifecycle.
+- `registration.cjs:87` writes active Grit check files and `rules.json` after
+  manifest and baseline checks.
+- `architecture.ts:16` keeps `manifestPath`, `gritPattern`, `hookScope`, and
+  other rule fields optional on a broad `HarnessRule`.
+- `plugin.js:213` maps all `grit-check` rules to the canonical Grit catalog
+  target without Pattern Authority lifecycle discrimination.
+
+The packet no longer asks source implementation to infer target behavior from
+those facts. `design.md:83` defines the target state family; `design.md:99`
+classifies current terms as compatibility projections or adjacent-owner facts;
+`design.md:168` gives the target discriminated state model; and `tasks.md:38`
+turns that into an implementation sequence.
+
+## Topology Assessment
+
+### Source Topology
+
+Accepted. The packet maps the current Pattern Authority and generator topology
+accurately enough for design/specification acceptance.
+
+Current disk inventory observed during rereview:
+
+- 52 Habitat rules in `tools/habitat-harness/src/rules/rules.json`.
+- 32 `ownerTool: "grit-check"` rules, 31 enforced and one advisory.
+- 31 `grit-check` rules with `hookScope: "pre-commit"`.
+- 0 active rules with `manifestPath`.
+- 32 check patterns under `.grit/patterns/habitat/checks`.
+- 3 apply patterns under `.grit/patterns/habitat/apply`.
+- 0 committed candidate files under
+  `tools/habitat-harness/src/rules/pattern-authority/candidates`.
+- 0 committed registered Pattern Authority JSON manifests under
+  `tools/habitat-harness/src/rules/pattern-authority/*.json`.
+
+The repaired packet accounts for the most important topology risk: existing
+active Grit rules without `manifestPath` are compatibility facts, not complete
+D8 admissions. That is stated in `design.md:30`, `proposal.md:130`, and
+`design.md:281`.
+
+### Vendor Ownership
+
+Accepted. `design.md:65` maps vendor ownership cleanly:
+
+- Grit owns GritQL syntax, Markdown pattern conventions, native pattern samples,
+  `grit check`, and `grit apply`.
+- Biome owns formatter, linter, import sorting, and `biome ci` behavior.
+- Nx owns generator mechanics, schema/default handling, project graph plugins,
+  inferred tasks, and task execution.
+
+This matches official docs: Grit documents separate `check`, `apply`, and
+`patterns test` commands, and its authoring guide defines Markdown pattern
+file/frontmatter conventions; Biome's CLI distinguishes safe write flags from
+CI/read-only use; Nx local generator docs make `schema.json` and generator
+entrypoints the generator option surface, and Nx project graph plugins own graph
+and inferred-task mechanics. The D8 packet correctly keeps Habitat admission
+outside these vendor-owned semantics.
+
+### Public Surfaces
+
+Accepted. `proposal.md:96` lists the D8-adjacent public/durable surfaces:
+pattern generator schema/options/messages/output, candidate and registered
+manifest JSON, validation issue names, package exports, `rules.json`, active
+Grit paths, baseline references, command output, docs, examples, and guidance.
+`proposal.md:98` blocks source implementation until concrete D0 rows exist for
+touched surfaces, and `tasks.md:10`/`tasks.md:12` make D0/D1 checks explicit
+pre-source tasks.
+
+The current `tools/habitat-harness/generators.json:14` description still says
+the pattern generator creates a Grit pattern and matching rule-pack entry,
+while candidate generation is candidate-only. That is not a D8 P1/P2 blocker
+because the repaired packet already treats generator public wording as a
+D0/D13-gated surface before source changes. It should remain visible during
+implementation as a P3 public-guidance cleanup if that surface is touched.
+
+### Write Set And Protected Paths
+
+Accepted. `design.md:200` names the later source write set and the conditional
+rule-registry/Grit write paths. `design.md:232` protects baselines, existing
+Grit checks, apply patterns, Grit config, command engine, hooks, Grit adapter,
+Grit apply, baseline library, plugin/Nx graph config, product roots, generated
+artifacts, lockfiles, `.civ7`, and vendor caches.
+
+The write set now prevents the earlier implementation hazard where D8 could
+silently mutate D5 baselines, D6 Grit acquisition/projection, D7 command
+engine/reporting, D9 apply transactions, D11 hooks, D3/Nx graph, or product
+source while claiming Pattern Governance work.
+
+### Stale Outputs And Guidance
+
+Accepted with P3 residuals. Current docs have stale counts:
+`tools/habitat-harness/docs/CAPABILITIES.md:81` says 51 registered rules,
+`CAPABILITIES.md:86` says 31 `grit-check` rules, and
+`CAPABILITIES.md:131` says 31 check patterns. Current disk has 52 rules, 32
+`grit-check` rules, and 32 check patterns. The repaired downstream ledger
+handles this correctly: `downstream-realignment-ledger.md:22` says docs/examples
+update only for public guidance changes and stale current counts are not D8
+topology authority.
+
+This is acceptable for design/specification acceptance because the stale counts
+are not used as D8 admission truth, the packet blocks public guidance changes
+behind D0 rows, and implementation validation must characterize current
+registry/catalog state before semantic migration (`tasks.md:25`).
+
+### Validation Gates
+
+Accepted. The packet separates design-time gates from later implementation
+gates:
+
+- `design.md:251` and `phase-record.md:54` define design-time OpenSpec,
+  wording, final rereview, and diff-hygiene gates with non-claims.
+- `design.md:263`, `phase-record.md:64`, and `tasks.md:101` define later
+  implementation gates for manifest/generator tests, D8 state/projection tests,
+  diagnostic-without-apply tests, projection-only consumers, D5
+  `baseline-integrity`, native Grit sample tests for touched files, classify
+  observations, and stack/worktree hygiene.
+
+Commands run from
+`/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation`:
+
+| Gate | Result | Non-claim |
+| --- | --- | --- |
+| `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict` | Passed: `Change 'deep-habitat-d8-pattern-governance' is valid`. | OpenSpec shape only. |
+| `bun run openspec:validate` | Passed: 249 items passed, 0 failed. | Full OpenSpec corpus shape only. |
+| `git diff --check` | Passed with no output. | Diff hygiene only. |
+| Complete-standard wording audit | No active reduced-standard guidance found in the repaired D8 packet, D8 scratch, or packet index beyond the canonical D13 packet title/slug classified by the closure record as exact traceability text rather than D8 guidance. | Historical scratch remains negative-control input. |
+
+## Residual P3 Notes
+
+- P3: `tools/habitat-harness/docs/CAPABILITIES.md` has stale registry and Grit
+  counts. D8 handles this as non-authority; update only through the public-docs
+  owner path if implementation changes user guidance.
+- P3: `tools/habitat-harness/generators.json:14` describes the pattern generator
+  as creating a matching rule-pack entry. Candidate generation is
+  candidate-only in current source. If later D8/D13 implementation touches the
+  pattern generator public surface, include this description in the D0/D13
+  compatibility/write-set decision.
+- P3: The D8 packet's vendor boundary is correct, but implementation records
+  should cite the exact official vendor doc URLs used for any vendor-behavior
+  claim, especially Grit `check` versus `apply`, Biome write/CI semantics, and
+  Nx generator/schema behavior.
+
+## Final Finding
+
+No unresolved P1/P2 code/vendor topology blockers remain against the repaired
+D8 disk state. D8 is accepted for design/specification only from this
+code/vendor topology lane. Source implementation remains blocked behind the
+packet's stated public-surface, projection, protected-path, downstream-owner,
+and validation prerequisites.
+
+Skills used: domain-design, information-design, solution-design,
+testing-design, civ7-open-spec-workstream, civ7-habitat-dra-workstream,
+civ7-systematic-workstream.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-final-cross-domino-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-final-cross-domino-review.md
@@ -1,0 +1,151 @@
+# D8 Final Cross-Domino Rereview
+
+Status: ACCEPTED FOR DESIGN/SPECIFICATION ONLY.
+
+D8 Pattern Governance satisfies the cross-domino acceptance bar for the
+repaired OpenSpec packet. I found no unresolved P1/P2 findings in D8
+dependencies, downstream handoffs, source blockers, packet-index status
+language, or D9/D11/D13/G-HOST non-claims.
+
+This review does not authorize source implementation, does not mark D8
+implementation-complete, and does not update the packet index by itself.
+
+## Scope
+
+Reviewed as design/specification only:
+
+- `openspec/changes/deep-habitat-d8-pattern-governance/**`.
+- `docs/projects/habitat-harness/openspec-remediation/context.md`.
+- `docs/projects/habitat-harness/openspec-remediation/packet-index.md`.
+- D8 first-wave scratch under
+  `docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-*.md`.
+- Existing final D8 domain/ontology, TypeScript/validation, and
+  OpenSpec/information rereviews.
+- Accepted D0-D7 packet records where they define D8-consumed contracts.
+- Source and starter packets/current incomplete records for D9, D11, D13, and
+  G-HOST.
+- Current Pattern Authority source and tests as behavior evidence only.
+
+Skill anchors read before review:
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`.
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`.
+- `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`.
+- `/Users/mateicanavra/.agents/skills/system-design/SKILL.md`.
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/SKILL.md`.
+- Civ7 Open Spec Workstream references: `source-map.md`, `phase-loop.md`,
+  `artifact-contracts.md`, and `validation-checks.md`.
+
+## Cross-Domino Findings
+
+No P1/P2 findings.
+
+### Dependencies
+
+Accepted. D8 now names the full consumed-contract set and separates design-time
+acceptance from source implementation blockers.
+
+The repaired proposal requires D0, D1, D2, D5, D6, D7, and D10/G-HOST where
+touched. The phase record adds D9 and D13 as handoff dependencies rather than
+D8-owned implementation domains. The consumed-contract matrix in
+`openspec/changes/deep-habitat-d8-pattern-governance/design.md` explicitly
+forbids D8 from changing public surfaces without D0 rows, inventing D1 output
+families, reading whole D2 rows as authority, deciding D5 baseline truth,
+parsing raw D6 diagnostics, building D7 reports, encoding D10/G-HOST policy,
+executing D9 transactions, or creating D13 generator files.
+
+This repairs the first-wave D1/D7/D10/G-HOST omission. Conditional D7 and
+D10/G-HOST handling is acceptable because D8 only consumes those owners where
+current-tree outcomes, protected zones, host policy, scan roots, probes, apply
+paths, or host gates are touched.
+
+### Downstream Handoffs
+
+Accepted. The downstream ledger now gives exact owner-facing rows for D0, D1,
+D2, D5, D6, D7, D10/G-HOST, D9, D11, D13, recovery, docs, tests, and packet
+index movement.
+
+The key downstream projections are complete:
+
+- D9 consumes only `ApplyAdmissionProjection` or explicit D8 apply refusal.
+- D11 consumes local-feedback eligibility only through D8/D7/D10 projections.
+- D13 consumes `CandidateHandoffProjection` and hands registration/admission to
+  D8.
+- Recovery records consume `PatternRecoveryProjection`.
+
+No downstream packet is forced to reconstruct lifecycle semantics from file
+presence, Grit markdown, baseline files, generator options, rule lanes, hook
+fields, or whole Pattern Authority manifests.
+
+### Source Blockers
+
+Accepted. Source implementation remains blocked behind concrete prerequisites
+instead of being treated as a design cleanup task.
+
+The packet blocks source work behind concrete D0 rows, D1 output-family
+citations, live D2 `ruleGovernanceFacts`/`ruleGritFacts`/`ruleBaselineFacts`,
+D5 `BaselineAuthorityProjection` or refusal, D6 diagnostic projections,
+accepted D7 check outcome projections where consumed, D10/G-HOST protected-zone
+or host-policy contracts where touched, and D9/D13 handoff inputs where apply
+or candidate behavior is touched.
+
+The write set and protected paths in `design.md` are sufficient for later
+implementation planning and protect baselines, apply patterns, Grit config,
+hook/command/apply/baseline libraries, product roots, generated artifacts,
+lockfiles, vendor caches, and unrelated source roots unless an owning packet
+authorizes the change.
+
+### Packet Index Language
+
+Accepted with sequencing constraint. At review time, the live packet index still
+kept D8 in blocking packet status, which was correct until final rereviews and
+validation were aggregated by the workstream owner.
+
+The downstream ledger provides complete post-acceptance language for the D8
+index row: design/specification accepted only, final rereviews found no
+unresolved P1/P2, not implementation-complete, and source implementation still
+blocked behind D0/D1/D2/D5/D6/D7/D10/G-HOST prerequisites where touched.
+
+At closure aggregation time, the domain/ontology, TypeScript/validation,
+OpenSpec/information, code/vendor topology, and cross-domino final review files
+exist on disk and record no unresolved P1/P2 findings. Packet-index movement
+depends on the workstream owner recording those lanes plus validation in the
+durable control records.
+
+### D9/D11/D13/G-HOST Non-Claims
+
+Accepted. D8 now publishes the required adjacent-domain non-claims:
+
+- D9 owns dry-run, live writes, rollback, path approval, formatter handoff,
+  transaction gates, recovery, and transaction failure semantics. D8 apply
+  admission does not execute or approve writes.
+- D11 owns hook sequencing, staged-file behavior, local output, and
+  local-feedback non-claims. D8 local-feedback admission is eligibility only.
+- D13 owns candidate file creation and candidate/refusal surfaces. D8 owns
+  registration/admission; D13 must not write active Grit patterns, rule rows,
+  baseline state, hook eligibility, or apply admission by implication.
+- G-HOST owns host declarations, generated/protected-zone ownership, host
+  gates, unsupported host starter shapes, and host-policy missing refusals. D8
+  may reference host-policy decisions but must not encode Civ/MapGen host
+  semantics inside Pattern Governance.
+
+## Validation Observed
+
+- `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict`:
+  passed.
+- `bun run openspec:validate`: passed, 249 items validated.
+- `git diff --check`: passed.
+- Complete-standard wording audit over D8 packet, D8 scratch, and packet index
+  found no active reduced-standard D8 guidance beyond the canonical D13 packet
+  title/slug classified by the closure record as exact traceability text.
+
+## Residual Non-Blocking Notes
+
+- The packet index must not be updated to accepted status until the remaining
+  final-review aggregation and validation rules in the D8 workstream records
+  are satisfied.
+- D8 source implementation remains a later phase. The repaired packet is
+  accepted as design/specification input only.
+
+Skills used: domain-design, information-design, solution-design, system-design,
+civ7-open-spec-workstream.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-final-domain-ontology-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-final-domain-ontology-review.md
@@ -1,0 +1,165 @@
+# D8 Final Domain/Ontology Review
+
+Status: ACCEPTED FOR DESIGN/SPECIFICATION ONLY.
+
+D8 Pattern Governance now satisfies the domain/ontology acceptance bar for the
+repaired OpenSpec packet. I found no unresolved P1/P2 findings in the repaired
+disk state for Pattern Governance versus Pattern Authority language, lifecycle
+states, capability admission states, refusal taxonomy, naming repair, upstream
+owner boundaries, downstream projection semantics, or inherited lazy terms.
+
+This review does not authorize source refactor implementation and does not
+claim implementation completion.
+
+## Sources Read
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`.
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`.
+- `/Users/mateicanavra/.agents/skills/ontology-design/SKILL.md`.
+- Ontology Design direct references: `axes.md`, `principles.md`,
+  `where-defaults-hide.md`, `representation-choices.md`,
+  `operationalization.md`, `maintenance.md`, `examples.md`, and
+  `source-map.md`.
+- `AGENTS.md`.
+- `docs/projects/habitat-harness/openspec-remediation/context.md`.
+- `docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md`.
+- `openspec/changes/deep-habitat-d8-pattern-governance/proposal.md`.
+- `openspec/changes/deep-habitat-d8-pattern-governance/design.md`.
+- `openspec/changes/deep-habitat-d8-pattern-governance/specs/habitat-harness/spec.md`.
+- `openspec/changes/deep-habitat-d8-pattern-governance/tasks.md`.
+- D8 workstream files under
+  `openspec/changes/deep-habitat-d8-pattern-governance/workstream/`.
+- First-wave D8 investigation inputs:
+  `domino-D8-domain-ontology-investigation.md`,
+  `domino-D8-typescript-state-investigation.md`,
+  `domino-D8-openspec-information-testing-investigation.md`,
+  `domino-D8-code-vendor-topology-investigation.md`, and
+  `domino-D8-cross-domino-investigation.md`.
+
+## Acceptance Assessment
+
+### Pattern Governance And Pattern Authority
+
+Accepted. The repaired packet uses `Pattern Governance` for the bounded context
+and `Pattern Authority` for the durable decision authority and decision record
+inside that context. The boundary is stated directly in
+`openspec/changes/deep-habitat-d8-pattern-governance/design.md:78`, and D8's
+owned responsibilities include Pattern Authority decision records, lifecycle
+state, capability admission state, refusal/retirement taxonomy, and consumer
+projections at
+`openspec/changes/deep-habitat-d8-pattern-governance/design.md:41`.
+
+This repairs the earlier ambiguity where Pattern Authority could have meant a
+manifest format, process, board, package module, or registry side effect.
+
+### Lifecycle And Admission States
+
+Accepted. The target state family is closed for design/specification and
+implementation planning:
+`candidate-draft`, `candidate-under-review`, `manifest-invalid-candidate`,
+`diagnostic-admitted`, `local-feedback-admitted`, `apply-admitted`, `refused`,
+and `retired` are defined with required owner inputs and consumer meaning at
+`openspec/changes/deep-habitat-d8-pattern-governance/design.md:83`.
+
+The spec backs those states with normative scenarios for candidate generation,
+review, diagnostic admission, local-feedback admission, apply admission,
+refusal, and retirement at
+`openspec/changes/deep-habitat-d8-pattern-governance/specs/habitat-harness/spec.md:3`.
+It also states that diagnostic admission is not apply admission at
+`openspec/changes/deep-habitat-d8-pattern-governance/specs/habitat-harness/spec.md:20`
+and requires new admission before a retired pattern is consumed again at
+`openspec/changes/deep-habitat-d8-pattern-governance/specs/habitat-harness/spec.md:48`.
+
+### Refusal Taxonomy
+
+Accepted. D8 now declares closed refusal reasons for missing, malformed,
+placeholder, contradicted, orphan, candidate-invalid, Grit-only, Nx-only,
+D2/D5/D6 missing or rejected, fixture, false-positive, current-tree, hook,
+apply, collision, retirement, and public-compatibility failures at
+`openspec/changes/deep-habitat-d8-pattern-governance/design.md:138`.
+
+The refusal model is first-class lifecycle output, not error-string parsing:
+boundary messages may preserve compatibility, but internal implementation must
+project messages from typed refusal state at
+`openspec/changes/deep-habitat-d8-pattern-governance/design.md:165`.
+
+### Naming Repairs
+
+Accepted. The packet explicitly separates D8 admission vocabulary from D2
+registration vocabulary. `registered-advisory` and `registered-enforced` are
+limited to compatibility projections, while target language uses diagnostic,
+local-feedback, and apply admission terms at
+`openspec/changes/deep-habitat-d8-pattern-governance/design.md:99`.
+
+The stop conditions also prevent inherited lazy authority terms from reentering
+the target model: file presence, broad registry rows, baseline files, Grit
+metadata, generator options, diagnostic admission, and hook lane inference are
+all forbidden as admission shortcuts at
+`openspec/changes/deep-habitat-d8-pattern-governance/proposal.md:116`.
+
+### Upstream Owner Boundaries
+
+Accepted. The repaired consumed-contract matrix names exact owners and forbidden
+D8 behavior for D0, D1, D2, D5, D6, D7, D10/G-HOST, D9, and D13 at
+`openspec/changes/deep-habitat-d8-pattern-governance/design.md:113`.
+
+The domain boundary also keeps adjacent owner responsibilities outside D8:
+registry schema remains D2-owned, baseline truth remains D5-owned, diagnostic
+acquisition remains D6-owned, check report semantics remain D7-owned, protected
+and host policy remain D10/G-HOST-owned, apply transactions remain D9-owned,
+hook sequencing remains D11-owned, and generator file creation remains D13-owned
+at `openspec/changes/deep-habitat-d8-pattern-governance/design.md:51`.
+
+### Downstream Projection Semantics
+
+Accepted. The packet defines narrow projections instead of downstream access to
+whole manifests or broad governance state: `PatternAuthorityProjection`,
+`DiagnosticAdmissionProjection`, `LocalFeedbackAdmissionProjection`,
+`ApplyAdmissionProjection`, `CandidateHandoffProjection`, and
+`PatternRecoveryProjection` at
+`openspec/changes/deep-habitat-d8-pattern-governance/design.md:125`.
+
+The downstream ledger reinforces the projection boundary for D9, D11, D13,
+recovery, tests, docs, and packet index movement at
+`openspec/changes/deep-habitat-d8-pattern-governance/workstream/downstream-realignment-ledger.md:9`.
+
+### Active Reduced-Standard Language
+
+Accepted. I audited the D8 packet and scratch inputs for inherited
+reduced-standard language and authority-leak phrases. The remaining hits in the
+active packet are status gates, compatibility-disposition notes, or historical
+negative-control wording in first-wave scratch files. I did not find active D8
+guidance that treats a starter/draft state, file presence, Grit prose, baseline
+file presence, generator options, hook lane, or diagnostic registration as
+admission authority.
+
+## Residual P3
+
+P3: The packet uses `manifest-invalid-candidate` both as a state and as a
+refusal reason. This is acceptable for design/specification acceptance because
+the state is explicitly non-active and refuses before active writes, but later
+implementation must keep the relationship precise: the lifecycle state must
+carry a typed refusal result rather than making invalidity and refusal appear to
+be two unrelated facts.
+
+Reference:
+`openspec/changes/deep-habitat-d8-pattern-governance/design.md:89` defines the
+state, and
+`openspec/changes/deep-habitat-d8-pattern-governance/design.md:147` lists the
+matching refusal reason.
+
+## Validation Observed
+
+- `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict`:
+  passed.
+- `bun run openspec:validate`: passed, 249 items validated.
+- `git diff --check`: passed.
+
+## Final Finding
+
+No unresolved P1/P2 domain/ontology findings remain against the repaired D8 disk
+state. D8 is accepted for design/specification only from this domain/ontology
+review lane. Source implementation remains blocked behind the packet's stated
+D0, D1, D2, D5, D6, D7, D10/G-HOST, D9, D11, and D13 prerequisites.
+
+Skills used: domain-design, information-design, ontology-design.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-final-openspec-information-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-final-openspec-information-review.md
@@ -1,0 +1,174 @@
+# D8 Final OpenSpec / Information Rereview
+
+Status: ACCEPTED FOR DESIGN/SPECIFICATION ONLY
+
+This rereview assesses the repaired D8 Pattern Governance packet as
+design/specification input only. It does not authorize source refactor work, it
+does not mark D8 implementation-complete, and it does not replace the remaining
+final rereview lanes or packet-index closure step.
+
+## Sources Read
+
+- Mandatory skill anchors:
+  - `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+  - `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+  - `/Users/mateicanavra/.agents/skills/testing-design/SKILL.md`
+  - `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/SKILL.md`
+  - `civ7-open-spec-workstream/references/source-map.md`
+  - `civ7-open-spec-workstream/references/artifact-contracts.md`
+  - `civ7-open-spec-workstream/references/validation-checks.md`
+  - `civ7-open-spec-workstream/references/phase-loop.md`
+- Repo/workflow context:
+  - `AGENTS.md`
+  - `docs/projects/habitat-harness/openspec-remediation/context.md`
+  - `docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+  - `docs/projects/habitat-harness/openspec-remediation/review-disposition-ledger.md`
+- D8 controlling and repaired packet inputs:
+  - `docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/proposal.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/design.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/tasks.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/specs/habitat-harness/spec.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/workstream/phase-record.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/workstream/review-disposition-ledger.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/workstream/downstream-realignment-ledger.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/workstream/closure-checklist.md`
+- D8 first-wave findings:
+  - `docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-domain-ontology-investigation.md`
+  - `docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-typescript-state-investigation.md`
+  - `docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-code-vendor-topology-investigation.md`
+  - `docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-openspec-information-testing-investigation.md`
+  - `docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-cross-domino-investigation.md`
+
+## Review Result
+
+No unresolved P1/P2 findings remain for the OpenSpec/information rereview lane.
+
+The repaired packet now gives a later implementation agent a complete enough
+Pattern Governance contract without asking that agent to invent lifecycle names,
+admission inputs, refusal states, validation split, public-surface blockers,
+write ownership, or downstream projections while editing source.
+
+## Packet Assessment
+
+### Proposal And Scope
+
+`proposal.md` now states D8's product purpose as preventing candidates,
+diagnostics, local feedback, apply-capable patterns, refusals, and retirements
+from collapsing into one accidental state. It also classifies current source as
+present-state evidence only, not target authority.
+
+The proposal repairs the first-wave dependency gap by naming D0, D1, D2, D5,
+D6, D7, D10, and G-HOST conditions where D8 consumes public-surface,
+output/refusal, registry, baseline, diagnostic, current-tree, protected-zone,
+or host-policy authority. It also blocks source implementation behind concrete
+D0 rows for generator schema/output, manifest JSON, exports, `rules.json`,
+Grit paths, baselines, command output, docs, and guidance.
+
+The stop conditions are specific and useful: file presence, broad registry
+fields, baseline files, Grit frontmatter, generator options, diagnostic
+admission, hook fields, and legacy active Grit rows without `manifestPath` are
+all rejected as admission authority.
+
+### Design And Domain Information
+
+`design.md` is now the packet decision center. It defines current behavior as
+incomplete target evidence, gives D8 a precise domain boundary, records vendor
+boundaries for Grit/Biome/Nx, and separates Pattern Governance from Pattern
+Authority.
+
+The target ontology is closed enough for design/specification acceptance:
+`candidate-draft`, `candidate-under-review`, `manifest-invalid-candidate`,
+`diagnostic-admitted`, `local-feedback-admitted`, `apply-admitted`, `refused`,
+and `retired` are defined with owner inputs and consumer meaning. The packet
+also fixes historical naming risk by mapping `registered-advisory`,
+`registered-enforced`, `authorityAccepted`, `hookScope`, `applySafety`, Grit
+frontmatter/prose, and baseline file presence to compatibility or adjacent-owner
+meanings instead of treating them as D8 authority.
+
+The consumed-contract matrix and projection table are sufficient for
+implementation readiness planning. D8 consumes D0/D1/D2/D5/D6/D7/D10/G-HOST
+contracts and publishes narrow projections for D2, D6, D7, D9, D11, D13,
+recovery records, and users. This resolves the earlier risk that downstream
+owners would inspect whole manifests, registry rows, Grit markdown, baseline
+files, or generator options to recreate lifecycle semantics.
+
+The refusal taxonomy is now closed for implementation. The TypeScript state
+model, expected refactor moves, write set, protected paths, validation matrix,
+and non-claims give source implementers enough shape without authorizing source
+edits from this packet review.
+
+### Spec Delta
+
+`specs/habitat-harness/spec.md` now has multiple falsifiable requirement
+families instead of one broad requirement. It covers lifecycle admission,
+candidate non-authority, manifest validation as necessary-but-not-sufficient,
+D2 registry projection consumption, D5 baseline authority consumption, D6
+diagnostic capability consumption, explicit local-feedback admission, separated
+apply admission, stable refusal reasons, and downstream narrow projections.
+
+The scenarios include the central bad cases from the first-wave review:
+candidate output cannot become active by file presence, manifest success still
+requires owner inputs, broad rule rows cannot imply admission, baseline file
+presence cannot admit a pattern, native Grit success cannot imply D8 admission,
+diagnostic admission cannot become apply-ready, D9 cannot read diagnostic state
+as write authority, and D13 cannot register active state by implication.
+
+### Tasks And Execution Readiness
+
+`tasks.md` is now an implementation sequence, not a list of design prompts. It
+starts with packet readiness and source blockers, then moves through current
+behavior characterization, state model introduction, candidate and manifest
+admission, diagnostic/local-feedback admission, apply handoff, consumer
+projections, validation, downstream realignment, and closure.
+
+The source blockers are appropriately explicit: D0 rows, D1 output-family
+citations, live D2 projections, D5 baseline authority/refusal, D6 diagnostic
+inputs, and conditional D7/D10/G-HOST/D11/D9 prerequisites must exist where
+touched. The validation section correctly separates source implementation gates
+from design-time OpenSpec validation.
+
+### Workstream Control Records
+
+The phase record, review ledger, downstream ledger, and closure checklist now
+match the repaired packet state.
+
+The review ledger imports every first-wave P1/P2 family and records repair
+evidence instead of treating global constraints as acceptance evidence. The
+phase record uses `$ACTIVE_REMEDIATION_WORKTREE` and
+`$ACTIVE_REMEDIATION_BRANCH`, which resolve to the requested worktree and
+`codex/d8-pattern-governance-packet` in `context.md`. The downstream ledger
+names concrete D0, D1, D2, D5, D6, D7, D10/G-HOST, D9, D11, D13, recovery,
+docs, tests, and packet-index dispositions.
+
+The packet index intentionally still marks D8 as blocking. That is not a
+remaining defect for this lane because the D8 closure checklist and downstream
+ledger both require packet-index movement only after all final rereviews and
+validation pass. The current index row enforces the active gate and prevents
+implementation from starting early.
+
+## Validation Evidence
+
+Commands run from
+`/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation`:
+
+| Gate | Result | Non-claim |
+| --- | --- | --- |
+| `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict` | Passed: `Change 'deep-habitat-d8-pattern-governance' is valid`. | OpenSpec shape only; does not prove source behavior. |
+| `bun run openspec:validate` | Passed: 249 items passed, 0 failed. | Full OpenSpec corpus shape only; does not prove Habitat runtime behavior. |
+| `git diff --check` | Passed with no output. | Diff hygiene only. |
+| Complete-standard wording audit over `$D8_CHANGE/**`, D8 scratch, and packet index | No active reduced-standard guidance found in the repaired D8 packet, D8 scratch, or packet index beyond the canonical D13 packet title/slug classified by the closure record as exact traceability text rather than D8 guidance. | Historical scratch remains negative-control input, not current guidance. |
+
+## Closure Notes
+
+- No source implementation was reviewed as complete or authorized.
+- No packet artifact needs an OpenSpec/information P1/P2 repair before this
+  lane can accept the repaired D8 design/specification packet.
+- Remaining unchecked closure items are expected workflow state: other final
+  rereview lanes, packet-index update, and final closure records must still run
+  before the D8 packet as a whole can move out of blocking status.
+- Source implementation remains blocked behind the concrete prerequisites named
+  in the D8 proposal, phase record, downstream ledger, and tasks.
+
+Skills used: domain-design, information-design, testing-design,
+civ7-open-spec-workstream.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-final-typescript-validation-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-final-typescript-validation-review.md
@@ -1,0 +1,59 @@
+# D8 Final TypeScript / Validation Rereview
+
+Status: ACCEPTED FOR DESIGN/SPECIFICATION ONLY
+
+No unresolved P1/P2 TypeScript state-space or validation blockers remain in the repaired D8 Pattern Governance packet. This acceptance is limited to the OpenSpec design/specification contract. It does not approve source implementation, does not mark D8 implementation-complete, and does not override the packet's source blockers for D0/D1/D2/D5/D6/D7/D10/G-HOST/D9/D13 inputs.
+
+## Review Scope
+
+Reviewed as a design/specification rereview only:
+
+- `openspec/changes/deep-habitat-d8-pattern-governance/**`
+- D8 first-wave scratch records under `docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-*.md`
+- Current Pattern Authority source and tests:
+  - `tools/habitat-harness/src/rules/pattern-authority/manifest.ts`
+  - `tools/habitat-harness/src/generators/pattern/generator.cjs`
+  - `tools/habitat-harness/src/generators/pattern/registration.cjs`
+  - `tools/habitat-harness/src/generators/pattern/schema.json`
+  - `tools/habitat-harness/test/rules/pattern-authority-manifest.test.ts`
+  - `tools/habitat-harness/test/generators/pattern-generator.test.ts`
+
+Skill anchors read in full before review:
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/SKILL.md`
+- Every TypeScript refactoring reference and asset under that skill's `references/` and `assets/`
+- `/Users/mateicanavra/.agents/skills/testing-design/SKILL.md`
+
+## Findings
+
+No P1/P2 findings.
+
+The first-wave TypeScript/validation blockers are repaired in the current packet:
+
+- State-space collapse is specified. `design.md:168-198` defines a closed `PatternAuthorityState` with candidate, review, invalid, diagnostic, local-feedback, apply, refused, and retired variants, and requires internal replacement of `authorityAccepted: boolean` with state narrowing. `tasks.md:38-52` turns that into implementation slices and preserves existing JSON/CLI behavior as compatibility projection only.
+- Diagnostic, local-feedback, and apply states are separated. `design.md:83-98` defines the target state families and explicitly states that admission is D8 vocabulary while registration is D2 vocabulary. `spec.md:178-228` falsifies diagnostic-to-apply conflation and D9 write-authority leakage.
+- Consumer projections are specified. `design.md:125-136` publishes `PatternAuthorityProjection`, `DiagnosticAdmissionProjection`, `LocalFeedbackAdmissionProjection`, `ApplyAdmissionProjection`, `CandidateHandoffProjection`, and `PatternRecoveryProjection`, and states that consumers receive projections rather than whole manifests. `tasks.md:89-99` requires projection builders and tests for D9, D13, diagnostic/apply separation, and retired-state rejection.
+- Write and protected sets are specified. `design.md:200-249` names the later implementation write set, runtime write projections, and protected paths. This directly repairs the prior implicit-write-set blocker and prevents implementation agents from editing baselines, apply patterns, Grit config, hook/command/apply/baseline libraries, product roots, generated artifacts, lockfiles, and vendor caches without owner authorization.
+- Safe refactor moves are specified. `design.md:185-198` requires lifecycle constructors first, compatibility-preserving manifest shape, replacement of `authorityAccepted`, typed admission results, projection builders, and diagnostic/apply separation. `tasks.md:25-99` sequences characterization, state model, candidate/manifest admission, diagnostic/local-feedback admission, apply handoff, and projection tests before closure.
+- Validation gates are now falsifiable. `design.md:251-279` separates design-time gates from later implementation gates, and `tasks.md:101-117` names exact validation commands. Later implementation gates include type-state/projection tests, diagnostic-without-apply tests, projection-only consumer tests, D5 baseline-integrity, native Grit sample tests for touched pattern files, classify observations with non-claims, and Graphite/worktree hygiene.
+- Implementation-time state-model decisions are blocked. `proposal.md:116-131` lists stop conditions for file-presence admission, registry/Grit/baseline/generator-option inference, diagnostic-to-apply conflation, hook-lane inference, whole-row/raw-file/raw-Grit reads, error-string authority, and legacy active rules without `manifestPath`. `review-disposition-ledger.md:10-27` imports the earlier P1/P2 findings and records repair evidence pending final rereview.
+
+## Current Source Cross-Check
+
+The current source still has the expected compatibility shape: `PatternAuthorityLifecycle` is `candidate | registered-advisory | registered-enforced`, `PatternAuthorityValidationResult` exposes `authorityAccepted`, generator promotion branches on string lifecycle, and registration writes active Grit check patterns plus `rules.json` after runtime checks. Those are implementation evidence and migration inputs, not acceptance blockers for this design/specification rereview, because the repaired packet explicitly classifies them as compatibility/present-state facts and specifies the target state collapse before source work.
+
+## Validation Run
+
+- `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict`: passed.
+- `bun run openspec:validate`: passed, 249 items passed and 0 failed.
+- `git diff --check`: passed.
+- Complete-standard wording audit grep was run over `$D8_CHANGE/**` and D8 scratch. Hits were historical first-wave findings, forbidden-language audit text, or active control/status language such as "pending final rereview" and "not implementation-complete"; I found no active TypeScript/validation reduced-standard guidance that changes this status.
+
+## P3 Suggestions
+
+- The final closure pass should keep the wording-audit disposition explicit, because the broad grep intentionally matches historical D8 scratch and active control rows. The useful closure evidence is not "no hits"; it is "no active reduced-standard guidance after classifying historical and forbidden-language-list hits."
+- When implementation begins, keep the first source slice narrow: add the D8 state/projection model and compatibility projections before changing generator behavior or public manifest/schema surfaces. That preserves the packet's state-collapse order and keeps D0/D1 compatibility blockers visible.
+
+Skills used: domain-design, information-design, typescript-refactoring, testing-design.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-openspec-information-testing-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-openspec-information-testing-investigation.md
@@ -1,0 +1,631 @@
+Status: BLOCKING
+
+# D8 OpenSpec / Information / Testing Investigation
+
+## Scope
+
+This investigation reviews D8 Pattern Governance as a design/specification
+packet only. It does not authorize Habitat source refactor work. The controlling
+input is the Phase 2 D8 packet, not the current D8 OpenSpec starter packet.
+
+The D8 packet is not execution-ready. The existing proposal, design, spec,
+tasks, and workstream files establish a useful starting structure, but they do
+not yet contain the complete Pattern Governance ontology, requirement families,
+bad-case matrix, validation oracles, implementation blockers, downstream
+handoffs, rereview evidence, or closure records that D0-D7 require before
+implementation.
+
+## Sources Read
+
+- Required skills:
+  - `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+  - `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+  - `/Users/mateicanavra/.agents/skills/testing-design/SKILL.md`
+  - `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`
+  - `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/SKILL.md`
+  - `civ7-open-spec-workstream/references/source-map.md`
+  - `civ7-open-spec-workstream/references/artifact-contracts.md`
+  - `civ7-open-spec-workstream/references/validation-checks.md`
+- D8 controlling and current packet inputs:
+  - `docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/proposal.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/design.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/specs/habitat-harness/spec.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/tasks.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/workstream/phase-record.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/workstream/review-disposition-ledger.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/workstream/downstream-realignment-ledger.md`
+  - `openspec/changes/deep-habitat-d8-pattern-governance/workstream/closure-checklist.md`
+- Remediation control records:
+  - `docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+  - `docs/projects/habitat-harness/openspec-remediation/review-disposition-ledger.md`
+- Accepted D0-D7 control-pattern inputs:
+  - D0-D7 `workstream/review-disposition-ledger.md`
+  - D0-D7 `workstream/phase-record.md`
+  - D0-D7 `workstream/closure-checklist.md`
+  - D7 `proposal.md`, `specs/habitat-harness/spec.md`, `tasks.md`
+  - `docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D7-final-openspec-information-review.md`
+- Domain and current-code evidence:
+  - `docs/projects/habitat-harness/domain-mapping/domain-design-packet.md`
+  - `tools/habitat-harness/src/generators/pattern/generator.cjs`
+  - `tools/habitat-harness/src/generators/pattern/registration.cjs`
+  - `tools/habitat-harness/src/rules/pattern-authority/manifest.ts`
+  - `tools/habitat-harness/test/generators/pattern-generator.test.ts`
+  - `tools/habitat-harness/test/rules/pattern-authority-manifest.test.ts`
+
+## OpenSpec Artifact Findings
+
+### Status Finding
+
+D8 must remain BLOCKING. The packet index already records D8 as a draft
+starter packet with global constraints applied and a per-domino adversarial gate
+blocking acceptance. The current D8 workstream review ledger repeats that global
+constraints are not acceptance evidence and that fresh per-domino domain,
+OpenSpec, topology, validation, information-design, and cross-domino review
+remain required.
+
+This investigation agrees with that status. The current D8 files do not contain
+complete proposal/design/spec/tasks/ledgers comparable to accepted D0-D7.
+
+### Proposal Findings
+
+`proposal.md` correctly names Pattern Governance, the source D8 packet, D0/D2/D5/D6
+dependencies, and D9/D13 consumers. It is not complete enough to authorize
+implementation because it omits:
+
+- a complete Pattern Governance lifecycle state table from the Phase 2 packet:
+  candidate draft, manifest-invalid candidate, registered diagnostic pattern,
+  registered hook-scoped pattern, registered apply-approved pattern, refused
+  pattern, and retired pattern;
+- explicit D0 public-surface blocker rows for generator schema/options, generated
+  candidate manifest shape, registered manifest shape, rule registry writes,
+  Pattern Authority package exports, docs/examples, command output, and tests;
+- a dependency matrix that distinguishes accepted D0/D2/D5/D6 design authority
+  from live source implementation prerequisites;
+- D5 `BaselineAuthorityProjection`, D6 diagnostic identity/projection, and D2
+  `ruleGovernanceFacts`/`ruleGritFacts`/`ruleBaselineFacts` consumption as source
+  blockers rather than broad references;
+- a stop condition for treating current `PatternAuthorityLifecycle` as the
+  target lifecycle without repair;
+- D13 starter packeting handoff rules for candidate generation and refusal output;
+- D9 handoff rules for apply-approved patterns and non-apply patterns.
+
+### Design Findings
+
+`design.md` states the right acceptance threshold: a later implementation agent
+must have no product, domain, naming, sequencing, public-surface, or validation
+decision to invent. It does not meet that threshold.
+
+The design needs a D8-specific decision center equivalent to D6/D7, including:
+
+- target ontology and rejected terminology;
+- current behavior diagnosis for generator, registration, manifest validation,
+  candidate storage, active Grit pattern writes, baseline contract validation,
+  and rule registry writes;
+- domain boundary and forbidden-owner matrix for D2, D5, D6, D7, D9, D13, Local
+  Feedback, and Transformation Transaction;
+- current-to-target lifecycle mapping from current source states
+  `candidate`, `registered-advisory`, and `registered-enforced` into the
+  complete D8 governance states;
+- closed state model for lifecycle admission, registration refusal, baseline
+  authority consumption, diagnostic identity consumption, hook-scope approval,
+  apply-safety disposition, retirement, and downstream projections;
+- Pattern Governance public-surface inventory and concrete D0 row placeholders;
+- implementation write set and protected paths;
+- design-time validation matrix and later implementation validation matrix;
+- exact refactor sequence that prevents file presence, Grit markdown, baseline
+  existence, generator options, or registry row presence from becoming
+  admission authority.
+
+Current code shows why this is required. The generator can write candidate
+manifests and registered outputs; registration validates a manifest, checks a
+baseline contract, writes an active Grit pattern, and appends a broad
+`rules.json` entry. The manifest validator already rejects many bad states, but
+the target OpenSpec packet still has to decide which of those are D8 target
+states, which are compatibility facts, and which must be replaced by
+D2/D5/D6/D9 projections.
+
+### Spec Findings
+
+`specs/habitat-harness/spec.md` contains one broad requirement with two
+scenarios. That is insufficient for D8. It does not encode the Phase 2 contract
+or provide enough falsifiable scenarios for implementation.
+
+The spec must be expanded into separate requirement families for lifecycle
+identity, candidate non-enforcement, manifest validation, registration
+admission, baseline authority consumption, diagnostic catalog consumption,
+hook-scope approval, apply-safety separation, refusal reasons, retirement,
+consumer projections, D0 blockers, and prohibited inferences.
+
+### Task Findings
+
+`tasks.md` still leaves implementation agents to design the actual model. Tasks
+such as "Define pattern lifecycle states and admission gates" and "Connect
+governance to D2 facets and D5 baselines" are unresolved design work, not
+execution steps.
+
+The accepted D0-D7 pattern requires tasks to separate packet readiness,
+implementation prerequisites, characterization, state-model introduction,
+semantic migration slices, validation, downstream realignment, and closure.
+D8 tasks must do the same.
+
+### Workstream Findings
+
+The D8 workstream files are generic and cannot support closure:
+
+- `phase-record.md` records the branch as `codex/deep-habitat-openspec-remediation`,
+  but this active worktree is on `codex/d8-pattern-governance-packet`.
+- `phase-record.md` lists commands without expected status, actual status,
+  bad case, cache/freshness stance, non-claims, or blocker disposition.
+- `review-disposition-ledger.md` has no imported D8-specific P1/P2 findings,
+  no repair evidence, and no final rereview evidence.
+- `downstream-realignment-ledger.md` has generic pending rows and does not name
+  the exact D2/D5/D6/D9/D13/D0 handoffs.
+- `closure-checklist.md` is still unchecked and does not require D8-specific
+  ontology, lifecycle state matrix, validation bad cases, wording audit, or
+  final rereview lanes.
+
+## Information Architecture Repair
+
+### Reader And Task
+
+The reader is a later implementation agent and reviewer with enough repo context
+to execute Habitat changes, but not enough authority to invent D8 product
+decisions. The task is not to understand the old Phase 2 packet; it is to
+execute an already-reviewed Pattern Governance contract.
+
+The repaired packet should therefore make `design.md` the decision center,
+`spec.md` the normative scenario contract, `tasks.md` the implementation
+sequence, and workstream files the control record. The implementation agent
+should never need to infer target behavior from current source, old scratch,
+or broad Phase 2 prose.
+
+### Required Packet Shape
+
+`proposal.md` should answer:
+
+- why D8 exists in product terms;
+- exactly which authority inputs control D8;
+- what changes and what does not change;
+- dependency state for D0, D2, D5, D6, D9, and D13;
+- public-surface inventory and D0 blockers;
+- D8 stop conditions and prohibited inferences;
+- design-time validation and later implementation validation.
+
+`design.md` should contain these D8-specific sections:
+
+- Current Behavior Diagnosis
+- Product Scenario And Acceptance Threshold
+- Domain Boundary And Forbidden Owners
+- Target Ontology
+- Rejected Terms And Compatibility Facts
+- Lifecycle State Matrix
+- Consumed Upstream Contracts
+- Published Downstream Projections
+- Public Surface / D0 Compatibility Inventory
+- Target State Model
+- Bad-Case Matrix
+- Implementation Write Set
+- Protected Paths
+- Refactor Sequence
+- Validation Matrix
+- Non-Claims
+
+`spec.md` should contain multiple falsifiable requirement families rather than
+one broad requirement. Every scenario should make one invalid state impossible
+or rejected.
+
+`tasks.md` should be ordered as:
+
+1. Packet readiness and source blockers.
+2. Current behavior characterization.
+3. D0/D2/D5/D6 prerequisite citation.
+4. D8 lifecycle state model.
+5. Candidate generation migration.
+6. Manifest validation and admission migration.
+7. Registered diagnostic and hook-scoped registration migration.
+8. Apply-safety handoff to D9.
+9. Retirement/refusal state handling.
+10. D13 candidate/generator handoff.
+11. Validation and bad-case tests.
+12. Downstream realignment and closure.
+
+Workstream files should mirror the D0-D7 accepted control pattern: status,
+first investigation inputs, imported findings, repair evidence, final rereview
+evidence, validation results, write set, non-claims, and closure checklist.
+
+## Required Spec Requirements
+
+The D8 spec must include at least these requirement families.
+
+### Requirement: Pattern Governance Owns Lifecycle Admission
+
+D8 SHALL be the single authority for governed pattern lifecycle admission.
+
+Required scenarios:
+
+- Candidate draft is created and remains non-enforcing.
+- Manifest-invalid candidate is rejected before registration.
+- Registered diagnostic pattern is admitted only with accepted manifest,
+  diagnostic identity, fixtures, false-positive model, current-tree scan result,
+  and baseline authority projection.
+- Registered hook-scoped pattern is admitted only after an explicit hook-scope
+  decision and matching rule registry reference.
+- Registered apply-approved pattern is admitted only through an explicit
+  apply-safety disposition and D9 handoff.
+- Refused pattern records a stable refusal reason.
+- Retired pattern cannot be selected as active enforcement without a new
+  admission decision.
+
+### Requirement: Candidate Artifacts Are Never Active Authority
+
+D8 SHALL prevent candidate files, candidate manifests, and generator options
+from acting as active rule, baseline, hook, or apply authority.
+
+Required bad cases:
+
+- Candidate manifest has `registration.accepted: true`.
+- Candidate manifest is stored under registered manifest path.
+- Candidate Grit markdown exists with Habitat tags but no accepted manifest.
+- Candidate generator output collides with active Grit pattern, baseline, or
+  rule registry row.
+- Candidate has a baseline file or hook scope and is still treated as candidate
+  success.
+
+### Requirement: Manifest Validation Is Necessary But Not Sufficient
+
+D8 SHALL define manifest validation as one admission input, not complete
+Pattern Governance acceptance.
+
+Required scenarios:
+
+- Missing manifest refuses registered promotion.
+- Malformed manifest refuses registered promotion.
+- Placeholder authority or proof fields refuse registered promotion.
+- Grit frontmatter/prose refuses as authority.
+- Nx generator options refuse as authority.
+- Registered manifest outside canonical registered path refuses.
+- Orphan manifest without matching D2 governance reference refuses.
+- Manifest/rule reference mismatch refuses.
+- Manifest validation success still waits for D5/D6/D9/D13-specific gates where
+  applicable.
+
+### Requirement: D2 Governance Facts Are Consumed, Not Recomputed
+
+D8 SHALL consume D2 governance, baseline, and Grit projections rather than whole
+registry rows or optional field inference.
+
+Required scenarios:
+
+- D8 consumes `ruleGovernanceFacts` for Pattern Authority references.
+- D8 consumes `ruleGritFacts` or D6 diagnostic identity projection for Grit
+  diagnostic relation.
+- D8 consumes `ruleBaselineFacts` and D5 `BaselineAuthorityProjection` for
+  baseline relation.
+- D8 refuses source implementation while those projections are absent where
+  touched.
+- Whole `HarnessRule`, prose `scope`, `lane`, `gritPattern`, `manifestPath`, or
+  file presence cannot become D8 target authority after projections exist.
+
+### Requirement: D5 Baseline Authority Is Consumed As Projection
+
+D8 SHALL use D5 baseline authority results without redefining baseline truth.
+
+Required scenarios:
+
+- Explicit empty baseline allows eligible registration only through accepted D5
+  projection.
+- Explicit debt baseline records accepted debt without erasing D8 admission
+  requirements.
+- External exception projection remains D5-owned and must not become Pattern
+  Governance proof by prose.
+- Baseline refused by D5 refuses D8 admission.
+- Baseline file presence alone cannot admit a registered pattern.
+- Rule-introduction manifest mismatch refuses D8 admission.
+
+### Requirement: D6 Diagnostic Catalog Is Consumed Without Admission Leakage
+
+D8 SHALL consume diagnostic identity and diagnostic consumer projection from D6
+without absorbing diagnostic acquisition.
+
+Required scenarios:
+
+- Registered diagnostic pattern consumes accepted diagnostic identity.
+- Missing, unexpected, malformed, or projection-missed diagnostic identity
+  refuses admission.
+- Native Grit command success does not imply D8 admission.
+- Injected probe or fixture success does not imply hook scope or apply safety.
+- D6 diagnostic failures remain diagnostic failures and do not become D8
+  lifecycle states except through explicit refusal projection.
+
+### Requirement: Hook Scope Is An Explicit Governance Decision
+
+D8 SHALL make hook scope a closed decision, not a property inferred from rule
+lane, manifest prose, or generated output.
+
+Required scenarios:
+
+- Hook decision `none` admits a non-hook registered pattern when all other gates
+  pass.
+- Hook decision `pre-commit` requires registered enforced lifecycle and matching
+  rule registry hook reference.
+- Manifest says pre-commit but D2/D11-facing rule reference omits hook scope:
+  refused.
+- Rule reference says pre-commit but manifest says none: refused.
+- Advisory pattern with pre-commit hook scope: refused.
+
+### Requirement: Apply Approval Is Separate From Diagnostic Registration
+
+D8 SHALL separate diagnostic registration from apply approval and SHALL NOT
+treat registered diagnostic state as apply-safe.
+
+Required scenarios:
+
+- `grit-check` registered pattern with `applySafety.kind: apply` is refused or
+  handed to D9 as a separate decision, according to the accepted D8/D9 contract.
+- `grit-apply` pattern without apply safety proof fields is refused.
+- Apply-approved pattern requires D9-owned dry-run/no-write/applied-diff/rollback
+  and type/test proof references.
+- Non-apply pattern records `not-apply` rationale and cannot be consumed by D9
+  as apply-ready.
+- D9 apply transaction failure cannot be flattened into D8 diagnostic refusal.
+
+### Requirement: Refusal Reasons Are Stable And Exhaustive
+
+D8 SHALL represent refusal as first-class lifecycle output.
+
+Minimum refusal reasons:
+
+- missing manifest;
+- malformed manifest;
+- placeholder manifest;
+- contradicted manifest;
+- orphan manifest;
+- manifest-invalid candidate;
+- Grit metadata only;
+- Nx options only;
+- missing D2 governance facts;
+- missing D5 baseline authority projection;
+- baseline contract rejected;
+- missing D6 diagnostic identity;
+- diagnostic projection rejected;
+- missing fixture strategy;
+- missing false-positive model;
+- current-tree scan blocks registration;
+- hook-scope mismatch;
+- apply-safety absent or contradicted;
+- active artifact collision;
+- retired pattern referenced as active.
+
+### Requirement: Downstream Consumers Receive Narrow Projections
+
+D8 SHALL publish consumer-specific projections rather than expose the full
+Pattern Governance state model.
+
+Required projections:
+
+- D9 apply governance projection: apply-approved, not-apply, or refused with
+  stable reason and D9-owned next action.
+- D13 candidate/generator projection: candidate generated, candidate refused,
+  registration prerequisites missing, or registration handoff required.
+- D7/D11 enforcement/hook-facing projection where hook-scoped enforcement needs
+  a lifecycle/hook decision without owning D8 admission.
+- D2 registry write projection for canonical governance facts.
+
+### Requirement: Public Surface Changes Wait For D0 Rows
+
+D8 implementation SHALL stop before changing public or durable surfaces without
+concrete D0 rows.
+
+Required surfaces:
+
+- generator schema/options and lifecycle values;
+- generated candidate manifest JSON;
+- registered Pattern Authority manifest JSON;
+- active Grit pattern output;
+- `rules.json` write shape;
+- package exports in `src/rules/pattern-authority/manifest.ts`;
+- Pattern Authority validation issue reasons;
+- command output/errors from generator registration;
+- docs/examples/guidance;
+- tests that encode public compatibility behavior.
+
+## Required Tasks/Validation
+
+### Required Task Repairs
+
+The repaired D8 `tasks.md` must convert design gaps into executable steps:
+
+- import this investigation and all fresh D8-specific lane findings into the
+  review ledger;
+- rewrite proposal/design/spec/tasks/control records before source
+  implementation;
+- record D8 write set and protected paths;
+- block source edits until concrete D0 rows, live D2 governance/baseline/Grit
+  projections, live D5 baseline projection, live D6 diagnostic identity or
+  consumer projection, and accepted D9/D13 handoff contracts exist where
+  touched;
+- characterize current source behavior for candidate generation, registered
+  promotion, manifest validation, baseline contract validation, hook scope, and
+  rule registry writes;
+- introduce the D8 closed lifecycle state model;
+- migrate current source state names only after D0 compatibility handling is
+  cited;
+- delete or reject file-presence admission paths;
+- add tests for each bad-case family above;
+- run final rereview lanes before packet index movement.
+
+### Required Design-Time Validation Gates
+
+These gates are required before D8 can move from BLOCKING to accepted for
+design/specification:
+
+| Gate | Command Or Check | Expected Result | Non-Claim |
+| --- | --- | --- | --- |
+| D8-OPEN | `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict` | exit 0 after repaired packet | Does not prove source implementation. |
+| D8-ALL-OPEN | `bun run openspec:validate` | exit 0 for full OpenSpec corpus | Does not prove Habitat behavior. |
+| D8-DIFF | `git diff --check` | exit 0 | Diff hygiene only. |
+| D8-WORDING | complete-standard wording audit over `$D8_CHANGE/**`, D8 active packet/control files, and D8 final scratch | no active reduced-standard guidance | Historical reduced-standard wording is allowed only as superseded finding text. |
+| D8-FINAL-REREVIEW | fresh final domain/ontology, TypeScript/validation, OpenSpec/information, code/topology, and cross-domino rereview | no unresolved P1/P2 | Design/specification acceptance only. |
+
+### Required Later Implementation Validation Gates
+
+Later implementation gates must include exact expected status, actual status,
+cache/freshness stance, non-claims, and blocker disposition. Minimum gates:
+
+- `bun run --cwd tools/habitat-harness test -- test/generators/pattern-generator.test.ts`
+  with bad cases for candidate non-registration, registered promotion without
+  manifest, placeholder manifest, baseline missing, hook mismatch, active
+  artifact collision, and candidate baseline collision.
+- `bun run --cwd tools/habitat-harness test -- test/rules/pattern-authority-manifest.test.ts`
+  with bad cases for missing/malformed/placeholder/contradicted/orphan
+  manifests, Grit-only authority, Nx-options-only authority, hook mismatch,
+  apply-safety contradiction, and retired/manifest-invalid lifecycle.
+- Focused D2/D5/D6 integration tests proving D8 consumes projections and refuses
+  when projections are absent, malformed, or contradicted.
+- Focused D9 handoff tests proving diagnostic registration does not imply
+  apply-safe state.
+- Focused D13 handoff tests proving generated candidate output remains
+  non-enforcing and registration prerequisites are explicit.
+- `bun run habitat classify tools/habitat-harness/src/rules/rules.json` only as
+  a D2/D4 compatibility observation, not as D8 admission proof.
+- A current-tree command proof only after D0/D1/D7 decide the relevant command
+  output families; otherwise command proof remains blocked and non-authoritative.
+- `git status --short --branch` recorded only for dirty-state classification;
+  clean status is not proof of Pattern Governance correctness.
+
+### Complete-Standard Wording Audit
+
+D8 needs a complete-standard wording audit across:
+
+- `openspec/changes/deep-habitat-d8-pattern-governance/**`;
+- `docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md`
+  as source input;
+- D8 investigation scratch;
+- D8 final review/rereview scratch records;
+- packet index row after any status movement.
+
+Audit terms include:
+
+- reduced-scope implementation language: `starter packet`, `draft`, `pending`,
+  `optional`, `only if needed`, `fallback`, `shim`, `temporary`, `dual path`,
+  `support both`, `silent skip`, `compatibility until later`,
+  `generated-output hand edit`;
+- authority leaks: `file presence implies`, `Grit prose proves`,
+  `baseline file proves`, `generator options prove`, `registered diagnostic is
+  apply-safe`, `hook scoped by lane`;
+- closure overclaims: `implementation-ready`, `accepted`, `complete`, `green`,
+  or `validated` without final rereview and recorded gates.
+
+Allowed hits must be explicitly marked as historical source wording, negative
+finding text, forbidden-language lists, or superseded prior state. Active packet
+language must use complete-standard wording.
+
+## Control Record Repairs
+
+### Phase Record
+
+Repair `workstream/phase-record.md` to include:
+
+- Status: BLOCKING until repaired packet and final rereviews record no
+  unresolved P1/P2.
+- Active worktree and branch using remediation variables or the correct current
+  branch, not the stale branch currently recorded.
+- Objective: specify complete Pattern Governance lifecycle/admission before
+  source implementation.
+- Current gate: design/specification repair gate open.
+- First investigation inputs table including this file and all other D8-specific
+  scratch records.
+- Dependency state table for D0, D2, D5, D6, D9, D13, and any D7/D11 hook-facing
+  consumer.
+- Source implementation blockers.
+- Design-time validation matrix with expected/result/non-claim columns.
+- Later implementation validation matrix with bad cases.
+- Write set and protected paths.
+- Non-claims.
+
+### Review Disposition Ledger
+
+Repair `workstream/review-disposition-ledger.md` to:
+
+- import each accepted P1/P2 finding from this investigation and sibling D8
+  investigations;
+- mark global constraints as applied but not acceptance evidence;
+- record exact repair evidence by artifact and section;
+- record fresh final rereview evidence after repairs;
+- state that D8 remains BLOCKING until all accepted P1/P2 findings are repaired
+  and final rereviews find no unresolved P1/P2.
+
+### Downstream Realignment Ledger
+
+Repair `workstream/downstream-realignment-ledger.md` with separate rows for:
+
+- D0 public-surface matrix and concrete D0 rows;
+- D2 `ruleGovernanceFacts`, `ruleGritFacts`, and `ruleBaselineFacts`;
+- D5 `BaselineAuthorityProjection`;
+- D6 diagnostic identity/consumer projection;
+- D7/D11 hook-scoped enforcement/local-feedback consumers, if touched;
+- D9 apply transaction handoff;
+- D13 candidate/generator refusal handoff;
+- packet index status;
+- docs/examples;
+- tests and fixtures;
+- generated outputs as regenerated-only, never hand-edited.
+
+Each row needs disposition, required action, owner packet, source blocker, and
+non-claim.
+
+### Closure Checklist
+
+Repair `workstream/closure-checklist.md` so design/specification acceptance
+requires:
+
+- proposal cites controlling authority, source packet, and exact dependency
+  states;
+- design defines current diagnosis, ontology, lifecycle state matrix, consumed
+  contracts, published projections, D0 inventory, write set, protected paths,
+  validation matrix, and non-claims;
+- spec contains all required normative requirement families and bad-case
+  scenarios;
+- tasks are executable implementation slices, not design prompts;
+- review ledger has no accepted unresolved P1/P2 findings;
+- downstream ledger has concrete D8 handoffs;
+- complete-standard wording audit passes;
+- strict D8 OpenSpec validation passes;
+- full OpenSpec validation passes;
+- `git diff --check` passes;
+- final rereview lanes read repaired disk state and record no unresolved P1/P2;
+- packet index is updated only after acceptance evidence exists, and only to
+  accepted for design/specification, not implementation-complete.
+
+## P1/P2 Blockers
+
+| ID | Severity | Finding | Required Repair |
+| --- | --- | --- | --- |
+| D8-INFO-001 | P1 | Current D8 artifacts do not define the complete Pattern Governance lifecycle required by the Phase 2 packet. | Add complete lifecycle state matrix to proposal/design/spec/tasks: candidate draft, manifest-invalid candidate, registered diagnostic, registered hook-scoped, registered apply-approved, refused, and retired. |
+| D8-INFO-002 | P1 | `spec.md` has one broad requirement and two scenarios, leaving most D8 authority decisions to implementation. | Expand spec into the requirement families listed in this investigation, with falsifiable bad-case scenarios. |
+| D8-INFO-003 | P1 | `design.md` lacks D8 target ontology, current diagnosis, closed state model, consumed-contract matrix, published projections, D0 inventory, and refactor sequence. | Rewrite design as the D8 decision center before implementation. |
+| D8-INFO-004 | P1 | Current tasks are unresolved design prompts. | Rewrite tasks into ordered packet readiness, prerequisite, characterization, semantic migration, validation, downstream realignment, and closure steps. |
+| D8-INFO-005 | P1 | D8 does not block source implementation behind concrete D0 rows for generator, manifest, registry, export, command, docs, and test surfaces. | Add D0 public-surface inventory and source stop conditions across proposal/design/spec/tasks/phase record. |
+| D8-INFO-006 | P1 | D8 does not state live D2/D5/D6 projection prerequisites precisely enough to prevent whole-row or file-presence admission. | Add source blockers for D2 governance/Grit/baseline projections, D5 baseline authority projection, and D6 diagnostic identity/projection. |
+| D8-INFO-007 | P1 | D8 does not separate diagnostic registration, hook-scope approval, and apply approval into distinct target states and handoffs. | Add hook-scope and apply-safety requirements plus D9 handoff and D13 candidate/generator handoff. |
+| D8-INFO-008 | P1 | Workstream ledgers cannot support acceptance or closure. | Repair phase record, review ledger, downstream ledger, and closure checklist to D0-D7 control standard. |
+| D8-INFO-009 | P1 | D8 has no final rereview evidence and global constraints are not acceptance evidence. | Keep status BLOCKING until fresh final D8 rereviews record no unresolved P1/P2 against repaired disk state. |
+| D8-TEST-001 | P2 | Validation gates are command names without expected status, actual status, oracle, bad case, cache stance, non-claim, or blocker disposition. | Add design-time and later implementation validation matrices with exact oracles and bad cases. |
+| D8-TEST-002 | P2 | The current validation set does not falsify the central bad case: candidate output without accepted manifest, fixture proof, baseline authority, hook-scope decision, or apply-safety decision becomes registered or active. | Add candidate-not-registered bad-case tests and registration refusal tests. |
+| D8-TEST-003 | P2 | `bun run habitat classify tools/habitat-harness/src/rules/rules.json` is listed as a D8 gate even though it does not prove Pattern Governance admission. | Reclassify this as a compatibility observation with non-claims, or replace it with D8-specific projection/admission tests. |
+| D8-CTRL-001 | P2 | `phase-record.md` records a stale branch value. | Replace with `$ACTIVE_REMEDIATION_BRANCH` or the correct active branch. |
+| D8-CTRL-002 | P2 | Downstream realignment is generic and does not name the D9/D13 consumer contracts D8 enables. | Add concrete downstream rows for D9 apply governance and D13 candidate/generator refusal. |
+| D8-CTRL-003 | P2 | D8 closure checklist can pass without complete-standard wording audit or final rereview evidence. | Add wording audit and final rereview gates before any packet-index status movement. |
+
+## Acceptance Rule
+
+D8 remains BLOCKING. It can move only to accepted for design/specification after
+the packet is rewritten to the complete standard, all accepted P1/P2 findings
+are repaired, strict and full OpenSpec validation pass, diff hygiene passes,
+the D8 complete-standard wording audit passes, and fresh final rereview lanes
+record no unresolved P1/P2 against the repaired disk state.
+
+Even after that movement, D8 remains not implementation-complete. Source
+implementation must remain blocked behind concrete D0 rows and live D2/D5/D6
+projection facts wherever those surfaces are touched.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-typescript-state-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D8-typescript-state-investigation.md
@@ -2,9 +2,9 @@
 
 Status: BLOCKING
 
-D8 is not acceptable implementation input yet. The source packet correctly requires Pattern Authority lifecycle separation, but the current OpenSpec scaffold does not yet specify the complete type model, consumer projections, exact write set, protected paths, or falsifying TypeScript gates required to prevent candidate/registered/apply-safe conflation.
+D8 is not acceptable implementation input yet. The source packet correctly requires Pattern Authority lifecycle separation, but the current OpenSpec packet does not yet specify the complete type model, consumer projections, exact write set, protected paths, or falsifying TypeScript gates required to prevent candidate/registered/apply-safe conflation.
 
-The current disk state partially prevents bad promotion by runtime tests and manifest validation. It does not fully prevent conflation at the packet level: the scaffold still leaves the concrete state model and implementation boundaries for a later agent to invent, and the live rule registry contains optional Pattern Authority fields without any checked-in `manifestPath` entries proving active Pattern Authority admission.
+The current disk state incompletely prevents bad promotion by runtime tests and manifest validation. It does not fully prevent conflation at the packet level: the current packet still leaves the concrete state model and implementation boundaries for a later agent to invent, and the live rule registry contains optional Pattern Authority fields without any checked-in `manifestPath` entries proving active Pattern Authority admission.
 
 ## Sources Read
 
@@ -330,13 +330,13 @@ Suggested exact later command set:
 
 ### P1: Packet does not yet specify the complete Pattern Authority state model
 
-The OpenSpec scaffold says lifecycle states must exist, but the spec requirement only names "candidate, reviewed, registered, refused, and retired" at `openspec/changes/deep-habitat-d8-pattern-governance/specs/habitat-harness/spec.md:3-13`. It does not specify diagnostic registered versus hook-scoped versus apply-approved variants, nor the required fields/projections per state.
+The OpenSpec starter packet says lifecycle states must exist, but the spec requirement only names "candidate, reviewed, registered, refused, and retired" at `openspec/changes/deep-habitat-d8-pattern-governance/specs/habitat-harness/spec.md:3-13`. It does not specify diagnostic registered versus hook-scoped versus apply-approved variants, nor the required fields/projections per state.
 
 Required repair: add normative requirements for `PatternAuthorityState`, lifecycle-specific admission inputs, typed refusal results, and consumer projections.
 
 ### P1: Packet does not yet prevent diagnostic/apply-safe conflation
 
-The source packet explicitly says registered diagnostic pattern is not apply-safe at `D8-pattern-governance.md:105-109`, and current manifest validation rejects `grit-check` plus `applySafety.kind === "apply"` at `manifest.ts:628-645`. The OpenSpec scaffold does not carry that into a complete spec requirement. A later implementation agent could preserve the runtime check but still expose a registered manifest projection that implies apply safety by whole-record leakage.
+The source packet explicitly says registered diagnostic pattern is not apply-safe at `D8-pattern-governance.md:105-109`, and current manifest validation rejects `grit-check` plus `applySafety.kind === "apply"` at `manifest.ts:628-645`. The OpenSpec starter packet does not carry that into a complete spec requirement. A later implementation agent could preserve the runtime check but still expose a registered manifest projection that implies apply safety by whole-record leakage.
 
 Required repair: add a distinct `RegisteredApplyApprovedPattern` state and state that diagnostic consumers never receive apply safety fields.
 
@@ -354,7 +354,7 @@ Required repair: state that current rule-pack metadata is present-behavior evide
 
 ### P2: Validation gates are too generic
 
-The current D8 scaffold validation gates include the manifest test, classify, OpenSpec validation, and `git diff --check`, but they do not include negative type-state gates, whole-record leakage gates, apply safety separation gates, or protected write-set tests.
+The current D8 starter packet validation gates include the manifest test, classify, OpenSpec validation, and `git diff --check`, but they do not include negative type-state gates, whole-record leakage gates, apply safety separation gates, or protected write-set tests.
 
 Required repair: add a validation matrix tied to TypeScript state collapse, not only runtime smoke tests.
 

--- a/docs/projects/habitat-harness/openspec-remediation/context.md
+++ b/docs/projects/habitat-harness/openspec-remediation/context.md
@@ -13,7 +13,7 @@ variables below.
 | Variable | Value |
 | --- | --- |
 | `$ACTIVE_REMEDIATION_WORKTREE` | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation` |
-| `$ACTIVE_REMEDIATION_BRANCH` | `codex/d7-structural-enforcement-packet` |
+| `$ACTIVE_REMEDIATION_BRANCH` | `codex/d8-pattern-governance-packet` |
 
 ## Path Variables
 
@@ -126,6 +126,27 @@ variables below.
 | `$D7_PHASE_RECORD` | `$D7_CHANGE/workstream/phase-record.md`. |
 | `$D7_DOWNSTREAM_LEDGER` | `$D7_CHANGE/workstream/downstream-realignment-ledger.md`. |
 | `$D7_CLOSURE_CHECKLIST` | `$D7_CHANGE/workstream/closure-checklist.md`. |
+
+## D8 Variables
+
+| Variable | Meaning |
+| --- | --- |
+| `$D8_CHANGE` | `$OPENSPEC_CHANGES/deep-habitat-d8-pattern-governance`. |
+| `$D8_SOURCE_PACKET` | `$PHASE2_PACKET_DIR/D8-pattern-governance.md`. |
+| `$D8_DOMAIN_REVIEW` | `$AGENT_SCRATCH/domino-D8-domain-ontology-investigation.md`. |
+| `$D8_TYPESCRIPT_REVIEW` | `$AGENT_SCRATCH/domino-D8-typescript-state-investigation.md`. |
+| `$D8_TOPOLOGY_REVIEW` | `$AGENT_SCRATCH/domino-D8-code-vendor-topology-investigation.md`. |
+| `$D8_INFORMATION_REVIEW` | `$AGENT_SCRATCH/domino-D8-openspec-information-testing-investigation.md`. |
+| `$D8_CROSS_DOMINO_REVIEW` | `$AGENT_SCRATCH/domino-D8-cross-domino-investigation.md`. |
+| `$D8_FINAL_DOMAIN_REVIEW` | `$AGENT_SCRATCH/domino-D8-final-domain-ontology-review.md`. |
+| `$D8_FINAL_TYPESCRIPT_VALIDATION_REVIEW` | `$AGENT_SCRATCH/domino-D8-final-typescript-validation-review.md`. |
+| `$D8_FINAL_OPENSPEC_INFORMATION_REVIEW` | `$AGENT_SCRATCH/domino-D8-final-openspec-information-review.md`. |
+| `$D8_FINAL_CODE_TOPOLOGY_REVIEW` | `$AGENT_SCRATCH/domino-D8-final-code-vendor-topology-review.md`. |
+| `$D8_FINAL_CROSS_DOMINO_REVIEW` | `$AGENT_SCRATCH/domino-D8-final-cross-domino-review.md`. |
+| `$D8_REVIEW_LEDGER` | `$D8_CHANGE/workstream/review-disposition-ledger.md`. |
+| `$D8_PHASE_RECORD` | `$D8_CHANGE/workstream/phase-record.md`. |
+| `$D8_DOWNSTREAM_LEDGER` | `$D8_CHANGE/workstream/downstream-realignment-ledger.md`. |
+| `$D8_CLOSURE_CHECKLIST` | `$D8_CHANGE/workstream/closure-checklist.md`. |
 
 ## Path Templates
 

--- a/docs/projects/habitat-harness/openspec-remediation/packet-index.md
+++ b/docs/projects/habitat-harness/openspec-remediation/packet-index.md
@@ -2,13 +2,13 @@
 
 This index tracks the conversion of the Phase 2 domino suite into OpenSpec
 change packets. It is part of the remediation frame, not an implementation
-commitment. Most rows remain draft scaffolding: global review findings have
+commitment. Most rows remain incomplete packets: global review findings have
 been converted into shared constraints, but each domino remains blocking until
 its own per-domino adversarial review has run and all accepted P1/P2 findings
-are repaired. D0, D1, D2, D3, D4, D5, D6, and D7 are the current exceptions: they are
+are repaired. D0, D1, D2, D3, D4, D5, D6, D7, and D8 are the current exceptions: they are
 accepted for design/specification after their per-domino final reviews found no
-unresolved P1/P2 blockers. D0-D7 are not implementation-complete, and
-D8-D15/G-HOST remain blocking unless their own status rows say otherwise.
+unresolved P1/P2 blockers. D0-D8 are not implementation-complete, and
+D9-D15/G-HOST remain blocking unless their own status rows say otherwise.
 
 Path variables and operational checkout fixtures are defined in
 `$REMEDIATION_DIR/context.md`. This index records packet identity and sequencing;
@@ -24,15 +24,15 @@ it does not repeat local worktree paths or branch names.
 | D5 | D5 Baseline Authority | `deep-habitat-d5-baseline-authority` | D0, D2; concrete D0 rows and live D2 `ruleBaselineFacts`/baseline projections required before source implementation | D7, D8 | accepted for design/specification; final domain/ontology, OpenSpec/testing, and topology/TypeScript/cross-domino rereviews found no unresolved P1/P2 blockers; not implementation-complete |
 | D6 | D6 Diagnostic Pattern Catalog | `deep-habitat-d6-diagnostic-pattern-catalog` | D0, D1, D2; concrete D0 rows, D1 output-family decisions where touched, and live D2 `ruleGritFacts` required before source implementation | D7, D8, D9, D11, D15 evaluation | accepted for design/specification; final after-observed-identity domain/ontology, TypeScript/validation, OpenSpec/information, and code/vendor topology rereviews found no unresolved P1/P2 blockers; not implementation-complete |
 | D7 | D7 Structural Enforcement Pipeline | `deep-habitat-d7-structural-enforcement-pipeline` | D0, D1, D2, D3, D5, D6, D10; concrete D0 rows, D1 output-family handling, live D2/D3/D5/D6 projections, and accepted D10 guard contract required before source implementation where touched | D11, D12 | accepted for design/specification; final domain/ontology, TypeScript/validation, OpenSpec/information, and code/topology/cross-domino rereviews found no unresolved P1/P2 blockers; not implementation-complete |
-| D8 | D8 Pattern Governance | `deep-habitat-d8-pattern-governance` | D0, D2, D5, D6 | D9, D13 | draft scaffold; global constraints applied; per-domino adversarial gate BLOCKING |
-| G-HOST | Host Policy Boundary Gate | `deep-habitat-host-policy-boundary-gate` | D0, D1 | D10, D13 | draft scaffold; global constraints applied; per-domino adversarial gate BLOCKING |
-| D9 | D9 Transformation Transaction | `deep-habitat-d9-transformation-transaction` | D0, D1, D6, D8, D10 | D11 | draft scaffold; global constraints applied; per-domino adversarial gate BLOCKING |
-| D10 | D10 Protected Zone Authority | `deep-habitat-d10-protected-zone-authority` | D0, D1, D2, G-HOST | D7, D9, D11 | draft scaffold; global constraints applied; per-domino adversarial gate BLOCKING |
-| D11 | D11 Local Feedback | `deep-habitat-d11-local-feedback` | D0, D1, D7, D9, D10 | none | draft scaffold; global constraints applied; per-domino adversarial gate BLOCKING |
-| D12 | D12 Verify Handoff Receipt | `deep-habitat-d12-verify-handoff-receipt` | D0, D1, D3, D7 | D14 | draft scaffold; global constraints applied; per-domino adversarial gate BLOCKING |
-| D13 | D13 Scaffolding And Refusal Contracts | `deep-habitat-d13-scaffolding-refusal-contracts` | D0, D2, D8, G-HOST | D14 | draft scaffold; global constraints applied; per-domino adversarial gate BLOCKING |
-| D14 | D14 Authoring Topology Fence | `deep-habitat-d14-authoring-topology-fence` | D0, D4, D12, D13 | none | draft scaffold; global constraints applied; per-domino adversarial gate BLOCKING |
-| D15 | D15 Execution Provenance Trigger | `deep-habitat-d15-execution-provenance-trigger` | D6, D7, D9, or D11 consuming packet identifies impossible local states | A future packet-local substrate decision only when triggered | draft scaffold; global constraints applied; per-domino adversarial gate BLOCKING |
+| D8 | D8 Pattern Governance | `deep-habitat-d8-pattern-governance` | D0, D1, D2, D5, D6; D7 where current-tree/check admission input is consumed; D10/G-HOST where protected/generated-zone or host-policy paths/gates are touched; concrete D0 rows, D1 output-family citations, live D2 `ruleGovernanceFacts`/`ruleGritFacts`/`ruleBaselineFacts`, D5 `BaselineAuthorityProjection`, and D6 diagnostic projections required before source implementation | D9, D13; D11 through local-feedback eligibility/recovery projections | accepted for design/specification; final domain/ontology, TypeScript/validation, OpenSpec/information, code/vendor topology, and cross-domino rereviews found no unresolved P1/P2 blockers; not implementation-complete |
+| G-HOST | Host Policy Boundary Gate | `deep-habitat-host-policy-boundary-gate` | D0, D1 | D10, D13 | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
+| D9 | D9 Transformation Transaction | `deep-habitat-d9-transformation-transaction` | D0, D1, D6, D8, D10 | D11 | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
+| D10 | D10 Protected Zone Authority | `deep-habitat-d10-protected-zone-authority` | D0, D1, D2, G-HOST | D7, D9, D11 | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
+| D11 | D11 Local Feedback | `deep-habitat-d11-local-feedback` | D0, D1, D7, D9, D10 | none | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
+| D12 | D12 Verify Handoff Receipt | `deep-habitat-d12-verify-handoff-receipt` | D0, D1, D3, D7 | D14 | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
+| D13 | D13 Scaffolding And Refusal Contracts | `deep-habitat-d13-scaffolding-refusal-contracts` | D0, D2, D8, G-HOST | D14 | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
+| D14 | D14 Authoring Topology Fence | `deep-habitat-d14-authoring-topology-fence` | D0, D4, D12, D13 | none | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
+| D15 | D15 Execution Provenance Trigger | `deep-habitat-d15-execution-provenance-trigger` | D6, D7, D9, or D11 consuming packet identifies impossible local states | A future packet-local substrate decision only when triggered | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
 
 ## Review Gate Semantics
 
@@ -40,7 +40,7 @@ it does not repeat local worktree paths or branch names.
   They are not packet-specific acceptance evidence.
 - Each domino must still run its own adversarial domain-language, OpenSpec,
   topology, validation, information-design, and cross-domino review before the
-  packet can advance from draft scaffold to accepted execution authority.
+  packet can advance from blocking packet status to accepted execution authority.
 - Per-domino review is a design-time gate, not an implementation-time cleanup
   task. Implementation cannot start from a packet whose review ledger still
   marks that gate as blocking.

--- a/openspec/changes/deep-habitat-d8-pattern-governance/design.md
+++ b/openspec/changes/deep-habitat-d8-pattern-governance/design.md
@@ -2,71 +2,291 @@
 
 ## Frame
 
-D8 Pattern Governance is a downstream implementation-control packet derived from
-`D8-pattern-governance.md`. The packet is complete only when it leaves the later execution
-agent with no product, domain, naming, sequencing, public-surface, or validation
-decision to invent.
+D8 is the Pattern Governance packet. It resolves how Habitat admits, refuses,
+retires, and publishes structural pattern states. Its acceptance threshold is
+high: a later implementation agent must not decide lifecycle names, admission
+inputs, refusal reasons, public compatibility, write ownership, or downstream
+handoffs while editing TypeScript.
 
-The existing packet is input, not output. Current Habitat code is
-present-behavior evidence. This design chooses target language from Habitat's
-generic repo-maintenance product scenarios rather than preserving accidental
-module or DTO names.
+Pattern Governance is a repo-maintenance domain. It keeps a candidate pattern
+from becoming an active diagnostic, local-feedback signal, or apply transform
+until the required owner contracts have accepted that use.
+
+## Current Behavior Diagnosis
+
+Current code is useful but incomplete target evidence:
+
+- `tools/habitat-harness/src/rules/pattern-authority/manifest.ts` exposes
+  `candidate`, `registered-advisory`, and `registered-enforced` lifecycles,
+  Pattern Authority manifest validation, rule-reference checks, baseline
+  contract fields, hook-scope fields, and apply-safety fields.
+- `tools/habitat-harness/src/generators/pattern/generator.cjs` writes
+  candidate artifacts under the Pattern Authority candidate root and routes
+  non-candidate requests into registration.
+- `tools/habitat-harness/src/generators/pattern/registration.cjs` validates a
+  manifest, checks baseline files and rule-introduction manifests, refuses
+  collisions, writes an active Grit check pattern, and appends a `rules.json`
+  row.
+- `tools/habitat-harness/src/rules/rules.json` has active Grit rules with
+  `gritPattern` and often `hookScope`, but the current catalog generally lacks
+  `manifestPath`; those rows cannot be treated as complete D8 admission.
+- Existing tests cover candidate non-registration, manifest validation,
+  placeholder rejection, missing baseline rejection, hook mismatch, and
+  collision protection. They do not cover the complete D8 lifecycle model,
+  retired patterns, consumer projections, or live D2/D5/D6 projection
+  prerequisites.
 
 ## Domain Boundary
 
-- Owner: Pattern Governance.
-- Primary scenario: A maintainer promotes or rejects structural patterns through Pattern Authority without confusing draft generation, diagnostic catalog entries, and enforced rules.
-- Adjacent domains consume this packet through explicit contracts and may not
-  recreate its authority locally.
+D8 owns:
 
-## Target Contract
+- Pattern identity admission.
+- Pattern Authority decision records.
+- Lifecycle state and capability admission state.
+- Admission/refusal/retirement reason taxonomy.
+- Manifest acceptance as one admission input.
+- Consumer projections that prevent adjacent domains from inferring admission
+  from file presence or broad records.
 
-- Define pattern lifecycle states and admission gates.
-- Separate generated candidate drafts from registered enforcement.
-- Connect governance to D2 facets and D5 baselines.
+D8 does not own:
 
-## Non-Goals
+- Registry row schema or consumer projections owned by D2.
+- Baseline integrity, baseline growth, external exception sources, or baseline
+  application owned by D5.
+- Grit command acquisition, diagnostic projection, diagnostic catalog identity,
+  injected-probe cleanup, or scan-root validation owned by D6.
+- Check report assembly, rendering, or exit status owned by D7.
+- Protected/generated-zone authority owned by D10.
+- Apply transaction behavior owned by D9.
+- Hook sequencing and staged-file behavior owned by D11.
+- Candidate file creation and generator refusal surfaces owned by D13.
+- Host policy owned by G-HOST.
 
-- No Grit diagnostic execution ownership.
-- No scaffold/generator product expansion.
-- No baseline expansion by admission side effect.
+## Vendor Boundary
 
-## Naming And Language Decisions
+- Grit owns GritQL syntax, Markdown pattern conventions, pattern samples,
+  native `grit check`, and native `grit apply`. Habitat may add Pattern
+  Authority metadata, but Grit frontmatter and prose are not Habitat admission
+  authority.
+- Biome owns formatter/linter/import-sorting behavior and `biome ci` semantics.
+  Biome outcomes are not Pattern Governance lifecycle decisions.
+- Nx owns generator mechanics, generator schema/default handling, project graph
+  plugins, inferred tasks, and task execution. Habitat owns which generator
+  requests it supports and which generated outputs are candidates versus
+  admitted patterns.
 
-- Use standard engineering terms that name the actual workflow object:
-  receipts, checks, diagnostics, guard decisions, transactions, refusals,
-  recovery instructions, metadata projections, command outcomes, and handoff
-  records.
-- Treat legacy proof/evidence-shaped code names as compatibility facts unless
-  this packet explicitly accepts them as target language.
-- Do not create generic artifact machinery when a smaller command result,
-  receipt, or diagnostic contract serves the scenario.
+## Target Ontology
 
-## Implementation Readiness
+Use `Pattern Governance` for the bounded context and `Pattern Authority` for
+the durable decision authority and decision record inside that context.
 
-Before implementation starts, the executor must have:
+Target state families:
 
-- D0 compatibility disposition for every public command, JSON, export, script,
-  target, generator, and hook surface touched by this packet.
-- A concrete write set and protected path list.
-- Tests and command gates from this packet copied into the phase record.
-- Review findings dispositioned with accepted P1/P2 repaired.
+| State | Meaning | Required owner inputs | Consumer meaning |
+| --- | --- | --- | --- |
+| `candidate-draft` | Proposed pattern output exists. | D13 candidate request plus D8 candidate identity. | Not active, not baselined, not hook-eligible, not apply-capable. |
+| `candidate-under-review` | Candidate entered governance review. | Candidate identity plus required decision-input checklist. | Still not active; consumers may only show review status. |
+| `manifest-invalid-candidate` | Candidate or promotion input has invalid Pattern Authority metadata. | D8 validation issue set. | Registration refuses before active writes. |
+| `diagnostic-admitted` | Pattern is admitted for diagnostic/check use. | D2 governance/Grit facts, D5 baseline projection, D6 diagnostic capability, fixture strategy, false-positive assessment, current-tree disposition. | D7/D6 may consume diagnostic eligibility; D9 cannot consume it as write authority. |
+| `local-feedback-admitted` | Diagnostic pattern may be surfaced to local feedback consumers. | `diagnostic-admitted`, explicit hook-scope decision, D11-compatible eligibility input, and D7/D10 inputs where touched. | D11 may present eligible local feedback; D11 still owns hook behavior. |
+| `apply-admitted` | Pattern may be offered to D9 for apply consideration. | Explicit D9 apply-safety input, D10/G-HOST path authority where touched, and D8 admission decision. | D9 may evaluate transaction execution; D8 does not approve writes. |
+| `refused` | Admission is rejected with a closed reason. | Failed owner input, protected write set, recovery action. | Consumers must not infer active lifecycle from the rejected input. |
+| `retired` | Prior admission is withdrawn. | Retirement authority, replacement/disposition, migration guidance. | New enforcement/apply/local feedback use stops unless a new admission decision exists. |
 
-## Review Lanes
+Capability admissions are not synonyms for registry membership. Registration is
+D2 vocabulary. Admission is D8 vocabulary.
 
-- Domain-language adversary: names, owner, authority, and inherited terminology.
-- OpenSpec packet review: proposal/design/tasks/spec consistency and shortcut
-  language.
-- TypeScript state-space review: invalid states removed without type machinery
-  that exceeds the product need.
-- Testing/validation review: gates are falsifying, scenario-grounded, and have
-  exact command expectations.
-- Cross-domino review: dependencies, public-surface compatibility, and
-  downstream realignment.
+## Term Disposition
 
-## Structural Alternative Rejected
+| Current term | D8 target disposition |
+| --- | --- |
+| `registered-advisory` | Compatibility projection for diagnostic-admitted advisory rule output until D0/D2 approve public rename. |
+| `registered-enforced` | Compatibility projection for diagnostic-admitted enforced rule output; local-feedback admission remains a separate D8 decision. |
+| `authorityAccepted: boolean` | Boundary compatibility fact; target internals should narrow on lifecycle/admission state. |
+| `provingSources` | Compatibility field name. Target language should use validation inputs, acceptance inputs, fixture results, command records, or decision records. |
+| `proof` in current code fields | Compatibility field where already public or test-pinned; new D8 target docs should name the engineering object directly. |
+| `hookScope` | D2/D11-facing compatibility field; D8 target is local-feedback admission. |
+| `applySafety` | D9-facing compatibility field; D8 target is apply admission plus transaction handoff. |
+| Grit frontmatter/prose | Vendor metadata only, never D8 authority. |
+| Baseline file presence | D5 input only, never D8 authority. |
 
-The rejected alternative is to implement the existing domino packet directly
-and let the execution agent create missing proposal, design, spec, task, and
-ledger details while coding. That path already caused design drift. This
-OpenSpec packet resolves the execution-control layer before implementation.
+## Consumed Upstream Contracts
+
+| Owner | D8 consumes | D8 must not do |
+| --- | --- | --- |
+| D0 | Public-surface compatibility rows for all touched commands, JSON, exports, generator fields, docs, tests, and generated/help surfaces. | Change public surfaces before a concrete D0 row exists. |
+| D1 | Command outcome and refusal-family vocabulary for malformed/refused admission exposed to users or command JSON. | Invent a new output family during implementation. |
+| D2 | `ruleGovernanceFacts`, `ruleGritFacts`, and `ruleBaselineFacts`. | Read whole registry rows, prose `scope`, or field presence as target authority. |
+| D5 | `BaselineAuthorityProjection` or baseline refusal result. | Load, grow, shrink, sort, accept, or refuse baselines locally. |
+| D6 | Diagnostic capability, accepted diagnostic identity, fixture/sample result, injected probe result, current-tree diagnostic limitation, and diagnostic non-claims. | Parse raw Grit output or treat diagnostic success as admission by itself. |
+| D7 | Check/current-tree outcome projection where D8 uses current-tree state as admission input. | Build reports, derive `CheckReport.ok`, or decide exit semantics. |
+| D10/G-HOST | Protected/generated-zone and host-policy decisions for scan roots, probe paths, apply paths, or host-specific gates. | Encode host semantics or protected-zone policy locally. |
+
+## Published Downstream Projections
+
+| Projection | Consumer | Contents |
+| --- | --- | --- |
+| `PatternAuthorityProjection` | D2, D13, recovery records | Pattern id, manifest path, lifecycle state, admitted capabilities, refusal reason, supersession. |
+| `DiagnosticAdmissionProjection` | D6, D7 | Diagnostic admission state, diagnostic identity, fixture strategy reference, false-positive assessment, current-tree disposition, non-claims. |
+| `LocalFeedbackAdmissionProjection` | D11 through D7/D10 | Hook/local-feedback eligibility, lifecycle state, D11-owned next action, non-claims. |
+| `ApplyAdmissionProjection` | D9 | Apply-admitted/not-apply/refused state, pattern identity, manifest path, D9-owned transaction inputs, protected-zone/host-policy references where needed. |
+| `CandidateHandoffProjection` | D13 | Candidate output paths, candidate-only state, registration prerequisites, refusal next action. |
+| `PatternRecoveryProjection` | Recovery ledgers and users | Refusal/retirement reason, owner, next allowed action, replacement/disposition. |
+
+Consumers receive projections, not the whole manifest or whole governance state.
+
+## Refusal Taxonomy
+
+D8 refusal reasons are closed for implementation:
+
+- `missing-manifest`.
+- `malformed-manifest`.
+- `placeholder-manifest`.
+- `contradicted-manifest`.
+- `orphan-manifest`.
+- `manifest-invalid-candidate`.
+- `grit-metadata-only`.
+- `nx-options-only`.
+- `missing-d2-governance-facts`.
+- `missing-d5-baseline-authority`.
+- `baseline-contract-rejected`.
+- `missing-d6-diagnostic-identity`.
+- `diagnostic-projection-rejected`.
+- `missing-fixture-strategy`.
+- `missing-false-positive-model`.
+- `current-tree-blocks-registration`.
+- `hook-scope-mismatch`.
+- `apply-safety-missing`.
+- `apply-safety-contradicted`.
+- `active-artifact-collision`.
+- `retired-pattern-referenced`.
+- `public-surface-compatibility-missing`.
+
+Boundary command messages may preserve existing wording where D0 requires it,
+but internal D8 implementation should project messages from typed refusal state.
+
+## TypeScript State Model
+
+The later implementation should collapse state space from optional broad records
+to discriminated states:
+
+```ts
+type PatternAuthorityState =
+  | { kind: "candidate-draft"; candidate: CandidatePatternDraft }
+  | { kind: "candidate-under-review"; review: PatternReviewInput }
+  | { kind: "manifest-invalid-candidate"; refusal: PatternAdmissionRefusal }
+  | { kind: "diagnostic-admitted"; admission: DiagnosticAdmissionProjection }
+  | { kind: "local-feedback-admitted"; admission: LocalFeedbackAdmissionProjection }
+  | { kind: "apply-admitted"; admission: ApplyAdmissionProjection }
+  | { kind: "refused"; refusal: PatternAdmissionRefusal }
+  | { kind: "retired"; retirement: PatternRetirementDecision };
+```
+
+Expected refactor moves:
+
+- Introduce lifecycle-specific constructors before moving consumers.
+- Keep existing manifest JSON shape as compatibility until D0 rows authorize
+  public schema changes.
+- Replace internal `authorityAccepted: boolean` decisions with state narrowing.
+- Convert generator/promotion failure sequencing to typed admission results,
+  with boundary errors projected from those results where compatibility
+  requires thrown generator errors.
+- Add projection builders so rule entry, diagnostic catalog, baseline relation,
+  hook/local feedback, apply transaction, and recovery consumers cannot access
+  whole manifests.
+- Separate diagnostic admission from apply admission. A `grit-check` diagnostic
+  state cannot carry apply-ready projection.
+
+## Write Set
+
+Allowed later D8 source implementation files:
+
+- `tools/habitat-harness/src/rules/pattern-authority/manifest.ts`.
+- `tools/habitat-harness/src/generators/pattern/generator.cjs`.
+- `tools/habitat-harness/src/generators/pattern/registration.cjs`.
+- `tools/habitat-harness/src/generators/pattern/schema.json`, only with D0/D13
+  compatibility handling.
+- `tools/habitat-harness/src/index.ts`, only for D0-approved exports.
+- `tools/habitat-harness/src/rules/architecture.ts`, only for typed projection
+  consumption after D2 compatibility.
+- `tools/habitat-harness/src/rules/rules.json`, only when D2/D8 admission
+  authorizes a specific test fixture or migration row.
+- `tools/habitat-harness/test/rules/pattern-authority-manifest.test.ts`.
+- `tools/habitat-harness/test/generators/pattern-generator.test.ts`.
+- New focused D8 tests under `tools/habitat-harness/test/rules/` or
+  `tools/habitat-harness/test/generators/`.
+- D8 OpenSpec and remediation records under `$D8_CHANGE/**` and
+  `$REMEDIATION_DIR/**`.
+- Pattern Authority docs/ledgers explicitly named by the D8 implementation
+  plan.
+
+Runtime write projections:
+
+- Candidate generation may write candidate Pattern Authority files under the
+  candidate root only.
+- Diagnostic/local-feedback admission may write an active Grit check pattern
+  and the corresponding rule registry row only after D2/D5/D6/D8 gates pass.
+- Apply admission may publish an apply-admission projection for D9; D9 owns
+  actual apply transaction behavior.
+
+## Protected Paths
+
+- `tools/habitat-harness/baselines/**` unless D5 explicitly owns the edit.
+- Existing `.grit/patterns/habitat/checks/**` except a D8-approved admitted
+  test fixture or migration row.
+- `.grit/patterns/habitat/apply/**` unless D9 owns the edit.
+- `.grit/grit.yaml`, `.gritignore`, `.gitignore`, and Grit acquisition config.
+- `tools/habitat-harness/src/lib/baseline.ts`.
+- `tools/habitat-harness/src/lib/grit.ts`.
+- `tools/habitat-harness/src/lib/grit-apply.ts`.
+- `tools/habitat-harness/src/lib/command-engine.ts`.
+- `tools/habitat-harness/src/lib/hooks.ts`.
+- `tools/habitat-harness/src/plugin.js`, Nx project graph config, and root Nx
+  target config unless D3/D0 authorize the change.
+- Product source roots under `apps/**`, `packages/**`, and `mods/**` except
+  explicit D8 fixtures.
+- Generated artifacts, lockfiles, `dist/**`, `mod/**`, `.civ7/**`, and vendor
+  caches.
+
+## Validation Matrix
+
+Design-time gates:
+
+| Gate | Expected result | Non-claim |
+| --- | --- | --- |
+| `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict` | D8 change validates. | Does not implement source behavior. |
+| `bun run openspec:validate` | Full OpenSpec corpus validates. | Does not prove Habitat behavior. |
+| `git diff --check` | Diff hygiene passes. | Does not prove design completeness. |
+| Complete-standard wording audit over `$D8_CHANGE/**` and D8 scratch | No active reduced-standard guidance. | Historical finding text may remain only when marked as non-guidance. |
+| Fresh final D8 rereviews | No unresolved P1/P2. | Design/specification acceptance only. |
+
+Later implementation gates:
+
+- `bun run --cwd tools/habitat-harness test -- test/rules/pattern-authority-manifest.test.ts test/generators/pattern-generator.test.ts`.
+- D8 type-state tests proving candidate, invalid, admitted, refused, and
+  retired states cannot be confused.
+- Tests proving registered diagnostic state does not expose apply-ready
+  projection.
+- Tests proving consumers receive projections, not whole manifests.
+- D5-focused `bun run habitat check --rule baseline-integrity --json` where
+  registered pattern admission touches baselines.
+- Native Grit pattern sample tests only for pattern files touched by the D8
+  implementation; this validates vendor pattern syntax/behavior, not D8
+  admission.
+- `bun run habitat classify tools/habitat-harness/src/rules/rules.json` and
+  `bun run habitat classify tools/habitat-harness/src/rules/pattern-authority/manifest.ts`
+  as routing observations with non-claims.
+- `git status --short --branch` and `gt status` for stack hygiene.
+
+## Non-Claims
+
+- A valid candidate is not an admitted pattern.
+- Manifest validation is necessary but not sufficient for admission.
+- Existing Grit pattern files are not Pattern Authority decisions.
+- Existing rule rows without `manifestPath` are compatibility facts, not
+  complete D8 admissions.
+- Baseline file presence is not baseline authority.
+- Diagnostic success is not apply permission.
+- Hook scope does not prove D11 local-feedback behavior.
+- Apply admission does not execute or approve writes; D9 owns transaction
+  execution.

--- a/openspec/changes/deep-habitat-d8-pattern-governance/proposal.md
+++ b/openspec/changes/deep-habitat-d8-pattern-governance/proposal.md
@@ -2,79 +2,143 @@
 
 ## Summary
 
-Open the D8 Pattern Governance OpenSpec packet for Deep Habitat Phase 2 remediation. This
-change converts the existing D8 domino packet into a review-gated
-OpenSpec packet scaffold. It resolves scope, owner, public surface impact,
-validation gates, downstream realignment, and stop conditions before any
-TypeScript implementation resumes.
+D8 specifies Pattern Governance for Habitat's structural pattern workflow. It
+defines the lifecycle and admission contract that keeps generated pattern
+candidates, diagnostic patterns, hook-eligible patterns, apply-capable patterns,
+refused patterns, and retired patterns from collapsing into one accidental
+state.
+
+The current source tree already contains useful Pattern Authority manifest and
+pattern generator behavior, but that behavior is present-state evidence only.
+The D8 OpenSpec packet must decide the target domain model before source
+implementation resumes.
 
 ## Authority
 
-- Current user decision to restart OpenSpec packet preparation from square one.
-- Remediation frame: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation-frame.md.
-- Phase 2 packet suite: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets.
-- Root AGENTS.md Graphite/OpenSpec workflow guidance.
-- Domain Design and Information Design skills as mandatory language and artifact gates.
-- Current Habitat Toolkit code and tests as present-behavior evidence only.
-- Source domino packet: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md.
+- Remediation frame: `$HABITAT_PROJECT/openspec-remediation-frame.md`.
+- Context router: `$REMEDIATION_DIR/context.md`.
+- Source domino packet: `$D8_SOURCE_PACKET`.
+- D8 first-wave investigations:
+  - `$D8_DOMAIN_REVIEW`.
+  - `$D8_TYPESCRIPT_REVIEW`.
+  - `$D8_TOPOLOGY_REVIEW`.
+  - `$D8_INFORMATION_REVIEW`.
+  - `$D8_CROSS_DOMINO_REVIEW`.
+- Accepted design/specification packets D0-D7, with their source
+  implementation blockers still in force.
+- Current Habitat source and tests as behavior evidence, not target-domain
+  authority.
+- Official vendor documentation for Grit, Biome, and Nx where D8 depends on
+  their tools.
 
 ## Product Scenario
 
-A maintainer promotes or rejects structural patterns through Pattern Authority without confusing draft generation, diagnostic catalog entries, and enforced rules.
+A maintainer or agent introduces a structural pattern and can see exactly what
+state it is in: candidate, under review, admitted for diagnostics, admitted for
+local feedback, admitted for apply consideration, refused, or retired. No file,
+registry row, baseline file, Grit frontmatter, generator option, hook field, or
+apply pattern becomes authority by existing.
 
 ## What Changes
 
-- Define pattern lifecycle states and admission gates.
-- Separate generated candidate drafts from registered enforcement.
-- Connect governance to D2 facets and D5 baselines.
+- Define Pattern Governance as the owner of lifecycle and admission decisions.
+- Define Pattern Authority as the durable decision record and projection source
+  inside Pattern Governance.
+- Replace file-presence admission with closed lifecycle states, capability
+  admissions, and typed refusal outcomes.
+- Specify consumed upstream contracts from D0, D1, D2, D5, D6, D7, and D10.
+- Specify downstream projections for D7, D9, D11, D13, and recovery records.
+- State the write set, protected paths, validation matrix, and source
+  implementation blockers for later D8 implementation.
 
 ## What Does Not Change
 
-- No Grit diagnostic execution ownership.
-- No scaffold/generator product expansion.
-- No baseline expansion by admission side effect.
+- D8 does not execute Grit diagnostics or parse native Grit output; D6 owns
+  diagnostic acquisition and projection.
+- D8 does not define baseline truth, baseline expansion, external exception
+  sources, or shrink-only behavior; D5 owns those.
+- D8 does not own check report construction, rendering, or exit status; D7 owns
+  the structural enforcement pipeline.
+- D8 does not own apply transactions, dry-run/write safety, rollback, formatter
+  handoff, or path mutation approval; D9 owns those.
+- D8 does not own hook sequencing or staged-file behavior; D11 owns local
+  feedback.
+- D8 does not own generator file creation; D13 owns generator and refusal
+  surfaces that produce D8 candidates or hand registration to D8.
+- D8 does not encode Civ, MapGen, or other host-specific policy; G-HOST owns
+  host policy boundaries.
 
 ## Requires
 
-- D0
-- D2
-- D5
-- D6
+- D0 for every public or durable command, JSON, export, generator, hook, docs,
+  target, and generated/help surface touched by later implementation.
+- D1 for command outcome and refusal-family language where D8 exposes malformed
+  admission input or registration refusal.
+- D2 for `ruleGovernanceFacts`, `ruleGritFacts`, and `ruleBaselineFacts`
+  projections.
+- D5 for `BaselineAuthorityProjection` and baseline refusal results.
+- D6 for diagnostic capability, fixture/sample result, injected probe result,
+  observed diagnostic identity, and diagnostic non-claims.
+- D7 where D8 consumes Habitat check/current-tree outcomes as admission input.
+- D10 and G-HOST where scan roots, probe roots, candidate roots, apply paths, or
+  host gates touch generated/protected or host-owned areas.
 
 ## Enables
 
-- D9
-- D13
+- D9 may consume only D8's apply-admission projection, never diagnostic
+  registration as write authority.
+- D13 may create candidate drafts and hand registration requests to D8 without
+  deciding admission locally.
+- D11 may consume hook eligibility through D8/D7 projections without deciding
+  lifecycle.
+- Recovery records may cite stable D8 refusal and retirement outcomes.
 
-## Affected Owners
+## Public And Durable Surfaces
 
-- Domain owner: Pattern Governance.
-- OpenSpec change path: `openspec/changes/deep-habitat-d8-pattern-governance/**`.
-- Expected Habitat implementation write set named in `design.md`; no code is
-  authorized by this remediation packet itself.
+D8 implementation is source-blocked until concrete D0 rows exist for touched
+surfaces:
 
-## Forbidden Owners
-
-- Adjacent dominoes may not redefine Pattern Governance authority.
-- Current code names may not become target-domain language without this packet
-  accepting the term.
-- Implementation agents may not add shims, fallbacks, dual paths, silent skips,
-  optional target shape, or generated-output hand edits.
-
-## Consumer Impact
-
-Generator and docs guidance may change to clarify candidate vs registered pattern status.
+- `@internal/habitat-harness:pattern` generator schema, options, messages, and
+  generated output.
+- Candidate Pattern Authority manifest JSON.
+- Registered Pattern Authority manifest JSON.
+- Pattern Authority validation issue/reason names.
+- `tools/habitat-harness/src/index.ts` Pattern Authority exports.
+- `tools/habitat-harness/src/rules/rules.json` governance and pattern
+  references.
+- Active Grit pattern paths under `.grit/patterns/habitat/checks/**` and
+  `.grit/patterns/habitat/apply/**`.
+- Baseline references under `tools/habitat-harness/baselines/**`, without D8
+  editing baseline truth.
+- Human and JSON command output for registration refusals.
+- Docs, examples, and capability guidance that describe pattern lifecycle.
 
 ## Stop Conditions
 
-- Generated pattern candidates become enforced rules automatically.
-- Pattern status inferred from file presence.
-- Governance states are unnamed or optional.
+Stop D8 implementation if any of these remain true:
 
-## Verification Gates
+- Candidate output can be selected as an active rule by file presence.
+- A `rules.json` row, `gritPattern`, `hookScope`, baseline file, Grit
+  frontmatter, or generator option can imply D8 admission.
+- Diagnostic admission can be consumed as apply admission.
+- Hook eligibility can be inferred from rule lane without a D8 hook-admission
+  projection.
+- D8 reads whole registry rows, raw baseline files, or raw Grit reports where
+  D2/D5/D6 projections are required.
+- Refusal outcomes are error-string parsing rather than typed admission
+  results with compatibility messages projected at boundaries.
+- Existing active Grit rules without `manifestPath` are treated as complete D8
+  admitted patterns.
 
-- bun run --cwd tools/habitat-harness test -- test/rules/pattern-authority-manifest.test.ts
-- bun run habitat classify tools/habitat-harness/src/rules/rules.json
-- bun run openspec -- validate deep-habitat-d8-pattern-governance --strict
-- `bun run openspec:validate`
-- `git diff --check`
+## Design-Time Validation
+
+- `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict`.
+- `bun run openspec:validate`.
+- `git diff --check`.
+- Complete-standard wording audit over `$D8_CHANGE/**` and
+  `$AGENT_SCRATCH/domino-D8-*.md`.
+- Fresh final D8 domain/ontology, TypeScript/validation, OpenSpec/information,
+  code/topology, and cross-domino rereviews with no unresolved P1/P2.
+
+These gates accept D8 for design/specification only. They do not implement
+source behavior.

--- a/openspec/changes/deep-habitat-d8-pattern-governance/specs/habitat-harness/spec.md
+++ b/openspec/changes/deep-habitat-d8-pattern-governance/specs/habitat-harness/spec.md
@@ -1,13 +1,276 @@
 ## ADDED Requirements
 
-### Requirement: D8 Pattern Governance Is Resolved Before Implementation
+### Requirement: Pattern Governance Owns Pattern Admission
 
-Habitat Pattern Governance SHALL define explicit candidate, reviewed, registered, refused, and retired states before a generated or cataloged pattern can affect enforcement.
+Habitat SHALL use D8 Pattern Governance as the single owner of pattern
+lifecycle admission, refusal, and retirement.
 
-#### Scenario: Candidate pattern is generated
-- **WHEN** a pattern generator creates a draft
-- **THEN** Habitat marks it as non-enforcing until Pattern Authority admits it
+#### Scenario: Candidate draft is generated
+- **WHEN** a pattern candidate is generated from a supported request
+- **THEN** Habitat records `candidate-draft`
+- **AND** the candidate has no active rule, baseline, hook, diagnostic
+  admission, local-feedback admission, or apply admission projection.
 
-#### Scenario: Pattern is registered
-- **WHEN** Pattern Authority accepts a pattern
-- **THEN** the registry records lifecycle state, owner, diagnostic relation, and baseline policy before enforcement consumes it
+#### Scenario: Candidate enters review
+- **WHEN** a candidate is selected for Pattern Authority review
+- **THEN** Habitat records `candidate-under-review`
+- **AND** the state lists every required admission input still needed before
+  diagnostic, local-feedback, or apply use.
+
+#### Scenario: Pattern is admitted for diagnostics
+- **WHEN** D8 has a valid Pattern Authority decision, D2 governance/Grit facts,
+  D5 baseline authority projection, D6 diagnostic capability, fixture strategy,
+  false-positive assessment, and current-tree disposition
+- **THEN** Habitat records `diagnostic-admitted`
+- **AND** the projection states that diagnostic admission is not apply admission.
+
+#### Scenario: Pattern is admitted for local feedback
+- **WHEN** a diagnostic-admitted pattern has an explicit hook/local-feedback
+  admission decision and the required D7/D10/D11 inputs
+- **THEN** Habitat records `local-feedback-admitted`
+- **AND** D11 remains the owner of hook sequencing, staged-file behavior, and
+  local output.
+
+#### Scenario: Pattern is admitted for apply consideration
+- **WHEN** a pattern has explicit apply admission inputs and D9-owned
+  transaction-safety references
+- **THEN** Habitat records `apply-admitted`
+- **AND** D9 remains the owner of dry-run, live writes, rollback, path approval,
+  formatter handoff, and recovery.
+
+#### Scenario: Admission is refused
+- **WHEN** any required admission input is missing, malformed, contradicted,
+  refused by its owner, or incompatible with public-surface rules
+- **THEN** Habitat records `refused`
+- **AND** the refusal names one D8 refusal reason and protected paths that were
+  not written.
+
+#### Scenario: Pattern is retired
+- **WHEN** a previously admitted pattern is withdrawn
+- **THEN** Habitat records `retired`
+- **AND** new diagnostic, local-feedback, or apply consumption requires a new
+  admission decision.
+
+### Requirement: Candidate Artifacts Are Never Active Authority
+
+Candidate files, candidate manifests, and generator options SHALL NOT act as
+active diagnostic, baseline, hook, or apply authority.
+
+#### Scenario: Candidate has active-looking Grit markdown
+- **WHEN** a candidate Markdown file exists under the candidate root
+- **THEN** Habitat treats it as candidate material only
+- **AND** it is not loaded as an active Grit check by D8 admission.
+
+#### Scenario: Candidate tries to mark registration accepted
+- **WHEN** candidate metadata says registration is accepted
+- **THEN** Habitat records `manifest-invalid-candidate`
+- **AND** registration refuses before active writes.
+
+#### Scenario: Candidate collides with active surfaces
+- **WHEN** candidate generation would collide with an active Grit pattern,
+  baseline file, or `rules.json` row
+- **THEN** Habitat refuses the candidate request before writing candidate files.
+
+#### Scenario: Candidate carries baseline or hook state
+- **WHEN** candidate input includes baseline, hook, diagnostic, or apply state
+  that only admitted patterns may carry
+- **THEN** Habitat refuses or records invalid candidate state
+- **AND** no adjacent owner consumes that input as authority.
+
+### Requirement: Manifest Validation Is Necessary But Not Sufficient
+
+A valid Pattern Authority manifest SHALL be one admission input, not complete
+admission by itself.
+
+#### Scenario: Manifest is missing
+- **WHEN** registered promotion lacks a manifest path
+- **THEN** Habitat records `missing-manifest`
+- **AND** no active Grit pattern or rule row is written.
+
+#### Scenario: Manifest is malformed
+- **WHEN** a manifest is not a valid Pattern Authority object
+- **THEN** Habitat records `malformed-manifest`.
+
+#### Scenario: Manifest uses placeholder authority
+- **WHEN** manifest decision fields contain placeholders or unresolved template
+  language
+- **THEN** Habitat records `placeholder-manifest`.
+
+#### Scenario: Grit metadata is presented as Habitat authority
+- **WHEN** Grit frontmatter, Markdown prose, or a native Grit sample is the only
+  authority input
+- **THEN** Habitat records `grit-metadata-only`.
+
+#### Scenario: Nx generator options are presented as Habitat authority
+- **WHEN** generator options or schema fields are the only authority input
+- **THEN** Habitat records `nx-options-only`.
+
+#### Scenario: Manifest validation succeeds
+- **WHEN** a manifest passes structure validation
+- **THEN** Habitat still requires D2, D5, D6, and applicable D7/D10/D9/D13
+  admission inputs before recording an admitted state.
+
+### Requirement: Registry Metadata Is Consumed Through D2 Projections
+
+D8 SHALL consume D2 registry projections and SHALL NOT treat whole registry rows
+or optional fields as Pattern Governance authority.
+
+#### Scenario: Governance facts are available
+- **WHEN** D2 publishes `ruleGovernanceFacts` for a pattern
+- **THEN** D8 may consume the governance relation and manifest reference.
+
+#### Scenario: Grit facts are available
+- **WHEN** D2 publishes `ruleGritFacts`
+- **THEN** D8 may consume pattern identity and scan-root relation through D2/D6
+  projections.
+
+#### Scenario: Baseline facts are available
+- **WHEN** D2 publishes `ruleBaselineFacts`
+- **THEN** D8 may relate the pattern to D5 baseline authority without reading
+  baseline truth locally.
+
+#### Scenario: Only broad rule row exists
+- **WHEN** only `lane`, `scope`, `gritPattern`, `hookScope`, or `manifestPath`
+  field presence is available
+- **THEN** D8 does not record admission from those fields alone.
+
+### Requirement: Baseline Authority Is Consumed Through D5
+
+D8 SHALL consume D5 baseline authority projection or refusal result and SHALL
+NOT define baseline truth.
+
+#### Scenario: Baseline projection accepts empty baseline
+- **WHEN** D5 publishes an accepted explicit-empty baseline projection
+- **THEN** D8 may use that as one diagnostic admission input.
+
+#### Scenario: Baseline projection accepts debt
+- **WHEN** D5 publishes accepted explicit debt
+- **THEN** D8 may use that projection without erasing D8 admission inputs.
+
+#### Scenario: Baseline authority refuses
+- **WHEN** D5 refuses baseline authority
+- **THEN** D8 records a baseline-related refusal and does not admit the pattern.
+
+#### Scenario: Baseline file exists without authority projection
+- **WHEN** a baseline JSON file exists but no D5 projection is available
+- **THEN** D8 does not treat file presence as admission input.
+
+### Requirement: Diagnostic Capability Is Consumed Through D6
+
+D8 SHALL consume D6 diagnostic capability and diagnostic projections without
+owning Grit acquisition or diagnostic catalog behavior.
+
+#### Scenario: Diagnostic capability is accepted
+- **WHEN** D6 publishes accepted diagnostic identity, fixture/sample result,
+  injected-probe result where required, and diagnostic non-claims
+- **THEN** D8 may use those as diagnostic-admission inputs.
+
+#### Scenario: Diagnostic identity is missing or unexpected
+- **WHEN** D6 reports missing, unexpected, malformed, or projection-missed
+  diagnostic identity
+- **THEN** D8 refuses diagnostic admission.
+
+#### Scenario: Native Grit command passes
+- **WHEN** native Grit command execution passes
+- **THEN** D8 does not infer admission unless the D6 projection and remaining
+  D8 inputs are present.
+
+#### Scenario: Diagnostic pattern has no apply admission
+- **WHEN** a pattern is diagnostic-admitted only
+- **THEN** D9 cannot consume it as apply-ready.
+
+### Requirement: Local Feedback Admission Is Explicit
+
+D8 SHALL make local-feedback admission explicit and SHALL NOT infer hook
+eligibility from rule lane, Grit metadata, or generator output.
+
+#### Scenario: Hook decision is none
+- **WHEN** a diagnostic-admitted pattern declares no local-feedback admission
+- **THEN** Habitat does not publish a local-feedback admission projection.
+
+#### Scenario: Pre-commit local feedback is admitted
+- **WHEN** D8 records local-feedback admission for an enforced diagnostic
+  pattern and D11-compatible inputs are present
+- **THEN** Habitat publishes local-feedback eligibility
+- **AND** D11 still owns hook sequencing and staged-file behavior.
+
+#### Scenario: Hook scope mismatches registry relation
+- **WHEN** Pattern Authority state and D2/D11-facing hook relation disagree
+- **THEN** Habitat records `hook-scope-mismatch`.
+
+#### Scenario: Advisory pattern requests pre-commit hook scope
+- **WHEN** advisory diagnostic admission requests pre-commit local feedback
+- **THEN** Habitat refuses local-feedback admission.
+
+### Requirement: Apply Admission Is Separate From Diagnostics
+
+D8 SHALL separate apply admission from diagnostic admission and SHALL NOT allow
+diagnostic registration to imply write capability.
+
+#### Scenario: Diagnostic pattern claims apply safety
+- **WHEN** a `grit-check` diagnostic pattern carries apply-ready fields
+- **THEN** Habitat records `apply-safety-contradicted`
+- **AND** D9 receives no apply-admission projection.
+
+#### Scenario: Apply pattern lacks transaction inputs
+- **WHEN** an apply-capable pattern lacks D9-owned dry-run, no-write, diff,
+  rollback, type/test, protected-path, or recovery inputs
+- **THEN** Habitat records `apply-safety-missing`.
+
+#### Scenario: Apply admission is published
+- **WHEN** D8 records `apply-admitted`
+- **THEN** the D9 projection contains pattern identity, manifest path,
+  D9-owned transaction inputs, protected-zone/host-policy references where
+  applicable, and non-claims.
+
+#### Scenario: Apply transaction fails
+- **WHEN** D9 reports a transaction failure
+- **THEN** D8 does not convert that failure into diagnostic admission state.
+
+### Requirement: Refusal Reasons Are Stable
+
+D8 SHALL represent refusal as first-class lifecycle output with closed reason
+names.
+
+#### Scenario: Owner projection is missing
+- **WHEN** required D2, D5, D6, D7, D10, D11, D9, D13, or G-HOST projection is
+  missing for the requested admission
+- **THEN** D8 records a refusal naming the missing owner input.
+
+#### Scenario: Public compatibility is missing
+- **WHEN** later implementation would change public or durable surfaces without
+  concrete D0 rows
+- **THEN** D8 records `public-surface-compatibility-missing` and source
+  implementation stops.
+
+#### Scenario: Retired pattern is referenced as active
+- **WHEN** a retired pattern is selected for diagnostic, local-feedback, or
+  apply consumption
+- **THEN** D8 records `retired-pattern-referenced`.
+
+### Requirement: Downstream Consumers Receive Narrow Projections
+
+D8 SHALL publish consumer-specific projections and SHALL NOT expose whole
+Pattern Authority manifests to downstream owners as their target API.
+
+#### Scenario: D9 consumes apply admission
+- **WHEN** D9 needs apply eligibility
+- **THEN** it receives `ApplyAdmissionProjection`
+- **AND** it does not read diagnostic admission or whole manifest state as write
+  authority.
+
+#### Scenario: D13 consumes candidate state
+- **WHEN** D13 creates or reports a generated pattern candidate
+- **THEN** it receives `CandidateHandoffProjection`
+- **AND** it does not write active `.grit`, baseline, rule registry, hook, or
+  apply state by implication.
+
+#### Scenario: D11 consumes local-feedback eligibility
+- **WHEN** local feedback needs pattern eligibility
+- **THEN** it receives local-feedback eligibility through D8/D7/D10 projections
+- **AND** it does not infer eligibility from rule lane or hook fields alone.
+
+#### Scenario: Recovery consumes refusal
+- **WHEN** recovery guidance is needed
+- **THEN** it receives `PatternRecoveryProjection` with owner, refusal or
+  retirement reason, next action, and non-claims.

--- a/openspec/changes/deep-habitat-d8-pattern-governance/tasks.md
+++ b/openspec/changes/deep-habitat-d8-pattern-governance/tasks.md
@@ -1,33 +1,146 @@
 # Tasks
 
-## 1. Pre-Implementation Grounding
+## 1. Packet Readiness
 
-- [ ] 1.1 Read `D8-pattern-governance.md`, the remediation frame, D0 compatibility records,
-  and this OpenSpec packet.
-- [ ] 1.2 Confirm the branch/worktree starts from the approved implementation
-  stack and is clean before source edits.
-- [ ] 1.3 Record the concrete write set and protected paths in the phase record.
-- [ ] 1.4 Re-run or cite the required dependency gates: D0, D2, D5, D6.
+- [ ] 1.1 Read `$D8_SOURCE_PACKET`, `$D8_CHANGE/**`,
+  `$REMEDIATION_DIR/context.md`, and accepted D0-D7 packets before source
+  edits.
+- [ ] 1.2 Confirm active branch/worktree with `git status --short --branch` and
+  `gt status`.
+- [ ] 1.3 Confirm concrete D0 rows exist for every public/durable surface the
+  implementation touches; stop where rows are missing.
+- [ ] 1.4 Confirm D1 output-family citations for any user-facing D8 command
+  outcome, refusal message, or JSON field changed by implementation.
+- [ ] 1.5 Confirm live D2 `ruleGovernanceFacts`, `ruleGritFacts`, and
+  `ruleBaselineFacts` projections exist where D8 source reads registry
+  relations.
+- [ ] 1.6 Confirm live D5 `BaselineAuthorityProjection` or baseline refusal
+  result exists where D8 admission depends on baseline state.
+- [ ] 1.7 Confirm live D6 diagnostic capability/projection inputs exist where
+  D8 admits diagnostic patterns.
+- [ ] 1.8 Confirm D7/D10/G-HOST/D11/D9 prerequisites for any current-tree,
+  protected-zone, host-policy, local-feedback, or apply-admission behavior the
+  implementation touches.
 
-## 2. Implementation
+## 2. Current Behavior Characterization
 
-- [ ] 2.1 Define pattern lifecycle states and admission gates.
-- [ ] 2.2 Separate generated candidate drafts from registered enforcement.
-- [ ] 2.3 Connect governance to D2 facets and D5 baselines.
+- [ ] 2.1 Characterize current Pattern Authority manifest validation behavior in
+  `tools/habitat-harness/src/rules/pattern-authority/manifest.ts`.
+- [ ] 2.2 Characterize current candidate generation behavior in
+  `tools/habitat-harness/src/generators/pattern/generator.cjs`.
+- [ ] 2.3 Characterize current registered promotion behavior in
+  `tools/habitat-harness/src/generators/pattern/registration.cjs`.
+- [ ] 2.4 Characterize current active rule registry and Grit catalog state,
+  including legacy rows without `manifestPath`.
+- [ ] 2.5 Record characterization output in the implementation phase record
+  before semantic migration.
 
-## 3. Validation
+## 3. Pattern Authority State Model
 
-- [ ] 3.1 Run `bun run --cwd tools/habitat-harness test -- test/rules/pattern-authority-manifest.test.ts`.
-- [ ] 3.2 Run `bun run habitat classify tools/habitat-harness/src/rules/rules.json`.
-- [ ] 3.3 Run `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict`.
-- [ ] 3.4 Run `bun run openspec:validate`.
-- [ ] 3.5 Run `git diff --check`.
+- [ ] 3.1 Add a closed D8 state model for `candidate-draft`,
+  `candidate-under-review`, `manifest-invalid-candidate`,
+  `diagnostic-admitted`, `local-feedback-admitted`, `apply-admitted`,
+  `refused`, and `retired`.
+- [ ] 3.2 Add lifecycle-specific constructors or equivalent typed functions so
+  registered admission without manifest path, local-feedback admission without
+  hook decision, and apply admission without D9 inputs are not representable in
+  target internals.
+- [ ] 3.3 Keep existing manifest JSON and generator CLI behavior as
+  compatibility projections until D0 rows authorize public changes.
+- [ ] 3.4 Replace internal `authorityAccepted: boolean` decisions with state
+  narrowing, while preserving boundary compatibility if required.
 
-## 4. Review And Realignment
+## 4. Candidate And Manifest Admission
 
-- [ ] 4.1 Run domain-language, OpenSpec, TypeScript, validation, and
-  cross-domino review lanes.
-- [ ] 4.2 Repair accepted P1/P2 findings before packet closure.
-- [ ] 4.3 Update downstream docs, examples, specs, tests, and packet index rows
-  affected by implementation facts.
-- [ ] 4.4 Leave the worktree clean or write a zero-context next packet.
+- [ ] 4.1 Preserve candidate generation as candidate-only output: candidate
+  files, no active rule row, no baseline, no hook eligibility, no apply
+  projection.
+- [ ] 4.2 Convert candidate invalidity into `manifest-invalid-candidate` or
+  `refused` state before active writes.
+- [ ] 4.3 Preserve missing, malformed, placeholder, contradicted, orphan,
+  Grit-metadata-only, and Nx-options-only manifest refusals as typed D8
+  refusal outcomes.
+- [ ] 4.4 Ensure manifest validation success still waits for required D2/D5/D6
+  and applicable D7/D10/D9/D13 inputs.
+
+## 5. Diagnostic And Local-Feedback Admission
+
+- [ ] 5.1 Consume D2 governance/Grit facts and D6 diagnostic projections instead
+  of whole registry rows or raw Grit output.
+- [ ] 5.2 Consume D5 baseline authority projection or refusal result instead of
+  loading baseline truth locally.
+- [ ] 5.3 Build `DiagnosticAdmissionProjection` for admitted diagnostic
+  patterns.
+- [ ] 5.4 Build `LocalFeedbackAdmissionProjection` only after explicit
+  local-feedback admission and applicable D7/D10/D11 inputs.
+- [ ] 5.5 Preserve hook-scope mismatch and advisory-pre-commit refusals before
+  writes.
+
+## 6. Apply Admission Handoff
+
+- [ ] 6.1 Keep diagnostic admission and apply admission as separate states.
+- [ ] 6.2 Refuse diagnostic patterns that claim apply-ready state.
+- [ ] 6.3 Refuse apply admission without D9-owned transaction inputs,
+  protected-path references, and applicable D10/G-HOST decisions.
+- [ ] 6.4 Publish `ApplyAdmissionProjection` only for `apply-admitted` state.
+- [ ] 6.5 Do not edit `tools/habitat-harness/src/lib/grit-apply.ts` or apply
+  patterns unless D9 owns that implementation slice.
+
+## 7. Consumer Projections
+
+- [ ] 7.1 Add projection builders so rule registry, diagnostic catalog,
+  baseline relation, local feedback, apply transaction, and recovery consumers
+  cannot consume whole Pattern Authority manifests as their target API.
+- [ ] 7.2 Add tests proving diagnostic consumers receive no apply fields.
+- [ ] 7.3 Add tests proving D9 receives only apply-admission projection.
+- [ ] 7.4 Add tests proving D13 receives candidate handoff/refusal projection
+  and cannot register active state by implication.
+- [ ] 7.5 Add tests proving retired patterns cannot be consumed as active
+  without a new admission decision.
+
+## 8. Validation
+
+- [ ] 8.1 Run `bun run --cwd tools/habitat-harness test -- test/rules/pattern-authority-manifest.test.ts test/generators/pattern-generator.test.ts`.
+- [ ] 8.2 Run focused D8 type-state/projection tests added by the implementation.
+- [ ] 8.3 Run `bun run habitat check --rule baseline-integrity --json` where
+  registered pattern admission touches baseline state.
+- [ ] 8.4 Run native Grit pattern sample tests only for pattern files touched by
+  implementation, recording that this validates vendor pattern behavior, not
+  D8 admission.
+- [ ] 8.5 Run `bun run habitat classify tools/habitat-harness/src/rules/rules.json`
+  and
+  `bun run habitat classify tools/habitat-harness/src/rules/pattern-authority/manifest.ts`
+  as routing observations with non-claims.
+- [ ] 8.6 Run `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict`.
+- [ ] 8.7 Run `bun run openspec:validate`.
+- [ ] 8.8 Run `git diff --check`.
+- [ ] 8.9 Run `git status --short --branch` and `gt status`.
+
+## 9. Downstream Realignment
+
+- [ ] 9.1 Update D9 handoff records so D9 consumes only
+  `ApplyAdmissionProjection` or explicit D8 apply refusal.
+- [ ] 9.2 Update D13 handoff records so candidate generation remains
+  candidate-only and registration requests are handed to D8.
+- [ ] 9.3 Update D11/D7 handoff records where local-feedback admission is
+  consumed.
+- [ ] 9.4 Update recovery docs/ledgers where refusal or retirement states are
+  user-visible.
+- [ ] 9.5 Update public docs/examples only for D0-approved compatibility
+  changes.
+
+## 10. Design/Specification Closure
+
+- [ ] 10.1 Import D8 first-wave investigation findings into
+  `$D8_REVIEW_LEDGER`.
+- [ ] 10.2 Repair all accepted P1/P2 findings in packet artifacts.
+- [ ] 10.3 Run complete-standard wording audit over `$D8_CHANGE/**` and
+  `$AGENT_SCRATCH/domino-D8-*.md`.
+- [ ] 10.4 Run fresh final D8 domain/ontology, TypeScript/validation,
+  OpenSpec/information, code/topology, and cross-domino rereviews against the
+  repaired disk state.
+- [ ] 10.5 Update `$D8_PHASE_RECORD`, `$D8_REVIEW_LEDGER`,
+  `$D8_DOWNSTREAM_LEDGER`, `$D8_CLOSURE_CHECKLIST`, and packet index only after
+  final rereviews record no unresolved P1/P2.
+- [ ] 10.6 Mark D8 accepted for design/specification only, not
+  implementation-complete.

--- a/openspec/changes/deep-habitat-d8-pattern-governance/workstream/closure-checklist.md
+++ b/openspec/changes/deep-habitat-d8-pattern-governance/workstream/closure-checklist.md
@@ -1,20 +1,59 @@
 # Closure Checklist: D8 Pattern Governance
 
-## Design Readiness
+## Design/Specification Acceptance
 
-- [ ] Proposal cites controlling authority and source packet.
-- [ ] Design resolves naming, domain owner, forbidden owners, and non-goals.
-- [ ] Tasks are implementation steps, not unresolved design questions.
-- [ ] Spec delta uses normative SHALL language with scenarios.
-- [ ] Review ledger has no accepted unresolved P1/P2 findings.
-- [ ] Downstream realignment is recorded.
-- [ ] OpenSpec validation passes for `deep-habitat-d8-pattern-governance`.
+- [x] Proposal cites controlling authority, source packet, dependency state, and
+  public/durable surfaces.
+- [x] Design defines current behavior diagnosis, domain boundary, vendor
+  boundary, target ontology, term disposition, consumed contracts, downstream
+  projections, refusal taxonomy, state model, write set, protected paths,
+  validation, and non-claims.
+- [x] Spec delta contains normative requirement families for lifecycle
+  admission, candidate non-authority, manifest validation, D2/D5/D6 consumption,
+  local-feedback admission, apply admission, refusal, and downstream
+  projections.
+- [x] Tasks are executable implementation slices and closure gates, not design
+  prompts.
+- [x] Review ledger imports D8 first-wave P1/P2 findings as accepted and
+  repaired by the current packet, then cites final rereview acceptance.
+- [x] Downstream ledger names D0, D1, D2, D5, D6, D7, D10/G-HOST, D9, D11, D13,
+  recovery, docs, tests, and packet index handoffs.
+- [x] Complete-standard wording audit over `$D8_CHANGE/**`,
+  `$AGENT_SCRATCH/domino-D8-*.md`, and `$PACKET_INDEX` returns only the D13
+  source packet title and slug; those two rows are classified narrowly as exact
+  traceability text rather than D8 guidance.
+- [x] `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict`
+  passes.
+- [x] `bun run openspec:validate` passes.
+- [x] `git diff --check` passes.
+- [x] Fresh final D8 domain/ontology rereview records no unresolved P1/P2.
+- [x] Fresh final D8 TypeScript/validation rereview records no unresolved P1/P2.
+- [x] Fresh final D8 OpenSpec/information rereview records no unresolved P1/P2.
+- [x] Fresh final D8 code/topology rereview records no unresolved P1/P2.
+- [x] Fresh final D8 cross-domino rereview records no unresolved P1/P2.
+- [x] Packet index updated after final rereviews and validation passed.
 
-## Implementation Closure (Later)
+## Source Implementation Closure (Later)
 
+- [ ] Source implementation starts only after D8 accepted design/specification
+  and concrete blockers in `$D8_PHASE_RECORD` are satisfied.
 - [ ] Source changes stay inside the approved write set.
-- [ ] Validation gates pass with exact command output recorded.
-- [ ] Public-surface changes are dispositioned through D0 compatibility.
-- [ ] Downstream docs/tests/specs are realigned.
-- [ ] Graphite layer is clean, reviewable, and does not proceed past unresolved
-  packet approval.
+- [ ] Protected paths remain untouched unless their owner packet authorizes the
+  change.
+- [ ] Public-surface changes cite concrete D0 rows.
+- [ ] Command-facing output changes cite D1 output-family decisions.
+- [ ] D8 consumes live D2/D5/D6 projections instead of local whole-record or
+  file-presence authority.
+- [ ] D9/D11/D13 handoffs consume D8 projections and do not recreate lifecycle
+  semantics.
+- [ ] Implementation validation gates in `$D8_CHANGE/tasks.md` pass with exact
+  results recorded.
+- [ ] Graphite layer is clean and reviewable.
+
+## Non-Closure Notes
+
+- D8 is not implementation-complete after design/specification acceptance.
+- Existing active Grit rules without complete Pattern Authority manifests remain
+  compatibility facts, not complete D8 admissions.
+- Native Grit samples, baseline checks, and clean git status do not replace D8
+  lifecycle/admission validation.

--- a/openspec/changes/deep-habitat-d8-pattern-governance/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/deep-habitat-d8-pattern-governance/workstream/downstream-realignment-ledger.md
@@ -1,9 +1,29 @@
 # Downstream Realignment Ledger: D8 Pattern Governance
 
-| Downstream Surface | Disposition | Required Action |
-| --- | --- | --- |
-| Phase 2 packet suite | pending | Mark D8 as OpenSpec-packetized after review. |
-| D0 compatibility matrix | pending | Confirm public surfaces touched by D8 are classified before implementation. |
-| Habitat docs/examples | pending | Update only when implementation facts change or public guidance must be clarified. |
-| Tests and command fixtures | pending | Add or update during implementation according to tasks.md. |
-| Later domino packets | pending | Update dependency assumptions if review changes D8 contract. |
+## Status
+
+D8 downstream realignment is accepted for design/specification only after final
+rereview. No downstream source implementation is authorized by this ledger.
+
+| Surface | Disposition | Required Action | Owner / Non-Claim |
+| --- | --- | --- | --- |
+| D0 public-surface matrix | source-blocking prerequisite | Concrete D0 rows must cover touched generator options/output, manifest JSON, validation reasons, package exports, `rules.json`, command messages, docs/examples, and generated/help surfaces. | D8 does not decide compatibility handling. |
+| D1 output/refusal families | source-blocking prerequisite | D8 command-facing refusals must cite D1 output-family terms before source implementation changes messages or JSON. | D8 does not create a new output family locally. |
+| D2 registry metadata | source-blocking prerequisite | D8 consumes `ruleGovernanceFacts`, `ruleGritFacts`, and `ruleBaselineFacts`; later source work must not read whole registry rows as admission authority. | D2 owns registry projections. |
+| D5 baseline authority | source-blocking prerequisite | D8 consumes `BaselineAuthorityProjection` or baseline refusal result for registered admission. | D5 owns baseline truth, growth, shrink-only integrity, and external exception projection. |
+| D6 diagnostic catalog | source-blocking prerequisite | D8 consumes diagnostic capability, identity, fixture/sample result, injected probe result, limitation, and non-claims. | D6 owns diagnostic acquisition/projection and Grit adapter behavior. |
+| D7 structural enforcement | conditional source prerequisite and downstream consumer | D8 consumes D7 current-tree/check outcome only when admission requires that input; D7 consumes D8 diagnostic/local-feedback eligibility through projections. | D7 owns report construction, rendering, and exit semantics. |
+| D10/G-HOST protected and host policy | conditional source prerequisite | D8 consumes protected/generated-zone and host-policy decisions for scan roots, probes, apply paths, or host gates. | D8 must not encode host-specific policy. |
+| D9 transformation transaction | downstream design may consume accepted D8 projections; source remains blocked behind live D8 facts | D9 consumes only `ApplyAdmissionProjection` or explicit apply refusal from D8. | D9 may not promote diagnostic admission to write authority; D9 owns transaction execution. |
+| D11 local feedback | downstream/indirect consumer | D11 consumes local-feedback eligibility only through D8/D7/D10 projections. | D11 owns hook sequencing, staged-file behavior, local output, and local-feedback non-claims. |
+| D13 generator and refusal | downstream design may consume accepted D8 projections; source remains blocked behind live D8 facts | D13 may create candidate drafts and hand registration to D8 through `CandidateHandoffProjection`. | D13 must not write active Grit patterns, rule rows, baseline state, hook eligibility, or apply admission by implication. |
+| Recovery ledgers | downstream update after implementation facts | Refused and retired patterns publish `PatternRecoveryProjection` with owner, reason, next action, and non-claims. | Recovery records do not create admission. |
+| Docs/examples | update only for public guidance changes | Capability docs and examples may need D0-approved updates after source implementation. | Stale current counts are not D8 topology authority. |
+| Tests/fixtures | implementation validation input | Add focused D8 state/projection tests and update existing manifest/generator tests during implementation. | Native Grit samples validate vendor pattern behavior, not D8 admission. |
+| Packet index | accepted for design/specification only | Packet index may mark D8 accepted for design/specification after final rereviews and validation passed. | D8 remains not implementation-complete. |
+
+## Downstream Acceptance Language
+
+If final rereviews pass, the packet index row may say:
+
+`accepted for design/specification; final domain/ontology, TypeScript/validation, OpenSpec/information, code/topology, and cross-domino rereviews found no unresolved P1/P2 blockers; not implementation-complete; source implementation remains blocked behind concrete D0 rows, D1 output-family citations, live D2 ruleGovernanceFacts/ruleGritFacts/ruleBaselineFacts, D5 BaselineAuthorityProjection, D6 diagnostic projections, accepted D7 check outcome projections where consumed, and D10/G-HOST protected-zone or host-policy contracts where touched`.

--- a/openspec/changes/deep-habitat-d8-pattern-governance/workstream/phase-record.md
+++ b/openspec/changes/deep-habitat-d8-pattern-governance/workstream/phase-record.md
@@ -2,35 +2,92 @@
 
 ## State
 
-- Status: OpenSpec packet drafted for remediation review; implementation not
-  started.
-- Worktree: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation.
-- Branch: codex/deep-habitat-openspec-remediation.
-- Source packet: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D8-pattern-governance.md.
-- OpenSpec change: openspec/changes/deep-habitat-d8-pattern-governance/.
+- Status: accepted for design/specification only after final rereview; not
+  implementation-complete.
+- Worktree: `$ACTIVE_REMEDIATION_WORKTREE`.
+- Branch: `$ACTIVE_REMEDIATION_BRANCH`.
+- Source packet: `$D8_SOURCE_PACKET`.
+- OpenSpec change: `$D8_CHANGE`.
+- Implementation status: not started; source implementation remains blocked
+  behind the dependency state below.
 
 ## Objective
 
-Convert D8 into a review-gated OpenSpec packet scaffold for Pattern Governance
-without reopening implementation or carrying forward lazy domain language.
+Specify complete Pattern Governance lifecycle and admission before source
+implementation. D8 must prevent candidate, diagnostic, local-feedback, apply,
+refused, and retired pattern states from being inferred from file presence,
+registry fields, baseline files, Grit metadata, generator options, or adjacent
+domain behavior.
 
 ## Current Gate
 
-Design/preparation gate. The packet can authorize later implementation only
-after review ledgers contain no accepted unresolved P1/P2 findings.
+Design/specification gate closed after final D8 domain/ontology,
+TypeScript/validation, OpenSpec/information, code/vendor topology, and
+cross-domino rereviews found no unresolved P1/P2 findings. Source
+implementation remains a later phase.
 
-## Exact Validation Gates
+## Investigation Inputs
 
-- bun run --cwd tools/habitat-harness test -- test/rules/pattern-authority-manifest.test.ts
-- bun run habitat classify tools/habitat-harness/src/rules/rules.json
-- bun run openspec -- validate deep-habitat-d8-pattern-governance --strict
-- bun run openspec:validate
-- git diff --check
+| Input | Status | Use |
+| --- | --- | --- |
+| `$D8_DOMAIN_REVIEW` | imported negative-control findings | Domain language, ontology, naming, owner boundaries. |
+| `$D8_TYPESCRIPT_REVIEW` | imported negative-control findings | Type-state collapse, write/protected set, validation. |
+| `$D8_TOPOLOGY_REVIEW` | imported negative-control findings | Code topology, vendor ownership, public surfaces. |
+| `$D8_INFORMATION_REVIEW` | imported negative-control findings | OpenSpec shape, requirements, closure gates. |
+| `$D8_CROSS_DOMINO_REVIEW` | imported negative-control findings | Upstream dependencies and downstream handoffs. |
+
+These files are not final acceptance evidence. They are the findings input for
+this repaired packet.
+
+## Dependency State
+
+| Dependency | D8 use | Source blocker |
+| --- | --- | --- |
+| D0 | Public/durable compatibility rows. | Source edits stop wherever concrete D0 rows are missing. |
+| D1 | User-facing refusal/output families. | Source edits stop wherever D8 changes command output without D1 citation. |
+| D2 | `ruleGovernanceFacts`, `ruleGritFacts`, `ruleBaselineFacts`. | Source edits stop where live projections are absent and whole-row reads would be needed. |
+| D5 | `BaselineAuthorityProjection` or baseline refusal. | Source edits stop where D8 would decide baseline truth locally. |
+| D6 | Diagnostic capability and diagnostic projections. | Source edits stop where D8 would parse raw Grit or infer diagnostic identity locally. |
+| D7 | Check/current-tree outcomes consumed as admission inputs. | Source edits stop where D7 projections are absent and current-tree outcome is needed. |
+| D10/G-HOST | Protected/generated-zone and host-policy decisions. | Source edits stop where touched paths/gates require those authorities. |
+| D9 | Apply transaction inputs and non-claims. | D8 may publish apply admission only; D9 owns transaction execution. |
+| D13 | Candidate generation and generator refusal surfaces. | D13 creates candidates; D8 owns registration/admission. |
+
+## Design-Time Validation
+
+| Gate | Command or check | Expected result | Non-claim |
+| --- | --- | --- | --- |
+| D8 strict OpenSpec | `bun run openspec -- validate deep-habitat-d8-pattern-governance --strict` | passed | Does not prove source behavior. |
+| Full OpenSpec | `bun run openspec:validate` | passed, 249 items | Does not prove Habitat runtime behavior. |
+| Diff hygiene | `git diff --check` | passed | Whitespace/path hygiene only. |
+| Wording audit | `rg -n -i "<audit terms>" $D8_CHANGE $PACKET_INDEX $AGENT_SCRATCH/domino-D8-*.md` | returned only the D13 source packet title and slug in `$PACKET_INDEX`, classified as exact traceability text rather than D8 guidance | Historical findings may remain only as non-guidance. |
+| Final rereview | `$D8_FINAL_DOMAIN_REVIEW`, `$D8_FINAL_TYPESCRIPT_VALIDATION_REVIEW`, `$D8_FINAL_OPENSPEC_INFORMATION_REVIEW`, `$D8_FINAL_CODE_TOPOLOGY_REVIEW`, `$D8_FINAL_CROSS_DOMINO_REVIEW` | all accepted for design/specification only; no unresolved P1/P2 | Design/specification acceptance only. |
+
+## Later Implementation Validation
+
+| Gate | Required scenario |
+| --- | --- |
+| `bun run --cwd tools/habitat-harness test -- test/rules/pattern-authority-manifest.test.ts test/generators/pattern-generator.test.ts` | Candidate, manifest, registration, hook, baseline, collision, and no-write behaviors. |
+| Focused D8 state/projection tests | Candidate, invalid, diagnostic, local-feedback, apply, refused, and retired states cannot be confused. |
+| `bun run habitat check --rule baseline-integrity --json` | D5 baseline relation where D8 touches registered admission. |
+| Native Grit sample tests for touched patterns | Vendor pattern syntax/behavior only. |
+| `bun run habitat classify tools/habitat-harness/src/rules/rules.json` | Routing observation only. |
+| `bun run habitat classify tools/habitat-harness/src/rules/pattern-authority/manifest.ts` | Routing observation only. |
+| `git status --short --branch` and `gt status` | Stack/worktree hygiene. |
+
+## Write Set
+
+The later source write set is the one listed in `$D8_CHANGE/design.md`. All
+other source, generated, baseline, apply, hook, command-engine, graph, product,
+vendor, cache, lockfile, and generated-output paths are protected unless the
+owning packet explicitly authorizes them.
 
 ## Non-Claims
 
-- This remediation packet does not implement Habitat source changes.
-- This packet does not prove runtime behavior.
-- This packet does not approve Graphite submission for later implementation.
-- Legacy code names remain compatibility facts unless design.md accepts them as
-  target language.
+- This packet does not implement Habitat source changes.
+- D8 design acceptance does not make existing Grit rules complete Pattern
+  Authority admissions.
+- Manifest validation does not prove diagnostic capability, baseline authority,
+  hook eligibility, apply admission, or current-tree behavior.
+- Diagnostic admission does not prove apply admission.
+- Apply admission does not execute or approve writes.

--- a/openspec/changes/deep-habitat-d8-pattern-governance/workstream/review-disposition-ledger.md
+++ b/openspec/changes/deep-habitat-d8-pattern-governance/workstream/review-disposition-ledger.md
@@ -1,10 +1,53 @@
 # Review Disposition Ledger: deep-habitat-d8-pattern-governance
 
+## Status
+
+D8 is accepted for design/specification only after final rereview. It is not
+implementation-complete, and source implementation remains blocked behind the
+dependencies recorded in `$D8_PHASE_RECORD`.
+
+## Imported Findings
+
 | Finding | Severity | Disposition | Repair Evidence |
 | --- | --- | --- | --- |
-| Global domain-language concern catalog applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-domain-adversary.md and docs/projects/habitat-harness/openspec-remediation/review-disposition-ledger.md. Per-domino domain-language review remains blocking. |
-| Global OpenSpec artifact-shape constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-openspec-architect.md and packet traceability index. Per-domino OpenSpec review remains blocking. |
-| Global information-design constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-information-design-reviewer.md and traceability/evidence policy repairs. Per-domino information-design review remains blocking. |
-| Global validation-design constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-testing-validation-designer.md and packet validation gates. Per-domino validation review remains blocking. |
-| Global cross-domino sequencing constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-cross-domino-sequencer.md and dependency/trigger repairs. Per-domino sequencing compatibility review remains blocking. |
-| Per-domino adversarial review gate required before packet acceptance or source edits. | P1 | blocking, pending design-time review | Fresh per-domino domain, OpenSpec, topology, validation, information-design, and cross-domino reviewers must disposition findings before this packet can be accepted or used for implementation. |
+| Current packet did not define complete Pattern Governance lifecycle ontology. | P1 | accepted and repaired | `$D8_CHANGE/design.md` Target Ontology and `$D8_CHANGE/specs/habitat-harness/spec.md` Pattern Governance requirements define candidate, review, invalid, diagnostic, local-feedback, apply, refused, and retired states; final domain/ontology and TypeScript/validation rereviews accepted. |
+| Pattern Governance and Pattern Authority boundary was undefined. | P1 | accepted and repaired | `$D8_CHANGE/design.md` Domain Boundary, Target Ontology, and Consumed Upstream Contracts define D8 owner boundaries and Pattern Authority decision role; final domain/ontology rereview accepted. |
+| D8 consumed-contract matrix was missing. | P1 | accepted and repaired | `$D8_CHANGE/design.md` Consumed Upstream Contracts and `$D8_PHASE_RECORD` Dependency State name D0, D1, D2, D5, D6, D7, D10/G-HOST, D9, and D13 inputs/blockers; final cross-domino rereview accepted. |
+| Refusal taxonomy was absent. | P1 | accepted and repaired | `$D8_CHANGE/design.md` Refusal Taxonomy and spec refusal scenarios define closed refusal families; final domain/ontology rereview accepted. |
+| Consumer projections were absent. | P1 | accepted and repaired | `$D8_CHANGE/design.md` Published Downstream Projections and spec downstream projection requirement define D7/D9/D11/D13/recovery projections; final cross-domino and TypeScript/validation rereviews accepted. |
+| Diagnostic registration and apply admission could still be conflated. | P1 | accepted and repaired | `$D8_CHANGE/design.md` state model and spec apply admission requirement separate diagnostic, local-feedback, and apply admission; final TypeScript/validation rereview accepted. |
+| Write set and protected paths were unresolved. | P1 | accepted and repaired | `$D8_CHANGE/design.md` Write Set and Protected Paths plus `$D8_PHASE_RECORD` write-set note define allowed and protected surfaces; final code/vendor topology rereview accepted. |
+| Public-surface blockers were incomplete. | P1 | accepted and repaired | `$D8_CHANGE/proposal.md` Public And Durable Surfaces and tasks 1.3-1.4 block source implementation behind D0/D1; final OpenSpec/information and code/vendor topology rereviews accepted. |
+| Current active Grit rules without `manifestPath` could be mistaken for complete admission. | P1 | accepted and repaired | `$D8_CHANGE/design.md` Current Behavior Diagnosis and Non-Claims explicitly classify existing rows as compatibility facts; final code/vendor topology rereview accepted. |
+| D8 source dependencies omitted D1 and under-specified D7/D10/G-HOST. | P1 | accepted and repaired | `$D8_CHANGE/proposal.md` Requires and `$D8_PHASE_RECORD` Dependency State add D1 and conditional D7/D10/G-HOST blockers; final cross-domino rereview accepted. |
+| Existing tasks were unresolved design prompts. | P1 | accepted and repaired | `$D8_CHANGE/tasks.md` now gives prerequisite, characterization, state-model, admission, projection, validation, downstream, and closure steps; final OpenSpec/information rereview accepted. |
+| Spec had one broad requirement and two scenarios. | P1 | accepted and repaired | `$D8_CHANGE/specs/habitat-harness/spec.md` now contains multiple normative requirement families and bad-case scenarios; final OpenSpec/information rereview accepted. |
+| Validation gates were too generic. | P2 | accepted and repaired | `$D8_CHANGE/design.md`, `$D8_CHANGE/tasks.md`, and `$D8_PHASE_RECORD` separate design-time gates from later implementation gates and name non-claims; final TypeScript/validation and OpenSpec/information rereviews accepted. |
+| Vendor ownership split was missing. | P1 | accepted and repaired | `$D8_CHANGE/design.md` Vendor Boundary records Grit, Biome, and Nx ownership boundaries; final code/vendor topology rereview accepted. |
+| Downstream D9/D11/D13/G-HOST handoffs were generic. | P2 | accepted and repaired | `$D8_DOWNSTREAM_LEDGER` names downstream owners, allowed facts, forbidden decisions, blockers, and non-claims; final cross-domino rereview accepted. |
+| `$ACTIVE_REMEDIATION_BRANCH` was stale. | P2 | accepted and repaired | `$REMEDIATION_DIR/context.md` now records `codex/d8-pattern-governance-packet` and D8 variables. |
+
+## Final Rereview Evidence
+
+All final rereview files exist and record no unresolved P1/P2 against the
+repaired disk state:
+
+- `$D8_FINAL_DOMAIN_REVIEW`: accepted for design/specification only; one P3 on
+  precise `manifest-invalid-candidate` implementation relationship.
+- `$D8_FINAL_TYPESCRIPT_VALIDATION_REVIEW`: accepted for design/specification
+  only; P3 notes on closure wording classification and source-slice order.
+- `$D8_FINAL_OPENSPEC_INFORMATION_REVIEW`: accepted for design/specification
+  only.
+- `$D8_FINAL_CODE_TOPOLOGY_REVIEW`: accepted for design/specification only; P3
+  notes on stale capability counts, generator description, and vendor-doc URL
+  citation discipline during implementation.
+- `$D8_FINAL_CROSS_DOMINO_REVIEW`: accepted for design/specification only.
+
+## Control Notes
+
+- Global remediation constraints remain applied background constraints, not
+  packet-specific acceptance evidence.
+- The first-wave D8 investigations are negative-control findings input, not
+  final acceptance evidence.
+- Packet index may mark D8 accepted for design/specification only. D8 remains
+  not implementation-complete.


### PR DESCRIPTION
Specify the D8 Pattern Governance OpenSpec packet as accepted for design/specification only. The packet defines the lifecycle/admission state model, Pattern Authority projections, upstream D0/D1/D2/D5/D6/D7/D10/G-HOST blockers, downstream D9/D11/D13 handoffs, final rereview evidence, and control-record closure. D8 remains not implementation-complete and source implementation remains blocked behind the named live facts and compatibility rows.

Validation: complete-standard wording audit with only canonical D13 traceability hits; bun run openspec -- validate deep-habitat-d8-pattern-governance --strict; bun run openspec:validate; git diff --check.