### PR TITLE
feat(habitat): introduce Effect-backed vendor providers and oRPC service layer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -299,10 +299,19 @@
         "@nx/devkit": "22.7.5",
         "@oclif/core": "^4.11.4",
         "@oclif/plugin-help": "^6.2.50",
+        "@orpc/client": "1.14.6",
+        "@orpc/contract": "1.14.6",
+        "@orpc/server": "1.14.6",
+        "@orpc/shared": "^1.14.4",
+        "@standard-schema/spec": "^1.1.0",
         "effect": "3.21.3",
+        "effect-orpc": "0.5.0",
         "typebox": "^1.0.80",
       },
     },
+  },
+  "patchedDependencies": {
+    "effect-orpc@0.5.0": "patches/effect-orpc@0.5.0.patch",
   },
   "overrides": {
     "@types/node": "^22.19.21",
@@ -3674,6 +3683,8 @@
     "@inquirer/select/@inquirer/core": ["@inquirer/core@9.2.1", "", { "dependencies": { "@inquirer/figures": "^1.0.6", "@inquirer/type": "^2.0.0", "@types/mute-stream": "^0.0.4", "@types/node": "^22.5.5", "@types/wrap-ansi": "^3.0.0", "ansi-escapes": "^4.3.2", "cli-width": "^4.1.0", "mute-stream": "^1.0.0", "signal-exit": "^4.1.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.2" } }, "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg=="],
 
     "@inquirer/select/@inquirer/type": ["@inquirer/type@1.5.5", "", { "dependencies": { "mute-stream": "^1.0.0" } }, "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA=="],
+
+    "@internal/habitat-harness/effect-orpc": ["effect-orpc@0.5.0", "", { "peerDependencies": { "@orpc/client": ">=1.13.0", "@orpc/contract": ">=1.13.0", "@orpc/server": ">=1.13.0", "@orpc/shared": ">=1.13.0", "effect": ">=3.18.0", "typescript": "^5" } }, "sha512-cnRcrz9L4GXp1IrMNlOV29YzF5cxDEK2XDypcy8i2ohOY2UDhwZ1BuG/jiTIpPZV2p1Vw1+D9ScWsIl46JHj9A=="],
 
     "@mintlify/cli/@inquirer/prompts": ["@inquirer/prompts@7.9.0", "", { "dependencies": { "@inquirer/checkbox": "^4.3.0", "@inquirer/confirm": "^5.1.19", "@inquirer/editor": "^4.2.21", "@inquirer/expand": "^4.0.21", "@inquirer/input": "^4.2.5", "@inquirer/number": "^3.0.21", "@inquirer/password": "^4.0.21", "@inquirer/rawlist": "^4.1.9", "@inquirer/search": "^3.2.0", "@inquirer/select": "^4.4.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A=="],
 

--- a/openspec/changes/deep-habitat-effect-vendor-providers/tasks.md
+++ b/openspec/changes/deep-habitat-effect-vendor-providers/tasks.md
@@ -2,34 +2,46 @@
 
 ## 1. Provider Contracts
 
-- [ ] 1.1 Define shared provider command and failure contract under `src/providers/command/**`.
-- [ ] 1.2 Add Git provider.
-- [ ] 1.3 Define Grit provider contracts, fake/live Layers, and pure command/output parsing seams; defer adapter draining to `deep-habitat-effect-grit-apply-cutover`.
-- [ ] 1.4 Add Biome provider.
-- [ ] 1.5 Add Nx provider.
-- [ ] 1.6 Add Husky delegator provider.
+- [x] 1.1 Define shared provider command and failure contract under `src/providers/command/**`.
+- [x] 1.2 Add Git provider.
+- [x] 1.3 Define Grit provider contracts, fake/live Layers, and pure command/output parsing seams; defer adapter draining to `deep-habitat-effect-grit-apply-cutover`.
+- [x] 1.4 Add Biome provider.
+- [x] 1.5 Add Nx provider.
+- [x] 1.6 Add Husky delegator provider.
 - [ ] 1.7 Remove the temporary `HabitatProcess` migration bridge from
   `src/lib/habitat-process.ts`; Grit, Biome, Nx, Git, and Husky callsites must
   consume provider services directly before this train is done.
+  Remaining bridge owner: follow-on cutover packets. Current branch keeps the
+  bridge only where older callsites still need adjacent-domino migration.
 
 ## 2. Migration
 
 - [ ] 2.1 Replace raw Git calls in baseline/check/hook/verify write sets through follow-on domain packets; this packet only creates provider contracts and first callsites required for parity tests.
+  Current branch moves verify base/status and affected execution to
+  `GitProvider`/`NxProvider`; baseline/check/hook remain with their owning
+  cutover packets.
 - [ ] 2.2 Replace `WorkspaceToolProvider` command-name map with provider command builders.
-- [ ] 2.3 Keep provider outputs mapped to existing public command/report shapes.
-- [ ] 2.4 Reject any new shim, fallback, or duplicate process path; bridges may
+- [x] 2.3 Keep provider outputs mapped to existing public command/report shapes.
+- [x] 2.4 Reject any new shim, fallback, or duplicate process path; bridges may
   exist only between adjacent dominos and must be deleted by their assigned
   cutover packet.
+  Current branch removes provider exports from the root public surface and
+  restores the bounded Grit live-source batch refusal until provider-owned
+  scheduling exists.
 
 ## 3. Proof
 
-- [ ] 3.1 Provider fake-layer unit tests.
-- [ ] 3.2 Grit parser/scan-root/projection matrix.
-- [ ] 3.3 Biome read-only/write command construction tests.
-- [ ] 3.4 Nx graph/target/affected tests with fake and resolved metadata.
-- [ ] 3.5 Git staged/status/merge-base tests.
-- [ ] 3.6 `bun run --cwd tools/habitat-harness test`
+- [x] 3.1 Provider fake-layer unit tests.
+- [x] 3.2 Grit parser/scan-root/projection matrix.
+- [x] 3.3 Biome read-only/write command construction tests.
+- [x] 3.4 Nx affected tests with fake provider metadata.
+- [x] 3.5 Git status/merge-base tests.
+- [x] 3.6 `bun run --cwd tools/habitat-harness test`
 - [ ] 3.7 `bun run habitat:check -- --json`
-- [ ] 3.8 `bun run openspec -- validate deep-habitat-effect-vendor-providers --strict`
-- [ ] 3.9 `bun run openspec:validate`
-- [ ] 3.10 `git diff --check`
+  Boundary: `bun run habitat:check` was run on 2026-06-20 and still fails on
+  existing locked source-pattern findings plus docs-local advisory debt. The
+  prior 120s Grit timeout failure mode no longer reproduces; source patterns
+  fail in a bounded batch.
+- [x] 3.8 `bun run openspec -- validate deep-habitat-effect-vendor-providers --strict`
+- [x] 3.9 `bun run openspec:validate`
+- [x] 3.10 `git diff --check`

--- a/openspec/changes/deep-habitat-effect-vendor-providers/workstream/phase-record.md
+++ b/openspec/changes/deep-habitat-effect-vendor-providers/workstream/phase-record.md
@@ -4,18 +4,55 @@
 
 - Project: Habitat Harness deep refactor
 - Phase: Vendor providers
-- Owner: Effect-first planning lane
-- Branch/Graphite stack: `agent-DRA-effect-first-openspec-domino-plan` stacked on `agent-DRA-effect-first-repair-backlog`
+- Owner: Effect-first implementation lane
+- Branch/Graphite stack: `agent-DRA-effect-vendor-providers` stacked on `agent-DRA-effect-runtime-config-errors`
 - Started: 2026-06-19
-- Status: design packet opened
+- Last updated: 2026-06-20
+- Status: implemented and submitted as Graphite PR #1863
 
 ## Objective
 
 - Target movement: turn external tools into typed Effect providers.
-- Non-goals: domain service migration beyond provider callsites.
+- Non-goals: full check/baseline/hook/graph domain cutover, Grit apply
+  transaction cutover, and final deletion of migration bridges.
 - Done condition: providers have live/fake layers and vendor non-claims.
 
 ## Verification
 
-- Commands run: pending implementation.
-- Evidence boundary: design-only.
+- Commands run:
+  - `bun run --cwd tools/habitat-harness check`
+  - `bun run --cwd tools/habitat-harness test -- test/lib/verify-service.test.ts test/commands/habitat-commands.test.ts test/lib/grit-adapter.test.ts`
+  - `bun run --cwd tools/habitat-harness test`
+  - `bun run --cwd tools/habitat-harness build`
+  - `bun run biome:ci`
+  - `bun run openspec -- validate deep-habitat-effect-vendor-providers --strict`
+  - `bun run openspec:validate`
+  - `node tools/habitat-harness/bin/run.js verify --help`
+  - `git diff --check`
+- Boundary:
+  - `bun run habitat:check` still fails on existing locked source-pattern findings
+    plus docs-local advisory debt.
+  - The previous broad Grit timeout failure mode no longer reproduces after the
+    live-source batch guard was restored.
+
+## Implementation Notes
+
+- Added `src/providers/{biome,git,grit,husky,nx}` plus shared command runner
+  result projection.
+- Added live/fake provider layers and merged them into `HabitatRuntimeLive`.
+- Added the internal `src/service/**` Effect-oRPC spine and routed
+  `habitat verify` through the owned verify service module.
+- Kept provider internals off the root public package surface.
+- Restored the bounded Grit live-source batch refusal until a later Grit
+  provider scheduler cutover replaces it.
+
+## Follow-On Owners
+
+- `deep-habitat-effect-command-result-model`: replace optional command result
+  fields with discriminated command observation variants.
+- `deep-habitat-effect-verify-graph-cutover`: move remaining verify/workspace
+  graph contracts into owned domains and remove `SpawnResult` handoff pressure.
+- `deep-habitat-effect-check-baseline-cutover`: move check/baseline decisions
+  to Effect services and provider seams.
+- `deep-habitat-effect-grit-apply-cutover`: replace the bounded refusal with
+  provider-owned Grit scheduling and drain adapter bridges.

--- a/package.json
+++ b/package.json
@@ -121,5 +121,8 @@
     "typescript": "^5.9.3",
     "@types/node": "^22.19.21",
     "rimraf": "^6.1.2"
+  },
+  "patchedDependencies": {
+    "effect-orpc@0.5.0": "patches/effect-orpc@0.5.0.patch"
   }
 }

--- a/patches/effect-orpc@0.5.0.patch
+++ b/patches/effect-orpc@0.5.0.patch
@@ -1,0 +1,21 @@
+diff --git a/package.json b/package.json
+index 090229169f12cccdbf38c135b8242317bdde99a4..9cbd7356210acbccde8b64c9765bdfad9a0ec5a9 100644
+--- a/package.json
++++ b/package.json
+@@ -20,8 +20,14 @@
+   ],
+   "type": "module",
+   "exports": {
+-    ".": "./src/index.ts",
+-    "./node": "./src/node.ts"
++    ".": {
++      "types": "./src/index.ts",
++      "default": "./dist/index.js"
++    },
++    "./node": {
++      "types": "./src/node.ts",
++      "default": "./dist/node.js"
++    }
+   },
+   "publishConfig": {
+     "exports": {

--- a/tools/habitat-harness/package.json
+++ b/tools/habitat-harness/package.json
@@ -90,7 +90,13 @@
     "@nx/devkit": "22.7.5",
     "@oclif/core": "^4.11.4",
     "@oclif/plugin-help": "^6.2.50",
+    "@orpc/client": "1.14.6",
+    "@orpc/contract": "1.14.6",
+    "@orpc/server": "1.14.6",
+    "@orpc/shared": "^1.14.4",
+    "@standard-schema/spec": "^1.1.0",
     "effect": "3.21.3",
+    "effect-orpc": "0.5.0",
     "typebox": "^1.0.80"
   },
   "oclif": {

--- a/tools/habitat-harness/src/adapters/grit/request.ts
+++ b/tools/habitat-harness/src/adapters/grit/request.ts
@@ -1,7 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { Effect } from "effect";
+import { CommandFailed, CommandInterrupted, CommandUnavailable } from "../../errors/index.js";
 import {
   diagnosticAdapterFailureForCacheObservation,
   diagnosticCacheObservationFromCommand,
@@ -12,14 +13,9 @@ import {
   nativeGritCheckRequestFromProcessRequest,
   renderDiagnosticScanRootRefusal,
 } from "../../lib/diagnostic-catalog/index.js";
-import { gritMachineOutputEnv } from "../../lib/grit-env.js";
-import {
-  GritToolUnavailable,
-  HabitatProcess,
-  type HabitatProcessRequest,
-} from "../../lib/habitat-process.js";
-import { repoRoot } from "../../lib/paths.js";
-import { defaultGritCommandTimeoutMs, gritBin } from "./constants.js";
+import { GritToolUnavailable, type HabitatProcessRequest } from "../../lib/habitat-process.js";
+import { captureOutput, makeHabitatCommandResult } from "../../providers/command/index.js";
+import { GritProvider, gritCheckRequest } from "../../providers/grit/index.js";
 import { parseGritCheckOutput, parseGritCheckTextOutput } from "./output/index.js";
 import { decidePatternScanRoots } from "./scan-roots/index.js";
 import type { GritCheckOptions, GritCheckRequestOptions } from "./types.js";
@@ -38,7 +34,6 @@ export function gritCheckProgram(scanRoots: readonly string[], options: GritChec
           command: { kind: "not-run" as const, reason: "scan-root-refused" as const },
         };
       }
-      const process = yield* HabitatProcess;
       const cacheRequirement = diagnosticCacheRequirementForGritCheck({
         cacheMode: options.cacheMode,
         requireObservableCacheStatus: options.requireObservableCacheStatus,
@@ -52,25 +47,26 @@ export function gritCheckProgram(scanRoots: readonly string[], options: GritChec
             }
           : { outputFormat: options.outputFormat };
       const processRequest = gritCheckRequest(scanRoots, requestOptions);
+      const grit = yield* GritProvider;
       const nativeRequest = nativeGritCheckRequestFromProcessRequest({
         request: processRequest,
         commandFamily: nativeCommandFamilyForGritCheck(options),
         outputContract: nativeOutputContractForGritCheck(options),
         cacheRequirement,
       });
-      const result = yield* process.run(processRequest).pipe(
-        Effect.catchTag("GritToolUnavailable", (error) =>
-          Effect.fail(
-            new GritToolUnavailable({
-              commandId: error.commandId,
-              executable: error.executable,
-              argv: error.argv,
-              cwd: error.cwd,
-              cause: error.cause,
-            })
-          )
-        )
-      );
+      const result = yield* grit
+        .check({
+          scanRoots,
+          cacheDir: requestOptions.cacheDir,
+          observableCacheStatus: requestOptions.observableCacheStatus,
+          outputFormat: requestOptions.outputFormat,
+        })
+        .pipe(
+          Effect.catchTag("CommandInterrupted", (error) =>
+            Effect.succeed(interruptedGritResult(processRequest, error))
+          ),
+          Effect.mapError((error) => gritToolUnavailable(processRequest, error))
+        );
       if (
         options.requireObservableCacheStatus &&
         !diagnosticCacheRequirementSatisfied(
@@ -128,6 +124,37 @@ export function gritCheckProgram(scanRoots: readonly string[], options: GritChec
   );
 }
 
+function interruptedGritResult(request: HabitatProcessRequest, error: CommandInterrupted) {
+  return makeHabitatCommandResult(request, {
+    requestedExecutable: request.executable,
+    exit: { code: 130, signal: error.signal, interrupted: true },
+    stderr: captureOutput(`${error.cause}\n`),
+    failureTag: "GritCommandFailed",
+  });
+}
+
+function gritToolUnavailable(
+  request: HabitatProcessRequest,
+  error: CommandUnavailable | CommandFailed
+) {
+  if (error._tag === "CommandFailed") {
+    return new GritToolUnavailable({
+      commandId: error.commandId,
+      executable: error.executable,
+      argv: error.argv,
+      cwd: error.cwd,
+      cause: `command exited ${error.exitCode}: ${error.stderr}`,
+    });
+  }
+  return new GritToolUnavailable({
+    commandId: error.commandId,
+    executable: error.executable || request.executable,
+    argv: error.argv.length > 0 ? error.argv : request.argv,
+    cwd: error.cwd || request.cwd,
+    cause: error.cause,
+  });
+}
+
 function nativeCommandFamilyForGritCheck(
   options: GritCheckOptions
 ): "current-tree-json-check" | "docs-text-check" {
@@ -141,35 +168,7 @@ function nativeOutputContractForGritCheck(
   return options.outputFormat === "text" ? "standard-text-report" : "json-report";
 }
 
-export function gritCheckRequest(
-  scanRoots: readonly string[],
-  options: GritCheckRequestOptions = {}
-): HabitatProcessRequest {
-  const cacheDir = options.cacheDir ?? path.join(repoRoot, ".habitat", "cache", "patterns");
-  mkdirSync(cacheDir, { recursive: true });
-  return {
-    commandId: "pattern-check-current-tree",
-    kind: "pattern-check",
-    executable: gritBin,
-    argv:
-      options.outputFormat === "text"
-        ? ["check", "--level", "error", ...scanRoots]
-        : ["--json", "check", "--level", "error", ...scanRoots],
-    cwd: repoRoot,
-    env: {
-      ...gritMachineOutputEnv,
-      GRIT_CACHE_DIR: cacheDir,
-      GRIT_TELEMETRY_DISABLED: "true",
-    },
-    scanRoots,
-    timeoutMs: options.timeoutMs ?? defaultGritCommandTimeoutMs,
-    cachePolicy: {
-      mode: "isolated",
-      cacheDir,
-      observableStatus: options.observableCacheStatus ?? "unknown",
-    },
-  };
-}
+export { gritCheckRequest };
 
 function acquireGritCheckCacheDir() {
   return Effect.acquireRelease(

--- a/tools/habitat-harness/src/adapters/grit/runner.ts
+++ b/tools/habitat-harness/src/adapters/grit/runner.ts
@@ -1,4 +1,5 @@
-import { Effect, type Layer } from "effect";
+import { Effect, Layer } from "effect";
+import { CommandUnavailable } from "../../errors/index.js";
 import {
   type DiagnosticAdapterFailureKind,
   type DiagnosticCacheObservation,
@@ -8,7 +9,12 @@ import {
   renderDiagnosticScanRootRefusal,
 } from "../../lib/diagnostic-catalog/index.js";
 import { runHabitatEffect } from "../../lib/effect-runtime.js";
-import { HabitatProcess, HabitatProcessLive } from "../../lib/habitat-process.js";
+import { HabitatProcess } from "../../lib/habitat-process.js";
+import {
+  GritProvider,
+  type GritProviderService,
+  gritCheckRequest,
+} from "../../providers/grit/index.js";
 import type { RuleRunResult } from "../../rules/architecture.js";
 import type { RulePatternFacts } from "../../rules/registry/index.js";
 import {
@@ -34,6 +40,7 @@ import type {
 interface GritRunOptions {
   scanRoots?: readonly string[];
   processLayer?: Layer.Layer<HabitatProcess>;
+  providerLayer?: Layer.Layer<GritProvider>;
   cacheMode?: GritCheckCacheMode;
   requireObservableCacheStatus?: boolean;
   diagnostics?: GritDiagnosticOptions;
@@ -138,14 +145,17 @@ async function runGritRuleOutcomeGroup(
       ])
     );
   }
-
+  const program = gritCheckProgram(scanRoots, {
+    cacheMode: options.cacheMode,
+    requireObservableCacheStatus: options.requireObservableCacheStatus,
+    allowDocsRoot: selectedRules.some(ruleHasDocsScanRoot),
+    outputFormat,
+  });
+  const providerLayer = options.processLayer
+    ? gritProviderLayerForOptions(options)
+    : options.providerLayer;
   const acquisition = await runHabitatEffect(
-    gritCheckProgram(scanRoots, {
-      cacheMode: options.cacheMode,
-      requireObservableCacheStatus: options.requireObservableCacheStatus,
-      allowDocsRoot: selectedRules.some(ruleHasDocsScanRoot),
-      outputFormat,
-    }).pipe(Effect.provide(options.processLayer ?? HabitatProcessLive))
+    providerLayer ? program.pipe(Effect.provide(providerLayer)) : program
   );
   switch (acquisition.kind) {
     case "parsed":
@@ -195,6 +205,50 @@ function liveSourceBatchSchedulingFailure(
     "This Habitat adapter cannot schedule broad source-wide Grit execution safely yet.",
     "Move this lane to GritProvider batching/resource scheduling before enabling aggregate execution.",
   ].join(" ");
+}
+
+function gritProviderLayerForOptions(options: GritRunOptions): Layer.Layer<GritProvider> {
+  const processLayer = options.processLayer;
+  if (!processLayer) throw new Error("processLayer is required for test-backed Grit provider");
+  return Layer.effect(
+    GritProvider,
+    HabitatProcess.pipe(
+      Effect.map(
+        (process): GritProviderService => ({
+          check: (request) =>
+            process
+              .run(
+                gritCheckRequest(request.scanRoots, {
+                  cacheDir: request.cacheDir,
+                  observableCacheStatus: request.observableCacheStatus,
+                  outputFormat: request.outputFormat,
+                  timeoutMs: request.timeoutMs,
+                })
+              )
+              .pipe(
+                Effect.mapError((error) =>
+                  error._tag === "GritToolUnavailable"
+                    ? new CommandUnavailable({
+                        commandId: error.commandId,
+                        executable: error.executable,
+                        argv: error.argv,
+                        cwd: error.cwd,
+                        cause: error.cause,
+                      })
+                    : error
+                )
+              ),
+          checkRequest: (request) =>
+            gritCheckRequest(request.scanRoots, {
+              cacheDir: request.cacheDir,
+              observableCacheStatus: request.observableCacheStatus,
+              outputFormat: request.outputFormat,
+              timeoutMs: request.timeoutMs,
+            }),
+        })
+      )
+    )
+  ).pipe(Layer.provide(processLayer));
 }
 
 function missingCacheObservation(

--- a/tools/habitat-harness/src/commands/verify.ts
+++ b/tools/habitat-harness/src/commands/verify.ts
@@ -1,18 +1,8 @@
 import { Flags } from "@oclif/core";
 import { HabitatCommand } from "../base/HabitatCommand.js";
-import {
-  checkCommandContext,
-  createCheckReport,
-  renderCheckReport,
-  verifyCheckSummary,
-} from "../lib/check-report.js";
-import {
-  createVerifyReceipt,
-  readVerifyTargetPlan,
-  resolveVerifyBase,
-  runAffectedVerification,
-  stringifyVerifyReceipt,
-} from "../lib/verify/index.js";
+import { renderCheckReport, verifyCheckSummary } from "../lib/check-report.js";
+import { stringifyVerifyReceipt } from "../lib/verify/index.js";
+import { createHabitatServiceClient } from "../service/client.js";
 
 export default class Verify extends HabitatCommand {
   static override summary = "Run Habitat check plus affected verification targets";
@@ -34,59 +24,40 @@ export default class Verify extends HabitatCommand {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Verify);
-    const startedAt = new Date().toISOString();
-    const startedMs = Date.now();
-    const baseDecision = resolveVerifyBase(flags.base);
-    if (baseDecision.kind === "refused") {
-      this.error(baseDecision.message, { exit: 1 });
-    }
-    const base = baseDecision.base;
-    const report = await createCheckReport({
-      base,
-      baselineIntegrity: true,
-      command: checkCommandContext(this.rawArgv()),
+    const service = createHabitatServiceClient();
+    const result = await service.verify.run({
+      base: flags.base,
+      commandArgs: this.rawArgv(),
     });
-    const checkSummary = verifyCheckSummary(report);
-    const targetPlan = await readVerifyTargetPlan();
-    let affectedResult: ReturnType<typeof runAffectedVerification> | undefined;
-    let exitCode = 0;
-    if (!checkSummary.allowsAffectedExecution) exitCode = 1;
-    else if (targetPlan.kind === "verify-target-plan-refused") exitCode = 1;
-    else affectedResult = runAffectedVerification(base, targetPlan);
-    if (affectedResult) exitCode = affectedResult.exitCode;
+    if (result.kind === "base-refused") this.error(result.message, { exit: 1 });
+    const checkSummary = verifyCheckSummary(result.checkReport);
+    const exitCode = result.receipt.command.exitCode;
 
     if (flags.json) {
-      const receipt = createVerifyReceipt({
-        requestedBase: flags.base,
-        resolvedBase: base,
-        baseSource: baseDecision.source,
-        commandArgs: this.rawArgv(),
-        startedAt,
-        durationMs: Date.now() - startedMs,
-        exitCode,
-        checkReport: report,
-        verifyTargetPlan: targetPlan,
-        affectedResult,
-      });
-      this.log(stringifyVerifyReceipt(receipt));
+      this.log(stringifyVerifyReceipt(result.receipt));
       if (exitCode !== 0) this.exitWith(exitCode);
       return;
     }
 
-    this.log(renderCheckReport(report));
+    this.log(renderCheckReport(result.checkReport));
     if (!checkSummary.allowsAffectedExecution) this.exit(1);
-    if (targetPlan.kind === "verify-target-plan-refused") {
+    if (result.targetPlan.kind === "verify-target-plan-refused") {
       const message =
-        targetPlan.refusal.kind === "graph-refusal"
-          ? targetPlan.refusal.message
+        result.targetPlan.refusal.kind === "graph-refusal"
+          ? result.targetPlan.refusal.message
           : "Workspace graph refused verify target planning.";
       this.error(message, { exit: 1 });
     }
 
-    this.log(`\nhabitat verify: running repo Nx affected (base=${base}) ...`);
-    const result = affectedResult ?? runAffectedVerification(base, targetPlan);
-    process.stdout.write(result.stdout);
-    process.stderr.write(result.stderr);
-    this.exitWith(result.exitCode);
+    this.log(`\nhabitat verify: running repo Nx affected (base=${result.base}) ...`);
+    if (!result.affectedResult) {
+      this.error("Habitat verify service did not return affected verification output.", {
+        exit: 1,
+      });
+    }
+    const affectedResult = result.affectedResult;
+    process.stdout.write(affectedResult.stdout);
+    process.stderr.write(affectedResult.stderr);
+    this.exitWith(affectedResult.exitCode);
   }
 }

--- a/tools/habitat-harness/src/index.ts
+++ b/tools/habitat-harness/src/index.ts
@@ -154,19 +154,6 @@ export {
   WorkspaceToolProvider,
   WorkspaceToolProviderLive,
 } from "./lib/workspace-tools.js";
-export type { CommandRunnerService } from "./providers/command/index.js";
-export {
-  CommandRunner,
-  CommandRunnerLive,
-  makeFakeCommandRunnerLayer,
-  runSyncHabitatCommand,
-} from "./providers/command/index.js";
-export type { HabitatReportEvent, HabitatReporterService } from "./providers/reporter/index.js";
-export {
-  HabitatReporter,
-  HabitatReporterLive,
-  makeFakeHabitatReporterLayer,
-} from "./providers/reporter/index.js";
 export { executeRule, type HarnessRule, ruleById, rules } from "./rules/architecture.js";
 export type {
   CandidatePatternManifest,

--- a/tools/habitat-harness/src/lib/verify/base.ts
+++ b/tools/habitat-harness/src/lib/verify/base.ts
@@ -1,6 +1,7 @@
+import { Effect } from "effect";
 import { Value } from "typebox/value";
-import { repoRoot } from "../paths.js";
-import { run } from "../spawn.js";
+import { GitProvider } from "../../providers/git/index.js";
+import { runHabitatEffect } from "../../runtime/index.js";
 import { type VerifyBaseResolution, VerifyBaseResolutionSchema } from "./schema.js";
 
 /** Options accepted by the verify orchestration layer after Oclif parses CLI flags. */
@@ -21,36 +22,30 @@ export interface VerifyOptions {
  * @param base - Optional base ref supplied by the caller.
  * @returns A TypeBox-validated resolution or refusal.
  */
-export function resolveVerifyBase(base?: string): VerifyBaseResolution {
+export function resolveVerifyBaseEffect(base?: string) {
   if (base)
-    return Value.Parse(VerifyBaseResolutionSchema, { kind: "resolved", base, source: "flag" });
-  const defaultBranch = remoteDefaultBranch();
-  const resolved = defaultBranch ? mergeBaseForRef(defaultBranch) : null;
-  if (resolved) {
+    return Effect.succeed(
+      Value.Parse(VerifyBaseResolutionSchema, { kind: "resolved", base, source: "flag" })
+    );
+  return Effect.gen(function* () {
+    const git = yield* GitProvider;
+    const defaultBranch = yield* git.remoteDefaultBranch();
+    const resolved = defaultBranch ? yield* git.mergeBase(defaultBranch) : null;
+    if (resolved) {
+      return Value.Parse(VerifyBaseResolutionSchema, {
+        kind: "resolved",
+        base: resolved,
+        source: "merge-base",
+      });
+    }
     return Value.Parse(VerifyBaseResolutionSchema, {
-      kind: "resolved",
-      base: resolved,
-      source: "merge-base",
+      kind: "refused",
+      message:
+        "could not resolve verify base from the remote default branch; pass --base explicitly.",
     });
-  }
-  return Value.Parse(VerifyBaseResolutionSchema, {
-    kind: "refused",
-    message:
-      "could not resolve verify base from the remote default branch; pass --base explicitly.",
   });
 }
 
-function remoteDefaultBranch(): string | null {
-  const result = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], {
-    cwd: repoRoot,
-  });
-  if (result.exitCode !== 0) return null;
-  const ref = result.stdout.trim();
-  return ref || null;
-}
-
-function mergeBaseForRef(ref: string): string | null {
-  const result = run(["git", "merge-base", "HEAD", ref], { cwd: repoRoot });
-  if (result.exitCode !== 0) return null;
-  return result.stdout.trim() || null;
+export async function resolveVerifyBase(base?: string): Promise<VerifyBaseResolution> {
+  return runHabitatEffect(resolveVerifyBaseEffect(base));
 }

--- a/tools/habitat-harness/src/lib/verify/index.ts
+++ b/tools/habitat-harness/src/lib/verify/index.ts
@@ -1,7 +1,8 @@
 /** Public verify module barrel for command orchestration and receipt contracts. */
 export type { VerifyOptions } from "./base.js";
-export { resolveVerifyBase } from "./base.js";
-export { runAffectedVerification } from "./nx-affected.js";
+export { resolveVerifyBase, resolveVerifyBaseEffect } from "./base.js";
+export { runAffectedVerification, runAffectedVerificationEffect } from "./nx-affected.js";
+export { observeGitStatus, observeGitStatusEffect } from "./post-state.js";
 export type { VerifyReceiptInput } from "./receipt.js";
 export { createVerifyReceipt, readVerifyTargetPlan, verifyAffectedTargets } from "./receipt.js";
 export type { VerifyBaseResolution, VerifyReceipt } from "./schema.js";

--- a/tools/habitat-harness/src/lib/verify/nx-affected.ts
+++ b/tools/habitat-harness/src/lib/verify/nx-affected.ts
@@ -1,5 +1,11 @@
-import { repoRoot } from "../paths.js";
-import { run, type SpawnResult } from "../spawn.js";
+import { Effect } from "effect";
+import {
+  affectedArgv,
+  NxProvider,
+  spawnResultFromCommandResult,
+} from "../../providers/nx/index.js";
+import { runHabitatEffect } from "../../runtime/index.js";
+import type { SpawnResult } from "../spawn.js";
 import type { VerifyTargetPlan } from "../workspace-graph/index.js";
 import { boundedPreview } from "./command-output.js";
 import type { VerifyReceipt } from "./schema.js";
@@ -12,17 +18,7 @@ import type { VerifyReceipt } from "./schema.js";
  * @returns Argument vector passed to the repository-local Nx entrypoint.
  */
 export function affectedVerificationArgv(base: string, targetPlan: VerifyTargetPlan): string[] {
-  return [
-    "nx",
-    "affected",
-    "-t",
-    targetPlan.targets.join(","),
-    "--base",
-    base,
-    "--head",
-    "HEAD",
-    "--outputStyle=static",
-  ];
+  return affectedArgv({ base, targets: targetPlan.targets });
 }
 
 /**
@@ -35,10 +31,18 @@ export function affectedVerificationArgv(base: string, targetPlan: VerifyTargetP
 export function runAffectedVerification(
   base: string,
   targetPlan: Extract<VerifyTargetPlan, { kind: "verify-target-plan" }>
-): SpawnResult {
-  return run(affectedVerificationArgv(base, targetPlan), {
-    cwd: repoRoot,
-  });
+): Promise<SpawnResult> {
+  return runHabitatEffect(runAffectedVerificationEffect(base, targetPlan));
+}
+
+export function runAffectedVerificationEffect(
+  base: string,
+  targetPlan: Extract<VerifyTargetPlan, { kind: "verify-target-plan" }>
+) {
+  return NxProvider.pipe(
+    Effect.flatMap((nx) => nx.affected({ base, targets: targetPlan.targets })),
+    Effect.map(spawnResultFromCommandResult)
+  );
 }
 
 /**

--- a/tools/habitat-harness/src/lib/verify/post-state.ts
+++ b/tools/habitat-harness/src/lib/verify/post-state.ts
@@ -1,5 +1,8 @@
+import { Effect } from "effect";
+import { GitProvider, spawnResultFromCommandResult } from "../../providers/git/index.js";
+import { runHabitatEffect } from "../../runtime/index.js";
 import { repoRoot } from "../paths.js";
-import { run, type SpawnResult } from "../spawn.js";
+import type { SpawnResult } from "../spawn.js";
 import { boundedPreview } from "./command-output.js";
 import type { VerifyReceipt } from "./schema.js";
 
@@ -8,8 +11,15 @@ import type { VerifyReceipt } from "./schema.js";
  *
  * @returns Spawn result for `git status --short --branch`.
  */
-export function observeGitStatus(): SpawnResult {
-  return run(["git", "status", "--short", "--branch"], { cwd: repoRoot });
+export function observeGitStatus(): Promise<SpawnResult> {
+  return runHabitatEffect(observeGitStatusEffect());
+}
+
+export function observeGitStatusEffect() {
+  return GitProvider.pipe(
+    Effect.flatMap((git) => git.statusShortBranch()),
+    Effect.map(spawnResultFromCommandResult)
+  );
 }
 
 /**

--- a/tools/habitat-harness/src/lib/verify/receipt.ts
+++ b/tools/habitat-harness/src/lib/verify/receipt.ts
@@ -13,7 +13,7 @@ import {
 } from "../workspace-graph/index.js";
 import { selectedVerifyEnv } from "./command-output.js";
 import { affectedVerificationArgv, completedNxAffected, skippedNxAffected } from "./nx-affected.js";
-import { observeGitStatus, postStateObservation } from "./post-state.js";
+import { postStateObservation } from "./post-state.js";
 import {
   type VerifyBaseResolution,
   VerifyHabitatCheckSummarySchema,
@@ -45,6 +45,8 @@ export interface VerifyReceiptInput {
   verifyTargetPlan?: VerifyTargetPlan;
   /** Optional affected command result; absent means verify skipped affected execution. */
   affectedResult?: SpawnResult;
+  /** Git status observation captured through the Git provider before receipt assembly. */
+  gitStatus: SpawnResult;
 }
 
 /** Verify target names currently owned by the workspace graph boundary. */
@@ -71,7 +73,6 @@ export async function readVerifyTargetPlan(): Promise<VerifyTargetPlan> {
 export function createVerifyReceipt(input: VerifyReceiptInput): VerifyReceipt {
   const targetPlan = input.verifyTargetPlan ?? verifyTargetPlan();
   const nxArgv = affectedVerificationArgv(input.resolvedBase, targetPlan);
-  const gitStatus = observeGitStatus();
   const habitatCheckSummary = verifyCheckSummary(input.checkReport);
   const nxAffected =
     habitatCheckSummary.allowsAffectedExecution &&
@@ -82,7 +83,7 @@ export function createVerifyReceipt(input: VerifyReceiptInput): VerifyReceipt {
           nxArgv,
           habitatCheckSummary.allowsAffectedExecution ? targetPlan : undefined
         );
-  const postState = postStateObservation(gitStatus);
+  const postState = postStateObservation(input.gitStatus);
   return Value.Parse(VerifyReceiptSchema, {
     schemaVersion: 1,
     outcome: receiptOutcome({

--- a/tools/habitat-harness/src/providers/biome/index.ts
+++ b/tools/habitat-harness/src/providers/biome/index.ts
@@ -1,0 +1,71 @@
+import type { CommandExecutor } from "@effect/platform/CommandExecutor";
+import { Context, Effect, Layer } from "effect";
+import type { HabitatConfig } from "../../config/index.js";
+import type { CommandProviderError } from "../../errors/index.js";
+import { repoRoot } from "../../lib/paths.js";
+import type { HabitatClock } from "../../resources/index.js";
+import { CommandRunner } from "../command/index.js";
+import type { HabitatCommandResult } from "../command/types.js";
+
+type BiomeProviderRequirements = CommandExecutor | HabitatConfig | HabitatClock | CommandRunner;
+
+export type BiomeCommandKind = "format" | "check" | "ci";
+
+export interface BiomeCommandRequest {
+  kind: BiomeCommandKind;
+  paths?: readonly string[];
+  write?: boolean;
+  noErrorsOnUnmatched?: boolean;
+}
+
+export interface BiomeProviderService {
+  readonly run: (
+    request: BiomeCommandRequest
+  ) => Effect.Effect<HabitatCommandResult, CommandProviderError, BiomeProviderRequirements>;
+  readonly argv: (request: BiomeCommandRequest) => string[];
+}
+
+export class BiomeProvider extends Context.Tag("@internal/habitat-harness/BiomeProvider")<
+  BiomeProvider,
+  BiomeProviderService
+>() {}
+
+export const BiomeProviderLive = Layer.succeed(BiomeProvider, makeLiveBiomeProvider());
+
+export function makeFakeBiomeProviderLayer(
+  handler: (request: BiomeCommandRequest) => HabitatCommandResult
+) {
+  return Layer.succeed(BiomeProvider, {
+    run: (request) => Effect.sync(() => handler(request)),
+    argv: biomeArgv,
+  });
+}
+
+function makeLiveBiomeProvider(): BiomeProviderService {
+  return {
+    run: (request) =>
+      CommandRunner.pipe(
+        Effect.flatMap((runner) =>
+          runner.run({
+            commandId: `biome-${request.kind}`,
+            kind: "biome-handoff",
+            executable: "biome",
+            argv: biomeArgv(request).slice(1),
+            cwd: repoRoot,
+            captureGitState: false,
+          })
+        )
+      ),
+    argv: biomeArgv,
+  };
+}
+
+export function biomeArgv(request: BiomeCommandRequest): string[] {
+  return [
+    "biome",
+    request.kind,
+    ...(request.kind === "format" && request.write ? ["--write"] : []),
+    ...(request.noErrorsOnUnmatched ? ["--no-errors-on-unmatched"] : []),
+    ...(request.paths && request.paths.length > 0 ? request.paths : ["."]),
+  ];
+}

--- a/tools/habitat-harness/src/providers/command/index.ts
+++ b/tools/habitat-harness/src/providers/command/index.ts
@@ -11,6 +11,7 @@ export {
   redactEnvDelta,
 } from "./output.js";
 export { CommandRunner, CommandRunnerLive, runSyncHabitatCommand } from "./runner.js";
+export { spawnResultFromCommandResult } from "./spawn-result.js";
 export type {
   CommandCachePolicy,
   CommandRunnerService,

--- a/tools/habitat-harness/src/providers/command/spawn-result.ts
+++ b/tools/habitat-harness/src/providers/command/spawn-result.ts
@@ -1,0 +1,10 @@
+import type { SpawnResult } from "../../lib/spawn.js";
+import type { HabitatCommandResult } from "./types.js";
+
+export function spawnResultFromCommandResult(result: HabitatCommandResult): SpawnResult {
+  return {
+    exitCode: result.exit.code,
+    stdout: result.stdout.text,
+    stderr: result.stderr.text,
+  };
+}

--- a/tools/habitat-harness/src/providers/git/index.ts
+++ b/tools/habitat-harness/src/providers/git/index.ts
@@ -1,0 +1,109 @@
+import type { CommandExecutor } from "@effect/platform/CommandExecutor";
+import { Context, Effect, Layer } from "effect";
+import type { HabitatConfig } from "../../config/index.js";
+import type { CommandProviderError } from "../../errors/index.js";
+import { repoRoot } from "../../lib/paths.js";
+import type { HabitatClock } from "../../resources/index.js";
+import { CommandRunner, spawnResultFromCommandResult } from "../command/index.js";
+import type { HabitatCommandResult } from "../command/types.js";
+
+type GitProviderRequirements = CommandExecutor | HabitatConfig | HabitatClock | CommandRunner;
+type GitCommandEffect = Effect.Effect<
+  HabitatCommandResult,
+  CommandProviderError,
+  GitProviderRequirements
+>;
+type GitTextEffect = Effect.Effect<string | null, never, GitProviderRequirements>;
+
+export interface GitCommandOptions {
+  cwd?: string;
+}
+
+export interface GitProviderService {
+  readonly command: (argv: readonly string[], options?: GitCommandOptions) => GitCommandEffect;
+  readonly currentBranch: (options?: GitCommandOptions) => GitTextEffect;
+  readonly head: (options?: GitCommandOptions) => GitTextEffect;
+  readonly statusShort: (options?: GitCommandOptions) => GitCommandEffect;
+  readonly statusShortBranch: (options?: GitCommandOptions) => GitCommandEffect;
+  readonly remoteDefaultBranch: (options?: GitCommandOptions) => GitTextEffect;
+  readonly mergeBase: (ref: string, options?: GitCommandOptions) => GitTextEffect;
+  readonly add: (paths: readonly string[], options?: GitCommandOptions) => GitCommandEffect;
+  readonly diffNameOnly: (
+    input?: { cached?: boolean; paths?: readonly string[] } & GitCommandOptions
+  ) => GitCommandEffect;
+  readonly diffNameStatus: (input?: { cached?: boolean } & GitCommandOptions) => GitCommandEffect;
+}
+
+export class GitProvider extends Context.Tag("@internal/habitat-harness/GitProvider")<
+  GitProvider,
+  GitProviderService
+>() {}
+
+export const GitProviderLive = Layer.succeed(GitProvider, makeLiveGitProvider());
+
+export function makeFakeGitProviderLayer(
+  handler: (argv: readonly string[], options: Required<GitCommandOptions>) => HabitatCommandResult
+) {
+  return Layer.succeed(GitProvider, makeGitProviderFromCommandHandler(handler));
+}
+
+export function makeGitProviderFromCommandHandler(
+  handler: (argv: readonly string[], options: Required<GitCommandOptions>) => HabitatCommandResult
+): GitProviderService {
+  const command: GitProviderService["command"] = (argv, options = {}) =>
+    Effect.sync(() => handler(argv, { cwd: options.cwd ?? repoRoot }));
+  return providerFromCommand(command);
+}
+
+function makeLiveGitProvider(): GitProviderService {
+  const command: GitProviderService["command"] = (argv, options = {}) =>
+    CommandRunner.pipe(
+      Effect.flatMap((runner) =>
+        runner.run({
+          commandId: `git-${argv.join("-")}`,
+          kind: "git-state",
+          executable: "git",
+          argv,
+          cwd: options.cwd ?? repoRoot,
+          captureGitState: false,
+        })
+      )
+    );
+  return providerFromCommand(command);
+}
+
+function providerFromCommand(command: GitProviderService["command"]): GitProviderService {
+  const textOrNull = (effect: GitCommandEffect): GitTextEffect =>
+    effect.pipe(
+      Effect.map((result) => (result.exit.code === 0 ? result.stdout.text.trim() || null : null)),
+      Effect.catchAll(() => Effect.succeed(null))
+    );
+  return {
+    command,
+    currentBranch: (options) => textOrNull(command(["branch", "--show-current"], options)),
+    head: (options) => textOrNull(command(["rev-parse", "HEAD"], options)),
+    statusShort: (options) => command(["status", "--short"], options),
+    statusShortBranch: (options) => command(["status", "--short", "--branch"], options),
+    remoteDefaultBranch: (options) =>
+      textOrNull(
+        command(["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], options)
+      ),
+    mergeBase: (ref, options) => textOrNull(command(["merge-base", "HEAD", ref], options)),
+    add: (paths, options) => command(["add", "--", ...paths], options),
+    diffNameOnly: (input = {}) =>
+      command(
+        [
+          "diff",
+          ...(input.cached ? ["--cached"] : []),
+          "--name-only",
+          "-z",
+          ...(input.paths ? ["--", ...input.paths] : []),
+        ],
+        input
+      ),
+    diffNameStatus: (input = {}) =>
+      command(["diff", ...(input.cached ? ["--cached"] : []), "--name-status", "-z"], input),
+  };
+}
+
+export { spawnResultFromCommandResult };

--- a/tools/habitat-harness/src/providers/grit/index.ts
+++ b/tools/habitat-harness/src/providers/grit/index.ts
@@ -1,0 +1,97 @@
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import type { CommandExecutor } from "@effect/platform/CommandExecutor";
+import { Context, Effect, Layer } from "effect";
+import { defaultGritCommandTimeoutMs, gritBin } from "../../adapters/grit/constants.js";
+import type { HabitatConfig } from "../../config/index.js";
+import type { CommandProviderError } from "../../errors/index.js";
+import { gritMachineOutputEnv } from "../../lib/grit-env.js";
+import { repoRoot } from "../../lib/paths.js";
+import type { HabitatClock } from "../../resources/index.js";
+import { CommandRunner } from "../command/index.js";
+import type { HabitatCommandResult, HabitatProcessRequest } from "../command/types.js";
+
+type GritProviderRequirements = CommandExecutor | HabitatConfig | HabitatClock | CommandRunner;
+
+export interface GritCheckProviderRequest {
+  scanRoots: readonly string[];
+  outputFormat?: "json" | "text";
+  cacheDir?: string;
+  timeoutMs?: number;
+  observableCacheStatus?: "unknown" | "fresh" | "cache-hit" | "replay";
+}
+
+export interface GritProviderService {
+  readonly check: (
+    request: GritCheckProviderRequest
+  ) => Effect.Effect<HabitatCommandResult, CommandProviderError, GritProviderRequirements>;
+  readonly checkRequest: (request: GritCheckProviderRequest) => HabitatProcessRequest;
+}
+
+export class GritProvider extends Context.Tag("@internal/habitat-harness/GritProvider")<
+  GritProvider,
+  GritProviderService
+>() {}
+
+export const GritProviderLive = Layer.succeed(GritProvider, makeLiveGritProvider());
+
+export function makeFakeGritProviderLayer(
+  handler: (request: GritCheckProviderRequest) => HabitatCommandResult
+) {
+  return Layer.succeed(GritProvider, {
+    check: (request) => Effect.sync(() => handler(request)),
+    checkRequest: gritProviderCheckRequest,
+  });
+}
+
+function makeLiveGritProvider(): GritProviderService {
+  return {
+    check: (request) =>
+      CommandRunner.pipe(Effect.flatMap((runner) => runner.run(gritProviderCheckRequest(request)))),
+    checkRequest: gritProviderCheckRequest,
+  };
+}
+
+export function gritCheckRequest(
+  scanRoots: readonly string[],
+  options: {
+    cacheDir?: string;
+    outputFormat?: "json" | "text";
+    timeoutMs?: number;
+    observableCacheStatus?: "unknown" | "fresh" | "cache-hit" | "replay";
+  } = {}
+): HabitatProcessRequest {
+  const cacheDir = options.cacheDir ?? path.join(repoRoot, ".habitat", "cache", "patterns");
+  mkdirSync(cacheDir, { recursive: true });
+  return {
+    commandId: "pattern-check-current-tree",
+    kind: "pattern-check",
+    executable: gritBin,
+    argv:
+      options.outputFormat === "text"
+        ? ["check", "--level", "error", ...scanRoots]
+        : ["--json", "check", "--level", "error", ...scanRoots],
+    cwd: repoRoot,
+    env: {
+      ...gritMachineOutputEnv,
+      GRIT_CACHE_DIR: cacheDir,
+      GRIT_TELEMETRY_DISABLED: "true",
+    },
+    scanRoots,
+    timeoutMs: options.timeoutMs ?? defaultGritCommandTimeoutMs,
+    cachePolicy: {
+      mode: "isolated",
+      cacheDir,
+      observableStatus: options.observableCacheStatus ?? "unknown",
+    },
+  };
+}
+
+function gritProviderCheckRequest(request: GritCheckProviderRequest): HabitatProcessRequest {
+  return gritCheckRequest(request.scanRoots, {
+    cacheDir: request.cacheDir,
+    observableCacheStatus: request.observableCacheStatus,
+    outputFormat: request.outputFormat,
+    timeoutMs: request.timeoutMs,
+  });
+}

--- a/tools/habitat-harness/src/providers/husky/index.ts
+++ b/tools/habitat-harness/src/providers/husky/index.ts
@@ -1,0 +1,34 @@
+import { Context, Layer } from "effect";
+
+export type HuskyHookName = "pre-commit" | "pre-push";
+
+export interface HuskyDelegator {
+  hook: HuskyHookName;
+  argv: readonly string[];
+}
+
+export interface HuskyProviderService {
+  readonly delegator: (hook: HuskyHookName) => HuskyDelegator;
+}
+
+export class HuskyProvider extends Context.Tag("@internal/habitat-harness/HuskyProvider")<
+  HuskyProvider,
+  HuskyProviderService
+>() {}
+
+export const HuskyProviderLive = Layer.succeed(HuskyProvider, {
+  delegator: huskyDelegator,
+});
+
+export function makeFakeHuskyProviderLayer(
+  service: HuskyProviderService = { delegator: huskyDelegator }
+) {
+  return Layer.succeed(HuskyProvider, service);
+}
+
+export function huskyDelegator(hook: HuskyHookName): HuskyDelegator {
+  return {
+    hook,
+    argv: ["bun", "run", "habitat", "hook", hook],
+  };
+}

--- a/tools/habitat-harness/src/providers/nx/index.ts
+++ b/tools/habitat-harness/src/providers/nx/index.ts
@@ -1,0 +1,74 @@
+import type { CommandExecutor } from "@effect/platform/CommandExecutor";
+import { Context, Effect, Layer } from "effect";
+import type { HabitatConfig } from "../../config/index.js";
+import type { CommandProviderError } from "../../errors/index.js";
+import { repoRoot } from "../../lib/paths.js";
+import type { HabitatClock } from "../../resources/index.js";
+import { CommandRunner, spawnResultFromCommandResult } from "../command/index.js";
+import type { HabitatCommandResult } from "../command/types.js";
+
+type NxProviderRequirements = CommandExecutor | HabitatConfig | HabitatClock | CommandRunner;
+
+export interface NxAffectedRequest {
+  base: string;
+  targets: readonly string[];
+  head?: string;
+}
+
+export interface NxProviderService {
+  readonly affected: (
+    request: NxAffectedRequest
+  ) => Effect.Effect<HabitatCommandResult, CommandProviderError, NxProviderRequirements>;
+  readonly affectedArgv: (request: NxAffectedRequest) => string[];
+}
+
+export class NxProvider extends Context.Tag("@internal/habitat-harness/NxProvider")<
+  NxProvider,
+  NxProviderService
+>() {}
+
+export const NxProviderLive = Layer.succeed(NxProvider, makeLiveNxProvider());
+
+export function makeFakeNxProviderLayer(
+  handler: (request: NxAffectedRequest) => HabitatCommandResult
+) {
+  return Layer.succeed(NxProvider, {
+    affected: (request) => Effect.sync(() => handler(request)),
+    affectedArgv,
+  });
+}
+
+function makeLiveNxProvider(): NxProviderService {
+  return {
+    affected: (request) =>
+      CommandRunner.pipe(
+        Effect.flatMap((runner) =>
+          runner.run({
+            commandId: "nx-affected",
+            kind: "workspace-tool",
+            executable: "nx",
+            argv: affectedArgv(request).slice(1),
+            cwd: repoRoot,
+            captureGitState: false,
+          })
+        )
+      ),
+    affectedArgv,
+  };
+}
+
+export function affectedArgv(request: NxAffectedRequest): string[] {
+  return [
+    "nx",
+    "affected",
+    "-t",
+    request.targets.join(","),
+    "--base",
+    request.base,
+    "--head",
+    request.head ?? "HEAD",
+    "--outputStyle=static",
+  ];
+}
+
+export { spawnResultFromCommandResult };

--- a/tools/habitat-harness/src/runtime/layers.ts
+++ b/tools/habitat-harness/src/runtime/layers.ts
@@ -1,7 +1,12 @@
 import { NodeContext } from "@effect/platform-node";
 import { Layer } from "effect";
 import { HabitatConfigLive } from "../config/index.js";
+import { BiomeProviderLive } from "../providers/biome/index.js";
 import { CommandRunnerLive } from "../providers/command/index.js";
+import { GitProviderLive } from "../providers/git/index.js";
+import { GritProviderLive } from "../providers/grit/index.js";
+import { HuskyProviderLive } from "../providers/husky/index.js";
+import { NxProviderLive } from "../providers/nx/index.js";
 import { HabitatReporterLive } from "../providers/reporter/index.js";
 import {
   HabitatClockLive,
@@ -20,5 +25,10 @@ export const HabitatRuntimeLive = Layer.mergeAll(
   HabitatWriteSetLive,
   WorkspaceLockLive,
   CommandRunnerLive,
+  GitProviderLive,
+  GritProviderLive,
+  BiomeProviderLive,
+  NxProviderLive,
+  HuskyProviderLive,
   HabitatReporterLive
 );

--- a/tools/habitat-harness/src/runtime/run.ts
+++ b/tools/habitat-harness/src/runtime/run.ts
@@ -5,7 +5,7 @@ import { HabitatRuntimeLive } from "./layers.js";
  * Host-edge bridge for Habitat programs that need live repository resources.
  *
  * Domain code should return `Effect` programs and receive capabilities through
- * services. CLI commands, tests, and compatibility adapters use this bridge to
+ * services. CLI commands and tests use this bridge to
  * run those programs against the assembled live layer.
  */
 export function runHabitatEffect<A, E, R>(program: Effect.Effect<A, E, R>): Promise<A> {

--- a/tools/habitat-harness/src/runtime/test-layers.ts
+++ b/tools/habitat-harness/src/runtime/test-layers.ts
@@ -1,5 +1,10 @@
 export { makeHabitatConfigLayer } from "../config/index.js";
+export { makeFakeBiomeProviderLayer } from "../providers/biome/index.js";
 export { makeFakeCommandRunnerLayer } from "../providers/command/index.js";
+export { makeFakeGitProviderLayer } from "../providers/git/index.js";
+export { makeFakeGritProviderLayer } from "../providers/grit/index.js";
+export { makeFakeHuskyProviderLayer } from "../providers/husky/index.js";
+export { makeFakeNxProviderLayer } from "../providers/nx/index.js";
 export {
   makeFakeHabitatClockLayer,
   makeFakeHabitatFileSystemLayer,

--- a/tools/habitat-harness/src/service/base.ts
+++ b/tools/habitat-harness/src/service/base.ts
@@ -1,0 +1,9 @@
+import { Context } from "effect";
+
+export interface HabitatServiceContext {
+  readonly correlationId?: string;
+}
+
+export class HabitatServiceRuntime extends Context.Tag(
+  "@internal/habitat-harness/HabitatServiceRuntime"
+)<HabitatServiceRuntime, { readonly service: "habitat" }>() {}

--- a/tools/habitat-harness/src/service/client.ts
+++ b/tools/habitat-harness/src/service/client.ts
@@ -1,0 +1,12 @@
+import { createRouterClient } from "@orpc/server";
+import type { HabitatServiceContext } from "./base.js";
+import { habitatServiceContract } from "./contract.js";
+import { habitatServiceRouter } from "./router.js";
+
+export { habitatServiceContract };
+
+export function createHabitatServiceClient(context: HabitatServiceContext = {}) {
+  return createRouterClient(habitatServiceRouter, { context });
+}
+
+export type HabitatServiceClient = ReturnType<typeof createHabitatServiceClient>;

--- a/tools/habitat-harness/src/service/contract.ts
+++ b/tools/habitat-harness/src/service/contract.ts
@@ -1,0 +1,10 @@
+import { eoc } from "effect-orpc";
+import { type VerifyServiceContract, verifyServiceContract } from "./modules/verify/contract.js";
+
+export type HabitatServiceContract = Readonly<{
+  verify: VerifyServiceContract;
+}>;
+
+export const habitatServiceContract: HabitatServiceContract = eoc.router({
+  verify: verifyServiceContract,
+});

--- a/tools/habitat-harness/src/service/errors.ts
+++ b/tools/habitat-harness/src/service/errors.ts
@@ -1,0 +1,7 @@
+export type HabitatServiceErrorMap = {
+  readonly INTERNAL_SERVER_ERROR: {};
+};
+
+export const habitatServiceErrorMap: HabitatServiceErrorMap = {
+  INTERNAL_SERVER_ERROR: {},
+};

--- a/tools/habitat-harness/src/service/impl.ts
+++ b/tools/habitat-harness/src/service/impl.ts
@@ -1,0 +1,26 @@
+import { Layer, ManagedRuntime } from "effect";
+import { type EffectImplementer, implementEffect } from "effect-orpc";
+import { HabitatRuntimeLive } from "../runtime/layers.js";
+import { type HabitatServiceContext, HabitatServiceRuntime } from "./base.js";
+import { habitatServiceContract } from "./contract.js";
+
+export const habitatServiceLayer = Layer.mergeAll(
+  HabitatRuntimeLive,
+  Layer.succeed(HabitatServiceRuntime, { service: "habitat" })
+);
+
+export type HabitatServiceRequirements = Layer.Layer.Success<typeof habitatServiceLayer>;
+export type HabitatServiceRuntimeError = Layer.Layer.Error<typeof habitatServiceLayer>;
+
+export const habitatServiceEffectRuntime = ManagedRuntime.make(habitatServiceLayer);
+
+export const habitatServiceImplementer: EffectImplementer<
+  typeof habitatServiceContract,
+  HabitatServiceContext & Record<never, never>,
+  HabitatServiceContext,
+  HabitatServiceRequirements,
+  HabitatServiceRuntimeError
+> = implementEffect(
+  habitatServiceContract,
+  habitatServiceEffectRuntime
+).$context<HabitatServiceContext>();

--- a/tools/habitat-harness/src/service/metadata.ts
+++ b/tools/habitat-harness/src/service/metadata.ts
@@ -1,0 +1,1 @@
+export type HabitatServiceProcedureMeta = Record<never, never>;

--- a/tools/habitat-harness/src/service/modules/verify/contract.ts
+++ b/tools/habitat-harness/src/service/modules/verify/contract.ts
@@ -1,0 +1,76 @@
+import type { ContractProcedure } from "@orpc/contract";
+import { eoc } from "effect-orpc";
+import { type Static, Type } from "typebox";
+import { CheckReportSchema } from "../../../lib/check/schema.js";
+import { VerifyReceiptSchema } from "../../../lib/verify/schema.js";
+import { VerifyTargetPlanSchema } from "../../../lib/workspace-graph/index.js";
+import { type HabitatServiceErrorMap, habitatServiceErrorMap } from "../../errors.js";
+import type { HabitatServiceProcedureMeta } from "../../metadata.js";
+import { toStandardSchema } from "../../typebox-standard-schema.js";
+
+const VerifyServiceRunInputSchema = Type.Object(
+  {
+    base: Type.Optional(Type.String({ minLength: 1 })),
+    commandArgs: Type.Optional(Type.Array(Type.String())),
+  },
+  { additionalProperties: false, description: "Habitat verify service run request." }
+);
+export type VerifyServiceRunInput = Static<typeof VerifyServiceRunInputSchema>;
+
+const VerifyServiceAffectedResultSchema = Type.Object(
+  {
+    exitCode: Type.Integer(),
+    stdout: Type.String(),
+    stderr: Type.String(),
+  },
+  { additionalProperties: false, description: "Raw affected command streams for CLI handoff." }
+);
+export type VerifyServiceAffectedResult = Static<typeof VerifyServiceAffectedResultSchema>;
+
+const VerifyServiceRunOutputSchema = Type.Union(
+  [
+    Type.Object(
+      {
+        kind: Type.Literal("base-refused"),
+        message: Type.String({ minLength: 1 }),
+      },
+      { additionalProperties: false, description: "Verify refused before structural checks." }
+    ),
+    Type.Object(
+      {
+        kind: Type.Literal("completed"),
+        base: Type.String({ minLength: 1 }),
+        checkReport: CheckReportSchema,
+        targetPlan: VerifyTargetPlanSchema,
+        affectedResult: Type.Optional(VerifyServiceAffectedResultSchema),
+        receipt: VerifyReceiptSchema,
+      },
+      { additionalProperties: false, description: "Completed Habitat verify service result." }
+    ),
+  ],
+  { description: "Habitat verify service run result." }
+);
+export type VerifyServiceRunOutput = Static<typeof VerifyServiceRunOutputSchema>;
+
+const VerifyServiceRunInputStandardSchema = toStandardSchema(VerifyServiceRunInputSchema);
+const VerifyServiceRunOutputStandardSchema = toStandardSchema(VerifyServiceRunOutputSchema);
+
+export type VerifyServiceRunContract = ContractProcedure<
+  typeof VerifyServiceRunInputStandardSchema,
+  typeof VerifyServiceRunOutputStandardSchema,
+  HabitatServiceErrorMap,
+  HabitatServiceProcedureMeta
+>;
+
+export const verifyServiceRunContract: VerifyServiceRunContract = eoc
+  .errors(habitatServiceErrorMap)
+  .input(VerifyServiceRunInputStandardSchema)
+  .output(VerifyServiceRunOutputStandardSchema);
+
+export type VerifyServiceContract = Readonly<{
+  run: VerifyServiceRunContract;
+}>;
+
+export const verifyServiceContract: VerifyServiceContract = {
+  run: verifyServiceRunContract,
+};

--- a/tools/habitat-harness/src/service/modules/verify/module.ts
+++ b/tools/habitat-harness/src/service/modules/verify/module.ts
@@ -1,0 +1,18 @@
+import type { EffectImplementerInternal } from "effect-orpc";
+import type { HabitatServiceContext } from "../../base.js";
+import {
+  type HabitatServiceRequirements,
+  type HabitatServiceRuntimeError,
+  habitatServiceImplementer as impl,
+} from "../../impl.js";
+import type { VerifyServiceContract } from "./contract.js";
+
+export type VerifyServiceModule = EffectImplementerInternal<
+  VerifyServiceContract,
+  HabitatServiceContext & Record<never, never>,
+  HabitatServiceContext,
+  HabitatServiceRequirements,
+  HabitatServiceRuntimeError
+>;
+
+export const module: VerifyServiceModule = impl.verify;

--- a/tools/habitat-harness/src/service/modules/verify/router.ts
+++ b/tools/habitat-harness/src/service/modules/verify/router.ts
@@ -1,0 +1,8 @@
+import { module as verifyModule } from "./module.js";
+import { runVerifyService } from "./run.js";
+
+export const verifyRouter = {
+  run: verifyModule.run.effect(({ input }) => runVerifyService(input)),
+};
+
+export const router = verifyRouter;

--- a/tools/habitat-harness/src/service/modules/verify/run.ts
+++ b/tools/habitat-harness/src/service/modules/verify/run.ts
@@ -1,0 +1,80 @@
+import { ORPCError } from "@orpc/server";
+import { Effect } from "effect";
+import {
+  checkCommandContext,
+  createCheckReport,
+  verifyCheckSummary,
+} from "../../../lib/check-report.js";
+import type { SpawnResult } from "../../../lib/spawn.js";
+import {
+  createVerifyReceipt,
+  observeGitStatusEffect,
+  readVerifyTargetPlan,
+  resolveVerifyBaseEffect,
+  runAffectedVerificationEffect,
+} from "../../../lib/verify/index.js";
+import { HabitatClock } from "../../../resources/index.js";
+import type { VerifyServiceRunInput } from "./contract.js";
+
+export function runVerifyService(input: VerifyServiceRunInput) {
+  return Effect.gen(function* () {
+    const clock = yield* HabitatClock;
+    const startedAt = (yield* clock.currentDate).toISOString();
+    const startedMs = yield* clock.currentTimeMillis;
+    const baseDecision = yield* resolveVerifyBaseEffect(input.base);
+    if (baseDecision.kind === "refused") {
+      return { kind: "base-refused" as const, message: baseDecision.message };
+    }
+
+    const base = baseDecision.base;
+    const checkReport = yield* Effect.promise(() =>
+      Promise.resolve(
+        createCheckReport({
+          base,
+          baselineIntegrity: true,
+          command: checkCommandContext(input.commandArgs ?? []),
+        })
+      )
+    );
+    const checkSummary = verifyCheckSummary(checkReport);
+    const targetPlan = yield* Effect.promise(() => Promise.resolve(readVerifyTargetPlan()));
+    let affectedResult: SpawnResult | undefined;
+    let exitCode = 0;
+    if (!checkSummary.allowsAffectedExecution) exitCode = 1;
+    else if (targetPlan.kind === "verify-target-plan-refused") exitCode = 1;
+    else {
+      affectedResult = yield* runAffectedVerificationEffect(base, targetPlan).pipe(
+        Effect.mapError(verifyServiceInternalError)
+      );
+      exitCode = affectedResult.exitCode;
+    }
+    const endedMs = yield* clock.currentTimeMillis;
+    const receipt = createVerifyReceipt({
+      requestedBase: input.base,
+      resolvedBase: base,
+      baseSource: baseDecision.source,
+      commandArgs: input.commandArgs,
+      startedAt,
+      durationMs: Math.max(0, endedMs - startedMs),
+      exitCode,
+      checkReport,
+      verifyTargetPlan: targetPlan,
+      affectedResult,
+      gitStatus: yield* observeGitStatusEffect().pipe(Effect.mapError(verifyServiceInternalError)),
+    });
+    return {
+      kind: "completed" as const,
+      base,
+      checkReport,
+      targetPlan,
+      affectedResult,
+      receipt,
+    };
+  });
+}
+
+function verifyServiceInternalError() {
+  return new ORPCError("INTERNAL_SERVER_ERROR", {
+    message: "Habitat verify service failed.",
+  });
+}

--- a/tools/habitat-harness/src/service/router.ts
+++ b/tools/habitat-harness/src/service/router.ts
@@ -1,0 +1,12 @@
+import type { Router } from "@orpc/server";
+import type { HabitatServiceContext } from "./base.js";
+import { habitatServiceContract } from "./contract.js";
+import { habitatServiceImplementer } from "./impl.js";
+import { verifyRouter } from "./modules/verify/router.js";
+
+export const habitatServiceRouter: Router<typeof habitatServiceContract, HabitatServiceContext> =
+  habitatServiceImplementer.router({
+    verify: verifyRouter,
+  });
+
+export type HabitatServiceRouter = typeof habitatServiceRouter;

--- a/tools/habitat-harness/src/service/typebox-standard-schema.ts
+++ b/tools/habitat-harness/src/service/typebox-standard-schema.ts
@@ -1,0 +1,66 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { Static, TSchema } from "typebox";
+import { Compile } from "typebox/compile";
+
+const TYPEBOX_SCHEMA = Symbol.for("@internal/habitat-harness/typebox-schema");
+
+type OrpcContractProcedureWithSchemas = Readonly<{
+  "~orpc": Readonly<{
+    inputSchema?: unknown;
+    outputSchema?: unknown;
+  }>;
+}>;
+
+export function toStandardSchema<TypeSchema extends TSchema>(
+  schema: TypeSchema
+): StandardSchemaV1<Static<TypeSchema>, Static<TypeSchema>> {
+  const validator = Compile(schema);
+  const standardSchema: StandardSchemaV1<Static<TypeSchema>, Static<TypeSchema>> = {
+    "~standard": {
+      version: 1,
+      vendor: "typebox",
+      validate(value) {
+        if (validator.Check(value)) return { value: value as Static<TypeSchema> };
+        return {
+          issues: [...validator.Errors(value)].map((error) => ({
+            message: error.message,
+            path: pathSegments(error.instancePath),
+          })),
+        };
+      },
+    },
+  };
+  Object.defineProperty(standardSchema, TYPEBOX_SCHEMA, { value: schema });
+  return standardSchema;
+}
+
+export function typeboxInputSchemaFromContractProcedure<
+  const Procedure extends OrpcContractProcedureWithSchemas,
+>(procedure: Procedure): TSchema {
+  return typeboxSchemaFromStandard(procedure["~orpc"].inputSchema, "input");
+}
+
+export function typeboxOutputSchemaFromContractProcedure<
+  const Procedure extends OrpcContractProcedureWithSchemas,
+>(procedure: Procedure): TSchema {
+  return typeboxSchemaFromStandard(procedure["~orpc"].outputSchema, "output");
+}
+
+function typeboxSchemaFromStandard(value: unknown, label: string): TSchema {
+  const schema = (value as { [TYPEBOX_SCHEMA]?: TSchema } | null)?.[TYPEBOX_SCHEMA];
+  if (!schema) throw new Error(`Habitat service contract ${label} schema is not TypeBox-backed.`);
+  return schema;
+}
+
+function pathSegments(path: string): StandardSchemaV1.PathSegment[] {
+  if (path.length === 0) return [];
+  return path
+    .split("/")
+    .slice(1)
+    .map((segment) => ({ key: pathKey(segment) }));
+}
+
+function pathKey(segment: string): string | number {
+  const decoded = segment.replace(/~1/g, "/").replace(/~0/g, "~");
+  return /^\d+$/.test(decoded) ? Number(decoded) : decoded;
+}

--- a/tools/habitat-harness/test/commands/habitat-commands.test.ts
+++ b/tools/habitat-harness/test/commands/habitat-commands.test.ts
@@ -13,32 +13,40 @@ const mockVerifyTargetPlan = vi.hoisted(() => ({
   targets: ["build"],
   states: [],
 }));
+const mockVerifyRun = vi.hoisted(() => vi.fn());
 
-vi.mock("../../src/lib/check-report.js", () => ({
-  checkCommandContext: vi.fn((argv: string[]) => ({
-    bin: "habitat",
-    id: "check",
-    argv,
-    serialized: ["habitat", "check", ...argv].join(" "),
-  })),
-  createCheckReport: vi.fn(() => mockReport),
-  describeRuleSelectionFailure: vi.fn(() => "invalid selector"),
-  expandBaselines: vi.fn(() => ({ ok: true, messages: ["baseline written: demo-rule (1 entry)"] })),
-  renderCheckReport: vi.fn(() => '{"ok":true}'),
-  verifyCheckSummary: vi.fn(() => ({
-    reportSchemaVersion: 1,
-    requestedSelectors: {},
-    selectedRuleIds: [],
-    selectedRealRuleIds: [],
-    builtInRuleIds: [],
-    statusCounts: {},
-    advisoryCount: 0,
-    failingCount: 0,
-    refusedCount: 0,
-    notApplicableCount: 0,
-    allowsAffectedExecution: true,
-  })),
-}));
+vi.mock("../../src/lib/check-report.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/lib/check-report.js")>();
+  return {
+    ...actual,
+    checkCommandContext: vi.fn((argv: string[]) => ({
+      bin: "habitat",
+      id: "check",
+      argv,
+      serialized: ["habitat", "check", ...argv].join(" "),
+    })),
+    createCheckReport: vi.fn(() => mockReport),
+    describeRuleSelectionFailure: vi.fn(() => "invalid selector"),
+    expandBaselines: vi.fn(() => ({
+      ok: true,
+      messages: ["baseline written: demo-rule (1 entry)"],
+    })),
+    renderCheckReport: vi.fn(() => '{"ok":true}'),
+    verifyCheckSummary: vi.fn(() => ({
+      reportSchemaVersion: 1,
+      requestedSelectors: {},
+      selectedRuleIds: [],
+      selectedRealRuleIds: [],
+      builtInRuleIds: [],
+      statusCounts: {},
+      advisoryCount: 0,
+      failingCount: 0,
+      refusedCount: 0,
+      notApplicableCount: 0,
+      allowsAffectedExecution: true,
+    })),
+  };
+});
 
 vi.mock("../../src/lib/classify.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/lib/classify.js")>();
@@ -83,70 +91,16 @@ vi.mock("../../src/lib/hooks.js", () => ({
   runHook: vi.fn(() => ({ exitCode: 0, stdout: "hook ok\n", stderr: "" })),
 }));
 
-vi.mock("../../src/lib/verify/index.js", () => ({
-  createVerifyReceipt: vi.fn(() => ({
-    schemaVersion: 1,
-    outcome: "succeeded",
-    command: {
-      argv: ["habitat", "verify", "--json"],
-      cwd: "/repo",
-      env: {},
-      startedAt: "2026-06-13T00:00:00.000Z",
-      durationMs: 1,
-      exitCode: 0,
-    },
-    base: { requested: "HEAD~1", resolved: "HEAD~1", source: "flag" },
-    habitatCheck: {
-      reportSchemaVersion: 1,
-      selectedRuleIds: [],
-      selectedRealRuleIds: ["adapter-boundary"],
-      builtInRuleIds: [],
-      statusCounts: {},
-      advisoryCount: 0,
-      failingCount: 0,
-      refusedCount: 0,
-      notApplicableCount: 0,
-      consumption: "allows-affected-execution",
-      selectorState: { kind: "none" },
-    },
-    targetPlan: { kind: "target-plan-ready", targets: ["build"] },
-    nxAffected: {
-      kind: "executed",
-      argv: ["nx", "affected", "-t", "build", "--base", "HEAD~1"],
-      targets: ["build"],
-      projects: [],
-      cacheStateByTask: [],
-      exitCode: 0,
-      stdoutLength: 12,
-      stderrLength: 0,
-      stdoutPreview: "affected ok\n",
-      stderrPreview: "",
-      stdoutTruncated: false,
-      stderrTruncated: false,
-    },
-    postState: {
-      kind: "observed-clean",
-      gitStatus: {
-        argv: ["git", "status", "--short", "--branch"],
-        cwd: "/repo",
-        exitCode: 0,
-        stdoutLength: 0,
-        stderrLength: 0,
-        stdoutPreview: "",
-        stderrPreview: "",
-        stdoutTruncated: false,
-        stderrTruncated: false,
-      },
-    },
-  })),
-  readVerifyTargetPlan: vi.fn(() => mockVerifyTargetPlan),
-  resolveVerifyBase: vi.fn((base?: string) => ({
-    kind: "resolved",
-    base: base ?? "merge-base",
-    source: base ? "flag" : "merge-base",
-  })),
-  runAffectedVerification: vi.fn(() => ({ exitCode: 0, stdout: "affected ok\n", stderr: "" })),
-  stringifyVerifyReceipt: vi.fn((receipt) => JSON.stringify(receipt, null, 2)),
+vi.mock("../../src/lib/verify/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/lib/verify/index.js")>();
+  return {
+    ...actual,
+    stringifyVerifyReceipt: vi.fn((receipt) => JSON.stringify(receipt, null, 2)),
+  };
+});
+
+vi.mock("../../src/service/client.js", () => ({
+  createHabitatServiceClient: vi.fn(() => ({ verify: { run: mockVerifyRun } })),
 }));
 
 import Check from "../../src/commands/check.js";
@@ -161,6 +115,7 @@ import * as fix from "../../src/lib/fix.js";
 import * as graph from "../../src/lib/graph.js";
 import * as hooks from "../../src/lib/hooks.js";
 import * as verifyReceipt from "../../src/lib/verify/index.js";
+import * as serviceClient from "../../src/service/client.js";
 
 describe("Habitat oclif commands", () => {
   let stdout: string[];
@@ -175,6 +130,17 @@ describe("Habitat oclif commands", () => {
     stdout = [];
     stderr = [];
     logs = [];
+    mockVerifyRun.mockImplementation(async (input: { base?: string; commandArgs?: string[] }) => {
+      const base = input.base ?? "merge-base";
+      return {
+        kind: "completed",
+        base,
+        checkReport: mockReport,
+        targetPlan: mockVerifyTargetPlan,
+        affectedResult: { exitCode: 0, stdout: "affected ok\n", stderr: "" },
+        receipt: verifyReceiptPayload(base, input),
+      };
+    });
     stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
       stdout.push(String(chunk));
       return true;
@@ -260,54 +226,26 @@ describe("Habitat oclif commands", () => {
   test("verify awaits check and affected target execution", async () => {
     await Verify.run(["--base", "HEAD~1"]);
 
-    expect(checkReport.createCheckReport).toHaveBeenCalledWith(
-      expect.objectContaining({
-        base: "HEAD~1",
-        baselineIntegrity: true,
-        command: expect.objectContaining({
-          argv: ["--base", "HEAD~1"],
-          bin: "habitat",
-          id: "check",
-        }),
-      })
-    );
-    expect(verifyReceipt.runAffectedVerification).toHaveBeenCalledWith(
-      "HEAD~1",
-      mockVerifyTargetPlan
-    );
+    expect(serviceClient.createHabitatServiceClient).toHaveBeenCalled();
+    expect(mockVerifyRun).toHaveBeenCalledWith({
+      base: "HEAD~1",
+      commandArgs: ["--base", "HEAD~1"],
+    });
     expect(checkReport.verifyCheckSummary).toHaveBeenCalledWith(mockReport);
+    expect(checkReport.renderCheckReport).toHaveBeenCalledWith(mockReport);
     expect(stdout.join("")).toContain("affected ok");
   });
 
   test("verify can emit structured receipt JSON", async () => {
     await Verify.run(["--base", "HEAD~1", "--json"]);
 
-    expect(checkReport.createCheckReport).toHaveBeenCalledWith(
-      expect.objectContaining({
-        base: "HEAD~1",
-        baselineIntegrity: true,
-        command: expect.objectContaining({
-          argv: ["--base", "HEAD~1", "--json"],
-          bin: "habitat",
-          id: "check",
-        }),
-      })
-    );
-    expect(verifyReceipt.runAffectedVerification).toHaveBeenCalledWith(
-      "HEAD~1",
-      mockVerifyTargetPlan
-    );
+    expect(mockVerifyRun).toHaveBeenCalledWith({
+      base: "HEAD~1",
+      commandArgs: ["--base", "HEAD~1", "--json"],
+    });
     expect(checkReport.verifyCheckSummary).toHaveBeenCalledWith(mockReport);
-    expect(verifyReceipt.createVerifyReceipt).toHaveBeenCalledWith(
-      expect.objectContaining({
-        requestedBase: "HEAD~1",
-        resolvedBase: "HEAD~1",
-        commandArgs: ["--base", "HEAD~1", "--json"],
-        exitCode: 0,
-        checkReport: mockReport,
-        verifyTargetPlan: mockVerifyTargetPlan,
-        baseSource: "flag",
-      })
+    expect(verifyReceipt.stringifyVerifyReceipt).toHaveBeenCalledWith(
+      expect.objectContaining({ schemaVersion: 1 })
     );
     const payload = JSON.parse(capturedOutput()) as { schemaVersion: number };
     expect(payload.schemaVersion).toBe(1);
@@ -350,3 +288,65 @@ describe("Habitat oclif commands", () => {
     return `${stdout.join("")}${logs.join("\n")}`;
   }
 });
+
+function verifyReceiptPayload(base: string, input: { base?: string; commandArgs?: string[] }) {
+  return {
+    schemaVersion: 1,
+    outcome: "succeeded",
+    command: {
+      argv: ["habitat", "verify", ...(input.commandArgs ?? [])],
+      cwd: "/repo",
+      env: {},
+      startedAt: "2026-06-13T00:00:00.000Z",
+      durationMs: 1,
+      exitCode: 0,
+    },
+    base: {
+      requested: input.base ?? null,
+      resolved: base,
+      source: input.base ? "flag" : "merge-base",
+    },
+    habitatCheck: {
+      reportSchemaVersion: 1,
+      selectedRuleIds: [],
+      selectedRealRuleIds: ["adapter-boundary"],
+      builtInRuleIds: [],
+      statusCounts: {},
+      advisoryCount: 0,
+      failingCount: 0,
+      refusedCount: 0,
+      notApplicableCount: 0,
+      consumption: "allows-affected-execution",
+      selectorState: { kind: "none" },
+    },
+    targetPlan: { kind: "target-plan-ready", targets: ["build"] },
+    nxAffected: {
+      kind: "executed",
+      argv: ["nx", "affected", "-t", "build", "--base", base],
+      targets: ["build"],
+      projects: [],
+      cacheStateByTask: [],
+      exitCode: 0,
+      stdoutLength: 12,
+      stderrLength: 0,
+      stdoutPreview: "affected ok\n",
+      stderrPreview: "",
+      stdoutTruncated: false,
+      stderrTruncated: false,
+    },
+    postState: {
+      kind: "observed-clean",
+      gitStatus: {
+        argv: ["git", "status", "--short", "--branch"],
+        cwd: "/repo",
+        exitCode: 0,
+        stdoutLength: 0,
+        stderrLength: 0,
+        stdoutPreview: "",
+        stderrPreview: "",
+        stdoutTruncated: false,
+        stderrTruncated: false,
+      },
+    },
+  };
+}

--- a/tools/habitat-harness/test/lib/vendor-providers.test.ts
+++ b/tools/habitat-harness/test/lib/vendor-providers.test.ts
@@ -1,0 +1,207 @@
+import { Effect } from "effect";
+import { describe, expect, test } from "vitest";
+import { repoRoot } from "../../src/lib/paths.js";
+import {
+  BiomeProvider,
+  biomeArgv,
+  makeFakeBiomeProviderLayer,
+} from "../../src/providers/biome/index.js";
+import { captureOutput, makeHabitatCommandResult } from "../../src/providers/command/index.js";
+import { GitProvider, makeFakeGitProviderLayer } from "../../src/providers/git/index.js";
+import { GritProvider, makeFakeGritProviderLayer } from "../../src/providers/grit/index.js";
+import { huskyDelegator } from "../../src/providers/husky/index.js";
+import { affectedArgv, makeFakeNxProviderLayer, NxProvider } from "../../src/providers/nx/index.js";
+import { runHabitatEffect } from "../../src/runtime/index.js";
+
+describe("vendor providers", () => {
+  test("GitProvider fake layer owns git command families without spawning", async () => {
+    const observed: string[][] = [];
+    const result = await runHabitatEffect(
+      Effect.gen(function* () {
+        const git = yield* GitProvider;
+        return {
+          defaultBranch: yield* git.remoteDefaultBranch(),
+          mergeBase: yield* git.mergeBase("origin/main"),
+          status: yield* git.statusShortBranch(),
+        };
+      }).pipe(
+        Effect.provide(
+          makeFakeGitProviderLayer((argv, options) => {
+            observed.push([...argv]);
+            const stdout =
+              argv[0] === "symbolic-ref"
+                ? "origin/main\n"
+                : argv[0] === "merge-base"
+                  ? "abc123\n"
+                  : "## agent-DRA-effect-vendor-providers\n";
+            return commandResult("git-state", "git", argv, options.cwd, stdout);
+          })
+        )
+      )
+    );
+
+    expect(result.defaultBranch).toBe("origin/main");
+    expect(result.mergeBase).toBe("abc123");
+    expect(result.status.stdout.text).toContain("agent-DRA-effect-vendor-providers");
+    expect(observed).toEqual([
+      ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+      ["merge-base", "HEAD", "origin/main"],
+      ["status", "--short", "--branch"],
+    ]);
+  });
+
+  test("NxProvider exposes affected argv and fake execution at the provider boundary", async () => {
+    const request = { base: "HEAD~1", targets: ["build", "test"] };
+
+    expect(affectedArgv(request)).toEqual([
+      "nx",
+      "affected",
+      "-t",
+      "build,test",
+      "--base",
+      "HEAD~1",
+      "--head",
+      "HEAD",
+      "--outputStyle=static",
+    ]);
+
+    const result = await runHabitatEffect(
+      Effect.gen(function* () {
+        const nx = yield* NxProvider;
+        return yield* nx.affected(request);
+      }).pipe(
+        Effect.provide(
+          makeFakeNxProviderLayer((affectedRequest) =>
+            commandResult(
+              "workspace-tool",
+              "nx",
+              affectedArgv(affectedRequest).slice(1),
+              repoRoot,
+              "ok\n"
+            )
+          )
+        )
+      )
+    );
+
+    expect(result.commandId).toBe("workspace-tool-nx");
+    expect(result.stdout.text).toBe("ok\n");
+  });
+
+  test("BiomeProvider owns safe command-vector construction", async () => {
+    const request = {
+      kind: "format" as const,
+      paths: ["tools/habitat-harness/src/index.ts"],
+      write: true,
+      noErrorsOnUnmatched: true,
+    };
+
+    expect(biomeArgv(request)).toEqual([
+      "biome",
+      "format",
+      "--write",
+      "--no-errors-on-unmatched",
+      "tools/habitat-harness/src/index.ts",
+    ]);
+
+    const result = await runHabitatEffect(
+      Effect.gen(function* () {
+        const biome = yield* BiomeProvider;
+        return yield* biome.run(request);
+      }).pipe(
+        Effect.provide(
+          makeFakeBiomeProviderLayer((biomeRequest) =>
+            commandResult(
+              "biome-handoff",
+              "biome",
+              biomeArgv(biomeRequest).slice(1),
+              repoRoot,
+              "formatted\n"
+            )
+          )
+        )
+      )
+    );
+
+    expect(result.argv).toEqual([
+      "format",
+      "--write",
+      "--no-errors-on-unmatched",
+      "tools/habitat-harness/src/index.ts",
+    ]);
+    expect(result.stdout.text).toBe("formatted\n");
+  });
+
+  test("GritProvider owns check request construction and cache policy", async () => {
+    const result = await runHabitatEffect(
+      Effect.gen(function* () {
+        const grit = yield* GritProvider;
+        const request = grit.checkRequest({
+          scanRoots: ["tools/habitat-harness/src"],
+          outputFormat: "json",
+          cacheDir: "/tmp/habitat-grit-provider-test-cache",
+          timeoutMs: 1234,
+        });
+        return {
+          request,
+          checked: yield* grit.check({
+            scanRoots: ["tools/habitat-harness/src"],
+            outputFormat: "json",
+          }),
+        };
+      }).pipe(
+        Effect.provide(
+          makeFakeGritProviderLayer((request) =>
+            commandResult(
+              "pattern-check",
+              "grit",
+              ["--json", "check", "--level", "error", ...request.scanRoots],
+              repoRoot,
+              ""
+            )
+          )
+        )
+      )
+    );
+
+    expect(result.request.argv).toEqual([
+      "--json",
+      "check",
+      "--level",
+      "error",
+      "tools/habitat-harness/src",
+    ]);
+    expect(result.request.cachePolicy).toMatchObject({
+      mode: "isolated",
+      cacheDir: "/tmp/habitat-grit-provider-test-cache",
+    });
+    expect(result.request.timeoutMs).toBe(1234);
+    expect(result.checked.kind).toBe("pattern-check");
+  });
+
+  test("HuskyProvider stays limited to hook delegator facts", () => {
+    expect(huskyDelegator("pre-commit")).toEqual({
+      hook: "pre-commit",
+      argv: ["bun", "run", "habitat", "hook", "pre-commit"],
+    });
+  });
+});
+
+function commandResult(
+  kind: Parameters<typeof makeHabitatCommandResult>[0]["kind"],
+  executable: string,
+  argv: readonly string[],
+  cwd: string,
+  stdout: string
+) {
+  return makeHabitatCommandResult(
+    {
+      commandId: `${kind}-${executable}`,
+      kind,
+      executable,
+      argv,
+      cwd,
+    },
+    { stdout: captureOutput(stdout) }
+  );
+}

--- a/tools/habitat-harness/test/lib/verify-receipt.test.ts
+++ b/tools/habitat-harness/test/lib/verify-receipt.test.ts
@@ -1,18 +1,6 @@
-import { describe, expect, test, vi } from "vitest";
-import type { CheckReport } from "../../src/lib/diagnostics.js";
-
-const runMock = vi.hoisted(() =>
-  vi.fn((argv: string[]) => {
-    if (argv[0] === "git") return { exitCode: 0, stdout: "", stderr: "" };
-    return { exitCode: 0, stdout: "", stderr: "" };
-  })
-);
-
-vi.mock("../../src/lib/spawn.js", () => ({
-  run: runMock,
-}));
-
 import { Value } from "typebox/value";
+import { describe, expect, test } from "vitest";
+import type { CheckReport } from "../../src/lib/diagnostics.js";
 import {
   createVerifyReceipt,
   VerifyReceiptSchema,
@@ -31,6 +19,7 @@ describe("verify receipt", () => {
       exitCode: 0,
       checkReport: checkReport(),
       verifyTargetPlan: verifyTargetPlanFixture(),
+      gitStatus: gitStatusFixture(),
       affectedResult: {
         exitCode: 0,
         stdout:
@@ -85,6 +74,7 @@ describe("verify receipt", () => {
       exitCode: 0,
       checkReport: checkReport(),
       verifyTargetPlan: verifyTargetPlanFixture(),
+      gitStatus: gitStatusFixture(),
       affectedResult: {
         exitCode: 0,
         stdout,
@@ -108,6 +98,7 @@ describe("verify receipt", () => {
       exitCode: 1,
       checkReport: checkReport({ ok: false }),
       verifyTargetPlan: verifyTargetPlanFixture(),
+      gitStatus: gitStatusFixture(),
     });
 
     expect(receipt.outcome).toBe("blocked");
@@ -157,6 +148,7 @@ describe("verify receipt", () => {
       exitCode: 1,
       checkReport: checkReport({ ok: false }),
       verifyTargetPlan: verifyTargetPlanFixture(),
+      gitStatus: gitStatusFixture(),
       affectedResult: {
         exitCode: 0,
         stdout: "should not be serialized",
@@ -178,6 +170,7 @@ describe("verify receipt", () => {
       exitCode: 1,
       checkReport: checkReport(),
       verifyTargetPlan: verifyTargetPlanFixture(),
+      gitStatus: gitStatusFixture({ stdout: " M tools/habitat-harness/src/index.ts\n" }),
       affectedResult: {
         exitCode: 1,
         stdout: "affected failed\n",
@@ -205,6 +198,7 @@ describe("verify receipt", () => {
       exitCode: 1,
       checkReport: checkReport(),
       verifyTargetPlan: refusedVerifyTargetPlanFixture(),
+      gitStatus: gitStatusFixture(),
     });
 
     expect(receipt.outcome).toBe("blocked");
@@ -234,6 +228,7 @@ describe("verify receipt", () => {
       exitCode: 0,
       checkReport: checkReport(),
       verifyTargetPlan: verifyTargetPlanFixture(),
+      gitStatus: gitStatusFixture(),
       affectedResult: {
         exitCode: 0,
         stdout: "affected ok\n",
@@ -278,6 +273,14 @@ function refusedVerifyTargetPlanFixture(): VerifyTargetPlan {
       reason: "nx-read-failure",
       message: "graph unavailable",
     },
+  };
+}
+
+function gitStatusFixture(options: { stdout?: string; stderr?: string; exitCode?: number } = {}) {
+  return {
+    exitCode: options.exitCode ?? 0,
+    stdout: options.stdout ?? "",
+    stderr: options.stderr ?? "",
   };
 }
 

--- a/tools/habitat-harness/test/lib/verify-service.test.ts
+++ b/tools/habitat-harness/test/lib/verify-service.test.ts
@@ -1,0 +1,137 @@
+import { Effect, Layer } from "effect";
+import { describe, expect, test, vi } from "vitest";
+import * as checkReport from "../../src/lib/check-report.js";
+import { repoRoot } from "../../src/lib/paths.js";
+import { captureOutput, makeHabitatCommandResult } from "../../src/providers/command/index.js";
+import { makeFakeGitProviderLayer } from "../../src/providers/git/index.js";
+import { affectedArgv, makeFakeNxProviderLayer } from "../../src/providers/nx/index.js";
+import { makeFakeHabitatClockLayer } from "../../src/resources/index.js";
+
+const mockReport = vi.hoisted(() => ({
+  schemaVersion: 1,
+  command: "habitat check --json",
+  startedAt: "2026-06-13T00:00:00.000Z",
+  ok: true,
+  rules: [],
+}));
+
+const mockVerifyTargetPlan = vi.hoisted(() => ({
+  kind: "verify-target-plan" as const,
+  targets: ["build", "test"],
+  states: [],
+}));
+
+vi.mock("../../src/lib/check-report.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/lib/check-report.js")>();
+  return {
+    ...actual,
+    checkCommandContext: vi.fn((argv: string[]) => ({
+      bin: "habitat",
+      id: "check",
+      argv,
+      serialized: ["habitat", "check", ...argv].join(" "),
+    })),
+    createCheckReport: vi.fn(() => mockReport),
+    verifyCheckSummary: vi.fn(() => ({
+      reportSchemaVersion: 1,
+      requestedSelectors: {},
+      selectedRuleIds: [],
+      selectedRealRuleIds: [],
+      builtInRuleIds: [],
+      statusCounts: {},
+      advisoryCount: 0,
+      failingCount: 0,
+      refusedCount: 0,
+      notApplicableCount: 0,
+      allowsAffectedExecution: true,
+    })),
+  };
+});
+
+vi.mock("../../src/lib/workspace-graph/index.js", async () => {
+  const schema = await import("../../src/lib/workspace-graph/schema.js");
+  return {
+    ...schema,
+    readWorkspaceGraph: vi.fn(() => ({
+      kind: "graph-ready",
+      snapshot: { projects: [] },
+    })),
+    verifyTargetNames: vi.fn(() => ["build", "test"]),
+    verifyTargetPlan: vi.fn(() => mockVerifyTargetPlan),
+  };
+});
+
+describe("Habitat verify service", () => {
+  test("uses provided Git and Nx layers for owned verify orchestration", async () => {
+    expect(vi.isMockFunction(checkReport.createCheckReport)).toBe(true);
+    const { runVerifyService } = await import("../../src/service/modules/verify/run.js");
+    const gitCalls: string[][] = [];
+    const nxRequests: Array<{ base: string; targets: readonly string[] }> = [];
+    const layer = Layer.mergeAll(
+      makeFakeHabitatClockLayer(Date.parse("2026-06-13T00:00:00.000Z")),
+      makeFakeGitProviderLayer((argv, options) => {
+        gitCalls.push([...argv]);
+        const stdout =
+          argv[0] === "symbolic-ref"
+            ? "origin/main\n"
+            : argv[0] === "merge-base"
+              ? "fake-merge-base\n"
+              : "";
+        return commandResult("git-state", "git", argv, options.cwd, stdout);
+      }),
+      makeFakeNxProviderLayer((request) => {
+        nxRequests.push(request);
+        return commandResult(
+          "workspace-tool",
+          "nx",
+          affectedArgv(request).slice(1),
+          repoRoot,
+          "affected ok\n"
+        );
+      })
+    );
+
+    const result = await Effect.runPromise(
+      runVerifyService({ commandArgs: ["--json"] }).pipe(Effect.provide(layer))
+    );
+
+    expect(result.kind).toBe("completed");
+    if (result.kind !== "completed") throw new Error("expected completed verify service result");
+    expect(result.base).toBe("fake-merge-base");
+    expect(result.affectedResult?.stdout).toBe("affected ok\n");
+    expect(result.receipt.base).toEqual({
+      requested: null,
+      resolved: "fake-merge-base",
+      source: "merge-base",
+    });
+    expect(nxRequests).toEqual([{ base: "fake-merge-base", targets: ["build", "test"] }]);
+    expect(gitCalls).toEqual([
+      ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+      ["merge-base", "HEAD", "origin/main"],
+      ["status", "--short", "--branch"],
+    ]);
+    expect(checkReport.createCheckReport).toHaveBeenCalledWith(
+      expect.objectContaining({ base: "fake-merge-base" })
+    );
+  });
+});
+
+function commandResult(
+  kind: Parameters<typeof makeHabitatCommandResult>[0]["kind"],
+  executable: string,
+  argv: readonly string[],
+  cwd: string,
+  stdout: string
+) {
+  return makeHabitatCommandResult(
+    {
+      commandId: `${kind}-${executable}`,
+      kind,
+      executable,
+      argv,
+      cwd,
+      captureGitState: false,
+    },
+    { stdout: captureOutput(stdout) }
+  );
+}

--- a/tools/habitat-harness/tsconfig.json
+++ b/tools/habitat-harness/tsconfig.json
@@ -2,8 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "types": ["node"],
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "noEmit": false,
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
Introduces a typed service layer for Habitat verify orchestration using oRPC and Effect, replacing direct imperative calls in the `verify` command with a structured client/router/contract pattern.

The `verify` command now delegates to `createHabitatServiceClient`, which routes through a typed oRPC contract backed by an Effect-native implementation. The verify service procedure resolves the git base, runs the check report, plans affected targets, executes Nx affected, and captures git status — all through injected Effect providers rather than direct spawning.

Five new provider modules are introduced — `GitProvider`, `GritProvider`, `NxProvider`, `BiomeProvider`, and `HuskyProvider` — each with a live implementation backed by `CommandRunner` and a fake layer factory for testing. These replace ad-hoc `run()`/spawn calls scattered across verify orchestration and the grit adapter. The grit adapter's `gritCheckRequest` function is relocated to the `GritProvider` module and the adapter now consumes `GritProvider` directly.

`createVerifyReceipt` no longer calls `observeGitStatus()` internally; callers are now responsible for passing a `gitStatus` field, which the verify service provides via `observeGitStatusEffect`.

A TypeBox-to-Standard Schema adapter (`toStandardSchema`) is added to bridge TypeBox schemas into the oRPC contract system. `effect-orpc@0.5.0` is patched to expose compiled JS exports alongside TypeScript source exports so the package resolves correctly at runtime.

The TypeScript module/moduleResolution settings for `habitat-harness` are updated from `NodeNext` to `ESNext`/`Bundler` to align with the oRPC and effect-orpc package expectations.