### PR TITLE
feat(habitat): add check service module and architecture guardrails

### DIFF
--- a/openspec/changes/deep-habitat-effect-owned-service-modules/design.md
+++ b/openspec/changes/deep-habitat-effect-owned-service-modules/design.md
@@ -1,0 +1,82 @@
+# Design: Deep Habitat Effect Owned Service Modules
+
+## Target Shape
+
+```text
+host adapter -> service module procedure -> domain/service logic -> provider/resource
+```
+
+Host adapters parse flags and render output. Service modules own Habitat
+capability procedures. Domain/service logic decides Habitat outcomes. Providers
+acquire and execute vendor/resource capabilities.
+
+## Service Module Tree
+
+Each owned Habitat capability follows this shape:
+
+```text
+tools/habitat-harness/src/service/
+  base.ts
+  impl.ts
+  contract.ts
+  router.ts
+  client.ts
+  modules/
+    <capability>/
+      contract.ts
+      module.ts
+      router.ts
+      run.ts
+      model/**        # only when the capability owns DTOs/policy/errors
+      procedures/**   # only when a module needs multiple procedure files
+```
+
+The root service contract composes module contracts. The root router composes
+module routers. `impl.ts` owns `implementEffect` and the `ManagedRuntime`.
+Module `module.ts` files narrow the implementer to one contract subtree. Module
+routers bind procedure atoms with `.effect(...)`.
+
+## Capability Ownership
+
+Initial owned service modules:
+
+- `verify`: verification orchestration and receipt creation.
+- `check`: structural check report orchestration and baseline expansion command
+  behavior.
+
+Required follow-on service modules:
+
+- `fix`: repair/codemod orchestration.
+- `graph`: workspace graph/orientation views.
+- `hook`: hook runtime orchestration.
+- `classify`: routing/classification views.
+- `patterns`: pattern/generator/scaffolding authoring surfaces.
+- `transactions`: transformation transaction lifecycle.
+
+`src/lib/**` remains implementation material only while it is drained into
+named modules/domains. New owned orchestration must not be added there.
+
+## Provider Relationship
+
+Providers are explicit Effect resources for Git, Grit, Biome, Nx, Husky,
+command execution, filesystem, clock, reporter, and workspace tooling. They
+return typed provider observations/errors. They do not decide Habitat product
+outcomes, render command output, own CLI behavior, or import service modules.
+
+## Error And Config Relationship
+
+Expected failures cross service procedure boundaries as typed outputs or
+registered service errors. Defects can still throw only for impossible internal
+invariants. Config, filesystem, clock, command execution, and reporters are
+available through Effect layers/resources, not through ambient process globals
+inside service modules.
+
+## Guardrails
+
+- Runtime construction is allowed in `src/service/impl.ts` and `src/runtime/**`
+  only.
+- `effect-orpc` contract authoring is allowed in `src/service/**` only.
+- Provider code must not import service or domain modules.
+- Root service router must contain composition only, with no handler logic.
+- CLI command handlers should call `createHabitatServiceClient()` for any
+  capability that has a service module.

--- a/openspec/changes/deep-habitat-effect-owned-service-modules/proposal.md
+++ b/openspec/changes/deep-habitat-effect-owned-service-modules/proposal.md
@@ -1,0 +1,53 @@
+# Change: Deep Habitat Effect Owned Service Modules
+
+## Why
+
+Habitat's owned capabilities must be the product surface over provider
+capabilities, not incidental `src/lib` workflows or provider-shaped APIs. The
+Effect-oRPC spine introduced for `verify` needs to become the controlling shape
+for Habitat commands, hooks, checks, fixes, graph/orientation, scaffolding, and
+transformation orchestration.
+
+## What Changes
+
+- Establish `src/service/modules/*` as the home for owned Habitat capability
+  procedures.
+- Keep `src/providers/*` as resource/vendor dependencies consumed by service
+  modules, not as product modules.
+- Add the `check` service module and route `habitat check` through the
+  in-process Habitat service client.
+- Add service architecture tests that keep runtime construction, module
+  bindings, and provider imports in their assigned homes.
+
+## What Does Not Change
+
+- No public CLI output contract changes.
+- No CheckReport v1 schema change.
+- No provider owns Habitat policy decisions.
+- No final compatibility shim, fallback, or duplicate active implementation is
+  introduced by this packet.
+
+## Affected Owners
+
+- `tools/habitat-harness/src/service/**`
+- `tools/habitat-harness/src/commands/check.ts`
+- `tools/habitat-harness/src/lib/check/**` as implementation material only
+- `tools/habitat-harness/test/service/**`
+
+## Stop Conditions
+
+- A service module is only a provider wrapper and does not represent an owned
+  Habitat capability.
+- A provider imports `src/service/**` or `src/domains/**`.
+- Runtime construction escapes `src/service/impl.ts` or `src/runtime/**`.
+- CLI commands bypass an available service module for owned orchestration.
+- New code preserves stale behavior through fallbacks, shims, or dual paths.
+
+## Verification
+
+- Service architecture guard tests.
+- Focused check service/CLI tests.
+- `bun run --cwd tools/habitat-harness check`
+- `bun run --cwd tools/habitat-harness test`
+- `bun run openspec -- validate deep-habitat-effect-owned-service-modules --strict`
+- `bun run openspec:validate`

