### PR TITLE
docs(habitat): add D11 cross-domino product review

### DIFF
--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-code-vendor-topology-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-code-vendor-topology-investigation.md
@@ -1,0 +1,324 @@
+# D11 Local Feedback Code/Vendor Topology Investigation
+
+Status: investigation/review input only. This document is not D11 acceptance input, does not update the packet index, and does not close any D11 review lane.
+
+Current-disk note: while this investigation was being written, other D11 repair work landed in the active worktree. I re-read the updated D11 `proposal.md`, `design.md`, `tasks.md`, and spec delta before finalizing this scratch. The repaired `proposal.md` and `design.md` now cover much of the code/vendor topology contract; the blocking findings below focus on the latest disk state, especially stale `tasks.md`, underspecified spec delta, missing concrete D0 rows, and workstream/control-record drift.
+
+## Source Authority Read Register
+
+Primary instructions and skills read:
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/source-map.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/phase-loop.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/validation-checks.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/team-and-review-lanes.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/artifact-contracts.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/failure-patterns.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/smell-catalog.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/refactoring-mechanics.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/paradigms-and-patterns.md`
+
+Repo and packet sources read or targeted for D11-relevant contract facts:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/AGENTS.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/**`
+- Upstream accepted design/specification packets: D0, D1, D3, D6, D7, D9, and D10 under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/`
+- Live hook code/tests: `tools/habitat-harness/src/lib/hooks.ts`, `tools/habitat-harness/src/commands/hook.ts`, `tools/habitat-harness/src/lib/command-engine.ts`, `tools/habitat-harness/src/index.ts`, `tools/habitat-harness/test/lib/hooks.test.ts`, `.husky/pre-commit`, `.husky/pre-push`
+
+Official/native vendor sources consulted:
+
+- Nx affected docs: https://nx.dev/docs/features/ci-features/affected
+- Nx command reference: https://nx.dev/docs/reference/nx-commands
+- Biome git hooks recipe: https://biomejs.dev/recipes/git-hooks/
+- Biome CLI reference: https://biomejs.dev/reference/cli/
+- Husky docs: https://typicode.github.io/husky/
+- Git hooks docs: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
+- Grit CLI reference: https://docs.grit.io/cli/reference
+
+Repo state at entrance: active worktree `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation`, branch `codex/d11-local-feedback-packet`, clean before writing this scratch file.
+
+## Current Flow Map
+
+### Husky Entrypoints
+
+- `.husky/pre-commit` is a one-line native hook delegator: `bun run habitat hook pre-commit`.
+- `.husky/pre-push` is a one-line native hook delegator: `bun run habitat hook pre-push`.
+- Husky/Git should remain a runner boundary. D11 owns what `habitat hook <name>` does after invocation; it should not make Husky into a policy authority.
+
+### CLI Entrypoint
+
+- `tools/habitat-harness/src/commands/hook.ts` defines the Oclif command `habitat hook [name]` with optional `--base`.
+- The command imports `runHook` from `../lib/command-engine.js`, not directly from `../lib/hooks.js`.
+- `tools/habitat-harness/src/lib/command-engine.ts` re-exports `runHook` from `./hooks.js`.
+- `tools/habitat-harness/src/index.ts` exports `runHook` from `command-engine`.
+
+This makes `runHook` a package-export/public-surface candidate on at least two planes: command behavior and package export compatibility.
+
+### Pre-Commit Sequence In Current Code
+
+Current `runPreCommit` in `tools/habitat-harness/src/lib/hooks.ts` performs:
+
+1. Write banner `habitat hook pre-commit` and the legacy local-feedback notice.
+2. Classify resource state with `classifyResourcesState`.
+3. If resources are not allowed, return `resource-blocked` before file-layer, Biome, Grit, or resource publishing.
+4. Read staged paths from `git diff --cached --name-status -z`, ignoring deleted paths and including both old/new paths for rename/copy.
+5. Run staged file-layer check via `bun tools/habitat-harness/bin/dev.ts check --staged --tool file-layer --json`.
+6. If file-layer fails, stop before Biome/Grit.
+7. Compute Biome candidate paths by extension.
+8. Refuse partial staging by checking `git diff --name-only -z -- <biomePaths>`.
+9. Hash Biome candidate files, run `biome format --write --no-errors-on-unmatched <biomePaths>`, then restage only hash-changed paths with `git add -- <touched>`.
+10. Run `biome check --no-errors-on-unmatched <biomePaths>`.
+11. Compute staged Grit scan roots by extension plus `validateScanRoots(..., { requireExisting: false })`.
+12. If roots exist, run `bun tools/habitat-harness/bin/dev.ts check --staged --tool grit-check --json`.
+13. Parse whole `CheckReport` JSON from stdout/stderr and use `report.ok`; regex-detect selected Grit adapter parse failures inside diagnostic messages.
+14. Return `grit-command-failed`, `grit-parse-failed`, `grit-finding`, or `pass`.
+
+Side effects:
+
+- Biome may rewrite files.
+- D11 restages only formatter-touched Biome paths by content hash.
+- D11 does not call the resource publisher from hook execution; it only prints publisher/status/init/unlock recovery commands.
+- D11 reads repo state before/after when a trace is supplied.
+
+### Pre-Push Sequence In Current Code
+
+Current `runPrePush` performs:
+
+1. Write legacy local-feedback notice.
+2. Capture pre-state when a trace is supplied.
+3. Resolve base from explicit `--base`, else `gt branch info --no-interactive` parent, else `mergeBase("main")`, else literal `main`.
+4. Run `nx affected -t biome:ci,boundaries,grit:check,habitat:check,test --base <base> --head HEAD --outputStyle=static`.
+5. Return `pass` only when the Nx command exits 0; otherwise `affected-failed`.
+
+Current risks:
+
+- The literal `main` fallback is an observed fallback path. D11 must decide whether it is acceptable local-feedback behavior or a blocked base-resolution state after D3/D0 compatibility.
+- Pre-push target truth is currently hard-coded in D11 code. D3 owns graph target facts; D11 may only consume a D3 target plan/projection once available.
+
+## Public-Surface Inventory
+
+D11 must not authorize source changes until D0 rows and D1 handling exist for every touched public/durable surface below.
+
+| Surface | Current path | Plane(s) | D11 concern |
+| --- | --- | --- | --- |
+| `.husky/pre-commit` | `.husky/pre-commit` | hook runner / repository automation | Stable delegator command; changes affect native Git hook behavior. |
+| `.husky/pre-push` | `.husky/pre-push` | hook runner / repository automation | Stable delegator command; changes affect native Git hook behavior. |
+| `habitat hook` command | `tools/habitat-harness/src/commands/hook.ts` | CLI verb, command behavior, help output | `name` argument and `--base` are public command surfaces. |
+| `--base` flag | `tools/habitat-harness/src/commands/hook.ts` | CLI flag / pre-push behavior | D11 must define compatibility and intended use; current description says probes and CI diagnostics. |
+| `runHook` facade | `tools/habitat-harness/src/lib/command-engine.ts`, `tools/habitat-harness/src/index.ts` | package export | Currently exported publicly through `index.ts`; D0/D1 required before rename/narrow/facade. |
+| `runPreCommit`, `runPrePush`, `createHookTrace`, `HookTrace`, trace interfaces | `tools/habitat-harness/src/lib/hooks.ts` | package-internal or package-export risk, test-facing API | Tests import directly; D0 must classify public vs internal before target schema changes. |
+| Human output notice | `tools/habitat-harness/src/lib/hooks.ts` | human output, tests/docs | Current wording uses legacy local-feedback language; D1 treats it as compatibility-only. D11 should replace only through D0/D1 handling. |
+| Outcome strings and command phase strings | `tools/habitat-harness/src/lib/hooks.ts` | machine/test trace | Need closed trace contract if retained. |
+| Hook test expectations | `tools/habitat-harness/test/lib/hooks.test.ts`, `tools/habitat-harness/test/commands/habitat-commands.test.ts` | public behavior characterization | Tests pin current text, commands, sequence, and trace fields. |
+
+The expected durable D0 matrix file `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/public-surface-compatibility-matrix.md` is absent in this worktree. That absence alone blocks D11 source implementation for all touched hook surfaces.
+
+## Vendor/Native Constraint Notes
+
+### Git/Husky
+
+- Git hooks are native local scripts. A nonzero pre-commit/pre-push hook exit aborts the local Git action; hook success is still local-only and bypassable by native Git mechanisms.
+- Husky uses Git's `core.hooksPath`, follows native hook organization, and supports POSIX shell hooks. Husky should remain a delegator to `habitat hook`, not a Habitat policy owner.
+- Biome's own git-hook recipe notes that Husky does not provide staged-file lists and is commonly paired with a staged-file tool. This repo currently gets staged paths directly from Git inside `hooks.ts`, so D11 must specify that Git is the staged-path source.
+
+### Biome
+
+- Biome `check` runs formatter, linter, and import sorting; `format` runs the formatter.
+- Biome supports explicit file paths and hook recipes using `--no-errors-on-unmatched`.
+- Biome has native `--staged` support, but current D11 code does not use it. It feeds explicit paths from Git and restages formatter-touched files itself.
+- D11 may orchestrate explicit Biome path execution and restaging, but it must not redefine Biome formatting/check semantics. Restage scope must stay limited to formatter-touched staged Biome candidates unless D0/D1 and D11 explicitly version that policy.
+
+### Grit
+
+- Grit CLI distinguishes `grit check` from `grit apply`. `grit check` reports pattern violations; `grit apply` can modify files and has `--dry-run`, `--force`, interactive, output, cache, and path options.
+- D11 currently does not call native Grit directly; it calls `habitat check --staged --tool grit-check --json`.
+- D11 must consume D6/D7 structured diagnostic/check projections. It should not parse rendered Grit failure text or infer Grit adapter failure from regexes over diagnostic messages once upstream projections exist.
+
+### Nx
+
+- Nx affected uses Git history plus the Nx project graph. Official docs define `base` and `head` inputs; the default base is `main` and default head is the current file system. The current D11 code explicitly runs `--base <resolved> --head HEAD`.
+- D3 owns target availability, dependency declaration resolution, graph read/refusal states, and affected target truth. D11 may choose when to invoke a local pre-push affected command, but it must consume D3 target-plan/base/provenance facts rather than hard-code graph truth.
+
+## Write/Protected Set For Later D11 Implementation
+
+Later D11 may own only the local-feedback orchestration surfaces:
+
+- `tools/habitat-harness/src/lib/hooks.ts`
+- `tools/habitat-harness/src/commands/hook.ts`
+- `tools/habitat-harness/src/lib/command-engine.ts` only for D0/D1-compatible hook facade/export handling
+- `tools/habitat-harness/src/index.ts` only if D0 classifies the hook exports and authorizes facade/preserve/version handling
+- `tools/habitat-harness/test/lib/hooks.test.ts`
+- `tools/habitat-harness/test/commands/habitat-commands.test.ts` only for CLI dispatch/help compatibility
+- `.husky/pre-commit`
+- `.husky/pre-push`
+- Adjacent hook docs/examples only after D0/D1 public-surface handling exists
+
+Protected paths for D11:
+
+- D0 compatibility matrix and D1/D3/D6/D7/D9/D10 packet/control files, except downstream ledger/index dependency notes explicitly authorized by the workstream owner.
+- D7 check implementation internals except consuming a published `LocalFeedbackCheckProjection`.
+- D6 Grit/native diagnostic acquisition/projection internals.
+- D9 transformation transaction implementation and rollback/apply safety internals.
+- D10 generated/protected-zone declaration and guard-policy implementation.
+- D3 workspace graph target/base/affected truth implementation.
+- Generated outputs, `dist/**`, lockfiles, `mod/**`, Nx cache, official resources, and unrelated Civ7/MapGen domains.
+
+## Dependency Map
+
+| Dependency | D11 must consume | D11 must not do | Current packet state |
+| --- | --- | --- | --- |
+| D0 | Concrete rows for hook command, flags, human output, package exports, Husky delegators, docs/examples, test-pinned output. | Change public surfaces without row id and closed compatibility handling. | D11 mentions D0, but the durable matrix is absent. |
+| D1 | `HookTrace`/local-feedback trace family, canonical non-claims, refusal/recovery relationship vocabulary, legacy hook notice handling. | Use legacy authority terminology as target language. | D11 mentions D1 only generally; no surface inventory or non-claim ids. |
+| D3 | Pre-push base/target-plan/affected graph facts and graph refusal states. | Hard-code or repair graph target truth. | Proposal has a D3 note but D3 is not in `Requires`/tasks dependency gates. |
+| D6 | Hook-eligible diagnostic projections and adapter/projection failure states. | Parse Grit JSON/text or own diagnostic taxonomy. | D6 is now named in repaired proposal/design; tasks/spec/control records still need to mirror it. |
+| D7 | `LocalFeedbackCheckProjection`, check outcome/refusal/protected-zone projection, pass/fail rendering input. | Infer check semantics from raw JSON/human output. | D11 says consume D7 but does not name projection or unavailable-projection stop behavior. |
+| D9 | Local-feedback-safe transaction states and recovery instructions if hook ever renders fix/apply state. | Recompute apply safety, rollback status, path approval, or gate semantics. | D11 says consume D9 but does not define where D9 applies to current hook scope. |
+| D10 | Protected mutation decisions/refusals and recovery instructions for staged paths through D7/local-feedback-safe projection. | Match protected/generated paths locally after D10 exists. | D11 says consume D10 but does not name D10-origin refusal stop sequencing. |
+
+## Findings Against Current D11 Packet
+
+### P1: Tasks And Spec Still Lag Behind The Repaired Proposal/Design
+
+The current `proposal.md` and `design.md` have been substantially repaired: they now name D0/D1/D3/D6/D7/D9/D10 dependencies, public surfaces, write/protected sets, state models, vendor boundaries, restage policy, pre-push graph boundaries, and stop conditions. `tasks.md` and `specs/habitat-harness/spec.md` still reflect the old underspecified packet state. `tasks.md` still omits D3/D6, still uses broad implementation tasks, and still contains the unsafe help gate. The spec still has one broad requirement and two scenarios.
+
+Repair: update `tasks.md`, spec delta, phase record, downstream ledger, and closure checklist to mirror the repaired proposal/design before D11 can be accepted.
+
+### P1: D0/D1 Compatibility Is Blocking, And D0 Matrix Rows Are Absent
+
+D11 touches hook human output, `HookTrace`, `runHook`, `habitat hook`, `--base`, `.husky/*`, tests, and possibly package exports. D0 says later packets must cite rows before redesigning hook output, exports, command flags, scripts, or docs. The durable matrix file is absent in this worktree, so there are no row ids to cite.
+
+Repair: D11 must remain source-blocked until concrete D0 rows exist for all hook surfaces. The packet can design target behavior, but every source task that changes a public/durable surface must say `blocked pending D0 row`.
+
+### P1: Dependency Gates Are Incomplete In Tasks/Control Records And Could Permit False Local Passes
+
+The repaired proposal/design now name D3 and D6, but current `tasks.md` still cites only D0/D1/D7/D9/D10 and the workstream records still do not mirror the full dependency set. That leaves two implementation-control gaps:
+
+- Grit diagnostic projection unavailable could still be treated as a parse/text problem instead of a blocked local-feedback dependency.
+- D3 graph facts unavailable could still let pre-push fall through to current literal `main`/hard-coded target behavior.
+
+Repair: add D3 and D6 to tasks and workstream dependency gates. Add a normative rule in the spec and validation tasks: if a required upstream projection for a D11 stage is unavailable, the hook must produce blocked local feedback, not success.
+
+### P1: Current Code Duplicates Upstream Authority In D11-Owned Hook Logic
+
+Current `hooks.ts` duplicates or locally interprets:
+
+- D6/D7 diagnostic semantics by parsing `CheckReport` and regex-matching Grit adapter failure text.
+- D7/D10 staged protected-zone semantics by treating file-layer command failure as the only structured gate without specifying the D10-origin refusal projection.
+- D6 scan-root eligibility by calling `validateScanRoots` in hook-local `hookGritScanRoots`.
+- D3 graph target truth by hard-coding pre-push Nx target names and base fallback behavior.
+
+Some current delegation is appropriate: calling `habitat check --staged --tool file-layer --json` delegates to check/file-layer code, and calling `habitat check --staged --tool grit-check --json` delegates acquisition. The target repair is to consume structured projections from D6/D7/D10/D3 instead of parsing raw reports/text or revalidating ownership.
+
+Repair: D11 design should identify each current duplicate path and assign it to a later migration step: preserve under compatibility until upstream live projections exist, then delete local interpretation.
+
+### P1: The Normative Spec Is Underspecified For Unsafe Hook Success
+
+The spec has one broad requirement and two scenarios. It does not cover resource states, staged path collection, file-layer refusal, partial staging, formatter restage scope, Biome check failure, Grit malformed/finding states, pre-push base resolution, Nx affected failure, unsupported hook names, trace records, D0/D1 compatibility, or unavailable upstream authority.
+
+Repair: split spec requirements by hook stage and public surface. Add scenarios for every stop condition and bad case listed in the source domino.
+
+### P2: Validation Gates Include An Invalid/Unsafe Help Command
+
+Current D11 gates list `bun run habitat hook pre-commit -- --help`. The current Oclif command has `name` and `--base`; there is no hook dry-run flag, and help should be validated through `bun run habitat hook --help` or a D0-classified equivalent. A command that names `pre-commit` risks executing a live hook rather than inspecting help, depending on argument forwarding behavior.
+
+Repair: replace with non-executing help gates and focused unit/command tests. If D11 wants `--dry-run`, classify and design it as a new D0 public command contract first.
+
+### P2: Restage Policy Is Correctly Narrow In Code And Repaired In Design, But Missing From Spec/Tasks
+
+Current code hashes only Biome candidate paths and runs `git add -- <touched>` only for hash-changed formatter paths. Tests assert that foreign staged paths are not restaged. The repaired design makes this a D11 target contract, but the spec and tasks do not yet require it.
+
+Repair: add a D11 spec requirement and validation tasks that formatter restage scope is exactly formatter-touched staged paths and that any broader restage or stash behavior is refused unless D0/D1 and D11 explicitly redesign it.
+
+### P2: Resource State Model Is Repaired In Design But Not Yet In Spec/Tasks
+
+The source domino calls out `ResourceState.kind` plus `allowPreCommit` contradiction risk. Current code uses constructors for failures but still exposes `allowPreCommit` on all variants. The repaired design now defines `ResourcePreCommitDecision`; the spec and tasks still do not make resource-state variants and bad-case tests mandatory.
+
+Repair: add closed resource-state requirements and tests for `not-configured`, `clean`, `staged-gitlink`, `dirty-submodule`, `unstaged-gitlink`, `locked`, and inspection/uninitialized failures with recovery instructions.
+
+### P2: Pre-Push Base Resolution Is Repaired In Design But Not Yet In Spec/Tasks
+
+Current code has implicit states: explicit base, Graphite parent, merge-base with main/origin main through `mergeBase`, and literal `main` fallback. The repaired design defines provenance states and D3 availability boundaries; the spec and tasks still do not require those states or validation cases.
+
+Repair: add spec scenarios and tests for explicit base, Graphite parent, merge-base fallbacks, literal fallback, D3 graph unavailable, D3 target unavailable, and Nx affected failure. Do not allow a missing D3/Graphite/base authority to become an unqualified pass.
+
+### P2: Trace Schema Compatibility Is Still Unresolved Outside Design
+
+`HookTrace` records command argv/cwd/env/exit/duration, pre/post repo snapshots, outcomes, paths, restaged paths, and base. Tests pin some of this. The repaired design treats `HookTrace` / `LocalFeedbackTrace` as D1-constrained and D0-classified, but the spec and tasks do not define compatibility rows, trace field preservation/versioning, or non-claim validation.
+
+Repair: D11 should either preserve current `HookTrace` under D0/D1 compatibility or define `LocalFeedbackTrace` as a versioned/facaded target. It should not silently drift fields.
+
+### P3: Current Help Text Still Carries Old H7 Language
+
+`commands/hook.ts` description says hook wiring is intentionally deferred until `habitat-git-hooks`, but `.husky/*` now delegates to `habitat hook`. This may be stale human-output compatibility text rather than target D11 language.
+
+Repair: classify through D0, then update command help only if compatibility handling permits.
+
+## Repair Recommendations By Artifact
+
+### `proposal.md`
+
+Current status: largely repaired on latest disk. Keep the repaired D0/D1/D3/D6/D7/D9/D10 dependency table, public-surface list, write/protected set, validation split, and stop conditions. Reviewers should verify the D0 matrix absence is represented as a source blocker, not as implementation-ready state.
+
+### `design.md`
+
+Current status: substantially repaired on latest disk. Remaining design-level improvement is optional: add a compact "proper delegation vs duplication" table that names each current local interpretation path and the upstream projection that replaces it. This would make later source deletion less guessy, but the current design already states the key boundaries.
+
+### `specs/habitat-harness/spec.md`
+
+Add normative requirements and scenarios for:
+
+- local-feedback non-claims and D1 non-claim ids;
+- unsupported hook refusal;
+- resource blocked before later stages;
+- staged clean resource gitlink allowance and dirty/unstaged/locked refusal;
+- staged path source from Git;
+- D10/D7 protected-zone refusal stops downstream hook work;
+- partial staging refusal before formatting/restaging;
+- formatter restages only formatter-touched staged paths;
+- Biome format/check failure stops appropriately;
+- D6/D7 Grit projection clean/findings/adapter-failed/malformed/unavailable states;
+- pre-push explicit base, Graphite parent, merge-base, and unavailable-base behavior;
+- D3 unavailable graph/target plan blocks local feedback;
+- Nx affected nonzero is local feedback failure, not CI authority;
+- HookTrace/LocalFeedbackTrace compatibility and non-claims.
+
+### `tasks.md`
+
+- Replace broad implementation tasks with ordered implementation slices and prerequisites.
+- Add a pre-implementation inventory task for D0 row ids and D1 handling.
+- Add a dependency readiness task for D3/D6/D7/D9/D10 projections.
+- Add unit tests for each stage and bad case rather than only `hooks.test.ts` as a broad gate.
+- Replace `bun run habitat hook pre-commit -- --help` with non-executing help tests.
+- Add `git status --short --branch` before/after any live hook or fixture that can write/restage.
+
+### Workstream Records
+
+- Update `phase-record.md` branch field to the active branch `codex/d11-local-feedback-packet`.
+- Add validation result recording table with expected status, actual status, oracle, bad case, freshness/cache stance, and non-claims.
+- Keep the review ledger blocking until D11 final review lanes accept the repaired packet.
+- Downstream ledger should name D3/D6/D7/D9/D10 projection facts and D0 row blockers, not generic docs/tests.
+
+## Verdict
+
+Blocking.
+
+The latest D11 proposal/design are directionally strong and cover most code/vendor topology concerns. The D11 packet is still not acceptance-ready because `tasks.md`, the spec delta, and workstream records have not caught up, and because concrete D0 compatibility rows are absent. In the current disk state, a later executor could still rely on stale tasks/spec and let hooks pass after unavailable D3/D6/D7/D10 authority, preserve regex/text parsing as diagnostic truth, broaden formatter restaging, or change hook public surfaces without D0/D1 compatibility rows.
+
+The missing contracts are:
+
+- concrete D0 rows for hook command/export/human-output/Husky/docs surfaces;
+- D1 HookTrace/local-feedback trace and non-claim handling in spec/tasks/control records;
+- D3 pre-push base/target-plan availability and unavailable-graph blocking behavior in spec/tasks;
+- D6 diagnostic projection availability for staged Grit local feedback in spec/tasks;
+- D7 `LocalFeedbackCheckProjection` consumption and refusal semantics in spec/tasks;
+- D10 D11-safe protected-mutation refusal projection in spec/tasks;
+- exact restage/partial-staging/base-resolution contracts in spec/tasks;
+- workstream phase/ledger/checklist alignment with the repaired proposal/design.
+
+D11 should remain blocked until those are repaired in the packet. Source implementation should not start from the current tasks/spec/control artifacts.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-cross-domino-product-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-cross-domino-product-investigation.md
@@ -4,9 +4,9 @@
 
 Verdict: keep D11 blocking.
 
-D11 is not implementation-ready as currently scaffolded. It can proceed with hidden dependency assumptions around D6 staged diagnostic projections, D3 pre-push graph facts, D8 local-feedback admission/eligibility, G-HOST transitive protected/host policy gates, and D0/D1 compatibility for touched hook output and traces. The current packet has the right intent, but it is still a thin scaffold rather than an implementation authority.
+D11 is not implementation-ready in the reviewed disk state. It can proceed with hidden dependency assumptions around D6 staged diagnostic projections, D3 pre-push graph facts, D8 local-feedback admission/eligibility, G-HOST transitive protected/host policy gates, and D0/D1 compatibility for touched hook output and traces. The current packet has the right intent, but it is still underspecified rather than an implementation authority.
 
-This document is investigation/review input only. It is not acceptance evidence and does not update the packet index, closure records, or D11 packet files.
+This document is investigation/review input only. It is not acceptance input and does not update the packet index, closure records, or D11 packet files.
 
 ## Source Authority Read Register
 
@@ -54,10 +54,10 @@ Upstream packet contracts read:
 - D8 proposal/spec for Pattern Governance and explicit local-feedback admission/eligibility.
 - D9 proposal/spec for local-feedback-safe transaction projections.
 - D10 proposal/spec for protected/generated/host-owned mutation decisions and D11 staged refusal consumption.
-- D15 OpenSpec scaffold plus source packet for trigger evidence fields.
-- G-HOST OpenSpec scaffold for host-policy boundary.
+- D15 OpenSpec packet plus source packet for trigger records.
+- G-HOST OpenSpec packet for host-policy boundary.
 
-Current behavior evidence read:
+Current behavior inputs read:
 
 - `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/hooks.ts`
 - `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/hooks.test.ts`
@@ -87,11 +87,11 @@ The fast recovery path should be stage-ordered:
 Pre-push feedback needs a different recovery model:
 
 - It should explain the selected affected base as observed Graphite/git state only.
-- It should state that `nx affected` success/failure is local feedback and not CI, Graphite readiness, review completion, or product proof.
+- It should state that `nx affected` success/failure is local feedback and not CI, Graphite readiness, review completion, or product readiness.
 - It should consume D3 graph target facts for target availability and graph refusals instead of treating raw `nx affected` exit status as target truth.
 - It should give a recovery path for missing Graphite parent, graph-read failure, unresolved targets, and affected failure.
 
-The current D11 scaffold has the non-claim headline, but it does not yet specify the recovery taxonomy, projection ownership, stop sequence, or output/trace compatibility envelope tightly enough for execution.
+The current D11 packet has the non-claim headline, but it does not yet specify the recovery taxonomy, projection ownership, stop sequence, or output/trace compatibility envelope tightly enough for execution.
 
 ## Dependency Graph
 
@@ -125,7 +125,7 @@ No extra dependency should be added for D12: D11 non-claims should say hooks do 
 
 ## D15 Trigger Assessment
 
-D15 should remain dormant for D11 unless D11 records a concrete representation failure. Current evidence does not yet prove such a failure; local discriminated DTOs appear sufficient if D11 narrows its model to owned hook orchestration plus upstream projections.
+D15 should remain dormant for D11 unless D11 records a concrete representation failure. Current inputs do not show such a failure; local discriminated DTOs appear sufficient if D11 narrows its model to owned hook orchestration plus upstream projections.
 
 If D11 does trigger D15, the exact trigger row should be:
 
@@ -136,11 +136,11 @@ If D11 does trigger D15, the exact trigger row should be:
 | Local DTO alternative rejected | A D11-owned discriminated `LocalFeedbackStageOutcome` with variants for resource, file-layer check projection, partial-staging refusal, formatter handoff, D6 diagnostic projection, D9 transaction projection, pre-push graph/affected projection, and blocked-missing-upstream-projection. |
 | Runtime command fields required | argv, cwd, bounded stdout/stderr or digests, exit code, duration, env subset if relevant, cache/freshness stance, staged paths, pre/post git snapshot, Graphite base observation for pre-push, and non-claim identifiers. |
 | Public output impact | Any HookTrace schema, human notice, help text, docs example, or exported type change must cite concrete D0 rows and D1 output-family handling. |
-| Proof class | Local feedback trace/provenance only; not CI, review proof, apply safety, product/runtime proof, Graphite readiness, OpenSpec acceptance, current-tree cleanliness, or rule correctness. |
+| Claim boundary | Local feedback trace/provenance only; not CI, review readiness, apply safety, product/runtime readiness, Graphite readiness, OpenSpec acceptance, current-tree cleanliness, or rule correctness. |
 | Rollback/escape plan | Keep provenance packet-local; if shared substrate is still required, move it into one sequential owner packet before D6/D7/D9/D11 implementation shares it. |
 | Type-check/performance risk | Measure compile/test impact and avoid broad Effect/substrate migration unless it removes a named contradictory state. |
 
-Absent that evidence, D11 should specify no D15 activation.
+Absent that representation failure, D11 should specify no D15 activation.
 
 ## Downstream Realignment Plan
 
@@ -149,14 +149,14 @@ After D11 implementation facts exist, realign at least these surfaces:
 - D11 OpenSpec packet and workstream ledgers: source authority, dependency graph, write set, projection contracts, validation gates, and review dispositions.
 - Packet index: D11 dependency row must include D6 and D3 for pre-push affected behavior, plus D8/G-HOST conditional wording.
 - D0 public-surface compatibility matrix: concrete rows for `habitat hook pre-commit`, `habitat hook pre-push`, `habitat hook --help`, hook human notice, HookTrace/LocalFeedbackTrace schema if public/exported, docs examples, Husky delegators, and any package exports.
-- D1 output-family records: hook trace non-claims, refusal/recovery instructions, Graphite observation handling, and legacy proof-shaped notice compatibility.
+- D1 output-family records: hook trace non-claims, refusal/recovery instructions, Graphite observation handling, and legacy local-feedback notice compatibility.
 - Tests: hook trace tests, resource-state constructor tests, staged D10 refusal stop tests, D6 diagnostic projection rendering tests, D7 local-feedback check projection tests, D9 transaction projection rendering tests, pre-push D3 graph/base/affected tests, partial-staging refusal tests, and public-output bad-case tests.
 - `docs/process/resources-submodule.md`: already aligned with current explicit publish/refusal behavior; keep it as the model.
 - `docs/process/CONTRIBUTING.md`: currently says resource diffs are auto-committed/pushed via pre-commit. D11 implementation should update this to match explicit `bun run resources:publish` plus hook refusal behavior.
 - `docs/process/GRAPHITE.md`: if D11 changes pre-push base detection or Graphite handoff guidance, add a local-feedback/non-claim note rather than treating hook pass as PR readiness.
 - Root `AGENTS.md` hook guidance: update only if behavior changes, preserving the rule that hooks reduce local friction while CI remains authoritative.
 - `.husky/pre-commit` and `.husky/pre-push`: keep stable unless D0 compatibility rows authorize any command-path change.
-- Tool docs/examples under `tools/habitat-harness/docs/**`: update examples that show proof-shaped hook output or old recovery behavior.
+- Tool docs/examples under `tools/habitat-harness/docs/**`: update examples that show legacy hook notice output or old recovery behavior.
 
 ## Findings
 
@@ -182,7 +182,7 @@ Repair: add a D11 stage contract table with `stage`, `upstream owner`, `input pr
 
 D11 currently says HookTrace and human output may change under D0/D1 compatibility, but does not require concrete D0 row IDs before changing hook output, help, docs examples, trace schema, package exports, or Husky command paths. D0 matrix file is not yet present in the expected project path, so implementation cannot cite concrete rows today.
 
-Repair: make D11 source implementation blocked until concrete D0 rows exist for every touched hook surface. Add D1 canonical non-claim IDs to the D11 spec, not just prose notices. Legacy "hook proof" text must be either preserved as a D0 compatibility phrase or replaced only through D0-approved versioning/deprecation.
+Repair: make D11 source implementation blocked until concrete D0 rows exist for every touched hook surface. Add D1 canonical non-claim IDs to the D11 spec, not just prose notices. Legacy hook notice text must be either preserved as a D0 compatibility phrase or replaced only through D0-approved versioning/deprecation.
 
 ### P2: D8 local-feedback admission is underspecified
 
@@ -204,7 +204,7 @@ Repair: add scenario map and acceptance cases for each failure family. Each case
 
 ### P2: Current hook behavior demonstrates target risks D11 must explicitly repair
 
-Current `hooks.ts` has target-risk patterns: `ResourceState.kind` plus `allowPreCommit` boolean correlation, legacy proof-shaped hook notice, local parsing of `CheckReport`/Grit adapter message text, direct fixed `nx affected` target list, and Graphite base observation recorded as hook trace state. These are acceptable as evidence, not target authority.
+Current `hooks.ts` has target-risk patterns: `ResourceState.kind` plus `allowPreCommit` boolean correlation, legacy hook notice wording, local parsing of `CheckReport`/Grit adapter message text, direct fixed `nx affected` target list, and Graphite base observation recorded as hook trace state. These are acceptable as current-behavior inputs, not target authority.
 
 Repair: D11 should require discriminated resource states with allowed/refused derived from variant; projection-based diagnostic and check handling; D3-backed pre-push target/graph handling; D1 non-claim IDs; and tests that make contradictory states unrepresentable or rejected.
 
@@ -228,7 +228,7 @@ Repair: add this to D11 downstream realignment. The doc should point to `bun run
 ### `openspec/changes/deep-habitat-d11-local-feedback/design.md`
 
 - Add a local feedback stage table with owner, projection, output, stop/continue rule, recovery instruction, trace field, and non-claims.
-- Define target `LocalFeedbackTrace`/`HookTrace` semantics as D1-bounded local feedback, not proof.
+- Define target `LocalFeedbackTrace`/`HookTrace` semantics as D1-bounded local feedback, not authority outside the local hook.
 - Define resource state as discriminated variants: `clean`, `not-configured`, `staged-gitlink-allowed`, `dirty-submodule-refused`, `unstaged-gitlink-refused`, `locked-refused`, `uninitialized-refused`, `inspection-failed-refused`.
 - Define pre-push graph consumption through D3 target facts and graph refusals; raw `nx affected` exit status is command outcome, not target truth.
 - Define D15 trigger minimization and explicitly state no trigger unless the local DTO alternative fails.
@@ -244,7 +244,7 @@ Repair: add this to D11 downstream realignment. The doc should point to `bun run
 - Add pre-implementation tasks to cite concrete D0 rows and D1 output-family/non-claim decisions.
 - Add D6, D3, D8 conditional, and G-HOST-through-D10/D9 dependency checks.
 - Split implementation tasks by stage, not by vague "clarify output".
-- Add falsifying tests for staged D10 refusal, D6 diagnostic projection failure, D8 missing admission, D9 transaction recovery projection, D3 graph refusal, resource-state contradiction, and proof-shaped notice compatibility.
+- Add falsifying tests for staged D10 refusal, D6 diagnostic projection failure, D8 missing admission, D9 transaction recovery projection, D3 graph refusal, resource-state contradiction, and legacy notice compatibility.
 
 ### `openspec/changes/deep-habitat-d11-local-feedback/workstream/phase-record.md`
 
@@ -275,7 +275,7 @@ Recommendation only; no source edits in this review pass.
 - Later implementation should stop local parsing of raw Grit/check output as target diagnostic authority and consume accepted projections.
 - Replace boolean-correlated `ResourceState` with discriminated constructors.
 - Keep restaging restricted to formatter-touched files and prove partial-staging refusal remains before writes.
-- Replace proof-shaped notice or preserve it only through D0/D1 compatibility.
+- Replace legacy hook notice wording or preserve it only through D0/D1 compatibility.
 - Make pre-push target/base behavior consume D3 graph facts and render Graphite base as observed state only.
 
 ## Stop Condition Check

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-cross-domino-product-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-cross-domino-product-investigation.md
@@ -1,0 +1,290 @@
+# D11 Local Feedback Cross-Domino Product Investigation
+
+## Status And Verdict
+
+Verdict: keep D11 blocking.
+
+D11 is not implementation-ready as currently scaffolded. It can proceed with hidden dependency assumptions around D6 staged diagnostic projections, D3 pre-push graph facts, D8 local-feedback admission/eligibility, G-HOST transitive protected/host policy gates, and D0/D1 compatibility for touched hook output and traces. The current packet has the right intent, but it is still a thin scaffold rather than an implementation authority.
+
+This document is investigation/review input only. It is not acceptance evidence and does not update the packet index, closure records, or D11 packet files.
+
+## Source Authority Read Register
+
+Mandatory skills and references read:
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/system-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/principles.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/operationalization.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/maintenance.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/axes.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/source-map.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/phase-loop.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/validation-checks.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/team-and-review-lanes.md`
+
+Repo/worktree and routers read:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/AGENTS.md`
+- Active worktree confirmed: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation`
+- Active branch confirmed: `codex/d11-local-feedback-packet`
+- Initial `git status --short --branch` was clean.
+
+D11 inputs read:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/proposal.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/design.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/specs/habitat-harness/spec.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/tasks.md`
+- D11 workstream phase record, review ledger, downstream realignment ledger, and closure checklist.
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+
+Upstream packet contracts read:
+
+- D0 proposal/spec for public-surface compatibility.
+- D1 design/spec for hook traces, non-claims, refusal/recovery, Graphite observation boundaries.
+- D3 proposal/spec for Workspace Graph target facts and graph refusals.
+- D6 proposal/spec for diagnostic catalog, diagnostic projections, and D11 consumption.
+- D7 proposal/spec for Structural Enforcement, `LocalFeedbackCheckProjection`, and D10-origin refusal projection.
+- D8 proposal/spec for Pattern Governance and explicit local-feedback admission/eligibility.
+- D9 proposal/spec for local-feedback-safe transaction projections.
+- D10 proposal/spec for protected/generated/host-owned mutation decisions and D11 staged refusal consumption.
+- D15 OpenSpec scaffold plus source packet for trigger evidence fields.
+- G-HOST OpenSpec scaffold for host-policy boundary.
+
+Current behavior evidence read:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/hooks.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/hooks.test.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/PROCESS.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/process/CONTRIBUTING.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/process/GRAPHITE.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/process/resources-submodule.md`
+
+## User And Agent Scenario Map
+
+A developer or agent needs pre-commit feedback to answer four questions quickly:
+
+1. What stopped my commit?
+2. Which owner owns that stop?
+3. What exact local action should I take next?
+4. What does hook success not prove?
+
+The fast recovery path should be stage-ordered:
+
+- Resource state first: clean, not configured, clean staged gitlink, dirty submodule, unstaged gitlink, locked, uninitialized, or inspection failure. Refusals need exact recovery commands and must not publish resources automatically.
+- Staged protected/generated/forbidden mutations next: D11 should render D10-origin refusals through D7 local-feedback-safe projection and stop before Biome, Grit, generated publish, resource publish, or restaging.
+- Partial staging before formatter writes: D11 should refuse before Biome writes or restaging and list exact files.
+- Formatter handoff: D11 may restage only formatter-touched files under explicit policy and must report that this is local hygiene, not review or CI.
+- Staged diagnostics: D11 should render D6 diagnostic projections, through D7 where the check outcome is structural, without parsing raw Grit JSON or diagnostic message strings.
+- Transaction feedback, if present: D11 should render D9 transaction projection states such as unavailable, refused, dry-run, applied, rolled-back, rollback-failed, and recovery-required without recomputing apply safety.
+
+Pre-push feedback needs a different recovery model:
+
+- It should explain the selected affected base as observed Graphite/git state only.
+- It should state that `nx affected` success/failure is local feedback and not CI, Graphite readiness, review completion, or product proof.
+- It should consume D3 graph target facts for target availability and graph refusals instead of treating raw `nx affected` exit status as target truth.
+- It should give a recovery path for missing Graphite parent, graph-read failure, unresolved targets, and affected failure.
+
+The current D11 scaffold has the non-claim headline, but it does not yet specify the recovery taxonomy, projection ownership, stop sequence, or output/trace compatibility envelope tightly enough for execution.
+
+## Dependency Graph
+
+Required direct dependencies:
+
+- D0: public-surface matrix and compatibility handling for every hook command, hook output, human text, trace schema, package export, docs example, help text, root script, and generated/help surface D11 touches.
+- D1: Hook traces are local feedback only; canonical non-claim identifiers; refusal and recovery instruction discipline; Graphite/OpenSpec observations are not command receipt substitutes.
+- D6: D11 consumes hook/staged diagnostic projections. D11 must not parse raw Grit reports, infer diagnostic identity, or own adapter failure taxonomy.
+- D7: D11 consumes `LocalFeedbackCheckProjection`, including D10-origin protected-zone refusal projections rendered by Structural Enforcement.
+- D9: D11 consumes local-feedback-safe transaction projections for apply/fix state and recovery. It does not recompute apply safety.
+- D10: D11 consumes staged protected/generated/forbidden mutation refusals through D10/D7 projections and stops hook sequencing at the file-layer refusal.
+
+Conditional or transitive dependencies that must be explicit:
+
+- D3: required for pre-push affected behavior, target availability, graph refusals, dependency resolution, and target truth. The current D11 design mentions this, but the packet index D11 row omits it.
+- D8: required when local feedback eligibility or hook-scope/admission is in scope. D11 should consume eligibility through D8/D7/D10 projections and not infer from rule lane, `hookScope`, Grit metadata, or generator output.
+- G-HOST: not a direct D11 behavior owner unless D11 touches host-policy declarations directly. It is relevant through D10 protected/host decisions and D9 host gates. If those projections are missing, D11 reports the missing upstream authority rather than embedding host-specific paths or policy.
+- D15: not a default dependency. D11 records a trigger only if local discriminated hook DTOs cannot represent required command/state observations without contradiction.
+
+## Missing And Extra Dependency Findings
+
+Missing direct D6 dependency: D11 packet files currently list D0, D1, D7, D9, and D10 but omit D6 in proposal/tasks/index, despite the source packet and D6 accepted contract saying D11 consumes hook/staged diagnostic projections.
+
+Missing D3 blocker in packet index: D11 design includes a D3 note, but the packet index row still says D11 requires only D0, D1, D7, D9, D10. Pre-push affected behavior depends on D3 graph facts and cannot be implementation-ready without D3 as at least a conditional blocker for pre-push target selection, graph refusal, affected-base provenance, and target truth.
+
+Missing D8 eligibility edge: D11 should not decide whether a pattern is hook/local-feedback eligible. D8 owns explicit local-feedback admission; D7/D10 may project check/path decisions. D11 needs a required/conditional edge when pattern local-feedback admission, hook scope, or eligibility appears in hook behavior or recovery output.
+
+G-HOST should remain transitive: D11 should not require G-HOST directly for all hook work. It should require accepted/live D10/D9 projections that already encode host-policy decisions. If D11 implementation touches host declarations or host-policy authoring guidance directly, that is a scope change and G-HOST becomes direct.
+
+No extra dependency should be added for D12: D11 non-claims should say hooks do not replace verify handoff receipt, but D11 does not consume D12 to render local feedback.
+
+## D15 Trigger Assessment
+
+D15 should remain dormant for D11 unless D11 records a concrete representation failure. Current evidence does not yet prove such a failure; local discriminated DTOs appear sufficient if D11 narrows its model to owned hook orchestration plus upstream projections.
+
+If D11 does trigger D15, the exact trigger row should be:
+
+| Trigger field | D11 value to record |
+| --- | --- |
+| Concrete scenario | `habitat hook pre-commit --dry-run` or normal pre-commit must correlate staged paths, pre/post git snapshots, upstream projection outcomes, delegated command argv/cwd/exit/duration, local-only non-claims, and restage decisions in one trace. |
+| Current contradictory state | Hook trace can report `pass` while delegated command provenance lacks enough bounded state to prove which upstream projection was consumed, or can report a command/failure category based only on parsed text rather than a typed owner projection. |
+| Local DTO alternative rejected | A D11-owned discriminated `LocalFeedbackStageOutcome` with variants for resource, file-layer check projection, partial-staging refusal, formatter handoff, D6 diagnostic projection, D9 transaction projection, pre-push graph/affected projection, and blocked-missing-upstream-projection. |
+| Runtime command fields required | argv, cwd, bounded stdout/stderr or digests, exit code, duration, env subset if relevant, cache/freshness stance, staged paths, pre/post git snapshot, Graphite base observation for pre-push, and non-claim identifiers. |
+| Public output impact | Any HookTrace schema, human notice, help text, docs example, or exported type change must cite concrete D0 rows and D1 output-family handling. |
+| Proof class | Local feedback trace/provenance only; not CI, review proof, apply safety, product/runtime proof, Graphite readiness, OpenSpec acceptance, current-tree cleanliness, or rule correctness. |
+| Rollback/escape plan | Keep provenance packet-local; if shared substrate is still required, move it into one sequential owner packet before D6/D7/D9/D11 implementation shares it. |
+| Type-check/performance risk | Measure compile/test impact and avoid broad Effect/substrate migration unless it removes a named contradictory state. |
+
+Absent that evidence, D11 should specify no D15 activation.
+
+## Downstream Realignment Plan
+
+After D11 implementation facts exist, realign at least these surfaces:
+
+- D11 OpenSpec packet and workstream ledgers: source authority, dependency graph, write set, projection contracts, validation gates, and review dispositions.
+- Packet index: D11 dependency row must include D6 and D3 for pre-push affected behavior, plus D8/G-HOST conditional wording.
+- D0 public-surface compatibility matrix: concrete rows for `habitat hook pre-commit`, `habitat hook pre-push`, `habitat hook --help`, hook human notice, HookTrace/LocalFeedbackTrace schema if public/exported, docs examples, Husky delegators, and any package exports.
+- D1 output-family records: hook trace non-claims, refusal/recovery instructions, Graphite observation handling, and legacy proof-shaped notice compatibility.
+- Tests: hook trace tests, resource-state constructor tests, staged D10 refusal stop tests, D6 diagnostic projection rendering tests, D7 local-feedback check projection tests, D9 transaction projection rendering tests, pre-push D3 graph/base/affected tests, partial-staging refusal tests, and public-output bad-case tests.
+- `docs/process/resources-submodule.md`: already aligned with current explicit publish/refusal behavior; keep it as the model.
+- `docs/process/CONTRIBUTING.md`: currently says resource diffs are auto-committed/pushed via pre-commit. D11 implementation should update this to match explicit `bun run resources:publish` plus hook refusal behavior.
+- `docs/process/GRAPHITE.md`: if D11 changes pre-push base detection or Graphite handoff guidance, add a local-feedback/non-claim note rather than treating hook pass as PR readiness.
+- Root `AGENTS.md` hook guidance: update only if behavior changes, preserving the rule that hooks reduce local friction while CI remains authoritative.
+- `.husky/pre-commit` and `.husky/pre-push`: keep stable unless D0 compatibility rows authorize any command-path change.
+- Tool docs/examples under `tools/habitat-harness/docs/**`: update examples that show proof-shaped hook output or old recovery behavior.
+
+## Findings
+
+### P1: D6 staged diagnostic dependency is missing from D11 execution authority
+
+D11 source authority says Diagnostic Pattern Catalog owns staged Grit diagnostics, and D6 accepted spec says D11 consumes hook/staged diagnostic projections. Current D11 OpenSpec `Requires` omits D6, and tasks only say D7/D9/D10. This lets an implementation parse raw Grit JSON, inspect `CheckReport` internals, or classify adapter failures locally in hooks.
+
+Repair: add D6 as a D11 direct requirement in proposal, design, tasks, spec scenarios, phase record, and packet-index recommendation. D11 must consume D6 projections directly or via D7 `LocalFeedbackCheckProjection` where the check outcome owns the final structural status. It must not parse raw Grit reports, raw process records, or diagnostic message text as target behavior.
+
+### P1: Packet index omits D3 despite pre-push affected behavior depending on graph truth
+
+D11 design notes that pre-push affected-target feedback consumes D3 graph facts, but the packet index D11 row omits D3. The current hook runs `nx affected` with fixed targets and Graphite/merge-base base detection; D3 owns target availability, dependency resolution, graph refusals, and false-green prevention.
+
+Repair: keep D11 blocking until the packet index and D11 artifacts state that pre-push base/affected behavior is blocked by D3 graph facts. D11 may specify pre-commit-only work without D3 only if pre-push behavior is explicitly out of scope, but the current D11 packet includes `habitat hook pre-push`.
+
+### P1: D11 does not specify a projection-only owner map for local recovery output
+
+Current D11 says "consume D7/D9/D10 decisions" but does not enumerate the exact local feedback stage outcomes, owner for each outcome, recovery shape, stop point, and non-claims. That leaves implementation to invent semantics for resource state, file-layer refusal, D6 diagnostics, D8 eligibility, D9 transaction state, and D3 affected failures.
+
+Repair: add a D11 stage contract table with `stage`, `upstream owner`, `input projection`, `D11 output`, `stop/continue rule`, `recovery instruction`, `trace fields`, and `non-claims`. Required stages: resource state, D10/D7 staged guard, partial staging, formatter handoff/restage, D6/D7 diagnostics, D9 transaction feedback if rendered, pre-push D3 graph/base/affected.
+
+### P1: Public output and trace compatibility are too generic for implementation
+
+D11 currently says HookTrace and human output may change under D0/D1 compatibility, but does not require concrete D0 row IDs before changing hook output, help, docs examples, trace schema, package exports, or Husky command paths. D0 matrix file is not yet present in the expected project path, so implementation cannot cite concrete rows today.
+
+Repair: make D11 source implementation blocked until concrete D0 rows exist for every touched hook surface. Add D1 canonical non-claim IDs to the D11 spec, not just prose notices. Legacy "hook proof" text must be either preserved as a D0 compatibility phrase or replaced only through D0-approved versioning/deprecation.
+
+### P2: D8 local-feedback admission is underspecified
+
+D8 owns explicit local-feedback admission and says hook eligibility cannot be inferred from rule lane, Grit metadata, hook fields, or generator output. D11 currently has no conditional D8 dependency or scenario for missing/refused local-feedback admission.
+
+Repair: add D8 as conditional dependency where D11 reports pattern eligibility, hook scope, or local-feedback admission. D11 should consume eligibility through D8/D7/D10 projections and render refused/missing admission as local recovery, not silently skip or decide eligibility locally.
+
+### P2: G-HOST relevance needs transitive wording to preserve generic Habitat
+
+D10 and D9 require G-HOST for host-owned generated/protected surfaces and host gates. D11 should not embed Civ7/MapGen/resource path policy. Current D11 does not say whether host-policy failures reach hook output through D10/D9 projections.
+
+Repair: state that G-HOST is consumed only through D10 and D9 projections unless D11 directly touches host-policy declarations. If a D10/D9 projection reports missing host declaration or host gate, D11 renders the missing-authority recovery and remains generic.
+
+### P2: Product recovery behavior is not strong enough for agents
+
+The current D11 product scenario says fast feedback, but not what a developer/agent does next after each failure. The hook can fail from resources, partial staging, protected mutation, formatter, Grit diagnostics, malformed JSON, Graphite base, graph refusal, or Nx affected. These need exact recovery instructions and non-claims.
+
+Repair: add scenario map and acceptance cases for each failure family. Each case must name owner, stage, blocked next commands, exact local action, whether retrying commit/push is appropriate, and what hook success still does not prove.
+
+### P2: Current hook behavior demonstrates target risks D11 must explicitly repair
+
+Current `hooks.ts` has target-risk patterns: `ResourceState.kind` plus `allowPreCommit` boolean correlation, legacy proof-shaped hook notice, local parsing of `CheckReport`/Grit adapter message text, direct fixed `nx affected` target list, and Graphite base observation recorded as hook trace state. These are acceptable as evidence, not target authority.
+
+Repair: D11 should require discriminated resource states with allowed/refused derived from variant; projection-based diagnostic and check handling; D3-backed pre-push target/graph handling; D1 non-claim IDs; and tests that make contradictory states unrepresentable or rejected.
+
+### P3: Downstream docs contain stale hook/resource guidance
+
+`docs/process/resources-submodule.md` correctly says publishing is explicit and hooks only check/refuse. `docs/process/CONTRIBUTING.md` still says resource diffs are auto-committed/pushed via `habitat hook pre-commit`.
+
+Repair: add this to D11 downstream realignment. The doc should point to `bun run resources:publish` and describe hook refusal/retry, not automatic publish.
+
+## Exact Repair Recommendations By Artifact
+
+### `openspec/changes/deep-habitat-d11-local-feedback/proposal.md`
+
+- Add D6 to `Requires`.
+- Add conditional D3 requirement for all pre-push affected/base/target behavior.
+- Add conditional D8 requirement for local-feedback eligibility/hook-scope admission.
+- Add transitive G-HOST wording through D10/D9 projections.
+- Replace "Consume D7/D9/D10 decisions" with D6/D7/D8/D9/D10/D3 projection-specific wording.
+- Add D0 blocker text requiring concrete rows before touching hook command, human output, trace schema, help, Husky delegators, docs/examples, or exports.
+
+### `openspec/changes/deep-habitat-d11-local-feedback/design.md`
+
+- Add a local feedback stage table with owner, projection, output, stop/continue rule, recovery instruction, trace field, and non-claims.
+- Define target `LocalFeedbackTrace`/`HookTrace` semantics as D1-bounded local feedback, not proof.
+- Define resource state as discriminated variants: `clean`, `not-configured`, `staged-gitlink-allowed`, `dirty-submodule-refused`, `unstaged-gitlink-refused`, `locked-refused`, `uninitialized-refused`, `inspection-failed-refused`.
+- Define pre-push graph consumption through D3 target facts and graph refusals; raw `nx affected` exit status is command outcome, not target truth.
+- Define D15 trigger minimization and explicitly state no trigger unless the local DTO alternative fails.
+
+### `openspec/changes/deep-habitat-d11-local-feedback/specs/habitat-harness/spec.md`
+
+- Expand beyond the current two scenarios.
+- Add requirements for D6 diagnostic projection rendering, D7 local-feedback check projection, D10/D7 protected mutation refusal, D9 transaction projection rendering, D3 pre-push graph facts, D8 local-feedback eligibility, D0/D1 compatibility/non-claims, and D15 trigger/no-trigger decision.
+- Add scenarios for blocked-missing-upstream-projection so missing D6/D7/D8/D9/D10/D3 inputs cannot be reported as hook success.
+
+### `openspec/changes/deep-habitat-d11-local-feedback/tasks.md`
+
+- Add pre-implementation tasks to cite concrete D0 rows and D1 output-family/non-claim decisions.
+- Add D6, D3, D8 conditional, and G-HOST-through-D10/D9 dependency checks.
+- Split implementation tasks by stage, not by vague "clarify output".
+- Add falsifying tests for staged D10 refusal, D6 diagnostic projection failure, D8 missing admission, D9 transaction recovery projection, D3 graph refusal, resource-state contradiction, and proof-shaped notice compatibility.
+
+### `openspec/changes/deep-habitat-d11-local-feedback/workstream/phase-record.md`
+
+- Correct stale branch value from `codex/deep-habitat-openspec-remediation` to the active `codex/d11-local-feedback-packet` when packet files are repaired.
+- Record the expanded dependencies and exact no-code status.
+- Add pre-push D3 blocker and D6 staged diagnostic blocker as current gate conditions.
+
+### `openspec/changes/deep-habitat-d11-local-feedback/workstream/review-disposition-ledger.md`
+
+- Record these P1/P2 findings as accepted/repaired/rejected during D11 packet repair.
+- Do not mark per-domino review complete until D6, D3, D8, D0/D1, and product recovery repairs are dispositioned.
+
+### `openspec/changes/deep-habitat-d11-local-feedback/workstream/downstream-realignment-ledger.md`
+
+- Add rows for packet index dependency repair, D0 matrix rows, D1 non-claim/output family, resources/contributing docs, Graphite workflow docs if pre-push behavior changes, root AGENTS hook guidance, Husky delegators, and tool docs/examples.
+
+### `docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+
+Recommendation only; do not edit in this review pass.
+
+- Change D11 `Requires` from `D0, D1, D7, D9, D10` to `D0, D1, D6, D7, D9, D10; D3 for pre-push affected/base/target behavior; D8 where hook eligibility/local-feedback admission is consumed; G-HOST through D10/D9 where host-owned protected/generated surfaces or host gates are projected`.
+- Keep D11 status blocking until per-domino review repairs accepted P1/P2 findings.
+
+### Current hook code/tests
+
+Recommendation only; no source edits in this review pass.
+
+- Later implementation should stop local parsing of raw Grit/check output as target diagnostic authority and consume accepted projections.
+- Replace boolean-correlated `ResourceState` with discriminated constructors.
+- Keep restaging restricted to formatter-touched files and prove partial-staging refusal remains before writes.
+- Replace proof-shaped notice or preserve it only through D0/D1 compatibility.
+- Make pre-push target/base behavior consume D3 graph facts and render Graphite base as observed state only.
+
+## Stop Condition Check
+
+D11 must remain blocking because all four stop conditions in the user prompt are currently present:
+
+- Hidden dependency assumptions: yes, D6 and D3 are not fully represented in D11/index requirements.
+- Stale packet index blockers: yes, D11 index row omits D6 and D3 conditional blocker.
+- Missing D6 diagnostic dependency: yes, direct blocker.
+- Unclear product recovery behavior: yes, the packet does not yet specify recovery and non-claims per hook failure family.
+
+Skills used: domain-design, information-design, solution-design, system-design, ontology-design, civ7-open-spec-workstream.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-domain-ontology-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-domain-ontology-investigation.md
@@ -1,0 +1,350 @@
+# D11 Local Feedback Domain/Ontology Investigation
+
+## Verdict
+
+Blocking for packet repair input.
+
+The current D11 packet has the correct top-level intent: hooks are local feedback, not CI, review readiness, safe-apply completion, product readiness, or structural authority. It is not yet implementation-ready because it does not define the Local Feedback ontology, state families, consumer projections, native-tool roles, or compatibility terminology tightly enough for a later execution agent to implement without inventing domain decisions.
+
+The packet must be repaired before source implementation. The blocking ambiguity is exact: D11 does not yet say which states Local Feedback owns, which upstream projection fields it consumes, what a hook may claim, what it must never claim, and how resource state, staged-path decisions, partial-staging refusal, formatter restage, and pre-push base selection become closed impossible-state-resistant models.
+
+## Source Authority Read Register
+
+Read in full:
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/axes.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/examples.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/maintenance.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/operationalization.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/principles.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/representation-choices.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/source-map.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/where-defaults-hide.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/artifact-contracts.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/failure-patterns.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/phase-loop.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/source-map.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/team-and-review-lanes.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/validation-checks.md`
+
+Read as D11 control/input records:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/AGENTS.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation-frame.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/proposal.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/design.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/tasks.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/specs/habitat-harness/spec.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/workstream/closure-checklist.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/workstream/downstream-realignment-ledger.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/workstream/phase-record.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/workstream/review-disposition-ledger.md`
+
+Read as accepted upstream contract sources:
+
+- D1 design/spec under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d1-receipt-contract-boundary/`
+- D6 spec under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d6-diagnostic-pattern-catalog/`
+- D7 design/spec under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d7-structural-enforcement-pipeline/`
+- D9 design/spec under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d9-transformation-transaction/`
+- D10 design/spec under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d10-protected-zone-authority/`
+
+Read as present-behavior input only:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/hooks.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/hooks.test.ts`
+
+## Competency Questions
+
+The repaired D11 packet must answer these without implementation-time judgment:
+
+1. What is a hook allowed to claim when it passes, fails, refuses, skips, or cannot inspect a required local state?
+2. Which D1 non-claim identifiers must appear on hook output, HookTrace/LocalFeedbackTrace, and any public compatibility projection?
+3. Which Local Feedback states are D11-owned, and which states are D7, D9, D10, D6, D1, D3, Git, Graphite, Nx, Biome, Grit, or Husky facts consumed by D11?
+4. What is the closed hook stage model for pre-commit and pre-push?
+5. What is the closed local feedback result model, and how does it derive exit status and human output?
+6. Which upstream projection is consumed for staged structural checks, protected-zone refusals, staged Grit diagnostics, apply/fix transaction feedback, and affected-target feedback?
+7. How does resource state make `kind` vs allowed commit behavior impossible to contradict?
+8. Which resource states allow pre-commit, refuse pre-commit, or represent non-claiming absence of resource configuration?
+9. How are staged path decisions represented from Git name-status without inventing a second VCS model?
+10. What exactly triggers partial-staging refusal, and what must not run after that refusal?
+11. What exactly authorizes formatter restage, and how is restage limited to formatter-touched Biome-supported staged files?
+12. How does a D10-origin file-layer refusal stop hook sequencing before Biome, Grit, publish, generated publish, or restage work?
+13. How are Graphite parent observation, explicit base override, Git merge-base fallback, literal main fallback, and Nx affected execution represented without claiming PR readiness or graph truth?
+14. Is the legacy hook notice a target term, a legacy human-output phrase, or a D0/D1 compatibility surface?
+15. What are the stop conditions if D7/D9/D10/D6/D1 projections are unavailable or malformed?
+
+## Target Ontology Commitments
+
+D11 should add a concrete target ontology section to `design.md` and matching OpenSpec requirements/scenarios. Required accepted commitments:
+
+- `LocalFeedback`: D11 bounded context for hook-time feedback to a local developer or agent. It sequences local checks and records outcomes. It does not decide check truth, diagnostic identity, path authority, transaction safety, graph target truth, CI status, review approval, product/runtime behavior, or OpenSpec acceptance.
+- `HookInvocation`: requested hook command and hook name, limited to `pre-commit` and `pre-push` unless D0 versions the public command surface.
+- `HookStage`: closed stage identity. Current inputs suggest at least `resource-state`, `staged-paths`, `file-layer-check`, `partial-staging-check`, `biome-format`, `formatter-restage`, `biome-check`, `staged-grit-check`, `pre-push-base-selection`, and `pre-push-affected`. Keep `repo-state` and command capture as trace observation, not product authority.
+- `HookCommandRecord`: D11-local command observation for hook sequencing. It records argv, cwd, environment projection if allowed, exit code, timing, and phase. It is not a `CommandReceipt`, CI authority, or structural truth source. If exported or serialized, it needs D0/D1 compatibility classification.
+- `HookTrace` / `LocalFeedbackTrace`: hook-scoped event and command feedback record. It must carry `local-feedback-only` and relevant D1 non-claims. It must distinguish pre-state/post-state observations from accepted authority.
+- `LocalFeedbackResult`: terminal result family such as `passed`, `failed`, `refused`, `blocked`, and `not-applicable` or more specific variants for pre-commit/pre-push. Exit status must derive from this result.
+- `ResourceState`: closed union where allowed behavior derives from variant, not from an independent boolean. Required variants from source packet/current behavior: `clean`, `not-configured`, `staged-gitlink-allowed`, `dirty-submodule-refused`, `unstaged-gitlink-refused`, `uninitialized-refused`, `locked-refused`, and `inspection-failed-refused`. Do not preserve `allowPreCommit` as target state.
+- `StagedPathDecision`: Git-derived path-action decision over staged adds/modifies/deletes/renames/copies. D11 may consume normalized Git name-status; it must not redefine Git.
+- `PartialStagingRefusal`: refusal for Biome-supported staged files with unstaged changes. It must stop before formatting, restage, Biome check, staged Grit, publish, or downstream commands.
+- `FormatterRestageDecision`: D11 decision to run `git add -- <paths>` only for formatter-touched, Biome-supported, staged paths. It is not apply safety, not transaction success, and not authorization for unrelated staged paths.
+- `PrePushBaseDecision`: closed observed-base decision: explicit override, Graphite parent observed, Git merge-base observed, fallback literal main, or blocked/unavailable if the packet decides fallback is no longer acceptable. The decision must be an observation for Nx affected, not PR readiness.
+- `AffectedTargetFeedback`: D11 pre-push local feedback from Nx affected execution. It must consume D3 graph facts when target truth is claimed and otherwise remain a native Nx command result with non-claims.
+- `UpstreamConsumerProjection`: explicit D11-consumed projection relation for D7 `LocalFeedbackCheckProjection`, D10 `ProtectedMutationGuardProjection`/D7-projected protected refusal, D9 local-feedback-safe transaction projection when apply/fix state is surfaced, D6 diagnostic failure only through D7 unless D11 names a direct bounded D6 projection, and D1 non-claim/compatibility records.
+- `NonClaim`: canonical D1 identifiers, not prose-only disclaimers. Required base set for hooks: `local-feedback-only`, `does-not-prove-ci`, `does-not-prove-runtime`, `does-not-prove-product-completion`, `does-not-prove-graphite-readiness`, `does-not-prove-openspec-acceptance`, `does-not-prove-apply-safety`, `does-not-prove-current-tree-cleanliness`, and `does-not-prove-rule-correctness` when check/diagnostic projections are surfaced.
+
+Native role commitments:
+
+- Husky owns hook delegation mechanics. Habitat owns the `habitat hook <name>` command behavior behind that delegator.
+- Git owns staged identity, name-status, diffs, branch/head observations, merge-base mechanics, and submodule/gitlink facts.
+- Graphite owns stack/parent facts. D11 may observe a Graphite parent for base selection and must not turn it into PR readiness.
+- Nx owns affected target execution, target scheduling, cache, and graph behavior. D11 may run Nx and report the command result; target truth requires accepted D3 graph facts.
+- Biome owns formatting/lint/import-sort semantics. D11 owns the decision to invoke Biome locally and restage only Biome-touched staged files.
+- Grit owns native diagnostic execution and output syntax. D11 must not parse raw Grit truth as target authority; it consumes D7/D6 projections.
+
+## Rejected Or Compatibility Terms
+
+Treat these as compatibility facts unless D0/D1 explicitly preserve or version them:
+
+- Legacy hook notice wording: human-output compatibility phrase only. Target phrase should be `local feedback` or `local feedback trace`. If preserved, the packet must call it a D0/D1 compatibility surface and bind it to `local-feedback-only`.
+- Legacy authority vocabulary in target D11 product language: rejected. Use `feedback`, `trace`, `result`, `scenario`, `validation gate`, or `non-claim`.
+- Target D11 type names should use `observation`, `command record`, `trace`, `result`, or `decision` when naming source/current-behavior inputs.
+- `allowPreCommit`: rejected target field. Allowed behavior must derive from `ResourceState` variant.
+- `file-layer` as domain language: compatibility owner-tool label. Target meaning is D10 protected mutation guard rendered through D7 local feedback projection.
+- `grit-check` as semantic source: compatibility/native tool label. Target meaning is D6 diagnostic outcome projected through D7 for local feedback.
+- `formatter restage` as broad write authority: compatibility stage label. Target is a bounded formatter restage decision over formatter-touched staged paths only.
+- Pre-push affected authority claims: rejected. Target is Nx affected local feedback with Graphite/Git base observation and non-claims.
+- `skip` without reason: rejected. Use `not-applicable`, `dependency-refused`, `blocked`, or an owner-specific refusal reason.
+
+## Findings Against Current Packet
+
+### P1: The packet lacks a D11-owned target ontology and leaves core state design to implementation
+
+Current `design.md` names the owner and repeats the high-level target contract, but it does not define `LocalFeedback`, `HookStage`, `LocalFeedbackResult`, `ResourceState`, `StagedPathDecision`, `PartialStagingRefusal`, `FormatterRestageDecision`, `PrePushBaseDecision`, or `UpstreamConsumerProjection`. Current `spec.md` has only two generic scenarios. That fails the ontology competency test: an implementation agent cannot answer which states exist, who owns them, or which invalid states are impossible.
+
+Repair:
+
+- Add a `Target Ontology` section to `design.md` with the commitments above.
+- Add a `State Model` section to `design.md` with closed variants for pre-commit, pre-push, resource state, staged path decisions, formatter restage, and upstream-consumer results.
+- Expand `specs/habitat-harness/spec.md` beyond the current generic requirement into separate normative requirements for hook scope/non-claims, resource state, staged path decision, partial staging, formatter restage, D7/D10/D6 consumption, D9 projection consumption if applicable, and pre-push base/Nx feedback.
+- Replace tasks 2.1-2.3 with implementation steps that name the state families and projections, not broad "define/consume/clarify" placeholders.
+
+### P1: Resource state still permits the impossible state the source packet identified
+
+The source domino explicitly flags `ResourceState.kind` and `allowPreCommit` as contradictory if not constructed centrally. Current OpenSpec artifacts do not repair that design; they only say D11 should define scope and non-claims. Present code still has `ResourceState.kind` plus `allowPreCommit`, while tests rely on behavior like dirty submodule taking precedence over staged gitlink.
+
+Repair:
+
+- In `design.md`, replace the boolean-correlated model with a closed resource union whose variant determines commit allowance.
+- In `spec.md`, add scenarios for `clean`, `not-configured`, `staged-gitlink-allowed`, `dirty-submodule-refused`, `unstaged-gitlink-refused`, `uninitialized-refused`, `locked-refused`, and inspection failure.
+- Make precedence normative: dirty submodule and inspection failures refuse before staged gitlink allowance is considered.
+- Require resource refusals to carry recovery instructions and D1 non-claims.
+
+### P1: Upstream consumption is named but not specified, so D11 can recreate upstream authority
+
+D11 says it consumes D7/D9/D10 and current hook inputs include staged file-layer checks and Grit checks, but the packet does not cite the accepted upstream projections. D7 already defines `LocalFeedbackCheckProjection` for D11. D10 defines that D11 stops at D10-origin staged protected mutation refusal. D9 defines a D11 local-feedback-safe transaction projection. D1 defines HookTrace/local feedback non-claims and compatibility treatment. D6 owns diagnostic identity and adapter failures. Current D11 does not bind to these projection names, fields, or non-ownership boundaries.
+
+Repair:
+
+- In `design.md`, add an `Upstream Consumer Matrix`:
+  - D1: canonical non-claims, HookTrace/LocalFeedbackTrace boundary, compatibility handling for the legacy hook notice.
+  - D7: `LocalFeedbackCheckProjection` fields and refusal labels.
+  - D10 through D7: protected/generated/forbidden staged mutation refusals stop hook sequencing before Biome/Grit/publish/restage.
+  - D6 through D7: malformed Grit JSON, adapter failure, findings, projection miss, and unavailable diagnostic states are local feedback outcomes, not D11 diagnostic truth.
+  - D9: only consume local-feedback-safe transaction projection if D11 surfaces apply/fix state; otherwise state D9 is a non-owned adjacent contract and D11 must not claim apply safety.
+  - D3/Nx/Graphite: pre-push affected execution is native Nx feedback; target truth requires D3 graph facts.
+- In `spec.md`, add scenarios for unavailable/malformed projections causing blocked or refused local feedback rather than pass.
+
+### P1: The packet cannot answer what a hook may claim and must never claim at each output boundary
+
+The packet says hooks are local feedback and not CI, but it does not bind non-claims to specific output surfaces: human output, exit status, HookTrace, HookCommandRecord, pre-commit pass, pre-push pass, resource refusal, D10-origin refusal, Grit failure, formatter restage, and Nx affected result. D1 already requires canonical non-claim identifiers.
+
+Repair:
+
+- Add `Claim Boundary` to `design.md`: every hook result may claim only "these configured local hook stages completed/refused/failed under this local invocation." It must never claim CI, review approval, full verification, product/runtime correctness, generated freshness, safe apply completion, Graphite readiness, OpenSpec acceptance, D7 rule correctness, D6 diagnostic correctness, D10 path authority beyond consumed decision, or D9 transaction success.
+- Add `NonClaim Mapping` by result family and surface.
+- Add `spec.md` scenarios requiring non-claims on pass, refusal, dependency unavailable, pre-push affected failure, and legacy human-output phrase.
+
+### P2: The legacy hook notice is not explicitly rejected or compatibility-handled in D11 target artifacts
+
+D1 says the legacy hook notice is a D0-classified human-output compatibility phrase whose target meaning is `local-feedback-only`. Current D11 design has a general rule for legacy authority-shaped names but never names the legacy hook notice as a rejected target term. Current tests assert the legacy phrase.
+
+Repair:
+
+- Add `Term Disposition` to `design.md` with the legacy hook notice as `legacy-human-output-compatibility`, target `LocalFeedbackTrace`/`local feedback`, D0/D1 handling required before changing text.
+- Add a `spec.md` scenario: when legacy phrase or D0-approved replacement is rendered, its target meaning is `local-feedback-only` and it does not imply CI authority.
+- In `tasks.md`, add an inventory task for all hook human-output, HookTrace, and package export surfaces touched by D11.
+
+### P2: Native tool roles are under-modeled, inviting Habitat-invented abstractions
+
+The hard acceptance question asks whether Graphite, Husky, Nx, Biome, and Grit are represented by native roles. Current packet mentions Graphite, Husky, Nx, Biome, and Grit but does not define their native authority. Without that, implementation can turn Habitat into a second VCS, formatter, graph engine, or diagnostic engine.
+
+Repair:
+
+- Add `Native Tool Authority` to `design.md`:
+  - Husky delegates.
+  - Git supplies staged/submodule/branch/head/merge-base observations.
+  - Graphite supplies parent observation only.
+  - Nx runs affected targets and owns target/scheduler/cache behavior.
+  - Biome formats/checks; D11 only sequences and bounds restage.
+  - Grit diagnostics arrive through D6/D7 projections.
+- Add spec scenarios that forbid parsing D7 human output, raw Grit output, Graphite text, or Nx success as broader Habitat authority.
+
+### P2: Staged path, partial-staging, and formatter-restage boundaries are too implicit
+
+The source packet requires staged path policy, partial staging refusal, and formatter restage decisions. Current D11 artifacts do not define path action semantics, deleted/renamed/copied path handling, Biome-supported file filtering, partial staging detection, or restage scope. Current code inputs show this behavior exists, but current code is not target authority.
+
+Repair:
+
+- Add `Staged Path Model` to `design.md`: Git name-status is normalized to repo-relative path decisions; deleted paths are not formatter candidates; renames/copies preserve both path observations where needed; path existence filtering is an observation, not authority.
+- Add `PartialStagingRefusal` requirements: if a Biome-supported staged file has unstaged changes, refuse before formatting/restage/Grit and give recovery instructions.
+- Add `FormatterRestageDecision` requirements: after Biome format, restage only paths whose hash changed among Biome-supported staged candidates; do not restage foreign paths.
+- Add bad-case tests/gates in `tasks.md`: partially staged file, formatter touches one staged file and not another, deleted/renamed path, restage command failure.
+
+### P2: Pre-push base selection and affected-target feedback remain ambiguous
+
+The proposal adds a D3 note saying D11 may plan pre-push feedback before D3 but cannot implement or close target selection/base detection/target truth until D3 graph facts are stable. That is directionally right but still ambiguous. D11 must decide which base-selection states are local observations and which conditions are blocked. Current behavior falls back from Graphite parent to Git merge-base to literal `main`, but the packet does not accept, reject, or constrain that fallback.
+
+Repair:
+
+- Add `PrePushBaseDecision` states to `design.md`: explicit override, Graphite parent observed, Git merge-base observed, literal main fallback, and base unavailable/refused if fallback should become blocking.
+- Add `AffectedTargetFeedback` state: Nx affected command result with target list, base, head, exit, and non-claims.
+- State that Graphite parent observation does not prove PR readiness and Nx affected success does not prove CI, graph target truth, or product/runtime behavior.
+- If D3 is required for target truth, add D3 to D11 prerequisites for pre-push implementation or split pre-push affected feedback into a later D3-dependent slice.
+
+### P2: HookTrace and HookCommandRecord identity, relationships, and public compatibility are underspecified
+
+Current code exposes `HookCommandRecord` and `HookTrace` types, and D1 recognizes HookTrace/LocalFeedbackTrace as local feedback. D11 does not define whether HookCommandRecord is public, internal, serialized, or a compatibility wrapper over D1 command execution concepts. It also does not define trace relationships to hook invocation, upstream projections, resource state, or non-claims.
+
+Repair:
+
+- In `design.md`, define `HookTrace` identity, lifecycle, and relation semantics:
+  - records-local-feedback-for `HookInvocation`;
+  - contains `HookStageResult`;
+  - observes `HookCommandRecord`;
+  - consumes upstream projection ids where applicable;
+  - bounded-by D1 non-claims.
+- If `HookCommandRecord` remains exported or serialized, route it through D0 compatibility and D1 command-record boundary.
+- Add spec scenarios proving trace records refused/blocked states without converting them to passing receipts.
+
+### P3: D11 phase record branch is stale relative to the active D11 worktree
+
+The requested active branch is `codex/d11-local-feedback-packet`, and `git status --short --branch` confirms that branch. D11 `workstream/phase-record.md` says branch `codex/deep-habitat-openspec-remediation`. This is not a domain ontology defect, but it is an artifact hygiene issue that can mislead the next agent.
+
+Repair:
+
+- Update `workstream/phase-record.md` during packet repair to record the active branch/worktree accurately, or explicitly state that the old branch name is historical.
+
+### P3: Validation gates are not scenario-complete for the target ontology
+
+The current validation gates include hook tests and `pre-commit --help`, but D11's ontology needs falsifying bad cases: resource refusal precedence, D10-origin refusal sequencing, partial staging, formatter restage scope, malformed Grit projection, Graphite/Nx base decisions, and non-claim rendering. This is partly a validation lane issue, but the domain model cannot be considered implementation-ready without these scenario anchors.
+
+Repair:
+
+- In `tasks.md`, replace broad validation with scenario-specific tests tied to each D11 state family.
+- Add both pre-commit and pre-push command behavior gates or explicitly split pre-push into a later D3-dependent slice.
+
+## Exact Repair Recommendations By Artifact
+
+### `/openspec/changes/deep-habitat-d11-local-feedback/design.md`
+
+Add these sections:
+
+- `Target Ontology`
+- `Term Disposition`
+- `Native Tool Authority`
+- `Upstream Consumer Matrix`
+- `Claim Boundary And Non-Claims`
+- `State Model`
+- `Pre-Commit Stage Model`
+- `Pre-Push Stage Model`
+- `Trace And Relationship Model`
+- `Public Compatibility Inventory`
+
+The state model must include closed variants for resource state, hook stage result, local feedback result, staged path decision, partial staging refusal, formatter restage decision, D7/D10/D6 projected check feedback, D9 transaction feedback if surfaced, and Graphite/Nx pre-push base/affected feedback.
+
+### `/openspec/changes/deep-habitat-d11-local-feedback/specs/habitat-harness/spec.md`
+
+Replace the single generic requirement with multiple requirements:
+
+- `D11 Hooks Report Local Feedback Only`
+- `D11 Resource State Determines Commit Allowance By Variant`
+- `D11 Consumes D7 LocalFeedbackCheckProjection`
+- `D11 Stops At D10-Origin Staged Mutation Refusals`
+- `D11 Surfaces D6 Diagnostic Failures Only Through Accepted Projections`
+- `D11 Refuses Partial Staging Before Formatting`
+- `D11 Restages Only Formatter-Touched Staged Paths`
+- `D11 Represents HookTrace As Local Feedback, Not Receipt Or External Authority`
+- `D11 Pre-Push Base Decision Is Observed State Only`
+- `D11 Nx Affected Feedback Does Not Claim CI Or Graph Truth`
+- `D11 Handles Legacy Hook Notice As Compatibility Language Only`
+
+Each requirement needs at least one positive scenario and one bad-case/refusal scenario.
+
+### `/openspec/changes/deep-habitat-d11-local-feedback/tasks.md`
+
+Replace tasks 2.1-2.3 with implementation steps that name the work:
+
+- Define Local Feedback state families and constructors.
+- Replace `ResourceState.kind` plus `allowPreCommit` with a closed variant-derived allowance.
+- Consume D7 `LocalFeedbackCheckProjection` instead of parsing D7 human output or raw check JSON as target semantics.
+- Preserve D10-origin refusal sequencing.
+- Encode partial staging refusal and formatter restage scope.
+- Encode HookTrace/HookCommandRecord compatibility and non-claim mapping.
+- Encode pre-push base decision and affected-target feedback with Graphite/Nx/D3 boundaries.
+
+Add validation tasks for each falsifying scenario.
+
+### `/openspec/changes/deep-habitat-d11-local-feedback/proposal.md`
+
+Update `Requires` or add a dependency note that is not contradictory:
+
+- D6 is an accepted upstream contract D11 must respect, at least through D7 diagnostic projections.
+- D3 is required for any pre-push claim about affected-target truth; otherwise pre-push remains native Nx local feedback with non-claims.
+- D0/D1 compatibility rows are required before changing hook human output, JSON/trace schema, exports, scripts, help, or docs examples.
+
+Clarify that D11 enables clean local ergonomics and handoff reliability but does not enable downstream authority packets.
+
+### `/openspec/changes/deep-habitat-d11-local-feedback/workstream/phase-record.md`
+
+Correct or qualify the stale branch field. Copy the repaired validation matrix and protected write set into the phase record after packet repair.
+
+### `/openspec/changes/deep-habitat-d11-local-feedback/workstream/review-disposition-ledger.md`
+
+Record this investigation as a blocking per-domino domain/ontology review input. Do not mark it acceptance input until accepted P1/P2 repairs are completed and rereviewed.
+
+### `/openspec/changes/deep-habitat-d11-local-feedback/workstream/downstream-realignment-ledger.md`
+
+Add downstream surfaces that must be realigned after repair:
+
+- D0 compatibility matrix for hook human output, trace/export/schema, command behavior/help, and docs examples.
+- D1 non-claim and compatibility handling references.
+- D7 `LocalFeedbackCheckProjection` consumer contract.
+- D10 hook-facing refusal sequencing.
+- D9 local-feedback-safe transaction projection if D11 surfaces apply/fix state.
+- D3 pre-push affected-target dependency if D11 claims target truth.
+
+## Stop Conditions
+
+Keep D11 blocking if any of these remain true:
+
+- `ResourceState` has both a `kind` and independent allowed/pre-commit boolean.
+- Hook output or trace can be read as CI, review, verify, generated freshness, apply safety, Graphite readiness, OpenSpec acceptance, or product/runtime readiness.
+- The legacy hook notice appears as target language rather than D0/D1 compatibility phrase.
+- D11 parses D7 human output or raw Grit output to infer structural/diagnostic truth.
+- D11 matches protected/generated paths locally instead of consuming D10/D7 projections.
+- Partial staging behavior is not a refusal with a clear sequencing stop.
+- Formatter restage can include paths outside formatter-touched staged Biome candidates.
+- Graphite parent or Nx affected success can be interpreted as PR readiness, graph target truth, or CI success.
+- Pre-push affected-target behavior remains in scope without either accepted D3 graph facts or explicit local-feedback-only non-claims.
+- The packet leaves public compatibility decisions, trace schema, output wording, or hook command behavior for implementation to decide.
+
+## Final Verdict
+
+Blocking. D11 is directionally correct but currently underspecified. It must be repaired into an explicit Local Feedback ontology and state model before it can become implementation-ready design/specification authority.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-final-code-vendor-topology-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-final-code-vendor-topology-review.md
@@ -1,0 +1,189 @@
+# D11 Final Code/Vendor Topology Review
+
+Status: final code/vendor topology rereview against the repaired disk state.
+Date: 2026-06-18.
+Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation`.
+Branch: `codex/d11-local-feedback-packet`.
+
+## Verdict
+
+Accepted for design/specification only.
+
+No unresolved P1/P2 code/vendor topology blockers remain in the current repaired
+D11 packet. The previous topology blockers have been repaired as design
+constraints: current hook source risks are now treated as current-state input and
+future migration targets, not as implementation authority.
+
+This does not authorize source implementation. D11 source implementation remains
+blocked behind concrete D0 rows, D1 output-family/non-claim handling, and live
+upstream projections/facts for each touched slice: D3 graph/affected facts, D6
+staged diagnostic projections, D7 `LocalFeedbackCheckProjection`, D9
+local-feedback-safe transaction projection where surfaced, and D10
+protected/generated mutation projection. D8 remains conditional where
+hook/local-feedback eligibility or admission is consumed; G-HOST remains
+transitive through D9/D10 unless D11 directly touches host-owned surfaces.
+
+## Read Register
+
+Mandatory skills and references read:
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/axes.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/principles.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/where-defaults-hide.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/representation-choices.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/maintenance.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/operationalization.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/examples.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/source-map.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/references/axes/axes.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/references/principles/principles.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/references/defaults/where-defaults-hide.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/axes.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/principles/principles.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/defaults/where-defaults-hide.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/leaflet-software-testing.md`
+- `/Users/mateicanavra/.agents/skills/typescript/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/typescript/references/refactoring-patterns.md`
+- `/Users/mateicanavra/.agents/skills/typescript/references/module-organization.md`
+- `/Users/mateicanavra/.agents/skills/typescript/references/where-defaults-hide.md`
+
+Repo and packet inputs read:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/AGENTS.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md`
+- Every file under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback`
+- D11 first-wave scratch files:
+  - `domino-D11-code-vendor-topology-investigation.md`
+  - `domino-D11-cross-domino-product-investigation.md`
+  - `domino-D11-domain-ontology-investigation.md`
+  - `domino-D11-openspec-information-testing-investigation.md`
+  - `domino-D11-typescript-state-investigation.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/context.md`
+
+Code inputs read:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/hooks.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/commands/hook.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/command-engine.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/index.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/hooks.test.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/.husky/pre-commit`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/.husky/pre-push`
+
+Official/native docs consulted:
+
+- Husky docs: https://typicode.github.io/husky/
+- Git hooks docs: https://git-scm.com/docs/githooks
+- Biome git hooks recipe: https://biomejs.dev/recipes/git-hooks/
+- Biome CLI reference: https://biomejs.dev/reference/cli/
+- Nx affected docs: https://nx.dev/docs/features/ci-features/affected
+- Nx command reference: https://nx.dev/docs/reference/nx-commands
+- Grit CLI reference: https://docs.grit.io/cli/reference
+
+## Review Notes
+
+The current hook code remains a monolithic current-state implementation, not the
+target model. `hooks.ts` still contains the known topology risks: `ResourceState`
+has both `kind` and `allowPreCommit` (`hooks.ts:29` and `hooks.ts:38`), the hook
+parses `CheckReport`/Grit output locally (`hooks.ts:371` and `hooks.ts:814`),
+pre-push targets are hard-coded (`hooks.ts:152`), and pre-push falls back through
+Graphite/Git/literal `main` before invoking Nx (`hooks.ts:403` and
+`hooks.ts:613`). These are not unresolved acceptance blockers because the
+repaired D11 packet now names them as current-behavior input and blocks source
+work until the correct upstream projections exist.
+
+The packet maps public/durable hook surfaces to D0/D1 compatibility gates.
+`proposal.md:131` through `proposal.md:149` inventories `.husky` delegators,
+`habitat hook`, help/dry-run behavior, human output, `runHook`, exported trace
+types, docs/examples, and script/Nx reporting. `tasks.md:12` through
+`tasks.md:27` requires public surface inventory, concrete D0 rows, live upstream
+facts, and a recorded implementation write/protected set before source edits.
+
+The packet maps the later write set without authorizing upstream implementation
+edits. `proposal.md:151` through `proposal.md:174` limits later D11 source work
+to hook source, hook command/export routing under D0/D1 compatibility, hook tests,
+Husky delegators only if D0-backed, adjacent docs/examples where accepted
+behavior changes, and D11 packet/control records. The same section protects D6
+diagnostic acquisition/projection, D7 report construction, D9 transaction
+behavior, D10/G-HOST path policy, D3 graph authority, generated outputs,
+lockfiles, baselines, resources, and product/runtime Civ7 control code.
+`tasks.md:24` through `tasks.md:27` repeats that D11 must not edit D3/D6/D7/D9/D10
+authority implementation as a shortcut.
+
+Vendor/native boundaries are now represented correctly enough for design
+acceptance. Husky remains a delegator and public durable surface, while `.husky`
+currently contains only `bun run habitat hook pre-commit` and
+`bun run habitat hook pre-push`. Git owns staged/submodule/base facts; D11 only
+collects or observes them, with staged path collection called out in
+`design.md:142` and partial-staging/restage boundaries in `spec.md:117` through
+`spec.md:135`. Biome owns formatter/check semantics; D11 may invoke Biome with
+explicit candidate paths and bound restage, matching the official Biome
+`--no-errors-on-unmatched` guidance. Grit owns native diagnostic execution; D11
+must consume D6/D7 projections rather than raw output, as specified in
+`spec.md:60` through `spec.md:83`. Nx owns affected execution and the project
+graph behavior; D11 may render local affected feedback but must consume D3
+graph/target availability where required, as specified in `spec.md:150` through
+`spec.md:172`.
+
+Validation gates avoid unsafe live hook help commands. The repaired task list
+explicitly says not to use `habitat hook pre-commit --help` or any command shape
+that can execute a live hook as a help gate unless D0 defines it (`tasks.md:112`
+through `tasks.md:114`). Controlled probes require fixtures and before/after
+`git status --short --branch` checks (`tasks.md:115` through `tasks.md:117`).
+The proposal also records current command-surface behavior for `hook --help`,
+`hook pre-commit --help`, and `hook pre-commit --dry-run` as behavior that must
+be preserved or D0-routed (`proposal.md:203` through `proposal.md:206`).
+
+The packet index is aligned with the repaired dependency topology. The D11 row
+now lists D0, D1, D3 for pre-push graph/affected facts, D6 staged diagnostic
+projections, D7 local-feedback check projection, D9 where surfaced, D10 protected
+mutation projection, conditional D8, and transitive G-HOST through D9/D10. It
+also preserves the non-implementation-complete source blocker.
+
+## Findings
+
+### P1
+
+No P1 findings.
+
+### P2
+
+No P2 findings.
+
+### P3
+
+No P3 findings recorded in this lane. Remaining risks are intentionally modeled
+as source implementation blockers rather than design/specification blockers.
+
+## Validation Run
+
+Commands run from the active worktree:
+
+- `bun run openspec -- validate deep-habitat-d11-local-feedback --strict`: pass.
+- `bun run openspec:validate`: pass, 249 items passed and 0 failed.
+- `git diff --check`: pass.
+
+No live hook help, dry-run, pre-commit, or pre-push command was executed for this
+review, because those command shapes can inspect or mutate live repo state unless
+D0 and controlled fixtures define the behavior.
+
+## Acceptance Statement
+
+Code/vendor topology lane accepts D11 for design/specification only, with no
+unresolved P1/P2 findings.
+
+D11 remains not implementation-complete. Source implementation must remain
+blocked behind concrete D0 rows, D1 output/non-claim handling, and live D3/D6/D7/D9/D10
+projections for the touched surfaces. Hook success remains local feedback only
+and does not prove CI, review approval, OpenSpec acceptance, Graphite readiness,
+safe apply completion, generated freshness, graph completeness, current-tree
+cleanliness, or product/runtime correctness.
+
+Skills used: domain-design, information-design, ontology-design, solution-design,
+testing-design, typescript.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-final-cross-domino-product-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-final-cross-domino-product-review.md
@@ -1,0 +1,99 @@
+# D11 Final Cross-Domino/Product Review
+
+## Read Register
+
+Mandatory skill grounding read:
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/SKILL.md`
+- All ontology references under `/Users/mateicanavra/.agents/skills/ontology-design/references/`: `axes.md`, `principles.md`, `where-defaults-hide.md`, `representation-choices.md`, `operationalization.md`, `maintenance.md`, `source-map.md`, and `examples.md`.
+- Relevant `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`, `/Users/mateicanavra/.agents/skills/system-design/SKILL.md`, `/Users/mateicanavra/.agents/skills/team-design/SKILL.md`, and `/Users/mateicanavra/.agents/skills/testing-design/SKILL.md`.
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/SKILL.md`
+- OpenSpec workstream references for authority, review lanes, artifact contracts, and validation checks: `source-map.md`, `team-and-review-lanes.md`, `artifact-contracts.md`, and `validation-checks.md`.
+
+Repo and control grounding read:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/AGENTS.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/context.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+- Active worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation`
+- Active branch: `codex/d11-local-feedback-packet`
+
+D11 packet inputs read:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md`
+- Every file under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback`
+- First-wave D11 scratch inputs under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-*.md`, excluding this final output.
+
+Accepted upstream and downstream surfaces read where D11 references them:
+
+- D0 public-surface compatibility contract.
+- D1 hook trace, local-feedback, refusal/recovery, and canonical non-claim contract.
+- D3 workspace graph target, affected, graph-read, and graph-refusal contract.
+- D6 staged diagnostic projection and adapter/refusal contract.
+- D7 `LocalFeedbackCheckProjection` contract.
+- D8 local-feedback admission/eligibility contract.
+- D9 local-feedback-safe transaction projection contract.
+- D10 protected/generated mutation and D11 hook-stop projection contract.
+- G-HOST host-policy boundary packet.
+- D12 verify handoff receipt packet.
+- D15 execution provenance trigger packet.
+
+Fresh non-mutating checks run from the active worktree:
+
+- `git diff --check`: passed.
+- `bun run openspec -- validate deep-habitat-d11-local-feedback --strict`: passed; OpenSpec shape only.
+- `bun run openspec:validate`: passed; full OpenSpec corpus shape only.
+
+## Verdict
+
+Accepted for cross-domino/product design/specification only. No unresolved P1/P2 blockers remain in this lane.
+
+D11 now satisfies the product outcome: a developer or agent can understand local hook stops as recoverable local repo-maintenance feedback without reading hook success as CI, review, OpenSpec, Graphite, safe-apply, generated-freshness, graph-completeness, or runtime/product readiness. The repaired packet defines Local Feedback ownership, stage ordering, non-claims, recovery surfaces, public compatibility blockers, and dependency boundaries tightly enough for design/spec acceptance.
+
+This is not implementation-complete. It does not authorize source changes. D11 source implementation remains blocked behind concrete D0 public-surface rows, D1 output-family/non-claim handling, and live upstream projections for each touched source slice.
+
+## Cross-Domino Acceptance Checks
+
+- D6 direct staged diagnostics: accepted. D11 names D6 staged diagnostic projections directly in the upstream edge table and forbids raw Grit output, diagnostic message text, and D7-only ownership collapse (`proposal.md:72-80`, `proposal.md:112`, `design.md:60-62`, `spec.md:60-83`, `tasks.md:61-64`). This matches D6's bounded consumer projection contract (`deep-habitat-d6-diagnostic-pattern-catalog/spec.md:246-255`) and D6's D11 downstream row (`workstream/downstream-realignment-ledger.md:18`).
+- D7 check projection: accepted. D11 consumes `LocalFeedbackCheckProjection` and does not parse D7 human output or `CheckReport` internals (`proposal.md:113`, `design.md:143-145`, `spec.md:84-102`, `tasks.md:50-51`). This matches D7's D11-safe projection contract (`deep-habitat-d7-structural-enforcement-pipeline/spec.md:175-187`).
+- D9 transaction projection where surfaced: accepted. D11 consumes D9 only when hook-facing apply/fix or transaction recovery feedback is surfaced and does not infer apply/write safety locally (`proposal.md:76-77`, `proposal.md:114`, `spec.md:136-149`, `tasks.md:68-71`). This matches D9's D11 projection contract (`deep-habitat-d9-transformation-transaction/spec.md:286-293`).
+- D10 protected mutation projection: accepted. D11 consumes D10/D7 protected mutation refusals and stops before downstream hook work (`proposal.md:78-79`, `proposal.md:115`, `spec.md:103-116`, `tasks.md:52-54`). This matches D10's D11 hook-stop requirement (`deep-habitat-d10-protected-zone-authority/spec.md:124-131`).
+- D3 pre-push graph facts: accepted. D11 now names D3 graph/base/target facts for pre-push affected behavior and refuses unavailable required graph/target state instead of treating no-op or unresolved affected behavior as hook success (`proposal.md:80`, `proposal.md:111`, `design.md:150-165`, `spec.md:150-173`, `tasks.md:82-92`). This is consistent with D3's graph authority and non-claims (`deep-habitat-d3-workspace-graph-boundary/phase-record.md:14-24`, `phase-record.md:65-69`).
+- D8 conditional eligibility/admission: accepted. D11 does not make D8 a blanket source blocker. It requires D8 only if hook eligibility, pattern admission, hook scope, or local-feedback admission is consumed (`tasks.md:72-75`, `downstream-realignment-ledger.md:16`, `packet-index.md:31`). That matches D8's local-feedback-admitted lifecycle and prohibition on inferring hook eligibility from rule lane or metadata (`deep-habitat-d8-pattern-governance/design.md:90-94`, `proposal.md:121-125`).
+- G-HOST transitive relation: accepted. D11 keeps G-HOST transitive through D9/D10 projections unless D11 directly touches host-owned declarations, protected/generated path policy, or hook policy surfaces (`proposal.md:116`, `tasks.md:76-78`, `downstream-realignment-ledger.md:19`, `packet-index.md:31`). That preserves G-HOST's generic/host boundary (`deep-habitat-host-policy-boundary-gate/proposal.md:23-34`, `spec.md:3-13`).
+- D12 non-consumed: accepted. D11 records that D12 may observe D11 non-claims and trace boundaries but may not treat hook pass as verify handoff completion (`design.md:224-233`, `downstream-realignment-ledger.md:20`). D12 remains the verify handoff owner (`deep-habitat-d12-verify-handoff-receipt/spec.md:3-13`).
+- D15 dormant unless impossible local state is named: accepted. D11 triggers D15 only for a concrete local command/state observation that cannot be represented through D1/D3/D6/D7/D9/D10 projections (`design.md:228-231`, `downstream-realignment-ledger.md:21`). This matches D15's trigger-only contract (`deep-habitat-d15-execution-provenance-trigger/spec.md:3-13`).
+
+## Packet Index And Downstream State
+
+The packet index matches the repaired pre-acceptance disk state without overclaiming. The D11 row lists the repaired dependencies and says D11 is repaired after first-wave investigations, still requiring final per-domino rereview, not implementation-complete, and source-blocked behind concrete D0 rows, D1 handling, and live upstream projections (`packet-index.md:31`).
+
+After the workstream owner incorporates this final lane with the other required D11 final lanes, the D11 packet-index status can move to accepted for design/specification only. The index must keep the source blockers: concrete D0 rows, D1 output-family handling, live D3/D6/D7/D9/D10 projections where consumed, conditional D8 projection where consumed, and transitive G-HOST through D9/D10 unless D11 directly touches host-owned surfaces.
+
+Downstream realignment is actionable and does not imply implementation readiness. The D11 downstream ledger names D0, D1, D3, D6, D7, D8, D9, D10, G-HOST, D12, D15, Husky, tests, docs/examples, and packet index dispositions (`downstream-realignment-ledger.md:9-25`). It correctly says docs/tests/specs should update only after public-surface and implementation facts justify the change.
+
+## Findings
+
+### P1
+
+None.
+
+### P2
+
+None.
+
+### P3
+
+None.
+
+The absence of concrete D0 row artifacts is not a design/spec blocker for this lane because D11 now names it as a source implementation blocker rather than pretending rows exist (`proposal.md:131-149`, `tasks.md:17-23`, `phase-record.md:91-103`). The public-surface compatibility matrix file is absent in the active worktree, so source edits touching hook output, traces, exports, help, Husky delegators, docs/examples, or script/generated-help surfaces remain blocked.
+
+## Explicit Acceptance Statement
+
+Cross-domino/product lane accepts D11 for design/specification only, with no unresolved P1/P2 findings.
+
+This acceptance does not mean implementation-ready source state. D11 source work remains blocked behind concrete D0 rows and live upstream projections. Hook success remains local feedback only and does not prove CI, review approval, OpenSpec acceptance, Graphite readiness, safe apply completion, generated freshness, graph completeness, current-tree cleanliness, or product/runtime correctness.
+
+Skills used: domain-design, information-design, ontology-design, solution-design, system-design, team-design, testing-design, civ7-open-spec-workstream.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-final-domain-ontology-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-final-domain-ontology-review.md
@@ -1,0 +1,197 @@
+# D11 Final Domain/Ontology Rereview
+
+## Verdict
+
+Accepted for design/specification only.
+
+I found no unresolved P1/P2 domain or ontology blockers in the repaired D11
+OpenSpec packet. D11 is accepted for design/specification only, not
+implementation-complete. Source implementation remains blocked behind concrete
+D0 rows and live upstream projections.
+
+This acceptance is limited to the D11 Local Feedback domain model, naming,
+owner boundaries, state/trace ontology, and upstream consumption semantics. It
+does not authorize source edits, public surface changes, or claims that hook
+behavior is implemented.
+
+## Read Register
+
+Mandatory skills and references read in full:
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/axes.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/examples.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/maintenance.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/operationalization.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/principles.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/representation-choices.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/source-map.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/where-defaults-hide.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/SKILL.md`
+
+Required D11 and control inputs read:
+
+- `docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md`
+- `docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+- `docs/projects/habitat-harness/openspec-remediation/context.md`
+- every file under `openspec/changes/deep-habitat-d11-local-feedback/`
+- first-wave D11 scratch files:
+  - `domino-D11-domain-ontology-investigation.md`
+  - `domino-D11-typescript-state-investigation.md`
+  - `domino-D11-code-vendor-topology-investigation.md`
+  - `domino-D11-openspec-information-testing-investigation.md`
+  - `domino-D11-cross-domino-product-investigation.md`
+- current hook behavior inputs:
+  - `tools/habitat-harness/src/lib/hooks.ts`
+  - `tools/habitat-harness/test/lib/hooks.test.ts`
+
+Upstream/conditional packet sections read for relation checks:
+
+- D0 public-surface compatibility spec.
+- D1 hook trace, non-claim, compatibility, refusal/recovery spec.
+- D3 workspace graph target/refusal spec.
+- D6 diagnostic catalog, adapter failure, projection, consumer spec.
+- D7 structural enforcement and `LocalFeedbackCheckProjection` spec.
+- D8 local-feedback admission/eligibility spec.
+- D9 transformation transaction and downstream projection spec.
+- D10 protected/generated/host-zone guard and D11 local-feedback stop spec.
+- G-HOST host policy boundary gate spec.
+
+Commands run:
+
+- `git status --short --branch` confirmed branch `codex/d11-local-feedback-packet`
+  with existing repaired D11/control/scratch changes before this final scratch.
+- `bun run openspec -- validate deep-habitat-d11-local-feedback --strict`:
+  passed.
+- `bun run openspec:validate`: passed, 249 items.
+- `git diff --check`: passed.
+
+## Acceptance Basis
+
+### Domain Boundary
+
+D11 now defines Local Feedback as a bounded context for hook-time developer/agent
+feedback, not as structural, diagnostic, graph, protected-zone, transaction,
+CI, review, Graphite, OpenSpec, generated-freshness, or runtime/product
+authority. The repaired design states that current `hooks.ts` is input rather
+than the target model and that D11 consumes D6, D7, D9, D10, and D3 projections
+instead of parsing or recomputing their truth
+(`openspec/changes/deep-habitat-d11-local-feedback/design.md:5`,
+`:12`, `:17`). The domain boundary table assigns D11 only hook command,
+local-feedback rendering, resource readiness, staged workflow, and pre-push
+routing, while excluding adjacent truth domains (`design.md:39`-`:47`).
+
+### Ontology And Naming
+
+The packet now has explicit target terms for `LocalFeedbackTrace`/`HookTrace`,
+`HookStage`, `HookStageOutcome`, `ResourcePreCommitDecision`,
+`StagedPathDecision`, `PartialStagingRefusal`, `FormatterRestageDecision`,
+`LocalFeedbackCheckProjection`, `StagedDiagnosticProjection`,
+`TransactionLocalFeedbackProjection`, `ProtectedMutationLocalFeedback`, and
+`AffectedTargetFeedback` (`design.md:49`-`:64`). It also classifies or rejects
+legacy/inherited terms: legacy hook output is D0/D1 compatibility only,
+`allowPreCommit` is rejected as target state, raw Grit output is rejected as
+target D11 input, legacy authority wording is rejected unless preserved by a D0
+row, and hook `dry-run` requires explicit D0/D1 treatment (`design.md:66`-`:74`).
+
+### State And Stage Model
+
+The repaired resource state model is a discriminated decision whose commit
+allowance is derived from the variant, with allowed states, refused states, and
+inspection failure represented directly (`design.md:76`-`:97`; spec
+`openspec/changes/deep-habitat-d11-local-feedback/specs/habitat-harness/spec.md:22`-`:39`).
+Pre-commit and pre-push stage outcomes are explicit (`design.md:99`-`:132`),
+and the hook pipeline orders resource refusal, staged paths, D7/D10 structural
+feedback, partial staging, Biome, formatter restage, D6 diagnostics, D3 graph
+availability, and Nx affected invocation (`design.md:134`-`:165`).
+
+### Upstream Relations
+
+D11 now names the required upstream edges and prohibited inferences:
+D0 compatibility, D1 trace/non-claim vocabulary, D3 graph/affected facts, D6
+diagnostics, D7 `LocalFeedbackCheckProjection`, D9 transaction projections, D10
+protected mutation projections, and G-HOST only through D9/D10 where host-owned
+paths or host gates are touched (`proposal.md:105`-`:116`). D6/D7 diagnostic
+ownership is especially clear: D7 may mediate local-feedback labels, but D6
+remains diagnostic owner and D11 may not inspect raw Grit output or infer
+diagnostic truth from D7 internals (`proposal.md:118`-`:129`; spec `:60`-`:82`).
+
+Conditional D8 and G-HOST relations are sufficient for D11 design/spec:
+implementation must consume D8 only if hook eligibility, pattern admission, or
+local-feedback admission is part of the source slice (`tasks.md:66`-`:78`), and
+G-HOST remains transitive through D9/D10 unless D11 directly touches host-owned
+declarations or hook policy (`proposal.md:115`-`:116`; downstream ledger
+`workstream/downstream-realignment-ledger.md:16`-`:19`; packet index
+`docs/projects/habitat-harness/openspec-remediation/packet-index.md:31`).
+
+### Trace, Non-Claim, And False-Green Model
+
+D11 trace records are specified as local feedback records with ordered stage
+outcomes, consumed authority metadata, command records, terminal outcome,
+recovery text, and D1 non-claims (`spec.md:188`-`:200`). The packet makes hook
+pass impossible after missing required authority, contradictory upstream
+projection, diagnostic parse/adapter failure, protected-zone refusal, partial
+staging refusal, formatter/restage failure, or affected-target failure
+(`spec.md:202`-`:214`). Downstream packets may not cite D11 hook pass as CI,
+review, product, Graphite, OpenSpec, apply-safety, or runtime readiness
+(`design.md:224`-`:233`).
+
+### Public Compatibility And Implementation Blockers
+
+Public compatibility blockers are explicit and correctly scoped. D11 source
+implementation is blocked until concrete D0 rows classify hook commands, help,
+human output, Husky delegators, docs/examples, `runHook`, trace/schema/export
+surfaces, script/Nx output, and any new dry-run behavior (`proposal.md:131`-`:149`;
+`design.md:178`-`:188`; `spec.md:174`-`:186`). The task list also keeps source
+implementation blocked behind concrete D0 rows, D1 handling, and live D3/D6/D7/D9/D10
+projections (`tasks.md:7`-`:27`, `:123`-`:134`).
+
+## Current-Code Input Check
+
+The current hook code still has the old state-space and authority-risk shapes:
+`ResourceState.kind` plus `allowPreCommit` (`tools/habitat-harness/src/lib/hooks.ts:29`-`:43`),
+legacy hook notice wording (`hooks.ts:152`-`:155`), raw `CheckReport`/Grit parsing
+(`hooks.ts:371`-`:393`, `:802`-`:823`), and string-only pre-push base/target behavior
+(`hooks.ts:403`-`:433`, `:613`-`:640`). The repaired D11 packet correctly treats
+these as current-behavior input and later implementation targets, not as accepted
+D11 domain semantics (`design.md:12`-`:19`, `:167`-`:176`).
+
+The tests characterize existing behavior for resource refusal precedence,
+partial staging refusal, formatter-touched restage, malformed Grit fail-closed,
+pre-push base selection, and Nx affected failure
+(`tools/habitat-harness/test/lib/hooks.test.ts:16`-`:198`, `:200`-`:460`,
+`:463`-`:612`). D11 correctly records those tests as current/later validation
+inputs rather than design-time implementation proof (`proposal.md:189`-`:208`;
+`phase-record.md:78`-`:89`).
+
+## Findings
+
+No unresolved P1 findings.
+
+No unresolved P2 findings.
+
+No P3 domain/ontology findings requiring packet repair before
+design/specification acceptance. The retained first-wave scratch files still
+contain old blocking language, but the current phase record explicitly
+classifies them as negative repair input rather than acceptance input
+(`workstream/phase-record.md:43`-`:55`), and the review ledger records their
+accepted P1/P2 findings as repaired and accepted for design/specification
+after final rereview
+(`workstream/review-disposition-ledger.md:18`-`:38`).
+
+## Final Acceptance Statement
+
+D11 Local Feedback is accepted for design/specification only. It has a coherent
+Local Feedback ontology, owner boundary, target terms, compatibility/rejected
+terms, resource state model, hook stage/outcome model, trace/non-claim model,
+D6/D7/D9/D10/D3 consumption relations, conditional D8/G-HOST relations, and
+public compatibility blockers.
+
+D11 is not implementation-complete. Source implementation remains blocked behind
+concrete D0 rows and live upstream projections.
+
+Skills used: domain-design, information-design, ontology-design,
+solution-design, typescript-refactoring.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-final-openspec-information-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-final-openspec-information-review.md
@@ -1,0 +1,162 @@
+# D11 Final OpenSpec / Information Review
+
+## Verdict
+
+Accepted for design/specification only.
+
+I found no unresolved P1/P2 blockers in the current repaired D11 OpenSpec packet
+for the OpenSpec/information lane. D11 remains not implementation-complete and
+source implementation remains blocked behind concrete D0 rows, D1 output-family
+and non-claim handling, and live upstream projections for D3, D6, D7, D9, and
+D10 where the later implementation consumes those surfaces.
+
+This review does not accept source behavior, runtime behavior, hook
+implementation, CI readiness, Graphite readiness, OpenSpec closure, generated
+freshness, apply safety, or product/runtime correctness.
+
+## Read Register
+
+### Mandatory Skills
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/axes.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/principles.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/where-defaults-hide.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/representation-choices.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/operationalization.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/maintenance.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/examples.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/source-map.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/axes.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/principles/principles.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/principles/universal.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/principles/heuristics.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/defaults/where-defaults-hide.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/leaflet-software-testing.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/source-map.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/phase-loop.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/team-and-review-lanes.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/artifact-contracts.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/validation-checks.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/failure-patterns.md`
+
+### Repo And Packet Inputs
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/AGENTS.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/context.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+- Every file under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback`
+- First-wave D11 scratch files:
+  - `domino-D11-domain-ontology-investigation.md`
+  - `domino-D11-typescript-state-investigation.md`
+  - `domino-D11-openspec-information-testing-investigation.md`
+  - `domino-D11-cross-domino-product-investigation.md`
+  - `domino-D11-code-vendor-topology-investigation.md`
+
+## Evidence Checked
+
+- Worktree/branch observed: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation` on `codex/d11-local-feedback-packet`.
+- Graphite is installed (`gt` available); no staging or commit was performed.
+- Existing dirty state was already present in the repaired packet/control files and first-wave scratch files before this final scratch write.
+- `bun run openspec -- validate deep-habitat-d11-local-feedback --strict`: passed; OpenSpec shape only.
+- `bun run openspec:validate`: passed; full OpenSpec corpus shape only.
+- `git diff --check`: passed.
+
+## Acceptance Rationale
+
+The repaired proposal now frames D11 as the complete Local Feedback contract and
+keeps hook success scoped to local hook completion only. It names D6 staged
+diagnostic projections, D7 `LocalFeedbackCheckProjection`, D9
+local-feedback-safe transaction projection, D10 protected mutation projection,
+D3 graph target/base facts, D1 non-claims, and D0 compatibility rows as consumed
+or blocking inputs. It also blocks source implementation until D0 rows classify
+hook command behavior, human output, generated help, Husky delegators,
+docs/examples, `runHook`, and trace/schema surfaces.
+
+The repaired design defines the domain boundary, target terms, rejected
+compatibility terms, resource pre-commit decision model, pre-commit and pre-push
+outcome families, hook pipeline order, TypeScript refactoring application,
+public compatibility gates, validation split, downstream trigger model, and
+wording discipline. The resource state issue identified in the source packet is
+now addressed as a discriminated decision whose allowance must derive from the
+variant rather than an independent mutable boolean.
+
+The spec delta is now normative enough for implementation planning. It includes
+requirement families and scenarios for hook command entrypoints, resource
+decisions, closed pre-commit stage pipeline, D6 diagnostic projection
+consumption, D7 check projection consumption, D10 protected mutation refusals,
+partial staging and formatter restage boundaries, D9 transaction projections,
+D3 pre-push graph/base/affected feedback, public compatibility, trace records,
+and false-green refusal.
+
+The task list is now an executable later-implementation plan rather than a recap.
+It names preconditions, public-surface inventory, D0/D1 blockers, live upstream
+projection blockers, resource/trace model slices, pre-commit slices, D9/D8/G-HOST
+boundaries, pre-push slices, wording/public compatibility, validation gates, and
+closure/review responsibilities. It also rejects live-hook unsafe help gates and
+requires controlled fixtures plus before/after `git status` checks for commands
+that can write, stage, or inspect the worktree.
+
+The workstream records agree with the accepted design/specification state: D11
+is repaired after first-wave investigation and final rereview, is not
+implementation-complete, and source work remains blocked by D0/D1 and live
+upstream projection availability. The packet index and context agree on the
+active worktree/branch and keep source implementation blocked.
+
+## Wording Audit Classification
+
+I did not find active D11 packet/control guidance that authorizes reduced
+standard implementation, hidden compatibility lanes, unstated no-op behavior,
+broad restaging, raw diagnostic parsing as target authority, live-hook unsafe
+command gates, or generated-output hand edits.
+
+Broad literal scans still find:
+
+- modeled pre-push `fallback` states in active D11 artifacts, constrained as
+  local feedback with non-claims and D3 unavailable states blocking pass;
+- historical first-wave scratch text containing old repair recommendations and
+  blocking verdicts.
+
+I classify the first-wave scratch hits as historical repair-provenance and
+negative review input, not active D11 guidance. The active packet/control files
+state that those findings are incorporated, repaired, and accepted for
+design/specification after final rereview.
+
+## Findings
+
+### P1
+
+None.
+
+### P2
+
+None.
+
+### P3
+
+None.
+
+## Explicit Acceptance Statement
+
+D11 is accepted by this final OpenSpec/information review for
+design/specification only. There are no unresolved P1/P2 findings in this lane.
+
+D11 is not implementation-complete. Source implementation remains blocked behind:
+
+- concrete D0 rows for every touched hook public/durable surface;
+- D1 output-family and non-claim decisions for hook output and trace records;
+- live D3 graph/target/base facts required by pre-push affected feedback;
+- live D6 staged diagnostic projections for hook diagnostic local feedback;
+- live D7 `LocalFeedbackCheckProjection` for structural check local feedback;
+- live D9 transaction projection where hook feedback surfaces apply/fix state;
+- live D10 protected/generated/forbidden mutation projection;
+- D8 local-feedback eligibility projection if hook eligibility/admission is
+  consumed directly.
+
+No source implementation, packet-index acceptance movement, staging, or commit
+was performed by this review.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-final-typescript-validation-review.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-final-typescript-validation-review.md
@@ -1,0 +1,108 @@
+# D11 Final TypeScript/Validation Rereview
+
+Lane: TypeScript state-space and validation.
+
+Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation`
+
+Branch: `codex/d11-local-feedback-packet`
+
+Reviewed change: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback`
+
+## Read Register
+
+Mandatory anchoring read:
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/axes.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/examples.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/maintenance.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/operationalization.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/principles.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/representation-choices.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/source-map.md`
+- `/Users/mateicanavra/.agents/skills/ontology-design/references/where-defaults-hide.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/llm-slop-cleanup.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/paradigms-and-patterns.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/refactoring-mechanics.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/smell-catalog.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/worked-examples.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/assets/refactor-findings-template.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/assets/refactor-plan-template.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/axes.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/principles/principles.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/principles/universal.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/principles/axis-1-2-assurance-and-mode.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/principles/axis-3-4-legibility-and-discovery.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/principles/axis-5-6-evidence-and-speed.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/principles/heuristics.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/defaults/where-defaults-hide.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/defaults/problem-framing.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/defaults/execution.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/defaults/design-judgment.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/leaflet-software-testing.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/examples.md`
+
+Required packet and implementation inputs read:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/AGENTS.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/packet-index.md`
+- Every file under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback`
+- D11 first-wave scratch files under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-*.md`, excluding this final output
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/hooks.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/hooks.test.ts`
+- Accepted upstream packet sections for D0, D1, D3, D6, D7, D9, and D10, targeted to public compatibility blockers, non-claims, graph/affected facts, diagnostic projections, local-feedback check projections, transaction projections, and protected mutation projections.
+
+Repo state observed before review:
+
+- Active branch: `codex/d11-local-feedback-packet`
+- Existing uncommitted repaired packet/scratch changes were present before this final scratch write.
+- No source, packet, or control files were edited by this review.
+
+## Verdict
+
+Accepted for design/specification only.
+
+No unresolved P1/P2 TypeScript state-space or validation blockers remain in the current repaired D11 packet.
+
+D11 is not implementation-complete. Source implementation remains blocked behind concrete D0 compatibility rows, D1 output-family/non-claim handling, and live upstream projections/facts for the touched source slice: D3 graph/affected facts, D6 staged diagnostic projections, D7 `LocalFeedbackCheckProjection`, D9 local-feedback-safe transaction projection where surfaced, D10 protected/generated mutation projection, and D8 eligibility/admission only if consumed.
+
+## Acceptance Basis
+
+The repaired D11 design now collapses the relevant state space instead of preserving the current accidental states:
+
+- Resource commit allowance is no longer accepted as independent target state. `design.md` and `specs/habitat-harness/spec.md` require a discriminated resource decision where allowed/refused behavior derives from the variant, and legacy `allowPreCommit` can exist only as a compatibility projection.
+- Optional trace soup is not the target. D11 now defines ordered stage outcomes, terminal local feedback, consumed authority metadata, recovery text, and D1 non-claims, with legacy `HookTrace` handled through D0/D1 compatibility.
+- Raw diagnostic parsing is not a target. D11 requires D6 staged diagnostic projections directly or through D7 with D6 owner metadata; parsing raw Grit output, D7 human output, or diagnostic message text is rejected as target authority.
+- Hidden fallback pass is blocked. Required D3/D6/D7/D9/D10 authority being missing, malformed, unavailable, refused, or contradictory makes hook pass impossible for the required stage. Literal pre-push `main` fallback is constrained as local feedback only and cannot hide required graph/target unavailability.
+
+The implementation plan is ordered enough for later execution without inventing design decisions:
+
+- public surface inventory and D0/D1 compatibility first;
+- internal resource union and facade if needed;
+- target trace/stage outcome model;
+- pre-commit stage-local results;
+- D9/D8 boundary decisions only where consumed;
+- pre-push base/affected model;
+- public wording/docs compatibility;
+- behavior validation after the logical moves.
+
+The validation matrix separates design-time shape checks from later source behavior tests and names false-green scenarios explicitly: unavailable authority, protected mutation refusal, partial staging, formatter/restage failure, D6 diagnostic finding/unavailable states, D7 refusal, D9 projection refusal where consumed, D3 graph/target unavailable, Nx affected failure, unsupported hook/help behavior, and working-tree residue checks.
+
+## Findings
+
+No P1 findings.
+
+No P2 findings.
+
+No P3 findings recorded for this lane. Remaining risks are intentionally represented as source blockers, not design/specification blockers.
+
+## Acceptance Statement
+
+D11 may be treated as accepted for TypeScript/validation design/specification. This acceptance does not authorize source implementation until concrete D0 rows and live upstream projections are available for the touched surfaces and slices.
+
+Skills used: domain-design, information-design, ontology-design, typescript-refactoring, testing-design.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-openspec-information-testing-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-openspec-information-testing-investigation.md
@@ -1,6 +1,6 @@
 # D11 Local Feedback OpenSpec Information/Testing Investigation
 
-Status: investigation/review input only; not acceptance evidence and not a
+Status: investigation/review input only; not acceptance input and not a
 closure record.
 
 Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation`.
@@ -30,11 +30,11 @@ Live branch observed: `codex/d11-local-feedback-packet`.
 
 | Source | Read | Notes |
 | --- | --- | --- |
-| Source domino packet `$PHASE2_PACKET_DIR/D11-local-feedback.md` | full | Richer scenario inventory than current OpenSpec packet; still contains old proof vocabulary. |
+| Source domino packet `$PHASE2_PACKET_DIR/D11-local-feedback.md` | full | Richer scenario inventory than current OpenSpec packet; still contains old local-authority vocabulary. |
 | Current D11 packet `$OPENSPEC_CHANGES/deep-habitat-d11-local-feedback/**` | full | Proposal, design, spec, tasks, phase record, review ledger, downstream ledger, closure checklist. |
 | Packet index `$REMEDIATION_DIR/packet-index.md` | full | D11 remains incomplete/blocking; index currently lists D11 dependencies without D6. |
 | Current hook code `$HABITAT_TOOL/src/lib/hooks.ts` | full | Present behavior includes resource state, staged file-layer, partial staging, Biome, Grit JSON parsing, Graphite base, Nx affected, HookTrace. |
-| Current hook tests `$HABITAT_TOOL/test/lib/hooks.test.ts` | full | Current tests cover several D11 scenarios but still assert legacy `hook proof` wording. |
+| Current hook tests `$HABITAT_TOOL/test/lib/hooks.test.ts` | full | Current tests cover several D11 scenarios but still assert legacy hook notice wording. |
 | D0/D1/D6/D7/D9/D10 OpenSpec specs and targeted designs | read relevant full specs plus projection sections | Used to identify exact upstream projections and prohibited inferences. |
 | `$REMEDIATION_DIR/context.md` | read relevant section | Operational fixture has stale `$ACTIVE_REMEDIATION_BRANCH` value: `codex/d10-protected-zone-authority-packet`. |
 | Root `AGENTS.md` in active worktree | full | Confirms Graphite workflow, absolute `apply_patch` rule, hooks are local friction reduction while CI is authoritative. |
@@ -69,7 +69,7 @@ Blocking gaps:
 
 ### Design
 
-The design is a scaffold. It names the domain boundary and rejected alternative
+The design is underspecified. It names the domain boundary and rejected alternative
 but does not resolve enough decisions for implementation.
 
 Missing design decisions:
@@ -126,7 +126,7 @@ Tasks are not implementation slices. They are broad reminders.
 Problems:
 
 - 2.1 through 2.3 are design statements, not executable source/test slices.
-- No task names the exact later write set. At minimum, D11 must name
+- No task names the exact later write set. Required D11 write-set records include
   `$HABITAT_TOOL/src/lib/hooks.ts`, hook CLI entrypoint/command wiring if
   touched, `$HABITAT_TOOL/test/lib/hooks.test.ts`, any new test fixtures, and
   D0 matrix/docs surfaces before implementation.
@@ -156,7 +156,7 @@ Problems:
 
 ## Required Spec Requirement Families And Scenario List
 
-D11 needs a materially larger spec delta. The minimum complete requirement
+D11 needs a materially larger spec delta. The complete requirement
 families are below.
 
 ### 1. Hook Commands Are Local Feedback Entrypoints
@@ -296,7 +296,7 @@ Scenarios:
 
 - Any hook command, hook output, help text, `HookTrace`, exported type, docs
   example, or D0 plane touched by D11 cites concrete D0 surface rows.
-- Existing `hook proof` phrase is treated only as D1/D0 compatibility wording
+- Existing legacy hook notice phrase is treated only as D1/D0 compatibility wording
   whose target meaning is `local-feedback-only`.
 - Target code/product terms use checks, diagnostics, command records, receipts,
   decisions, transactions, outcomes, validation gates, and non-claims.
@@ -340,7 +340,7 @@ checks passed.
 | Nx affected failure | existing pre-push test | exit follows Nx nonzero; outcome `affected-failed`; false-green impossible. |
 | Unknown hook/help | `bun run habitat hook -- --help`, `bun run habitat hook definitely-not-a-hook` or unit equivalent | help exits per D0 row; unknown exits nonzero with expected names and no passing trace. |
 | Public compatibility | D0 matrix validation plus D11 changed-surface audit | every changed hook output/trace/export/docs surface has D0 row and closed handling. |
-| Wording audit | `rg -n "proof|evidence|fallback|shim|temporary|dual path|silent skip|optional target|only if needed" $D11_CHANGE` | only historical/source critique or forbidden-language sections may match; target terms repaired. |
+| Wording audit | scan for legacy authority terms and shortcut terms in `$D11_CHANGE` | only source critique or forbidden-language sections may match; target terms repaired. |
 | OpenSpec shape | `bun run openspec -- validate deep-habitat-d11-local-feedback --strict` | exit 0; shape only, not implementation readiness. |
 | Full OpenSpec corpus | `bun run openspec:validate` | exit 0 before packet acceptance; shape only. |
 | Whitespace | `git diff --check` | exit 0 before commit/closure. |
@@ -352,15 +352,15 @@ validation after code changes.
 
 ## Wording Audit Concerns
 
-- Source D11 uses `proof` throughout. That is acceptable as historical input
+- Source D11 uses legacy authority wording throughout. That is acceptable as historical input
   only; target D11 packet language should use validation gates, command
   records, local feedback traces, outcomes, receipts, decisions, diagnostics,
   transactions, and non-claims.
-- Current D11 packet still says "present-behavior evidence" and "Repair
-  Evidence" in ledgers. For control artifacts this is tolerable if the word is
-  not target product vocabulary, but D11 should avoid carrying those words into
+- Current D11 packet still says "present-behavior input" and repair records
+  in ledgers. For control artifacts this is tolerable if the wording is
+  not target product vocabulary, but D11 should avoid carrying authority terms into
   hook output, type names, product docs, or target spec requirements.
-- Current hook code and tests still assert `hook proof: local feedback only; CI
+- Current hook code and tests still assert the legacy hook notice that says local feedback only and CI
   remains authoritative.` D1 treats this as a D0-classified compatibility
   phrase, not target meaning. D11 must either preserve through explicit D0 row
   or replace/version it through D0 handling.
@@ -375,10 +375,10 @@ validation after code changes.
 | ID | Finding | Why It Blocks | Required Repair |
 | --- | --- | --- | --- |
 | D11-P1-001 | D11 omits D6 as a direct consumed authority in proposal/requirements and has no D6 diagnostic scenarios. | Supervisor watchpoint requires D11 to explicitly consume D6 staged diagnostic projections. Without this, implementation can collapse diagnostic feedback into current hook Grit parsing or D7-only check output. | Add D6 to `Requires`; define D6 `DiagnosticRunOutcome` / hook-eligible diagnostic projection consumption; name D7 `LocalFeedbackCheckProjection` only as mediation, with prohibited inference that D7 owns D6 diagnostic truth. |
-| D11-P1-002 | Spec delta is too thin to be an implementation authority. | Two scenarios leave product/domain trade-offs to implementation: stage order, terminal states, upstream unavailable states, false-green refusal, public compatibility, and hook trace compatibility. | Replace with complete D11 requirement families and normative scenarios listed above. |
+| D11-P1-002 | Spec delta is underspecified as an implementation authority. | Two scenarios leave product/domain trade-offs to implementation: stage order, terminal states, upstream unavailable states, false-green refusal, public compatibility, and hook trace compatibility. | Replace with complete D11 requirement families and normative scenarios listed above. |
 | D11-P1-003 | False-green refusals are not normative. | Hook pass remains spec-representable after unavailable required authority, unparseable diagnostics, protected-zone refusal, partial staging, formatter/restage failure, or affected-target failure. | Add a false-green refusal requirement and focused scenarios/tests that make those pass states unrepresentable or validation-rejected. |
 | D11-P1-004 | Tasks are not executable slices and do not name write set/protected paths. | Later implementation would decide file ownership, sequencing, public compatibility, and validation oracles while coding. | Rewrite tasks into ordered slices with exact write set, protected paths, dependencies, and per-slice validation commands/oracles. |
-| D11-P1-005 | Public compatibility is deferred generically. | D0/D1 require hook output, help, HookTrace, exports, docs examples, and legacy proof wording to be classified before changes. | Add D0 matrix rows/gates as explicit pre-source blockers and task requirements; do not allow hook output/trace changes without D0 closed handling. |
+| D11-P1-005 | Public compatibility is deferred generically. | D0/D1 require hook output, help, HookTrace, exports, docs examples, and legacy hook notice wording to be classified before changes. | Add D0 matrix rows/gates as explicit pre-source blockers and task requirements; do not allow hook output/trace changes without D0 closed handling. |
 
 ### P2 Findings
 

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-openspec-information-testing-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-openspec-information-testing-investigation.md
@@ -1,0 +1,486 @@
+# D11 Local Feedback OpenSpec Information/Testing Investigation
+
+Status: investigation/review input only; not acceptance evidence and not a
+closure record.
+
+Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation`.
+Live branch observed: `codex/d11-local-feedback-packet`.
+
+## Source Authority Read Register
+
+### Mandatory Skills And References Read
+
+| Source | Read | Use In This Investigation |
+| --- | --- | --- |
+| `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md` | full | Single-owner domain boundary, authority overlap, seam and ambiguity tests. |
+| `/Users/mateicanavra/.agents/skills/information-design/SKILL.md` | full | Artifact hierarchy, reader task, traceability, signal/noise, current vs historical status. |
+| `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md` | full | Frame challenge, stakeholder/consumer fit, reversible vs high-commitment packet decisions. |
+| `/Users/mateicanavra/.agents/skills/testing-design/SKILL.md` | full | Falsification-first validation, oracle requirement, risk-proportional testing. |
+| `/Users/mateicanavra/.agents/skills/testing-design/references/principles/universal.md` | full | Falsification, explicit oracle, equivalence/boundaries, spec-gap detection. |
+| `/Users/mateicanavra/.agents/skills/testing-design/references/principles/heuristics.md` | full | Oracle decision tree, state-transition explosion rule, boundary testing rule. |
+| `/Users/mateicanavra/.agents/skills/testing-design/references/leaflet-software-testing.md` | full | Software test layering, contract tests, mutation of weak oracles, environment-independent checks. |
+| `/Users/mateicanavra/.agents/skills/testing-design/references/axes.md` | full | D11 validation posture: rigorous enough for local false-green prevention, binary command outcomes, fast feedback. |
+| `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/SKILL.md` | full | OpenSpec workstream loop, downstream spec role, shortcut-language refusal. |
+| `civ7-open-spec-workstream/references/source-map.md` | full | Authority order and OpenSpec artifact locations. |
+| `civ7-open-spec-workstream/references/artifact-contracts.md` | full | Proposal/design/spec/tasks contract and compaction-safe phase records. |
+| `civ7-open-spec-workstream/references/phase-loop.md` | full | Phase readiness, verification, downstream realignment, closure distinction. |
+| `civ7-open-spec-workstream/references/validation-checks.md` | full | Phase readiness checks, shortcut scan, closure validation. |
+
+### D11 Inputs Read
+
+| Source | Read | Notes |
+| --- | --- | --- |
+| Source domino packet `$PHASE2_PACKET_DIR/D11-local-feedback.md` | full | Richer scenario inventory than current OpenSpec packet; still contains old proof vocabulary. |
+| Current D11 packet `$OPENSPEC_CHANGES/deep-habitat-d11-local-feedback/**` | full | Proposal, design, spec, tasks, phase record, review ledger, downstream ledger, closure checklist. |
+| Packet index `$REMEDIATION_DIR/packet-index.md` | full | D11 remains incomplete/blocking; index currently lists D11 dependencies without D6. |
+| Current hook code `$HABITAT_TOOL/src/lib/hooks.ts` | full | Present behavior includes resource state, staged file-layer, partial staging, Biome, Grit JSON parsing, Graphite base, Nx affected, HookTrace. |
+| Current hook tests `$HABITAT_TOOL/test/lib/hooks.test.ts` | full | Current tests cover several D11 scenarios but still assert legacy `hook proof` wording. |
+| D0/D1/D6/D7/D9/D10 OpenSpec specs and targeted designs | read relevant full specs plus projection sections | Used to identify exact upstream projections and prohibited inferences. |
+| `$REMEDIATION_DIR/context.md` | read relevant section | Operational fixture has stale `$ACTIVE_REMEDIATION_BRANCH` value: `codex/d10-protected-zone-authority-packet`. |
+| Root `AGENTS.md` in active worktree | full | Confirms Graphite workflow, absolute `apply_patch` rule, hooks are local friction reduction while CI is authoritative. |
+
+### Commands Run
+
+| Command | Result | Interpretation |
+| --- | --- | --- |
+| `git -C $ACTIVE_REMEDIATION_WORKTREE status --short --branch` | clean on `codex/d11-local-feedback-packet` | Start state clean. |
+| `gt status` | clean worktree reported through Graphite/git | Graphite is present enough to use Graphite workflow later; no commit made here. |
+| `bun run openspec -- validate deep-habitat-d11-local-feedback --strict` | exit 0; change is valid | Shape validation passes only. It does not establish implementation readiness. |
+
+## Artifact-By-Artifact Critique
+
+### Proposal
+
+The proposal correctly frames D11 as local feedback rather than CI, verify,
+apply, or rule/check ownership. It is not implementation-ready.
+
+Blocking gaps:
+
+- `Requires` omits D6 even though the source packet, accepted D6 contract, and
+  supervisor watchpoint require D11 to consume D6 staged diagnostic projections.
+- `What Changes` says D7/D9/D10 only; it does not say D11 consumes D6
+  diagnostics directly or through a D7 `LocalFeedbackCheckProjection`.
+- The D3 pre-push note is useful, but it leaves pre-push behavior split between
+  D3, D7, D12, and D11 without naming the exact D11-owned hook local-feedback
+  scope vs graph/verify owners.
+- Verification gates include `habitat hook pre-commit -- --help`, but no
+  expected output/exit oracle, no `pre-push` help/unknown-hook oracle, and no
+  bad-case command gates for required false-green refusals.
+
+### Design
+
+The design is a scaffold. It names the domain boundary and rejected alternative
+but does not resolve enough decisions for implementation.
+
+Missing design decisions:
+
+- No hook stage state machine. The source packet requires a pipeline of local
+  feedback stages; the current design does not define stage order, terminal
+  outcomes, stage inputs, or which stage owns stopping.
+- No resource state union design. The source packet explicitly calls out
+  `ResourceState.kind` / `allowPreCommit` contradiction; current design does
+  not choose constructors or discriminated states.
+- No exact D6/D7/D9/D10 projection consumption. It says "consume D7/D9/D10"
+  but not the projection names, state families, prohibited inferences, or
+  unavailable-state behavior.
+- No public compatibility map. D0 requires hook output, human-output claims,
+  HookTrace, package exports, CLI hook surfaces, and docs examples to have rows
+  before source changes. D11 only says a disposition is needed later.
+- No staged mutation semantics for Git name-status actions, deleted files,
+  rename/copy pairs, partial staging, formatter touched paths, or restage
+  failures.
+- No state-space reduction plan for HookTrace and outcomes. Current trace can
+  record command phases, but the target design does not define which trace
+  states are compatibility-only vs target `LocalFeedbackTrace`.
+- No pre-push base resolution algorithm. It must be deterministic: explicit
+  base override, Graphite parent observation, merge-base fallback, and final
+  refusal/pass behavior when required authority is unavailable.
+
+### Spec Delta
+
+The spec delta has one broad requirement and two scenarios. That is insufficient
+for a D11 authority packet.
+
+Spec gaps:
+
+- It does not define D11-owned hook commands, hook-local feedback stages,
+  `LocalFeedbackTrace`/`HookTrace`, resource states, partial staging, restaging,
+  pre-push base resolution, or non-claims as normative requirements.
+- It has no normative scenario for D6 diagnostic finding, D6 diagnostic
+  adapter failure, D6 unavailable/refusal, or Grit diagnostic local feedback.
+- It has no normative scenario for D7 `LocalFeedbackCheckProjection`
+  unavailable/refusal.
+- It has no normative scenario for D9 transaction projection unavailable or
+  refused local feedback.
+- It has no normative scenario for D10 protected-zone/forbidden-artifact
+  refusals stopping the hook before Biome, Grit, generated publish, resource
+  publish, or restaging.
+- It has no false-green refusal requirement. A hook pass is still representable
+  after unavailable required authority, unparseable diagnostic output,
+  protected-zone refusal, partial staging, or affected-target failure.
+
+### Tasks
+
+Tasks are not implementation slices. They are broad reminders.
+
+Problems:
+
+- 2.1 through 2.3 are design statements, not executable source/test slices.
+- No task names the exact later write set. At minimum, D11 must name
+  `$HABITAT_TOOL/src/lib/hooks.ts`, hook CLI entrypoint/command wiring if
+  touched, `$HABITAT_TOOL/test/lib/hooks.test.ts`, any new test fixtures, and
+  D0 matrix/docs surfaces before implementation.
+- No protected path list. D11 must protect generated outputs, resources,
+  lockfiles, `dist/`, `mod/`, D6/D7/D9/D10 source redesign files unless a task
+  explicitly owns a projection-consumption seam.
+- No tasks for D6/D7/D9/D10 projection adapters, current HookTrace
+  compatibility, or D0/D1 public compatibility handling.
+- Validation tasks do not state oracles. They name commands but not expected
+  exit status, required output fragments, cache/freshness stance, bad-case
+  setup, or non-claims.
+
+### Workstream Ledgers And Control Files
+
+- `phase-record.md` has stale branch `codex/deep-habitat-openspec-remediation`;
+  live branch is `codex/d11-local-feedback-packet`.
+- `$REMEDIATION_DIR/context.md` has stale `$ACTIVE_REMEDIATION_BRANCH`:
+  `codex/d10-protected-zone-authority-packet`.
+- `review-disposition-ledger.md` correctly marks per-domino review blocking,
+  but it has no D11-specific findings yet.
+- `downstream-realignment-ledger.md` is too generic. It should name D6, D7,
+  D9, D10, D0/D1 public compatibility, current hook tests, docs/examples, and
+  packet index dependency repair.
+- `closure-checklist.md` separates design and later implementation, but it
+  does not include D11-specific upstream projection, false-green, wording, or
+  public compatibility closure gates.
+
+## Required Spec Requirement Families And Scenario List
+
+D11 needs a materially larger spec delta. The minimum complete requirement
+families are below.
+
+### 1. Hook Commands Are Local Feedback Entrypoints
+
+Scenarios:
+
+- `habitat hook pre-commit` runs configured local stages and emits canonical
+  D1 non-claims.
+- `habitat hook pre-push` runs pre-push local feedback without claiming CI,
+  review, Graphite readiness, OpenSpec acceptance, product/runtime behavior, or
+  apply safety.
+- Unsupported or missing hook name exits nonzero with expected-name message and
+  produces no passing trace.
+- Hook help output is public-surface compatible through D0 rows.
+
+### 2. Hook Stage State Machine Is Closed
+
+Scenarios:
+
+- Clean pre-commit passes only after all required stages return pass or
+  explicit not-applicable.
+- Resource-blocked state refuses before file-layer, Biome, Grit, publish, and
+  restage commands.
+- File-layer failed state stops before Biome, Grit, generated publish, resource
+  publish, or restaging.
+- Partial staging refusal stops before formatting/restaging.
+- Biome format failure stops before restage/check/Grit.
+- Formatter restage failure stops before Biome check/Grit.
+- Biome check failure stops before Grit.
+- Grit diagnostic finding produces local diagnostic feedback and nonzero hook
+  result.
+- Every terminal state maps to exactly one hook outcome and trace state.
+
+### 3. D6 Diagnostic Projection Consumption Is Explicit
+
+Scenarios:
+
+- D6 `DiagnosticRunOutcome.kind == "findings"` or hook-eligible diagnostic
+  projection renders at least one normalized diagnostic and cannot pass.
+- D6 clean diagnostic projection may contribute to pass only for that
+  diagnostic stage and does not imply current-tree cleanliness.
+- D6 adapter failures `tool-unavailable`, command failed/interrupted,
+  `GritNoJson`, `GritMalformedJson`, `GritSchemaDrift`,
+  `GritUnexpectedResultShape`, `projection-missed`,
+  `unexpected-diagnostic-identity`, or `cache-observation-missing` are
+  non-passing local feedback states.
+- D11 must not parse raw Grit JSON/text/process records or current hook message
+  text as target semantics.
+- D11 must not infer Pattern Governance, apply safety, hook sequencing, or
+  full current-tree cleanliness from a D6 diagnostic projection.
+
+If mediated through D7: D11 consumes D7 `LocalFeedbackCheckProjection` with
+kind `diagnostic-unavailable` or other check outcome labels. The prohibited
+inference is: treating `diagnostic-unavailable` as a D7-owned diagnostic domain,
+or treating D7's local-feedback-safe projection as a replacement for D6
+`DiagnosticRunOutcome` ownership.
+
+### 4. D7 Check Projection Consumption Is Explicit
+
+Scenarios:
+
+- D11 consumes `LocalFeedbackCheckProjection`, not D7 human output.
+- Projection `pass`, `advisory-only`, `fail`, `selector-refused`,
+  `dependency-refused`, `diagnostic-unavailable`, `baseline-refused`,
+  `protected-zone-refused`, and `not-applicable` have closed hook outcomes.
+- Any required selected-rule refusal or unavailable dependency blocks hook pass.
+- D7 projection non-claims are preserved in hook human output and trace.
+
+### 5. D10 Protected/Generated/Forbidden Refusals Stop Hook Work
+
+Scenarios:
+
+- D10-origin `ProtectedMutationGuardProjection` with
+  `refused-direct-generated-edit`, `refused-direct-protected-edit`,
+  `refused-forbidden-artifact`, `blocked-missing-host-declaration`,
+  `blocked-declaration-conflict`, malformed D2 projection, or unknown zone
+  reference blocks pre-commit.
+- D11 does not match protected paths locally to decide policy.
+- D10 refusal output includes repo-relative path/action, owner authority,
+  recovery instruction, and D1 non-claims.
+- Hook stops before Biome, Grit, generated publish, resource publish, or
+  restaging after D10-origin refusal.
+
+### 6. D9 Transaction Local Feedback Is Projection-Only
+
+Scenarios:
+
+- If D11 surfaces apply/fix local feedback, it consumes a D9 projection for
+  unavailable, refused, dry-run, applied, rolled-back, rollback-failed, or
+  recovery-required outcomes.
+- D9 projection unavailable/refused blocks any local success claim for the
+  apply/fix feedback stage.
+- D11 must not recompute apply safety from diagnostic findings, dry-run output,
+  changed paths, or formatter results.
+
+### 7. Resource State Is A Discriminated Union
+
+Scenarios:
+
+- `clean` allows pre-commit resource stage.
+- `not-configured` is a local non-claim pass only if D11 explicitly keeps that
+  behavior under D0/D1 compatibility.
+- `staged-gitlink` is allowed only when the submodule worktree is clean.
+- `dirty-submodule`, `unstaged-gitlink`, `locked`, `uninitialized`, and
+  inspection failure states refuse with recovery instructions.
+- State construction cannot represent `allowPreCommit: true` for refused
+  resource variants.
+
+### 8. Staged Paths, Partial Staging, Formatting, And Restage Are Bounded
+
+Scenarios:
+
+- Deleted, renamed, copied, added, and modified staged paths are normalized to
+  repo-relative path/action facts.
+- Partially staged Biome-supported file refuses before formatting.
+- Biome format failure blocks pass.
+- Restage command failure blocks pass.
+- Only formatter-touched staged paths are restaged.
+- Formatter or restage must not alter protected paths outside the stage policy.
+
+### 9. Pre-Push Base And Affected Targets Are Local Feedback
+
+Scenarios:
+
+- Explicit base override is used without Graphite probing.
+- Graphite parent, when available, is observed as local base state only.
+- Merge-base fallback is used only under the specified priority.
+- Required pre-push base authority unavailable/refused cannot be a silent pass
+  if D11 chooses to make that authority required.
+- Nx affected nonzero exit maps to `affected-failed` and blocks hook pass.
+- Pre-push pass does not claim CI, Graphite readiness, OpenSpec acceptance, or
+  product/runtime behavior.
+
+### 10. Public Compatibility And Legacy Wording Are Controlled
+
+Scenarios:
+
+- Any hook command, hook output, help text, `HookTrace`, exported type, docs
+  example, or D0 plane touched by D11 cites concrete D0 surface rows.
+- Existing `hook proof` phrase is treated only as D1/D0 compatibility wording
+  whose target meaning is `local-feedback-only`.
+- Target code/product terms use checks, diagnostics, command records, receipts,
+  decisions, transactions, outcomes, validation gates, and non-claims.
+
+### 11. False-Green Refusal Is Normative
+
+Scenarios:
+
+- Hook pass cannot occur after unavailable required authority.
+- Hook pass cannot occur after unparseable diagnostic output.
+- Hook pass cannot occur after D6 adapter failure.
+- Hook pass cannot occur after D10 protected/generated/forbidden refusal.
+- Hook pass cannot occur after partial staging refusal.
+- Hook pass cannot occur after Biome format/restage/check failure.
+- Hook pass cannot occur after affected-target failure.
+- Hook pass cannot occur after contradictory `CheckReport` / local feedback
+  projection validation.
+
+## Validation Matrix With Command/Test Oracles
+
+This is a design for later implementation validation, not a record that those
+checks passed.
+
+| Scenario | Later Command/Test | Oracle |
+| --- | --- | --- |
+| Clean pre-commit local feedback | `bun run --cwd tools/habitat-harness test -- test/lib/hooks.test.ts -t "passes clean"` | exit 0; trace outcome `pass`; D1 non-claims present; no CI/apply/product claims. |
+| Resource-blocked | focused hook test for dirty/locked/uninitialized resources | exit 1; no file-layer/Biome/Grit/publish/restage calls; recovery instruction present. |
+| File-layer failed / D10 refusal | focused hook test with D7 `LocalFeedbackCheckProjection` carrying D10 refusal | exit 1; stops before Biome/Grit/restage; renders D10 owner/recovery without path-policy recomputation. |
+| D6 diagnostic finding | hook-stage unit/contract test with D6 findings projection | exit 1; renders at least one normalized diagnostic; no raw Grit parsing. |
+| D6 adapter unavailable/refusal | table test for `tool-unavailable`, `GritNoJson`, `GritMalformedJson`, schema drift, unexpected identity, projection miss | exit 1; terminal outcome is diagnostic unavailable/refused; false-green impossible. |
+| D7 projection unavailable/refusal | contract test for each `LocalFeedbackCheckProjection.kind` | only `pass` or allowed `advisory-only` can contribute to hook pass; refused/unavailable states block. |
+| D9 projection unavailable/refused | contract test for D9 local-feedback projection | D11 renders recovery/non-claims; never computes apply safety; unavailable/refused blocks success for that stage. |
+| Protected-zone refusal | hook test using `ProtectedMutationGuardProjection` or D7 projection `protected-zone-refused` | exit 1; no Biome/Grit/publish/restage; output stays local feedback. |
+| Partial staging | existing plus expanded test for supported and unsupported extensions | supported partial staged path exits 1 before format/restage; unsupported path behavior is explicitly specified. |
+| Biome format/check failure | focused tests for nonzero formatter/check | nonzero hook result; later stages not run after failure. |
+| Restage failure | focused test where `git add --` fails | nonzero hook result; trace outcome `formatter-restage-failed`; no Grit. |
+| Grit diagnostic local feedback | focused test with D6/D7 projection rather than parsed message text | finding blocks pass and local output includes diagnostic owner/recovery if present. |
+| Pre-push explicit base | existing pre-push test | explicit base used; Graphite/merge-base not probed; non-claims present. |
+| Pre-push Graphite parent | existing/expanded pre-push test | Graphite parent observed as base; not PR readiness. |
+| Pre-push fallback unavailable | new test for Graphite and merge-base unavailable | either specified fallback to `main` with non-claim or explicit refusal; no silent success if authority is required. |
+| Nx affected failure | existing pre-push test | exit follows Nx nonzero; outcome `affected-failed`; false-green impossible. |
+| Unknown hook/help | `bun run habitat hook -- --help`, `bun run habitat hook definitely-not-a-hook` or unit equivalent | help exits per D0 row; unknown exits nonzero with expected names and no passing trace. |
+| Public compatibility | D0 matrix validation plus D11 changed-surface audit | every changed hook output/trace/export/docs surface has D0 row and closed handling. |
+| Wording audit | `rg -n "proof|evidence|fallback|shim|temporary|dual path|silent skip|optional target|only if needed" $D11_CHANGE` | only historical/source critique or forbidden-language sections may match; target terms repaired. |
+| OpenSpec shape | `bun run openspec -- validate deep-habitat-d11-local-feedback --strict` | exit 0; shape only, not implementation readiness. |
+| Full OpenSpec corpus | `bun run openspec:validate` | exit 0 before packet acceptance; shape only. |
+| Whitespace | `git diff --check` | exit 0 before commit/closure. |
+
+Design-time gates are the packet repair review, strict OpenSpec validation,
+wording audit, and review-ledger disposition. Later implementation gates are
+source tests, hook command probes, D0 matrix checks, and source/corpus
+validation after code changes.
+
+## Wording Audit Concerns
+
+- Source D11 uses `proof` throughout. That is acceptable as historical input
+  only; target D11 packet language should use validation gates, command
+  records, local feedback traces, outcomes, receipts, decisions, diagnostics,
+  transactions, and non-claims.
+- Current D11 packet still says "present-behavior evidence" and "Repair
+  Evidence" in ledgers. For control artifacts this is tolerable if the word is
+  not target product vocabulary, but D11 should avoid carrying those words into
+  hook output, type names, product docs, or target spec requirements.
+- Current hook code and tests still assert `hook proof: local feedback only; CI
+  remains authoritative.` D1 treats this as a D0-classified compatibility
+  phrase, not target meaning. D11 must either preserve through explicit D0 row
+  or replace/version it through D0 handling.
+- The proposal includes shortcut terms only as forbidden strategy, which is
+  acceptable. The repaired packet should keep shortcut terms out of allowed
+  implementation tasks.
+
+## Findings
+
+### P1 Findings
+
+| ID | Finding | Why It Blocks | Required Repair |
+| --- | --- | --- | --- |
+| D11-P1-001 | D11 omits D6 as a direct consumed authority in proposal/requirements and has no D6 diagnostic scenarios. | Supervisor watchpoint requires D11 to explicitly consume D6 staged diagnostic projections. Without this, implementation can collapse diagnostic feedback into current hook Grit parsing or D7-only check output. | Add D6 to `Requires`; define D6 `DiagnosticRunOutcome` / hook-eligible diagnostic projection consumption; name D7 `LocalFeedbackCheckProjection` only as mediation, with prohibited inference that D7 owns D6 diagnostic truth. |
+| D11-P1-002 | Spec delta is too thin to be an implementation authority. | Two scenarios leave product/domain trade-offs to implementation: stage order, terminal states, upstream unavailable states, false-green refusal, public compatibility, and hook trace compatibility. | Replace with complete D11 requirement families and normative scenarios listed above. |
+| D11-P1-003 | False-green refusals are not normative. | Hook pass remains spec-representable after unavailable required authority, unparseable diagnostics, protected-zone refusal, partial staging, formatter/restage failure, or affected-target failure. | Add a false-green refusal requirement and focused scenarios/tests that make those pass states unrepresentable or validation-rejected. |
+| D11-P1-004 | Tasks are not executable slices and do not name write set/protected paths. | Later implementation would decide file ownership, sequencing, public compatibility, and validation oracles while coding. | Rewrite tasks into ordered slices with exact write set, protected paths, dependencies, and per-slice validation commands/oracles. |
+| D11-P1-005 | Public compatibility is deferred generically. | D0/D1 require hook output, help, HookTrace, exports, docs examples, and legacy proof wording to be classified before changes. | Add D0 matrix rows/gates as explicit pre-source blockers and task requirements; do not allow hook output/trace changes without D0 closed handling. |
+
+### P2 Findings
+
+| ID | Finding | Impact | Required Repair |
+| --- | --- | --- | --- |
+| D11-P2-001 | D9 consumption is named but not designed. | If D11 surfaces apply/fix local feedback, implementation may parse legacy transaction objects or infer apply safety. | Define D9 local-feedback-safe transaction projection states and D11 non-ownership. If D11 will not surface D9 in this slice, explicitly carve it out and remove/adjust dependency claims. |
+| D11-P2-002 | Pre-push graph and affected-target boundary is ambiguous. | D11 may accidentally own graph truth, verify semantics, or D12 affected-target receipt behavior. | Define D11 pre-push as local feedback only; name D3/D7/D12 ownership and D11's exact base-resolution and Nx-result rendering responsibilities. |
+| D11-P2-003 | Resource state design from source packet is absent. | Existing `kind` + `allowPreCommit` contradiction remains a known invalid-state risk. | Add discriminated resource states and constructor/oracle scenarios. |
+| D11-P2-004 | Current control files have stale branch metadata. | Continuity records can misroute later agents. | Repair `workstream/phase-record.md` branch to `codex/d11-local-feedback-packet`; update `$REMEDIATION_DIR/context.md` operational fixture if that file is in scope for packet/control edits. |
+| D11-P2-005 | Downstream realignment ledger is generic. | Consumers cannot see which D6/D7/D9/D10/D0/D1 assumptions changed or need no-patch disposition. | Add explicit rows for D6 diagnostic projections, D7 local-feedback projection, D9 transaction projection, D10 local feedback/guard projections, D0/D1 public compatibility, hook tests/docs, and packet index D6 dependency. |
+
+### P3 Findings
+
+| ID | Finding | Repair |
+| --- | --- | --- |
+| D11-P3-001 | `design.md` says "Affected owners" and "Adjacent domains consume this packet" but does not include a compact upstream/downstream projection table. | Add one table naming owner, D11 consumes, D11 must not infer, and source blocker. |
+| D11-P3-002 | Validation gates in proposal/phase record do not separate design-time from implementation-time gates. | Split into `Design packet gates` and `Later implementation gates`. |
+| D11-P3-003 | `openspec validate` passes, which could be misread as readiness. | Record in phase/closure language that strict validation is shape validation only. |
+
+## Repair Recommendations By Artifact
+
+### `proposal.md`
+
+- Add D6 to `Requires`.
+- Replace `Consume D7/D9/D10 decisions` with explicit D6/D7/D9/D10 projection
+  consumption.
+- Add public compatibility blockers for hook commands, help, human output,
+  `HookTrace`/`LocalFeedbackTrace`, package exports, docs examples, and legacy
+  wording.
+- Split verification gates into design-time and later implementation gates with
+  expected outcomes.
+
+### `design.md`
+
+- Add a stage state machine table: stage, input projection, owner, pass
+  condition, refusal condition, terminal outcome, trace fields, next stage.
+- Add upstream projection table:
+  - D6: `DiagnosticRunOutcome` / diagnostic consumer projection; no Pattern
+    Governance, apply safety, raw Grit, or hook sequencing inference.
+  - D7: `LocalFeedbackCheckProjection`; no human-output parsing or D6/D10
+    authority absorption.
+  - D9: local-feedback-safe transaction projection; no apply-safety
+    recomputation.
+  - D10: `ProtectedMutationGuardProjection`, `ForbiddenArtifactProjection`,
+    D7-rendered protected-zone refusal; no local path-policy matching.
+- Add resource-state discriminated union and invalid-state rejection.
+- Add pre-push base priority and affected-target failure handling.
+- Add D0/D1 public compatibility plan and exact target language decisions.
+
+### `specs/habitat-harness/spec.md`
+
+- Replace the current broad requirement with the requirement families and
+  scenario list above.
+- Include normative false-green refusal scenarios.
+- Include mediated-D6-through-D7 wording that names the projection and
+  prohibited inference.
+- Include public compatibility and non-claim scenarios.
+
+### `tasks.md`
+
+Rewrite into slices such as:
+
+1. D0/D1 compatibility rows for D11 surfaces.
+2. D6 diagnostic projection consumption adapter/tests.
+3. D7 `LocalFeedbackCheckProjection` consumption adapter/tests.
+4. D10 protected/forbidden refusal hook sequencing tests.
+5. Resource state union and constructor tests.
+6. Partial staging/Biome/restage stage tests.
+7. Pre-push base/affected local feedback tests.
+8. Hook output/trace compatibility and wording audit.
+9. Docs/examples/downstream realignment.
+10. Final design and implementation validation gates.
+
+Each slice should include write set, protected paths, expected test command,
+oracle, and non-claims.
+
+### Workstream Files
+
+- Repair stale branch in `workstream/phase-record.md`.
+- Consider repairing `$REMEDIATION_DIR/context.md` operational fixture branch
+  during control-file edits.
+- Add D11-specific findings to `review-disposition-ledger.md` when accepted by
+  the workstream owner.
+- Expand downstream ledger rows as described above.
+- Add false-green, D6/D7/D9/D10 projection, public compatibility, and wording
+  gates to closure checklist.
+
+## Verdict
+
+D11 is blocking.
+
+The packet is OpenSpec-shape valid, but it is not implementation-ready. It still
+allows later implementation agents to decide product/domain trade-offs,
+validation oracles, upstream projection ownership, false-green behavior, public
+compatibility handling, and target wording.
+
+The highest-priority ambiguity is D6: D11 must explicitly consume D6 staged
+diagnostic projections. D7's `LocalFeedbackCheckProjection` may mediate
+local-feedback-safe check rendering, but D11 must not collapse D6 diagnostic
+ownership into D7 or into current hook Grit parsing. Until that is repaired in
+proposal/design/spec/tasks and control files, D11 should not authorize source
+implementation.
+
+Skills used: domain-design, information-design, solution-design, testing-design,
+civ7-open-spec-workstream.

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-typescript-state-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-typescript-state-investigation.md
@@ -4,7 +4,7 @@ Investigation lane: TypeScript refactoring and state-space collapse.
 
 Verdict: blocking. The current D11 OpenSpec packet is not implementation-ready. Later execution would still have to decide the concrete local hook state model, public compatibility treatment, write set, and validation oracle. Those are design authority decisions, not implementation details.
 
-This document is review input only. It is not acceptance evidence, does not update the packet index, and does not close D11.
+This document is review input only. It is not acceptance input, does not update the packet index, and does not close D11.
 
 ## Source Authority Read Register
 
@@ -62,8 +62,8 @@ Live implementation inputs read:
 
 Important authority facts:
 
-- D11 owns local hook feedback only. It does not own CI proof, review proof, OpenSpec acceptance, generated/protected-zone policy, Grit semantics, transformation safety, or Nx graph authority.
-- D1 owns canonical target naming, non-claims, and public-surface compatibility routing. D1 names `HookTrace` / `LocalFeedbackTrace` as local feedback traces, not proof artifacts.
+- D11 owns local hook feedback only. It does not own CI readiness, review readiness, OpenSpec acceptance, generated/protected-zone policy, Grit semantics, transformation safety, or Nx graph authority.
+- D1 owns canonical target naming, non-claims, and public-surface compatibility routing. D1 names `HookTrace` / `LocalFeedbackTrace` as local feedback traces, not authority artifacts.
 - D6 owns diagnostic pattern acquisition/projection. D11 must consume diagnostic outcomes; it must not interpret raw Grit output or message text as semantic authority.
 - D7 owns structural enforcement and local-feedback-safe check projection. D11 may decide hook sequencing and staged-file handling, but must consume D7 projection rather than parse D7 human output.
 - D9 owns apply/fix transaction semantics. D11 may only consume D9 local-feedback-safe outcomes.
@@ -196,11 +196,10 @@ Current symbols:
 
 D1 identifies `HookTrace` / `LocalFeedbackTrace` as a target family, and D0 controls public compatibility. The D11 packet does not yet decide whether current exported types are target contracts, legacy public compatibility, or implementation internals. It also does not cite D0 rows for changing the human output string:
 
-```ts
-hook proof: local feedback only; CI remains authoritative.
-```
+The current implementation emits a legacy local-feedback notice that includes
+old authority vocabulary.
 
-The word "proof" is target-hostile even though D1 records it as an existing compatibility phrase. D11 must not silently change it without D0 authority, but it also must not bless it as target terminology.
+That legacy vocabulary is target-hostile even though D1 records it as an existing compatibility phrase. D11 must not silently change it without D0 authority, but it also must not bless it as target terminology.
 
 ### P2: Repeated Branching Instead Of Stage Model
 
@@ -261,9 +260,9 @@ Current symbol:
 
 - `const prePushTargets = ["biome:ci", "boundaries", "grit:check", "habitat:check", "test"]`
 
-D11 can define that pre-push runs a local affected feedback command, but it should not become the canonical owner of Nx target availability or graph dependency truth. That authority belongs to D3/Nx workspace integration and owning package targets. The D11 packet should require target selection to be consumed from accepted upstream graph/command contracts or explicitly mark this list as local hook configuration, not proof of graph coverage.
+D11 can define that pre-push runs a local affected feedback command, but it should not become the canonical owner of Nx target availability or graph dependency truth. That authority belongs to D3/Nx workspace integration and owning package targets. The D11 packet should require target selection to be consumed from accepted upstream graph/command contracts or explicitly mark this list as local hook configuration, not graph coverage authority.
 
-### P3: Proof-Shaped Names In Local Feedback Code
+### P3: Legacy Authority Names In Local Feedback Code
 
 Current symbol:
 
@@ -488,7 +487,7 @@ D11 should require these slices in order. Each slice has a compiler/test gate be
    - Gate: explicit base, Graphite parent, merge-base `main`, merge-base `origin/main`, literal `main`, and Nx affected failure tests.
 
 8. Delete compatibility-only shapes only after D0 permits it.
-   - Remove `allowPreCommit` from target code, proof-shaped names, and legacy optional DTO fields only when public compatibility has a documented preserve/version/facade/deprecate decision.
+   - Remove `allowPreCommit` from target code, legacy authority-shaped names, and legacy optional DTO fields only when public compatibility has a documented preserve/version/facade/deprecate decision.
    - Gate: D0 rows plus hook tests plus OpenSpec validation.
 
 ## Allowed Write And Protected Path Recommendations
@@ -549,7 +548,7 @@ File-layer and protected/generated-zone stops:
 
 - D10-origin refusal stops before Biome, Grit, generated publish, resource publish, and restage
 - D11 consumes D7/D10 local-feedback-safe projection rather than parsing text
-- generated/protected-zone refusal remains local feedback, not CI proof or generated freshness proof
+- generated/protected-zone refusal remains local feedback, not CI readiness or generated freshness authority
 
 Grit/Biome/Nx command results:
 
@@ -575,7 +574,7 @@ Trace and public compatibility:
 - every terminal state includes D1 non-claims
 - target trace stage sequence is closed and exhaustively matched
 - compatibility trace, if retained, exactly matches current public tests
-- human output does not add new proof claims
+- human output does not add new external-authority claims
 - any output text or exported DTO change has a D0 compatibility row
 
 Recommended gates after each logical move:
@@ -710,7 +709,7 @@ Add:
 
 - D11 is a state-space collapse and local-feedback contract repair.
 - D11 keeps Habitat generic and repo-local.
-- D11 does not create proof authority.
+- D11 does not create external authority.
 - D11 success means later implementation has no remaining decisions about state model, public compatibility, write set, or validation oracle.
 
 ### `design.md`

--- a/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-typescript-state-investigation.md
+++ b/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-typescript-state-investigation.md
@@ -1,0 +1,801 @@
+# D11 Local Feedback TypeScript State Investigation
+
+Investigation lane: TypeScript refactoring and state-space collapse.
+
+Verdict: blocking. The current D11 OpenSpec packet is not implementation-ready. Later execution would still have to decide the concrete local hook state model, public compatibility treatment, write set, and validation oracle. Those are design authority decisions, not implementation details.
+
+This document is review input only. It is not acceptance evidence, does not update the packet index, and does not close D11.
+
+## Source Authority Read Register
+
+Read in full:
+
+- `/Users/mateicanavra/.agents/skills/domain-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/information-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/solution-design/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/smell-catalog.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/refactoring-mechanics.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/paradigms-and-patterns.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/llm-slop-cleanup.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/references/worked-examples.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/assets/refactor-plan-template.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/typescript-refactoring/assets/refactor-findings-template.md`
+- `/Users/mateicanavra/.agents/skills/typescript/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/SKILL.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/principles/heuristics.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/principles/universal.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/principles/axis-3-4-legibility-and-discovery.md`
+- `/Users/mateicanavra/.agents/skills/testing-design/references/leaflet-software-testing.md`
+
+Repo and project authority read:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/AGENTS.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/README.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/process/GRAPHITE.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/FRAME.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/dra-takeover-frame.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/recovery-claim-ledger.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-habitat-dra-workstream/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-habitat-dra-workstream/references/authority-map.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/SKILL.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/source-map.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.agents/skills/civ7-open-spec-workstream/references/phase-loop.md`
+
+D11 and upstream packet inputs read:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/proposal.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/design.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/tasks.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/specs/habitat-harness/spec.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/workstream/phase-record.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/workstream/review-disposition-ledger.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/workstream/downstream-realignment-ledger.md`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/deep-habitat-d11-local-feedback/workstream/closure-checklist.md`
+- D1, D6, D7, D9, and D10 OpenSpec packet directories under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/openspec/changes/`
+
+Live implementation inputs read:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/hooks.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/hooks.test.ts`
+
+Important authority facts:
+
+- D11 owns local hook feedback only. It does not own CI proof, review proof, OpenSpec acceptance, generated/protected-zone policy, Grit semantics, transformation safety, or Nx graph authority.
+- D1 owns canonical target naming, non-claims, and public-surface compatibility routing. D1 names `HookTrace` / `LocalFeedbackTrace` as local feedback traces, not proof artifacts.
+- D6 owns diagnostic pattern acquisition/projection. D11 must consume diagnostic outcomes; it must not interpret raw Grit output or message text as semantic authority.
+- D7 owns structural enforcement and local-feedback-safe check projection. D11 may decide hook sequencing and staged-file handling, but must consume D7 projection rather than parse D7 human output.
+- D9 owns apply/fix transaction semantics. D11 may only consume D9 local-feedback-safe outcomes.
+- D10 owns protected/generated-zone mutation authority. D11 must stop before downstream stages when D10-origin file-layer refusal is reported.
+- The D0 public compatibility matrix path described by upstream docs was not present in this worktree. Therefore public output and exported DTO changes remain blocked unless D11 requires preserving/facading legacy surfaces or first lands the missing D0 rows.
+
+## Current Code Topology Summary
+
+Current hook source:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/hooks.ts`
+
+Current hook tests:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/hooks.test.ts`
+
+The source is a single 878-line hook module. The tests are a single 834-line hook test module. The source currently mixes these concerns:
+
+- public hook entrypoints: `runHook`, `runPreCommit`, `runPrePush`
+- command execution abstraction: `HookRuntime`, `HookCommandRecord`, `runCommandRecord`
+- reporter abstraction: `HookReporter`, `createStdoutReporter`, `createMemoryReporter`
+- resource publishing abstraction: `ResourcePublisher`, `createResourcePublisher`
+- resource submodule classification: `classifyResourcesState`, `readGitmodules`, `submoduleStatus`, `detectUnstagedGitlink`, `detectStagedGitlink`, `resourceFailure`
+- local pre-commit sequencing: staged path discovery, file-layer check, partial staging detection, Biome format/check, formatter restage, Grit check
+- Grit/CheckReport interpretation: `parseCheckReport`, `hasGritAdapterParseFailure`
+- pre-push base and affected target behavior: `resolvePrePushBase`, `graphiteParent`, `mergeBase`, `prePushTargets`
+- trace construction: `PreCommitTrace`, `PrePushTrace`, `HookTrace`
+
+The tests already characterize several critical behaviors:
+
+- clean resources pass pre-commit
+- dirty resources fail before file-layer, Biome, Grit, or resource publishing
+- missing or uninitialized resource submodule states refuse pre-commit
+- staged resource gitlink is allowed
+- dirty submodule state takes precedence over staged gitlink state
+- `not-configured` resources are allowed
+- pre-commit does not invoke resource publishing implicitly
+- generated/protected file-layer failure stops before Biome/Grit/publish
+- partial staging refuses before format/restage/Grit
+- formatter restage stages only formatter-touched paths
+- malformed Grit JSON and Grit findings fail closed
+- pre-push chooses explicit base, Graphite parent, merge-base fallback, or literal `main`
+- Nx affected failures propagate
+- trace and reporter injection are characterized
+
+Those tests are valuable characterization tests. They are not enough to make D11 implementation-ready, because the packet does not yet define the target state model or compatibility facade that the implementation should converge toward.
+
+## TypeScript Smell Catalog Against Current Symbols
+
+### P1: Correlated Flag And Kind
+
+Current symbols:
+
+- `type ResourceStateKind`
+- `interface ResourceState`
+- `ResourceState.allowPreCommit`
+- `classifyResourcesState`
+- `resourceFailure`
+- `runPreCommit`
+
+Current shape:
+
+```ts
+interface ResourceState {
+  readonly kind: ResourceStateKind;
+  readonly allowPreCommit: boolean;
+  readonly detail: string;
+  readonly remediation: readonly string[];
+}
+```
+
+The smell is correlated boolean plus kind. A value can represent impossible states such as `{ kind: "dirty-submodule", allowPreCommit: true }` or `{ kind: "clean", allowPreCommit: false }`. The constructors currently avoid some contradictions by convention, but the type permits them. D11 must collapse this state space with a discriminated union and derive commit allowance from the variant.
+
+Safe move: introduce a target resource gate union with constructors, then adapt to the legacy `ResourceState` shape only if public compatibility requires it.
+
+### P1: Optional Property Soup In Trace DTOs
+
+Current symbols:
+
+- `interface PreCommitTrace`
+- `interface PrePushTrace`
+- `export type HookTrace`
+- `PreCommitOutcome`
+- `PrePushOutcome`
+
+Current traces store terminal outcome as a separate union while many fields are optional or meaningful only for some outcomes:
+
+- `preState?`
+- `postState?`
+- `endedAtMs?`
+- `durationMs?`
+- `resourceState?`
+- `base?`
+- arrays whose meaning depends on `outcome`
+
+The smell is temporal optional state. The type does not encode which fields exist at each lifecycle point or which stage produced a refusal/failure. D11 should define a closed local feedback trace with stage results, terminal state, and D1 non-claims. If the existing exported shape is public, D11 must require a compatibility projection rather than mutate it without D0 authority.
+
+### P1: Hook Code Reinterprets Upstream Authority
+
+Current symbols:
+
+- `parseCheckReport`
+- `hasGritAdapterParseFailure`
+- `runPreCommit`
+- `CheckReport`
+- `DiagnosticSummary`
+
+The current code parses `CheckReport` and identifies malformed Grit output by regex over diagnostic messages:
+
+```ts
+message: /native Grit emitted malformed JSON/i
+message: /native Grit did not emit JSON/i
+message: /Failed to parse native Grit JSON/i
+```
+
+This is a D6/D7 authority leak. It makes D11 local hook behavior depend on diagnostic wording rather than accepted diagnostic/check projections. D11 should specify that hooks consume typed D6/D7 projection outcomes and only preserve this regex path as a temporary compatibility bridge if upstream projection implementation is not yet available.
+
+### P1: Target Contract Versus Legacy Public Compatibility Is Undecided
+
+Current symbols:
+
+- `export type HookCommandPhase`
+- `export type PreCommitOutcome`
+- `export type PrePushOutcome`
+- `export interface HookCommandRecord`
+- `export interface PreCommitTrace`
+- `export interface PrePushTrace`
+- `export type HookTrace`
+- `localHookProofNotice`
+
+D1 identifies `HookTrace` / `LocalFeedbackTrace` as a target family, and D0 controls public compatibility. The D11 packet does not yet decide whether current exported types are target contracts, legacy public compatibility, or implementation internals. It also does not cite D0 rows for changing the human output string:
+
+```ts
+hook proof: local feedback only; CI remains authoritative.
+```
+
+The word "proof" is target-hostile even though D1 records it as an existing compatibility phrase. D11 must not silently change it without D0 authority, but it also must not bless it as target terminology.
+
+### P2: Repeated Branching Instead Of Stage Model
+
+Current symbols:
+
+- `runPreCommit`
+- `runPrePush`
+- `HookCommandPhase`
+- `PreCommitOutcome`
+- `PrePushOutcome`
+
+The current pre-commit function is a long procedural pipeline that manually pushes commands, mutates trace arrays, and returns terminal outcomes at many points. This is the "repeated branch means missing model" smell. D11 should not replace it with generic artifact machinery. It should define small local result records for each hook stage.
+
+Safe move: extract behavior-preserving stage functions only after each stage has a discriminated result type and tests.
+
+### P2: Inspection Failure Overloaded As Uninitialized Resource State
+
+Current symbols:
+
+- `ResourceStateKind`
+- `classifyResourcesState`
+- `resourceFailure`
+
+Several inspection failures are represented as `kind: "uninitialized"`:
+
+- missing resource root
+- non-worktree resource root
+- wrong top-level
+- `git-dir` inspection failure
+- submodule status command failure
+- unstaged/staged gitlink inspection command failure
+
+The source domino names an inspection-failure refused state. D11 should separate actual initialization problems from inspection failures. This reduces state ambiguity and improves recovery messages without changing the hook authority boundary.
+
+### P2: Pre-Push Base Is String-Only
+
+Current symbols:
+
+- `resolvePrePushBase`
+- `graphiteParent`
+- `mergeBase`
+- `PrePushTrace.base`
+- `PrePushTrace.commands`
+
+Current behavior chooses explicit base, Graphite parent, merge-base fallback, or literal `main`, but the target trace only preserves the chosen base string and command records. D11 needs a typed base decision:
+
+- explicit base
+- Graphite parent
+- merge-base with candidate provenance
+- literal `main` fallback
+- affected command failure surfaced separately
+
+D11 must also state how D3/Nx graph failures are surfaced. Literal `main` fallback is acceptable only as a local-feedback fallback with non-claims; it must not hide affected-target failures or graph authority gaps.
+
+### P2: Embedded Target List Can Become False Authority
+
+Current symbol:
+
+- `const prePushTargets = ["biome:ci", "boundaries", "grit:check", "habitat:check", "test"]`
+
+D11 can define that pre-push runs a local affected feedback command, but it should not become the canonical owner of Nx target availability or graph dependency truth. That authority belongs to D3/Nx workspace integration and owning package targets. The D11 packet should require target selection to be consumed from accepted upstream graph/command contracts or explicitly mark this list as local hook configuration, not proof of graph coverage.
+
+### P3: Proof-Shaped Names In Local Feedback Code
+
+Current symbol:
+
+- `localHookProofNotice`
+
+This is a naming smell. D11 target language should use "local feedback notice" or "local non-claim notice." If the emitted string is public compatibility, keep it through a facade until D0 permits renaming.
+
+## Target State Model
+
+D11 should specify target state as discriminated unions with constructors. Allowed behavior should be derived, never stored as a mutable or independently-set boolean.
+
+### Resource Gate
+
+Target internal model:
+
+```ts
+type ResourcePreCommitGate =
+  | {
+      readonly kind: "allowed";
+      readonly state: "clean" | "not-configured" | "staged-gitlink";
+      readonly detail: string;
+      readonly remediation: readonly [];
+    }
+  | {
+      readonly kind: "refused";
+      readonly state:
+        | "uninitialized"
+        | "locked"
+        | "dirty-submodule"
+        | "unstaged-gitlink"
+        | "inspection-failed";
+      readonly detail: string;
+      readonly remediation: NonEmptyReadonlyArray<ResourceRecoveryInstruction>;
+    };
+
+const allowsPreCommit = (gate: ResourcePreCommitGate): gate is Extract<ResourcePreCommitGate, { kind: "allowed" }> =>
+  gate.kind === "allowed";
+```
+
+Compatibility projection if current `ResourceState` is public:
+
+```ts
+type LegacyResourceState = {
+  readonly kind: ResourceStateKind;
+  readonly allowPreCommit: boolean;
+  readonly detail: string;
+  readonly remediation: readonly string[];
+};
+
+const toLegacyResourceState = (gate: ResourcePreCommitGate): LegacyResourceState => ({
+  kind: gate.state,
+  allowPreCommit: gate.kind === "allowed",
+  detail: gate.detail,
+  remediation: gate.remediation,
+});
+```
+
+D11 must decide whether `ResourceState` remains exported as legacy compatibility, is versioned, or is replaced by the target union. Without a D0 row, the safe packet requirement is: keep the old export as a facade and use the target union internally.
+
+### Hook Terminal State
+
+Target local hook terminal state:
+
+```ts
+type LocalFeedbackTerminal =
+  | {
+      readonly kind: "pass";
+      readonly nonClaims: NonEmptyReadonlyArray<D1NonClaimId>;
+    }
+  | {
+      readonly kind: "refused";
+      readonly reason: LocalFeedbackRefusalReason;
+      readonly recovery: NonEmptyReadonlyArray<RecoveryInstruction>;
+      readonly nonClaims: NonEmptyReadonlyArray<D1NonClaimId>;
+    }
+  | {
+      readonly kind: "failed";
+      readonly stage: LocalFeedbackStageId;
+      readonly command?: HookCommandRecord;
+      readonly recovery: readonly RecoveryInstruction[];
+      readonly nonClaims: NonEmptyReadonlyArray<D1NonClaimId>;
+    }
+  | {
+      readonly kind: "skipped";
+      readonly reason: LocalFeedbackSkipReason;
+      readonly nonClaims: NonEmptyReadonlyArray<D1NonClaimId>;
+    };
+```
+
+The terminal state should map to D1 closed feedback states: `pass`, `failed`, `refused`, and `skipped`. Current `PreCommitOutcome` and `PrePushOutcome` may remain compatibility enums, but the target contract should be terminal state plus stage result.
+
+### Pre-Commit Stage Results
+
+D11 should specify small local stage records, not a generic artifact framework:
+
+```ts
+type ResourceGateResult = ResourcePreCommitGate;
+
+type StagedPathSelection =
+  | { readonly kind: "none"; readonly stagedPaths: readonly [] }
+  | {
+      readonly kind: "selected";
+      readonly stagedPaths: NonEmptyReadonlyArray<string>;
+      readonly biomePaths: readonly string[];
+      readonly gritScanRoots: readonly string[];
+    };
+
+type FileLayerFeedbackResult =
+  | { readonly kind: "pass"; readonly projection: D7LocalFeedbackCheckProjection }
+  | { readonly kind: "refused"; readonly projection: D7LocalFeedbackCheckProjection }
+  | { readonly kind: "failed"; readonly command: HookCommandRecord; readonly projection?: D7LocalFeedbackCheckProjection };
+
+type PartialStagingDecision =
+  | { readonly kind: "clean"; readonly checkedPaths: readonly string[] }
+  | { readonly kind: "refused"; readonly partiallyStagedPaths: NonEmptyReadonlyArray<string> };
+
+type FormatterRestageDecision =
+  | { readonly kind: "no-candidates" }
+  | { readonly kind: "format-failed"; readonly command: HookCommandRecord }
+  | {
+      readonly kind: "restaged";
+      readonly formatterTouchedPaths: readonly string[];
+      readonly restagedPaths: readonly string[];
+    }
+  | { readonly kind: "restage-failed"; readonly command: HookCommandRecord; readonly attemptedPaths: readonly string[] }
+  | { readonly kind: "check-failed"; readonly command: HookCommandRecord }
+  | { readonly kind: "pass"; readonly formatterTouchedPaths: readonly string[] };
+
+type DiagnosticFeedbackResult =
+  | { readonly kind: "not-applicable"; readonly reason: "no-approved-scan-roots" }
+  | { readonly kind: "pass"; readonly projection: D6DiagnosticProjection | D7LocalFeedbackCheckProjection }
+  | { readonly kind: "findings"; readonly projection: D6DiagnosticProjection | D7LocalFeedbackCheckProjection }
+  | { readonly kind: "adapter-failed"; readonly projection: D6DiagnosticProjection | D7LocalFeedbackCheckProjection }
+  | { readonly kind: "parse-failed"; readonly projection: D6DiagnosticProjection | D7LocalFeedbackCheckProjection }
+  | { readonly kind: "command-failed"; readonly command: HookCommandRecord };
+```
+
+The exact imported names can differ, but the authority boundary cannot. D11 should say these records consume accepted upstream projections and do not derive protected-zone, diagnostic, or apply semantics locally.
+
+### Pre-Push Base And Affected Result
+
+Target pre-push base model:
+
+```ts
+type PrePushBaseDecision =
+  | { readonly kind: "explicit-base"; readonly base: string }
+  | { readonly kind: "graphite-parent"; readonly base: string; readonly command: HookCommandRecord }
+  | {
+      readonly kind: "merge-base";
+      readonly candidate: "main" | "origin/main";
+      readonly base: string;
+      readonly command: HookCommandRecord;
+    }
+  | {
+      readonly kind: "literal-main-fallback";
+      readonly base: "main";
+      readonly failedCandidates: readonly HookCommandRecord[];
+      readonly nonClaims: NonEmptyReadonlyArray<D1NonClaimId>;
+    };
+
+type AffectedFeedbackResult =
+  | { readonly kind: "pass"; readonly command: HookCommandRecord }
+  | { readonly kind: "failed"; readonly command: HookCommandRecord }
+  | {
+      readonly kind: "blocked";
+      readonly reason: "graph-facts-unavailable" | "target-contract-unavailable";
+      readonly recovery: NonEmptyReadonlyArray<RecoveryInstruction>;
+    };
+```
+
+D11 should allow explicit base, Graphite parent, merge-base fallback, and literal `main` fallback only as local feedback. Nx affected command failure must stay visible as `failed` or `blocked`; D11 must not turn graph failures into a successful local hook signal.
+
+### Hook Trace And Compatibility
+
+D11 should separate target trace from compatibility DTOs:
+
+- Target contract: `LocalFeedbackTrace`, with terminal state, ordered stage results, command records, D1 non-claims, and schema authority.
+- Legacy compatibility: existing `HookTrace`, `PreCommitTrace`, `PrePushTrace`, `PreCommitOutcome`, `PrePushOutcome`, and `HookCommandPhase`, unless D0 explicitly allows changing them.
+
+Recommended D11 rule:
+
+- If no D0 row exists for an exported hook type or human output line, implementation must preserve the old shape through a facade and build it from the target internal model.
+- If D0 rows are added, D11 may require versioning or deprecation, but not silent replacement.
+- The string currently named `localHookProofNotice` is legacy compatibility, not target language.
+
+## Behavior-Preserving Refactor Slices
+
+D11 should require these slices in order. Each slice has a compiler/test gate before the next slice starts.
+
+1. Public surface inventory and D0 check.
+   - Identify exported hook types, CLI output, JSON trace records, Husky hook entrypoints, docs examples, and package exports.
+   - Gate: no code behavior changes. D11 remains blocked if D0 rows are absent and the implementation would change public shape or text.
+
+2. Introduce internal resource gate union and constructors.
+   - Add target constructors for allowed/refused resource states.
+   - Keep existing `ResourceState` facade if public compatibility is unresolved.
+   - Replace direct construction in `classifyResourcesState`.
+   - Gate: hook tests, type check, and a new constructor/exhaustiveness test.
+
+3. Derive commit permission.
+   - Replace `resources.allowPreCommit` decisions with `allowsPreCommit(resourceGate)`.
+   - Keep `allowPreCommit` only in the legacy projection if required.
+   - Gate: hook tests prove no behavior drift for clean, staged gitlink, dirty submodule, unstaged gitlink, locked, uninitialized, and not-configured states.
+
+4. Add target local feedback trace builder.
+   - Build stage results and terminal state internally.
+   - Project to existing `HookTrace` until D0 authorizes a public shape change.
+   - Gate: existing trace tests plus new terminal-state/non-claim tests.
+
+5. Extract stage-local functions after stage result types exist.
+   - Extract staged path selection, file-layer feedback, partial staging decision, formatter restage decision, diagnostic feedback, and pre-push base decision.
+   - Do not create generic artifact or stage framework.
+   - Gate: hook tests after each extraction or tightly grouped pair.
+
+6. Replace D6/D7 semantic reinterpretation.
+   - Consume typed D6/D7 projections for Grit/check outcomes.
+   - Keep regex message interpretation only as a temporary bridge if upstream projection implementation does not exist, and mark that bridge as a D11 blocker for final closure.
+   - Gate: malformed Grit, Grit findings, adapter failure, projection-missed, and command failure tests.
+
+7. Introduce pre-push base decision union.
+   - Preserve current behavior but expose explicit provenance internally.
+   - Gate: explicit base, Graphite parent, merge-base `main`, merge-base `origin/main`, literal `main`, and Nx affected failure tests.
+
+8. Delete compatibility-only shapes only after D0 permits it.
+   - Remove `allowPreCommit` from target code, proof-shaped names, and legacy optional DTO fields only when public compatibility has a documented preserve/version/facade/deprecate decision.
+   - Gate: D0 rows plus hook tests plus OpenSpec validation.
+
+## Allowed Write And Protected Path Recommendations
+
+This investigation wrote only:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation/agent-scratch/domino-D11-typescript-state-investigation.md`
+
+Recommended later implementation write set after D11 repair:
+
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/hooks.ts`
+- `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/hooks.test.ts`
+- narrowly-scoped hook source files under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/src/lib/` if D11 explicitly permits splitting after deletion/state collapse
+- CLI hook command files only if public command behavior is D0-classified first
+- adjacent docs/examples only if D11 implementation changes public behavior and D0 permits the documentation update
+
+Protected paths for the D11 repair pass:
+
+- source domino packets under `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/`
+- upstream D0, D1, D6, D7, D9, and D10 packet authorities, except to add cross-links through the owning process if explicitly requested
+- generated outputs such as `dist/`, `mod/`, and generated baselines
+- lockfiles and root package manager metadata
+- protected-zone/generated-zone source except fixtures designed for tests
+- D6/D7/D9/D10 core semantic implementation files unless D11 has a separately accepted dependency repair
+- Civ7 runtime/product packages, because D11 is local Habitat feedback only
+
+## Validation And Test Matrix
+
+D11 should require the following validation oracle before implementation starts.
+
+Resource state:
+
+- every allowed variant constructs through the allowed constructor
+- every refused variant constructs through the refused constructor
+- `allowsPreCommit` is derived from the union tag
+- impossible kind/allowance combinations cannot type-check in target code
+- dirty submodule takes precedence over staged gitlink
+- inspection failure is distinguishable from uninitialized resource state
+- legacy `ResourceState.allowPreCommit`, if preserved, is produced only by projection
+
+Partial staging:
+
+- a Biome-supported file that is both staged and unstaged refuses before formatting
+- no stash, checkout, reset, or hidden rewrite command is invoked
+- refusal occurs before formatter restage, Biome check, Grit check, resource publish, or generated publish
+- refusal gives local feedback and D1 non-claims
+
+Formatter restage:
+
+- only hash-changed Biome candidate paths are passed to `git add`
+- unchanged Biome paths are not restaged
+- foreign staged paths are not restaged
+- foreign unstaged paths are not restaged
+- formatter-created or formatter-deleted path behavior is explicitly covered
+- restage failure reports attempted paths and does not continue into diagnostic checks
+
+File-layer and protected/generated-zone stops:
+
+- D10-origin refusal stops before Biome, Grit, generated publish, resource publish, and restage
+- D11 consumes D7/D10 local-feedback-safe projection rather than parsing text
+- generated/protected-zone refusal remains local feedback, not CI proof or generated freshness proof
+
+Grit/Biome/Nx command results:
+
+- Biome format failure fails local pre-commit
+- Biome check failure fails local pre-commit
+- Grit findings fail closed
+- malformed Grit output fails closed as parse/adapter failure
+- D6 adapter failure is consumed from projection, not regex over human text
+- Nx affected failure fails local pre-push and preserves command result
+- Nx graph or target contract absence is surfaced as failed/blocked, not hidden as success
+
+Pre-push base:
+
+- explicit base skips Graphite and merge-base probing
+- Graphite parent is used when available
+- merge-base `main` and `origin/main` fallback provenance is preserved
+- literal `main` fallback is represented as a fallback state with non-claims
+- affected command receives the chosen base and `HEAD`
+- base decision does not claim Graphite readiness or CI equivalence
+
+Trace and public compatibility:
+
+- every terminal state includes D1 non-claims
+- target trace stage sequence is closed and exhaustively matched
+- compatibility trace, if retained, exactly matches current public tests
+- human output does not add new proof claims
+- any output text or exported DTO change has a D0 compatibility row
+
+Recommended gates after each logical move:
+
+- `bun test /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/tools/habitat-harness/test/lib/hooks.test.ts`
+- root type check or the nearest Habitat Harness type-check target reported by `bun run habitat classify`
+- `bun run openspec -- validate deep-habitat-d11-local-feedback --strict`
+- root `bun run openspec:validate`
+- `git diff --check`
+
+The exact root/package script names should be resolved through `package.json` and `habitat classify` during implementation. The D11 packet should define the oracle, not leave the executor to infer it.
+
+## Findings Against Current D11 Packet
+
+### P1: Target State Model Is Missing
+
+The current D11 packet names local feedback goals but does not define the concrete resource gate, stage result, terminal state, trace, or compatibility model. This leaves implementation to decide whether `ResourceState.allowPreCommit`, `PreCommitOutcome`, `PrePushTrace`, `HookCommandPhase`, and `HookTrace` are target contracts, legacy compatibility, or internals.
+
+Repair:
+
+- Add a D11 design section named "Target State Model."
+- Specify `ResourcePreCommitGate`, local terminal states, pre-commit stage results, pre-push base decision, and affected feedback result.
+- State that commit allowance is derived from the resource gate union.
+- State that current exported trace/outcome types are compatibility facades unless D0 rows authorize replacement.
+
+### P1: Upstream Contract Consumption Is Underspecified
+
+The packet says D11 consumes D7/D9/D10 but does not define the exact boundary. Current code can still parse D7/CheckReport output and infer Grit adapter failures from diagnostic message text.
+
+Repair:
+
+- Add explicit "Consumed Upstream Contracts" tables for D6, D7, D9, and D10.
+- For each consumed projection, list the allowed local D11 decisions and forbidden reinterpretations.
+- Require D11 to consume typed projection outcomes for diagnostic/check results.
+- Mark any message-regex bridge as temporary compatibility and non-closable for final D11 unless upstream projection is unavailable by an accepted dependency deferral.
+
+### P1: Public Compatibility Is Blocked Pending D0
+
+The packet does not inventory hook public surfaces or require D0 rows before changing them. Relevant current surfaces include exported types, trace JSON shape, human output text, hook command entrypoints, and Husky integration.
+
+Repair:
+
+- Add a D0/D1 compatibility section.
+- Inventory `HookTrace`, `PreCommitTrace`, `PrePushTrace`, `PreCommitOutcome`, `PrePushOutcome`, `HookCommandPhase`, hook CLI output, and hook command invocation.
+- Require preserve/facade behavior until D0 rows exist.
+- Treat `localHookProofNotice` as legacy compatibility wording, not target terminology.
+
+### P1: Implementation Write Set And Protected Paths Are Missing
+
+The packet does not constrain the future implementation write set. That leaves later execution free to edit unrelated source, upstream contracts, or packet control files.
+
+Repair:
+
+- Add an "Allowed Writes" section to D11.
+- Name `hooks.ts`, `hooks.test.ts`, and narrowly-scoped adjacent hook files as the implementation write set.
+- Protect upstream packet authorities, generated outputs, root package manager metadata, and unrelated product/runtime packages.
+
+### P2: Pipeline Design Is Too Vague
+
+The source domino asks for local hook feedback as a consumer of accepted contracts. The current packet does not decide whether the target is a typed pipeline model, stage result union, or smaller local result records.
+
+Repair:
+
+- Choose smaller local result records.
+- Forbid generic artifact machinery in D11 unless a later accepted design proves repeated cross-domain need.
+- Define stage records for resource gate, staged path selection, file-layer feedback, partial staging, formatter restage, diagnostic feedback, pre-push base, and affected feedback.
+
+### P2: Pre-Push Base Semantics Need Provenance
+
+The packet says Graphite-aware pre-push base resolution but does not define state/refusal implications. Current code can fall back to literal `main`, but the trace target does not encode why.
+
+Repair:
+
+- Define `PrePushBaseDecision`.
+- Allow explicit base, Graphite parent, merge-base fallback, and literal `main` fallback as local feedback only.
+- Require Nx affected failures to propagate.
+- Route any canonical graph-target truth or target availability question to D3/Nx authority.
+
+### P2: Partial Staging And Formatter Restage Need Normative Tests
+
+The current tests cover the important behavior, but the D11 spec does not make it normative.
+
+Repair:
+
+- Add spec scenarios requiring partial staging refusal before formatting/restaging.
+- Add spec scenarios requiring formatter restage to include only formatter-touched paths.
+- Add a foreign-path restage regression scenario.
+- Forbid stash/rewrite hidden behavior.
+
+### P2: Resource Inspection Failure Needs Its Own Variant
+
+The source domino names inspection failure. Current code overloads several inspection failures as `uninitialized`.
+
+Repair:
+
+- Add `inspection-failed` refused resource variant.
+- Define which command inspection errors map to it.
+- Preserve existing human recovery text only through compatibility projection if needed.
+
+### P3: Phase Record Branch Is Stale
+
+Current D11 phase record names branch `codex/deep-habitat-openspec-remediation`, but the actual active branch is `codex/d11-local-feedback-packet`.
+
+Repair:
+
+- Update D11 phase record only through the packet owner process, not in this scratch-only investigation.
+
+### P3: Dry-Run And Help Gates Are Inconsistent
+
+The source domino mentions a possible dry-run/local feedback behavior. The current D11 proposal validation gate mentions `bun run habitat hook pre-commit -- --help`, while current `HookOptions` only exposes `base?: string` and no dry-run model.
+
+Repair:
+
+- Decide whether dry-run is a public hook command contract.
+- If yes, route through D0 and specify behavior.
+- If no, remove dry-run expectations and keep help output as compatibility/invocation validation only.
+
+### P3: Tasks Are Not Refactor Slices
+
+Current tasks are broad design statements rather than behavior-preserving refactor moves.
+
+Repair:
+
+- Replace generic tasks with the ordered slices in this investigation.
+- Add compiler/test/OpenSpec gates after each logical move.
+
+## Exact Repair Recommendations By Artifact
+
+### `proposal.md`
+
+Add:
+
+- D11 is a state-space collapse and local-feedback contract repair.
+- D11 keeps Habitat generic and repo-local.
+- D11 does not create proof authority.
+- D11 success means later implementation has no remaining decisions about state model, public compatibility, write set, or validation oracle.
+
+### `design.md`
+
+Add:
+
+- Target state model section.
+- Consumed upstream contracts section for D1/D6/D7/D9/D10.
+- D0/D1 compatibility section for exported types and human output.
+- Local result record design, explicitly not generic artifact machinery.
+- Pre-push base decision design.
+- Partial staging and formatter restage write policy.
+- Implementation write set and protected paths.
+- Blocking decisions section naming unresolved D0 rows and projection dependencies.
+
+### `tasks.md`
+
+Replace broad tasks with ordered implementation-ready slices:
+
+1. Inventory public hook surfaces and D0 rows.
+2. Add resource gate target union and constructors.
+3. Project target resource gate to legacy `ResourceState` if needed.
+4. Add local feedback trace builder and compatibility facade.
+5. Extract resource/staged/file-layer/partial/formatter/diagnostic/base/affected stage records.
+6. Replace D6/D7 text parsing with projection consumption.
+7. Add pre-push base decision union.
+8. Add validation matrix tests.
+9. Run and record gates.
+10. Delete legacy compatibility only when D0 permits.
+
+### `specs/habitat-harness/spec.md`
+
+Add normative requirements and scenarios for:
+
+- resource gate discriminated union with derived allowance
+- no contradictory resource allowance states
+- resource inspection failure refused state
+- D10-origin refusal stops before downstream stages
+- partial staging refused before formatting/restaging
+- no stash/rewrite behavior
+- formatter restage only formatter-touched paths
+- foreign path restage regression
+- D6/D7 projection consumption for Grit/check outcomes
+- malformed Grit/adapter failure fail closed
+- pre-push base provenance
+- Nx affected failure propagation
+- D1 non-claims in all hook terminal states
+- public trace/output compatibility pending D0
+
+### `workstream/phase-record.md`
+
+After packet owner review, fix stale branch metadata and record that the D11 design gate remains blocked until the target state model, D0 compatibility decision, write set, and validation oracle are in the packet.
+
+### `workstream/review-disposition-ledger.md`
+
+Record P1 design blockers from this scratch investigation. Do not mark adversarial review complete until packet repairs address the model and compatibility gaps.
+
+### `workstream/downstream-realignment-ledger.md`
+
+Add downstream rows for:
+
+- D0 public compatibility rows for hook output and trace/exported types
+- D6/D7 projection availability for diagnostics/check consumption
+- D3/Nx target/base authority for pre-push affected behavior if target list/base semantics exceed local feedback
+- later implementation tests for state model and formatter restage
+
+### `workstream/closure-checklist.md`
+
+Do not check design readiness until:
+
+- target state model is explicit
+- public compatibility treatment is explicit
+- upstream projection consumption is explicit
+- write/protected paths are explicit
+- validation matrix is explicit
+
+## Stop Condition
+
+D11 remains blocking because later implementation would still have to decide:
+
+- the concrete state model for resource gate, hook terminal states, stage results, and pre-push base
+- whether `PreCommitOutcome`, `PrePushTrace`, `HookCommandPhase`, and `HookTrace` are target contracts or legacy public compatibility
+- whether and how `localHookProofNotice` can be renamed without violating D0
+- the permitted source/test/doc write set
+- the validation oracle for state-space collapse, formatter restage, partial staging, and upstream projection consumption
+- whether D11 can consume accepted D6/D7/D9/D10 projections now or must carry a temporary compatibility bridge
+
+Until those decisions are in the packet, D11 is not a complete implementation-ready design/specification authority.

--- a/docs/projects/habitat-harness/openspec-remediation/context.md
+++ b/docs/projects/habitat-harness/openspec-remediation/context.md
@@ -13,7 +13,7 @@ variables below.
 | Variable | Value |
 | --- | --- |
 | `$ACTIVE_REMEDIATION_WORKTREE` | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation` |
-| `$ACTIVE_REMEDIATION_BRANCH` | `codex/d10-protected-zone-authority-packet` |
+| `$ACTIVE_REMEDIATION_BRANCH` | `codex/d11-local-feedback-packet` |
 
 ## Path Variables
 
@@ -190,6 +190,27 @@ variables below.
 | `$D10_PHASE_RECORD` | `$D10_CHANGE/workstream/phase-record.md`. |
 | `$D10_DOWNSTREAM_LEDGER` | `$D10_CHANGE/workstream/downstream-realignment-ledger.md`. |
 | `$D10_CLOSURE_CHECKLIST` | `$D10_CHANGE/workstream/closure-checklist.md`. |
+
+## D11 Variables
+
+| Variable | Meaning |
+| --- | --- |
+| `$D11_CHANGE` | `$OPENSPEC_CHANGES/deep-habitat-d11-local-feedback`. |
+| `$D11_SOURCE_PACKET` | `$PHASE2_PACKET_DIR/D11-local-feedback.md`. |
+| `$D11_DOMAIN_REVIEW` | `$AGENT_SCRATCH/domino-D11-domain-ontology-investigation.md`. |
+| `$D11_TYPESCRIPT_REVIEW` | `$AGENT_SCRATCH/domino-D11-typescript-state-investigation.md`. |
+| `$D11_TOPOLOGY_REVIEW` | `$AGENT_SCRATCH/domino-D11-code-vendor-topology-investigation.md`. |
+| `$D11_INFORMATION_REVIEW` | `$AGENT_SCRATCH/domino-D11-openspec-information-testing-investigation.md`. |
+| `$D11_CROSS_DOMINO_REVIEW` | `$AGENT_SCRATCH/domino-D11-cross-domino-product-investigation.md`. |
+| `$D11_FINAL_DOMAIN_REVIEW` | `$AGENT_SCRATCH/domino-D11-final-domain-ontology-review.md`. |
+| `$D11_FINAL_TYPESCRIPT_VALIDATION_REVIEW` | `$AGENT_SCRATCH/domino-D11-final-typescript-validation-review.md`. |
+| `$D11_FINAL_OPENSPEC_INFORMATION_REVIEW` | `$AGENT_SCRATCH/domino-D11-final-openspec-information-review.md`. |
+| `$D11_FINAL_CODE_VENDOR_TOPOLOGY_REVIEW` | `$AGENT_SCRATCH/domino-D11-final-code-vendor-topology-review.md`. |
+| `$D11_FINAL_CROSS_DOMINO_PRODUCT_REVIEW` | `$AGENT_SCRATCH/domino-D11-final-cross-domino-product-review.md`. |
+| `$D11_REVIEW_LEDGER` | `$D11_CHANGE/workstream/review-disposition-ledger.md`. |
+| `$D11_PHASE_RECORD` | `$D11_CHANGE/workstream/phase-record.md`. |
+| `$D11_DOWNSTREAM_LEDGER` | `$D11_CHANGE/workstream/downstream-realignment-ledger.md`. |
+| `$D11_CLOSURE_CHECKLIST` | `$D11_CHANGE/workstream/closure-checklist.md`. |
 
 ## Path Templates
 

--- a/docs/projects/habitat-harness/openspec-remediation/packet-index.md
+++ b/docs/projects/habitat-harness/openspec-remediation/packet-index.md
@@ -5,10 +5,10 @@ change packets. It is part of the remediation frame, not an implementation
 commitment. Most rows remain incomplete packets: global review findings have
 been converted into shared constraints, but each domino remains blocking until
 its own per-domino adversarial review has run and all accepted P1/P2 findings
-are repaired. D0, D1, D2, D3, D4, D5, D6, D7, D8, D9, and D10 are the current exceptions: they are
+are repaired. D0, D1, D2, D3, D4, D5, D6, D7, D8, D9, D10, and D11 are the current exceptions: they are
 accepted for design/specification after their per-domino final reviews found no
-unresolved P1/P2 blockers. D0-D10 are not implementation-complete, and
-D11-D15/G-HOST remain blocking unless their own status rows say otherwise.
+unresolved P1/P2 blockers. D0-D11 are not implementation-complete, and
+D12-D15/G-HOST remain blocking unless their own status rows say otherwise.
 
 Path variables and operational checkout fixtures are defined in
 `$REMEDIATION_DIR/context.md`. This index records packet identity and sequencing;
@@ -28,7 +28,7 @@ it does not repeat local worktree paths or branch names.
 | G-HOST | Host Policy Boundary Gate | `deep-habitat-host-policy-boundary-gate` | D0, D1 | D10, D13 | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
 | D9 | D9 Transformation Transaction | `deep-habitat-d9-transformation-transaction` | D0, D1, D6, D8, D10, G-HOST where host-specific gates are touched; concrete D0 rows, D8 apply-admission projections, D10 path/zone decisions, and G-HOST host-gate declarations required before source implementation where touched | D11, D13; D15 only if D9 records an impossible local state | accepted for design/specification; final domain/ontology, TypeScript/validation, OpenSpec/information, code/vendor topology, and cross-domino/product rereviews found no unresolved P1/P2 blockers; not implementation-complete |
 | D10 | D10 Protected Zone Authority | `deep-habitat-d10-protected-zone-authority` | D0, D1, D2, G-HOST | D7, D8 where protected/generated paths are touched, D9, D11 | accepted for design/specification; final domain/ontology, TypeScript/validation, OpenSpec/information, code/vendor topology, and cross-domino/product rereviews found no unresolved P1/P2 blockers; not implementation-complete; source implementation blocked behind concrete D0 rows, D1 output-family handling, live D2 generated-zone projections, accepted/live G-HOST host declarations, and accepted/live D10 projections |
-| D11 | D11 Local Feedback | `deep-habitat-d11-local-feedback` | D0, D1, D7, D9, D10 | none | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
+| D11 | D11 Local Feedback | `deep-habitat-d11-local-feedback` | D0, D1, D3 for pre-push graph/affected facts, D6 staged diagnostic projections, D7 local-feedback check projection, D9 local-feedback-safe transaction projection where surfaced, D10 protected mutation projection; D8 conditional for hook eligibility/admission; G-HOST only through D9/D10 projections unless D11 touches host-owned surfaces | D12, D15 only when D11 records an impossible local state | accepted for design/specification; final domain/ontology, TypeScript/validation, OpenSpec/information, code/vendor topology, and cross-domino/product rereviews found no unresolved P1/P2 blockers; not implementation-complete; source implementation blocked behind concrete D0 rows, D1 output-family handling, live D3/D6/D7/D9/D10 projections where consumed, conditional D8 projection where consumed, and G-HOST only through accepted D9/D10 projections unless D11 touches host-owned surfaces |
 | D12 | D12 Verify Handoff Receipt | `deep-habitat-d12-verify-handoff-receipt` | D0, D1, D3, D7 | D14 | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
 | D13 | D13 Scaffolding And Refusal Contracts | `deep-habitat-d13-scaffolding-refusal-contracts` | D0, D2, D8, G-HOST | D14 | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |
 | D14 | D14 Authoring Topology Fence | `deep-habitat-d14-authoring-topology-fence` | D0, D4, D12, D13 | none | incomplete packet; global constraints applied; per-domino adversarial gate BLOCKING |

--- a/openspec/changes/deep-habitat-d11-local-feedback/design.md
+++ b/openspec/changes/deep-habitat-d11-local-feedback/design.md
@@ -2,79 +2,240 @@
 
 ## Frame
 
-D11 Local Feedback is a downstream implementation-control packet derived from
-`D11-local-feedback.md`. The packet is complete only when it leaves the later execution
-agent with no product, domain, naming, sequencing, public-surface, or validation
-decision to invent.
+D11 specifies the Local Feedback domain: Habitat's fast, local hook workflow for
+commit and push preparation. The product goal is a hook that is helpful,
+recoverable, and bounded. It should answer: "What local repo-maintenance issue
+blocks this commit or push right now, and what should I do next?" It must not
+answer: "Is this ready for CI, review, product/runtime use, Graphite submission,
+OpenSpec closure, or safe apply?"
 
-The existing packet is input, not output. Current Habitat code is
-present-behavior evidence. This design chooses target language from Habitat's
-generic repo-maintenance product scenarios rather than preserving accidental
-module or DTO names.
+Current code is input. It is not the target model. The current
+`hooks.ts` module combines hook orchestration, resource submodule inspection,
+staged path discovery, file-layer checks, partial staging policy, Biome
+format/check, formatter restaging, Grit/check parsing, Graphite base detection,
+Nx affected invocation, human output, reporter events, and trace capture. D11
+keeps hook orchestration local but removes ambiguous ownership by consuming D6,
+D7, D9, D10, and D3 projections instead of parsing or recomputing their domain
+truth.
+
+## Solution Design
+
+- **Frame:** rugged/high-commitment design space. A weak D11 packet lets a hook
+  look green after missing diagnostic authority, protected-zone refusal,
+  formatter restage drift, partial staging, or affected-target failure.
+- **Aspiration threshold:** implementation agents can execute the packet without
+  inventing hook states, dependency projections, public compatibility decisions,
+  validation oracles, or recovery semantics.
+- **Constraint reality:** D0-D10 are accepted for design/specification only.
+  D11 may design against their target projections, but source implementation is
+  blocked where concrete D0 rows or live D3/D6/D7/D9/D10 projections are absent.
+- **Rejected shortcut:** keep `ResourceState.allowPreCommit` and add comments.
+  That preserves boolean correlation and lets impossible states compile.
+- **Rejected shortcut:** keep the current Grit JSON parse in hooks as target
+  behavior. D6 owns diagnostic projection; D11 may render hook-safe results.
+- **Rejected shortcut:** add a generic hook stage framework. D11 needs a small,
+  explicit hook pipeline and typed outcomes, not generic workflow machinery.
 
 ## Domain Boundary
 
-- Owner: Local Feedback.
-- Primary scenario: A local hook gives fast feedback without pretending to be CI, full structural verification, product approval, or safe-apply completion.
-- Adjacent domains consume this packet through explicit contracts and may not
-  recreate its authority locally.
+| Concern | D11 owns | D11 does not own |
+| --- | --- | --- |
+| Hook command | `habitat hook pre-commit`, `habitat hook pre-push`, unsupported-hook refusal, hook-local rendering, and trace capture. | Oclif/global CLI behavior outside hook surfaces. |
+| Local feedback scope | Non-claim rendering and local recovery instructions for hook outcomes. | CI, review, OpenSpec, Graphite, runtime/product, apply-safety, or generated-freshness authority. |
+| Resource state | Local resource submodule readiness for pre-commit and recovery commands. | Resource publishing implementation, host resource semantics, or submodule content ownership. |
+| Staged path workflow | Staged path collection, partial-staging refusal before formatting, formatter-touched restage only. | Structural check truth, generated/protected policy, diagnostic identity, or transaction write safety. |
+| Pre-push routing | Local base selection request and affected-target command invocation. | Workspace graph truth, Nx target validity, Graphite stack correctness, or CI target coverage. |
 
-## Target Contract
+## Target Terms
 
-- Define hook-local feedback scope and non-claims.
-- Consume D7/D9/D10 decisions instead of recomputing them.
-- Clarify human output and machine records for hook traces.
+| Term | Meaning |
+| --- | --- |
+| `LocalFeedbackTrace` / `HookTrace` | D1-constrained local hook record. Current `HookTrace` may remain a compatibility name until D0 decides export handling. |
+| `HookStage` | A named local step in the hook pipeline, such as resource decision, staged scope, structural check projection, formatter, diagnostic projection, or pre-push affected invocation. |
+| `HookStageOutcome` | Discriminated stage result: passed, refused, failed, unavailable, not applicable, or skipped because an earlier terminal outcome stopped the hook. |
+| `ResourcePreCommitDecision` | D11-owned discriminated resource state; commit allowance is derived from variant. |
+| `StagedPathDecision` | D11-owned staged scope classification for formatter and diagnostic stages. |
+| `PartialStagingRefusal` | Terminal refusal before formatting/restaging when staged formatter-supported paths also have unstaged changes. |
+| `FormatterRestageDecision` | D11-owned decision recording formatter-touched paths and the exact paths eligible for restage. |
+| `LocalFeedbackCheckProjection` | D7-owned projection consumed by D11 for structural check outcomes. |
+| `StagedDiagnosticProjection` | D6-owned diagnostic projection consumed by D11 directly or carried through D7 with D6 owner metadata. |
+| `TransactionLocalFeedbackProjection` | D9-owned transaction state projection consumed by D11 when hook feedback references apply/fix state. |
+| `ProtectedMutationLocalFeedback` | D10/D7-carried local feedback for staged protected/generated/forbidden mutation refusals. |
+| `AffectedTargetFeedback` | D11 pre-push local rendering of an Nx affected invocation built from D3 graph/base facts. |
 
-## Non-Goals
+## Rejected Or Compatibility Terms
 
-- No CI authority.
-- No verify handoff ownership.
-- No rule/check/apply domain ownership.
+| Current term/phrase | D11 handling |
+| --- | --- |
+| Legacy hook human output | D0/D1 compatibility phrase. Target text is local feedback only. |
+| `allowPreCommit` | Rejected as target state. Replace with variant-derived allowance. |
+| Raw `Grit` result in hooks | Rejected as target D11 input. Consume D6 projection or D7 projection carrying D6-origin labels. |
+| Legacy authority wording in hook output | Rejected target language unless a D0 row preserves a legacy human-output surface. |
+| `dry-run` hook gate | Not current public behavior. Adding it requires D0/D1 compatibility and explicit D11 command contract. |
 
-## Naming And Language Decisions
+## State Model
 
-- Use standard engineering terms that name the actual workflow object:
-  receipts, checks, diagnostics, guard decisions, transactions, refusals,
-  recovery instructions, metadata projections, command outcomes, and handoff
-  records.
-- Treat legacy proof/evidence-shaped code names as compatibility facts unless
-  this packet explicitly accepts them as target language.
-- Do not create generic artifact machinery when a smaller command result,
-  receipt, or diagnostic contract serves the scenario.
+### Resource Pre-Commit Decision
 
-## Implementation Readiness
+Target model:
 
-Before implementation starts, the executor must have:
+```ts
+type ResourcePreCommitDecision =
+  | { kind: "not-configured"; commit: "allowed"; detail: string }
+  | { kind: "clean"; commit: "allowed"; detail: string }
+  | { kind: "staged-gitlink"; commit: "allowed"; detail: string }
+  | { kind: "uninitialized"; commit: "refused"; detail: string; recovery: NonEmptyReadonlyArray<string> }
+  | { kind: "locked"; commit: "refused"; detail: string; recovery: NonEmptyReadonlyArray<string> }
+  | { kind: "dirty-submodule"; commit: "refused"; detail: string; recovery: NonEmptyReadonlyArray<string> }
+  | { kind: "unstaged-gitlink"; commit: "refused"; detail: string; recovery: NonEmptyReadonlyArray<string> }
+  | { kind: "inspection-failed"; commit: "refused"; detail: string; recovery: NonEmptyReadonlyArray<string>; command: HookCommandRecord };
+```
 
-- D0 compatibility disposition for every public command, JSON, export, script,
-  target, generator, and hook surface touched by this packet.
-- A concrete write set and protected path list.
-- Tests and command gates from this packet copied into the phase record.
-- Review findings dispositioned with accepted P1/P2 repaired.
+The implementation may choose equivalent names, but it must preserve the
+invariant: no boolean may contradict the variant. `commit` is a derived tag or
+encoded in separate allowed/refused union branches; it must not be an
+independent mutable flag.
 
-## Review Lanes
+### Pre-Commit Stage Outcomes
 
-- Domain-language adversary: names, owner, authority, and inherited terminology.
-- OpenSpec packet review: proposal/design/tasks/spec consistency and shortcut
-  language.
-- TypeScript state-space review: invalid states removed without type machinery
-  that exceeds the product need.
-- Testing/validation review: gates are falsifying, scenario-grounded, and have
-  exact command expectations.
-- Cross-domino review: dependencies, public-surface compatibility, and
-  downstream realignment.
+```ts
+type PreCommitLocalFeedbackOutcome =
+  | { kind: "resource-refused"; decision: ResourcePreCommitDecision }
+  | { kind: "structural-check-refused"; projection: LocalFeedbackCheckProjection }
+  | { kind: "protected-mutation-refused"; projection: ProtectedMutationLocalFeedback }
+  | { kind: "partial-staging-refused"; refusal: PartialStagingRefusal }
+  | { kind: "formatter-failed"; command: HookCommandRecord }
+  | { kind: "formatter-restage-failed"; command: HookCommandRecord; attemptedPaths: NonEmptyReadonlyArray<RepoRelativePath> }
+  | { kind: "format-check-failed"; command: HookCommandRecord }
+  | { kind: "diagnostic-unavailable"; projection: StagedDiagnosticProjection }
+  | { kind: "diagnostic-findings"; projection: StagedDiagnosticProjection }
+  | { kind: "passed"; trace: LocalFeedbackTrace };
+```
 
-## Structural Alternative Rejected
+The design permits D7 to carry D6-origin diagnostic labels through
+`LocalFeedbackCheckProjection`, but the trace must retain the owner relation so
+D11 cannot infer diagnostic truth locally.
 
-The rejected alternative is to implement the existing domino packet directly
-and let the execution agent create missing proposal, design, spec, task, and
-ledger details while coding. That path already caused design drift. This
-OpenSpec packet resolves the execution-control layer before implementation.
+### Pre-Push Stage Outcomes
 
-## Pre-Push Graph Boundary
+```ts
+type PrePushLocalFeedbackOutcome =
+  | { kind: "base-selected"; base: string; source: "explicit" | "graphite-parent" | "merge-base-main" | "merge-base-origin-main" | "literal-main-fallback" }
+  | { kind: "graph-unavailable"; graphRefusal: D3GraphRefusal }
+  | { kind: "affected-target-unavailable"; targetRefusal: D3TargetRefusal }
+  | { kind: "affected-command-failed"; base: string; command: HookCommandRecord }
+  | { kind: "passed"; base: string; command: HookCommandRecord; trace: LocalFeedbackTrace };
+```
 
-Pre-commit local feedback consumes structural checks, protected-zone decisions,
-and transaction guidance. Pre-push affected-target feedback additionally
-consumes D3 graph facts. If implementation wants a hook dry-run or new pre-push
-flag, D11 must treat it as a public command contract and route compatibility
-through D0 before source edits.
+Literal `main` fallback remains a local fallback state, not graph truth. If D3
+later publishes a stricter graph/base refusal, D11 consumes it and must not run
+`nx affected` as a no-op wrapper.
+
+## Hook Pipeline
+
+### Pre-Commit
+
+1. Render local-feedback scope and capture initial repo snapshot.
+2. Build `ResourcePreCommitDecision`.
+3. Stop on refused resource state before file-layer, Biome, Grit, resource
+   publish, or restage commands.
+4. Collect staged paths from Git and normalize to repo-relative paths.
+5. Consume D7 `LocalFeedbackCheckProjection` for staged structural checks.
+6. If the D7 projection carries D10-origin protected/generated/forbidden
+   refusal, render it and stop before Biome, Grit, publish, or restage.
+7. Classify formatter-supported staged paths and refuse partial staging before
+   formatting.
+8. Run Biome format/check only for formatter-supported staged paths, with
+   Biome's no-unmatched behavior where applicable.
+9. Restage only files whose hash changed due to the formatter.
+10. Consume D6 staged diagnostic projection for diagnostic/Grit feedback, either
+    directly or through D7 with D6-owner metadata.
+11. Emit pass only when every required stage passes or is explicitly not
+    applicable by owner-published state.
+
+### Pre-Push
+
+1. Render local-feedback scope and capture initial repo snapshot.
+2. Select base from explicit `--base`, Graphite parent, merge-base with `main`,
+   merge-base with `origin/main`, or literal fallback.
+3. Consume D3 graph/target availability before treating affected-target
+   behavior as runnable once D3 live projections exist.
+4. Run Nx affected with explicit base and `HEAD` only when graph/target state is
+   runnable.
+5. Emit affected failure as local feedback, not CI or review status.
+
+## TypeScript Refactoring Application
+
+| Current smell | Safe refactor move | D11 acceptance condition |
+| --- | --- | --- |
+| Boolean correlation: `ResourceState.kind` plus `allowPreCommit`. | Replace flag soup with discriminated allowed/refused resource decisions and constructors. | Contradictory resource allowance cannot compile. |
+| Whole-output parsing in hook Grit path. | Consume D6/D7 projections and preserve D6 owner relation. | Hook code does not parse raw Grit output as target diagnostic authority. |
+| Monolithic hook function mixes policy, shelling, rendering, and trace mutation. | Extract D11-owned stage decision helpers only where they collapse responsibility; keep `runPreCommit`/`runPrePush` orchestration readable. | No generic stage framework or pass-through wrapper layer. |
+| Legacy authority-shaped human output. | D0/D1-compatible wording replacement or legacy facade. | Target strings use local feedback/non-claim language. |
+| Restage command takes touched paths from hash comparison inside orchestration. | Model `FormatterRestageDecision` and test touched/untouched/foreign paths. | Foreign staged paths cannot be restaged. |
+| Pre-push fallback can hide graph/base uncertainty. | Model base source and graph/target availability states. | Affected-target pass cannot mask unavailable graph authority once D3 facts are live. |
+
+## Public Compatibility
+
+Later D11 implementation must cite D0 rows before changing:
+
+- hook command behavior, help, flags, unsupported hook exit/output, and any new
+  dry-run behavior;
+- `.husky` delegators;
+- hook stdout/stderr and current legacy local-feedback notice;
+- `runHook` export and any exported trace/resource types;
+- docs/examples that describe hooks;
+- script/Nx target behavior or generated help.
+
+Current command input:
+
+- `$HABITAT_TOOL/test/lib/hooks.test.ts` passes 28 current tests.
+- `bun tools/habitat-harness/bin/dev.ts hook --help` exits 2 while printing
+  help because `--help` is treated as a nonexistent flag.
+- `bun tools/habitat-harness/bin/dev.ts hook pre-commit --dry-run` exits 2
+  because no dry-run flag exists.
+- A live pre-push command can exceed an interactive design-check window, so
+  later gates need bounded fake-runtime tests or explicit timeout/oracle.
+
+## Validation Design
+
+Design-time validation proves packet shape only:
+
+- strict D11 OpenSpec validation;
+- full OpenSpec validation;
+- diff hygiene;
+- wording audit over active D11 packet/control/scratch;
+- fresh D11 final rereviews with no unresolved P1/P2.
+
+Later implementation validation must falsify false-green states:
+
+- resource state matrix;
+- staged protected mutation refusal stops before formatter/diagnostics;
+- partial staging refusal stops before formatting/restage;
+- formatter restages only touched paths;
+- D6 diagnostic unavailable/refused/finding cannot pass;
+- D7 check dependency/refusal cannot pass;
+- D9 transaction unavailable/refused cannot become local success where consumed;
+- D10 protected/generated refusal cannot become warning-only;
+- D3 graph/target unavailable cannot become affected-target success;
+- unsupported hook and command help behavior match D0/D1 decisions;
+- no hook test leaves working-tree residue.
+
+## Downstream And Trigger Model
+
+- D12 may rely on D11 only for local-feedback non-claims and hook trace
+  boundaries, not verify handoff completion.
+- D15 is triggered only if D11 records a concrete local command/state
+  observation that cannot be represented through D1 hook trace, D6 diagnostic
+  projection, D7 check projection, D9 transaction projection, D10 path
+  projection, or D3 graph projection.
+- No downstream packet may cite D11 hook pass as CI, review, product, Graphite,
+  OpenSpec, apply-safety, or runtime readiness.
+
+## Wording Discipline
+
+D11 active artifacts should avoid target-language use of legacy authority
+wording except when classifying current compatibility surfaces or historical
+source wording. Preferred terms: local feedback, trace, command record, diagnostic,
+check outcome, transaction projection, guard decision, refusal, recovery
+instruction, observation, and validation gate.

--- a/openspec/changes/deep-habitat-d11-local-feedback/proposal.md
+++ b/openspec/changes/deep-habitat-d11-local-feedback/proposal.md
@@ -1,87 +1,222 @@
 # Proposal: D11 Local Feedback
 
+## Path Variables
+
+- `$WORKTREE`: active remediation worktree.
+- `$HABITAT_TOOL`: `$WORKTREE/tools/habitat-harness`.
+- `$D11_CHANGE`: `$WORKTREE/openspec/changes/deep-habitat-d11-local-feedback`.
+- `$REMEDIATION_DIR`: `$WORKTREE/docs/projects/habitat-harness/openspec-remediation`.
+- `$D11_SOURCE_PACKET`: `$WORKTREE/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md`.
+
 ## Summary
 
-Open the D11 Local Feedback OpenSpec packet for Deep Habitat Phase 2 remediation. This
-change converts the existing D11 domino packet into a review-gated
-OpenSpec packet scaffold. It resolves scope, owner, public surface impact,
-validation gates, downstream realignment, and stop conditions before any
-TypeScript implementation resumes.
+Specify D11 as the complete Local Feedback contract for Habitat hook behavior.
+D11 owns the `habitat hook` local developer/agent feedback workflow, including
+hook sequencing, staged-file handling, local feedback trace shape, resource
+state handling, formatter restage policy, pre-push affected-target invocation,
+and local-only recovery rendering.
+
+D11 does not own structural check truth, diagnostic acquisition, protected-zone
+policy, apply transaction safety, workspace graph truth, Graphite stack state,
+CI status, review approval, or product/runtime correctness. It consumes bounded
+upstream projections and turns them into local feedback that helps a human or
+agent recover quickly before commit or push.
+
+This packet remains blocking until fresh D11 review lanes read the repaired disk
+state and record no unresolved P1/P2 findings. Acceptance, when reached, is
+design/specification only; source implementation remains blocked behind the
+live dependency and D0/D1 compatibility gates named below.
 
 ## Authority
 
-- Current user decision to restart OpenSpec packet preparation from square one.
-- Remediation frame: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/openspec-remediation-frame.md.
-- Phase 2 packet suite: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets.
-- Root AGENTS.md Graphite/OpenSpec workflow guidance.
-- Domain Design and Information Design skills as mandatory language and artifact gates.
-- Current Habitat Toolkit code and tests as present-behavior evidence only.
-- Source domino packet: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md.
+- Source domino packet: `$D11_SOURCE_PACKET`.
+- Remediation frame: `$WORKTREE/docs/projects/habitat-harness/openspec-remediation-frame.md`.
+- Packet index and accepted upstream status: `$REMEDIATION_DIR/packet-index.md`.
+- Current hook implementation and tests as current-behavior input:
+  `$HABITAT_TOOL/src/lib/hooks.ts`, `$HABITAT_TOOL/src/commands/hook.ts`, and
+  `$HABITAT_TOOL/test/lib/hooks.test.ts`.
+- Husky delegator surfaces: `$WORKTREE/.husky/pre-commit` and
+  `$WORKTREE/.husky/pre-push`.
+- Accepted design/specification inputs:
+  - D0 Command Surface Inventory.
+  - D1 Receipt And Command Record Boundary.
+  - D3 Workspace Graph Boundary.
+  - D6 Diagnostic Pattern Catalog.
+  - D7 Structural Enforcement Pipeline.
+  - D9 Transformation Transaction.
+  - D10 Protected Zone Authority.
+- Official/native tool behavior:
+  - Husky runs native Git hook scripts and can be disabled by the user.
+  - Biome CLI supports `--no-errors-on-unmatched` and hook recipes caution about
+    staged-file handling.
+  - Nx `affected` computes work from explicit `base` and `head` inputs.
+  - Grit owns diagnostic and rewrite pattern execution; D11 does not parse raw
+    Grit semantics when a D6/D7 projection exists.
 
 ## Product Scenario
 
-A local hook gives fast feedback without pretending to be CI, full structural verification, product approval, or safe-apply completion.
+A developer or agent runs a commit or push in a local checkout. Habitat hooks
+should quickly report local repo-maintenance feedback: staged generated/protected
+mutation refusals, structural check failures, staged diagnostic findings,
+formatter drift, partial staging hazards, resource submodule problems, and
+pre-push affected-target failures. The output must be recoverable and scoped:
+hook success means only that the local hook workflow completed its configured
+checks at that moment.
 
 ## What Changes
 
-- Define hook-local feedback scope and non-claims.
-- Consume D7/D9/D10 decisions instead of recomputing them.
-- Clarify human output and machine records for hook traces.
+- Defines Local Feedback as the D11 owner and the only owner of hook sequencing,
+  staged-file workflow, hook trace construction, hook human rendering, resource
+  state local handling, formatter restage policy, and pre-push affected-target
+  invocation.
+- Defines D11's upstream consumption model:
+  - D6 staged diagnostic projections for hook diagnostic/Grit local feedback.
+  - D7 `LocalFeedbackCheckProjection` for structural check outcomes, including
+    D6/D5/D10-origin labels carried through D7 without transferring ownership.
+  - D9 local-feedback-safe transaction projection for apply/fix state when hook
+    feedback needs to discuss transaction readiness or refusal.
+  - D10/D7 protected-zone refusal projection for staged generated/protected
+    mutation feedback.
+  - D3 graph target/base facts for pre-push affected-target behavior.
+  - D1 non-claim and local feedback trace vocabulary.
+  - D0 compatibility rows for every touched hook, human-output, command,
+    package export, generated help, script, docs, or example surface.
+- Replaces current `ResourceState.kind` plus `allowPreCommit` boolean
+  correlation with a discriminated resource decision where allowed behavior is
+  derived from the variant.
+- Treats current legacy hook human output as a D0/D1 compatibility surface, not
+  D11 target language.
+- Defines later implementation write set, protected paths, validation gates, and
+  false-green stop conditions.
 
 ## What Does Not Change
 
-- No CI authority.
-- No verify handoff ownership.
-- No rule/check/apply domain ownership.
+- D11 does not implement source changes during this remediation pass.
+- D11 does not redefine check report semantics, rule status, diagnostic
+  identity, baseline authority, protected/generated-zone policy, apply
+  transaction safety, workspace graph authority, or Graphite stack semantics.
+- D11 does not add a broad command-record or artifact substrate.
+- D11 does not authorize hidden stash behavior, unstaged hunk rewriting, broad
+  restaging, direct generated-output edits, or hook bypass policy changes.
+- D11 does not claim CI, review approval, product/runtime correctness, safe
+  apply completion, Graphite readiness, OpenSpec acceptance, or current-tree
+  cleanliness.
 
-## Requires
+## Required Upstream Edges
 
-- D0
-- D1
-- D7
-- D9
-- D10
+| Upstream | D11 consumes | Prohibited inference |
+| --- | --- | --- |
+| D0 | Closed compatibility rows for hook command behavior, hook human output, generated help, `.husky` delegators, docs/examples, `runHook` export, and any trace/schema surface. | D11 cannot change or rename public surfaces without row citation and closed D0 handling. |
+| D1 | `HookTrace` / `LocalFeedbackTrace`, non-claim identifiers, local feedback family, command record boundaries, and legacy wording compatibility handling. | D11 cannot keep legacy authority vocabulary as target language unless D0/D1 explicitly preserve it for a concrete surface. |
+| D3 | Workspace graph/affected-target facts and graph-refusal states needed by pre-push affected behavior. | D11 cannot treat a no-op `nx affected` wrapper, missing graph facts, or unresolved target as hook success. |
+| D6 | Staged diagnostic projections, diagnostic identity, adapter/projection/refusal outcomes, and D15 trigger conditions for unrepresentable diagnostic command observations. | D11 cannot parse raw Grit output, invent diagnostic meanings, or collapse D6 diagnostic feedback into D7 check projection. |
+| D7 | `LocalFeedbackCheckProjection` for structural check outcomes, including selected rule summaries, failure/advisory counts, dependency/refusal labels, recovery text, and local-only non-claims. | D11 cannot parse D7 human output or reinterpret `CheckReport` internals as hook truth. |
+| D9 | Local-feedback-safe transaction projection: unavailable/refused/dry-run/applied/rolled-back/rollback-failed plus recovery and non-claims. | D11 cannot assert apply/write safety, rollback correctness, or transaction readiness from hook state alone. |
+| D10 | Staged protected/generated/forbidden mutation decisions and recovery guidance, either directly through D10 consumer projection or carried through D7. | D11 cannot define path policy, downgrade refusal to warning-only, or equate staged guard refusal with generated freshness. |
+| G-HOST | Host declarations only through D10/D9 projections where host-owned paths or host gates are touched. | D11 cannot hard-code host-specific path semantics into generic Local Feedback. |
 
-## Enables
+## D6/D7 Dependency Clarification
 
-- None.
+D7 publishes D11-safe structural check projection, but D7 does not absorb D6
+diagnostic ownership. D11 must name both relations whenever hook feedback renders
+diagnostic/Grit results:
 
-## Affected Owners
+- D6 owns diagnostic identity, acquisition/projection/refusal states, adapter
+  failure states, and staged diagnostic facts.
+- D7 may carry D6-origin diagnostic labels inside
+  `LocalFeedbackCheckProjection` only as a bounded consumer projection.
+- D11 may render those labels as local feedback, but it may not inspect raw Grit
+  output or infer diagnostic truth from D7 report internals.
 
-- Domain owner: Local Feedback.
-- OpenSpec change path: `openspec/changes/deep-habitat-d11-local-feedback/**`.
-- Expected Habitat implementation write set named in `design.md`; no code is
-  authorized by this remediation packet itself.
+## Public And Durable Surfaces
 
-## Forbidden Owners
+D11 source implementation is blocked until D0 rows classify every touched
+surface from this list:
 
-- Adjacent dominoes may not redefine Local Feedback authority.
-- Current code names may not become target-domain language without this packet
-  accepting the term.
-- Implementation agents may not add shims, fallbacks, dual paths, silent skips,
-  optional target shape, or generated-output hand edits.
+- `.husky/pre-commit` and `.husky/pre-push` delegator behavior.
+- `habitat hook [NAME]` command behavior, unsupported hook behavior, `--base`,
+  Oclif help/generated help, and any new dry-run flag.
+- Hook human stdout/stderr, including the current legacy local feedback
+  notice.
+- `runHook` package export through `$HABITAT_TOOL/src/index.ts` and
+  `$HABITAT_TOOL/src/lib/command-engine.ts`.
+- Any exported or durable `HookTrace`, `PreCommitTrace`, `PrePushTrace`,
+  `HookCommandRecord`, resource state, hook outcome, or local feedback trace
+  shape.
+- Docs/examples under repo docs, Habitat docs, process docs, or generated help
+  that describe hook semantics.
+- Script/Nx target output if hook behavior changes target invocation or
+  reporting.
 
-## Consumer Impact
+## Expected Later Write Set
 
-Hook output and HookTrace may change under D0/D1 compatibility decisions.
+Later D11 implementation may touch only these paths, after the dependency gates
+above are live where needed:
+
+- `$HABITAT_TOOL/src/lib/hooks.ts` or D11-owned extracted hook modules under
+  `$HABITAT_TOOL/src/lib/`.
+- `$HABITAT_TOOL/src/commands/hook.ts` only for D0-backed command flags/help and
+  command rendering.
+- `$HABITAT_TOOL/src/lib/command-engine.ts` and `$HABITAT_TOOL/src/index.ts`
+  only for D0/D1-compatible export routing.
+- `$HABITAT_TOOL/test/lib/hooks.test.ts` and D11-owned focused hook tests.
+- `$WORKTREE/.husky/pre-commit` and `$WORKTREE/.husky/pre-push` only if D0 rows
+  authorize delegator changes.
+- Adjacent docs/examples only when D0 rows classify the public guidance surface
+  and the implementation changes accepted behavior.
+- `$D11_CHANGE/**`, `$REMEDIATION_DIR/packet-index.md`, and D11 scratch/final
+  review records for this design/specification layer.
+
+Protected from D11 implementation: D6 diagnostic acquisition/projection logic,
+D7 report construction and structural enforcement ownership, D9 transaction
+behavior, D10/G-HOST path policy, D3 graph authority, D8 Pattern Governance,
+D12 verify handoff, D13 generators, generated outputs, lockfiles, baselines,
+resource submodule contents, and product/runtime Civ7 control code.
+
+## Validation Gates
+
+Design-time gates before D11 acceptance:
+
+- D11 complete-standard wording audit over `$D11_CHANGE/**`,
+  `$REMEDIATION_DIR/packet-index.md`, and
+  `$REMEDIATION_DIR/agent-scratch/domino-D11-*.md`.
+- `bun run openspec -- validate deep-habitat-d11-local-feedback --strict`.
+- `bun run openspec:validate`.
+- `git diff --check`.
+- Fresh final D11 rereview lanes for domain/ontology, TypeScript/validation,
+  OpenSpec/information, code/vendor topology, and cross-domino/product.
+
+Later implementation gates:
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/hooks.test.ts` plus any
+  D11-owned split tests introduced by implementation.
+- Hook resource state matrix tests: not configured, clean, staged gitlink
+  allowed, dirty submodule refused, unstaged gitlink refused, locked refused,
+  uninitialized refused, and inspection failure refused.
+- Staged path tests: file-layer refusal, protected/generated refusal carried
+  through D10/D7, partial staging refusal, formatter touched-path restage only,
+  formatter failure, restage failure, Biome check failure, D6 diagnostic finding,
+  D6 diagnostic unavailable/refused/adapter failure, and clean pass.
+- Pre-push tests: explicit base, Graphite parent, merge-base fallback, literal
+  main fallback, D3 graph/target unavailable, Nx affected failure, and bounded
+  command timeout/oracle.
+- Command-surface checks for unsupported hook and any D0-backed help/dry-run
+  behavior. Current behavior input shows `hook --help`, `hook pre-commit
+  --help`, and `hook pre-commit --dry-run` exit 2; a future gate must either
+  preserve that public behavior or route a D0-backed change.
+- `git status --short --branch` after hook/apply-related tests that may touch
+  the working tree.
 
 ## Stop Conditions
 
-- Hooks claim CI or review completion.
-- Hook traces collapse check/apply/protected-zone authority.
-- Local failures are silently skipped.
-
-## Verification Gates
-
-- bun run --cwd tools/habitat-harness test -- test/lib/hooks.test.ts
-- bun run habitat hook pre-commit -- --help
-- bun run openspec -- validate deep-habitat-d11-local-feedback --strict
-- `bun run openspec:validate`
-- `git diff --check`
-
-## D3 Dependency Note
-
-Pre-push affected-target behavior depends on D3 Workspace Graph Boundary. D11 may
-plan local hook feedback before D3, but it must not implement or close pre-push
-target selection, base detection, or target-truth behavior until D3 graph facts
-are stable.
+- D11 renders diagnostic/Grit feedback from raw Grit output or D7 internals
+  instead of D6/D7 projections.
+- A hook can pass after required D6, D7, D9, D10, or D3 authority is unavailable
+  or refused.
+- Resource decision state can represent both allowed and refused behavior.
+- Formatter restage can include paths not touched by the formatter.
+- Partial staging is stashed, rewritten, silently skipped, or formatted.
+- Hook output, trace, docs, or tests describe hook success as CI, review,
+  OpenSpec, Graphite, apply-safety, runtime/product, or current-tree completion.
+- Public hook output/help/export behavior changes without concrete D0 row
+  citation and D1 output-family handling.

--- a/openspec/changes/deep-habitat-d11-local-feedback/specs/habitat-harness/spec.md
+++ b/openspec/changes/deep-habitat-d11-local-feedback/specs/habitat-harness/spec.md
@@ -1,13 +1,214 @@
 ## ADDED Requirements
 
-### Requirement: D11 Local Feedback Is Resolved Before Implementation
+### Requirement: D11 Hook Commands Are Local Feedback Entrypoints
 
-Habitat hooks SHALL provide local feedback by orchestrating owned checks and guards while explicitly refusing to claim CI, review approval, full verification, or safe-apply completion.
+Habitat SHALL treat `habitat hook pre-commit` and `habitat hook pre-push` as local feedback entrypoints that orchestrate accepted upstream projections and native command outcomes without claiming CI, review approval, OpenSpec acceptance, safe apply completion, generated freshness, graph completeness, or product/runtime correctness.
 
-#### Scenario: Hook passes locally
-- **WHEN** a local hook completes all configured local checks
-- **THEN** Habitat reports local feedback scope and non-claims
+#### Scenario: Pre-commit completes local feedback
+- **WHEN** the pre-commit hook completes every required local stage with pass or explicitly allowed not-applicable outcomes
+- **THEN** Habitat reports a local-feedback pass
+- **AND** the hook output and trace carry D1 non-claims for CI, review, OpenSpec, graph, apply, generated freshness, and runtime/product behavior
 
-#### Scenario: Hook cannot run a required local check
-- **WHEN** a local dependency or protected-zone decision is unavailable
-- **THEN** Habitat reports blocked local feedback rather than success
+#### Scenario: Pre-push completes local feedback
+- **WHEN** the pre-push hook resolves its local base decision and affected-target command completes successfully
+- **THEN** Habitat reports a local-feedback pass
+- **AND** the hook output and trace preserve D1 non-claims rather than claiming Graphite, CI, or review readiness
+
+#### Scenario: Unsupported hook name is requested
+- **WHEN** a user invokes a hook name outside the D11 command set
+- **THEN** Habitat refuses the command with the supported hook names
+- **AND** no local feedback trace is reported as passing
+
+### Requirement: D11 Resource Decisions Derive Commit Allowance From The Variant
+
+D11 SHALL model resource pre-commit state as a closed decision where commit allowance is derived from the discriminated variant, not stored as an independently writable boolean.
+
+#### Scenario: Resource state allows pre-commit
+- **WHEN** resources are `clean`, `not-configured`, or `staged-gitlink` with the resource worktree clean
+- **THEN** D11 represents the resource stage as allowed
+- **AND** any legacy `allowPreCommit` field is a compatibility projection from that allowed variant
+
+#### Scenario: Resource state refuses pre-commit
+- **WHEN** resources are dirty, locked, uninitialized, have an unstaged gitlink, or cannot be inspected
+- **THEN** D11 represents the resource stage as refused with recovery instructions
+- **AND** no representation can carry the refused variant together with commit allowance
+
+#### Scenario: Dirty resource worktree and staged gitlink coexist
+- **WHEN** a resource has a staged gitlink and the resource worktree is dirty
+- **THEN** the dirty-resource refusal wins
+- **AND** later hook stages do not run
+
+### Requirement: D11 Pre-Commit Stage Pipeline Is Closed
+
+D11 SHALL define the pre-commit hook as an ordered set of stage outcomes: resource decision, staged path selection, D7/D10 structural feedback, partial-staging decision, Biome formatting/checking, formatter restage, D6 diagnostic feedback, and terminal local feedback.
+
+#### Scenario: Required stage refuses
+- **WHEN** any required pre-commit stage returns a refusal, failed command, unavailable required authority, malformed upstream projection, or contradictory upstream projection
+- **THEN** the pre-commit terminal outcome is not pass
+- **AND** D11 stops before any downstream stage that depends on the refused stage
+
+#### Scenario: No staged paths need a stage
+- **WHEN** a stage is not applicable because no staged paths enter that stage
+- **THEN** D11 records an explicit not-applicable stage result
+- **AND** the not-applicable result does not hide required upstream authority for stages that are still applicable
+
+#### Scenario: Stage trace is emitted
+- **WHEN** D11 records hook trace data
+- **THEN** each stage record names its owner authority, consumed projection or native command, terminal result, recovery text when available, and D1 non-claims
+- **AND** D11 does not infer semantics absent from the consumed projection or native command outcome
+
+### Requirement: D11 Consumes D6 Diagnostic Projections For Staged Diagnostics
+
+D11 SHALL consume D6-owned staged diagnostic projections for Grit/native diagnostic local feedback and SHALL NOT parse raw Grit output, diagnostic message text, pattern identities, adapter failures, or current-tree diagnostic semantics as D11-owned truth.
+
+#### Scenario: D6 reports clean diagnostics
+- **WHEN** D6 publishes a hook-eligible staged diagnostic projection with a clean result
+- **THEN** D11 may continue past the diagnostic stage
+- **AND** D11 preserves diagnostic non-claims and owner metadata in hook trace or output where surfaced
+
+#### Scenario: D6 reports findings
+- **WHEN** D6 publishes a hook-eligible staged diagnostic projection with findings
+- **THEN** D11 reports local feedback failure for the diagnostic stage
+- **AND** the diagnostic projection remains D6-owned
+
+#### Scenario: D6 reports unavailable or malformed diagnostic state
+- **WHEN** D6 reports tool unavailable, command failure, no JSON, malformed JSON, schema drift, pattern projection miss, unexpected pattern identity, cache/freshness unrepresentable, or adapter failure
+- **THEN** D11 reports blocked or failed local diagnostic feedback
+- **AND** hook pass is impossible for a required diagnostic stage
+
+#### Scenario: D6 facts are mediated through D7
+- **WHEN** D7 publishes a local-feedback-safe check projection that includes D6 diagnostic facts
+- **THEN** D11 consumes the exact D7 projection field carrying those facts
+- **AND** D11 records that D7 mediates the local-feedback projection without owning D6 diagnostic semantics
+
+### Requirement: D11 Consumes D7 Check Projections For Structural Outcomes
+
+D11 SHALL consume D7 `LocalFeedbackCheckProjection` or its accepted successor for structural check outcomes and SHALL NOT parse D7 human output, `CheckReport` text, or rule diagnostics to recompute structural enforcement semantics.
+
+#### Scenario: D7 projection passes
+- **WHEN** D7 publishes a local-feedback-safe check projection with a pass or allowed advisory-only result
+- **THEN** D11 may continue the hook stage that consumed that projection
+- **AND** D11 preserves D7 non-claims
+
+#### Scenario: D7 projection refuses or fails
+- **WHEN** D7 publishes selector refusal, dependency refusal, baseline refusal, diagnostic unavailable, protected-zone refusal, or structural failure
+- **THEN** D11 reports non-pass local feedback
+- **AND** no downstream formatting, diagnostic, resource publish, generated publish, or restage step runs when it depends on the refused stage
+
+#### Scenario: D7 projection is unavailable
+- **WHEN** a required D7 local-feedback projection is unavailable
+- **THEN** D11 reports blocked local feedback
+- **AND** the missing projection cannot be represented as hook pass
+
+### Requirement: D11 Consumes D10 And D7 Protected Mutation Refusals Without Owning Zone Policy
+
+D11 SHALL consume D10-owned protected/generated/forbidden mutation refusals directly or through D7 local-feedback projections and SHALL NOT match protected paths locally to decide D10 policy.
+
+#### Scenario: Protected mutation is refused
+- **WHEN** D10 or a D7 projection carrying D10 authority reports refused direct generated edit, refused direct protected edit, refused forbidden artifact, missing host declaration, declaration conflict, malformed D2 projection, or unknown zone reference
+- **THEN** D11 reports blocked pre-commit local feedback
+- **AND** D11 stops before Biome, Grit, generated publish, resource publish, and formatter restage
+
+#### Scenario: Protected mutation details are rendered
+- **WHEN** D11 renders protected mutation feedback
+- **THEN** the output names the repo-relative path, action, owner authority, and recovery instruction supplied by D10 or the D7 projection
+- **AND** D11 does not recompute the protected-zone decision
+
+### Requirement: D11 Partial Staging And Formatter Restage Are Bounded
+
+D11 SHALL keep partial-staging refusal and formatter restage as hook-local safety decisions with exact write boundaries.
+
+#### Scenario: Partially staged supported path is detected
+- **WHEN** a Biome-supported staged path also has unstaged changes
+- **THEN** D11 refuses before formatting, restaging, diagnostic checks, resource publish, and generated publish
+- **AND** D11 does not stash, reset, checkout, or rewrite the worktree to inspect the path
+
+#### Scenario: Formatter changes staged files
+- **WHEN** Biome formatting changes staged candidate files
+- **THEN** D11 restages only formatter-touched staged candidate paths
+- **AND** unchanged paths, foreign staged paths, and unstaged-only paths are not restaged
+
+#### Scenario: Formatter or restage command fails
+- **WHEN** Biome format, Biome check, or `git add --` for formatter-touched paths fails
+- **THEN** D11 reports local feedback failure
+- **AND** no later diagnostic or publish stage is treated as passing
+
+### Requirement: D11 Consumes D9 Transaction Projections Without Claiming Apply Safety
+
+D11 SHALL consume D9 local-feedback-safe transaction projections only where hook-facing apply/fix or transaction recovery feedback is surfaced, and SHALL NOT infer apply safety from changed paths, dry-run output, diagnostics, or formatter results.
+
+#### Scenario: D9 transaction projection is surfaced
+- **WHEN** D11 renders apply/fix or transaction recovery local feedback
+- **THEN** D11 consumes a D9 projection for unavailable, refused, dry-run, applied, rolled-back, rollback-failed, or recovery-required outcomes
+- **AND** D11 output remains local feedback rather than safe-apply completion
+
+#### Scenario: D9 projection is unavailable for a required transaction stage
+- **WHEN** the required D9 local-feedback projection is unavailable or refused
+- **THEN** D11 reports non-pass local feedback for that stage
+- **AND** D11 does not recompute transaction safety locally
+
+### Requirement: D11 Pre-Push Feedback Consumes D3 Graph And Native Base Facts
+
+D11 SHALL model pre-push as local affected-target feedback that consumes D3 workspace graph/target availability where required and native base-resolution command outcomes without owning graph truth, target authority, or CI behavior.
+
+#### Scenario: Explicit pre-push base is supplied
+- **WHEN** a user provides an explicit pre-push base
+- **THEN** D11 records an explicit-base decision
+- **AND** D11 does not probe Graphite or merge-base before running the local affected command
+
+#### Scenario: Graphite or merge-base provides a local base
+- **WHEN** D11 observes a Graphite parent or merge-base candidate
+- **THEN** D11 records the base provenance
+- **AND** the result remains local feedback, not Graphite readiness or review readiness
+
+#### Scenario: Required graph or target fact is unavailable
+- **WHEN** D3 reports graph refusal, missing target, unresolved alias dependency, malformed graph JSON, Nx read failure, Nx daemon failure, or unavailable affected target facts required by D11 pre-push
+- **THEN** D11 reports blocked local feedback
+- **AND** D11 cannot report pre-push pass for that required affected-target stage
+
+#### Scenario: Nx affected command fails
+- **WHEN** the native affected command exits nonzero
+- **THEN** D11 reports affected-target local feedback failure
+- **AND** D11 does not reinterpret the failure as CI, graph, or review authority
+
+### Requirement: D11 Public Surface Compatibility Blocks Source Implementation
+
+D11 SHALL block source implementation for any touched hook public or durable surface until the surface has a concrete D0 compatibility row and D1 output/non-claim handling where applicable.
+
+#### Scenario: Hook output text changes
+- **WHEN** D11 changes hook human output, legacy hook notice wording, help text, command description, or command exit behavior
+- **THEN** the implementation cites the concrete D0 row and closed compatibility handling
+- **AND** D1 non-claim vocabulary remains explicit
+
+#### Scenario: Hook trace or export changes
+- **WHEN** D11 changes `HookTrace`, `PreCommitTrace`, `PrePushTrace`, `HookCommandRecord`, exported hook types, package exports, docs examples, or Husky delegator behavior
+- **THEN** the implementation cites the concrete D0 row and D1 output-family decision
+- **AND** silent shape drift is refused
+
+### Requirement: D11 Trace Records Preserve Owner Relations And Non-Claims
+
+D11 SHALL define hook trace records as local feedback records with ordered stage outcomes, consumed authority metadata, command records, terminal outcome, recovery text where available, and D1 non-claims.
+
+#### Scenario: Trace records a consumed projection
+- **WHEN** a hook stage consumes D3, D6, D7, D9, or D10 projection data
+- **THEN** the trace records the owner and projection identity or accepted compatibility field
+- **AND** D11 does not copy raw upstream internals into a D11-owned semantic model
+
+#### Scenario: Trace records terminal pass
+- **WHEN** a hook reports terminal pass
+- **THEN** the trace includes local-feedback non-claims
+- **AND** the trace contains no field that claims CI, review approval, generated freshness, graph completeness, safe apply completion, or product/runtime correctness
+
+### Requirement: D11 False-Green States Are Refused
+
+D11 SHALL make hook pass impossible after unavailable required authority, contradictory upstream projection, parse or adapter failure for a required diagnostic stage, protected-zone refusal, partial staging refusal, formatter/restage failure, or affected-target failure.
+
+#### Scenario: Required authority is absent
+- **WHEN** a required D3, D6, D7, D9, or D10 authority is missing, unavailable, malformed, or contradictory
+- **THEN** D11 reports blocked or failed local feedback
+- **AND** D11 does not use legacy parsing, fallback command text, or optimistic default state to report pass
+
+#### Scenario: Structured report contradicts stage result
+- **WHEN** structured hook data and stage status disagree
+- **THEN** D11 refuses the pass state
+- **AND** the implementation must repair the contradiction rather than emit a successful hook result

--- a/openspec/changes/deep-habitat-d11-local-feedback/tasks.md
+++ b/openspec/changes/deep-habitat-d11-local-feedback/tasks.md
@@ -1,33 +1,134 @@
 # Tasks
 
-## 1. Pre-Implementation Grounding
+These tasks describe the later D11 implementation work after this packet is
+accepted for design/specification. They do not authorize source edits while the
+source implementation blockers named in this packet remain unresolved.
 
-- [ ] 1.1 Read `D11-local-feedback.md`, the remediation frame, D0 compatibility records,
-  and this OpenSpec packet.
-- [ ] 1.2 Confirm the branch/worktree starts from the approved implementation
-  stack and is clean before source edits.
-- [ ] 1.3 Record the concrete write set and protected paths in the phase record.
-- [ ] 1.4 Re-run or cite the required dependency gates: D0, D1, D7, D9, D10.
+## 1. Preconditions And Public Surface Inventory
 
-## 2. Implementation
+- [ ] 1.1 Read `$D11_SOURCE_PACKET`, `$D11_CHANGE/proposal.md`,
+  `$D11_CHANGE/design.md`, this task list, and the accepted D0/D1/D3/D6/D7/D9/D10
+  packets before source edits.
+- [ ] 1.2 Inventory every touched D11 public or durable surface: `habitat hook`
+  command names, help text, human output, exit semantics, `HookTrace`,
+  `PreCommitTrace`, `PrePushTrace`, `HookCommandRecord`, exported hook types,
+  `.husky/pre-commit`, `.husky/pre-push`, package exports, docs examples, and
+  tests that pin hook behavior.
+- [ ] 1.3 Cite concrete D0 matrix rows and D1 output/non-claim handling for
+  each touched public surface before editing source. If a row is absent, keep
+  source implementation blocked or preserve the legacy surface through a facade.
+- [ ] 1.4 Confirm live upstream implementation facts needed by D11: D3 graph and
+  affected-target facts, D6 staged diagnostic projections, D7
+  `LocalFeedbackCheckProjection`, D9 local-feedback-safe transaction projection
+  where surfaced, and D10 protected mutation projection.
+- [ ] 1.5 Record the implementation write set and protected paths in the phase
+  record before source edits. D11 may touch hook source/tests and adjacent docs
+  only through D0/D1 compatibility; it must not edit D3/D6/D7/D9/D10 authority
+  implementation as a shortcut.
 
-- [ ] 2.1 Define hook-local feedback scope and non-claims.
-- [ ] 2.2 Consume D7/D9/D10 decisions instead of recomputing them.
-- [ ] 2.3 Clarify human output and machine records for hook traces.
+## 2. Resource State And Hook Trace Model
 
-## 3. Validation
+- [ ] 2.1 Replace target resource decision logic with a discriminated
+  `ResourcePreCommitDecision` or equivalent where commit allowance derives from
+  the variant.
+- [ ] 2.2 Preserve current `ResourceState`/`allowPreCommit` output only as a
+  D0/D1-compatible facade when public compatibility requires it.
+- [ ] 2.3 Add constructor/exhaustiveness tests proving refused resource variants
+  cannot also allow commit.
+- [ ] 2.4 Define the target local-feedback trace model with ordered stage
+  outcomes, consumed authority identities, terminal outcome, recovery text where
+  available, and D1 non-claims.
+- [ ] 2.5 Project the target trace to legacy `HookTrace` fields only through
+  explicit D0/D1 handling.
 
-- [ ] 3.1 Run `bun run --cwd tools/habitat-harness test -- test/lib/hooks.test.ts`.
-- [ ] 3.2 Run `bun run habitat hook pre-commit -- --help`.
-- [ ] 3.3 Run `bun run openspec -- validate deep-habitat-d11-local-feedback --strict`.
-- [ ] 3.4 Run `bun run openspec:validate`.
-- [ ] 3.5 Run `git diff --check`.
+## 3. Pre-Commit Pipeline Slices
 
-## 4. Review And Realignment
+- [ ] 3.1 Implement stage-local results for resource decision, staged path
+  selection, D7/D10 structural feedback, partial-staging decision, Biome
+  formatting/checking, formatter restage, D6 diagnostic feedback, and terminal
+  local feedback.
+- [ ] 3.2 Consume D7 local-feedback-safe check projection for structural check
+  outcomes. Do not parse D7 human output or `CheckReport` text as D11 authority.
+- [ ] 3.3 Consume D10 protected/generated/forbidden mutation refusals directly
+  or through D7 projection. Stop before Biome, Grit, publish, and restage when
+  D10 authority refuses a path/action.
+- [ ] 3.4 Keep partial-staging refusal before formatting, restaging, diagnostic
+  checks, resource publish, and generated publish. Do not introduce stash,
+  reset, checkout, or hidden worktree rewrite behavior.
+- [ ] 3.5 Restage only formatter-touched staged candidate paths after Biome
+  formatting. Add tests for unchanged staged paths, foreign staged paths,
+  unstaged-only paths, and restage command failure.
+- [ ] 3.6 Consume D6 staged diagnostic projections for Grit/native diagnostic
+  local feedback. Any current regex/message parsing may exist only as a named
+  compatibility bridge until live D6 projection consumption is implemented, and
+  the bridge cannot be the final D11 target model.
 
-- [ ] 4.1 Run domain-language, OpenSpec, TypeScript, validation, and
-  cross-domino review lanes.
-- [ ] 4.2 Repair accepted P1/P2 findings before packet closure.
-- [ ] 4.3 Update downstream docs, examples, specs, tests, and packet index rows
-  affected by implementation facts.
-- [ ] 4.4 Leave the worktree clean or write a zero-context next packet.
+## 4. D9 Transaction And D8 Eligibility Boundaries
+
+- [ ] 4.1 If D11 surfaces apply/fix or transaction recovery local feedback,
+  consume D9 local-feedback-safe transaction projection states and do not
+  recompute apply safety from changed paths, diagnostic findings, dry-run
+  output, or formatter output.
+- [ ] 4.2 If hook-scope eligibility, pattern admission, or local-feedback
+  admission is consumed, use the D8 accepted projection and record the exact
+  projection field. Otherwise record D8 as non-consumed for this D11 source
+  slice.
+- [ ] 4.3 Keep G-HOST consumption transitive through accepted D9/D10 projections
+  unless D11 directly edits host-owned declaration, protected-zone, generated
+  path, or hook policy surfaces.
+
+## 5. Pre-Push Pipeline Slices
+
+- [ ] 5.1 Model pre-push base decision as explicit base, Graphite parent,
+  merge-base candidate, literal-main local fallback, or blocked/unavailable
+  authority according to the accepted design.
+- [ ] 5.2 Consume D3 graph/target availability before reporting affected-target
+  pass where D11 depends on graph or target facts.
+- [ ] 5.3 Preserve native Nx affected command outcome as local feedback only.
+  Nonzero affected command exit blocks local pass and does not become CI,
+  Graphite, review, or graph authority.
+- [ ] 5.4 Add tests for explicit base, Graphite parent, merge-base `main`,
+  merge-base `origin/main`, literal-main local fallback with non-claims, D3
+  graph refusal, target unavailable, and Nx affected command failure.
+
+## 6. Public Compatibility, Documentation, And Wording
+
+- [ ] 6.1 Replace target product/code terminology such as legacy hook authority wording with local
+  feedback notice, local feedback trace, non-claim, command record, decision,
+  diagnostic, transaction, receipt, or outcome terms.
+- [ ] 6.2 Preserve existing public wording only through D0/D1 compatibility
+  handling. Any replacement, versioning, facade, deprecation, or refusal must
+  cite the concrete D0 row.
+- [ ] 6.3 Update `.husky/*`, docs, examples, and command help only when D0/D1
+  rows authorize the public-surface behavior.
+- [ ] 6.4 Keep all source code references repo-relative or fixture-variable
+  based in docs; do not introduce brittle host-local paths.
+
+## 7. Later Implementation Validation
+
+- [ ] 7.1 Run `bun run --cwd tools/habitat-harness test -- test/lib/hooks.test.ts`
+  and add focused tests for every D11 stage variant, refusal, unavailable
+  authority, and public compatibility projection touched by source edits.
+- [ ] 7.2 Run non-executing help/command-surface tests. Do not use `habitat hook
+  pre-commit --help` or any command shape that can execute a live hook as a help
+  gate unless D0 explicitly defines that behavior.
+- [ ] 7.3 Run hook command probes only in controlled fixtures with `git status
+  --short --branch` before and after any command that can write, stage, or
+  inspect the worktree.
+- [ ] 7.4 Run `bun run openspec -- validate deep-habitat-d11-local-feedback
+  --strict`, `bun run openspec:validate`, and `git diff --check`.
+- [ ] 7.5 Record which validation commands prove behavior, which validate
+  OpenSpec shape only, and which are non-claims.
+
+## 8. Review And Closure
+
+- [ ] 8.1 Run fresh final D11 rereview lanes after packet/control repair:
+  domain/ontology, TypeScript/validation, OpenSpec/information, code/vendor
+  topology, and cross-domino/product.
+- [ ] 8.2 Repair every accepted P1/P2 finding before packet-index acceptance
+  movement.
+- [ ] 8.3 Keep D11 source implementation blocked until concrete D0 rows and live
+  upstream projections exist for the touched surfaces.
+- [ ] 8.4 Update downstream docs, tests, specs, packet index, and workstream
+  records only after the current D11 packet state justifies the update.
+- [ ] 8.5 Leave the Graphite layer clean and reviewable.

--- a/openspec/changes/deep-habitat-d11-local-feedback/workstream/closure-checklist.md
+++ b/openspec/changes/deep-habitat-d11-local-feedback/workstream/closure-checklist.md
@@ -1,20 +1,60 @@
 # Closure Checklist: D11 Local Feedback
 
+## Current State
+
+D11 is accepted for design/specification only after final rereview. It remains
+not implementation-complete, and no source implementation is authorized by this
+checklist.
+
 ## Design Readiness
 
-- [ ] Proposal cites controlling authority and source packet.
-- [ ] Design resolves naming, domain owner, forbidden owners, and non-goals.
-- [ ] Tasks are implementation steps, not unresolved design questions.
-- [ ] Spec delta uses normative SHALL language with scenarios.
-- [ ] Review ledger has no accepted unresolved P1/P2 findings.
-- [ ] Downstream realignment is recorded.
-- [ ] OpenSpec validation passes for `deep-habitat-d11-local-feedback`.
+- [x] Proposal cites controlling authority and source packet.
+- [x] Proposal names D6 staged diagnostic projections, D7 local-feedback check
+  projection, D9 transaction projection, D10 protected mutation projection, D3
+  graph/affected facts, D0 compatibility rows, and D1 non-claims.
+- [x] Design resolves Local Feedback ownership, forbidden owners, target terms,
+  compatibility terms, resource decision model, pre-commit/pre-push stage
+  models, TypeScript refactor moves, and public compatibility gates.
+- [x] Spec delta uses normative SHALL language with scenario families for
+  hook commands, resource decisions, pre-commit stages, D6/D7/D10/D9/D3
+  consumption, public compatibility, trace records, and false-green refusal.
+- [x] Tasks are ordered implementation slices with source blockers, write-set
+  guardrails, and validation gates.
+- [x] Downstream realignment records D0/D1/D3/D6/D7/D8/D9/D10/G-HOST/D12/D15
+  relationships.
+- [x] First-wave D11 negative findings are imported into the review ledger and
+  dispositioned as repaired and accepted after final rereview.
+- [x] Complete-standard wording audit passes over `$D11_CHANGE/**`,
+  `$REMEDIATION_DIR/packet-index.md`, and `$AGENT_SCRATCH/domino-D11-*.md`.
+- [x] Remaining audit hits are packet-index canonical D13 traceability rows and
+  no active D11 guidance.
+- [x] `bun run openspec -- validate deep-habitat-d11-local-feedback --strict`
+  passes on the repaired packet.
+- [x] `bun run openspec:validate` passes on the repaired corpus.
+- [x] `git diff --check` passes.
+- [x] Fresh final D11 rereview lanes record no unresolved P1/P2 findings.
+- [x] Packet index marks D11 accepted for design/specification only after the
+  final gate closes.
+- [x] Post-closure reduced-standard and stale-status scan over
+  `$D11_CHANGE/**`, `$REMEDIATION_DIR/packet-index.md`, and
+  `$AGENT_SCRATCH/domino-D11-*.md` returns only canonical D13 packet-index
+  traceability rows outside active D11 guidance.
 
 ## Implementation Closure (Later)
 
-- [ ] Source changes stay inside the approved write set.
-- [ ] Validation gates pass with exact command output recorded.
-- [ ] Public-surface changes are dispositioned through D0 compatibility.
-- [ ] Downstream docs/tests/specs are realigned.
-- [ ] Graphite layer is clean, reviewable, and does not proceed past unresolved
-  packet approval.
+- [ ] Source changes stay inside the approved D11 write set.
+- [ ] Every touched public surface cites a concrete D0 row and D1 output-family
+  handling.
+- [ ] Live D3/D6/D7/D9/D10 projections exist wherever source code consumes them.
+- [ ] Resource decision tests prove contradictory allowance cannot compile or
+  cannot be constructed.
+- [ ] Hook tests cover staged generated/protected refusals, partial staging,
+  formatter-touched restage only, D6 diagnostic findings/unavailable states, D7
+  projection refusals, D9 transaction projection handling where consumed, D3
+  pre-push unavailable states, and unsupported hook behavior.
+- [ ] Any command that can write/stage has before/after `git status --short
+  --branch` checks in its validation record.
+- [ ] Downstream docs/tests/specs are realigned only after implementation facts
+  justify the change.
+- [ ] Graphite layer is clean, reviewable, and separate from adjacent packet
+  layers.

--- a/openspec/changes/deep-habitat-d11-local-feedback/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/deep-habitat-d11-local-feedback/workstream/downstream-realignment-ledger.md
@@ -1,9 +1,29 @@
 # Downstream Realignment Ledger: D11 Local Feedback
 
-| Downstream Surface | Disposition | Required Action |
+## Status
+
+D11 is accepted for design/specification only after final rereview and remains
+not implementation-complete. Source work remains blocked behind concrete D0
+rows, D1 output-family/non-claim handling, live D3/D6/D7/D9/D10 projections
+where consumed, conditional D8 projection where consumed, and G-HOST only
+through accepted D9/D10 projections unless D11 touches host-owned surfaces.
+This ledger records downstream assumptions that must stay aligned during later
+implementation.
+
+| Surface | D11 relationship | Required downstream state |
 | --- | --- | --- |
-| Phase 2 packet suite | pending | Mark D11 as OpenSpec-packetized after review. |
-| D0 compatibility matrix | pending | Confirm public surfaces touched by D11 are classified before implementation. |
-| Habitat docs/examples | pending | Update only when implementation facts change or public guidance must be clarified. |
-| Tests and command fixtures | pending | Add or update during implementation according to tasks.md. |
-| Later domino packets | pending | Update dependency assumptions if review changes D11 contract. |
+| D0 command/public surface inventory | D11 source work can touch hook commands, help, output, trace, exports, Husky delegators, docs/examples, and script surfaces only with concrete D0 rows. | D11 remains source-blocked wherever those rows are absent. Later implementation must cite row ids for every touched surface. |
+| D1 output/non-claim boundary | D11 consumes local feedback trace, command record, and non-claim vocabulary; legacy hook wording is compatibility handling only. | Hook output and trace changes must preserve or version D1 output-family handling; target product terms stay local-feedback-oriented. |
+| D3 workspace graph boundary | D11 pre-push local feedback consumes graph/target/base availability and graph-refusal states. | D11 cannot report affected-target pass when required D3 graph/target facts are refused or unavailable. D12 may not treat D11 pass as graph verification. |
+| D6 diagnostic pattern catalog | D11 consumes staged diagnostic projections for Grit/native local feedback. | D11 must not parse raw Grit output or collapse diagnostic ownership into D7. D6 remains owner of diagnostic identity, adapter failure, projection miss, and D15 trigger conditions. |
+| D7 structural enforcement pipeline | D11 consumes `LocalFeedbackCheckProjection` for structural check outcomes and may receive D6/D10-origin labels through D7. | D7 remains owner of check/report construction. D11 renders local feedback and sequencing only. |
+| D8 Pattern Governance | D11 consumes D8 only if hook eligibility, pattern admission, hook scope, or local-feedback admission becomes part of the D11 source slice. | If consumed, D8 projection field and prohibited inference must be named. Otherwise D8 remains a conditional downstream relation, not a direct source blocker. |
+| D9 transformation transaction | D11 consumes D9 local-feedback-safe transaction projection only when hook output references apply/fix or transaction recovery. | D11 cannot infer apply safety, rollback correctness, or transaction readiness from diagnostics, changed paths, dry-run text, or formatter output. |
+| D10 protected/generated-zone authority | D11 consumes D10 protected/generated/forbidden mutation refusals directly or through D7. | D11 must stop local hook stages on D10 refusal and must not own path policy or generated/protected-zone semantics. |
+| G-HOST | D11 consumes host-owned policy only through D9/D10 projections unless it directly touches host declarations or hook policy. | G-HOST remains transitive for this packet unless direct host surfaces are introduced by a later D11 implementation decision with accepted D0/D1 rows. |
+| D12 verification handoff | D12 may observe D11 local feedback non-claims and trace boundaries. | D12 must not cite hook pass as verification completion, CI, graph authority, or product/runtime readiness. |
+| D15 trigger | D11 can trigger D15 only when a concrete local command/state observation cannot be represented by D1, D3, D6, D7, D9, or D10 projections. | No D15 trigger is accepted by this packet without a named impossible local state and final review disposition. |
+| `.husky/pre-commit` and `.husky/pre-push` | D11 owns hook workflow semantics but Husky delegators are public durable surfaces. | Any delegator change requires D0 row citation. No implementation claim until source changes and hook tests pass. |
+| Hook tests and fixtures | D11 later implementation must expand hook tests around the target state matrix. | `hooks.test.ts` current pass is current-behavior grounding only. Later behavior gates must cover D6/D7/D9/D10/D3 projections and false-green refusals. |
+| Docs/examples/process guidance | D11 may need to realign docs that describe hook semantics, resource behavior, Graphite/pre-push, or local feedback. | Docs should update only after D0/D1 public guidance rows authorize the behavior; no brittle host-local paths should be introduced. |
+| Packet index | D11 row reflects D6 and D3 dependency repair, conditional D8/G-HOST handling, and accepted design/specification state. | Keep D11 not implementation-complete; source implementation remains blocked by concrete D0 rows, D1 output-family/non-claim handling, live D3/D6/D7/D9/D10 projections where consumed, conditional D8 projection where consumed, and G-HOST only through accepted D9/D10 projections unless D11 touches host-owned surfaces. |

--- a/openspec/changes/deep-habitat-d11-local-feedback/workstream/phase-record.md
+++ b/openspec/changes/deep-habitat-d11-local-feedback/workstream/phase-record.md
@@ -1,36 +1,118 @@
 # Phase Record: D11 Local Feedback
 
+## Path Variables
+
+- `$REPO_ROOT`: active remediation checkout root.
+- `$D11_CHANGE`: `$REPO_ROOT/openspec/changes/deep-habitat-d11-local-feedback`.
+- `$D11_SOURCE_PACKET`: `$REPO_ROOT/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md`.
+- `$REMEDIATION_DIR`: `$REPO_ROOT/docs/projects/habitat-harness/openspec-remediation`.
+- `$AGENT_SCRATCH`: `$REMEDIATION_DIR/agent-scratch`.
+- `$HABITAT_TOOL`: `$REPO_ROOT/tools/habitat-harness`.
+
 ## State
 
-- Status: OpenSpec packet drafted for remediation review; implementation not
-  started.
-- Worktree: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation.
-- Branch: codex/deep-habitat-openspec-remediation.
-- Source packet: /Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-deep-habitat-openspec-remediation/docs/projects/habitat-harness/phase2-workstream-packets/D11-local-feedback.md.
-- OpenSpec change: openspec/changes/deep-habitat-d11-local-feedback/.
+- Status: accepted for design/specification after final D11 rereview; not
+  implementation-complete.
+- Worktree fixture: `$ACTIVE_REMEDIATION_WORKTREE` from
+  `$REMEDIATION_DIR/context.md`.
+- Branch: `codex/d11-local-feedback-packet`.
+- Source packet: `$D11_SOURCE_PACKET`.
+- OpenSpec change: `$D11_CHANGE`.
+- Implementation: not started and not authorized by this state.
 
 ## Objective
 
-Convert D11 into a review-gated OpenSpec packet scaffold for Local Feedback
-without reopening implementation or carrying forward lazy domain language.
+Specify D11 as the complete Local Feedback OpenSpec packet: hook command
+semantics, staged-file workflow, resource pre-commit decisions, D6/D7/D9/D10/D3
+projection consumption, local feedback trace/non-claims, public compatibility
+gates, and validation oracles. D11 must remain generic Habitat repo-maintenance
+infrastructure and must not own diagnostic, graph, protected-zone, transaction,
+CI, review, Graphite, or runtime/product truth.
 
 ## Current Gate
 
-Design/preparation gate. The packet can authorize later implementation only
-after review ledgers contain no accepted unresolved P1/P2 findings.
+D11's design/specification gate is closed. Fresh final rereview lanes read the
+repaired disk state and recorded no unresolved P1/P2 findings:
 
-## Exact Validation Gates
+- `$AGENT_SCRATCH/domino-D11-final-domain-ontology-review.md`;
+- `$AGENT_SCRATCH/domino-D11-final-typescript-validation-review.md`;
+- `$AGENT_SCRATCH/domino-D11-final-openspec-information-review.md`;
+- `$AGENT_SCRATCH/domino-D11-final-code-vendor-topology-review.md`;
+- `$AGENT_SCRATCH/domino-D11-final-cross-domino-product-review.md`.
 
-- bun run --cwd tools/habitat-harness test -- test/lib/hooks.test.ts
-- bun run habitat hook pre-commit -- --help
-- bun run openspec -- validate deep-habitat-d11-local-feedback --strict
-- bun run openspec:validate
-- git diff --check
+The first-wave investigation files remain negative repair input. The final
+rereview files are the acceptance input for design/specification only.
+
+## Incorporated First-Wave Inputs
+
+| Input | Current disposition |
+| --- | --- |
+| `$AGENT_SCRATCH/domino-D11-domain-ontology-investigation.md` | Accepted as blocking repair input for Local Feedback ontology, resource-state naming, upstream owner boundaries, native tool roles, staged-path policy, pre-push base/affected semantics, and branch metadata. |
+| `$AGENT_SCRATCH/domino-D11-typescript-state-investigation.md` | Accepted as blocking repair input for TypeScript state-space collapse, discriminated resource decisions, trace compatibility, raw diagnostic parsing removal, stage extraction order, and behavior-preserving implementation slices. |
+| `$AGENT_SCRATCH/domino-D11-code-vendor-topology-investigation.md` | Accepted as blocking repair input for current hook topology, public surface inventory, D0/D1 blockers, D6/D3 dependency repair, vendor behavior, and invalid help-command validation. |
+| `$AGENT_SCRATCH/domino-D11-openspec-information-testing-investigation.md` | Accepted as blocking repair input for spec/task completeness, false-green refusal scenarios, D6 direct dependency, validation oracles, and stale branch metadata. |
+| `$AGENT_SCRATCH/domino-D11-cross-domino-product-investigation.md` | Accepted as blocking repair input for D6/D3/D8/G-HOST dependency modeling, product recovery behavior, D15 trigger discipline, and packet-index repair. |
+
+## Design-Time Validation Gates
+
+| Gate | Required current result | Scope |
+| --- | --- | --- |
+| D11 wording audit | No active reduced-standard guidance in `$D11_CHANGE/**`, `$REMEDIATION_DIR/packet-index.md`, or `$AGENT_SCRATCH/domino-D11-*.md` except explicitly classified legacy compatibility terms. | Artifact language control only. |
+| `bun run openspec -- validate deep-habitat-d11-local-feedback --strict` | Pass before final rereview and before any acceptance movement. | OpenSpec shape only. |
+| `bun run openspec:validate` | Pass before final rereview and before any acceptance movement. | Full OpenSpec corpus shape only. |
+| `git diff --check` | Pass before final rereview and before commit. | Whitespace/diff hygiene. |
+| Fresh final D11 rereviews | No unresolved P1/P2. | Design/specification acceptance gate. |
+
+## Current Validation Record
+
+Run from `$REPO_ROOT` after the first-wave D11 packet/control repair and final
+rereview integration:
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| D11 complete-standard wording audit | passed for active D11 artifacts and D11 scratch | Remaining scan hits are packet-index canonical D13 traceability rows and global packet-index wording/status policy rows, not active D11 guidance. |
+| `bun run openspec -- validate deep-habitat-d11-local-feedback --strict` | passed | OpenSpec shape only. |
+| `bun run openspec:validate` | passed | Full OpenSpec corpus shape only. |
+| `git diff --check` | passed | Diff hygiene only. |
+| Final D11 rereview set | passed | All five final lanes record no unresolved P1/P2. |
+| Post-closure reduced-standard and stale-status scan | passed for active D11 artifacts and all D11 scratch | Exact scan over `$D11_CHANGE/**`, `$REMEDIATION_DIR/packet-index.md`, and `$AGENT_SCRATCH/domino-D11-*.md` returns only canonical D13 packet-index traceability rows outside active D11 guidance. |
+| Post-closure strict D11 validation | passed | `bun run openspec -- validate deep-habitat-d11-local-feedback --strict`. |
+| Post-closure full OpenSpec validation | passed | `bun run openspec:validate`. |
+| Post-closure diff hygiene | passed | `git diff --check`. |
+
+## Later Implementation Gates
+
+These gates are not design-time acceptance claims:
+
+- `bun run --cwd tools/habitat-harness test -- test/lib/hooks.test.ts` plus
+  D11-owned focused tests for resource decisions, staged path workflow, D6/D7
+  projections, D9 transaction projection where consumed, D10 refusals, pre-push
+  D3/Nx behavior, unsupported hook behavior, and trace compatibility.
+- Controlled hook command probes only when they cannot mutate the active
+  checkout or have explicit before/after `git status --short --branch` checks.
+- D0 row validation for every touched command, output, help, trace, export,
+  docs, Husky, script, or generated-help surface.
+
+## Source Blockers
+
+Source implementation remains blocked wherever any of these are absent:
+
+- concrete D0 rows for touched hook public/durable surfaces;
+- D1 output-family and non-claim decisions for hook output and trace records;
+- live D3 graph/target/base facts required by pre-push affected feedback;
+- live D6 staged diagnostic projections for hook diagnostic local feedback;
+- live D7 `LocalFeedbackCheckProjection` for structural check local feedback;
+- live D9 transaction projection where hook feedback surfaces apply/fix state;
+- live D10 protected/generated/forbidden mutation projection;
+- D8 local-feedback eligibility projection if hook eligibility/admission is
+  consumed directly.
 
 ## Non-Claims
 
-- This remediation packet does not implement Habitat source changes.
-- This packet does not prove runtime behavior.
-- This packet does not approve Graphite submission for later implementation.
-- Legacy code names remain compatibility facts unless design.md accepts them as
-  target language.
+- This packet does not implement Habitat source changes.
+- This packet does not establish runtime behavior.
+- This packet does not authorize D11 source implementation until the source
+  blockers above are live for the touched implementation slice.
+- D11 hook pass is local feedback only; it is not CI, review, Graphite,
+  OpenSpec, apply-safety, generated freshness, graph completeness, or
+  product/runtime readiness.

--- a/openspec/changes/deep-habitat-d11-local-feedback/workstream/review-disposition-ledger.md
+++ b/openspec/changes/deep-habitat-d11-local-feedback/workstream/review-disposition-ledger.md
@@ -1,10 +1,52 @@
 # Review Disposition Ledger: deep-habitat-d11-local-feedback
 
-| Finding | Severity | Disposition | Repair Evidence |
+## Status
+
+D11 is accepted for design/specification after final rereview. It is not
+implementation-complete, and source implementation remains blocked behind the
+D0/D1/live-projection gates named in `phase-record.md`.
+
+## Global Constraints
+
+| Finding | Severity | Disposition | Repair record |
 | --- | --- | --- | --- |
-| Global domain-language concern catalog applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-domain-adversary.md and docs/projects/habitat-harness/openspec-remediation/review-disposition-ledger.md. Per-domino domain-language review remains blocking. |
-| Global OpenSpec artifact-shape constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-openspec-architect.md and packet traceability index. Per-domino OpenSpec review remains blocking. |
-| Global information-design constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-information-design-reviewer.md and traceability/evidence policy repairs. Per-domino information-design review remains blocking. |
-| Global validation-design constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-testing-validation-designer.md and packet validation gates. Per-domino validation review remains blocking. |
-| Global cross-domino sequencing constraints applied to draft scaffold. | Global constraint | applied, not acceptance evidence | See docs/projects/habitat-harness/openspec-remediation/agent-scratch/global-cross-domino-sequencer.md and dependency/trigger repairs. Per-domino sequencing compatibility review remains blocking. |
-| Per-domino adversarial review gate required before packet acceptance or source edits. | P1 | blocking, pending design-time review | Fresh per-domino domain, OpenSpec, topology, validation, information-design, and cross-domino reviewers must disposition findings before this packet can be accepted or used for implementation. |
+| Global domain-language concern catalog applied to draft packet. | Global constraint | applied, not acceptance input | D11 proposal/design/spec/tasks now name Local Feedback as owner, reject legacy authority-shaped target language, and separate D6/D7/D9/D10/D3 authority from D11 rendering. Per-domino final domain/ontology rereview remains blocking. |
+| Global OpenSpec artifact-shape constraints applied to draft packet. | Global constraint | applied, not acceptance input | D11 now has expanded proposal/design/spec/tasks/control records. Per-domino final OpenSpec/information rereview remains blocking. |
+| Global validation-design constraints applied to draft packet. | Global constraint | applied, not acceptance input | D11 now separates design-time OpenSpec/diff/wording gates from later source behavior gates. Per-domino final validation rereview remains blocking. |
+| Global cross-domino sequencing constraints applied to draft packet. | Global constraint | applied, not acceptance input | D11 now names D0/D1/D3/D6/D7/D9/D10 and conditional D8/G-HOST edges. Per-domino final cross-domino rereview remains blocking. |
+
+## First-Wave D11 Findings
+
+| Finding | Severity | Disposition | Repair record |
+| --- | --- | --- | --- |
+| D11 did not define a complete Local Feedback ontology/state model. | P1 | repaired and accepted | `design.md` now defines Local Feedback terms, hook stage outcomes, resource decisions, D6/D7/D9/D10/D3 projection boundaries, and public compatibility constraints. Final domain/ontology rereview found no unresolved P1/P2. |
+| Resource state allowed contradictory `kind` plus `allowPreCommit` values. | P1 | repaired and accepted | `design.md`, `spec.md`, and `tasks.md` require a discriminated `ResourcePreCommitDecision` with allowance derived from variant and legacy `allowPreCommit` only as compatibility projection. Final TypeScript/validation rereview found no unresolved P1/P2. |
+| D11 omitted D6 staged diagnostic projection as a direct dependency. | P1 | repaired and accepted | `proposal.md`, `spec.md`, `tasks.md`, phase record, downstream ledger, and packet index state D6 as a direct consumed authority for staged diagnostic local feedback. Final cross-domino/product rereview accepted the D6 edge. |
+| D11 could collapse D6 diagnostics into D7-only check projection or current raw Grit parsing. | P1 | repaired and accepted | `proposal.md` and `spec.md` require D6 owner metadata even when mediated through D7 and prohibit raw Grit/D7 human-output parsing as target behavior. Final domain/ontology and TypeScript/validation rereviews found no unresolved P1/P2. |
+| D11 omitted D3 graph/affected-target dependency for pre-push local feedback. | P1 | repaired and accepted | `proposal.md`, `design.md`, `spec.md`, `tasks.md`, downstream ledger, and packet index name D3 graph/target/base facts and graph-refusal states as D11 pre-push dependencies. Final cross-domino/product rereview accepted the D3 edge. |
+| Spec delta was underspecified for unsafe hook success. | P1 | repaired and accepted | `spec.md` now contains requirement families for command entrypoints, resource decisions, pre-commit stages, D6/D7/D10/D9/D3 consumption, public compatibility, trace records, and false-green refusal. Final OpenSpec/information rereview found no unresolved P1/P2. |
+| Tasks delegated implementation sequencing and write-set decisions to later agents. | P1 | repaired and accepted | `tasks.md` now defines preconditions, public surface inventory, state-model slices, pre-commit/pre-push slices, compatibility work, validation, and closure gates. Final OpenSpec/information and code/vendor topology rereviews found no unresolved P1/P2. |
+| Public hook surfaces and trace compatibility were deferred generically. | P1 | repaired and accepted | `proposal.md`, `spec.md`, `tasks.md`, and phase record block source work behind D0 rows and D1 output/non-claim handling for hook output, help, traces, exports, docs, Husky, and command behavior. Final code/vendor topology rereview accepted source blockers. |
+| Hook false-green states were not normative. | P1 | repaired and accepted | `spec.md` and validation gates make pass impossible after unavailable required authority, protected refusal, partial staging, formatter/restage failure, diagnostic failure, or affected-target failure. Final TypeScript/validation rereview accepted the state model. |
+| D9 transaction feedback relation was named but not designed. | P2 | repaired and accepted | `proposal.md`, `spec.md`, `tasks.md`, and downstream ledger define D9 local-feedback-safe projection consumption only where transaction/apply/fix feedback is surfaced. Final cross-domino/product rereview accepted the conditional relation. |
+| D8 local-feedback eligibility/admission relation was underspecified. | P2 | repaired and accepted | `tasks.md`, downstream ledger, and packet index make D8 conditional: consumed only when hook eligibility, pattern admission, or local-feedback admission appears. Final cross-domino/product rereview accepted the conditional relation. |
+| G-HOST relation was unclear. | P2 | repaired and accepted | `proposal.md`, `tasks.md`, downstream ledger, and packet index keep G-HOST transitive through D9/D10 unless D11 directly touches host-owned declarations or hook policy. Final cross-domino/product rereview accepted the transitive relation. |
+| Staged path, partial-staging, and restage policy were implicit. | P2 | repaired and accepted | `spec.md` and `tasks.md` require partial-staging refusal before writes and formatter-touched staged-path restage only. Final TypeScript/validation and code/vendor topology rereviews found no unresolved P1/P2. |
+| Pre-push base and affected behavior were ambiguous. | P2 | repaired and accepted | `design.md`, `spec.md`, and `tasks.md` define explicit base, Graphite parent, merge-base, literal fallback, D3 unavailable states, and Nx affected failure as local feedback only. Final cross-domino/product and code/vendor topology rereviews found no unresolved P1/P2. |
+| Hook trace schema and non-claims were unresolved outside design. | P2 | repaired and accepted | `spec.md` and `tasks.md` require stage owner/projection records, terminal outcome, recovery text, D1 non-claims, and D0/D1 compatibility for legacy trace shapes. Final domain/ontology and OpenSpec/information rereviews found no unresolved P1/P2. |
+| Validation gates included an unsafe help command shape. | P2 | repaired and accepted | `tasks.md` and phase record forbid help gates that can execute live hooks unless D0 defines that behavior. Final code/vendor topology rereview accepted the validation shape. |
+| Phase record branch metadata was stale. | P2 | repaired and accepted | `phase-record.md` now names `codex/d11-local-feedback-packet`; `$REMEDIATION_DIR/context.md` is updated to the same active branch. Final OpenSpec/information rereview accepted control-state alignment. |
+
+## Final Review Gate
+
+Fresh final rereview files recorded no unresolved P1/P2 against the repaired
+disk state:
+
+- `$AGENT_SCRATCH/domino-D11-final-domain-ontology-review.md`;
+- `$AGENT_SCRATCH/domino-D11-final-typescript-validation-review.md`;
+- `$AGENT_SCRATCH/domino-D11-final-openspec-information-review.md`;
+- `$AGENT_SCRATCH/domino-D11-final-code-vendor-topology-review.md`;
+- `$AGENT_SCRATCH/domino-D11-final-cross-domino-product-review.md`.
+
+D11 is accepted for design/specification only. D11 remains not
+implementation-complete.


### PR DESCRIPTION
docs(habitat): add D11 cross-domino product review

Record the local feedback dependency, product recovery, D15 trigger, and packet-index repair findings for the D11 OpenSpec remediation pass.

This is investigation input only and does not edit D11 packet/control files.

References:
- Project: Deep Habitat OpenSpec remediation
- Packet: D11 Local Feedback

docs(habitat): add D11 local feedback packet investigation

docs(habitat): accept D11 local feedback packet

Specify and accept the D11 Local Feedback OpenSpec packet for design/specification only. The packet defines hook-local feedback ownership, D6 staged diagnostic projection consumption, D7 local-feedback check projection consumption, D9 transaction projection boundaries, D10 protected mutation refusal handling, D3 pre-push graph/affected dependencies, D0/D1 public-surface blockers, and final review/control records. Adds D11 first-wave and final rereview scratch records with no unresolved P1/P2 findings.

Validation: D11 complete-standard wording audit; bun run openspec -- validate deep-habitat-d11-local-feedback --strict; bun run openspec:validate; git diff --check.