### PR TITLE
docs(habitat): accept D9 transformation transaction packet

### DIFF
--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-code-vendor-topology-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-code-vendor-topology-investigation.md
@@ -1,0 +1,460 @@
+# D9 Code/Vendor Topology Investigation
+
+## Verdict
+
+D9 is blocked from code/vendor topology acceptance in this lane.
+
+The current D9 OpenSpec packet names the right domain object, but it is
+not yet a complete implementation-control authority. It still leaves
+implementation agents to decide public-surface compatibility, transaction
+variants, write-set/protected-path policy, host-specific gates, and the exact
+vendor boundary between Grit, Biome, Git, Nx, and Habitat orchestration.
+
+The highest-risk gap is that current implementation can apply against
+`mods/*/src/maps/**` while D10 generated/protected-zone authority is not yet
+accepted. That includes `mods/mod-swooper-maps/src/maps/generated/**`, which is
+already modeled as generated output elsewhere. D9 cannot be accepted until its
+write authority explicitly consumes D10/G-HOST declarations and refuses those
+paths before any live write.
+
+## Sources Read
+
+- Source packet:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D9-transformation-transaction.md`
+- Current D9 OpenSpec packet:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/**`
+- Packet context/index:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation-frame.md`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/context.md`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/README.md`
+- Current code/tests:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/grit-apply.ts`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/grit.ts`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/habitat-process.ts`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/index.ts`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/commands/fix.ts`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/grit-apply.test.ts`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/.grit/patterns/habitat/apply/deep_import_to_public_surface.md`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/.grit/patterns/habitat/apply/docs_local_checkout_paths_rewrite.md`
+- Related owner packets:
+  D0, D6, D8, D10, and G-HOST source packets.
+- Official vendor docs:
+  - Grit CLI reference: https://docs.grit.io/cli/reference
+  - Grit authoring docs: https://docs.grit.io/guides/authoring
+  - Grit testing docs: https://docs.grit.io/guides/testing
+  - Biome CLI reference: https://biomejs.dev/reference/cli/
+  - Biome CI recipe: https://biomejs.dev/recipes/continuous-integration/
+  - Nx project graph plugin docs: https://nx.dev/docs/extending-nx/project-graph-plugins
+  - Nx inferred tasks docs: https://nx.dev/docs/concepts/inferred-tasks
+  - Nx task inputs docs: https://nx.dev/docs/guides/tasks--caching/configure-inputs
+  - Nx task outputs docs: https://nx.dev/docs/guides/tasks--caching/configure-outputs
+
+## Current D9-Related Code By Stage
+
+Current entrypoint:
+
+- `habitat fix` parses only `--dry-run` and calls `runFix({ dryRun })`.
+- `runFix` calls `runGritApplyPatterns`, which delegates directly to
+  `runGritApplyTransaction`.
+- There is no `habitat fix --json` flag today.
+
+Current source transaction stages in `grit-apply.ts`:
+
+1. Read initial Git state from `readGitState(repoRoot)`.
+2. Discover source roots from `mods/*/src/{recipes,maps}`.
+3. Discover docs roots as exact Markdown files under `docs/` containing local
+   absolute checkout references to `docs/...md`.
+4. Refuse live apply when the worktree is dirty unless `allowDirtyWorktree` is
+   set. Dirty dry-runs are allowed.
+5. Run source Grit dry-run:
+   `grit apply .grit/patterns/habitat/apply/deep_import_to_public_surface.md <source roots> --force --output compact --dry-run`.
+6. Parse dry-run output as `HABITAT_REWRITE ...` structured inventory, zero
+   matches, or failure.
+7. If source dry-run output is not structured/zero-match, run an isolated-copy
+   live apply against copied roots and classify the resulting diff. This is
+   current behavior, but D9 must decide whether this is an explicit transaction
+   state or a refused parse failure. It must not remain an implicit alternate
+   authority path.
+8. Classify structured inventory by approved roots and `approvedByPattern`.
+9. Run docs Grit dry-run when docs roots exist:
+   `grit apply .grit/patterns/habitat/apply/docs_local_checkout_paths_rewrite.md <exact docs md files> --dry-run --force --output standard`.
+10. Parse docs standard output for changed Markdown paths and run isolated-copy
+    proof for those exact paths.
+11. If `dryRun` or no approved paths, return success with no live source writes.
+12. Capture pre-apply file digests for approved paths.
+13. Run source live Grit apply.
+14. If source live apply fails or is interrupted, run Git rollback and return a
+    failure result.
+15. Run docs live Grit apply only for approved docs paths.
+16. If docs live apply fails, run Git rollback and return a failure result.
+17. Read changed paths from `git status --short`.
+18. If any changed path was not pre-approved, run Git rollback and return a
+    failure result.
+19. Run Biome handoff:
+    `biome check --write <changed paths>`.
+20. If Biome fails, run Git rollback and return a failure result.
+21. Run optional `gateCommands` sequentially; each failed gate triggers rollback.
+22. If `rollbackAfterApply` is set, roll back after success and report rollback
+    result.
+23. Return `GritApplyTransactionResult` with `ok`, `failureTag`, and a broad
+    `GritApplyTransactionProof` side object.
+
+Current tests prove:
+
+- dirty live worktree refusal before Grit execution;
+- dirty dry-run allowed;
+- Grit apply argv/env construction for source and docs;
+- parser refusal for unstructured dry-run text;
+- source dry-run mismatch when native output reports matches but isolated-copy
+  proof produces no diff;
+- inventory classification for approved/unapproved entries;
+- outside-root refusal;
+- create/delete refusal inside approved roots during isolated-copy proof;
+- rollback failure state;
+- rollback after source live apply failure/interruption;
+- rollback after Biome failure;
+- rollback after selected gate failure;
+- isolated-copy proof leaves source probe unchanged;
+- MapGen public-ops export validation blocks a missing export.
+
+Current tests do not prove:
+
+- `habitat fix --dry-run --json`, because that flag does not exist;
+- protected/generated-zone refusal for live apply;
+- D8 apply-approved lifecycle consumption;
+- G-HOST declaration consumption;
+- native Biome formatting semantics;
+- Nx task scheduling/caching semantics;
+- command JSON compatibility;
+- product/runtime correctness after a transformation.
+
+## Public/Durable Surfaces That Are D0 Blockers
+
+D9 cannot reshape these without D0 classification or an explicit compatibility
+decision:
+
+- CLI command surface: `habitat fix` currently supports only `--dry-run`.
+  Adding `--json`, changing stdout/stderr shape, or changing exit-code meaning
+  is a public command contract change.
+- Package exports from `tools/habitat-harness/src/index.ts`:
+  `GritApplyRewriteInventoryEntry`, `GritApplyTransactionOptions`,
+  `GritApplyTransactionProof`, `GritApplyTransactionResult`,
+  `classifyApplyRewriteInventory`, `parseApplyRewriteInventory`, and
+  `runGritApplyTransaction`.
+- `runFix` export from `command-engine.ts`, because it is exported through the
+  package root.
+- `HabitatCommandResult`, `HabitatProcessRequest`, `HabitatCommandKind`, and
+  command `kind` strings such as `grit-apply`, `biome-handoff`, and `git-proof`,
+  because D9 proof/receipt output embeds those shapes.
+- Current test expectations around command argv and proof fields.
+- Root/package scripts and Oclif help output when validation gates reference
+  `bun run habitat fix --help`.
+
+The current D9 proposal's validation command
+`bun run habitat fix --dry-run --json` is invalid against current code. D9 must
+either remove `--json` from its design validation or explicitly require D0 to
+classify and authorize the new JSON surface before implementation.
+
+## Responsibility Split
+
+### Grit Apply Patterns Own
+
+- Pattern matching and rewrite semantics.
+- File-language matching via Grit pattern language declarations.
+- Pattern-local path predicates such as the current `deep_import_to_public_surface`
+  filename constraint for `mods/*/src/{recipes,maps}/**/*.ts(x)`.
+- Pattern examples and native `grit patterns test` fixtures.
+- Pattern-owned structured dry-run inventory fields if D9 keeps
+  `HABITAT_REWRITE ...` as the inventory contract.
+
+D9 should not duplicate Grit's pattern language or invent a second matcher for
+which imports should rewrite. D9 may require that every apply-approved pattern
+declare its write contract and inventory mode through D8/G-HOST metadata.
+
+### Grit Command Invocation Owns
+
+- Invoking native `grit apply`, `grit check`, and `grit patterns test`.
+- Passing explicit pattern paths, scan/apply roots, `--dry-run`, `--force`, and
+  `--output`.
+- Capturing stdout/stderr/exit/interruption through `HabitatProcess`.
+- Using isolated cache/env settings (`GRIT_CACHE_DIR`,
+  `GRIT_TELEMETRY_DISABLED`, color-disabled env).
+
+Official Grit docs define `grit apply [OPTIONS] <PATTERN_OR_WORKFLOW> [PATHS]...`,
+including `--dry-run`, `--force`, and `--output` modes. They also define
+`grit patterns test --filter ...` for pattern fixture proof. D9 should cite
+those as vendor-owned semantics and avoid specifying how Grit computes rewrites.
+
+### Biome Formatter Handoff Owns
+
+- Formatting/lint/import-sort behavior for changed files.
+- The write behavior of `biome check --write`.
+- CI read-only behavior of `biome ci`.
+
+Biome docs state that `biome check` runs formatter, linter, and import sorting,
+and its CLI supports `--write`. Biome docs also state that `biome ci` is
+read-only and has no write/fix option. D9 should model Biome as a handoff gate
+with command result and non-claims, not as transaction safety proof.
+
+### Git Rollback Owns
+
+- Reverting tracked changed paths through `git checkout -- <paths>`.
+- Reporting rollback command status.
+
+D9 must not claim rollback covers untracked creations unless it explicitly
+handles them. Current isolated-copy classification blocks creates/deletes, but
+live rollback currently uses `git checkout --` over `git status --short` paths.
+That is enough for tracked modifications, not a general filesystem transaction.
+If D9 ever allows pattern-approved create/delete, it must specify cleanup
+commands separately.
+
+### Habitat Transaction Orchestration Owns
+
+- Selecting apply-approved patterns from D8 governance.
+- Consuming D10/G-HOST protected/generated-zone declarations before write.
+- Building explicit transaction request variants.
+- Sequencing dry-run inventory, isolated-copy proof, live apply, changed-path
+  verification, Biome handoff, selected gates, rollback, and recovery output.
+- Producing command-facing transaction records with proof-class non-claims.
+- Refusing missing host policy, missing apply approval, dirty worktree,
+  unstructured inventory where no explicit inventory mode exists, path
+  violations, unexpected live changed paths, formatter failure, gate failure, and
+  rollback failure.
+
+Habitat should remain an integration layer. It should not own Grit rewrite
+semantics, Biome formatting semantics, Nx task graph/caching semantics, or
+host-specific MapGen/Civ7 policy data.
+
+### Nx Task/Plugin Semantics Own
+
+- Project graph construction and inferred targets.
+- Task graph, cache inputs/outputs, and plugin-created target metadata.
+
+Nx docs describe project graph plugins through `createNodesV2` and
+`createDependencies`, and its inferred-task docs warn that plugin output must be
+deterministic and avoid machine-specific values because Nx hashes plugin-produced
+project graph nodes for caching. If D9 consumes Nx gates, D9 may record an
+explicit command result, but Nx owns scheduling, cache interpretation, graph
+metadata, and target inference.
+
+## Exact Write Set D9 Should Specify
+
+D9 should specify this target write set, with no implicit expansion:
+
+1. Source apply write set:
+   - Only paths produced by D8 apply-approved Grit patterns.
+   - Currently observed source roots are `mods/*/src/recipes/**` and
+     `mods/*/src/maps/**`.
+   - Current pattern language further limits source rewrites to TypeScript files
+     under `mods/*/src/{recipes,maps}/**`.
+   - D9 must not treat these current roots as generic permanent authority; they
+     are current-host declarations until G-HOST/D10 replace them.
+
+2. Docs apply write set:
+   - Only exact Markdown files under `docs/**/*.md` that the docs dry-run
+     identified and isolated-copy proof classified.
+   - Do not pass the whole `docs/` tree to live apply when exact candidate files
+     are known.
+   - The docs rewrite is suffix-based documentation hygiene only; it does not
+     prove historical checkout identity.
+
+3. Biome handoff write set:
+   - Exactly the live changed paths already approved by the transaction.
+   - Biome may mutate those paths during `biome check --write`.
+   - Any additional changed path after Biome is a transaction failure unless it
+     was already included in the approved changed-path set.
+
+4. Rollback write set:
+   - Exactly the paths reported dirty by Git after a failed write stage.
+   - Current rollback is tracked-file rollback via Git. It is not a filesystem
+     transaction and must not be claimed as one.
+
+5. Isolated-copy proof write set:
+   - Temporary directories under OS temp only.
+   - Source tree must remain untouched.
+   - Copy proof may produce diff evidence, digests, and normalized diff, but
+     does not authorize live write by itself unless D9 explicitly says that
+     inventory mode is valid for the pattern.
+
+6. Test fixture write set:
+   - `tools/habitat-harness/test/lib/grit-apply.test.ts` currently creates and
+     removes
+     `mods/mod-swooper-maps/src/recipes/standard/stages/habitat-apply-copy-proof/**`
+     as test-only probe files.
+   - D9 should keep such probes test-only and require cleanup proof.
+
+## Exact Protected Path Set D9 Should Specify
+
+D9 should consume D10/G-HOST for the durable protected set. Until those are
+accepted, D9 must name the current observed protected/refused set and mark it
+as dependency-bound:
+
+- Repo/VCS/tooling protected prefixes already modeled in Grit scan validation:
+  `.civ7/**`, `.git/**`, `.grit/cache/**`, `dist/**`, `node_modules/**`,
+  `tools/habitat-harness/dist/**`.
+- Generated zones currently modeled in `generated-zones.ts`:
+  `mods/mod-swooper-maps/src/maps/generated/**`,
+  `packages/civ7-types/generated/**`,
+  `packages/civ7-map-policy/src/civ7-tables.gen.ts`.
+- Generated/drift script paths:
+  `mods/mod-swooper-maps/src/maps/generated/**`,
+  `mods/mod-swooper-maps/mod/config/**`,
+  `mods/mod-swooper-maps/mod/swooper-maps.modinfo`,
+  `mods/mod-swooper-maps/mod/text/en_us/MapText.xml`.
+- Apply-created and apply-deleted files are protected by default unless D8
+  pattern approval explicitly authorizes create/delete and D9 specifies the
+  rollback/cleanup mechanism.
+- Host-specific validation paths such as MapGen public ops targets are not
+  generic D9 policy. They must move behind G-HOST apply-gate declarations.
+
+Important current risk: `discoverApplySourceRoots()` includes
+`mods/*/src/maps`, and the current Grit source pattern accepts
+`mods/*/src/maps/**/*.ts(x)`. That overlaps
+`mods/mod-swooper-maps/src/maps/generated/**`. D9 cannot be accepted while the
+protected-zone exclusion remains implicit or deferred.
+
+## Current Packet Gaps To Repair
+
+1. Replace the single broad requirement in `spec.md` with normative transaction
+   variants:
+   - dry-run zero-match/no-write;
+   - dry-run approved inventory/no-write;
+   - dry-run parse refusal;
+   - isolated-copy inventory mode success/failure;
+   - dirty live worktree refusal;
+   - missing D8 apply approval refusal;
+   - missing D10/G-HOST protected-path policy refusal;
+   - unapproved path refusal;
+   - live source apply success/failure;
+   - live docs apply success/failure;
+   - unexpected changed path refusal;
+   - Biome handoff success/failure;
+   - selected gate success/failure;
+   - rollback success/failure;
+   - recovery instruction emission.
+
+2. Define request variants instead of optional flags:
+   - dry-run request;
+   - live apply request;
+   - live apply plus rollback-after-apply test request;
+   - selected-gate request.
+
+   Current `GritApplyTransactionOptions` allows invalid or test-only
+   combinations such as `allowDirtyWorktree` with normal live apply,
+   `rollbackAfterApply` outside proof mode, generic `gateCommands` without host
+   declaration, and live apply without explicit D8 admission.
+
+3. Decide inventory mode explicitly:
+   - Structured inventory is pattern-owned.
+   - Isolated-copy diff proof is a transaction-owned approximation when a
+     pattern declares that mode.
+   - Parse failure is a refusal when no declared inventory mode applies.
+
+4. Remove or gate `--json` validation. It is not current command behavior.
+
+5. Move MapGen public-ops target validation out of generic transaction code or
+   specify it as a G-HOST apply gate consumed by D9. Current generic D9 code
+   knows `@mapgen/domain/.../ops`, which violates the G-HOST boundary.
+
+6. Specify post-Biome changed-path verification. Current code checks unexpected
+   paths before Biome, not after Biome. D9 should require the final changed-path
+   set after every write-capable handoff to remain inside the approved write set.
+
+7. State that D9 does not admit apply patterns. D8 owns apply approval.
+
+8. State that D9 does not define generated/protected zones. D10/G-HOST own them.
+
+9. State that D9 does not prove formatter semantics, current-tree diagnostics,
+   Nx scheduling, or product runtime behavior.
+
+## Validation That Proves D9 Without Overclaiming
+
+Design-time validation:
+
+- `bun run openspec -- validate deep-habitat-d9-transformation-transaction --strict`
+  - Proves only OpenSpec shape for this change.
+- `bun run openspec:validate`
+  - Proves only repository OpenSpec consistency.
+- `git diff --check`
+  - Proves only whitespace/diff hygiene.
+
+Native vendor proof:
+
+- `grit patterns test --filter=deep_import_to_public_surface`
+  - Proves native Grit pattern fixture behavior for the source apply pattern.
+  - Does not prove Habitat transaction safety.
+- `grit patterns test --filter=docs_local_checkout_paths_rewrite`
+  - Proves native Grit pattern fixture behavior for the docs rewrite pattern.
+  - Does not prove Habitat transaction safety.
+- Biome native proof, if added, must be a controlled fixture command such as
+  `biome check --write <fixture paths>`.
+  - Proves only Biome's own write handoff on those files.
+  - Does not prove Habitat approval or rollback.
+- Nx native proof, if D9 consumes Nx gate commands, must use explicit `nx`
+  commands and record cache/freshness.
+  - Proves only Nx task behavior for that command.
+  - Does not prove Habitat transaction safety.
+
+Habitat wrapper/unit proof:
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/grit-apply.test.ts`
+  - Proves D9 transaction unit behavior, rollback branches, isolated-copy proof,
+    and fake-process command sequencing.
+  - Does not prove command JSON, native Grit semantics, Biome semantics, D8
+    admission, or D10 protected zones unless new tests are added.
+- Add or require tests for:
+  - D8 apply-approved pattern admission;
+  - missing apply approval refusal;
+  - generated/protected-zone refusal before live apply;
+  - final post-Biome changed-path recheck;
+  - missing G-HOST apply gate refusal;
+  - MapGen public-ops validation as host gate, not generic transaction code.
+
+Command proof:
+
+- `bun run habitat fix --help`
+  - Proves Oclif command help exposes intended flags.
+- `bun run habitat fix --dry-run`
+  - Proves dry-run command path runs and returns without source writes in the
+    current tree.
+  - Must be paired with `git status --short --branch` before/after.
+  - Does not prove live apply safety.
+- Do not use `bun run habitat fix --dry-run --json` unless D0 authorizes and
+  D9 implements a JSON contract.
+
+Safe write proof:
+
+- Controlled fixture or unit-level proof should demonstrate:
+  - before clean git state;
+  - dry-run inventory;
+  - isolated-copy diff/digests;
+  - live apply on approved paths only;
+  - Biome handoff limited to approved paths;
+  - post-handoff changed paths still approved;
+  - rollback path and rollback failure path;
+  - final git state and non-claims.
+
+## Acceptance Conditions From This Lane
+
+D9 can become accepted for this lane only after the OpenSpec packet specifies:
+
+- D0 disposition for `habitat fix`, exported `GritApply*` types/functions, and
+  command result DTOs.
+- D8 apply-approval input shape and refusal behavior.
+- D10/G-HOST protected/generated path input shape and refusal behavior.
+- Exact transaction variants and disallowed request combinations.
+- Exact write set and protected path set, including generated-zone exclusions.
+- Vendor boundary table for Grit, Biome, Git, Nx, and Habitat.
+- Exact validation commands with expected exit status, proof class, freshness
+  stance, and non-claims.
+- Removal of invalid `--json` validation or D0-authorized JSON contract.
+
+Until then, D9 remains a useful source packet, not a complete OpenSpec design
+authority.
+
+## Skills Used
+
+Skills used: domain-design, information-design, solution-design,
+typescript-refactoring, civ7-habitat-dra-workstream, civ7-open-spec-workstream.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-cross-domino-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-cross-domino-investigation.md
@@ -1,0 +1,288 @@
+# D9 Cross-Domino Product Scenario Review
+
+## Verdict
+
+D9 Transformation Transaction is blocked from cross-domino/product-scenario acceptance.
+
+The current D9 OpenSpec packet is an incomplete packet, not a complete design authority. It
+names the right product lane - safe structural apply transactions - but it does
+not yet specify the closed transaction state model, upstream projection inputs,
+write authority, refusal taxonomy, public compatibility handling, downstream
+projection contract, or validation matrix with enough precision to prevent
+implementation-time design decisions.
+
+D9 should remain one cohesive OpenSpec change packet, but that packet must be
+expanded substantially before source implementation. Splitting D9 now would
+make the transaction lifecycle ambiguous across packet boundaries and would let
+formatter, rollback, host gate, and apply admission semantics drift into
+adjacent owners.
+
+## Upstream Contracts D9 May Consume Now
+
+D9 may consume the accepted D0-D8 packets as design/specification inputs, with
+the important limitation that accepted-for-design is not implementation-ready.
+
+Accepted inputs:
+
+- D0 Public Surface Compatibility: D9 may require D0 rows for `habitat fix`,
+  dry-run behavior, `GritApplyTransactionResult`, `GritApplyTransactionProof`,
+  docs examples, command output, package exports, and any stable human-output
+  claims. D9 may not change or version these surfaces until concrete D0 rows
+  exist and cite closed handling values.
+- D1 Receipt/Command Record Boundary: D9 may use `ApplyTransactionRecord`,
+  `RefusalRecord`, typed relationships, and canonical non-claims. D1 explicitly
+  leaves apply behavior to D9 and requires apply records to distinguish dirty
+  refusal, dry-run, ambiguous dry-run, live apply, rollback failure, and
+  non-claim boundaries.
+- D6 Diagnostic Pattern Catalog: D9 may consume diagnostic identity and
+  limitations as context only. D6 says diagnostics do not admit patterns, do not
+  prove apply safety, and do not own `GritApply*` failure semantics.
+- D7 Structural Enforcement Pipeline: D9 may consume the negative constraint
+  that check pass/current-tree results do not approve writes. D7's downstream
+  ledger explicitly says D7 pass does not approve writes and D9 must require
+  D8/D10/G-HOST/D9 transaction authority for apply safety.
+- D8 Pattern Governance: D9 may consume `ApplyAdmissionProjection` as the only
+  apply-eligibility input. D8 requires D9 to own dry-run, live writes, rollback,
+  path approval, formatter handoff, and recovery; D8 also says diagnostic
+  admission is not apply admission.
+
+Not yet consumable as accepted authority:
+
+- D10 Protected Zone Authority is still a blocking packet. D9 can design
+  placeholders for the D10 guard/refusal projection, but implementation cannot
+  assume protected/generated-zone semantics are stable.
+- G-HOST Host Policy Boundary Gate is still a blocking packet. D9 can state
+  that host-specific apply gates come through G-HOST, but cannot define host
+  policy, infer host semantics, or claim generic Habitat closure.
+- D11 and D13 are downstream incomplete packets only. They can inform expectations, not
+  constrain D9 as accepted upstream authority.
+
+Live source facts that still block D9 implementation:
+
+- No durable `docs/projects/habitat-harness/public-surface-compatibility-matrix.md`
+  exists in this worktree, so D9 cannot cite concrete D0 rows for `habitat fix`
+  or legacy apply transaction DTO/output compatibility.
+- `tools/habitat-harness/src/lib/grit-apply.ts` still combines transaction
+  mechanics, hard-coded apply pattern paths, MapGen source roots, docs checkout
+  path rewrites, public-ops export validation, Biome handoff, optional gates,
+  rollback, and legacy proof/result objects.
+- `GritApplyTransactionOptions` still permits broad optional combinations such
+  as `dryRun`, `allowDirtyWorktree`, `rollbackAfterApply`, injected gate
+  commands, and custom process/git readers without a packet-defined request
+  mode constructor.
+- Current `GritApplyTransactionResult` still uses `ok`, `failureTag`, and a
+  wide proof object. D1 accepts this only as legacy compatibility until D9
+  defines the target `ApplyTransactionRecord`.
+- Current safe paths are discovered from `mods/*/src/{recipes,maps}` and
+  docs markdown heuristics, not from accepted D8 apply admission plus D10/G-HOST
+  protected path authority.
+- Current generated/protected zones remain inline host-specific constants in
+  `generated-zones.ts`; D10/G-HOST have not yet converted them into accepted
+  declarations.
+- Current Pattern Authority `applySafety` fields still name proof strings such
+  as `dryRunCommand`, `noWriteProof`, `appliedDiffProof`, `rollbackProof`, and
+  `typeAndTestProof`; accepted D8 says D9 receives an apply-admission
+  projection, not whole manifests or proof-string authority.
+
+## Downstream Facts D11, D13, And Future Apply Packets May Rely On From D9
+
+D9 must publish narrow downstream facts. Downstream consumers should not inspect
+legacy proof blobs or raw Grit output.
+
+D11 Local Feedback may rely on:
+
+- A local-feedback-safe transaction projection that says whether an apply/fix
+  transaction is unavailable, refused, dry-run-only, applied, rolled back, or
+  requires manual recovery.
+- Stable local-feedback non-claims: hook success is not safe-apply completion,
+  not CI, not review proof, not runtime/product proof.
+- Explicit recovery guidance for transaction refusal or rollback failure that a
+  hook can display without owning apply safety.
+- A clear boundary that hooks may orchestrate or report D9 decisions but may
+  not recompute path approval, rollback status, apply admission, formatter
+  success, or host gate meaning.
+
+D13 Candidate Generation may rely on:
+
+- Candidate pattern generation does not imply apply safety.
+- D8 must produce apply admission before D9 accepts a pattern for transaction
+  evaluation.
+- D9 may define the transaction-input shape that an apply-capable candidate must
+  later satisfy, but D13 still owns candidate file creation and unsupported
+  candidate refusals.
+
+Future apply packets may rely on:
+
+- The closed D9 transaction state model and request-mode constructors.
+- The required inputs for an apply request: D8 apply admission, D10 path/zone
+  guard decision where touched, G-HOST host gate declaration where applicable,
+  approved write roots, dry-run observation, isolated-copy/diff evidence,
+  formatter handoff policy, post-apply gates, rollback plan, and D1 non-claims.
+- The non-claim that dry-run inventory does not prove live apply success.
+- The non-claim that apply success does not prove current-tree diagnostics are
+  clean unless D7 check runs separately.
+- The non-claim that apply success does not prove product/runtime behavior.
+
+## What D9 Must Not Claim
+
+D6 diagnostics:
+
+- D9 must not treat a diagnostic pattern, native Grit sample, injected probe, or
+  clean diagnostic run as apply-safe.
+- D9 must not parse raw diagnostic Grit reports as write authority.
+- D9 must not reuse D6 adapter failure states for apply transaction failures
+  except through owner-boundary translation.
+
+D8 admission:
+
+- D9 must not admit, register, retire, or refuse Pattern Governance lifecycle
+  state.
+- D9 must not read whole Pattern Authority manifests as its target input.
+- D9 must not infer apply eligibility from diagnostic admission, hook scope,
+  rule lane, file presence, Grit frontmatter, or generator options.
+- D9 must not convert transaction failure into D8 admission state.
+
+D10 protected/generated-zone authority:
+
+- D9 must not define generated/protected-zone policy, regeneration semantics,
+  forbidden artifacts, or missing-host declaration behavior.
+- D9 must not turn protected-zone violations into best-effort skips or warnings.
+- D9 must consume D10 guard/refusal projections for touched paths before
+  approving live writes.
+
+G-HOST host policy:
+
+- D9 must not hard-code Civ7/MapGen-specific roots, public-ops validation,
+  generated paths, or host gates as generic Habitat truth.
+- D9 may run host-specific gates only when G-HOST declares the gate and owner.
+- Missing host policy must be an explicit refusal, not a silent disabling of
+  protection.
+
+Biome:
+
+- D9 must not claim Biome owns transaction safety.
+- Biome handoff success may prove only the requested formatting/lint handoff
+  command result, with Biome-specific non-claims.
+- Biome failure after live writes is a D9 transaction state requiring rollback
+  or recovery, not a generic formatter note.
+
+Grit:
+
+- D9 must not claim native Grit owns Habitat write approval.
+- Native `grit apply --dry-run` output is an observation that D9 must classify,
+  not authority by itself.
+- Native `grit apply` success is not sufficient without D8 admission, D10/G-HOST
+  path gates, changed-path approval, formatter handoff, post-apply gates, and
+  rollback/recovery state.
+
+Nx:
+
+- D9 must not use Nx target success, generator mechanics, or cache behavior as
+  apply safety.
+- If D9 needs type/test gates, it must name them as post-apply gate handoffs
+  with command provenance and non-claims, not as implicit transaction success.
+- Nx cache/freshness may be observed only where the specific gate records it.
+
+## Packetization Decision
+
+D9 should remain one OpenSpec packet.
+
+The cohesive domain object is the transaction lifecycle from requested apply to
+dry-run, inventory classification, isolated-copy proof, live write, formatter
+handoff, gates, rollback, and recovery. Splitting this into separate packets
+would create exactly the ambiguity D9 is meant to remove: formatter failure
+could become "not apply," rollback could become "git proof," path approval
+could become "D10," and apply admission could become "D8." Those are inputs and
+handoffs, not separate owners of transaction state.
+
+The only split that may be warranted is not inside D9: if D9 proves that local
+DTOs cannot represent command provenance without contradictory states, it may
+trigger D15 as a separate/minimized substrate decision. That is not a default
+D9 split and must pass D15's trigger test.
+
+## Black-Ice Sequencing Traps
+
+1. D9 currently lists D10 as a dependency, but D10 and G-HOST are still
+   blocking packets. D9 can be designed against their expected projection
+   shape, but source implementation cannot start or close generic apply safety
+   until accepted D10/G-HOST contracts exist.
+
+2. D8 accepted apply-admission language depends on D9-owned transaction-safety
+   references. This is a mutual-design edge, not an implementation shortcut.
+   D8 can say what D9 must receive; D9 must now define the exact transaction
+   inputs/projections D8 may cite.
+
+3. The current D9 OpenSpec spec has only two scenarios. It omits no-match
+   dry-run, approved dry-run inventory, parse failure, dirty live refusal,
+   dirty dry-run allowance, unapproved path refusal, protected-zone refusal,
+   host gate missing/refused, isolated-copy mismatch, live apply success,
+   live apply failure before writes, live apply failure after writes, Biome
+   handoff failure, gate failure, rollback success, rollback failure, and manual
+   recovery.
+
+4. "Protected path list" appears in the incomplete D9 packet as an implementation
+   readiness item, but D9 must not author protected policy. D9 should require a
+   D10 guard projection for every touched path and refuse when it is absent.
+
+5. Existing `grit-apply.ts` public-ops validation is MapGen-specific. Without
+   G-HOST, preserving it as generic D9 behavior would violate the host boundary.
+   With G-HOST, it must become a declared host apply gate, not inline generic
+   code.
+
+6. The current packet says "approved patterns" but does not define the exact
+   D8 projection shape D9 consumes. Implementation would otherwise choose
+   between manifest fields, `applySafety`, Grit pattern paths, rule rows, or
+   current hard-coded constants.
+
+7. The incomplete D9 packet says "formatter handoff success/failure" but not whether
+   formatter failure after live writes requires rollback, whether formatter
+   success changes transaction state, or what Biome output does not claim.
+
+8. Dry-run inventory and isolated-copy proof are different observations. A
+   packet that treats dry-run matches, structured inventory, isolated-copy diff,
+   and live write success as one "ok" path will recreate the current boolean
+   state problem.
+
+9. Rollback can be requested intentionally for proof, or invoked after failure.
+   Current options use `rollbackAfterApply`; D9 must distinguish
+   proof-mode rollback from failure rollback and from manual recovery after
+   rollback failure.
+
+10. D11 is blocked on D9, but current D9 does not publish a downstream
+    local-feedback projection. If D9 closes without that projection, D11 will
+    either parse legacy proof/output or recompute apply safety inside hooks.
+
+11. D13 may need to describe apply-capable candidate requirements. If D9 does
+    not define transaction-input prerequisites, D13 will invent or copy D8
+    `applySafety` prose strings as generator contract.
+
+12. D15 is tempting because `grit-apply.ts` already uses Effect/process
+    machinery. D9 must not trigger D15 unless it records the exact contradictory
+    state that local transaction DTOs cannot represent. Current evidence points
+    first to a missing D9 state model, not necessarily a missing substrate.
+
+## Required Repairs Before Acceptance
+
+D9 needs a real OpenSpec design/specification pass before acceptance. Minimum
+repairs:
+
+- Define a closed `ApplyTransactionRecord` state family with request-mode
+  constructors and state-owned fields.
+- Define the D8 `ApplyAdmissionProjection` input shape D9 consumes and the
+  transaction-safety fields D8 may cite.
+- Define the D10/G-HOST guard/gate projection placeholders D9 requires, while
+  marking D10/G-HOST implementation as blocking until accepted.
+- Define write-set and changed-path approval semantics without host-specific
+  inline defaults.
+- Define dry-run, isolated-copy, live-apply, formatter, gate, rollback, and
+  recovery scenarios normatively in `spec.md`.
+- Define refusal reason names or map them explicitly to D1 `RefusalRecord`.
+- Define downstream projections for D11 local feedback, D8 recovery/admission
+  feedback, and future apply packets.
+- Cite the absent D0 public-surface matrix as a source-implementation blocker,
+  not a cleanup task.
+- Replace broad "run dependency gates" tasks with exact design-time acceptance
+  requirements and later implementation gates, including injected bad cases.
+
+Until those repairs exist, D9 remains a useful source packet plus incomplete OpenSpec packet, not
+an OpenSpec design/specification authority.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-domain-ontology-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-domain-ontology-investigation.md
@@ -1,0 +1,444 @@
+# D9 Domain/Ontology Investigation: Transformation Transaction
+
+## Verdict
+
+D9 is blocked from domain/ontology acceptance.
+
+The controlling D9 source packet has the right instinct: D9 should own the write
+transaction, not diagnostics, governance, host policy, protection policy, hook
+feedback, formatter semantics, or Grit rewrite semantics. The current OpenSpec
+packet does not yet convert that instinct into an authority-grade design. It is
+still an incomplete packet with one broad requirement, two scenarios, generic task
+phrases, and no closed transaction ontology. A later implementation agent would
+still have to invent state names, owner handoffs, refusal families, request
+constructors, and compatibility term disposition while editing
+`tools/habitat-harness/src/lib/grit-apply.ts`.
+
+## Exact D9 Domain And Single Owner
+
+The exact domain is **Transformation Transaction**.
+
+The single owner is **D9 Transformation Transaction**. Its authority is the
+admission and execution envelope for a Habitat-approved structural rewrite:
+request construction, dry-run inventory, write-set planning, live write
+execution, rollback, formatter handoff, gate handoff, transaction outcome, and
+recovery record.
+
+D9 owns the transaction boundary only after upstream owners provide their
+inputs. It does not approve patterns, define host policy, define protected
+zones, define diagnostics, own formatter semantics, or own native Grit rewrite
+semantics.
+
+The D9 domain should be described as:
+
+> A Transformation Transaction is a closed, recoverable attempt to execute a
+> D8-admitted structural rewrite against a D10/G-HOST-approved write set, with
+> dry-run inventory, path approval, live write, rollback, formatter handoff,
+> optional declared gates, refusal states, outcome states, recovery instructions,
+> and explicit non-claims.
+
+## Target Language
+
+Target D9 language should use standard engineering terms:
+
+- `TransformationTransaction`
+- `TransformationRequest`
+- `DryRunRequest`
+- `LiveWriteRequest`
+- `ApplyAdmissionProjection`
+- `TransactionAdmissionDecision`
+- `WriteSet`
+- `ApprovedWritePath`
+- `PathApprovalDecision`
+- `DryRunInventory`
+- `InventoryParseFailure`
+- `IsolatedCopyCheck`
+- `LiveWriteAttempt`
+- `RollbackAttempt`
+- `FormatterHandoff`
+- `GateHandoff`
+- `TransactionRefusal`
+- `TransactionOutcome`
+- `RecoveryInstruction`
+- `TransactionNonClaim`
+
+Habitat-specific terms should be elevated only when they are true invariants:
+`ApplyAdmissionProjection` is D8 vocabulary consumed by D9; protected/generated
+zone decisions are D10/G-HOST vocabulary consumed by D9; `Grit` is the native
+rewrite engine, not the transaction domain.
+
+## Bad Compatibility Facts, Not Target Language
+
+These current names are compatibility facts or implementation evidence. They
+should not become D9 target ontology unless the packet explicitly accepts and
+defines them.
+
+| Current term | Target disposition |
+| --- | --- |
+| `GritApplyTransactionOptions` | Compatibility DTO. Target should be closed request variants, not optional mode flags. |
+| `dryRun?: boolean` | Compatibility flag. Target should be `DryRunRequest` vs `LiveWriteRequest`. |
+| `allowDirtyWorktree?: boolean` | Compatibility escape hatch. Target should be explicit dirty-worktree policy with admitted isolated-copy/live-write variants. |
+| `rollbackAfterApply?: boolean` | Compatibility flag. Target should model rollback policy and rollback outcome as transaction state. |
+| `gateCommands?: HabitatProcessRequest[]` | Compatibility process list. Target should be declared `GateHandoff` records sourced from D8/G-HOST/D9 transaction inputs. |
+| `GritApplyTransactionResult extends SpawnResult` | Compatibility output surface. Target should be `TransactionOutcome`; process result is evidence inside an observation, not the transaction identity. |
+| `ok: boolean` plus optional fields | Bad target shape. Target must be a discriminated state model. |
+| `proof` / `GritApplyTransactionProof` | Proof-shaped compatibility language. Target should use transaction record, outcome record, recovery record, command observation, or non-claim. |
+| `diffEvidence` | Compatibility implementation detail. Target should use write-set diff observation or isolated-copy check observation. |
+| `fileDigests` | Compatibility evidence detail. Target should be file digest observation only where required for rollback/recovery. |
+| `transactionCopyCommand` | Compatibility name. Target is `IsolatedCopyCheck`. |
+| `gateCommands` | Compatibility name. Target is `GateHandoff` with owner, input, output, and non-claim. |
+| `biomeCommand` | Compatibility name. Target is `FormatterHandoff`; Biome owns formatter behavior. |
+| `GritApplyDirtyWorktree` | D9-owned failure compatibility tag; target should be `dirty-worktree-refusal`. |
+| `GritApplyDryRunMismatch` | D9-owned failure compatibility tag; target should distinguish inventory parse failure, dry-run/copy mismatch, and unapproved inventory refusal. |
+| `GritApplyUnexpectedFile` | D9-owned failure compatibility tag; target should distinguish outside write set, protected-zone refusal, create/delete not admitted, and live unexpected path. |
+| `GritApplyMissingTargetExport` | Host/MapGen gate compatibility tag. Target belongs behind G-HOST-declared apply gate, not generic D9 core language. |
+| `GritApplyRollbackFailed` | D9-owned failure compatibility tag; target should be `rollback-failed` outcome with recovery instructions. |
+| `HABITAT_REWRITE` | Current structured dry-run line protocol. Target should call it a native dry-run inventory contract or compatibility inventory format. |
+| `approvedByPattern` | Compatibility field. D9 target should consume D8 `ApplyAdmissionProjection` and D9 write-set/path decisions, not pattern self-approval as authority. |
+| `classification: expected/pre-approved/rejected/blocked` | Compatibility labels. Target should use closed admission/refusal/outcome states. |
+| `mods/mod-swooper-maps/**`, `@mapgen/domain/**/ops` public export validation | Host-specific current evidence. Target should move behind G-HOST apply gate declarations. |
+
+## Closed State Model D9 Should Specify
+
+D9 needs a closed model with distinct request, admission, execution, handoff,
+rollback, and outcome states. The source packet lists many of these states, but
+the current OpenSpec spec does not define them.
+
+### Transaction Request
+
+```ts
+type TransformationRequest =
+  | {
+      kind: "dry-run-request";
+      admission: ApplyAdmissionProjection;
+      writeSet: PlannedWriteSet;
+      protectedZoneDecision: ProtectedZoneDecisionReference;
+      hostPolicy?: HostApplyGateReference;
+    }
+  | {
+      kind: "live-write-request";
+      admission: ApplyAdmissionProjection;
+      writeSet: PlannedWriteSet;
+      protectedZoneDecision: ProtectedZoneDecisionReference;
+      hostPolicy?: HostApplyGateReference;
+      rollbackPolicy: "required";
+      formatterPolicy: FormatterHandoffPolicy;
+      gatePolicy: readonly GateHandoffPolicy[];
+    };
+```
+
+No target constructor may allow live write without D8 apply admission, protected
+path approval, and declared rollback policy.
+
+### Transaction Admission
+
+```ts
+type TransactionAdmissionDecision =
+  | { kind: "admitted-dry-run"; request: Extract<TransformationRequest, { kind: "dry-run-request" }> }
+  | { kind: "admitted-live-write"; request: Extract<TransformationRequest, { kind: "live-write-request" }> }
+  | { kind: "refused"; refusal: TransactionRefusal };
+```
+
+Closed refusal reasons should include:
+
+- `missing-apply-admission`
+- `apply-admission-refused`
+- `diagnostic-admission-only`
+- `missing-transaction-input`
+- `dirty-worktree`
+- `invalid-request-mode`
+- `missing-protected-zone-decision`
+- `protected-zone-refused`
+- `missing-host-policy`
+- `host-apply-gate-refused`
+- `write-path-outside-approved-set`
+- `write-action-not-admitted`
+- `formatter-handoff-not-declared`
+- `gate-handoff-not-declared`
+- `public-surface-compatibility-missing`
+
+### Dry-Run Inventory
+
+```ts
+type DryRunInventoryOutcome =
+  | { kind: "no-planned-edits"; observation: NativeApplyDryRunObservation }
+  | { kind: "planned-approved-write-set"; inventory: DryRunInventory; writeSet: PlannedWriteSet }
+  | { kind: "inventory-parse-failed"; failure: InventoryParseFailure }
+  | { kind: "dry-run-command-failed"; observation: NativeApplyDryRunObservation }
+  | { kind: "dry-run-interrupted"; observation: NativeApplyDryRunObservation }
+  | { kind: "dry-run-copy-mismatch"; dryRun: NativeApplyDryRunObservation; copy: IsolatedCopyCheck }
+  | { kind: "isolated-copy-refused"; copy: IsolatedCopyCheck; refusal: TransactionRefusal };
+```
+
+Dry-run success must not imply live write success. Dry-run inventory must not be
+accepted as pattern admission. Structured inventory parsing must remain a native
+contract observation, not target domain truth.
+
+### Path And Write-Set Decision
+
+```ts
+type PathApprovalDecision =
+  | { kind: "approved"; path: string; action: "modify"; source: "apply-admission-and-d10-policy" }
+  | { kind: "refused"; path: string; reason: PathRefusalReason };
+```
+
+Closed path refusal reasons should distinguish:
+
+- outside approved roots;
+- protected/generated zone refused by D10;
+- missing host declaration;
+- create not admitted;
+- delete not admitted;
+- live write produced unexpected path;
+- path changed after dry-run/copy approval.
+
+The current `GritApplyUnexpectedFile` bucket is too broad for target design.
+
+### Live Execution And Rollback
+
+```ts
+type LiveWriteOutcome =
+  | { kind: "not-run"; reason: "dry-run-only" | "no-planned-edits" | "admission-refused" }
+  | { kind: "write-succeeded"; changedPaths: readonly string[] }
+  | { kind: "write-failed-before-observable-change"; observation: NativeApplyObservation }
+  | { kind: "write-failed-after-observable-change"; observation: NativeApplyObservation; rollback: RollbackOutcome }
+  | { kind: "unexpected-path-after-write"; changedPaths: readonly string[]; rollback: RollbackOutcome };
+
+type RollbackOutcome =
+  | { kind: "not-needed" }
+  | { kind: "succeeded"; recoveredPaths: readonly string[] }
+  | { kind: "failed"; unrecoveredPaths: readonly string[]; recovery: RecoveryInstruction };
+```
+
+Rollback failure must be a distinct outcome, not merely a `failureTag` on a
+boolean result.
+
+### Formatter And Gate Handoffs
+
+```ts
+type FormatterHandoffOutcome =
+  | { kind: "not-run"; reason: "no-changed-paths" | "live-write-not-run" }
+  | { kind: "succeeded"; formatter: "biome"; observation: FormatterCommandObservation }
+  | { kind: "failed"; formatter: "biome"; observation: FormatterCommandObservation; rollback: RollbackOutcome };
+
+type GateHandoffOutcome =
+  | { kind: "not-run"; reason: "no-declared-gates" | "live-write-not-run" }
+  | { kind: "succeeded"; gateId: string; owner: "host-policy" | "transaction" | "pattern-governance"; observation: GateCommandObservation }
+  | { kind: "failed"; gateId: string; owner: "host-policy" | "transaction" | "pattern-governance"; observation: GateCommandObservation; rollback: RollbackOutcome };
+```
+
+Formatter and gate success are handoff outcomes only. They are not apply safety,
+diagnostic cleanliness, product correctness, or Biome semantic proof.
+
+### Transaction Outcome
+
+```ts
+type TransformationTransactionOutcome =
+  | { kind: "dry-run-clean"; inventory: Extract<DryRunInventoryOutcome, { kind: "no-planned-edits" }>; nonClaims: readonly TransactionNonClaim[] }
+  | { kind: "dry-run-planned"; inventory: Extract<DryRunInventoryOutcome, { kind: "planned-approved-write-set" }>; nonClaims: readonly TransactionNonClaim[] }
+  | { kind: "refused"; refusal: TransactionRefusal; recovery: RecoveryInstruction }
+  | { kind: "applied"; live: Extract<LiveWriteOutcome, { kind: "write-succeeded" }>; formatter: FormatterHandoffOutcome; gates: readonly GateHandoffOutcome[]; nonClaims: readonly TransactionNonClaim[] }
+  | { kind: "rolled-back"; failedStage: "live-write" | "formatter-handoff" | "gate-handoff"; rollback: Extract<RollbackOutcome, { kind: "succeeded" }>; recovery: RecoveryInstruction }
+  | { kind: "rollback-failed"; failedStage: "live-write" | "formatter-handoff" | "gate-handoff" | "explicit-rollback"; rollback: Extract<RollbackOutcome, { kind: "failed" }>; recovery: RecoveryInstruction };
+```
+
+This model closes the current illegal state where a success proof can coexist
+with a failed formatter/gate/rollback field, or where a failure can carry enough
+optional proof fields to look like success.
+
+## Forbidden Adjacent Owners
+
+D9 must explicitly forbid these adjacent domains from owning D9 concerns, and
+must forbid D9 from absorbing their authority:
+
+- **D6 Diagnostic Pattern Catalog** owns diagnostic identity, diagnostic
+  capability, native diagnostic acquisition, and diagnostic limitations. D6 may
+  provide diagnostic identity/limitations to D9. D9 must establish write safety
+  itself and must not accept D6 diagnostic success as write authority.
+- **D8 Pattern Governance** owns pattern lifecycle, apply admission, refusal,
+  and retirement. D9 consumes `ApplyAdmissionProjection` or explicit D8 apply
+  refusal only. D9 does not admit patterns.
+- **D10 Generated/Protected Zone Authority** owns generated/protected zone
+  declarations and guard decisions. D9 consumes D10 path/zone decisions and
+  must not define protected-zone policy locally.
+- **G-HOST Host Policy Boundary** owns host-specific declarations and
+  host-specific apply gates. D9 may run declared gate handoffs; it must not
+  embed MapGen/Civ7 paths, public ops semantics, or host policy as generic
+  transaction logic.
+- **D11 Local Feedback** owns hook feedback, staged-file behavior, local output,
+  and hook recovery presentation. D9 may publish recovery facts for D11; it must
+  not define hook behavior.
+- **Biome** owns formatting/lint/import sorting semantics. D9 owns only the
+  formatter handoff and rollback behavior around that handoff.
+- **Grit** owns native textual rewrite semantics, pattern syntax, native apply,
+  native output contracts, and vendor behavior. D9 owns Habitat's transaction
+  envelope around native apply, not the meaning of Grit rewrites.
+
+## Current Ambiguities In The D9 Packet
+
+1. **Owner name drift:** the source says "Apply transaction owner"; OpenSpec
+   says "Transformation Transaction." The target should choose one. Use
+   `Transformation Transaction` for the bounded domain and `apply` only as a
+   native/vendor operation or command path.
+
+2. **Admission is ambiguous:** D8 owns apply admission, but D9 also needs a
+   transaction admission decision before running. The packet must name both and
+   define their relationship. D8 admission is necessary but not sufficient for
+   D9 transaction admission.
+
+3. **State model is absent:** the spec says D9 shall model dry-run, live-write,
+   rollback, formatting, protected-zone refusal, and recovery states, but it
+   does not enumerate the closed states or refusal reasons.
+
+4. **Request construction is unresolved:** `GritApplyTransactionOptions` can
+   combine dry-run, live write, dirty worktree allowance, rollback mode, and gate
+   commands in invalid ways. The packet does not specify the target constructors
+   that make those combinations unrepresentable.
+
+5. **Path ownership is ambiguous:** the current code approves paths using roots,
+   structured inventory, isolated-copy diff evidence, and MapGen public ops
+   validation. The target packet does not split D9 write-set approval from D10
+   protected-zone decisions and G-HOST host-specific gates.
+
+6. **Host policy is still leaky:** current `validateAppliedTargetExports` and
+   `publicOpsTargetPath` encode `@mapgen/domain/**/ops` and
+   `mods/mod-swooper-maps/**` inside generic transaction code. D9 must classify
+   this as host-gate compatibility evidence and require G-HOST declarations.
+
+7. **Formatter handoff is under-modeled:** current OpenSpec names formatting but
+   does not define formatter handoff states, rollback behavior after formatter
+   failure, or non-claims.
+
+8. **Gate handoff is under-modeled:** current `gateCommands` are arbitrary
+   `HabitatProcessRequest`s. The target must require declared gate owners,
+   command contracts, failure states, rollback behavior, and non-claims.
+
+9. **Recovery is under-specified:** the source requires rollback/non-claim
+   proof and recovery, but the spec only says "reports rollback state and
+   recovery instructions." It does not define recovery instruction families or
+   unrecovered-path representation.
+
+10. **Proof vocabulary is unresolved:** current OpenSpec says proof-shaped names
+    are compatibility facts, but D9 source and current implementation still use
+    `proof`, `diffEvidence`, and digest fields heavily. The packet needs an
+    explicit term disposition table like D8.
+
+11. **D10/G-HOST dependency reality is not reflected:** packet index marks D10
+    and G-HOST incomplete. D9 can design against their source packet
+    constraints, but source implementation remains blocked where protected-zone
+    or host-policy decisions are touched.
+
+12. **Validation gates are too generic for ontology acceptance:** current D9
+    gates run `grit-apply.test.ts` and help/OpenSpec commands, but the packet
+    lacks required bad-case gates for missing D8 admission, missing D10 decision,
+    missing G-HOST gate, protected-zone refusal, create/delete refusal,
+    formatter failure, gate failure, and rollback failure as closed states.
+
+## P1 Blockers
+
+### P1. Complete D9 state ontology is missing
+
+The OpenSpec spec has one broad requirement and two scenarios. It does not
+define the closed request, admission, refusal, dry-run, write-set, live write,
+formatter, gate, rollback, outcome, recovery, and non-claim states. This leaves
+implementation-time design decisions open.
+
+Repair required: expand `design.md` and `spec.md` with the closed state model
+above or an equivalent model, including normative scenarios for every state
+family.
+
+### P1. D8 apply admission versus D9 transaction admission is unresolved
+
+D8 accepted design states that D9 consumes only `ApplyAdmissionProjection` or
+explicit apply refusal and that D8 admission does not execute or approve writes.
+D9 currently says "apply approval" and "path approval" without defining what is
+D8-owned versus D9-owned.
+
+Repair required: define D9 `TransactionAdmissionDecision` as a D9 state that
+requires D8 `ApplyAdmissionProjection`, D10 path decisions, and G-HOST
+declarations where touched.
+
+### P1. D10/G-HOST boundaries are not enforceable in D9
+
+Current implementation embeds MapGen-specific public ops validation and source
+roots in generic transaction code. D10/G-HOST are still incomplete packet rows,
+so D9 cannot claim generic closure for protected-zone or host-gate paths.
+
+Repair required: D9 must specify host-gate and protected-zone references as
+required inputs, block source implementation where those inputs are absent, and
+forbid generic D9 code from encoding Civ7/MapGen policy.
+
+### P1. Boolean/optional transaction result remains the implicit target
+
+The existing `GritApplyTransactionResult` can represent `ok` plus many optional
+proof fields. The current OpenSpec does not reject that shape with a concrete
+replacement.
+
+Repair required: require a discriminated `TransformationTransactionOutcome` and
+request constructors that make invalid mode combinations unrepresentable.
+
+### P1. Recovery and rollback failure are under-specified
+
+Rollback success/failure is listed in the source packet and tested in current
+code, but the OpenSpec spec only mentions rollback state generically.
+
+Repair required: define rollback outcomes, unrecovered path representation,
+recovery instruction families, and non-claims for rollback success/failure.
+
+## P2 Blockers
+
+### P2. Compatibility term disposition is incomplete
+
+D9 needs an explicit term table like D8's `Term Disposition`. Without it, current
+code terms such as `proof`, `diffEvidence`, `approvedByPattern`, and
+`GritApplyMissingTargetExport` will leak into product/domain language.
+
+### P2. Formatter and gate handoffs need owner-tagged outcomes
+
+Biome and arbitrary selected gates must be handoffs with owner, command
+observation, rollback behavior, and non-claims. They must not be reported as
+apply safety or product proof.
+
+### P2. Dry-run inventory states need bad-case scenarios
+
+The source packet requires dry-run clean/no matches, approved changes, and parse
+failure. Current spec has only "dry run is requested." It needs explicit
+inventory parse failure, mismatch, no-edit, approved-plan, and unapproved-entry
+scenarios.
+
+### P2. Write-set/path refusal taxonomy is too broad
+
+`GritApplyUnexpectedFile` currently collapses outside-root, create, delete,
+protected-zone, host-policy, and unexpected live-write cases. D9 target spec
+must keep these distinguishable.
+
+### P2. D1/D0 public output compatibility is not concrete
+
+D9 can say public output may change, but implementation readiness requires D0
+rows and D1 output/refusal families for command JSON/human changes. Current D9
+tasks leave this as "confirm" rather than listing the touched surfaces and
+blocking facts.
+
+## Acceptance Conditions For This Lane
+
+D9 can be accepted from the domain/ontology lane only when:
+
+- `design.md` names `Transformation Transaction` as the single D9 owner and
+  contains the forbidden-owner matrix above.
+- `design.md` includes a compatibility term disposition table for current code
+  names.
+- `design.md` and `spec.md` define the closed state model for request,
+  admission, refusal, dry-run inventory, write set, live write, formatter
+  handoff, gate handoff, rollback, outcome, recovery, and non-claims.
+- `spec.md` has normative scenarios for every P1 state family, not just a broad
+  umbrella requirement.
+- `tasks.md` sequences implementation slices by state-family construction and
+  includes bad-case tests for missing D8 admission, missing D10/G-HOST inputs,
+  dirty worktree, unapproved path, create/delete refusal, dry-run mismatch,
+  formatter failure, gate failure, rollback success, and rollback failure.
+- D9 records that source implementation touching protected/generated or
+  host-specific paths remains blocked until D10/G-HOST are accepted and live
+  declarations/projections exist.
+
+Until those repairs land, D9 remains a useful source packet and incomplete OpenSpec packet, but
+not a complete OpenSpec design/specification authority.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-final-code-vendor-topology-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-final-code-vendor-topology-review.md
@@ -1,0 +1,220 @@
+# D9 Final Code/Vendor Topology Review
+
+## Verdict
+
+Accepted for the design/specification lane. No unresolved P1/P2 findings in this
+code/vendor topology rereview.
+
+This is not source implementation acceptance. The repaired D9 packet correctly
+keeps later TypeScript implementation blocked wherever live D0 compatibility
+rows, D8 apply-admission projections, D10 protected/generated-zone decisions, or
+G-HOST host-gate declarations are absent for the touched surface.
+
+## P1/P2 Findings
+
+None.
+
+## Review Scope And Evidence
+
+I read current disk state only. I did not use previous final agents as evidence.
+The first-wave topology review was used only as discovery material and a repair
+checklist to challenge current files.
+
+Primary packet files reviewed:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/proposal.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/design.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/specs/habitat-harness/spec.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/tasks.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/phase-record.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/review-disposition-ledger.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/downstream-realignment-ledger.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/closure-checklist.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D9-transformation-transaction.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/context.md`
+
+Current code/tests/pattern evidence reviewed:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/grit-apply.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/commands/fix.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/index.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/grit-apply.test.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/.grit/patterns/habitat/apply/deep_import_to_public_surface.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/.grit/patterns/habitat/apply/docs_local_checkout_paths_rewrite.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/package.json`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/package.json`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/.grit/grit.yaml`
+
+Vendor references checked:
+
+- Grit CLI apply and pattern-test docs: `https://docs.grit.io/cli/reference`
+- Grit pattern and Markdown test docs: `https://docs.grit.io/language/patterns`, `https://docs.grit.io/guides/testing`
+- Biome CLI `check --write`: `https://biomejs.dev/reference/cli/`
+- Git status and restore/rollback primitives: `https://git-scm.com/docs/git-status`, `https://git-scm.com/docs/git-restore`
+- Nx affected/run-many command ownership: `https://nx.dev/docs/reference/nx-commands`
+
+## Acceptance Checks
+
+### Intent Versus Attempt
+
+Accepted. The repaired packet now distinguishes command intent from D9-produced
+write attempt:
+
+- `DryRunIntent` and `LiveWriteIntent` are the command/request-level variants.
+- `LiveWriteAttempt` is D9-produced only after D8 admission, dry-run/copy
+  observations, D10/G-HOST path decisions where touched, approved write set, and
+  rollback/handoff policy.
+- The spec explicitly says live-write intent carries user intent and D8 apply
+  admission only, and does not carry an approved write set before D9 planning.
+
+This resolves the important repaired point. The packet no longer requires an
+approved write set before D9 planning; it requires one before live write.
+
+### Write And Protected Surfaces
+
+Accepted. D9 now names the current evidence and the target rule:
+
+- Current source roots are `mods/*/src/{recipes,maps}` and current Grit pattern
+  matching further limits rewrites to TypeScript paths under those roots.
+- Current docs rewrites are exact Markdown candidate files under `docs/**/*.md`,
+  not raw `docs/` tree apply authority.
+- The packet names the generated/protected overlap:
+  `mods/*/src/maps/**` can include
+  `mods/mod-swooper-maps/src/maps/generated/**`.
+- The packet blocks later source implementation unless D10/G-HOST decisions are
+  consumed before approving protected/generated writes.
+- Create/delete effects remain refused unless D8 admission explicitly includes
+  create/delete capability and D9 specifies cleanup/rollback mechanics.
+
+This matches current code evidence: `grit-apply.ts` discovers source roots from
+mod recipe/map roots, runs docs apply against discovered exact Markdown files,
+blocks isolated-copy create/delete evidence today, and uses Git tracked-file
+checkout rollback. The packet correctly avoids claiming general filesystem
+transaction cleanup.
+
+### D0 Public Surface Blockers
+
+Accepted. The repaired packet identifies current public/durable surfaces that
+must have D0 rows before implementation changes or compatibility reliance:
+
+- `habitat fix` and `habitat fix --dry-run` CLI behavior, output, exit status,
+  and help text.
+- Any new `habitat fix --json` flag or JSON output.
+- Exported `GritApply*` types/functions and `runFix`-adjacent command/process
+  DTOs.
+- Pattern fixture/inventory expectations when D9 changes invocation or inventory
+  contracts.
+
+Current code confirms `fix` has only `--dry-run`; there is no `--json` flag. The
+repaired packet removes `habitat fix --dry-run --json` as a current validation
+gate and treats JSON as a separate D0-controlled surface if added later.
+
+### D8 Apply Admission
+
+Accepted. The packet consistently makes D9 consume D8 admission instead of
+deciding pattern lifecycle:
+
+- D9 requires `ApplyAdmissionProjection` before dry-run or live write.
+- Diagnostic-only, candidate-only, retired, refused, or missing apply admission
+  patterns are refused before native Grit invocation.
+- Raw pattern file presence does not authorize a transaction.
+
+This is stricter than current code, which still accepts current pattern files and
+pattern-owned inventory fields as implementation evidence. The packet correctly
+classifies that as source work blocked until live D8 projection exists.
+
+### D10/G-HOST Consumption
+
+Accepted. The packet preserves ownership boundaries:
+
+- D10/G-HOST own protected/generated path decisions and host-gate declarations.
+- D9 consumes their projections where protected/generated or host-specific
+  surfaces are touched.
+- Current `validateAppliedTargetExports()` MapGen public-ops logic is explicitly
+  classified as host-specific current evidence, not generic transaction policy.
+- The implementation task is either to move that behavior behind a declared
+  host gate or keep source implementation blocked.
+
+This directly addresses the highest-risk current-code topology leak: generic
+`grit-apply.ts` currently hard-codes `@mapgen/domain/**/ops` and
+`mods/mod-swooper-maps/**` public-ops validation.
+
+### Vendor-Native Boundaries
+
+Accepted. The packet now treats vendors and tools as owners of their native
+semantics:
+
+- Grit owns GritQL syntax, pattern matching, native `grit apply` behavior,
+  output modes, dry-run semantics, and `grit patterns test`.
+- Biome owns formatter/linter/import-sort behavior for `biome check --write`.
+- Git owns status and restore/checkout behavior; D9 records observations and
+  rollback command outcomes.
+- Nx owns graph, target, scheduling, cache, affected, and run-many semantics; D9
+  records explicit gate command outcomes only when gates are declared.
+
+Current repo scripts and code line up with that split: root scripts use Nx for
+workspace gates, Habitat invokes Biome as `check --write <changed paths>`, and
+rollback currently uses `git checkout -- <paths>` over status-derived paths.
+
+### Docs And Source Lane Separation
+
+Accepted. The repaired spec requires docs and source apply lanes to remain
+distinct, with separate roots, pattern ownership, observations, and write-set
+approval. This matches the current code shape: source apply uses the
+`deep_import_to_public_surface` pattern over mod recipe/map roots, while docs
+apply uses the docs-local-checkout-path rewrite over exact candidate Markdown
+files.
+
+### Exact Audit And D13 Traceability
+
+Accepted. I found no use of "exact" as a reduced acceptance standard. The active
+uses are canonical D13/downstream traceability, closure audit wording, exact
+candidate docs paths, and exact write-set/path-surface constraints. The packet
+does not weaken D9's review bar by substituting "exact audit hits" for the full
+topology acceptance criteria.
+
+### Validation Commands And Current CLI Facts
+
+Accepted. The repaired validation split is current:
+
+- Design-time gates: OpenSpec strict validation, all OpenSpec validation,
+  `git diff --check`, wording audit, and final rereviews.
+- Later implementation gates: focused Habitat harness tests, Grit pattern tests
+  when pattern invocation/fixtures change, `bun tools/habitat-harness/bin/dev.ts fix --dry-run`,
+  help/equivalent command check, and before/after `git status --short --branch`.
+- The invalid current gate `habitat fix --dry-run --json` is gone unless D0 later
+  authorizes JSON output.
+
+One non-blocking implementation note: current Oclif help invocation emitted
+usage for `bun tools/habitat-harness/bin/dev.ts fix --help` but also printed
+`Nonexistent flag: --help`. The phase record already permits "`fix --help` or
+equivalent Oclif help command", so this is not a D9 design/spec blocker.
+
+## Residual Risk
+
+The residual risk is implementation sequencing, not packet topology:
+
+- D9 source work must not start for public output/export changes without D0 rows.
+- D9 source work must not run apply transactions without D8 admission
+  projections.
+- D9 source work must not approve writes intersecting generated/protected or
+  host-specific surfaces without D10/G-HOST projections.
+- Current inline MapGen public-ops validation must be moved behind declared host
+  gates or left blocked.
+
+Those constraints are now stated clearly enough for the design/specification
+lane.
+
+## Verification
+
+- `git status --short --branch` before review showed the requested D9 branch with
+  existing packet changes and prior scratch files. I did not modify source or
+  packet files.
+- `bun tools/habitat-harness/bin/dev.ts fix --help` was run only to confirm
+  current CLI facts; it showed `fix` supports `--dry-run` and no `--json`.
+- `git diff --check` result after writing this scratch file: exit 0, no output.
+
+Skills used: domain-design, information-design, solution-design, system-design,
+typescript, civ7-open-spec-workstream.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-final-cross-domino-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-final-cross-domino-review.md
@@ -1,0 +1,153 @@
+# D9 Final Cross-Domino/Product Rereview
+
+## Verdict
+
+Accepted for design/specification lane.
+
+I found no unresolved P1/P2 cross-domino or product-scenario blockers in the
+current repaired D9 Transformation Transaction packet. D9 now gives a complete
+product contract for safe structural apply transactions as a design/spec packet:
+it owns the transaction lifecycle, consumes accepted D0-D8 design inputs without
+overclaiming implementation readiness, keeps D10/G-HOST source blockers explicit,
+publishes D11/D13 projections, avoids D15 by default, and prevents downstream
+owners from parsing legacy `GritApply*` proof/result blobs as authority.
+
+This verdict is for current disk state only. Previous final agents are not used
+as acceptance evidence. The first-wave cross-domino/product review was used only
+as the required repair-input artifact named in the prompt.
+
+## P1/P2 Findings
+
+None.
+
+## Review Basis
+
+Read current disk state under
+`/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation`
+on branch `codex/d9-transformation-transaction-packet`, including:
+
+- source packet:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D9-transformation-transaction.md`
+- packet index:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+- first-wave cross-domino/product review:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-cross-domino-investigation.md`
+- repaired D9 OpenSpec packet:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/proposal.md`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/design.md`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/specs/habitat-harness/spec.md`
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/tasks.md`
+  and D9 workstream ledgers/checklists.
+
+Mandatory review anchors read before review: Domain Design, Information Design,
+Solution Design, System Design, Team Design, TypeScript Design, and the Civ7
+Open Spec Workstream source map.
+
+## Lifecycle Circularity Challenge
+
+The repaired model solves the important circularity around intent versus live
+write attempt.
+
+The source packet asked for typed request-mode constructors but the first-wave
+review found that implementation could still choose between optional mode flags,
+preapproved write sets, or current hard-coded apply constants. The repaired
+`design.md` now separates:
+
+- `DryRunIntent`: command/user intent plus D8 admission and worktree
+  observation.
+- `LiveWriteIntent`: command/user intent plus D8 admission and worktree
+  observation.
+- `LiveWriteAttempt`: a D9-produced internal state requiring clean worktree,
+  approved write set, rollback policy, and formatter/gate handoff policy.
+
+The normative spec reinforces that command parsing may create only dry-run or
+live-write intent, and that D9 may construct `LiveWriteAttempt` only after
+dry-run/copy/path planning approves the write set. That keeps D9 responsible
+for deriving approved write sets before live attempts and prevents D8 admission,
+Grit file presence, or command flags from becoming direct live-write authority.
+
+## Product Scenario Completeness
+
+D9 now covers the required safe structural apply transaction scenario end to
+end:
+
+- apply request mode construction;
+- missing/refused D8 apply admission;
+- diagnostic-only patterns not authorizing writes;
+- dry-run zero-match, approved inventory, ambiguous output, parse failure,
+  command failure/interruption, and dry-run/copy mismatch;
+- dirty live refusal and dirty dry-run allowance;
+- outside-root, protected/generated-zone, host-policy, create/delete, and
+  unexpected-path refusals;
+- isolated-copy check as observation, not authority;
+- live write success and post-write path verification;
+- formatter handoff success/failure/path drift;
+- declared gate success/failure and prior-success non-claim;
+- rollback success, rollback failure, rollback probe distinction, residual
+  dirty paths, and recovery instructions;
+- docs/source apply lanes kept distinct;
+- public `habitat fix` compatibility gated by D0, with `--json` explicitly not
+  a current D9 surface unless D0 authorizes it;
+- downstream projections for D11 and D13.
+
+This is enough for a later implementation agent to avoid inventing transaction
+semantics while still leaving source work blocked where live dependency facts do
+not exist.
+
+## Sequencing And Dependency Compatibility
+
+D9 consumes accepted D0-D8 design inputs correctly:
+
+- D0 remains the required public-surface compatibility authority for `habitat
+  fix`, exports, DTOs, command output, docs examples, and any JSON addition.
+- D1 remains the receipt/record/non-claim boundary. Legacy proof/result exports
+  may only be compatibility projections from `ApplyTransactionRecord`.
+- D6 diagnostics are context only and cannot admit writes.
+- D7 check/current-tree results do not approve writes.
+- D8 is the only apply-admission source D9 consumes, via
+  `ApplyAdmissionProjection`.
+
+D10 and G-HOST remain explicit implementation blockers where touched. D9 may
+design against their projections, but it refuses or blocks source
+implementation without live protected/generated-zone decisions and host-gate
+declarations. This is the right cross-domino shape: D9 owns transaction state,
+not protected-zone policy or host policy.
+
+D9 stays one cohesive packet. Splitting it would move path approval, rollback,
+formatter, and gate failure semantics into neighboring owners and recreate the
+ambiguity D9 is meant to remove.
+
+## Downstream Handoff Acceptance
+
+D11 receives local-feedback-safe states: unavailable/refused/dry-run/applied/
+rolled-back/rollback-failed/recovery-required, plus recovery instructions and
+non-claims. It is not forced to recompute apply safety, path approval, rollback
+status, formatter success, or host gate meaning.
+
+D13 receives transaction prerequisites for future apply-capable candidates, but
+candidate generation remains separate from D8 apply admission and D9 write
+safety.
+
+D15 is not triggered. The repaired state model represents the local command,
+vendor, rollback, and handoff states inside D9-owned transaction records. D15
+remains a trigger only if a future concrete contradiction cannot be represented
+locally.
+
+## Validation
+
+- `bun run openspec -- validate deep-habitat-d9-transformation-transaction --strict`
+  passed: `Change 'deep-habitat-d9-transformation-transaction' is valid`.
+- `bun run openspec:validate` passed: 249 items passed, 0 failed.
+- `git diff --check` passed after writing this scratch file.
+
+## Residual Non-Blocking Risks
+
+- D9 is not implementation-complete and should not be marked source-ready.
+- Public-surface source changes remain blocked until concrete D0 rows exist.
+- Source implementation where apply admission is consumed remains blocked until
+  live D8 projections exist.
+- Protected/generated and host-specific source behavior remains blocked until
+  D10/G-HOST live projections exist.
+- Current code still contains legacy `GritApply*` state shapes and MapGen gate
+  logic; this review accepts the repaired design/spec contract, not the source
+  state.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-final-domain-ontology-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-final-domain-ontology-review.md
@@ -1,0 +1,106 @@
+# D9 Final Domain/Ontology Review: Transformation Transaction
+
+## Verdict
+
+Accepted for design/specification lane.
+
+I found no unresolved P1/P2 domain, ontology, or naming blockers in the repaired
+D9 Transformation Transaction packet. This is not source-implementation
+acceptance: the packet correctly keeps implementation blocked where concrete D0
+compatibility rows, live D8 apply-admission projections, D10 path/protected-zone
+decisions, or G-HOST host-gate declarations are required and absent.
+
+## Findings
+
+No P1 findings.
+
+No P2 findings.
+
+## Review Scope
+
+Fresh review evidence came only from the current disk state. Previous final
+agents were not used as evidence.
+
+Read inputs:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/context.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D9-transformation-transaction.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/proposal.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/design.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/specs/habitat-harness/spec.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/tasks.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/phase-record.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/review-disposition-ledger.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/downstream-realignment-ledger.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/closure-checklist.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-domain-ontology-investigation.md`
+
+Mandatory skill anchors read before review: Domain Design, Information Design,
+Ontology Design, Solution Design, and TypeScript references for decision axes,
+domain invariants/state-space patterns, safe refactoring, and default failure
+modes.
+
+## Acceptance Rationale
+
+The repaired packet names **D9 Transformation Transaction** as the single owner.
+The design defines D9 as the recoverable transaction envelope around a
+D8-admitted structural rewrite and keeps adjacent authorities out of the D9
+domain. D6 diagnostics do not authorize writes. D8 owns pattern apply
+admission. D10 and G-HOST own protected/generated and host-policy decisions.
+D11 owns local feedback, D13 owns candidate generation, and Grit/Biome/Git/Nx
+remain vendor/tool owners whose command outcomes D9 records without absorbing
+their semantics.
+
+The target ontology is now closed enough for implementation planning. The packet
+defines request, admission, dry-run, write-set, path-decision, live-write,
+formatter, gate, rollback, recovery, terminal outcome, and non-claim families.
+It also defines required brands and non-empty collections for boundary terms
+where plain strings or empty arrays would reopen invalid states.
+
+The repaired `DryRunIntent` / `LiveWriteIntent` / `LiveWriteAttempt` split
+removes the prior circularity. The command layer may construct user intent only.
+D9 constructs `LiveWriteAttempt` only after it has D8 admission, dry-run/copy
+observations, D10/G-HOST path decisions where touched, an approved write set,
+rollback policy, and handoff policy. The spec repeats the critical invariant:
+`LiveWriteIntent` must not carry an approved write set before D9 planning
+produces one.
+
+Legacy proof/evidence vocabulary is no longer target ontology. `proof`,
+`GritApplyTransactionProof`, `diffEvidence`, `GritApply*` names, and
+`ok: boolean` are classified as compatibility/current-behavior terms or rejected
+target shapes. Target language uses transaction record/outcome, observations,
+handoffs, recovery, refusals, and non-claims. The remaining proof/evidence
+mentions in active D9 artifacts are disposition or current-evidence context, not
+target-domain acceptance.
+
+MapGen and Civ7 public-ops language is also contained. The spec and design treat
+current MapGen public-ops validation as host-specific current evidence that must
+be consumed as a G-HOST-declared apply gate or kept source-blocked. D9 does not
+embed MapGen paths or public-ops semantics as generic transaction policy.
+
+The active artifacts do not overclaim completeness. Uses of "complete" are
+scoped to D9's design/specification contract or to "not implementation-complete"
+status. The packet index, phase record, closure checklist, and downstream ledger
+all keep D9 pending final rereviews and explicitly block source implementation
+until upstream live dependencies exist.
+
+## Residual Non-Blocking Constraints
+
+D9 can move to accepted for design/specification after the remaining final
+rereview lanes and validation gates pass, but source implementation remains
+blocked for any affected surface lacking D0 compatibility rows, D8
+apply-admission projections, D10 path/protected-zone decisions, or G-HOST
+host-gate declarations.
+
+No domain-language decision appears deferred to implementation in this lane.
+Implementation agents still must instantiate the packet, but they should not
+need to invent owner boundaries, target term names, request mode semantics,
+refusal families, or handoff/non-claim meanings.
+
+## Validation
+
+`git diff --check`: passed with no output.
+
+Skills used: domain-design, information-design, ontology-design,
+solution-design, typescript.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-final-openspec-information-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-final-openspec-information-review.md
@@ -1,0 +1,157 @@
+# D9 Final OpenSpec Information Review
+
+Role: fresh final rereview agent for D9 OpenSpec/information.
+
+Lane: artifact structure, information design, task executability, and
+validation-gate clarity. This review read the current disk state only and did
+not edit packet files or source implementation.
+
+## Verdict
+
+Accepted for the design/specification lane.
+
+No unresolved P1/P2 findings were found in this lane. D9 remains not
+implementation-complete and not source-ready; the packet correctly keeps later
+source work blocked wherever concrete D0 rows, live D8 apply-admission
+projections, D10 path/generated/protected-zone decisions, or G-HOST host-gate
+declarations are absent.
+
+## P1/P2 Findings
+
+None.
+
+## Inputs Read
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/AGENTS.md`
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/source-map.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/artifact-contracts.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/validation-checks.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/phase-loop.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/team-and-review-lanes.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/context.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-openspec-information-testing-investigation.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/proposal.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/design.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/specs/habitat-harness/spec.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/tasks.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/phase-record.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/review-disposition-ledger.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/downstream-realignment-ledger.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/closure-checklist.md`
+
+## Repo State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation`
+- Branch: `codex/d9-transformation-transaction-packet`
+- Observed pre-report dirty state: the D9 packet/context/index files were
+  already modified and five first-wave D9 scratch files were already untracked.
+  This review did not treat those pre-existing changes as my edits.
+- This review wrote only:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-final-openspec-information-review.md`
+
+## Review Notes
+
+The artifact set is complete for the requested design/specification packet:
+proposal, design, spec delta, tasks, phase record, review disposition ledger,
+downstream realignment ledger, closure checklist, remediation context, and
+packet index all agree on the D9 status. The packet is repaired after first-wave
+investigation, pending final rereviews, not implementation-complete, and not
+source-ready.
+
+The context router now defines D9 variables for the change root, source packet,
+review scratches, final review scratches, and workstream ledgers. The packet
+artifacts use those variables instead of hard-coded local paths, while command
+execution instructions still rely on repo-local commands. This satisfies the
+information-design requirement that durable routing facts live in the context
+fixture rather than being repeated across packet files.
+
+The packet index status is precise. D9 is not marked accepted yet; it is marked
+as repaired after first-wave D9 investigation with final domain/ontology,
+TypeScript/validation, OpenSpec/information, code/vendor topology, and
+cross-domino/product rereviews required before design/specification acceptance.
+It also preserves the implementation blocker: concrete D0 rows, D8
+apply-admission projections, D10 path/zone decisions, and G-HOST host-gate
+declarations are required before source implementation where touched.
+
+The design now distinguishes command/user intent from D9-produced write
+attempts. `DryRunIntent` and `LiveWriteIntent` are command-layer intents;
+`LiveWriteAttempt` is produced only after D9 planning has D8 admission, D10 or
+G-HOST path decisions where touched, dry-run inventory, an approved write set,
+and rollback policy. The spec and tasks repeat the same constraint: the command
+parser must not construct `LiveWriteAttempt`.
+
+The spec delta is executable as an OpenSpec contract. It has concrete
+requirements and falsifiable scenarios for explicit request modes, D8 admission
+consumption, diagnostic non-authority, dry-run inventory states, approved write
+sets, protected/host policy inputs, live-write preconditions, formatter/gate
+handoffs, rollback states, distinct docs/source lanes, public fix output
+compatibility, and downstream projections.
+
+The tasks are implementation-executable rather than open design questions. They
+sequence grounding, dependency confirmation, state-model construction,
+request/admission, dry-run/write-set approval, live-write/handoff/rollback,
+public projection, tests, validation, and closure. Where a prerequisite is not
+available, the task directs the implementer to keep the affected source work
+blocked and record the blocker instead of inventing a local decision.
+
+Design-time gates and later implementation gates are split consistently across
+proposal, phase record, closure checklist, and tasks. Design-time gates cover
+the D9 wording audit, strict D9 OpenSpec validation, full OpenSpec validation,
+`git diff --check`, and final rereview lanes. Later implementation gates cover
+source tests, command checks, bad-case transaction tests, native Grit pattern
+tests where touched, and worktree cleanliness around live-write/rollback
+fixtures.
+
+The invalid `habitat fix --dry-run --json` command is not used as a current
+gate. Active packet artifacts either say JSON is out of current D9 scope unless
+D0 authorizes it, or explicitly forbid running that command as a validation
+gate without D0 authorization and matching implementation. Literal occurrences
+of the invalid command in prior first-wave scratch files are historical review
+evidence, not current D9 gate instructions.
+
+The exact D13 wording audit over the requested active corpus reports only the
+canonical D13 title/slug traceability hits in
+`/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/packet-index.md`.
+Active D9 artifacts refer to D13 as candidate generation/prerequisite consumer
+and do not import D13's canonical title/slug language into the D9 target model.
+
+No implementation-time design question remains in this lane. The remaining
+unchecked boxes are explicit gates or external dependency blockers, not design
+ambiguity for an implementation agent to resolve ad hoc.
+
+## Validation Results
+
+- `bun run openspec -- validate deep-habitat-d9-transformation-transaction --strict`
+  - Result: pass.
+  - Output: `Change 'deep-habitat-d9-transformation-transaction' is valid`.
+- `bun run openspec:validate`
+  - Result: pass.
+  - Output: `Totals: 249 passed, 0 failed (249 items)`.
+- D9 exact D13 wording audit:
+  - Command searched the complete-standard phrase family plus the canonical
+    D13-title/slug phrase family across `$D9_CHANGE/**`,
+    `$REMEDIATION_DIR/packet-index.md`, and `$AGENT_SCRATCH/domino-D9-*.md`.
+  - Result: only the two packet-index rows that identify the canonical D13
+    packet title and slug for traceability.
+- `git diff --check`
+  - Result: pass after writing this report.
+  - Output: no output.
+
+## Non-Claims
+
+- This review does not accept D9 for source implementation.
+- This review does not claim D0/D8/D10/G-HOST live implementation blockers are
+  satisfied.
+- This review does not use previous final agents as evidence.
+- This review does not update the D9 packet index row or D9 workstream ledgers;
+  the requested output was this scratch review only.
+
+Skills used: domain-design, information-design, solution-design,
+testing-design, civ7-open-spec-workstream.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-final-typescript-validation-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-final-typescript-validation-review.md
@@ -1,0 +1,94 @@
+# D9 Final TypeScript/Validation Review
+
+## Verdict
+
+Accepted for the design/specification lane.
+
+No unresolved P1/P2 TypeScript state-space or validation findings remain against the current disk state of `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction`.
+
+This is not source acceptance. The current implementation evidence in `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/grit-apply.ts` still has the legacy flags, nullable proof DTO, boolean result, inline host validation, and broad orchestration module that D9 is meant to replace. The packet now treats that source as evidence, not target authority, and gives implementation agents a sufficiently exact replacement model and falsification suite.
+
+## Findings
+
+No P1/P2 findings.
+
+Minor non-blocking observation: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/specs/habitat-harness/spec.md` says live-write intent carries "user intent and D8 apply admission only", while the design type also includes `worktree: WorktreeObservation`. Read in context, the scenario is clearly forbidding pre-D9 approved write sets, not forbidding worktree observation, so this is not blocking. If touched later, changing "only" to "without an approved write set" would remove the ambiguity.
+
+## Review Evidence
+
+Required skill anchoring was completed from the current local skill corpus before review:
+
+- Domain Design: `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- Information Design: `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- Solution Design: `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`
+- Testing Design: `/Users/mateicanavra/.agents/skills/testing-design/SKILL.md`
+- TypeScript Design and relevant references under `/Users/mateicanavra/.agents/skills/typescript/`, including `where-defaults-hide.md`, `refactoring-patterns.md`, `design-patterns.md`, `philosophy.md`, `axes.md`, `integration-combos.md`, `module-organization.md`, `sdk-design.md`, `ecosystem.md`, and `real-world-examples.md`
+
+The duplicate TypeScript skill corpus under `/Users/mateicanavra/.codex/plugins/cache/rawr-hq/dev/1.0.0/skills/typescript` was checked by byte comparison for the relevant files and matched the primary corpus.
+
+Disk evidence reviewed:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/proposal.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/design.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/specs/habitat-harness/spec.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/tasks.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/review-disposition-ledger.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/closure-checklist.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/downstream-realignment-ledger.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/phase-record.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D9-transformation-transaction.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-typescript-state-investigation.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/grit-apply.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/grit-apply.test.ts`
+
+## TypeScript State-Space Review
+
+The repaired packet now specifies the exact collapse needed for D9 implementation:
+
+- Request construction is explicit: `DryRunIntent` and `LiveWriteIntent` are command-facing intent variants, while `LiveWriteAttempt` is D9-produced after dry-run/copy/path planning. `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/design.md` states that no command parser may construct `LiveWriteAttempt` directly, and `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/specs/habitat-harness/spec.md` makes the same distinction normative.
+- The prior circularity is removed. A live-write request no longer appears to require an already approved write set; it carries intent plus D8 admission, and D9 later constructs `LiveWriteAttempt` only after producing `ApprovedWriteSet`.
+- Terminal and intermediate states are closed discriminated unions: admission, dry-run inventory, write-set approval, live write, formatter handoff, gate handoff, rollback, recovery, refusal, non-claim, and terminal outcome.
+- Legacy `GritApplyTransactionOptions`, `GritApplyTransactionProof`, `GritApplyTransactionResult`, `ok: boolean`, nullable command fields, and `proof` language are classified as compatibility surfaces rather than target model.
+- Branded identifiers are required for authority-bearing strings: pattern ids, Grit pattern paths, repo-relative paths, approved write paths, write-set ids, command ids, SHA-256 digests, D0 surface ids, D1 non-claim ids, D8 admission ids, and D10 decision ids.
+- Non-empty collections are required where emptiness would make a state false-green: approved writes, blocked writes, rollback paths, recovery instructions, gate command records, and D0 citations.
+- Exhaustive `never` handling is required for command rendering and legacy projection.
+- The packet rejects broad proof DTO authority and requires `ApplyTransactionRecord` / `TransactionOutcome` as the target state source.
+
+## Boundary And Ownership Review
+
+The packet now protects D9 from owning adjacent domains:
+
+- D8 owns apply admission and lifecycle; D9 consumes `ApplyAdmissionProjection`.
+- D10/G-HOST own protected/generated and host-specific policy; D9 consumes path/gate projections.
+- Grit owns native pattern semantics and output behavior; D9 records and classifies observations.
+- Biome, Git, and Nx are modeled as tool/vendor owners whose command outcomes are recorded without turning them into product proof.
+- Current MapGen public-ops validation in generic transaction code is correctly treated as host-specific current evidence that must become a G-HOST/D10-declared gate or remain source-blocked.
+
+This satisfies the review bar for "no host-specific logic in generic D9".
+
+## Validation Review
+
+The repaired validation surface is adversarial enough for acceptance in the design/spec lane. `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/tasks.md` requires type-level/compile-time rejection of false states and runtime tests for dirty live refusal, dirty dry-run, zero-match dry-run, ambiguous dry-run, unapproved inventory, outside-root refusal, create/delete refusal, protected-zone refusal, missing host gate, unexpected live path, formatter failure, gate failure, rollback success, and rollback failure.
+
+The validation requirements are not just green-path command runs. They specifically target false-green states from the current implementation evidence:
+
+- `ok: true` plus failure state
+- dry-run carrying rollback-after-apply semantics
+- live write without D8 admission
+- live write without D10/G-HOST decisions where touched
+- rollback command outside rollback state
+- formatter/gate success inside failed outcomes
+- legacy proof projection reporting success from a refusal/failure target
+
+The implementation tasks are executable slices, not design deferrals. The sequence starts with state model construction and compile-time rejection tests, then request/admission, write-set approval, live write/handoffs/rollback, public compatibility projection, and focused validation. Source implementation remains explicitly blocked where D0/D8/D10/G-HOST live inputs are absent, which is a correct dependency gate rather than an underspecified task.
+
+## Commands Run
+
+- `bun run openspec -- validate deep-habitat-d9-transformation-transaction --strict`
+  - Result: passed. Output included `Change 'deep-habitat-d9-transformation-transaction' is valid`.
+- `bun run openspec:validate`
+  - Result: passed. Output reported `Totals: 249 passed, 0 failed (249 items)`.
+- `git diff --check`
+  - Result: passed with no output.
+
+Skills used: domain-design, information-design, solution-design, testing-design, typescript.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-openspec-information-testing-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-openspec-information-testing-investigation.md
@@ -1,0 +1,705 @@
+# D9 OpenSpec Information And Testing Investigation
+
+Role: D9 OpenSpec/information/testing design investigator.
+
+Lane: artifact shape and validation oracle only. This file does not authorize
+source refactor implementation and does not edit the D9 OpenSpec packet.
+
+## Verdict
+
+D9 is blocked from this lane.
+
+The current packet is a useful source input, but it is not yet a complete
+OpenSpec authority for implementation. The spec delta has only two scenarios,
+the task list leaves transaction states and public compatibility decisions to
+the implementer, and the workstream control files still carry global
+constraints rather than D9-specific accepted/repaired findings.
+
+The required target is a guarded write transaction contract for `habitat fix`:
+dry-run inventory, approved pattern admission, approved path ownership,
+isolated-copy proof, live write, rollback, formatter handoff, host/pattern gate
+handoff, public output, and no-residue behavior must be explicit states with
+falsifying tests.
+
+## Inputs Read
+
+- Root `AGENTS.md`.
+- Source packet:
+  `$PHASE2_PACKET_DIR/D9-transformation-transaction.md`.
+- D9 OpenSpec files:
+  `$OPENSPEC_CHANGES/deep-habitat-d9-transformation-transaction/proposal.md`,
+  `design.md`, `tasks.md`,
+  `specs/habitat-harness/spec.md`, and `workstream/*`.
+- Remediation context and packet index:
+  `$REMEDIATION_DIR/context.md`,
+  `$REMEDIATION_DIR/packet-index.md`.
+- Global remediation constraints:
+  `review-disposition-ledger.md`,
+  `agent-scratch/global-domain-adversary.md`,
+  `agent-scratch/global-openspec-architect.md`,
+  `agent-scratch/global-information-design-reviewer.md`,
+  `agent-scratch/global-testing-validation-designer.md`,
+  `agent-scratch/global-cross-domino-sequencer.md`.
+- Current code/test evidence:
+  `tools/habitat-harness/src/lib/grit-apply.ts`,
+  `tools/habitat-harness/src/lib/grit-failures.ts`,
+  `tools/habitat-harness/src/lib/command-engine.ts`,
+  `tools/habitat-harness/src/commands/fix.ts`,
+  `tools/habitat-harness/test/lib/grit-apply.test.ts`,
+  `tools/habitat-harness/test/commands/habitat-commands.test.ts`,
+  `tools/habitat-harness/test/commands/habitat-entrypoints.test.ts`.
+
+## Current Control State
+
+- Observed worktree branch: `codex/d9-transformation-transaction-packet`.
+- Observed repo state before writing this scratch file: clean.
+- `gt status` reported the git status pass-through as clean.
+- `bun run openspec -- list` reports
+  `deep-habitat-d9-transformation-transaction` at `0/16 tasks`.
+- The remediation context currently says
+  `$ACTIVE_REMEDIATION_BRANCH` is `codex/d8-pattern-governance-packet`, while
+  the actual branch for this investigation is
+  `codex/d9-transformation-transaction-packet`.
+- The context file defines D3-D8 variables but not D9 variables. That is not
+  fatal for this scratch file, but it is a packetization/control blocker for
+  D9 acceptance because future agents cannot route D9 artifacts through the
+  same durable variable convention.
+
+## Primary Blockers
+
+### D9-BLOCKER-001: `spec.md` is not an executable transaction contract
+
+The current D9 spec has one requirement and two scenarios:
+
+- dry run requested;
+- live apply fails after writes.
+
+That omits most of the source packet contract. It does not specify the dry-run
+zero-match state, approved-change inventory, parse/mismatch refusal, dirty
+worktree refusal, apply admission, protected-zone refusal, unexpected path,
+create/delete refusal, formatter handoff, gate handoff, rollback success,
+rollback failure, public output, or no-residue behavior.
+
+Required repair: expand `specs/habitat-harness/spec.md` into multiple
+requirements with concrete scenarios. The spec must make the invalid product
+states impossible or explicitly refused, not merely name "transaction" as a
+concept.
+
+### D9-BLOCKER-002: `tasks.md` leaves design decisions to implementation
+
+Current tasks 2.1-2.3 say:
+
+- define apply transaction states and rollback boundaries;
+- separate Grit diagnostic input from write transaction output;
+- use D1 receipt terms only for recovery records.
+
+Those are design decisions, not implementation slices. An implementation agent
+would still have to decide the transaction union variants, request modes,
+public output compatibility, gate ownership, rollback semantics, and exact
+test oracle while coding.
+
+Required repair: tasks must first repair the D9 packet itself, then sequence
+implementation slices only after spec/design acceptance. Every implementation
+task must name the artifact/code area, state variant, falsifying test, and
+upstream owner consumed.
+
+### D9-BLOCKER-003: D9 control files import global findings but do not
+disposition D9 findings
+
+The D9 review ledger says global constraints are applied and per-domino review
+is blocking. That is correct as an initial packet state, but it is not acceptance evidence.
+
+Required repair: import D9-specific blocker rows from this investigation and
+the applicable global constraints, then keep D9 blocked until accepted P1/P2
+rows are repaired or explicitly rejected with source evidence.
+
+### D9-BLOCKER-004: D9 is sequenced after D8/D10/G-HOST decisions, but those
+inputs are not named concretely
+
+The source packet correctly says D9 depends on D1, D6, D8, D10, and consumes
+G-HOST through D10 and directly for host-specific pattern gates. The OpenSpec
+proposal/design do not name the exact D8 apply-approved lifecycle state or the
+D10/G-HOST protected-zone and gate declaration inputs D9 must consume.
+
+Required repair: D9 design must name the projection/manifest/declaration fields
+it consumes. "Approved patterns" is not enough.
+
+### D9-BLOCKER-005: Public `habitat fix` compatibility is unresolved
+
+D1 has already identified `ApplyTransactionRecord` as the target meaning and
+treats `GritApplyTransactionProof` as legacy public surface unless D0 permits
+versioning. Current D9 proposal only says output "may change"; current D9 tasks
+only run `habitat fix --help`; global validation expects
+`bun run habitat fix --dry-run --json`, but current `fix.ts` exposes only
+`--dry-run`.
+
+Required repair: D9 must include a D0-backed output disposition before
+implementation:
+
+- preserve current human output only;
+- add JSON output under a versioned/additive contract;
+- facade legacy `GritApplyTransactionProof` behind `ApplyTransactionRecord`;
+- or refuse JSON scope for D9 and remove `--json` from D9 gates with a
+  downstream ledger entry explaining which packet owns it.
+
+The implementer must not invent this compatibility decision.
+
+## Missing `spec.md` Requirements And Scenarios
+
+### Requirement: Apply request modes are explicit
+
+Habitat SHALL construct apply transactions through closed request modes, not
+through freely-combinable booleans/options.
+
+Scenarios:
+
+- WHEN a dry-run request is created
+  THEN it cannot carry live-write, rollback-after-apply, formatter-write, or
+  post-write gate states.
+- WHEN a live approved transaction is created
+  THEN it requires an apply-approved pattern identity from D8, approved roots,
+  a clean-worktree requirement, and a dry-run inventory precondition.
+- WHEN a rollback-capable transaction is created
+  THEN it requires a live write state and changed-path ownership.
+- WHEN a gate handoff is created
+  THEN it requires a D10/G-HOST or pattern-owned declaration and cannot be an
+  anonymous caller-provided command.
+
+### Requirement: Dry-run inventory is a first-class transaction state
+
+Habitat SHALL distinguish dry-run no-match, dry-run approved changes, dry-run
+parse failure, dry-run command failure, and dry-run/live mismatch.
+
+Scenarios:
+
+- WHEN dry-run reports zero matches
+  THEN Habitat returns a no-mutation state with empty inventory and prohibited
+  inference that no live apply success was proven.
+- WHEN dry-run reports approved structured inventory
+  THEN every entry records pattern identity, file path, symbol/rewrite target,
+  approval source, and raw-output digest.
+- WHEN dry-run output is non-empty but not zero-match or structured inventory
+  THEN Habitat fails closed before live apply.
+- WHEN dry-run reports matches but isolated-copy apply produces no diff
+  THEN Habitat fails closed as a dry-run mismatch.
+
+### Requirement: Pattern admission is consumed, not decided, by D9
+
+Habitat SHALL apply only patterns whose D8 lifecycle state is apply-approved
+for the requested repair surface.
+
+Scenarios:
+
+- WHEN a diagnostic-registered pattern lacks apply approval
+  THEN D9 refuses before dry-run/live write.
+- WHEN a candidate file exists without D8 apply approval
+  THEN file presence does not authorize a transaction.
+- WHEN D8 records pattern refusal/retirement
+  THEN D9 refuses even if a Grit pattern file still exists.
+
+### Requirement: D6 diagnostic identity cannot imply apply safety
+
+Habitat SHALL treat diagnostic pattern findings as possible transaction input
+only after D8 apply approval and D9 dry-run/path checks.
+
+Scenarios:
+
+- WHEN D6 emits a diagnostic adapter failure
+  THEN D9 does not convert it into an apply transaction failure.
+- WHEN a diagnostic pattern has current-tree findings
+  THEN D9 still requires D8 apply approval and D9 transaction checks before
+  any write.
+
+### Requirement: Approved write set owns every changed path
+
+Habitat SHALL refuse changed paths outside approved roots and SHALL refuse
+create/delete effects unless a pattern-owned create/delete approval contract
+exists.
+
+Scenarios:
+
+- WHEN inventory names a path outside approved roots
+  THEN D9 refuses before live apply.
+- WHEN isolated-copy diff evidence changes a path outside approved roots
+  THEN D9 refuses before live apply.
+- WHEN isolated-copy diff evidence creates a file without pattern-owned create
+  approval
+  THEN D9 refuses.
+- WHEN isolated-copy diff evidence deletes a file without pattern-owned delete
+  approval
+  THEN D9 refuses.
+- WHEN live apply produces a changed path not present in the approved write set
+  THEN D9 rolls back and reports unexpected-path failure.
+
+### Requirement: Generated/protected-zone policy is a blocking input
+
+Habitat SHALL consume D10/G-HOST protected-zone and generated-zone declarations
+before live apply.
+
+Scenarios:
+
+- WHEN a planned write intersects a generated or protected zone without an
+  allowed mutation declaration
+  THEN D9 refuses before live apply.
+- WHEN host policy is missing for a host-specific apply gate
+  THEN D9 refuses rather than silently disabling the gate.
+- WHEN D10 reports next-safe-action/refusal for a protected path
+  THEN D9 reports that refusal as transaction refusal, not as diagnostic or
+  formatter failure.
+
+### Requirement: Live write is conditional on dry-run and copy proof
+
+Habitat SHALL run live apply only after dry-run inventory and isolated-copy
+proof have approved the exact write set.
+
+Scenarios:
+
+- WHEN live apply starts
+  THEN the pre-live git state is clean unless the transaction is explicitly an
+  isolated-copy proof that cannot mutate the source tree.
+- WHEN live apply succeeds and changed paths equal the approved set
+  THEN the transaction enters live-write-applied state and proceeds to handoffs.
+- WHEN live apply fails or is interrupted after possible writes
+  THEN Habitat attempts rollback and records the rollback relation.
+
+### Requirement: Rollback is an explicit state relation
+
+Habitat SHALL record rollback not as a nullable side field but as a state
+transition after a write or rollback-requested dry-run fixture.
+
+Scenarios:
+
+- WHEN live apply fails and rollback succeeds
+  THEN the transaction records failed-after-apply with rollback-succeeded and
+  final clean git state.
+- WHEN formatter handoff fails and rollback succeeds
+  THEN the formatter failure remains the cause and rollback is recorded as
+  recovery.
+- WHEN gate handoff fails and rollback succeeds
+  THEN gate failure remains the cause and rollback is recorded as recovery.
+- WHEN rollback fails
+  THEN the transaction records rollback-failed, residual changed paths, file
+  digests, recovery instructions, and prohibited inference that the tree is
+  clean.
+
+### Requirement: Formatter handoff is not apply safety proof
+
+Habitat SHALL run Biome or formatter handoff after live apply when changed
+paths require it, but SHALL label formatter outcome as hygiene handoff.
+
+Scenarios:
+
+- WHEN formatter succeeds
+  THEN D9 may continue to gates but does not claim formatter success proves
+  product behavior or apply safety.
+- WHEN formatter fails
+  THEN D9 attempts rollback and reports formatter-handoff-failed.
+
+### Requirement: Host/pattern gates are declared handoffs
+
+Habitat SHALL run only declared gates associated with the apply-approved pattern
+or host policy.
+
+Scenarios:
+
+- WHEN a declared gate succeeds
+  THEN D9 records the gate command result and its non-claims.
+- WHEN a declared gate fails
+  THEN D9 attempts rollback and reports gate-failed.
+- WHEN an implementation caller supplies an undeclared arbitrary gate command
+  THEN D9 refuses before live apply.
+
+### Requirement: Docs rewrite and source rewrite remain distinct apply lanes
+
+Habitat SHALL keep docs-local-checkout-path rewrites and source public-import
+rewrites in separate pattern lanes with separate roots, approval semantics, and
+handoff records.
+
+Scenarios:
+
+- WHEN docs dry-run finds a markdown candidate
+  THEN docs paths are approved only through the docs pattern lane.
+- WHEN source dry-run finds MapGen public import candidates
+  THEN source paths are approved only through the source pattern lane and its
+  pattern-specific public target gate.
+- WHEN docs dry-run lists a markdown file without a rewrite hunk
+  THEN it cannot become an approved changed path.
+
+### Requirement: Public fix output is compatibility-controlled
+
+Habitat SHALL expose `habitat fix` transaction output only through D0-backed
+compatibility disposition.
+
+Scenarios:
+
+- WHEN `GritApplyTransactionProof` remains exported or rendered
+  THEN it is a legacy-name facade for `ApplyTransactionRecord` semantics.
+- WHEN JSON output is added
+  THEN it has a schema/version decision, stable state tag field, non-claims,
+  and bad-case tests.
+- WHEN JSON output is not in D9 scope
+  THEN D9 validation gates must not require `--json`.
+
+### Requirement: No-residue behavior is observable
+
+Habitat SHALL leave no source-tree residue from dry-run, isolated-copy proof,
+or failed live transactions with successful rollback.
+
+Scenarios:
+
+- WHEN dry-run completes
+  THEN `git status --short --branch` before and after remains unchanged.
+- WHEN isolated-copy proof completes
+  THEN probe/source files remain byte-identical and temporary copy directories
+  are removed.
+- WHEN a failed live transaction rolls back successfully
+  THEN final git status is clean or contains only pre-existing non-D9 changes
+  explicitly recorded.
+
+### Requirement: D15 trigger is decided, not implied
+
+Habitat SHALL include a D15 decision row for D9 command provenance needs.
+
+Scenarios:
+
+- WHEN `habitat fix --dry-run --json` requires argv/cwd/env/cache/duration
+  fields that local D9 DTOs cannot represent without contradictory states
+  THEN D9 records the D15 trigger and either blocks on a single substrate owner
+  or narrows the output scope.
+- WHEN local DTO variants can represent the D9 transaction record
+  THEN D15 is rejected for D9 and no shared substrate edit is authorized.
+
+## Required Task Slices And Sequence
+
+### 0. Repair packet control before implementation
+
+1. Add D9 routing variables or a D9 traceability row that gives future agents a
+   durable path to D9 source packet, change root, review ledger, phase record,
+   downstream ledger, and scratch reviews.
+2. Correct branch/worktree fixture drift in control records or record a
+   no-patch disposition explaining why the D8 branch value is historical.
+3. Import this investigation as a D9 review ledger blocker.
+
+### 1. Close design authority
+
+1. Add the D9 state table to `design.md`: request modes, transaction states,
+   allowed transitions, owners, forbidden owners, and required fields.
+2. Add the D8 apply-approved pattern input table: lifecycle state, manifest
+   fields, pattern identity, approved roots, approved operation class,
+   create/delete authorization, and declared gates.
+3. Add the D10/G-HOST input table: protected/generated path facts, host gate
+   declarations, missing-host-policy refusal.
+4. Add the D1/D0 compatibility table for `ApplyTransactionRecord`,
+   `GritApplyTransactionProof`, command human output, command JSON output,
+   package exports, tests, and docs examples.
+5. Add the D15 decision row.
+
+### 2. Repair the normative spec
+
+1. Replace the current single requirement with the requirements listed above.
+2. Ensure each scenario is falsifiable and uses `WHEN`/`THEN`/`AND`.
+3. Avoid implementation names unless D0/D1 explicitly retain them as
+   compatibility surfaces.
+
+### 3. Replace generic tasks with executable slices
+
+1. State model and typed constructors.
+2. D8 apply-admission consumption.
+3. D10/G-HOST protected-zone and gate-declaration consumption.
+4. Dry-run inventory parser/refusal states.
+5. Isolated-copy proof and diff evidence states.
+6. Path approval and create/delete refusal.
+7. Live apply and unexpected-path rollback.
+8. Formatter handoff.
+9. Declared host/pattern gates.
+10. Rollback/recovery record and residual-state output.
+11. `habitat fix` human/JSON output compatibility.
+12. Docs/source pattern lane split.
+13. No-residue cleanup.
+14. Downstream docs/tests/spec updates.
+15. Validation and closure.
+
+Each task needs its own test or command oracle. Do not combine all behavior
+into "run grit-apply tests".
+
+### 4. Only then implement source refactor
+
+Implementation should not start until the D9 review ledger has no accepted
+unresolved P1/P2 findings and the packet index no longer marks D9 as blocking.
+
+## Review Ledger Findings To Import As Blockers
+
+| Finding | Severity | Required D9 disposition |
+| --- | --- | --- |
+| Per-domino review remains blocking. | P1 | Keep blocked until D9-specific domain, OpenSpec, TypeScript/state, validation, information, and cross-domino findings are dispositioned. |
+| `spec.md` lacks the source packet's transaction state coverage. | P1 | Add missing requirements/scenarios above. |
+| `tasks.md` contains unresolved design decisions. | P1 | Replace with design repair and implementation slices. |
+| D9 context fixture drift and missing D9 variables. | P2 | Repair context/index or record explicit no-patch disposition before handoff. |
+| Generic proof vocabulary can hide transaction semantics. | P1 | Use `ApplyTransactionRecord`/guarded write transaction language; treat `GritApplyTransactionProof` only as D0/D1 compatibility. |
+| Artifact owner can masquerade as domain authority. | P1 | State D9's decision right: guarded writes and rollback; forbid D6/D8/D10/Biome from deciding transaction safety. |
+| TypeScript state-space reduction alone is not acceptance. | P1 | Name the product-invalid states removed: unapproved apply, unexpected write, hidden rollback failure, formatter/gate proof inflation. |
+| Stale absolute paths and branch evidence can become executable proof. | P1 | Use repo-relative commands and current branch/status evidence for closure. |
+| Non-claims can be used to close failed gates. | P2 | State that non-claims narrow passing evidence only; failed required D9 gates block closure. |
+| D9 must not become a general auto-repair engine. | P1 | Keep `habitat fix` limited to D8 apply-approved patterns and declared gates. |
+| D15 substrate work needs one owner. | P2 | Add D15 decision row; do not authorize shared process/Effect edits from D9 unless trigger passes. |
+
+## Design-Time Gates Versus Later Implementation Gates
+
+### Design-time gates
+
+These must close before source refactor implementation starts:
+
+- D9 review ledger has D9-specific findings and no accepted unresolved P1/P2.
+- `proposal.md` states D9 boundary, dependencies, forbidden owners, public
+  output impact, and stop conditions without "may affect" ambiguity.
+- `design.md` contains the transaction state table, request mode constructors,
+  upstream input tables, public compatibility table, D15 row, and rejected
+  alternatives.
+- `spec.md` contains complete normative requirements and scenarios.
+- `tasks.md` is ordered and executable, not a list of decisions.
+- D0 compatibility disposition exists for any `habitat fix` output/export/docs
+  surface touched.
+- D8 apply-approved lifecycle fields consumed by D9 are named.
+- D10/G-HOST protected-path and gate-declaration inputs consumed by D9 are
+  named.
+- Validation commands have exact expected status, oracle, bad case,
+  cache/freshness stance, and non-claims.
+
+### Later implementation gates
+
+These prove implementation after packet acceptance; they cannot substitute for
+the design-time gates above:
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/grit-apply.test.ts`.
+- `bun run --cwd tools/habitat-harness test -- test/commands/habitat-commands.test.ts`.
+- `bun run --cwd tools/habitat-harness test -- test/commands/habitat-entrypoints.test.ts` if public CLI behavior changes.
+- `bun run habitat fix --dry-run` or `bun run habitat fix --dry-run --json`
+  depending on the D0/D9 public output decision.
+- `git status --short --branch` before and after dry-run/no-residue checks.
+- `bun run openspec -- validate deep-habitat-d9-transformation-transaction --strict`.
+- `bun run openspec:validate`.
+- `git diff --check`.
+
+## Falsifying Tests And Commands
+
+### Dry-run
+
+Falsifier: dry-run mutates the source tree, conflates no-match with live
+success, or treats malformed output as success.
+
+Required checks:
+
+- Unit: dry-run with dirty worktree is allowed only because it does not write;
+  proof records dirty pre-state and empty/approved inventory.
+- Unit: non-empty unstructured dry-run output returns dry-run mismatch.
+- Unit: dry-run reports matches but isolated copy returns no diff returns
+  mismatch.
+- Command: `git status --short --branch` before and after
+  `bun run habitat fix --dry-run` or `--dry-run --json` is unchanged.
+- Oracle: no live apply command, no formatter command, and no gate command runs
+  in dry-run-only mode unless the spec explicitly defines read-only dry-run
+  gate inventory.
+
+### Live write
+
+Falsifier: live apply runs without D8 apply-approved pattern, clean pre-state,
+dry-run inventory, isolated-copy proof, approved roots, and D10/G-HOST path
+approval.
+
+Required checks:
+
+- Unit: live apply refuses dirty worktree before running Grit.
+- Unit: live apply command is observed only after approved inventory/copy proof.
+- Unit: changed paths after live apply equal approved paths exactly.
+- Unit: `ok: true` with any failure tag or rollback-failed state is impossible
+  or rejected.
+- Command: live write fixture may alter only expected fixture files and must
+  record file digests.
+
+### Rollback
+
+Falsifier: post-write failure hides rollback attempt/outcome or reports clean
+success after rollback failure.
+
+Required checks:
+
+- Unit: live apply command failure after possible write triggers rollback.
+- Unit: live apply interruption triggers rollback and preserves signal metadata.
+- Unit: formatter failure triggers rollback.
+- Unit: gate failure triggers rollback.
+- Unit: rollback failure returns rollback-failed state with residual paths,
+  rollback command result, before/after file digests, and recovery instructions.
+- Command: post-rollback `git status --short --branch` is clean for
+  rollback-succeeded tests.
+
+### Unexpected path
+
+Falsifier: a path outside the approved write set survives as success or as a
+formatter/gate problem.
+
+Required checks:
+
+- Unit: structured inventory outside approved roots is blocked.
+- Unit: isolated-copy diff outside approved roots is blocked.
+- Unit: live apply that changes an unapproved path is rolled back and reported
+  as unexpected-path failure.
+
+### Create/delete refusal
+
+Falsifier: file creation or deletion inside approved roots is silently treated
+as an approved modification.
+
+Required checks:
+
+- Unit: isolated-copy create evidence with `beforeSha256: null` is blocked
+  unless the pattern has explicit create approval.
+- Unit: isolated-copy delete evidence with `afterSha256: null` is blocked
+  unless the pattern has explicit delete approval.
+- Spec: if create/delete approval is not part of D8's apply-approved lifecycle,
+  D9 SHALL refuse all create/delete effects.
+
+### Formatter handoff
+
+Falsifier: Biome success is reported as apply safety/product proof, or Biome
+failure leaves writes unrolled-back.
+
+Required checks:
+
+- Unit: formatter command runs only after live changed paths exist.
+- Unit: formatter success is recorded as hygiene handoff with non-claims.
+- Unit: formatter failure triggers rollback and produces
+  formatter-handoff-failed state.
+- Oracle: formatter handoff cannot authorize a write path that dry-run/copy
+  proof did not approve.
+
+### Gate handoff
+
+Falsifier: arbitrary caller-local gates decide transaction safety, or host gate
+failure is hidden as generic command failure.
+
+Required checks:
+
+- Unit: declared gate success is recorded with command id, owner, and
+  non-claims.
+- Unit: declared gate failure triggers rollback and records gate-failed state.
+- Unit: undeclared gate request is refused before live apply.
+- Unit: missing G-HOST/D10 host declaration refuses before live apply.
+
+### Docs/source pattern split
+
+Falsifier: docs markdown rewrites and source import rewrites share roots,
+approval semantics, or public-ops validation.
+
+Required checks:
+
+- Unit: source lane uses source apply pattern and source roots only.
+- Unit: docs lane uses docs pattern and markdown files only, never the whole
+  `docs` directory.
+- Unit: docs dry-run file with no rewrite hunk cannot become approved changed
+  path.
+- Unit: MapGen public ops export validation is pattern/host-specific, not
+  generic transaction truth.
+
+### Public output
+
+Falsifier: public fields change without D0 disposition, or `--json` is required
+by validation but not designed as a public contract.
+
+Required checks:
+
+- Unit/command: `Fix.run(["--dry-run"])` forwards dry-run and renders expected
+  human output.
+- If JSON is in scope: `bun run habitat fix --dry-run --json` has stable
+  schema/version, transaction state tag, non-claims, and bad-case fixtures.
+- If JSON is out of scope: D9 tasks/phase record do not require the `--json`
+  gate, and downstream validation notes are patched or dispositioned.
+
+### No-residue behavior
+
+Falsifier: dry-run, isolated-copy proof, injected probe, or failed transaction
+leaves untracked/tracked residue.
+
+Required checks:
+
+- Unit: isolated-copy proof leaves source probe file byte-identical.
+- Unit: missing-export probe cleanup removes injected files.
+- Command: `git status --short --branch` before/after dry-run and injected
+  probes matches expected state.
+- Unit: temporary copy roots are removed after success and failure paths, or the
+  design names a cleanup observation if direct temp existence is not testable.
+
+## Wording Audit Terms That Should Block Acceptance
+
+These terms may appear only in forbidden-language sections, historical input
+quotes, or explicit rejected alternatives. Their unqualified presence in
+proposal/design/spec/tasks/ledger rows blocks D9 acceptance:
+
+- `shim`
+- `implicit alternate authority path`
+- `temporary`
+- `optional target shape`
+- `dual path`
+- `support both`
+- `compatibility until later`
+- `silent skip`
+- `only if needed`
+- `best effort`
+- `when feasible`
+- `may affect`
+- `safe` without a falsifying criterion
+- `stable` without a compatibility/versioning criterion
+- `trustworthy` or `robust` without an oracle
+- `proof` as a generic noun where `ApplyTransactionRecord`, command result,
+  handoff record, assertion summary, or prohibited inference is meant
+- `non-claim` without naming the prohibited inference
+- `state-space reduction` without naming the product-invalid state removed
+- `approved pattern` without naming the D8 lifecycle state/fields
+- `gate` without naming owner, declaration source, and failure behavior
+- `generated/protected path` without naming D10/G-HOST owner and refusal
+  behavior
+- `ok: boolean` or nullable proof-field language as target design rather than
+  legacy compatibility
+
+## Current Code Evidence That The Spec Must Control
+
+- `GritApplyTransactionOptions` currently combines `dryRun`,
+  `allowDirtyWorktree`, `rollbackAfterApply`, and `gateCommands`; this is the
+  invalid-state source the D9 design must replace with constructors/request
+  variants.
+- `GritApplyTransactionResult` is currently `ok: boolean`, nullable
+  `failureTag`, and `proof`; D1 already identifies the target meaning as
+  `ApplyTransactionRecord`.
+- `grit-apply.ts` currently owns both generic mechanics and pattern-specific
+  details: source/docs pattern constants, docs root discovery, MapGen public
+  ops target validation, Biome handoff, gate execution, rollback, and
+  no-index diff proof.
+- `fix.ts` currently exposes `--dry-run` only and forwards to `runFix`; there
+  is no current `--json` flag in the command class.
+- `command-engine.ts` currently implements `runFix` as a direct
+  `runGritApplyPatterns({ dryRun })` call.
+- Existing tests cover many important states but not the complete D9 target
+  contract: arbitrary gate declaration/refusal, D8 lifecycle consumption,
+  D10/G-HOST generated/protected-zone refusal, public JSON output, and
+  docs/source lane authority split need explicit D9 packet decisions before
+  implementation expands tests.
+
+## Acceptance Checklist For D9 From This Lane
+
+D9 can move from blocked to accepted for design/specification only when:
+
+- D9 context/traceability is durable for future agents.
+- The D9 review ledger imports and dispositions the findings above.
+- `spec.md` contains complete guarded transaction requirements and scenarios.
+- `design.md` closes request modes, states, owners, public compatibility,
+  D8/D10/G-HOST inputs, D15, and rejected alternatives.
+- `tasks.md` is executable and ordered by dependency.
+- Validation gates include exact commands, expected status, oracle, bad case,
+  freshness/cache stance, and non-claims.
+- Wording audit finds no unqualified shortcut terms.
+
+Until those repairs exist, D9 implementation agents would still have to decide
+transaction states, write-set ownership, public compatibility, validation,
+rollback semantics, and downstream handoff while coding.
+
+Skills used: domain-design, information-design, solution-design,
+testing-design, civ7-open-spec-workstream, typescript-refactoring.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-typescript-state-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D9-typescript-state-investigation.md
@@ -1,0 +1,280 @@
+# D9 TypeScript State-Space Investigation
+
+## Verdict
+
+D9 is blocked from TypeScript state-space acceptance until the OpenSpec packet specifies a closed transformation-transaction model. The current incomplete packet names dry-run, live write, rollback, formatter handoff, path approval, and recovery, but it does not define the exact discriminated unions, branded identifiers, non-empty collections, module ownership, D0/D1 compatibility citations, or falsifying tests that implementation must follow.
+
+The simpler model is an `ApplyTransactionRecord` union built from separately owned projections: requested mode, D8 apply admission, D10 path/protected-zone approval, Grit adapter observations, write-set approval, live write result, rollback result, formatter handoff, selected gate handoff, refusal, and recovery instruction. Legacy `GritApplyTransactionProof` can remain only as a D0/D1 compatibility wrapper around that record.
+
+## Current Impossible States
+
+Current evidence is `tools/habitat-harness/src/lib/grit-apply.ts`, `tools/habitat-harness/src/lib/command-engine.ts`, `tools/habitat-harness/src/commands/fix.ts`, `tools/habitat-harness/src/index.ts`, and `tools/habitat-harness/test/lib/grit-apply.test.ts`.
+
+| Current shape | Impossible states admitted | Required D9 collapse |
+| --- | --- | --- |
+| `GritApplyTransactionOptions` with `dryRun?`, `allowDirtyWorktree?`, `rollbackAfterApply?`, and `gateCommands?` | Dry-run request can also request rollback-after-apply; live write can be constructed without D8 admission; dirty-live exception can be set without isolated transaction semantics; arbitrary gate commands can be injected without host/pattern declaration. | Replace with request variants: `DryRunApplyRequest`, `LiveApplyRequest`, `RollbackProbeRequest`, and `FormatterOrGateHandoffRequest`; no optional mode flags. |
+| `GritApplyTransactionResult extends SpawnResult` with `ok: boolean`, nullable `failureTag`, and always-present `proof` | `ok: true` with a failure tag is structurally valid; `ok: false` can carry success-looking `exitCode` if manually constructed; command stdout/stderr can imply success while rollback failed. | Replace with `ApplyTransactionOutcome = DryRunOutcome | LiveCommittedOutcome | RefusedOutcome | FailedRolledBackOutcome | FailedRollbackFailedOutcome`; legacy `SpawnResult` projection is derived, not authoritative. |
+| `GritApplyTransactionProof` with nullable `dryRunCommand`, `applyCommand`, `biomeCommand`, `rollbackCommand`, `transactionCopyCommand`, optional arrays, and free `appliedDiff` string | Rollback command can exist without a rollback state; live apply command can be absent from live success; dry-run can carry live changed paths; success can carry failed formatter/gate command; applied diff can exist without approved write set. | Replace with state-specific record members. Fields appear only in the state that owns them. |
+| `GritApplyRewriteInventoryEntry` with `approvedByPattern`, `classification`, optional `failureTag`, optional `failureReason` | `approvedByPattern: true` with `classification: blocked`; `classification: pre-approved` plus failure tag; `approvedByPattern: false` without refusal reason; `classification: expected` leaking past parsing. | Split parser DTO from approval result: `ParsedRewriteObservation` then `WriteSetApprovalEntry = ApprovedRewrite | RejectedRewrite | BlockedRewrite`. |
+| `GritApplyDiffEvidence` with `classification` plus optional failure fields | `pre-approved` diff with failure reason; blocked diff without reason; create/delete approvals are not typed as impossible versus explicitly admitted. | Use `ApprovedModificationDiff` versus `BlockedDiffChange`; create/delete are blocked unless D8 admission explicitly provides a create/delete capability variant. |
+| `ParsedInventory` with `ok` boolean | Same boolean-result smell as transaction result; parser failure and zero-match success are not semantically distinct enough for dry-run outcome. | Use `InventoryParseResult = StructuredInventory | ZeroMatchInventory | AmbiguousInventoryRefusal | MalformedInventoryFailure`. |
+| `IsolatedCopyApplyProof` with `ok` boolean and repeated evidence fields | Copy command failure, diff approval failure, missing target export, and success all share mostly the same bag of fields. | Use `IsolatedCopyOutcome = CopyProducedApprovedWriteSet | CopyRefusedByPathApproval | CopyRefusedByTargetExport | CopyCommandFailed`. |
+| `rollbackApplyTransaction` returns `{ command, failureTag, message }` | Rollback skipped, rollback succeeded, and rollback failed are encoded by nullable fields; a failed rollback can be accidentally ignored by a caller. | Use `RollbackOutcome = NotNeeded | Succeeded | Failed`; failed rollback is its own terminal transaction outcome. |
+| `runFix({ dryRun?: boolean })` and `fix --dry-run` | Command mode remains an optional boolean, so command construction can still default into live write. | Command layer must construct one explicit request variant from CLI flags before entering D9 transaction state. |
+| `src/index.ts` exports `GritApplyTransactionOptions`, `GritApplyTransactionProof`, and `GritApplyTransactionResult` | Internal transaction mechanics are public package-export candidates; proof-shaped names can become target language accidentally. | D9 must cite D0 package-export rows and D1 legacy wrapper rules before changing or preserving these exports. |
+
+Named TypeScript smells from the refactoring skill:
+
+- Flag/boolean soup and long parameter list: `dryRun`, `allowDirtyWorktree`, `rollbackAfterApply`, `gateCommands`.
+- Optional-property soup and temporary fields: nullable command members in the proof bag.
+- Primitive obsession: raw strings for pattern paths, roots, changed paths, command ids, digests, non-claim identifiers, and failure reasons.
+- Switch/missing model: repeated `if command failed -> rollback -> transactionFailure` branches instead of a closed transaction transition model.
+- Large module/divergent change: `grit-apply.ts` owns adapter invocation, write-set approval, MapGen export validation, docs rewrite handling, formatter handoff, gates, rollback, command result rendering, and legacy proof construction.
+- Feature envy/inappropriate intimacy: transaction code validates MapGen public ops exports directly instead of consuming a host/pattern gate projection.
+- Broad proof DTO and whole-record leakage: `GritApplyTransactionProof` is exported and always present, so consumers can depend on internals that should be state-specific projections.
+
+Safe refactor moves D9 must require:
+
+- Replace type code/flags with discriminated unions plus `never` exhaustiveness.
+- Introduce branded identifiers for pattern ids, pattern paths, repo-relative paths, approved write-set ids, command ids, SHA-256 digests, D0 surface ids, and D1 non-claim ids.
+- Introduce non-empty arrays for values that are only valid when present: approved writes, blocked writes, gate handoffs, recovery actions, rollback changed paths, and D0 citations.
+- Extract modules by responsibility after the type model exists.
+- Parse at the boundary: Grit stdout becomes observations, D8/D10 projections become typed authority inputs, and process results become handoff records.
+- Keep legacy public names only as D0/D1 compatibility facades.
+
+## Required Target Type-State Model
+
+The packet should require these target names or equally explicit aliases. Implementation may choose file names, but may not collapse these states back into nullable fields.
+
+```ts
+type ApplyTransactionRequest =
+  | DryRunApplyRequest
+  | LiveApplyRequest
+  | RollbackProbeRequest;
+
+type DryRunApplyRequest = {
+  kind: "dry-run";
+  invocation: FixCommandInvocation;
+  admission: ApplyAdmissionProjection;
+  worktree: WorktreeObservation;
+};
+
+type LiveApplyRequest = {
+  kind: "live";
+  invocation: FixCommandInvocation;
+  admission: ApplyAdmissionProjection;
+  worktree: CleanWorktreeObservation;
+  writeSetApproval: ApprovedWriteSet;
+  rollbackPolicy: RollbackRequired;
+  handoffPolicy: FormatterAndGateHandoffPolicy;
+};
+
+type RollbackProbeRequest = {
+  kind: "rollback-probe";
+  invocation: FixCommandInvocation;
+  writeSetApproval: ApprovedWriteSet;
+  rollbackPolicy: RollbackRequired;
+};
+```
+
+`allowDirtyWorktree` is not a boolean option. Dirty worktree states are:
+
+- `DryRunDirtyWorktreeAllowed`: dry-run may proceed and remains non-writing.
+- `LiveDirtyWorktreeRefusal`: live apply refuses before Grit.
+- `IsolatedCopyDirtyWorktreeAllowed`: isolated copy may run because it does not mutate the source tree.
+
+The dry-run outcome union:
+
+```ts
+type DryRunOutcome =
+  | { kind: "no-matches"; dryRun: GritDryRunObservation; docsDryRun?: DocsDryRunObservation; nonClaims: NonEmptyArray<NonClaimId> }
+  | { kind: "planned-approved-writes"; dryRun: GritDryRunObservation; writeSetApproval: ApprovedWriteSet; isolatedCopy: IsolatedCopyApproved; nonClaims: NonEmptyArray<NonClaimId> }
+  | { kind: "parse-refusal"; refusal: InventoryParseRefusal; recovery: NonEmptyArray<RecoveryInstruction> }
+  | { kind: "approval-refusal"; refusal: WriteSetRefusal; recovery: NonEmptyArray<RecoveryInstruction> };
+```
+
+The live outcome union:
+
+```ts
+type LiveTransactionOutcome =
+  | { kind: "committed"; writeSet: AppliedWriteSet; formatter: FormatterHandoffSucceeded | FormatterHandoffSkipped; gates: GateHandoffSucceeded | GateHandoffSkipped; postState: DirtyPostApplyObservation; nonClaims: NonEmptyArray<NonClaimId> }
+  | { kind: "failed-rolled-back"; failure: ApplyFailure | FormatterFailure | GateFailure | UnexpectedPathFailure; rollback: RollbackSucceeded; recovery: NonEmptyArray<RecoveryInstruction> }
+  | { kind: "failed-rollback-failed"; failure: ApplyFailure | FormatterFailure | GateFailure | UnexpectedPathFailure; rollback: RollbackFailed; recovery: NonEmptyArray<RecoveryInstruction> }
+  | { kind: "refused-before-write"; refusal: DirtyWorktreeRefusal | ProtectedPathRefusal | AdmissionRefusal | EmptyWriteSetRefusal; recovery: NonEmptyArray<RecoveryInstruction> };
+```
+
+Write-set approval:
+
+```ts
+type WriteSetApproval =
+  | { kind: "approved"; id: ApprovedWriteSetId; entries: NonEmptyArray<ApprovedRewrite>; paths: NonEmptyArray<ApprovedRepoPath>; source: "structured-inventory" | "isolated-copy" | "docs-dry-run"; d8Admission: ApplyAdmissionProjection; d10PathDecision: PathApprovalProjection }
+  | { kind: "empty"; reason: "zero-matches" | "docs-no-matches" }
+  | { kind: "refused"; refusal: WriteSetRefusal; blocked: NonEmptyArray<BlockedRewrite | BlockedDiffChange> };
+```
+
+Rollback outcome:
+
+```ts
+type RollbackOutcome =
+  | { kind: "not-needed"; reason: "no-source-write" | "no-changed-paths" }
+  | { kind: "succeeded"; command: CommandExecutionRecord; revertedPaths: NonEmptyArray<ApprovedRepoPath>; postState: CleanWorktreeObservation }
+  | { kind: "failed"; command: CommandExecutionRecord; dirtyPaths: NonEmptyArray<RepoRelativePath>; recovery: NonEmptyArray<RecoveryInstruction> };
+```
+
+Formatter/gate handoff outcome:
+
+```ts
+type FormatterHandoffOutcome =
+  | { kind: "skipped"; reason: "no-changed-paths" }
+  | { kind: "succeeded"; command: CommandExecutionRecord; formattedPaths: NonEmptyArray<ApprovedRepoPath>; nonClaims: NonEmptyArray<NonClaimId> }
+  | { kind: "failed"; command: CommandExecutionRecord; rollback: RollbackOutcome; recovery: NonEmptyArray<RecoveryInstruction> };
+
+type GateHandoffOutcome =
+  | { kind: "skipped"; reason: "no-selected-gates" }
+  | { kind: "succeeded"; commands: NonEmptyArray<CommandExecutionRecord>; nonClaims: NonEmptyArray<NonClaimId> }
+  | { kind: "failed"; failedGate: CommandExecutionRecord; completedBeforeFailure: readonly CommandExecutionRecord[]; rollback: RollbackOutcome; recovery: NonEmptyArray<RecoveryInstruction> };
+```
+
+Recovery/refusal outcome:
+
+```ts
+type TransactionRefusal =
+  | DirtyWorktreeRefusal
+  | InventoryParseRefusal
+  | AdmissionRefusal
+  | WriteSetRefusal
+  | ProtectedPathRefusal
+  | MissingTargetExportRefusal
+  | HostGateRefusal;
+
+type RecoveryInstruction =
+  | { kind: "restore-worktree"; command: "git status --short --branch" | "git checkout -- <paths>"; paths?: NonEmptyArray<RepoRelativePath> }
+  | { kind: "rerun-dry-run"; command: "bun run habitat fix --dry-run" }
+  | { kind: "repair-pattern-authority"; target: ApplyAdmissionProjectionId }
+  | { kind: "repair-protected-zone-decision"; target: D10ProtectedZoneDecisionId }
+  | { kind: "run-gate-manually"; commandId: CommandId };
+```
+
+Every union must have an exhaustive switch in command rendering and legacy compatibility projection. A compile-time `never` guard is mandatory for those projections.
+
+## Branded Identifiers And Non-Empty Collections
+
+D9 should require these brands so raw strings do not cross authority boundaries:
+
+| Brand | Prevents |
+| --- | --- |
+| `PatternId` | Confusing a D6 diagnostic pattern, D8 admitted apply pattern, and raw Grit path. |
+| `GritPatternPath` | Passing arbitrary repo paths to Grit apply. |
+| `RepoRelativePath` | Mixing absolute host paths, copy-root paths, and repo-relative write paths. |
+| `ApprovedRepoPath` | Treating observed changed paths as approved write paths before D10/D8 checks. |
+| `ApprovedWriteSetId` | Linking rollback/formatter/gates to a concrete approval rather than a loose array. |
+| `CommandId` | Free-form gate command ids becoming untyped behavior selectors. |
+| `Sha256Digest` | Distinguishing digests from arbitrary strings. |
+| `D0SurfaceId` | Public compatibility citation must point at an accepted D0 row. |
+| `D1NonClaimId` | Non-claims remain canonical identifiers, not prose blobs. |
+| `ApplyAdmissionProjectionId` | D9 consumes D8 admission without owning D8 governance. |
+| `D10ProtectedZoneDecisionId` | D9 consumes D10 path/protected-zone authority without reimplementing it. |
+
+Required non-empty arrays:
+
+- `NonEmptyArray<ApprovedRewrite>` for approved live write sets.
+- `NonEmptyArray<BlockedRewrite | BlockedDiffChange>` for refusal caused by blocked paths or unapproved pattern output.
+- `NonEmptyArray<ApprovedRepoPath>` for live changed paths, rollback paths, formatter paths, and applied write sets.
+- `NonEmptyArray<RecoveryInstruction>` for every refusal or failed rollback state.
+- `NonEmptyArray<CommandExecutionRecord>` for selected gates that actually ran.
+- `NonEmptyArray<D0SurfaceId>` on public compatibility wrappers touched by D9.
+
+Required projections:
+
+- `ApplyAdmissionProjection` from D8: pattern identity, manifest path, admitted apply capability, required dry-run/no-write/diff/rollback/type-test/protected-path inputs, and non-claims.
+- `PathApprovalProjection` from D10: allowed roots, protected/generated-zone decision, host-policy reference if applicable, and refusal reason when blocked.
+- `GritAdapterObservation` from adapter invocation: command record, stdout/stderr digests, parse status, match count, structured rewrite observations.
+- `ApplyTransactionRecord` from D9: the state-specific public command record.
+- `LegacyGritApplyTransactionProof` from D1/D0: compatibility projection only; cannot be the source of truth.
+
+## Module Ownership
+
+D9 must specify ownership at module-boundary level before code work:
+
+| Responsibility | Owning module/domain | Must not own |
+| --- | --- | --- |
+| Transaction lifecycle, state machine, terminal outcomes, rollback relation, recovery instructions | D9 Transformation Transaction, e.g. `apply-transaction.ts` | Grit stdout parsing details, D8 pattern admission, D10 protected-zone policy, Biome semantics. |
+| Grit adapter invocation and stdout/stderr parsing | Grit adapter/D6-adjacent adapter module, e.g. `grit-apply-adapter.ts` | Write approval, rollback, formatter/gate success, command public transaction shape. |
+| Pattern apply admission | D8 Pattern Governance projection | Live-write safety or rollback behavior. |
+| Path approval and protected/generated-zone refusal | D10 Protected Zone Authority projection | Grit invocation or formatter/gate execution. |
+| Write-set approval composition | D9, consuming D8 and D10 projections, e.g. `apply-write-set.ts` | Source-specific MapGen validation unless delivered as a host/pattern gate projection. |
+| MapGen public ops validation currently inline in `grit-apply.ts` | Host/pattern-specific gate declared by D8/G-HOST/D10, then consumed by D9 as a gate result | Generic transaction module. |
+| Biome handoff | Formatter handoff adapter, e.g. `formatter-handoff.ts` | Apply safety or product/runtime proof. Biome returns formatting command outcome only. |
+| Selected type/test gates | Gate handoff adapter, e.g. `apply-gates.ts` | Rollback semantics; gate failure hands back to D9 transaction state. |
+| CLI flag parsing and exit projection | Command layer (`commands/fix.ts`, `command-engine.ts`) | Transaction authority; it constructs a request variant and renders D9 outcome. |
+| Package export compatibility | D0/D1 constrained facade in `src/index.ts` | Target transaction model unless D0 classifies the export as safe to version/rename. |
+
+This is an Extract Module move by responsibility, but extraction is only safe after the DU state model exists. Splitting the current file first would rearrange complexity without deleting it.
+
+## D0/D1 Compatibility Constraints
+
+D9 implementation must cite D0 rows before changing any public or durable surface. Required row families:
+
+- CLI verb and flag rows for `habitat fix` and `habitat fix --dry-run`.
+- Command behavior/human output rows for dry-run, refusal, rollback, formatter/gate failure, and success text.
+- Command JSON rows if D9 adds or changes JSON output.
+- Package-export rows for `GritApplyTransactionOptions`, `GritApplyTransactionProof`, `GritApplyTransactionResult`, `GritApplyRewriteInventoryEntry`, `runGritApplyTransaction`, `parseApplyRewriteInventory`, and `classifyApplyRewriteInventory`.
+- Docs-example rows for any command examples or output guidance touched by D9.
+- Test-only rows for fixture-only helpers if they are moved or renamed.
+
+D0 design requires every row to carry `surface_id`, `plane`, `contract_state`, closed `compatibility_handling`, and typed relationships. D0 also names proof/evidence-shaped names as compatibility facts, not target language.
+
+D1 already sets the semantic boundary:
+
+- Target object is `ApplyTransactionRecord`.
+- `GritApplyTransactionProof` remains only a D0-backed legacy name under `preserve`, `version`, or `facade`.
+- D9 owns apply lifecycle and rollback behavior.
+- D1 owns shared non-claims, relationships, and compatibility wrapper rules.
+- Failed apply states must use `rolled-back-by` when rollback runs.
+- Canonical non-claim ids must be used; prose-only non-claims are not enough.
+
+Therefore D9 may define transaction behavior and state shape, but must not create a generic proof substrate, redefine D1 receipt vocabulary, or silently rename exported proof-shaped types without D0/D1 citation.
+
+## Tests That Must Falsify False-Green Transaction States
+
+The packet's validation section should require tests with explicit bad cases, not only green command runs.
+
+| Test/oracle | False green it must catch |
+| --- | --- |
+| Type-level construction tests for `ApplyTransactionOutcome` and `ApplyTransactionRequest` | `ok: true` plus `failureTag`; live success without apply command; rollback command outside rollback state; dry-run request with rollback-after-apply; live request without D8 admission or D10 approval. |
+| Legacy projection test | `GritApplyTransactionProof` wrapper cannot report success if target `ApplyTransactionRecord` is refusal/failure; D0 surface ids are present for compatibility wrappers. |
+| Dirty live refusal test | Live apply against dirty worktree refuses before any Grit command. Current test covers this and should be retained against the new request variant. |
+| Dirty dry-run test | Dry-run on dirty worktree remains a dry-run outcome, not live apply safety. Current test covers behavior but should assert the new `kind`. |
+| Ambiguous dry-run test | Dry-run reports matches but isolated copy produces no diff; outcome is parse/approval refusal, not success with empty changed paths. |
+| Unstructured output parse test | Non-empty Grit output that is neither zero-match nor structured inventory fails closed. |
+| Unapproved inventory test | Pattern output with `approved=false` cannot become an approved write-set entry and must carry a recovery instruction. |
+| Unexpected path test | Live apply changes a path outside the approved write set; rollback runs and terminal state is failure, never committed. |
+| D10 protected/generated-zone test | A generated/protected-zone write is refused through D10 projection; D9 does not best-effort skip or self-authorize the path. |
+| Create/delete without explicit admission test | Isolated copy create/delete inside an approved root is blocked unless D8 admission explicitly includes create/delete capability. Current tests cover block behavior; packet must require the capability rule. |
+| Missing target export / host gate test | Current inline MapGen export validation must become a declared gate or host projection; failure is a gate/refusal outcome, not generic Grit failure. |
+| Biome failure test | Biome handoff failure after writes triggers rollback and cannot be reported as apply safety or product proof. Current test covers rollback but should assert formatter-specific state. |
+| Selected gate failure test | Gate failure after writes triggers rollback; failed gate identity is preserved and earlier gate successes do not imply transaction success. |
+| Rollback succeeded test | Failed apply/formatter/gate with successful rollback reports `failed-rolled-back`, includes `rolled-back-by`, and final clean observation. |
+| Rollback failed test | Failed rollback reports `failed-rollback-failed`, includes dirty paths and recovery instructions, and cannot carry success exit projection. |
+| Public command projection test | `habitat fix --dry-run` output and exit code are derived from dry-run outcome only; live apply states never appear in dry-run output. |
+| Non-claim test | Apply success includes D1 non-claims such as not runtime/product/current-tree clean proof; formatter/gate success cannot erase them. |
+
+The focused suite remains `bun run --cwd tools/habitat-harness test -- test/lib/grit-apply.test.ts`, but D9 should also require command-layer tests for `commands/fix.ts` and export/compatibility tests if `src/index.ts` changes. OpenSpec validation alone is not enough.
+
+## Packet Repairs Required Before Acceptance
+
+The D9 OpenSpec packet should be repaired before any source implementation:
+
+1. Replace the generic target-contract text with the closed request/outcome/approval/rollback/handoff/refusal model above.
+2. Add an ownership table that protects D8 admission, D10 path/protected-zone authority, Grit adapter parsing, Biome handoff, and host-specific gates from being redefined inside generic transaction code.
+3. Add a D0/D1 compatibility table listing every public surface D9 may touch and requiring concrete D0 `surface_id` citations before source edits.
+4. Expand the spec delta beyond two scenarios to cover dirty live refusal, dirty dry-run, no-match dry-run, planned approved dry-run, parse refusal, unapproved path, protected-zone refusal, live committed, apply failure with rollback, rollback failure, formatter failure, gate failure, and legacy compatibility projection.
+5. Replace validation gates with falsifying oracles and injected bad cases, including expected terminal state names and non-claims.
+6. Record that `GritApplyTransactionProof` is not target language; it is a compatibility projection only if D0/D1 allow it.
+7. Block implementation until D8 apply-admission projection and D10 protected-zone projection are concrete enough for D9 to consume.
+
+## Lane Status
+
+D9 is not accepted from the TypeScript state-space lane. The lane is blocked on packet repair, not source code. The current implementation already contains useful behavioral tests and some fail-closed logic, but the OpenSpec packet does not yet prevent the next implementation agent from preserving the existing boolean/nullable proof bag or making design decisions while coding.
+
+Skills used: domain-design, information-design, solution-design, testing-design, typescript-refactoring.

--- a/docs/projects/habitat-harness/openspec-remediation/context.md
+++ b/docs/projects/habitat-harness/openspec-remediation/context.md
@@ -13,7 +13,7 @@ variables below.
 | Variable | Value |
 | --- | --- |
 | `$ACTIVE_REMEDIATION_WORKTREE` | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation` |
-| `$ACTIVE_REMEDIATION_BRANCH` | `codex/d8-pattern-governance-packet` |
+| `$ACTIVE_REMEDIATION_BRANCH` | `codex/d9-transformation-transaction-packet` |
 
 ## Path Variables
 
@@ -147,6 +147,27 @@ variables below.
 | `$D8_PHASE_RECORD` | `$D8_CHANGE/workstream/phase-record.md`. |
 | `$D8_DOWNSTREAM_LEDGER` | `$D8_CHANGE/workstream/downstream-realignment-ledger.md`. |
 | `$D8_CLOSURE_CHECKLIST` | `$D8_CHANGE/workstream/closure-checklist.md`. |
+
+## D9 Variables
+
+| Variable | Meaning |
+| --- | --- |
+| `$D9_CHANGE` | `$OPENSPEC_CHANGES/deep-habitat-d9-transformation-transaction`. |
+| `$D9_SOURCE_PACKET` | `$PHASE2_PACKET_DIR/D9-transformation-transaction.md`. |
+| `$D9_DOMAIN_REVIEW` | `$AGENT_SCRATCH/domino-D9-domain-ontology-investigation.md`. |
+| `$D9_TYPESCRIPT_REVIEW` | `$AGENT_SCRATCH/domino-D9-typescript-state-investigation.md`. |
+| `$D9_TOPOLOGY_REVIEW` | `$AGENT_SCRATCH/domino-D9-code-vendor-topology-investigation.md`. |
+| `$D9_INFORMATION_REVIEW` | `$AGENT_SCRATCH/domino-D9-openspec-information-testing-investigation.md`. |
+| `$D9_CROSS_DOMINO_REVIEW` | `$AGENT_SCRATCH/domino-D9-cross-domino-investigation.md`. |
+| `$D9_FINAL_DOMAIN_REVIEW` | `$AGENT_SCRATCH/domino-D9-final-domain-ontology-review.md`. |
+| `$D9_FINAL_TYPESCRIPT_VALIDATION_REVIEW` | `$AGENT_SCRATCH/domino-D9-final-typescript-validation-review.md`. |
+| `$D9_FINAL_OPENSPEC_INFORMATION_REVIEW` | `$AGENT_SCRATCH/domino-D9-final-openspec-information-review.md`. |
+| `$D9_FINAL_CODE_VENDOR_TOPOLOGY_REVIEW` | `$AGENT_SCRATCH/domino-D9-final-code-vendor-topology-review.md`. |
+| `$D9_FINAL_CROSS_DOMINO_REVIEW` | `$AGENT_SCRATCH/domino-D9-final-cross-domino-review.md`. |
+| `$D9_REVIEW_LEDGER` | `$D9_CHANGE/workstream/review-disposition-ledger.md`. |
+| `$D9_PHASE_RECORD` | `$D9_CHANGE/workstream/phase-record.md`. |
+| `$D9_DOWNSTREAM_LEDGER` | `$D9_CHANGE/workstream/downstream-realignment-ledger.md`. |
+| `$D9_CLOSURE_CHECKLIST` | `$D9_CHANGE/workstream/closure-checklist.md`. |
 
 ## Path Templates
 

--- a/docs/projects/habitat-harness/openspec-remediation/packet-index.md
+++ b/docs/projects/habitat-harness/openspec-remediation/packet-index.md
@@ -5,10 +5,10 @@ change packets. It is part of the remediation frame, not an implementation
 commitment. Most rows remain incomplete packets: global review findings have
 been converted into shared constraints, but each domino remains blocking until
 its own per-domino adversarial review has run and all accepted P1/P2 findings
-are repaired. D0, D1, D2, D3, D4, D5, D6, D7, and D8 are the current exceptions: they are
+are repaired. D0, D1, D2, D3, D4, D5, D6, D7, D8, and D9 are the current exceptions: they are
 accepted for design/specification after their per-domino final reviews found no
-unresolved P1/P2 blockers. D0-D8 are not implementation-complete, and
-D9-D15/G-HOST remain blocking unless their own status rows say otherwise.
+unresolved P1/P2 blockers. D0-D9 are not implementation-complete, and
+D10-D15/G-HOST remain blocking unless their own status rows say otherwise.
 
 Path variables and operational checkout fixtures are defined in
 `$REMEDIATION_DIR/context.md`. This index records packet identity and sequencing;
@@ -26,7 +26,7 @@ it does not repeat local worktree paths or branch names.
 | D7 | D7 Structural Enforcement Pipeline | `deep-habitat-d7-structural-enforcement-pipeline` | D0, D1, D2, D3, D5, D6, D10; concrete D0 rows, D1 output-family handling, live D2/D3/D5/D6 projections, and accepted D10 guard contract required before source implementation where touched | D11, D12 | accepted for design/specification; final domain/ontology, TypeScript/validation, OpenSpec/information, and code/topology/cross-domino rereviews found no unresolved P1/P2 blockers; not implementation-complete |
 | D8 | D8 Pattern Governance | `deep-habitat-d8-pattern-governance` | D0, D1, D2, D5, D6; D7 where current-tree/check admission input is consumed; D10/G-HOST where protected/generated-zone or host-policy paths/gates are touched; concrete D0 rows, D1 output-family citations, live D2 `ruleGovernanceFacts`/`ruleGritFacts`/`ruleBaselineFacts`, D5 `BaselineAuthorityProjection`, and D6 diagnostic projections required before source implementation | D9, D13; D11 through local-feedback eligibility/recovery projections | accepted for design/specification; final domain/ontology, TypeScript/validation, OpenSpec/information, code/vendor topology, and cross-domino rereviews found no unresolved P1/P2 blockers; not implementation-complete |
 | G-HOST | Host Policy Boundary Gate | `deep-habitat-host-policy-boundary-gate` | D0, D1 | D10, D13 | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
-| D9 | D9 Transformation Transaction | `deep-habitat-d9-transformation-transaction` | D0, D1, D6, D8, D10 | D11 | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
+| D9 | D9 Transformation Transaction | `deep-habitat-d9-transformation-transaction` | D0, D1, D6, D8, D10, G-HOST where host-specific gates are touched; concrete D0 rows, D8 apply-admission projections, D10 path/zone decisions, and G-HOST host-gate declarations required before source implementation where touched | D11, D13; D15 only if D9 records an impossible local state | accepted for design/specification; final domain/ontology, TypeScript/validation, OpenSpec/information, code/vendor topology, and cross-domino/product rereviews found no unresolved P1/P2 blockers; not implementation-complete |
 | D10 | D10 Protected Zone Authority | `deep-habitat-d10-protected-zone-authority` | D0, D1, D2, G-HOST | D7, D9, D11 | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
 | D11 | D11 Local Feedback | `deep-habitat-d11-local-feedback` | D0, D1, D7, D9, D10 | none | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
 | D12 | D12 Verify Handoff Receipt | `deep-habitat-d12-verify-handoff-receipt` | D0, D1, D3, D7 | D14 | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |

--- a/openspec/changes/deep-habitat-d9-transformation-transaction/design.md
+++ b/openspec/changes/deep-habitat-d9-transformation-transaction/design.md
@@ -2,71 +2,441 @@
 
 ## Frame
 
-D9 Transformation Transaction is a downstream implementation-control packet derived from
-`D9-transformation-transaction.md`. The packet is complete only when it leaves the later execution
-agent with no product, domain, naming, sequencing, public-surface, or validation
-decision to invent.
+D9 specifies the Transformation Transaction domain: Habitat's closed,
+recoverable envelope for executing a D8-admitted structural rewrite. The product
+goal is not a general command-record substrate and not another layer of
+rewrite logic. The product goal is a reliable apply transaction that an agent
+and human can understand, refuse, run, roll back, and recover from without
+guessing which owner decided which fact.
 
-The existing packet is input, not output. Current Habitat code is
-present-behavior evidence. This design chooses target language from Habitat's
-generic repo-maintenance product scenarios rather than preserving accidental
-module or DTO names.
+Current code is evidence. It is not the target model. The current
+`grit-apply.ts` module combines transaction sequencing, Grit invocation, source
+root discovery, docs transform invocation, MapGen public-ops validation, Biome
+handoff, optional gates, rollback, and a broad exported proof/result DTO. D9's
+design reduces that state space by naming one transaction owner, accepting
+upstream projections, and making illegal combinations unrepresentable.
+
+## Solution Design
+
+- **Frame:** rugged/high-commitment design space. A bad D9 packet would allow a
+  write path to look safe while missing D8 admission, D10/G-HOST authority, or
+  rollback recovery.
+- **Aspiration threshold:** implementation agents can execute the packet without
+  inventing state variants, public compatibility decisions, path authority,
+  vendor boundaries, or validation oracles.
+- **Constraint reality:** D0-D8 are accepted for design/specification only; D10
+  and G-HOST are still blocking. D9 may design against D10/G-HOST projection
+  inputs, but source implementation remains blocked wherever those live inputs
+  are absent.
+- **Rejected shortcut:** keep `GritApplyTransactionResult` as the target model
+  and add more fields. That preserves flag soup, nullable command bags, and
+  impossible success/failure combinations.
 
 ## Domain Boundary
 
-- Owner: Transformation Transaction.
-- Primary scenario: An agent applies a structural rewrite and needs dry-run, live write, rollback, formatting, and refusal behavior to be explicit and recoverable.
-- Adjacent domains consume this packet through explicit contracts and may not
-  recreate its authority locally.
+The single owner is **D9 Transformation Transaction**.
 
-## Target Contract
+D9 owns:
 
-- Define apply transaction states and rollback boundaries.
-- Separate Grit diagnostic input from write transaction output.
-- Use D1 receipt terms only for transaction handoff records that serve recovery.
+- explicit command intent, planning, live-write attempt, and rollback-probe
+  construction;
+- transaction admission after upstream projection inputs are present;
+- dry-run inventory observation and classification into transaction states;
+- approved write-set composition from D8 apply admission and D10/G-HOST path
+  decisions;
+- isolated-copy checks as transaction observations;
+- live Grit apply orchestration;
+- changed-path verification before and after write-capable handoffs;
+- rollback after write-stage failures or rollback-probe requests;
+- formatter and gate handoff state relation;
+- terminal transaction outcome, recovery instructions, and command-facing
+  transaction projection.
 
-## Non-Goals
+D9 does not own:
 
-- No diagnostic catalog ownership.
-- No generated-zone policy ownership.
-- No generic command provenance substrate unless D15 trigger passes.
+- D6 diagnostic acquisition, diagnostic identity, injected probes, or diagnostic
+  adapter state;
+- D8 pattern lifecycle, pattern admission, retirement, manifest acceptance, or
+  candidate governance;
+- D10 generated/protected-zone declaration, guard policy, or next-safe-action
+  semantics;
+- G-HOST host-specific policy, including Civ7/MapGen public-ops semantics;
+- D11 hook sequencing, staged-file behavior, or local feedback rendering;
+- D13 candidate generation contracts;
+- Grit rewrite semantics or GritQL pattern syntax;
+- Biome formatter/linter/import-sort semantics;
+- Nx graph, target, scheduling, cache, or inferred-task semantics.
 
-## Naming And Language Decisions
+## Target Ontology
 
-- Use standard engineering terms that name the actual workflow object:
-  receipts, checks, diagnostics, guard decisions, transactions, refusals,
-  recovery instructions, metadata projections, command outcomes, and handoff
-  records.
-- Treat legacy proof/evidence-shaped code names as compatibility facts unless
-  this packet explicitly accepts them as target language.
-- Do not create generic artifact machinery when a smaller command result,
-  receipt, or diagnostic contract serves the scenario.
+Use these target terms:
+
+- `TransformationTransaction`
+- `TransformationRequest`
+- `DryRunIntent`
+- `LiveWriteIntent`
+- `LiveWriteAttempt`
+- `ApplyAdmissionProjection`
+- `TransactionAdmissionDecision`
+- `WriteSet`
+- `ApprovedWritePath`
+- `PathApprovalDecision`
+- `DryRunInventory`
+- `InventoryParseFailure`
+- `IsolatedCopyCheck`
+- `LiveWriteAttempt`
+- `RollbackAttempt`
+- `FormatterHandoff`
+- `GateHandoff`
+- `TransactionRefusal`
+- `TransactionOutcome`
+- `RecoveryInstruction`
+- `TransactionNonClaim`
+
+Use `ApplyTransactionRecord` as the D1-aligned public meaning. Use `apply` only
+for the CLI/native operation and `Transformation Transaction` for the D9 domain.
+
+## Term Disposition
+
+| Current term | Target disposition |
+| --- | --- |
+| `GritApplyTransactionOptions` | D0/D1 compatibility DTO. Replace target construction with request variants. |
+| `dryRun?: boolean` | Compatibility flag. Target is `DryRunIntent` or `LiveWriteIntent`, followed by a D9-produced `LiveWriteAttempt` only after planning approves a write set. |
+| `allowDirtyWorktree?: boolean` | Compatibility escape hatch. Target is explicit dirty-worktree state: dry-run allowed, live refused, isolated copy allowed. |
+| `rollbackAfterApply?: boolean` | Compatibility test/probe flag. Target is rollback policy plus rollback outcome. |
+| `gateCommands?: HabitatProcessRequest[]` | Compatibility injection seam. Target is declared `GateHandoff` input from pattern/host policy. |
+| `GritApplyTransactionResult extends SpawnResult` | Compatibility output wrapper. Target is `ApplyTransactionRecord` / `TransactionOutcome`; process projection is derived. |
+| `ok: boolean` | Rejected target shape. Use discriminated terminal outcomes. |
+| `proof` / `GritApplyTransactionProof` | Compatibility language. Target is transaction record, outcome, command observation, recovery record, and non-claim. |
+| `diffEvidence` | Compatibility detail. Target is isolated-copy diff observation or write-set diff observation. |
+| `fileDigests` | Observation detail for rollback/recovery, not transaction identity. |
+| `transactionCopyCommand` | Compatibility name. Target is `IsolatedCopyCheck`. |
+| `biomeCommand` | Compatibility field. Target is `FormatterHandoff`. |
+| `GritApplyDirtyWorktree` | Compatibility failure tag. Target is `dirty-worktree-refusal`. |
+| `GritApplyDryRunMismatch` | Compatibility failure tag. Target distinguishes inventory parse failure, dry-run/copy mismatch, and unapproved inventory refusal. |
+| `GritApplyUnexpectedFile` | Compatibility failure tag. Target distinguishes outside root, protected-zone refusal, create/delete not admitted, and unexpected live path. |
+| `GritApplyMissingTargetExport` | Host/MapGen gate compatibility tag. Target is a G-HOST-declared apply gate failure/refusal. |
+| `GritApplyRollbackFailed` | Compatibility failure tag. Target is `rollback-failed` with residual path and recovery state. |
+| `HABITAT_REWRITE` | Current structured dry-run inventory protocol. Target is a pattern-owned inventory observation contract. |
+| `approvedByPattern` | Compatibility field. Target consumes D8 apply admission and D9/D10 path decisions. |
+| `classification: expected/pre-approved/rejected/blocked` | Compatibility labels. Target uses parsed observation, approved write, blocked write, or refusal states. |
+| `mods/mod-swooper-maps/**` and `@mapgen/domain/**/ops` validation | Host-specific current evidence. Target consumes G-HOST/D10 gate declarations. |
+
+## TypeScript State-Space Reduction
+
+D9 collapses these smells from the TypeScript refactoring skill:
+
+- flag/boolean soup in transaction options;
+- optional-property soup in the proof/result bag;
+- primitive obsession for pattern paths, repo paths, digests, command ids, D0
+  surface ids, and non-claim ids;
+- repeated branch logic for "command failed -> rollback -> transactionFailure";
+- divergent change in the large `grit-apply.ts` module;
+- inappropriate intimacy with MapGen public-ops semantics;
+- whole-record leakage through exported proof-shaped DTOs.
+
+Required safe moves:
+
+- define the closed discriminated state model before extracting modules;
+- parse native/vendor output at the boundary into observations;
+- consume D8/D10/G-HOST projections instead of whole manifests or host paths;
+- introduce branded ids for public/authority boundaries;
+- use non-empty arrays for live write sets, blocked writes, recovery
+  instructions, rollback paths, and D0 citations;
+- preserve or version legacy exports only through D0/D1 facades;
+- compile exhaustively with `never` guards in command rendering and legacy
+  projection.
+
+## Target State Families
+
+### Request And Lifecycle
+
+D9 separates user/CLI intent from the internal live-write attempt. The command
+layer may construct only intent. D9 owns producing an approved write set from
+D8 admission, dry-run/copy observations, and D10/G-HOST path decisions before
+it constructs a live-write attempt.
+
+```ts
+type TransformationRequest =
+  | DryRunIntent
+  | LiveWriteIntent
+  | LiveWriteAttempt
+  | RollbackProbeRequest;
+
+type DryRunIntent = {
+  kind: "dry-run-intent";
+  invocation: FixCommandInvocation;
+  admission: ApplyAdmissionProjection;
+  worktree: WorktreeObservation;
+};
+
+type LiveWriteIntent = {
+  kind: "live-write-intent";
+  invocation: FixCommandInvocation;
+  admission: ApplyAdmissionProjection;
+  worktree: WorktreeObservation;
+};
+
+type LiveWriteAttempt = {
+  kind: "live-write-attempt";
+  invocation: FixCommandInvocation;
+  admission: ApplyAdmissionProjection;
+  worktree: CleanWorktreeObservation;
+  writeSetApproval: ApprovedWriteSet;
+  rollbackPolicy: RollbackRequired;
+  handoffPolicy: FormatterAndGateHandoffPolicy;
+};
+
+type RollbackProbeRequest = {
+  kind: "rollback-probe";
+  invocation: FixCommandInvocation;
+  writeSetApproval: ApprovedWriteSet;
+  rollbackPolicy: RollbackRequired;
+};
+```
+
+No command parser may construct `LiveWriteAttempt` directly. No D9 constructor
+may produce `LiveWriteAttempt` without D8 apply admission, D10/G-HOST path
+decision where touched, a dry-run inventory precondition, approved write set,
+and rollback policy.
+
+### Admission
+
+```ts
+type TransactionAdmissionDecision =
+  | { kind: "admitted-dry-run-intent"; request: DryRunIntent }
+  | { kind: "admitted-live-write-intent"; request: LiveWriteIntent }
+  | { kind: "admitted-live-write-attempt"; request: LiveWriteAttempt }
+  | { kind: "refused"; refusal: TransactionRefusal };
+```
+
+Closed refusal reasons:
+
+- `missing-apply-admission`
+- `apply-admission-refused`
+- `diagnostic-admission-only`
+- `missing-transaction-input`
+- `dirty-worktree`
+- `invalid-request-mode`
+- `missing-protected-zone-decision`
+- `protected-zone-refused`
+- `missing-host-policy`
+- `host-apply-gate-refused`
+- `write-path-outside-approved-set`
+- `write-action-not-admitted`
+- `formatter-handoff-not-declared`
+- `gate-handoff-not-declared`
+- `public-surface-compatibility-missing`
+
+### Dry-Run Inventory
+
+```ts
+type DryRunInventoryOutcome =
+  | { kind: "no-planned-edits"; observation: NativeApplyDryRunObservation }
+  | { kind: "planned-approved-write-set"; inventory: DryRunInventory; writeSet: PlannedWriteSet }
+  | { kind: "inventory-parse-failed"; failure: InventoryParseFailure }
+  | { kind: "dry-run-command-failed"; observation: NativeApplyDryRunObservation }
+  | { kind: "dry-run-interrupted"; observation: NativeApplyDryRunObservation }
+  | { kind: "dry-run-copy-mismatch"; dryRun: NativeApplyDryRunObservation; copy: IsolatedCopyCheck }
+  | { kind: "isolated-copy-refused"; copy: IsolatedCopyCheck; refusal: TransactionRefusal };
+```
+
+Dry-run success does not imply live-write success. Native Grit output is an
+observation that D9 classifies after D8 admission and D10/G-HOST path authority
+are present.
+
+### Write Set And Path Decision
+
+```ts
+type WriteSetApproval =
+  | { kind: "approved"; id: ApprovedWriteSetId; entries: NonEmptyArray<ApprovedRewrite>; paths: NonEmptyArray<ApprovedWritePath>; source: "structured-inventory" | "isolated-copy" | "docs-dry-run"; admission: ApplyAdmissionProjection; pathDecision: PathApprovalProjection }
+  | { kind: "empty"; reason: "zero-matches" | "docs-no-matches" }
+  | { kind: "refused"; refusal: TransactionRefusal; blocked: NonEmptyArray<BlockedRewrite | BlockedDiffChange> };
+
+type PathApprovalDecision =
+  | { kind: "approved"; path: ApprovedWritePath; action: "modify" | "create" | "delete"; source: "apply-admission-and-zone-policy" }
+  | { kind: "refused"; path: RepoRelativePath; reason: PathRefusalReason };
+```
+
+Create/delete are refused unless D8 admission explicitly includes create/delete
+capability and D9 specifies cleanup/rollback mechanics for that capability.
+
+### Live Write
+
+```ts
+type LiveWriteOutcome =
+  | { kind: "not-run"; reason: "dry-run-only" | "no-planned-edits" | "admission-refused" }
+  | { kind: "write-succeeded"; changedPaths: NonEmptyArray<ApprovedWritePath> }
+  | { kind: "write-failed-before-observable-change"; observation: NativeApplyObservation }
+  | { kind: "write-failed-after-observable-change"; observation: NativeApplyObservation; rollback: RollbackOutcome }
+  | { kind: "unexpected-path-after-write"; changedPaths: NonEmptyArray<RepoRelativePath>; rollback: RollbackOutcome };
+```
+
+D9 must verify changed paths after native apply and after each write-capable
+handoff. A path drift after Biome is still a transaction failure.
+
+### Formatter And Gate Handoffs
+
+```ts
+type FormatterHandoffOutcome =
+  | { kind: "not-run"; reason: "no-changed-paths" | "live-write-not-run" }
+  | { kind: "succeeded"; formatter: "biome"; observation: FormatterCommandObservation; nonClaims: NonEmptyArray<TransactionNonClaim> }
+  | { kind: "failed"; formatter: "biome"; observation: FormatterCommandObservation; rollback: RollbackOutcome };
+
+type GateHandoffOutcome =
+  | { kind: "not-run"; reason: "no-declared-gates" | "live-write-not-run" }
+  | { kind: "succeeded"; gateId: GateId; owner: "host-policy" | "pattern-governance" | "transaction"; observation: GateCommandObservation; nonClaims: NonEmptyArray<TransactionNonClaim> }
+  | { kind: "failed"; gateId: GateId; owner: "host-policy" | "pattern-governance" | "transaction"; observation: GateCommandObservation; rollback: RollbackOutcome };
+```
+
+Formatter and gate outcomes are handoffs. They do not prove apply safety,
+current-tree cleanliness, runtime behavior, or vendor semantics beyond the
+specific command result.
+
+### Rollback And Recovery
+
+```ts
+type RollbackOutcome =
+  | { kind: "not-needed"; reason: "no-source-write" | "no-changed-paths" }
+  | { kind: "succeeded"; command: CommandExecutionRecord; revertedPaths: NonEmptyArray<ApprovedWritePath>; postState: CleanWorktreeObservation }
+  | { kind: "failed"; command: CommandExecutionRecord; dirtyPaths: NonEmptyArray<RepoRelativePath>; recovery: NonEmptyArray<RecoveryInstruction> };
+
+type RecoveryInstruction =
+  | { kind: "restore-worktree"; command: "git status --short --branch" | "git checkout -- <paths>"; paths?: NonEmptyArray<RepoRelativePath> }
+  | { kind: "rerun-dry-run"; command: "bun run habitat fix --dry-run" }
+  | { kind: "repair-pattern-authority"; target: ApplyAdmissionProjectionId }
+  | { kind: "repair-protected-zone-decision"; target: D10ProtectedZoneDecisionId }
+  | { kind: "run-gate-manually"; commandId: CommandId };
+```
+
+Rollback failure is terminal and visible. Current rollback uses Git tracked-file
+checkout; D9 must not claim filesystem transaction cleanup for untracked create
+or delete effects unless that capability is separately designed.
+
+### Terminal Outcome
+
+```ts
+type TransactionOutcome =
+  | { kind: "dry-run-clean"; inventory: Extract<DryRunInventoryOutcome, { kind: "no-planned-edits" }>; nonClaims: NonEmptyArray<TransactionNonClaim> }
+  | { kind: "dry-run-planned"; inventory: Extract<DryRunInventoryOutcome, { kind: "planned-approved-write-set" }>; nonClaims: NonEmptyArray<TransactionNonClaim> }
+  | { kind: "refused"; refusal: TransactionRefusal; recovery: NonEmptyArray<RecoveryInstruction> }
+  | { kind: "applied"; live: Extract<LiveWriteOutcome, { kind: "write-succeeded" }>; formatter: FormatterHandoffOutcome; gates: readonly GateHandoffOutcome[]; nonClaims: NonEmptyArray<TransactionNonClaim> }
+  | { kind: "rolled-back"; failedStage: "live-write" | "formatter-handoff" | "gate-handoff"; rollback: Extract<RollbackOutcome, { kind: "succeeded" }>; recovery: NonEmptyArray<RecoveryInstruction> }
+  | { kind: "rollback-failed"; failedStage: "live-write" | "formatter-handoff" | "gate-handoff" | "explicit-rollback"; rollback: Extract<RollbackOutcome, { kind: "failed" }>; recovery: NonEmptyArray<RecoveryInstruction> };
+```
+
+## Branded Identifiers And Non-Empty Collections
+
+Required brands:
+
+| Brand | Purpose |
+| --- | --- |
+| `PatternId` | Distinguish D6 diagnostic ids, D8 admitted apply patterns, and raw Grit pattern paths. |
+| `GritPatternPath` | Prevent arbitrary repo paths from being passed as apply patterns. |
+| `RepoRelativePath` | Keep absolute host paths, copy-root paths, and repo-relative write paths separate. |
+| `ApprovedWritePath` | Prevent observed changed paths from being treated as approved before D8/D10/D9 checks. |
+| `ApprovedWriteSetId` | Link live writes, formatter handoff, gates, and rollback to one approval. |
+| `CommandId` | Prevent free-form gate command ids from becoming behavior selectors. |
+| `Sha256Digest` | Keep digests distinct from arbitrary strings. |
+| `D0SurfaceId` | Require public compatibility citation. |
+| `D1NonClaimId` | Use canonical non-claims, not prose arrays. |
+| `ApplyAdmissionProjectionId` | Consume D8 admission without owning governance. |
+| `D10ProtectedZoneDecisionId` | Consume D10 policy without reimplementing it. |
+
+Required non-empty arrays:
+
+- approved writes in a live write set;
+- blocked writes in a refusal;
+- rollback changed paths;
+- recovery instructions for refusals and rollback failures;
+- gate command records when gates ran;
+- D0 surface ids on compatibility projections touched by D9.
+
+## Vendor Boundary
+
+| Owner | D9 relation |
+| --- | --- |
+| Grit | Owns GritQL/pattern syntax, native matching, native `grit apply`, native output behavior, and pattern fixture tests. D9 selects pattern paths and roots, records command outcomes, and classifies observations. |
+| Biome | Owns formatter/linter/import-sort behavior for `biome check --write`. D9 records formatter handoff success/failure and rollback relation. |
+| Git | Owns status and checkout command behavior. D9 records worktree observations and rollback command outcome. |
+| Nx | Owns graph/target/scheduling/cache semantics. D9 records explicit gate command outcomes only when gates are declared. |
+| Habitat D9 | Owns transaction sequencing, write-set approval, changed-path verification, rollback relation, recovery instructions, and public transaction projection. |
+
+## Current Write And Protected Surface Evidence
+
+Current source roots are discovered from `mods/*/src/{recipes,maps}`. The
+current source pattern further limits rewrites to TypeScript paths under those
+roots. This is present behavior, not permanent generic authority.
+
+Current docs rewrite behavior applies a Grit-owned Markdown pattern to exact
+candidate Markdown files under `docs/**/*.md`; D9 should preserve the exact-root
+contract and avoid raw `docs/` scans for transform execution.
+
+Current generated/protected risk: `mods/*/src/maps/**` overlaps
+`mods/mod-swooper-maps/src/maps/generated/**`. D9 source implementation must
+consume D10/G-HOST decisions and refuse generated/protected paths before live
+write. This cannot remain an implicit root filter.
+
+Current host-specific risk: `validateAppliedTargetExports()` hard-codes
+`@mapgen/domain/**/ops` and `mods/mod-swooper-maps/**` public ops targets inside
+generic transaction code. D9 target design requires that behavior to move behind
+a G-HOST-declared apply gate or remain source-blocked.
+
+## Public Compatibility Decisions
+
+D9 does not add `habitat fix --json` by default. Current `fix` supports
+`--dry-run` only. A JSON output surface is a separate D0-controlled public
+contract decision:
+
+- if preserved, D9 keeps human stdout/stderr compatibility and exposes the new
+  target record through internal/package exports only under D0 rows;
+- if versioned or added, D9 must define schema version, terminal `kind` field,
+  non-claim ids, recovery shape, and bad-case JSON tests;
+- if facaded, legacy `GritApplyTransactionProof` projects from
+  `ApplyTransactionRecord` and cannot be authoritative;
+- if deferred, remove any `--json` validation gate from D9 and record the owner
+  of that later decision.
+
+Until D0 rows exist, source implementation remains blocked for changes to
+`habitat fix` output/exit behavior and exported `GritApply*` types/functions.
+
+## Module Ownership For Later Implementation
+
+| Responsibility | D9 target module/domain | Must not own |
+| --- | --- | --- |
+| Transaction lifecycle and terminal outcomes | D9 transaction module, e.g. `apply-transaction.ts` | Grit rewrite semantics, D8 admission, D10 policy, host semantics. |
+| Native Grit apply invocation/observation | Grit adapter boundary | Write approval, rollback, formatter/gate state. |
+| Pattern apply admission | D8 `ApplyAdmissionProjection` | Live-write safety and rollback. |
+| Protected/generated path decision | D10/G-HOST projection | Native apply invocation and formatter/gate execution. |
+| Write-set approval composition | D9 write-set module | Host-specific public-ops validation unless declared as a gate. |
+| Formatter handoff | Formatter handoff adapter | Transaction success semantics or product correctness. |
+| Gate handoff | Gate handoff adapter | Gate declaration ownership. |
+| CLI request/rendering | `fix` command / command engine | Transaction authority. |
+| Legacy export compatibility | D0/D1 facade | Target transaction model source of truth. |
+
+## Downstream Projections
+
+D11 may consume only a local-feedback-safe projection:
+
+- transaction unavailable/refused/dry-run/applied/rolled-back/rollback-failed;
+- recovery instructions;
+- non-claims that hook success is not safe-apply completion, CI, review, or
+  runtime/product correctness.
+
+D13 may consume transaction-input prerequisites for future apply-capable
+candidate generation, but D13 does not gain write authority.
+
+D15 is not triggered by D9 unless D9 final design records a concrete
+contradiction that cannot be represented inside D9-owned transaction records.
 
 ## Implementation Readiness
 
-Before implementation starts, the executor must have:
+D9 is implementation-ready only after:
 
-- D0 compatibility disposition for every public command, JSON, export, script,
-  target, generator, and hook surface touched by this packet.
-- A concrete write set and protected path list.
-- Tests and command gates from this packet copied into the phase record.
-- Review findings dispositioned with accepted P1/P2 repaired.
-
-## Review Lanes
-
-- Domain-language adversary: names, owner, authority, and inherited terminology.
-- OpenSpec packet review: proposal/design/tasks/spec consistency and shortcut
-  language.
-- TypeScript state-space review: invalid states removed without type machinery
-  that exceeds the product need.
-- Testing/validation review: gates are falsifying, scenario-grounded, and have
-  exact command expectations.
-- Cross-domino review: dependencies, public-surface compatibility, and
-  downstream realignment.
-
-## Structural Alternative Rejected
-
-The rejected alternative is to implement the existing domino packet directly
-and let the execution agent create missing proposal, design, spec, task, and
-ledger details while coding. That path already caused design drift. This
-OpenSpec packet resolves the execution-control layer before implementation.
+- final D9 rereviews record no unresolved P1/P2 findings;
+- D0 compatibility rows exist for every touched public/durable surface;
+- D8 live apply-admission projection exists where D9 consumes apply admission;
+- D10/G-HOST live path/host projections exist where D9 touches protected,
+  generated, or host-specific surfaces;
+- D9 tasks and validation gates are copied into the implementation phase record;
+- packet index marks D9 accepted for design/specification only.

--- a/openspec/changes/deep-habitat-d9-transformation-transaction/proposal.md
+++ b/openspec/changes/deep-habitat-d9-transformation-transaction/proposal.md
@@ -2,80 +2,169 @@
 
 ## Summary
 
-Open the D9 Transformation Transaction OpenSpec packet for Deep Habitat Phase 2 remediation. This
-change converts the existing D9 domino packet into a review-gated
-OpenSpec packet scaffold. It resolves scope, owner, public surface impact,
-validation gates, downstream realignment, and stop conditions before any
-TypeScript implementation resumes.
+Specify D9 as the complete Transformation Transaction contract for Habitat
+structural rewrites. D9 owns the transaction envelope around a D8-admitted
+rewrite: request construction, dry-run inventory, write-set approval, isolated
+copy check, live write, rollback, formatter handoff, declared gate handoff,
+terminal outcome, recovery instruction, and public command projection.
+
+This packet remains design/specification only. It does not authorize source
+implementation until its final per-domino rereview gates pass and source
+blockers from D0, D8, D10, and G-HOST are satisfied where touched.
 
 ## Authority
 
-- Current user decision to restart OpenSpec packet preparation from square one.
-- Remediation frame: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation-frame.md.
-- Phase 2 packet suite: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets.
-- Root AGENTS.md Graphite/OpenSpec workflow guidance.
-- Domain Design and Information Design skills as mandatory language and artifact gates.
-- Current Habitat Toolkit code and tests as present-behavior evidence only.
-- Source domino packet: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D9-transformation-transaction.md.
+- Remediation router: `$REMEDIATION_DIR/context.md`.
+- Remediation frame: `$HABITAT_PROJECT/openspec-remediation-frame.md`.
+- Source domino packet: `$D9_SOURCE_PACKET`.
+- Accepted design inputs: D0, D1, D6, D7, and D8 accepted design/specification
+  packets.
+- Dependency inputs not yet implementation-ready: D10 Protected Zone Authority
+  and G-HOST Host Policy Boundary Gate.
+- Current code and tests under `$HABITAT_TOOL` as present-behavior evidence,
+  not target-domain authority.
+- Required skill anchors: Domain Design, Information Design, Solution Design,
+  TypeScript refactoring, and Civ7 OpenSpec Workstream.
 
 ## Product Scenario
 
-An agent applies a structural rewrite and needs dry-run, live write, rollback, formatting, and refusal behavior to be explicit and recoverable.
+An agent or human asks Habitat to apply a known structural repair. Habitat must
+show what would change, refuse unsafe or unauthorized writes, execute only
+approved write sets, run declared hygiene and gate handoffs, roll back after
+write-stage failures, and report recoverable terminal states without implying
+diagnostic cleanliness, product runtime correctness, or vendor semantics that
+Habitat does not own.
 
 ## What Changes
 
-- Define apply transaction states and rollback boundaries.
-- Separate Grit diagnostic input from write transaction output.
-- Use D1 receipt terms only for transaction handoff records that serve recovery.
+- Defines `Transformation Transaction` as the D9 owner and `ApplyTransactionRecord`
+  as the target public meaning inherited from D1.
+- Replaces optional/boolean transaction state with closed request, dry-run,
+  write-set, live-write, formatter, gate, rollback, refusal, outcome, recovery,
+  and non-claim state families.
+- Requires D8 `ApplyAdmissionProjection` before D9 evaluates any apply pattern.
+- Requires D10/G-HOST path and host-gate projections before D9 approves writes
+  into protected/generated or host-specific surfaces.
+- Treats Grit, Biome, Git, and Nx as vendor/tool owners whose command outcomes
+  D9 records without reimplementing their semantics.
+- Classifies legacy `GritApply*` exports and proof-shaped names as D0/D1
+  compatibility surfaces, not target terminology.
 
 ## What Does Not Change
 
-- No diagnostic catalog ownership.
-- No generated-zone policy ownership.
-- No generic command provenance substrate unless D15 trigger passes.
+- No TypeScript source implementation in this remediation layer.
+- No D6 diagnostic catalog ownership.
+- No D8 Pattern Governance lifecycle/admission ownership.
+- No D10 generated/protected-zone policy ownership.
+- No G-HOST host policy ownership, including Civ7/MapGen public-ops semantics.
+- No D11 hook sequencing or staged-file behavior.
+- No D13 generator or candidate creation behavior.
+- No D15 command-provenance substrate unless D9 records a concrete state that
+  cannot be represented inside D9-owned transaction records.
 
 ## Requires
 
-- D0
-- D1
-- D6
-- D8
-- D10
+- D0 for every public command, package export, JSON/human output, script, docs
+  example, or durable behavior surface touched by D9.
+- D1 for `ApplyTransactionRecord`, D1 non-claim identifiers, refusal record
+  relationships, and compatibility wrapper rules.
+- D6 for diagnostic identity and limitations only; D6 diagnostics do not
+  authorize writes.
+- D8 for `ApplyAdmissionProjection` and apply-refusal projections.
+- D10/G-HOST for protected/generated path decisions and host-specific apply
+  gate declarations where touched.
 
 ## Enables
 
-- D11
+- D11 Local Feedback may consume D9 local-feedback-safe transaction projections
+  for refused, dry-run, applied, rolled-back, rollback-failed, and recovery
+  states.
+- D13 may consume D9 transaction-input prerequisites for future apply-capable
+  candidates, while D13 still owns candidate generation.
+- Future apply packet work may rely on the D9 closed state model instead of
+  parsing legacy proof/result objects.
 
-## Affected Owners
+## Affected Public And Durable Surfaces
 
-- Domain owner: Transformation Transaction.
-- OpenSpec change path: `openspec/changes/deep-habitat-d9-transformation-transaction/**`.
-- Expected Habitat implementation write set named in `design.md`; no code is
-  authorized by this remediation packet itself.
+These surfaces require D0 row citation before source implementation may change
+or rely on compatibility handling:
 
-## Forbidden Owners
+- `habitat fix` and `habitat fix --dry-run` CLI behavior, human output, exit
+  status, and Oclif help text.
+- Any new `habitat fix --json` flag or JSON output. D9 does not treat JSON as a
+  current command surface; adding it requires an explicit D0-backed public
+  contract.
+- Package exports from `$HABITAT_TOOL/src/index.ts`: `GritApplyTransactionOptions`,
+  `GritApplyTransactionProof`, `GritApplyTransactionResult`,
+  `GritApplyRewriteInventoryEntry`, `classifyApplyRewriteInventory`,
+  `parseApplyRewriteInventory`, and `runGritApplyTransaction`.
+- Command/process DTOs that appear in apply transaction output:
+  `HabitatCommandResult`, `HabitatProcessRequest`, command `kind` strings, and
+  gate/formatter/rollback command records.
+- Apply pattern paths under `.grit/patterns/habitat/apply/**` when D9 changes
+  their transaction invocation or inventory expectations.
+- Habitat docs/examples that show fix/apply output or recovery behavior.
 
-- Adjacent dominoes may not redefine Transformation Transaction authority.
-- Current code names may not become target-domain language without this packet
-  accepting the term.
-- Implementation agents may not add shims, fallbacks, dual paths, silent skips,
-  optional target shape, or generated-output hand edits.
+## Write Set For Later Implementation
 
-## Consumer Impact
+Later D9 source work may touch only the D9-owned transaction and adjacent
+projection surfaces:
 
-Apply/fix output may change for transaction clarity under D0 compatibility rules.
+- `$HABITAT_TOOL/src/lib/grit-apply.ts` and D9-owned extracted modules for
+  transaction state, write-set approval, formatter handoff, gate handoff, and
+  rollback/recovery.
+- `$HABITAT_TOOL/src/lib/command-engine.ts` and `$HABITAT_TOOL/src/commands/fix.ts`
+  only to construct explicit D9 request variants and render D9 outcomes.
+- `$HABITAT_TOOL/src/index.ts` only under D0/D1 compatibility rules.
+- `$HABITAT_TOOL/test/lib/grit-apply.test.ts` and D9-specific follow-on test
+  files. The implementation should reduce the large single-file test burden
+  by moving transaction state, write-set approval, handoff, and integration
+  tests into owned files where practical.
+- Grit apply pattern fixture tests only when the D9 transaction contract changes
+  invocation or inventory expectations; Grit pattern semantics remain Grit/D8
+  owned.
 
-## Stop Conditions
-
-- Dry-run and live apply share ambiguous state.
-- Rollback failure is hidden.
-- Protected-zone violations become best-effort skips.
-- Transaction records become generic proof artifacts.
+Protected from D9 implementation: D6 diagnostic behavior, D8 governance and
+manifest lifecycle, D10/G-HOST policy definitions, D11 hooks, D13 generators,
+generated outputs, lockfiles, baseline JSON edits, and product mod source
+changes not justified as isolated D9 fixtures.
 
 ## Verification Gates
 
-- bun run --cwd tools/habitat-harness test -- test/lib/grit-apply.test.ts
-- bun run habitat fix --help
-- bun run openspec -- validate deep-habitat-d9-transformation-transaction --strict
+Design-time gates before D9 acceptance:
+
+- D9 complete-standard wording audit over `$D9_CHANGE/**`,
+  `$REMEDIATION_DIR/packet-index.md`, and `$AGENT_SCRATCH/domino-D9-*.md`.
+- `bun run openspec -- validate deep-habitat-d9-transformation-transaction --strict`
 - `bun run openspec:validate`
 - `git diff --check`
+- Fresh D9 final rereview lanes for domain/ontology, TypeScript/validation,
+  OpenSpec/information, code/vendor topology, and cross-domino/product.
+
+Later implementation gates:
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/grit-apply.test.ts`
+  plus any D9-owned split tests introduced by the implementation.
+- `bun run --cwd tools/habitat-harness test -- test/grit/grit-patterns.test.ts`
+  when apply pattern invocation or fixtures change.
+- `bun tools/habitat-harness/bin/dev.ts fix --dry-run` with
+  `git status --short --branch` before and after.
+- Native Grit pattern tests for every apply pattern whose transaction inventory
+  or fixture contract D9 touches.
+- Injected bad-case tests for missing D8 admission, missing D10/G-HOST
+  projection, dirty live worktree, dry-run parse mismatch, unapproved paths,
+  create/delete refusal, unexpected live changed path, formatter failure,
+  gate failure, rollback success, rollback failure, and post-handoff path drift.
+
+## Stop Conditions
+
+- A live write can be constructed without D8 apply admission.
+- A planned write can bypass D10/G-HOST protected/generated or host-gate
+  decisions where those surfaces are touched.
+- `ok: boolean` plus nullable command/proof fields remains the target model.
+- D9 embeds Civ7/MapGen public-ops validation as generic transaction policy
+  instead of consuming a declared host gate.
+- `habitat fix --json` appears as a gate or output without an explicit D0
+  compatibility decision.
+- Formatter, gate, rollback, or vendor command success is reported as product
+  correctness, current-tree diagnostic cleanliness, or runtime proof.

--- a/openspec/changes/deep-habitat-d9-transformation-transaction/specs/habitat-harness/spec.md
+++ b/openspec/changes/deep-habitat-d9-transformation-transaction/specs/habitat-harness/spec.md
@@ -1,13 +1,299 @@
 ## ADDED Requirements
 
-### Requirement: D9 Transformation Transaction Is Resolved Before Implementation
+### Requirement: Transformation Transaction Owns Apply Execution State
 
-Habitat transformation apply SHALL model dry-run, live-write, rollback, formatting, protected-zone refusal, and recovery states as an explicit transaction rather than a boolean success plus artifact side channel.
+Habitat SHALL model `habitat fix` structural rewrites as a closed
+`Transformation Transaction` state family rather than as `ok: boolean` plus
+nullable command/proof fields.
 
-#### Scenario: Dry run is requested
-- **WHEN** an apply command runs without write permission
-- **THEN** Habitat reports planned edits and refuses to mutate files
+#### Scenario: Transaction result is projected for compatibility
+- **WHEN** legacy `GritApplyTransactionResult` or `GritApplyTransactionProof`
+  surfaces remain exported or rendered
+- **THEN** they SHALL be D0/D1 compatibility projections from
+  `ApplyTransactionRecord`
+- **AND** they SHALL NOT be the authoritative target state.
 
-#### Scenario: Live apply fails after writes
-- **WHEN** a transaction cannot complete cleanly
-- **THEN** Habitat reports rollback state and recovery instructions
+#### Scenario: Terminal outcome is rendered
+- **WHEN** command rendering, package export projection, or legacy compatibility
+  wrapping consumes a transaction outcome
+- **THEN** the implementation SHALL use exhaustive discriminated-state handling
+  that fails compilation when a new terminal outcome is not rendered.
+
+### Requirement: Apply Request Modes Are Explicit
+
+Habitat SHALL construct D9 transactions through closed lifecycle variants:
+`DryRunIntent`, `LiveWriteIntent`, D9-produced `LiveWriteAttempt`, and
+`RollbackProbeRequest`.
+
+#### Scenario: Dry-run intent is created
+- **WHEN** the `fix` command constructs a dry-run intent
+- **THEN** it SHALL NOT carry live-write, rollback-after-apply, formatter-write,
+  or post-write gate states.
+
+#### Scenario: Live-write intent is created
+- **WHEN** the `fix` command constructs a live-write intent
+- **THEN** it SHALL carry user intent, D8 apply admission, and non-write
+  observations needed to plan the transaction
+- **AND** SHALL NOT carry an approved write set before D9 dry-run/copy/path
+  planning produces one.
+
+#### Scenario: Live-write attempt is created
+- **WHEN** D9 constructs a live-write attempt from a live-write intent
+- **THEN** it SHALL require a clean worktree observation, approved write set,
+  rollback policy, and formatter/gate handoff policy.
+
+#### Scenario: Anonymous gate command is supplied
+- **WHEN** a caller supplies a gate command without a D8, D10, G-HOST, or
+  transaction-owned gate declaration
+- **THEN** D9 SHALL refuse before live write.
+
+### Requirement: D8 Pattern Admission Is Consumed, Not Decided, By D9
+
+Habitat SHALL run apply transactions only for patterns that D8 publishes as
+apply-admitted through `ApplyAdmissionProjection`.
+
+#### Scenario: Diagnostic pattern lacks apply admission
+- **WHEN** a rule has diagnostic capability but no D8 apply admission
+- **THEN** D9 SHALL refuse before dry-run or live write.
+
+#### Scenario: Pattern file exists without apply admission
+- **WHEN** a Grit pattern file exists in the repository but D8 has not admitted
+  it for apply
+- **THEN** file presence SHALL NOT authorize a transaction.
+
+#### Scenario: D8 refuses or retires a pattern
+- **WHEN** D8 reports an apply refusal or retired apply lifecycle state
+- **THEN** D9 SHALL refuse the transaction even if native Grit can execute the
+  pattern file.
+
+### Requirement: Diagnostic Findings Cannot Authorize Writes
+
+Habitat SHALL NOT treat D6 diagnostic findings, injected probes, native Grit
+samples, or clean diagnostic runs as apply safety.
+
+#### Scenario: Diagnostic finding exists
+- **WHEN** D6 emits a finding for an apply-capable rule
+- **THEN** D9 SHALL still require D8 apply admission and D9 write-set/path
+  checks before any write.
+
+#### Scenario: Diagnostic adapter fails
+- **WHEN** D6 records a diagnostic adapter failure
+- **THEN** D9 SHALL NOT convert that diagnostic failure into a write transaction
+  failure unless an explicit apply transaction was requested and reached a D9
+  state.
+
+### Requirement: Dry-Run Inventory Is A First-Class Transaction State
+
+Habitat SHALL distinguish dry-run no-match, approved dry-run changes, dry-run
+parse failure, native dry-run failure/interruption, and dry-run/copy mismatch.
+
+#### Scenario: Dry-run reports zero matches
+- **WHEN** native apply dry-run reports zero matches
+- **THEN** D9 SHALL return a no-mutation state
+- **AND** SHALL NOT infer that live apply would succeed.
+
+#### Scenario: Dry-run reports approved inventory
+- **WHEN** native apply dry-run reports a pattern-owned structured inventory
+- **THEN** D9 SHALL record pattern identity, target path, rewrite target,
+  approval source, and output digest before write-set approval.
+
+#### Scenario: Dry-run output is ambiguous
+- **WHEN** native apply dry-run output is non-empty and is neither zero-match
+  output nor a declared inventory format
+- **THEN** D9 SHALL refuse before live write unless the pattern declares an
+  isolated-copy inventory mode.
+
+#### Scenario: Dry-run reports matches but copy check produces no diff
+- **WHEN** native dry-run reports matches and the isolated-copy check produces
+  no changed paths
+- **THEN** D9 SHALL fail closed as a dry-run/copy mismatch.
+
+### Requirement: Approved Write Set Owns Every Changed Path
+
+Habitat SHALL approve every transaction write path through D8 apply admission,
+D9 write-set approval, and D10/G-HOST path decision where applicable.
+
+#### Scenario: Inventory names path outside approved roots
+- **WHEN** dry-run inventory names a path outside the approved apply roots
+- **THEN** D9 SHALL refuse before live write.
+
+#### Scenario: Isolated-copy diff changes path outside approved roots
+- **WHEN** isolated-copy diff observation changes a path outside approved roots
+- **THEN** D9 SHALL refuse before live write.
+
+#### Scenario: Create is not admitted
+- **WHEN** isolated-copy or live write observation creates a file without an
+  explicit D8 create capability and D9 cleanup contract
+- **THEN** D9 SHALL refuse or roll back according to the observed stage.
+
+#### Scenario: Delete is not admitted
+- **WHEN** isolated-copy or live write observation deletes a file without an
+  explicit D8 delete capability and D9 cleanup contract
+- **THEN** D9 SHALL refuse or roll back according to the observed stage.
+
+#### Scenario: Live write produces unexpected path
+- **WHEN** live apply changes a path not present in the approved write set
+- **THEN** D9 SHALL roll back and report unexpected-path failure.
+
+### Requirement: Protected And Host Policy Inputs Are Blocking
+
+Habitat SHALL consume D10 protected/generated-zone decisions and G-HOST
+host-specific gate declarations before live write where touched.
+
+#### Scenario: Planned write intersects generated or protected zone
+- **WHEN** a planned write intersects a generated or protected zone and D10 does
+  not provide an allowed mutation decision
+- **THEN** D9 SHALL refuse before live write.
+
+#### Scenario: Host-specific apply gate is missing
+- **WHEN** a planned write requires host-specific validation and G-HOST does not
+  declare the gate
+- **THEN** D9 SHALL refuse rather than silently disabling that validation.
+
+#### Scenario: MapGen public-ops validation is required
+- **WHEN** the current MapGen public-ops validation is needed for an apply
+  pattern
+- **THEN** D9 SHALL consume it as a declared host gate
+- **AND** SHALL NOT embed Civ7/MapGen paths or public-ops semantics as generic
+  transaction policy.
+
+### Requirement: Live Write Is Conditional On Dry-Run And Copy Check
+
+Habitat SHALL run live apply only after dry-run inventory and isolated-copy
+checks approve the exact write set.
+
+#### Scenario: Dirty worktree live write is requested
+- **WHEN** a live-write transaction is requested while the worktree is dirty
+- **THEN** D9 SHALL refuse before invoking native Grit.
+
+#### Scenario: Dirty worktree dry-run is requested
+- **WHEN** a dry-run transaction is requested while the worktree is dirty
+- **THEN** D9 MAY run because the request is non-writing
+- **AND** SHALL report only dry-run state.
+
+#### Scenario: Live write succeeds
+- **WHEN** live apply succeeds and changed paths equal the approved write set
+- **THEN** D9 SHALL enter live-write-applied state and proceed only to declared
+  handoffs.
+
+#### Scenario: Live write fails after possible write
+- **WHEN** native live apply fails or is interrupted after possible writes
+- **THEN** D9 SHALL attempt rollback and record rollback outcome.
+
+### Requirement: Formatter Handoff Is Hygiene Handoff
+
+Habitat SHALL model Biome or other formatter invocation as a formatter handoff,
+not as apply safety or product correctness.
+
+#### Scenario: Formatter succeeds
+- **WHEN** formatter handoff succeeds after live write
+- **THEN** D9 MAY continue to declared gates
+- **AND** SHALL NOT claim current-tree diagnostic cleanliness, runtime behavior,
+  or apply admission from formatter success.
+
+#### Scenario: Formatter fails
+- **WHEN** formatter handoff fails after live write
+- **THEN** D9 SHALL attempt rollback
+- **AND** SHALL report formatter-handoff failure as the cause.
+
+#### Scenario: Formatter changes unexpected path
+- **WHEN** formatter handoff changes a path outside the approved write set
+- **THEN** D9 SHALL treat the path drift as transaction failure and attempt
+  rollback.
+
+### Requirement: Gate Handoffs Are Declared
+
+Habitat SHALL run only declared post-apply gates associated with the admitted
+pattern, host policy, or transaction contract.
+
+#### Scenario: Declared gate succeeds
+- **WHEN** a declared gate succeeds
+- **THEN** D9 SHALL record the gate command outcome and non-claims.
+
+#### Scenario: Declared gate fails
+- **WHEN** a declared gate fails after live write
+- **THEN** D9 SHALL attempt rollback
+- **AND** SHALL report the failed gate identity and owner.
+
+#### Scenario: Gate command sequence has prior successes
+- **WHEN** one gate fails after earlier gates succeeded
+- **THEN** D9 SHALL NOT report transaction success from the prior gates.
+
+### Requirement: Rollback Is An Explicit State Relation
+
+Habitat SHALL model rollback as a transaction state relation with success,
+failure, dirty-path, and recovery data.
+
+#### Scenario: Failure rollback succeeds
+- **WHEN** live write, formatter handoff, or gate handoff fails after writes and
+  rollback succeeds
+- **THEN** D9 SHALL report a rolled-back terminal state with the original failed
+  stage, rollback command outcome, reverted paths, and clean worktree
+  observation.
+
+#### Scenario: Failure rollback fails
+- **WHEN** rollback fails after a write-stage failure
+- **THEN** D9 SHALL report rollback-failed with residual dirty paths and
+  recovery instructions
+- **AND** SHALL NOT project success exit status.
+
+#### Scenario: Rollback probe is requested
+- **WHEN** a rollback probe is requested for transaction validation
+- **THEN** D9 SHALL distinguish that probe from failure rollback and SHALL keep
+  it out of normal live success semantics.
+
+### Requirement: Docs And Source Apply Lanes Stay Distinct
+
+Habitat SHALL keep docs-local-checkout-path rewrites and source structural
+rewrites in distinct apply lanes with distinct roots, pattern ownership, and
+write-set approval.
+
+#### Scenario: Docs dry-run finds Markdown candidate
+- **WHEN** the docs apply pattern reports a rewrite for an exact markdown file
+- **THEN** D9 SHALL approve only that docs path through the docs lane.
+
+#### Scenario: Docs dry-run reports file without rewrite hunk
+- **WHEN** native docs apply output lists a file without a rewrite hunk
+- **THEN** D9 SHALL NOT treat that file as an approved changed path.
+
+#### Scenario: Source structural rewrite is planned
+- **WHEN** the source apply pattern reports a TypeScript rewrite
+- **THEN** D9 SHALL approve it only through the source lane and any required
+  host/pattern gate.
+
+### Requirement: Public Fix Output Is Compatibility-Controlled
+
+Habitat SHALL expose `habitat fix` transaction output only through D0-backed
+compatibility decisions.
+
+#### Scenario: Existing fix command is used
+- **WHEN** `habitat fix` or `habitat fix --dry-run` behavior is preserved
+- **THEN** D9 SHALL cite D0 rows for the command surface and output/exit
+  compatibility before source implementation changes it.
+
+#### Scenario: JSON output is added
+- **WHEN** D9 adds a `--json` flag or JSON output
+- **THEN** D9 SHALL require D0 compatibility disposition, schema version, stable
+  terminal `kind`, non-claim identifiers, recovery shape, and bad-case JSON
+  tests.
+
+#### Scenario: JSON output is not in D9 scope
+- **WHEN** D9 does not add JSON output
+- **THEN** D9 validation SHALL NOT cite `habitat fix --dry-run --json`.
+
+### Requirement: Downstream Consumers Receive Projections
+
+Habitat SHALL publish D9 downstream projections instead of requiring downstream
+domains to parse legacy proof/result objects.
+
+#### Scenario: D11 consumes transaction state
+- **WHEN** D11 needs local feedback about apply/fix state
+- **THEN** it SHALL consume a D9 projection for unavailable, refused, dry-run,
+  applied, rolled-back, rollback-failed, or recovery-required outcomes
+- **AND** it SHALL NOT recompute apply safety.
+
+#### Scenario: D13 consumes transaction prerequisites
+- **WHEN** D13 describes an apply-capable candidate
+- **THEN** it MAY consume D9 transaction input prerequisites
+- **AND** SHALL NOT treat candidate generation as D8 apply admission or D9
+  write safety.

--- a/openspec/changes/deep-habitat-d9-transformation-transaction/tasks.md
+++ b/openspec/changes/deep-habitat-d9-transformation-transaction/tasks.md
@@ -2,32 +2,131 @@
 
 ## 1. Pre-Implementation Grounding
 
-- [ ] 1.1 Read `D9-transformation-transaction.md`, the remediation frame, D0 compatibility records,
-  and this OpenSpec packet.
-- [ ] 1.2 Confirm the branch/worktree starts from the approved implementation
-  stack and is clean before source edits.
-- [ ] 1.3 Record the concrete write set and protected paths in the phase record.
-- [ ] 1.4 Re-run or cite the required dependency gates: D0, D1, D6, D8, D10.
+- [ ] 1.1 Read `$D9_SOURCE_PACKET`, `$D9_CHANGE/proposal.md`,
+  `$D9_CHANGE/design.md`, `$D9_CHANGE/specs/habitat-harness/spec.md`, and D9
+  workstream ledgers.
+- [ ] 1.2 Confirm implementation starts on the accepted stack, not this
+  design-only layer unless the stack has been merged according to Graphite.
+- [ ] 1.3 Confirm concrete D0 rows exist for every touched `habitat fix`,
+  package export, command output, docs example, and DTO surface.
+- [ ] 1.4 Confirm live D8 `ApplyAdmissionProjection` exists for every apply
+  pattern D9 consumes.
+- [ ] 1.5 Confirm live D10/G-HOST path and host-gate projections exist for every
+  protected/generated or host-specific surface touched.
+- [ ] 1.6 If any dependency fact is absent, keep source implementation blocked
+  for the affected surface and record the exact blocker in the implementation
+  phase record.
 
-## 2. Implementation
+## 2. State Model Construction
 
-- [ ] 2.1 Define apply transaction states and rollback boundaries.
-- [ ] 2.2 Separate Grit diagnostic input from write transaction output.
-- [ ] 2.3 Use D1 receipt terms only for transaction handoff records that serve recovery.
+- [ ] 2.1 Introduce the D9 target state family:
+  `TransformationRequest`, `DryRunIntent`, `LiveWriteIntent`,
+  `LiveWriteAttempt`, `TransactionAdmissionDecision`,
+  `DryRunInventoryOutcome`, `WriteSetApproval`, `LiveWriteOutcome`,
+  `FormatterHandoffOutcome`, `GateHandoffOutcome`, `RollbackOutcome`,
+  `TransactionOutcome`, and `RecoveryInstruction`.
+- [ ] 2.2 Add branded identifiers for pattern ids, Grit pattern paths,
+  repo-relative paths, approved write paths, write-set ids, command ids,
+  SHA-256 digests, D0 surface ids, D1 non-claim ids, D8 admission ids, and D10
+  decision ids.
+- [ ] 2.3 Add non-empty collection types for approved writes, blocked writes,
+  rollback paths, recovery instructions, gate command records, and D0 citations.
+- [ ] 2.4 Add exhaustive `never` guards for command rendering and legacy
+  compatibility projection.
+- [ ] 2.5 Add type-level or compile-time tests that reject: `ok` plus failure,
+  dry-run plus rollback-after-apply, live write without D8 admission, live write
+  without D10/G-HOST path decision where touched, rollback command outside
+  rollback state, and formatter/gate success inside failed outcomes.
 
-## 3. Validation
+## 3. Request And Admission
 
-- [ ] 3.1 Run `bun run --cwd tools/habitat-harness test -- test/lib/grit-apply.test.ts`.
-- [ ] 3.2 Run `bun run habitat fix --help`.
-- [ ] 3.3 Run `bun run openspec -- validate deep-habitat-d9-transformation-transaction --strict`.
-- [ ] 3.4 Run `bun run openspec:validate`.
-- [ ] 3.5 Run `git diff --check`.
+- [ ] 3.1 Make `fix` command parsing construct explicit dry-run or live-write
+  intent variants before entering D9. The command parser must not construct
+  `LiveWriteAttempt`.
+- [ ] 3.2 Replace optional mode flags with intent/attempt constructors and
+  internal test seams that cannot be used as product request authority.
+- [ ] 3.3 Consume D8 `ApplyAdmissionProjection` before any dry-run or live-write
+  invocation.
+- [ ] 3.4 Refuse diagnostic-only, candidate-only, retired, refused, or missing
+  apply-admission patterns before native Grit invocation.
+- [ ] 3.5 Keep `habitat fix --json` out of implementation unless D0 authorizes a
+  JSON contract and D9 adds the matching schema/tests.
 
-## 4. Review And Realignment
+## 4. Dry-Run And Write-Set Approval
 
-- [ ] 4.1 Run domain-language, OpenSpec, TypeScript, validation, and
-  cross-domino review lanes.
-- [ ] 4.2 Repair accepted P1/P2 findings before packet closure.
-- [ ] 4.3 Update downstream docs, examples, specs, tests, and packet index rows
-  affected by implementation facts.
-- [ ] 4.4 Leave the worktree clean or write a zero-context next packet.
+- [ ] 4.1 Parse native Grit dry-run output into observations: zero-match,
+  structured inventory, ambiguous output, command failure, and interruption.
+- [ ] 4.2 Treat isolated-copy checks as explicit transaction observations, not
+  implicit alternate authority paths. Use them only when the pattern inventory
+  mode declares that path.
+- [ ] 4.3 Compose `ApprovedWriteSet` only from D8 admission, D9 inventory/copy
+  observation, D10 path decision, and G-HOST host policy where touched.
+- [ ] 4.4 Refuse outside-root paths, protected/generated-zone paths without D10
+  approval, host-specific paths without G-HOST declaration, and create/delete
+  effects without explicit create/delete capability plus cleanup contract.
+- [ ] 4.5 Preserve docs and source apply lanes as distinct pattern lanes with
+  distinct roots, observations, and handoff records.
+
+## 5. Live Write, Handoffs, And Rollback
+
+- [ ] 5.1 Refuse dirty live worktrees before native Grit invocation; allow dirty
+  dry-runs only as non-writing requests.
+- [ ] 5.2 Construct `LiveWriteAttempt` and run live native Grit apply only after
+  D9 has produced approved dry-run/copy write-set approval.
+- [ ] 5.3 Verify changed paths immediately after live apply and after every
+  write-capable handoff.
+- [ ] 5.4 Model Biome as formatter handoff; on formatter failure or formatter
+  path drift, run rollback and report formatter failure as cause.
+- [ ] 5.5 Model declared gates as owner-tagged handoffs; on gate failure, run
+  rollback and report failed gate identity and owner.
+- [ ] 5.6 Replace inline MapGen public-ops validation with a G-HOST/D10-declared
+  host gate, or keep the source implementation blocked for that behavior until
+  the gate declaration exists.
+- [ ] 5.7 Model rollback success and rollback failure as distinct terminal
+  outcomes with residual paths and recovery instructions.
+
+## 6. Public Compatibility And Projection
+
+- [ ] 6.1 Project `ApplyTransactionRecord` into legacy `GritApplyTransaction*`
+  exports only through D0/D1 compatibility handling.
+- [ ] 6.2 Preserve existing `habitat fix` human output and exit behavior unless
+  D0 rows authorize version/facade/deprecate/refuse handling.
+- [ ] 6.3 If D9 adds JSON output, implement schema/version, terminal `kind`,
+  recovery instructions, non-claim ids, and bad-case JSON tests in the same
+  compatibility-controlled slice.
+- [ ] 6.4 Publish a D11-safe local feedback projection and a D13-safe
+  transaction-prerequisite projection; do not expose raw legacy proof blobs as
+  downstream authority.
+
+## 7. Tests And Validation
+
+- [ ] 7.1 Run type-level/compile-time tests for invalid state construction and
+  exhaustive rendering/projection.
+- [ ] 7.2 Run transaction unit tests for dirty live refusal, dirty dry-run,
+  zero-match dry-run, approved dry-run, ambiguous dry-run, dry-run/copy
+  mismatch, unapproved inventory, outside-root refusal, create/delete refusal,
+  protected-zone refusal, missing host gate, unexpected live path, formatter
+  failure, gate failure, rollback success, and rollback failure.
+- [ ] 7.3 Run focused command tests for `habitat fix --help` and
+  `habitat fix --dry-run`; do not run `habitat fix --dry-run --json` unless D0
+  authorized and D9 implemented that surface.
+- [ ] 7.4 Run native Grit pattern tests for every apply pattern whose
+  transaction invocation or inventory contract changed.
+- [ ] 7.5 Run `git status --short --branch` before and after any live-write or
+  rollback fixture/probe command.
+- [ ] 7.6 Run `bun run --cwd tools/habitat-harness test -- test/lib/grit-apply.test.ts`
+  plus D9-owned split tests introduced during implementation.
+- [ ] 7.7 Run `bun run openspec -- validate deep-habitat-d9-transformation-transaction --strict`,
+  `bun run openspec:validate`, and `git diff --check`.
+
+## 8. Closure State
+
+- [x] 8.1 D9 final domain/ontology, TypeScript/validation,
+  OpenSpec/information, code/vendor-topology, and cross-domino/product
+  rereviews recorded no unresolved P1/P2 findings against current disk.
+- [x] 8.2 `$D9_REVIEW_LEDGER`, `$D9_PHASE_RECORD`,
+  `$D9_DOWNSTREAM_LEDGER`, `$D9_CLOSURE_CHECKLIST`, and packet index record D9
+  accepted for design/specification only.
+- [x] 8.3 Commit D9 as a design/specification layer only. Do not claim
+  implementation-complete or source-ready status where D0/D8/D10/G-HOST live
+  blockers remain.

--- a/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/closure-checklist.md
+++ b/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/closure-checklist.md
@@ -1,20 +1,53 @@
 # Closure Checklist: D9 Transformation Transaction
 
+## Current State
+
+D9 is accepted for design/specification after final rereview. It is not
+implementation-complete and not source-ready.
+
 ## Design Readiness
 
-- [ ] Proposal cites controlling authority and source packet.
-- [ ] Design resolves naming, domain owner, forbidden owners, and non-goals.
-- [ ] Tasks are implementation steps, not unresolved design questions.
-- [ ] Spec delta uses normative SHALL language with scenarios.
-- [ ] Review ledger has no accepted unresolved P1/P2 findings.
-- [ ] Downstream realignment is recorded.
-- [ ] OpenSpec validation passes for `deep-habitat-d9-transformation-transaction`.
+- [x] Proposal cites the source packet and remediation router.
+- [x] Proposal defines product scenario, affected surfaces, dependencies,
+  stop conditions, and design-time/later implementation gates.
+- [x] Design names Transformation Transaction as the single D9 owner.
+- [x] Design contains term disposition for legacy proof/result vocabulary.
+- [x] Design defines request, admission, dry-run, write-set, live-write,
+  formatter, gate, rollback, outcome, recovery, and non-claim state families.
+- [x] Design defines vendor/tool boundaries for Grit, Biome, Git, Nx, and
+  Habitat.
+- [x] Design records D0/D1 public compatibility blockers.
+- [x] Design records D8/D10/G-HOST source blockers.
+- [x] Spec delta contains normative requirements/scenarios for the accepted
+  first-wave P1/P2 findings.
+- [x] Tasks sequence state-model construction, request/admission, write-set,
+  live-write/handoff/rollback, public projection, validation, and review.
+- [x] Downstream realignment is recorded for D0, D1, D6, D7, D8, D10, G-HOST,
+  D11, D13, D15, packet index, and tests/fixtures.
+- [x] D9 complete-standard wording audit passes over `$D9_CHANGE/**`,
+  `$REMEDIATION_DIR/packet-index.md`, and `$AGENT_SCRATCH/domino-D9-*.md`.
+- [x] Strict D9 OpenSpec validation passes.
+- [x] Full OpenSpec validation passes.
+- [x] `git diff --check` passes.
+- [x] Fresh final D9 domain/ontology rereview records no unresolved P1/P2.
+- [x] Fresh final D9 TypeScript/validation rereview records no unresolved P1/P2.
+- [x] Fresh final D9 OpenSpec/information rereview records no unresolved P1/P2.
+- [x] Fresh final D9 code/vendor topology rereview records no unresolved P1/P2.
+- [x] Fresh final D9 cross-domino/product rereview records no unresolved P1/P2.
+- [x] Review ledger imports final rereviews as acceptance evidence.
+- [x] Packet index marks D9 accepted for design/specification only.
 
 ## Implementation Closure (Later)
 
-- [ ] Source changes stay inside the approved write set.
-- [ ] Validation gates pass with exact command output recorded.
-- [ ] Public-surface changes are dispositioned through D0 compatibility.
-- [ ] Downstream docs/tests/specs are realigned.
-- [ ] Graphite layer is clean, reviewable, and does not proceed past unresolved
-  packet approval.
+- [ ] Source changes stay inside the approved D9 write set.
+- [ ] Public-surface changes cite concrete D0 rows.
+- [ ] D8 apply admission is live wherever D9 consumes it.
+- [ ] D10/G-HOST path/host projections are live wherever D9 consumes them.
+- [ ] State construction tests reject invalid request/outcome combinations.
+- [ ] Transaction unit and focused integration tests cover all D9 bad cases.
+- [ ] Command checks prove `habitat fix --dry-run` and any D0-authorized JSON
+  surface exactly.
+- [ ] Native Grit/Biome/Nx gates are run only for the vendor/tool claims they
+  actually establish.
+- [ ] Worktree is clean after live-write/rollback fixtures.
+- [ ] Graphite layer is clean and subject/body commit message format is valid.

--- a/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/downstream-realignment-ledger.md
@@ -1,9 +1,22 @@
 # Downstream Realignment Ledger: D9 Transformation Transaction
 
-| Downstream Surface | Disposition | Required Action |
+## Status
+
+D9 is accepted for design/specification after final rereview. These rows
+describe the accepted design/specification contract; they do not authorize
+source implementation or downstream packet acceptance.
+
+| Surface | Current D9 disposition | Downstream action |
 | --- | --- | --- |
-| Phase 2 packet suite | pending | Mark D9 as OpenSpec-packetized after review. |
-| D0 compatibility matrix | pending | Confirm public surfaces touched by D9 are classified before implementation. |
-| Habitat docs/examples | pending | Update only when implementation facts change or public guidance must be clarified. |
-| Tests and command fixtures | pending | Add or update during implementation according to tasks.md. |
-| Later domino packets | pending | Update dependency assumptions if review changes D9 contract. |
+| D0 Public Surface Compatibility | D9 requires D0 rows for `habitat fix`, `habitat fix --dry-run`, any JSON output, package exports, command DTOs, and docs/examples before source changes. | D0 rows must exist before implementation touches those surfaces. D9 remains source-blocked for public changes without citations. |
+| D1 Receipt/Command Record Boundary | D9 uses `ApplyTransactionRecord`, D1 non-claim ids, refusal relationships, and compatibility wrapper rules. | Legacy `GritApplyTransactionProof` and `GritApplyTransactionResult` may only project from D9 target state through D0/D1 handling. |
+| D6 Diagnostic Pattern Catalog | D9 consumes diagnostic identity/limitations only as context. Diagnostics do not authorize writes. | D6 must not expose apply safety; D9 must not convert diagnostic adapter failures into transaction states without an apply request. |
+| D7 Structural Enforcement Pipeline | D7 check pass/fail does not approve writes. | D9 requires D8 admission, D10/G-HOST authority, and D9 transaction approval regardless of D7 check state. |
+| D8 Pattern Governance | D9 consumes only D8 `ApplyAdmissionProjection` or explicit D8 apply refusal. | D8 may cite D9 transaction-input requirements, but D8 does not execute writes or own rollback. |
+| D10 Protected Zone Authority | D9 requires D10 path/generated/protected-zone decisions before approving touched paths. D10 is not implementation-ready yet. | D9 source implementation remains blocked for protected/generated paths until accepted live D10 projections exist. |
+| G-HOST Host Policy Boundary Gate | D9 requires G-HOST declarations for host-specific apply gates, including current MapGen public-ops validation. G-HOST is not implementation-ready yet. | D9 may design the handoff but must not encode Civ7/MapGen policy as generic transaction logic. |
+| D11 Local Feedback | D9 publishes local-feedback-safe states: unavailable, refused, dry-run, applied, rolled-back, rollback-failed, and recovery-required. | D11 may render D9 projection and recovery instructions; D11 must not recompute apply safety, rollback status, path approval, or gate semantics. |
+| D13 Candidate Generation | D9 publishes transaction prerequisites for apply-capable candidates. | D13 may describe candidate requirements; candidate generation remains separate from D8 admission and D9 write safety. |
+| D15 Command Provenance Substrate | D9 does not trigger D15 by default. | Trigger D15 only if D9 final design records a concrete contradiction that D9-local transaction records cannot represent. |
+| Packet index | D9 is accepted for design/specification only after final rereviews. | Packet index now records D9 accepted for design/specification, not implementation-complete, with source work still blocked by concrete D0 rows, live D8 apply-admission projections, D10 path/zone decisions, and G-HOST host-gate declarations where touched. |
+| Tests and fixtures | D9 later implementation should reduce the current single-file apply test burden by moving state/write-set/handoff cases into owned test files where practical. | Do not keep adding all transaction behavior to the large `grit-apply.test.ts` file when an owned test split is available. |

--- a/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/phase-record.md
+++ b/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/phase-record.md
@@ -2,35 +2,78 @@
 
 ## State
 
-- Status: OpenSpec packet drafted for remediation review; implementation not
-  started.
-- Worktree: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation.
-- Branch: codex/deep-habitat-openspec-remediation.
-- Source packet: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D9-transformation-transaction.md.
-- OpenSpec change: openspec/changes/deep-habitat-d9-transformation-transaction/.
+- Status: Accepted for design/specification after fresh final rereview. Not
+  implementation-complete and not source-ready.
+- Worktree: `$ACTIVE_REMEDIATION_WORKTREE`.
+- Branch: `$ACTIVE_REMEDIATION_BRANCH`.
+- Source packet: `$D9_SOURCE_PACKET`.
+- OpenSpec change: `$D9_CHANGE`.
 
 ## Objective
 
-Convert D9 into a review-gated OpenSpec packet scaffold for Transformation Transaction
-without reopening implementation or carrying forward lazy domain language.
+Specify D9 as the complete Transformation Transaction design/specification
+authority: a closed transaction state model for D8-admitted structural rewrites,
+with explicit upstream projections, vendor/tool boundaries, write-set approval,
+handoffs, rollback, recovery, public compatibility blockers, and downstream
+projections.
 
 ## Current Gate
 
-Design/preparation gate. The packet can authorize later implementation only
-after review ledgers contain no accepted unresolved P1/P2 findings.
+Design/specification accepted. Fresh final D9 review lanes read the repaired
+disk state and recorded no unresolved P1/P2 findings.
 
-## Exact Validation Gates
+Source implementation remains blocked where concrete D0 rows, live D8 apply
+admission projections, live D10 protected/generated-zone decisions, or live
+G-HOST host-gate declarations are required and absent.
 
-- bun run --cwd tools/habitat-harness test -- test/lib/grit-apply.test.ts
-- bun run habitat fix --help
-- bun run openspec -- validate deep-habitat-d9-transformation-transaction --strict
-- bun run openspec:validate
-- git diff --check
+## First-Wave Investigation Inputs
+
+| Lane | Scratch | Current disposition |
+| --- | --- | --- |
+| Domain/ontology | `$D9_DOMAIN_REVIEW` | Imported negative findings; repaired in proposal/design/spec/tasks/control records; accepted by final rereview. |
+| TypeScript state-space | `$D9_TYPESCRIPT_REVIEW` | Imported negative findings; repaired with closed state model and TypeScript reduction requirements; accepted by final rereview. |
+| Code/vendor topology | `$D9_TOPOLOGY_REVIEW` | Imported negative findings; repaired with write/protected surfaces, vendor boundary, and invalid `--json` gate correction; accepted by final rereview. |
+| OpenSpec/information/testing | `$D9_INFORMATION_REVIEW` | Imported negative findings; repaired with expanded requirements/tasks and validation split; accepted by final rereview. |
+| Cross-domino/product | `$D9_CROSS_DOMINO_REVIEW` | Imported negative findings; repaired with upstream/downstream projections and source blockers; accepted by final rereview. |
+
+## Final Rereview Evidence
+
+| Lane | Scratch | Result |
+| --- | --- | --- |
+| Domain/ontology | `$D9_FINAL_DOMAIN_REVIEW` | Accepted for design/specification; no unresolved P1/P2 findings. |
+| TypeScript/validation | `$D9_FINAL_TYPESCRIPT_VALIDATION_REVIEW` | Accepted for design/specification; no unresolved P1/P2 findings. |
+| OpenSpec/information | `$D9_FINAL_OPENSPEC_INFORMATION_REVIEW` | Accepted for design/specification; no unresolved P1/P2 findings. |
+| Code/vendor topology | `$D9_FINAL_CODE_VENDOR_TOPOLOGY_REVIEW` | Accepted for design/specification; no unresolved P1/P2 findings. |
+| Cross-domino/product | `$D9_FINAL_CROSS_DOMINO_REVIEW` | Accepted for design/specification; no unresolved P1/P2 findings. |
+
+## Design-Time Validation Gates
+
+| Gate | Expected status | Claim |
+| --- | --- | --- |
+| D9 wording audit over `$D9_CHANGE/**`, `$REMEDIATION_DIR/packet-index.md`, and `$AGENT_SCRATCH/domino-D9-*.md` | Pass before acceptance | Active D9 guidance avoids reduced-standard wording except canonical traceability. |
+| `bun run openspec -- validate deep-habitat-d9-transformation-transaction --strict` | Pass before acceptance | OpenSpec shape for D9 is valid. |
+| `bun run openspec:validate` | Pass before acceptance | Repository OpenSpec corpus remains valid. |
+| `git diff --check` | Pass before acceptance | Diff hygiene is clean. |
+| Fresh final D9 rereviews | Passed | D9 is accepted for design/specification only. |
+
+## Later Implementation Gates
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/grit-apply.test.ts`
+  plus D9-owned split tests introduced during implementation.
+- `bun run --cwd tools/habitat-harness test -- test/grit/grit-patterns.test.ts`
+  when apply pattern invocation or fixtures change.
+- `bun tools/habitat-harness/bin/dev.ts fix --dry-run`.
+- `bun tools/habitat-harness/bin/dev.ts fix --help` or equivalent Oclif help
+  command.
+- `git status --short --branch` before and after live-write/rollback fixtures.
+- Injected bad-case tests listed in `$D9_CHANGE/tasks.md`.
 
 ## Non-Claims
 
-- This remediation packet does not implement Habitat source changes.
-- This packet does not prove runtime behavior.
-- This packet does not approve Graphite submission for later implementation.
-- Legacy code names remain compatibility facts unless design.md accepts them as
-  target language.
+- This phase does not implement TypeScript source changes.
+- This phase does not make D9 implementation-complete.
+- This phase does not authorize `habitat fix --json`; that requires D0-backed
+  public contract design and implementation.
+- This phase does not complete D10/G-HOST path or host policy authority.
+- This phase does not make D6 diagnostics, D8 admission, Biome, Grit, Git, Nx,
+  hooks, generators, or product runtime behavior D9-owned.

--- a/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/review-disposition-ledger.md
+++ b/openspec/changes/deep-habitat-d9-transformation-transaction/workstream/review-disposition-ledger.md
@@ -1,10 +1,35 @@
 # Review Disposition Ledger: deep-habitat-d9-transformation-transaction
 
+## Status
+
+D9 is accepted for design/specification after fresh final rereview. It is not
+implementation-complete and not source-ready. Source implementation remains
+blocked wherever concrete D0 rows, live D8 apply-admission projections, D10
+path/generated/protected-zone decisions, or G-HOST host-gate declarations are
+required and absent.
+
+## Dispositions
+
 | Finding | Severity | Disposition | Repair Evidence |
 | --- | --- | --- | --- |
-| Global domain-language concern catalog applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-domain-adversary.md and docs/projects/habitat-harness/openspec-remediation/review-disposition-ledger.md. Per-domino domain-language review remains blocking. |
-| Global OpenSpec artifact-shape constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-openspec-architect.md and packet traceability index. Per-domino OpenSpec review remains blocking. |
-| Global information-design constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-information-design-reviewer.md and traceability/evidence policy repairs. Per-domino information-design review remains blocking. |
-| Global validation-design constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-testing-validation-designer.md and packet validation gates. Per-domino validation review remains blocking. |
-| Global cross-domino sequencing constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-cross-domino-sequencer.md and dependency/trigger repairs. Per-domino sequencing compatibility review remains blocking. |
-| Per-domino adversarial review gate required before packet acceptance or source edits. | P1 | blocking, pending design-time review | Fresh per-domino domain, OpenSpec, topology, validation, information-design, and cross-domino reviewers must disposition findings before this packet can be accepted or used for implementation. |
+| First-wave domain/ontology review found no closed transaction ontology, unresolved D8/D9 admission boundary, D10/G-HOST leakage, boolean/optional result shape, and underspecified rollback/recovery. | P1 | accepted and repaired | `$D9_FINAL_DOMAIN_REVIEW` accepted the repaired domain/ontology model with no unresolved P1/P2 findings. |
+| First-wave TypeScript state-space review found optional mode flags, nullable proof/result bag, primitive strings, broad exported proof DTOs, and missing non-empty/brand constraints. | P1 | accepted and repaired | `$D9_FINAL_TYPESCRIPT_VALIDATION_REVIEW` accepted the repaired state-space and validation model with no unresolved P1/P2 findings. |
+| First-wave code/vendor topology review found missing write/protected sets, invalid `habitat fix --dry-run --json` gate, D8/D10/G-HOST input ambiguity, and vendor-boundary drift. | P1 | accepted and repaired | `$D9_FINAL_CODE_VENDOR_TOPOLOGY_REVIEW` accepted the repaired code/vendor topology with no unresolved P1/P2 findings. |
+| First-wave OpenSpec/information/testing review found one broad requirement, two scenarios, generic tasks, stale context routing, and missing validation split. | P1 | accepted and repaired | `$D9_FINAL_OPENSPEC_INFORMATION_REVIEW` accepted the repaired artifact structure and validation split with no unresolved P1/P2 findings. |
+| First-wave cross-domino/product review found missing upstream/downstream projections, D10/G-HOST implementation blockers, D11/D13 handoff gaps, and D15 trigger ambiguity. | P1 | accepted and repaired | `$D9_FINAL_CROSS_DOMINO_REVIEW` accepted the repaired cross-domino/product contract with no unresolved P1/P2 findings. |
+| Current implementation embeds MapGen public-ops validation in generic transaction code. | P1 | accepted and repaired | Final domain, topology, and cross-domino rereviews accepted the G-HOST/D10 host-gate treatment and source blocker. |
+| Current root discovery can touch `mods/*/src/maps/**`, overlapping generated/protected zones. | P1 | accepted and repaired | Final topology and cross-domino rereviews accepted the D10/G-HOST protected/generated-zone blocker. |
+| Public `habitat fix --json` was cited in prior gates despite no current `fix --json` flag. | P2 | accepted and repaired | Final OpenSpec/information and topology rereviews accepted the D0-controlled JSON disposition and removal of invalid current gate. |
+| Formatter and gate handoffs were underspecified and could imply apply safety or product correctness. | P2 | accepted and repaired | Final TypeScript/validation and cross-domino rereviews accepted handoff state and non-claim modeling. |
+| Docs and source apply lanes could collapse into one transaction path. | P2 | accepted and repaired | Final topology and OpenSpec/information rereviews accepted distinct docs/source lane requirements. |
+| Live-write request lifecycle appeared circular because it required an already approved write set. | P1 | accepted and repaired | Final rereviews accepted the `DryRunIntent` / `LiveWriteIntent` / D9-produced `LiveWriteAttempt` split. |
+
+## Final Rereview Evidence
+
+Accepted:
+
+- `$D9_FINAL_DOMAIN_REVIEW`: accepted for design/specification, no unresolved P1/P2.
+- `$D9_FINAL_TYPESCRIPT_VALIDATION_REVIEW`: accepted for design/specification, no unresolved P1/P2.
+- `$D9_FINAL_OPENSPEC_INFORMATION_REVIEW`: accepted for design/specification, no unresolved P1/P2.
+- `$D9_FINAL_CODE_VENDOR_TOPOLOGY_REVIEW`: accepted for design/specification, no unresolved P1/P2.
+- `$D9_FINAL_CROSS_DOMINO_REVIEW`: accepted for design/specification, no unresolved P1/P2.


### PR DESCRIPTION
Specify the D9 Transformation Transaction OpenSpec packet as accepted for design/specification only. The packet defines the closed apply transaction lifecycle, DryRunIntent/LiveWriteIntent/LiveWriteAttempt split, D8 apply-admission consumption, D10/G-HOST path and host-gate blockers, D0 public-surface blockers, vendor/tool handoff boundaries, downstream D11/D13 projections, and final review/control records.

Adds D9 first-wave investigation and final rereview scratch records with no unresolved P1/P2 findings. Source implementation remains blocked behind concrete D0 rows, live D8 apply-admission projections, D10 path/zone decisions, and G-HOST host-gate declarations where touched.

Validation: D9 complete-standard wording audit (only canonical D13 packet-index traceability hits); bun run openspec -- validate deep-habitat-d9-transformation-transaction --strict; bun run openspec:validate; git diff --check.