--- a/openspec/changes/deep-habitat-effect-owned-service-modules/specs/habitat-harness/spec.md
+++ b/openspec/changes/deep-habitat-effect-owned-service-modules/specs/habitat-harness/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Owned Habitat Capabilities Are Service Modules
+
+Habitat SHALL expose owned command, hook, check, fix, graph, verification,
+classification, pattern, scaffolding, and transformation capabilities through
+Effect-oRPC service modules rather than provider-shaped APIs or incidental
+`src/lib` workflows.
+
+#### Scenario: A command has an owned service module
+
+- **WHEN** a Habitat CLI command invokes a capability that has a service module
+- **THEN** the command calls the in-process Habitat service client for owned
+  orchestration
+- **AND** the command remains responsible only for flag parsing, rendering, and
+  exit behavior
+- **AND** it does not call the legacy `src/lib` workflow directly
+
+#### Scenario: A service module consumes vendor behavior
+
+- **WHEN** a Habitat service module needs Git, Grit, Biome, Nx, Husky,
+  filesystem, clock, command execution, or reporter behavior
+- **THEN** it consumes that behavior through Effect providers/resources
+- **AND** the provider returns typed provider observations or failures
+- **AND** the provider does not import service modules or decide Habitat
+  product policy
+
+#### Scenario: Service topology is extended
+
+- **WHEN** a new Habitat capability is moved into the service layer
+- **THEN** its contract lives under `src/service/modules/<capability>/contract.ts`
+- **AND** its module implementer binding lives under
+  `src/service/modules/<capability>/module.ts`
+- **AND** its procedure bindings live under a module router or procedure files
+- **AND** root service files compose module contracts and routers without
+  handler logic

--- a/openspec/changes/deep-habitat-effect-owned-service-modules/tasks.md
+++ b/openspec/changes/deep-habitat-effect-owned-service-modules/tasks.md
@@ -1,0 +1,25 @@
+# Tasks
+
+## 1. Service Module Shape
+
+- [x] 1.1 Define the owned service-module topology and provider relationship.
+- [x] 1.2 Add architecture tests for runtime, router, module, and provider boundaries.
+- [x] 1.3 Add the `check` service contract, module binding, router, and run functions.
+- [x] 1.4 Compose `check` into the root Habitat service contract/router/client.
+
+## 2. CLI Cutover
+
+- [x] 2.1 Route `habitat check` normal report execution through the `check` service module.
+- [x] 2.2 Route `habitat check --expand-baseline` through the `check` service module.
+- [x] 2.3 Preserve CheckReport v1 output and exit-code behavior.
+
+## 3. Guardrails And Verification
+
+- [x] 3.1 Add focused service tests for `check` orchestration with mocked implementation material.
+- [x] 3.2 Run `bun run --cwd tools/habitat-harness check`.
+- [x] 3.3 Run focused Habitat service/command tests.
+- [x] 3.4 Run `bun run --cwd tools/habitat-harness test`.
+- [x] 3.5 Run `bun run openspec -- validate deep-habitat-effect-owned-service-modules --strict`.
+- [x] 3.6 Run `bun run openspec:validate`.
+- [x] 3.7 Run `git diff --check`.
+- [x] 3.8 Run `bun run biome:ci`.

--- a/openspec/changes/deep-habitat-effect-owned-service-modules/workstream/phase-record.md
+++ b/openspec/changes/deep-habitat-effect-owned-service-modules/workstream/phase-record.md
@@ -1,0 +1,56 @@
+# Phase Record
+
+## Phase
+
+- Project: Habitat Harness deep refactor
+- Phase: Owned service modules
+- Owner: Effect-first implementation lane
+- Branch/Graphite stack: `agent-DRA-effect-owned-service-modules` stacked on `agent-DRA-effect-vendor-providers`
+- Started: 2026-06-20
+- Last updated: 2026-06-20
+- Status: implemented and validated
+
+## Objective
+
+- Target movement: make Effect-oRPC service modules the owned Habitat
+  capability surface and keep providers as resource dependencies.
+- Non-goals: full drain of every `src/lib/**` domain, command result
+  observation redesign, final provider bridge deletion.
+- Done condition: `check` joins `verify` as an owned service module, CLI check
+  routes through the service client, and guard tests pin the service/provider
+  boundary for follow-on dominos.
+
+## Authority Inputs
+
+- Direct user direction: owned service module logic belongs in Effect-oRPC,
+  while providers remain dependencies/resources.
+- `civ7-open-spec-workstream`
+- `civ7-orpc-control-architecture`
+- `civ7-systematic-workstream`
+- `domain-design`, `system-design`, `solution-design`, `typescript`
+- Official `effect-orpc` README/docs checked on 2026-06-20.
+- Reference service topology:
+  `/Users/mateicanavra/Documents/.nosync/DEV/magic-apply/magic-migration/collect-ingest/services/collect/src/service/**`
+
+## Verification
+
+- Commands run:
+  - `bun run --cwd tools/habitat-harness check`
+  - `bun run --cwd tools/habitat-harness test -- test/service/check-service.test.ts test/service/service-architecture.test.ts test/lib/verify-service.test.ts`
+  - `bun run --cwd tools/habitat-harness test -- test/commands/habitat-commands.test.ts`
+  - `bun run --cwd tools/habitat-harness test`
+  - `bun run openspec -- validate deep-habitat-effect-owned-service-modules --strict`
+  - `bun run openspec:validate`
+  - `bun run biome:ci`
+  - `git diff --check`
+
+## Implementation Notes
+
+- The previous top branch name `agent-DRA-effect-command-result-model` was
+  renamed before implementation because command observations are not the right
+  current domino until owned service modules are explicit.
+- Added the `check` service module and routed `habitat check` through the
+  in-process service client.
+- Added architecture guard tests for service runtime construction, root router
+  composition, module procedure bindings, provider direction, and CLI service
+  routing.

--- a/tools/habitat-harness/src/commands/check.ts
+++ b/tools/habitat-harness/src/commands/check.ts
@@ -1,12 +1,7 @@
 import { Flags } from "@oclif/core";
 import { HabitatCommand } from "../base/HabitatCommand.js";
-import {
-  checkCommandContext,
-  createCheckReport,
-  describeRuleSelectionFailure,
-  expandBaselines,
-  renderCheckReport,
-} from "../lib/check-report.js";
+import { checkCommandContext, renderCheckReport } from "../lib/check-report.js";
+import { createHabitatServiceClient } from "../service/client.js";
 
 export default class Check extends HabitatCommand {
   static override summary = "Run Habitat structural checks";
@@ -39,16 +34,21 @@ export default class Check extends HabitatCommand {
     const { flags } = await this.parse(Check);
     const selection = { owner: flags.owner, rule: flags.rule, tool: flags.tool };
     const base = flags.base ?? "main";
+    const client = createHabitatServiceClient();
     if (flags["expand-baseline"]) {
-      const expansion = await expandBaselines(selection, { base });
-      if (!expansion.ok) this.error(describeRuleSelectionFailure(expansion), { exit: 1 });
+      const expansion = await client.check.expandBaseline({
+        selectors: selection,
+        base,
+        command: checkCommandContext(this.rawArgv()),
+      });
+      if (expansion.kind === "refused") this.error(expansion.message, { exit: 1 });
       for (const message of expansion.messages) this.log(message);
       return;
     }
 
     const baselineIntegrity = flags["baseline-integrity"] || Boolean(flags.base);
-    const report = await createCheckReport({
-      ...selection,
+    const report = await client.check.run({
+      selectors: selection,
       ...(baselineIntegrity ? { base } : {}),
       baselineIntegrity,
       command: checkCommandContext(this.rawArgv()),

--- a/tools/habitat-harness/src/service/contract.ts
+++ b/tools/habitat-harness/src/service/contract.ts
@@ -1,10 +1,13 @@
 import { eoc } from "effect-orpc";
+import { type CheckServiceContract, checkServiceContract } from "./modules/check/contract.js";
 import { type VerifyServiceContract, verifyServiceContract } from "./modules/verify/contract.js";
 
 export type HabitatServiceContract = Readonly<{
+  check: CheckServiceContract;
   verify: VerifyServiceContract;
 }>;
 
 export const habitatServiceContract: HabitatServiceContract = eoc.router({
+  check: checkServiceContract,
   verify: verifyServiceContract,
 });

--- a/tools/habitat-harness/src/service/modules/check/contract.ts
+++ b/tools/habitat-harness/src/service/modules/check/contract.ts
@@ -1,0 +1,102 @@
+import type { ContractProcedure } from "@orpc/contract";
+import { eoc } from "effect-orpc";
+import { type Static, Type } from "typebox";
+import {
+  CheckCommandContextSchema,
+  CheckReportSchema,
+  SelectorRequestSchema,
+} from "../../../lib/check/schema.js";
+import { type HabitatServiceErrorMap, habitatServiceErrorMap } from "../../errors.js";
+import type { HabitatServiceProcedureMeta } from "../../metadata.js";
+import { toStandardSchema } from "../../typebox-standard-schema.js";
+
+const CheckServiceRunInputSchema = Type.Object(
+  {
+    selectors: Type.Optional(SelectorRequestSchema),
+    base: Type.Optional(Type.String({ minLength: 1 })),
+    baselineIntegrity: Type.Optional(Type.Boolean()),
+    command: Type.Optional(CheckCommandContextSchema),
+    commandArgs: Type.Optional(Type.Array(Type.String())),
+    staged: Type.Optional(Type.Boolean()),
+    stagedPaths: Type.Optional(Type.Array(Type.String())),
+  },
+  { additionalProperties: false, description: "Habitat check service run request." }
+);
+export type CheckServiceRunInput = Static<typeof CheckServiceRunInputSchema>;
+
+const CheckServiceExpandBaselineInputSchema = Type.Object(
+  {
+    selectors: Type.Optional(SelectorRequestSchema),
+    base: Type.Optional(Type.String({ minLength: 1 })),
+    command: Type.Optional(CheckCommandContextSchema),
+    commandArgs: Type.Optional(Type.Array(Type.String())),
+  },
+  { additionalProperties: false, description: "Habitat check baseline expansion request." }
+);
+export type CheckServiceExpandBaselineInput = Static<typeof CheckServiceExpandBaselineInputSchema>;
+
+const CheckServiceExpandBaselineOutputSchema = Type.Union(
+  [
+    Type.Object(
+      {
+        kind: Type.Literal("expanded"),
+        messages: Type.Array(Type.String()),
+      },
+      { additionalProperties: false, description: "Baseline expansion completed." }
+    ),
+    Type.Object(
+      {
+        kind: Type.Literal("refused"),
+        message: Type.String({ minLength: 1 }),
+      },
+      { additionalProperties: false, description: "Baseline expansion was refused." }
+    ),
+  ],
+  { description: "Habitat check baseline expansion result." }
+);
+export type CheckServiceExpandBaselineOutput = Static<
+  typeof CheckServiceExpandBaselineOutputSchema
+>;
+
+const CheckServiceRunInputStandardSchema = toStandardSchema(CheckServiceRunInputSchema);
+const CheckServiceRunOutputStandardSchema = toStandardSchema(CheckReportSchema);
+const CheckServiceExpandBaselineInputStandardSchema = toStandardSchema(
+  CheckServiceExpandBaselineInputSchema
+);
+const CheckServiceExpandBaselineOutputStandardSchema = toStandardSchema(
+  CheckServiceExpandBaselineOutputSchema
+);
+
+export type CheckServiceRunContract = ContractProcedure<
+  typeof CheckServiceRunInputStandardSchema,
+  typeof CheckServiceRunOutputStandardSchema,
+  HabitatServiceErrorMap,
+  HabitatServiceProcedureMeta
+>;
+
+export type CheckServiceExpandBaselineContract = ContractProcedure<
+  typeof CheckServiceExpandBaselineInputStandardSchema,
+  typeof CheckServiceExpandBaselineOutputStandardSchema,
+  HabitatServiceErrorMap,
+  HabitatServiceProcedureMeta
+>;
+
+export const checkServiceRunContract: CheckServiceRunContract = eoc
+  .errors(habitatServiceErrorMap)
+  .input(CheckServiceRunInputStandardSchema)
+  .output(CheckServiceRunOutputStandardSchema);
+
+export const checkServiceExpandBaselineContract: CheckServiceExpandBaselineContract = eoc
+  .errors(habitatServiceErrorMap)
+  .input(CheckServiceExpandBaselineInputStandardSchema)
+  .output(CheckServiceExpandBaselineOutputStandardSchema);
+
+export type CheckServiceContract = Readonly<{
+  run: CheckServiceRunContract;
+  expandBaseline: CheckServiceExpandBaselineContract;
+}>;
+
+export const checkServiceContract: CheckServiceContract = {
+  run: checkServiceRunContract,
+  expandBaseline: checkServiceExpandBaselineContract,
+};

--- a/tools/habitat-harness/src/service/modules/check/module.ts
+++ b/tools/habitat-harness/src/service/modules/check/module.ts
@@ -1,0 +1,18 @@
+import type { EffectImplementerInternal } from "effect-orpc";
+import type { HabitatServiceContext } from "../../base.js";
+import {
+  type HabitatServiceRequirements,
+  type HabitatServiceRuntimeError,
+  habitatServiceImplementer as impl,
+} from "../../impl.js";
+import type { CheckServiceContract } from "./contract.js";
+
+export type CheckServiceModule = EffectImplementerInternal<
+  CheckServiceContract,
+  HabitatServiceContext & Record<never, never>,
+  HabitatServiceContext,
+  HabitatServiceRequirements,
+  HabitatServiceRuntimeError
+>;
+
+export const module: CheckServiceModule = impl.check;

--- a/tools/habitat-harness/src/service/modules/check/router.ts
+++ b/tools/habitat-harness/src/service/modules/check/router.ts
@@ -1,0 +1,11 @@
+import { module as checkModule } from "./module.js";
+import { expandCheckBaselinesService, runCheckService } from "./run.js";
+
+export const checkRouter = {
+  run: checkModule.run.effect(({ input }) => runCheckService(input)),
+  expandBaseline: checkModule.expandBaseline.effect(({ input }) =>
+    expandCheckBaselinesService(input)
+  ),
+};
+
+export const router = checkRouter;

--- a/tools/habitat-harness/src/service/modules/check/run.ts
+++ b/tools/habitat-harness/src/service/modules/check/run.ts
@@ -1,0 +1,43 @@
+import { Effect } from "effect";
+import {
+  checkCommandContext,
+  createCheckReport,
+  describeRuleSelectionFailure,
+  expandBaselines,
+} from "../../../lib/check-report.js";
+import type {
+  CheckServiceExpandBaselineInput,
+  CheckServiceExpandBaselineOutput,
+  CheckServiceRunInput,
+} from "./contract.js";
+
+export function runCheckService(input: CheckServiceRunInput) {
+  return Effect.promise(() =>
+    createCheckReport({
+      ...selectorsFromInput(input),
+      ...(input.base ? { base: input.base } : {}),
+      baselineIntegrity: input.baselineIntegrity ?? false,
+      command: input.command ?? checkCommandContext(input.commandArgs ?? []),
+      staged: input.staged ?? false,
+      ...(input.stagedPaths ? { stagedPaths: input.stagedPaths } : {}),
+    })
+  );
+}
+
+export function expandCheckBaselinesService(input: CheckServiceExpandBaselineInput) {
+  return Effect.promise(async (): Promise<CheckServiceExpandBaselineOutput> => {
+    const expansion = await expandBaselines(selectorsFromInput(input), {
+      base: input.base ?? "main",
+    });
+    if (expansion.ok) return { kind: "expanded", messages: expansion.messages };
+    return { kind: "refused", message: describeRuleSelectionFailure(expansion) };
+  });
+}
+
+function selectorsFromInput(input: Pick<CheckServiceRunInput, "selectors">) {
+  return {
+    ...(input.selectors?.owner ? { owner: input.selectors.owner } : {}),
+    ...(input.selectors?.rule ? { rule: input.selectors.rule } : {}),
+    ...(input.selectors?.tool ? { tool: input.selectors.tool } : {}),
+  };
+}

--- a/tools/habitat-harness/src/service/router.ts
+++ b/tools/habitat-harness/src/service/router.ts
@@ -2,10 +2,12 @@ import type { Router } from "@orpc/server";
 import type { HabitatServiceContext } from "./base.js";
 import { habitatServiceContract } from "./contract.js";
 import { habitatServiceImplementer } from "./impl.js";
+import { checkRouter } from "./modules/check/router.js";
 import { verifyRouter } from "./modules/verify/router.js";
 
 export const habitatServiceRouter: Router<typeof habitatServiceContract, HabitatServiceContext> =
   habitatServiceImplementer.router({
+    check: checkRouter,
     verify: verifyRouter,
   });
 

--- a/tools/habitat-harness/test/commands/habitat-commands.test.ts
+++ b/tools/habitat-harness/test/commands/habitat-commands.test.ts
@@ -13,6 +13,8 @@ const mockVerifyTargetPlan = vi.hoisted(() => ({
   targets: ["build"],
   states: [],
 }));
+const mockCheckRun = vi.hoisted(() => vi.fn());
+const mockCheckExpandBaseline = vi.hoisted(() => vi.fn());
 const mockVerifyRun = vi.hoisted(() => vi.fn());
 
 vi.mock("../../src/lib/check-report.js", async (importOriginal) => {
@@ -100,7 +102,10 @@ vi.mock("../../src/lib/verify/index.js", async (importOriginal) => {
 });
 
 vi.mock("../../src/service/client.js", () => ({
-  createHabitatServiceClient: vi.fn(() => ({ verify: { run: mockVerifyRun } })),
+  createHabitatServiceClient: vi.fn(() => ({
+    check: { expandBaseline: mockCheckExpandBaseline, run: mockCheckRun },
+    verify: { run: mockVerifyRun },
+  })),
 }));
 
 import Check from "../../src/commands/check.js";
@@ -130,6 +135,11 @@ describe("Habitat oclif commands", () => {
     stdout = [];
     stderr = [];
     logs = [];
+    mockCheckRun.mockResolvedValue(mockReport);
+    mockCheckExpandBaseline.mockResolvedValue({
+      kind: "expanded",
+      messages: ["baseline written: demo-rule (1 entry)"],
+    });
     mockVerifyRun.mockImplementation(async (input: { base?: string; commandArgs?: string[] }) => {
       const base = input.base ?? "merge-base";
       return {
@@ -176,13 +186,16 @@ describe("Habitat oclif commands", () => {
       "HEAD",
     ]);
 
-    expect(checkReport.createCheckReport).toHaveBeenCalledWith(
+    expect(serviceClient.createHabitatServiceClient).toHaveBeenCalled();
+    expect(mockCheckRun).toHaveBeenCalledWith(
       expect.objectContaining({
         base: "HEAD",
         baselineIntegrity: true,
-        owner: "@internal/habitat-harness",
-        rule: "adapter-boundary",
-        tool: "pattern-check",
+        selectors: {
+          owner: "@internal/habitat-harness",
+          rule: "adapter-boundary",
+          tool: "pattern-check",
+        },
         staged: true,
         command: expect.objectContaining({
           argv: expect.arrayContaining(["--json", "--rule", "adapter-boundary"]),
@@ -201,18 +214,36 @@ describe("Habitat oclif commands", () => {
   test("check expand-baseline uses the authoring path instead of report emission", async () => {
     await Check.run(["--expand-baseline", "--rule", "demo-rule"]);
 
-    expect(checkReport.expandBaselines).toHaveBeenCalledWith(
-      {
-        owner: undefined,
-        rule: "demo-rule",
-        tool: undefined,
-      },
-      {
+    expect(mockCheckExpandBaseline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectors: {
+          owner: undefined,
+          rule: "demo-rule",
+          tool: undefined,
+        },
         base: "main",
-      }
+        command: expect.objectContaining({
+          argv: ["--expand-baseline", "--rule", "demo-rule"],
+          bin: "habitat",
+          id: "check",
+        }),
+      })
     );
+    expect(mockCheckRun).not.toHaveBeenCalled();
     expect(checkReport.createCheckReport).not.toHaveBeenCalled();
     expect(capturedOutput()).toContain("baseline written: demo-rule");
+  });
+
+  test("check expand-baseline exits on service refusal", async () => {
+    mockCheckExpandBaseline.mockResolvedValueOnce({
+      kind: "refused",
+      message: "invalid selector",
+    });
+
+    await expect(Check.run(["--expand-baseline", "--rule", "missing-rule"])).rejects.toMatchObject({
+      oclif: { exit: 1 },
+    });
+    expect(mockCheckRun).not.toHaveBeenCalled();
   });
 
   test("fix forwards dry-run intent to the transaction runner", async () => {

--- a/tools/habitat-harness/test/service/check-service.test.ts
+++ b/tools/habitat-harness/test/service/check-service.test.ts
@@ -1,0 +1,103 @@
+import { Effect } from "effect";
+import { describe, expect, test, vi } from "vitest";
+
+const mockReport = vi.hoisted(() => ({
+  schemaVersion: 1,
+  command: "habitat check --json",
+  startedAt: "2026-06-20T00:00:00.000Z",
+  ok: true,
+  rules: [],
+}));
+
+const expandBaselineResult = vi.hoisted(() => ({
+  current: { ok: true as const, messages: ["baseline written: rule-a (1 entries)"] },
+}));
+
+vi.mock("../../src/lib/check-report.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/lib/check-report.js")>();
+  return {
+    ...actual,
+    checkCommandContext: vi.fn((argv: string[]) => ({
+      bin: "habitat",
+      id: "check",
+      argv,
+      serialized: ["habitat", "check", ...argv].join(" "),
+    })),
+    createCheckReport: vi.fn(async () => mockReport),
+    expandBaselines: vi.fn(async () => expandBaselineResult.current),
+  };
+});
+
+describe("Habitat check service", () => {
+  test("runs owned check orchestration from service input", async () => {
+    const checkReport = await import("../../src/lib/check-report.js");
+    const { runCheckService } = await import("../../src/service/modules/check/run.js");
+
+    const result = await Effect.runPromise(
+      runCheckService({
+        selectors: { rule: "format-ci", tool: "biome" },
+        baselineIntegrity: true,
+        base: "origin/main",
+        commandArgs: ["--json"],
+        staged: true,
+        stagedPaths: ["tools/habitat-harness/src/commands/check.ts"],
+      })
+    );
+
+    expect(result).toBe(mockReport);
+    expect(checkReport.createCheckReport).toHaveBeenCalledWith({
+      rule: "format-ci",
+      tool: "biome",
+      base: "origin/main",
+      baselineIntegrity: true,
+      command: {
+        bin: "habitat",
+        id: "check",
+        argv: ["--json"],
+        serialized: "habitat check --json",
+      },
+      staged: true,
+      stagedPaths: ["tools/habitat-harness/src/commands/check.ts"],
+    });
+  });
+
+  test("projects baseline expansion into service output states", async () => {
+    const checkReport = await import("../../src/lib/check-report.js");
+    const { expandCheckBaselinesService } = await import("../../src/service/modules/check/run.js");
+
+    const expanded = await Effect.runPromise(
+      expandCheckBaselinesService({
+        selectors: { owner: "tools-habitat-harness" },
+        base: "main",
+      })
+    );
+
+    expect(expanded).toEqual({
+      kind: "expanded",
+      messages: ["baseline written: rule-a (1 entries)"],
+    });
+    expect(checkReport.expandBaselines).toHaveBeenCalledWith(
+      { owner: "tools-habitat-harness" },
+      { base: "main" }
+    );
+
+    expandBaselineResult.current = {
+      ok: false,
+      requested: { rule: "missing-rule" },
+      reason: "unknown-selector",
+      selectorFacts: [],
+      message: 'Unknown Habitat rule id: "missing-rule".',
+    };
+
+    const refused = await Effect.runPromise(
+      expandCheckBaselinesService({
+        selectors: { rule: "missing-rule" },
+      })
+    );
+
+    expect(refused).toEqual({
+      kind: "refused",
+      message: 'Unknown Habitat rule id: "missing-rule".',
+    });
+  });
+});

--- a/tools/habitat-harness/test/service/service-architecture.test.ts
+++ b/tools/habitat-harness/test/service/service-architecture.test.ts
@@ -1,0 +1,100 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const packageRoot = new URL("../..", import.meta.url).pathname;
+const sourceRoot = join(packageRoot, "src");
+const serviceRoot = join(sourceRoot, "service");
+const providerRoot = join(sourceRoot, "providers");
+const serviceModuleNames = ["check", "verify"] as const;
+
+describe("Habitat service architecture", () => {
+  test("keeps Effect-oRPC runtime construction in the root service seam", () => {
+    const impl = source("src/service/impl.ts");
+
+    expect(impl).toContain("implementEffect(");
+    expect(impl).toContain("ManagedRuntime.make");
+    expect(impl).toContain("HabitatRuntimeLive");
+
+    for (const file of serviceSourceFiles()) {
+      const text = source(file);
+      if (file === "src/service/impl.ts") continue;
+      expect(text).not.toContain("implementEffect(");
+      expect(text).not.toContain("ManagedRuntime.make");
+    }
+  });
+
+  test("keeps the root service router as module composition only", () => {
+    const router = source("src/service/router.ts");
+
+    expect(router).toContain("habitatServiceImplementer.router");
+    expect(router).toContain("check: checkRouter");
+    expect(router).toContain("verify: verifyRouter");
+    expect(router).not.toContain(".effect(");
+    expect(router).not.toContain("createCheckReport");
+    expect(router).not.toContain("runVerifyService");
+    expect(router).not.toContain("process.env");
+  });
+
+  test("keeps procedure bindings in owned service modules", () => {
+    for (const moduleName of serviceModuleNames) {
+      const moduleFile = source(`src/service/modules/${moduleName}/module.ts`);
+      const routerFile = source(`src/service/modules/${moduleName}/router.ts`);
+
+      expect(moduleFile).toContain("habitatServiceImplementer as impl");
+      expect(moduleFile).toContain(`impl.${moduleName}`);
+      expect(moduleFile).not.toContain("implementEffect");
+      expect(moduleFile).not.toContain("ManagedRuntime");
+      expect(moduleFile).not.toContain("Layer.succeed");
+
+      expect(routerFile).toContain(".effect(");
+      expect(routerFile).not.toContain(".router(");
+      expect(routerFile).not.toContain("ManagedRuntime");
+      expect(routerFile).not.toContain("Layer.succeed");
+    }
+  });
+
+  test("keeps providers below the service boundary", () => {
+    for (const file of providerSourceFiles()) {
+      const text = source(file);
+      expect(text).not.toMatch(/from\s+["'][^"']*service\//);
+      expect(text).not.toMatch(/from\s+["'][^"']*domains\//);
+      expect(text).not.toContain("effect-orpc");
+      expect(text).not.toContain("implementEffect");
+    }
+  });
+
+  test("routes check CLI orchestration through the service client", () => {
+    const checkCommand = source("src/commands/check.ts");
+
+    expect(checkCommand).toContain("createHabitatServiceClient");
+    expect(checkCommand).toContain("client.check.run");
+    expect(checkCommand).toContain("client.check.expandBaseline");
+    expect(checkCommand).not.toContain("createCheckReport");
+    expect(checkCommand).not.toContain("expandBaselines");
+  });
+});
+
+function serviceSourceFiles() {
+  return sourceFiles(serviceRoot);
+}
+
+function providerSourceFiles() {
+  return sourceFiles(providerRoot);
+}
+
+function sourceFiles(root: string): string[] {
+  return readdirSync(root)
+    .flatMap((entry) => {
+      const path = join(root, entry);
+      const stat = statSync(path);
+      if (stat.isDirectory()) return sourceFiles(path);
+      return path.endsWith(".ts") ? [path] : [];
+    })
+    .map((path) => relative(packageRoot, path).replaceAll("\\", "/"))
+    .sort();
+}
+
+function source(path: string): string {
+  return readFileSync(join(packageRoot, path), "utf8");
+}


### PR DESCRIPTION
This PR establishes owned Effect-oRPC service modules as the authoritative capability surface for Habitat commands, with `check` joining `verify` as the first new owned module under this architecture.

## What's Introduced

**`check` service module** (`src/service/modules/check/`) with the full owned module shape:
- `contract.ts` — typed input/output schemas for `run` and `expandBaseline` procedures, including a discriminated union output for expansion results (`expanded` | `refused`)
- `module.ts` — narrows the root implementer to the `check` contract subtree
- `router.ts` — binds procedure atoms via `.effect(...)` with no handler logic
- `run.ts` — owns check orchestration and baseline expansion, delegating to `src/lib/check-report.js` as implementation material

**Root service composition** updated to include `check` in both the contract and router, maintaining the rule that root files contain composition only.

## CLI Cutover

`habitat check` and `habitat check --expand-baseline` now route through `createHabitatServiceClient()` rather than calling `src/lib/check-report.js` directly. The command retains responsibility only for flag parsing, output rendering, and exit behavior. The `expandBaseline` path maps the service's `refused` discriminant to a CLI error exit.

## Architecture Guard Tests

`test/service/service-architecture.test.ts` pins the structural rules going forward:
- Runtime construction (`implementEffect`, `ManagedRuntime.make`) is confined to `src/service/impl.ts`
- The root router contains only module composition, no handler logic or direct lib calls
- Each module's `module.ts` narrows the implementer; its `router.ts` uses `.effect(...)` only
- Provider files do not import from `service/` or `domains/`, and do not reference `effect-orpc`
- The `check` CLI command routes through the service client

`test/service/check-service.test.ts` covers `runCheckService` and `expandCheckBaselinesService` in isolation with mocked implementation material, including the `refused` path for unknown selectors.

## Guardrails Documented

The accompanying openspec documents define the service module tree shape, provider relationship, error/config boundaries, and stop conditions — including that `src/lib/**` remains implementation material only while capabilities are drained into named modules, and that new orchestration must not be added there.