### PR TITLE
feat(habitat): add graph Effect-oRPC service module

### DIFF
--- a/openspec/changes/deep-habitat-effect-graph-service-module/design.md
+++ b/openspec/changes/deep-habitat-effect-graph-service-module/design.md
@@ -1,0 +1,43 @@
+# Design: Deep Habitat Effect Graph Service Module
+
+## Boundary
+
+`graph` is an owned Habitat read capability. It answers: "what project graph
+does Habitat expose to users and downstream tooling?" It does not own Nx command
+construction. Nx command construction belongs to `NxProvider`.
+
+## Target Flow
+
+```text
+Graph CLI -> Habitat service client -> graph service module -> NxProvider + HabitatFileSystem + scoped temp dir
+```
+
+The service creates the ephemeral graph output path through
+`acquireTempDirectory`, asks `NxProvider` to run the graph command, reads the
+JSON through `HabitatFileSystem`, projects `graph.graph ?? graph`, and returns a
+stable command result for CLI rendering.
+
+## Target Files
+
+```text
+tools/habitat-harness/src/service/modules/graph/contract.ts
+tools/habitat-harness/src/service/modules/graph/module.ts
+tools/habitat-harness/src/service/modules/graph/router.ts
+tools/habitat-harness/src/service/modules/graph/run.ts
+tools/habitat-harness/src/providers/nx/index.ts
+tools/habitat-harness/src/resources/filesystem.ts
+tools/habitat-harness/src/commands/graph.ts
+tools/habitat-harness/test/service/graph-service.test.ts
+```
+
+## Public Surface Handling
+
+This slice does not change the root package export list. New CLI behavior must
+not call `src/lib/graph.ts`. Public-surface drainage owns deletion or relocation
+of that legacy export so the final train has no duplicate active graph path.
+
+## Verification Boundary
+
+Unit tests prove service/module behavior and provider command construction.
+They do not prove the real Nx graph contents. Package tests and CLI tests prove
+existing output routing remains stable.

--- a/openspec/changes/deep-habitat-effect-graph-service-module/proposal.md
+++ b/openspec/changes/deep-habitat-effect-graph-service-module/proposal.md
@@ -1,0 +1,54 @@
+# Change: Deep Habitat Effect Graph Service Module
+
+## Why
+
+`habitat graph` still behaves like a script: the CLI calls `src/lib/graph`,
+which creates temp files, shells through the legacy spawn path, reads JSON from
+disk, and renders output directly. Habitat graph/orientation is an owned
+capability and should sit behind the Effect-oRPC service surface while Nx
+command execution stays provider-owned.
+
+## What Changes
+
+- Add a `graph` Habitat service module.
+- Route `habitat graph` through the in-process Habitat service client.
+- Add an Nx provider graph command for `target-check graph --file <path>`.
+- Use Effect-managed temp directory acquisition and Habitat filesystem reads
+  for graph JSON materialization.
+- Extend service architecture guard tests so `graph` follows the same module
+  topology as `check` and `verify`.
+
+## What Does Not Change
+
+- No public graph JSON output contract change.
+- No Nx target names or root scripts change.
+- No classify output contract change.
+- No alternate graph implementation is added.
+
+## Affected Owners
+
+- `tools/habitat-harness/src/service/modules/graph/**`
+- `tools/habitat-harness/src/providers/nx/index.ts`
+- `tools/habitat-harness/src/resources/filesystem.ts`
+- `tools/habitat-harness/src/commands/graph.ts`
+- `tools/habitat-harness/src/lib/graph.ts` remains untouched by this slice;
+  public-surface drainage owns deletion or relocation of that legacy export
+- `tools/habitat-harness/test/service/**`
+- `tools/habitat-harness/test/commands/habitat-commands.test.ts`
+
+## Stop Conditions
+
+- The graph service executes Nx directly instead of using `NxProvider`.
+- The CLI calls `src/lib/graph` for owned orchestration.
+- Temp-file lifecycle is unmanaged.
+- The service module changes graph JSON shape or exit behavior.
+
+## Verification
+
+- Focused graph service and CLI tests.
+- `bun run --cwd tools/habitat-harness check`
+- `bun run --cwd tools/habitat-harness test`
+- `bun run biome:ci`
+- `bun run openspec -- validate deep-habitat-effect-graph-service-module --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/deep-habitat-effect-graph-service-module/specs/habitat-harness/spec.md
+++ b/openspec/changes/deep-habitat-effect-graph-service-module/specs/habitat-harness/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Graph Runs Through Habitat Service And Nx Provider
+
+Habitat SHALL expose the graph command as an owned service module while keeping
+Nx graph command execution provider-owned.
+
+#### Scenario: Graph CLI runs
+
+- **WHEN** a user runs `habitat graph`
+- **THEN** the command calls the in-process Habitat service client
+- **AND** the service module owns graph JSON projection and command result
+  output
+- **AND** the CLI handles only flags, stream writes, and exit behavior
+
+#### Scenario: Graph service needs Nx output
+
+- **WHEN** the graph service needs a project graph JSON file
+- **THEN** it asks `NxProvider` to run the graph command
+- **AND** it uses Effect-managed temp directory acquisition for the output path
+- **AND** it reads the graph JSON through Habitat filesystem resources
+- **AND** it does not shell out or read files directly from the CLI

--- a/openspec/changes/deep-habitat-effect-graph-service-module/tasks.md
+++ b/openspec/changes/deep-habitat-effect-graph-service-module/tasks.md
@@ -1,0 +1,26 @@
+# Tasks
+
+## 1. Graph Service Module
+
+- [x] 1.1 Add graph service contract, module binding, router, and run function.
+- [x] 1.2 Compose `graph` into the root Habitat service contract and router.
+- [x] 1.3 Route `habitat graph` through the Habitat service client.
+
+## 2. Provider And Resource Boundary
+
+- [x] 2.1 Add `NxProvider.graph` and `graphArgv`.
+- [x] 2.2 Read graph JSON through `HabitatFileSystem`.
+- [x] 2.3 Use scoped temp-directory acquisition for the graph output file.
+
+## 3. Guardrails And Verification
+
+- [x] 3.1 Add graph service tests with fake Nx provider and fake filesystem.
+- [x] 3.2 Extend service architecture tests for the graph module and CLI route.
+- [x] 3.3 Update command tests to assert graph CLI service usage.
+- [x] 3.4 Run `bun run --cwd tools/habitat-harness check`.
+- [x] 3.5 Run focused graph service/command tests.
+- [x] 3.6 Run `bun run --cwd tools/habitat-harness test`.
+- [x] 3.7 Run `bun run biome:ci`.
+- [x] 3.8 Run `bun run openspec -- validate deep-habitat-effect-graph-service-module --strict`.
+- [x] 3.9 Run `bun run openspec:validate`.
+- [x] 3.10 Run `git diff --check`.

--- a/openspec/changes/deep-habitat-effect-graph-service-module/workstream/phase-record.md
+++ b/openspec/changes/deep-habitat-effect-graph-service-module/workstream/phase-record.md
@@ -1,0 +1,44 @@
+# Phase Record
+
+## Phase
+
+- Project: Habitat Harness deep refactor
+- Phase: Graph service module
+- Owner: Effect-first implementation lane
+- Branch/Graphite stack: `agent-DRA-effect-graph-service-module` stacked on `agent-DRA-effect-owned-service-modules`
+- Started: 2026-06-20
+- Last updated: 2026-06-20
+- Status: implementation complete; final validation and Graphite submit pending
+
+## Objective
+
+- Target movement: make `habitat graph` an owned Effect-oRPC service module and
+  move graph command execution into `NxProvider`.
+- Non-goals: full classify/domain graph migration, public `runGraph` export
+  deletion, or complete workspace graph domain drain.
+- Done condition: graph CLI routes through the service client, graph service
+  uses Nx provider/resource dependencies, and tests pin the boundary.
+
+## Authority Inputs
+
+- Direct active goal: Habitat internals must model clear service/provider
+  boundaries.
+- `deep-habitat-effect-owned-service-modules`
+- `deep-habitat-effect-orientation-workspace-graph`
+- `civ7-open-spec-workstream`
+- `civ7-orpc-control-architecture`
+- `typescript`
+- Official `effect-orpc` README/docs checked on 2026-06-20.
+
+## Verification
+
+- `bun run --cwd tools/habitat-harness check` - passed.
+- `bun run --cwd tools/habitat-harness test -- test/service/graph-service.test.ts test/service/service-architecture.test.ts test/commands/habitat-commands.test.ts` - passed.
+- Review repair: graph projection now preserves `graph.graph ?? graph`, provider
+  infrastructure failures return CLI command streams, and `graphArgv` has
+  provider-level test coverage.
+- `bun run --cwd tools/habitat-harness test` - passed.
+- `bun run biome:ci` - passed after organizing imports in the new graph service file.
+- `bun run openspec -- validate deep-habitat-effect-graph-service-module --strict` - passed.
+- `bun run openspec:validate` - passed.
+- `git diff --check` - passed.

--- a/tools/habitat-harness/src/commands/graph.ts
+++ b/tools/habitat-harness/src/commands/graph.ts
@@ -1,6 +1,6 @@
 import { Flags } from "@oclif/core";
 import { HabitatCommand } from "../base/HabitatCommand.js";
-import { runGraph } from "../lib/graph.js";
+import { createHabitatServiceClient } from "../service/client.js";
 
 export default class Graph extends HabitatCommand {
   static override summary = "Emit the current Nx project graph";
@@ -14,7 +14,8 @@ export default class Graph extends HabitatCommand {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Graph);
-    const result = runGraph({ json: flags.json });
+    const client = createHabitatServiceClient();
+    const result = await client.graph.run({ json: flags.json });
     process.stdout.write(result.stdout);
     process.stderr.write(result.stderr);
     this.exitWith(result.exitCode);

--- a/tools/habitat-harness/src/providers/command/index.ts
+++ b/tools/habitat-harness/src/providers/command/index.ts
@@ -11,7 +11,10 @@ export {
   redactEnvDelta,
 } from "./output.js";
 export { CommandRunner, CommandRunnerLive, runSyncHabitatCommand } from "./runner.js";
-export { spawnResultFromCommandResult } from "./spawn-result.js";
+export {
+  spawnResultFromCommandProviderError,
+  spawnResultFromCommandResult,
+} from "./spawn-result.js";
 export type {
   CommandCachePolicy,
   CommandRunnerService,

--- a/tools/habitat-harness/src/providers/command/spawn-result.ts
+++ b/tools/habitat-harness/src/providers/command/spawn-result.ts
@@ -1,3 +1,4 @@
+import type { CommandProviderError } from "../../errors/index.js";
 import type { SpawnResult } from "../../lib/spawn.js";
 import type { HabitatCommandResult } from "./types.js";
 
@@ -7,4 +8,15 @@ export function spawnResultFromCommandResult(result: HabitatCommandResult): Spaw
     stdout: result.stdout.text,
     stderr: result.stderr.text,
   };
+}
+
+export function spawnResultFromCommandProviderError(error: CommandProviderError): SpawnResult {
+  switch (error._tag) {
+    case "CommandFailed":
+      return { exitCode: error.exitCode, stdout: "", stderr: error.stderr };
+    case "CommandInterrupted":
+      return { exitCode: 127, stdout: "", stderr: `${error.cause}\n` };
+    case "CommandUnavailable":
+      return { exitCode: 127, stdout: "", stderr: `${error.cause}\n` };
+  }
 }

--- a/tools/habitat-harness/src/providers/nx/index.ts
+++ b/tools/habitat-harness/src/providers/nx/index.ts
@@ -4,7 +4,11 @@ import type { HabitatConfig } from "../../config/index.js";
 import type { CommandProviderError } from "../../errors/index.js";
 import { repoRoot } from "../../lib/paths.js";
 import type { HabitatClock } from "../../resources/index.js";
-import { CommandRunner, spawnResultFromCommandResult } from "../command/index.js";
+import {
+  CommandRunner,
+  spawnResultFromCommandProviderError,
+  spawnResultFromCommandResult,
+} from "../command/index.js";
 import type { HabitatCommandResult } from "../command/types.js";
 
 type NxProviderRequirements = CommandExecutor | HabitatConfig | HabitatClock | CommandRunner;
@@ -15,11 +19,19 @@ export interface NxAffectedRequest {
   head?: string;
 }
 
+export interface NxGraphRequest {
+  outputPath: string;
+}
+
 export interface NxProviderService {
   readonly affected: (
     request: NxAffectedRequest
   ) => Effect.Effect<HabitatCommandResult, CommandProviderError, NxProviderRequirements>;
   readonly affectedArgv: (request: NxAffectedRequest) => string[];
+  readonly graph: (
+    request: NxGraphRequest
+  ) => Effect.Effect<HabitatCommandResult, CommandProviderError, NxProviderRequirements>;
+  readonly graphArgv: (request: NxGraphRequest) => string[];
 }
 
 export class NxProvider extends Context.Tag("@internal/habitat-harness/NxProvider")<
@@ -29,12 +41,22 @@ export class NxProvider extends Context.Tag("@internal/habitat-harness/NxProvide
 
 export const NxProviderLive = Layer.succeed(NxProvider, makeLiveNxProvider());
 
+export interface FakeNxProviderHandlers {
+  readonly affected?: (request: NxAffectedRequest) => HabitatCommandResult;
+  readonly graph?: (request: NxGraphRequest) => HabitatCommandResult;
+}
+
 export function makeFakeNxProviderLayer(
-  handler: (request: NxAffectedRequest) => HabitatCommandResult
+  handlerOrHandlers: ((request: NxAffectedRequest) => HabitatCommandResult) | FakeNxProviderHandlers
 ) {
+  const handlers =
+    typeof handlerOrHandlers === "function" ? { affected: handlerOrHandlers } : handlerOrHandlers;
   return Layer.succeed(NxProvider, {
-    affected: (request) => Effect.sync(() => handler(request)),
+    affected: (request) =>
+      Effect.sync(() => requireFakeResult("affected", handlers.affected, request)),
     affectedArgv,
+    graph: (request) => Effect.sync(() => requireFakeResult("graph", handlers.graph, request)),
+    graphArgv,
   });
 }
 
@@ -54,6 +76,20 @@ function makeLiveNxProvider(): NxProviderService {
         )
       ),
     affectedArgv,
+    graph: (request) =>
+      CommandRunner.pipe(
+        Effect.flatMap((runner) =>
+          runner.run({
+            commandId: "nx-project-graph",
+            kind: "workspace-tool",
+            executable: "target-check",
+            argv: graphArgv(request).slice(1),
+            cwd: repoRoot,
+            captureGitState: false,
+          })
+        )
+      ),
+    graphArgv,
   };
 }
 
@@ -71,4 +107,17 @@ export function affectedArgv(request: NxAffectedRequest): string[] {
   ];
 }
 
-export { spawnResultFromCommandResult };
+export function graphArgv(request: NxGraphRequest): string[] {
+  return ["target-check", "graph", "--file", request.outputPath];
+}
+
+function requireFakeResult<Request>(
+  name: keyof FakeNxProviderHandlers,
+  handler: ((request: Request) => HabitatCommandResult) | undefined,
+  request: Request
+): HabitatCommandResult {
+  if (!handler) throw new Error(`Fake Nx provider missing ${name} handler.`);
+  return handler(request);
+}
+
+export { spawnResultFromCommandProviderError, spawnResultFromCommandResult };

--- a/tools/habitat-harness/src/resources/filesystem.ts
+++ b/tools/habitat-harness/src/resources/filesystem.ts
@@ -1,12 +1,13 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { Context, Effect, Layer } from "effect";
-import { FileWriteFailed } from "../errors/index.js";
+import { FileReadFailed, FileWriteFailed } from "../errors/index.js";
 
 export interface HabitatFileSystemService {
   readonly makeDirectory: (targetPath: string) => Effect.Effect<void, FileWriteFailed>;
   readonly makeTempDirectory: (prefix: string) => Effect.Effect<string, FileWriteFailed>;
+  readonly readText: (targetPath: string) => Effect.Effect<string, FileReadFailed>;
   readonly remove: (targetPath: string) => Effect.Effect<void, FileWriteFailed>;
 }
 
@@ -34,6 +35,15 @@ export const HabitatFileSystemLive = Layer.succeed(HabitatFileSystem, {
           cause: cause instanceof Error ? cause.message : String(cause),
         }),
     }),
+  readText: (targetPath) =>
+    Effect.try({
+      try: () => readFileSync(targetPath, "utf8"),
+      catch: (cause) =>
+        new FileReadFailed({
+          path: targetPath,
+          cause: cause instanceof Error ? cause.message : String(cause),
+        }),
+    }),
   remove: (targetPath) =>
     Effect.try({
       try: () => rmSync(targetPath, { recursive: true, force: true }),
@@ -45,7 +55,10 @@ export const HabitatFileSystemLive = Layer.succeed(HabitatFileSystem, {
     }).pipe(Effect.asVoid),
 });
 
-export function makeFakeHabitatFileSystemLayer(events: string[] = []) {
+export function makeFakeHabitatFileSystemLayer(
+  events: string[] = [],
+  files: ReadonlyMap<string, string> = new Map()
+) {
   return Layer.succeed(HabitatFileSystem, {
     makeDirectory: (targetPath) =>
       Effect.sync(() => {
@@ -56,6 +69,18 @@ export function makeFakeHabitatFileSystemLayer(events: string[] = []) {
         const targetPath = `/tmp/${prefix}fake`;
         events.push(`mkdtemp:${targetPath}`);
         return targetPath;
+      }),
+    readText: (targetPath) =>
+      Effect.gen(function* () {
+        events.push(`read:${targetPath}`);
+        const text = files.get(targetPath);
+        if (text !== undefined) return text;
+        return yield* Effect.fail(
+          new FileReadFailed({
+            path: targetPath,
+            cause: "Fake Habitat filesystem has no text fixture for path.",
+          })
+        );
       }),
     remove: (targetPath) =>
       Effect.sync(() => {

--- a/tools/habitat-harness/src/service/contract.ts
+++ b/tools/habitat-harness/src/service/contract.ts
@@ -1,13 +1,16 @@
 import { eoc } from "effect-orpc";
 import { type CheckServiceContract, checkServiceContract } from "./modules/check/contract.js";
+import { type GraphServiceContract, graphServiceContract } from "./modules/graph/contract.js";
 import { type VerifyServiceContract, verifyServiceContract } from "./modules/verify/contract.js";
 
 export type HabitatServiceContract = Readonly<{
   check: CheckServiceContract;
+  graph: GraphServiceContract;
   verify: VerifyServiceContract;
 }>;
 
 export const habitatServiceContract: HabitatServiceContract = eoc.router({
   check: checkServiceContract,
+  graph: graphServiceContract,
   verify: verifyServiceContract,
 });

--- a/tools/habitat-harness/src/service/modules/graph/contract.ts
+++ b/tools/habitat-harness/src/service/modules/graph/contract.ts
@@ -1,0 +1,47 @@
+import type { ContractProcedure } from "@orpc/contract";
+import { eoc } from "effect-orpc";
+import { type Static, Type } from "typebox";
+import { type HabitatServiceErrorMap, habitatServiceErrorMap } from "../../errors.js";
+import type { HabitatServiceProcedureMeta } from "../../metadata.js";
+import { toStandardSchema } from "../../typebox-standard-schema.js";
+
+const GraphServiceRunInputSchema = Type.Object(
+  {
+    json: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false, description: "Habitat graph service run request." }
+);
+export type GraphServiceRunInput = Static<typeof GraphServiceRunInputSchema>;
+
+const GraphServiceRunOutputSchema = Type.Object(
+  {
+    exitCode: Type.Integer(),
+    stdout: Type.String(),
+    stderr: Type.String(),
+  },
+  { additionalProperties: false, description: "Raw graph command streams for CLI handoff." }
+);
+export type GraphServiceRunOutput = Static<typeof GraphServiceRunOutputSchema>;
+
+const GraphServiceRunInputStandardSchema = toStandardSchema(GraphServiceRunInputSchema);
+const GraphServiceRunOutputStandardSchema = toStandardSchema(GraphServiceRunOutputSchema);
+
+export type GraphServiceRunContract = ContractProcedure<
+  typeof GraphServiceRunInputStandardSchema,
+  typeof GraphServiceRunOutputStandardSchema,
+  HabitatServiceErrorMap,
+  HabitatServiceProcedureMeta
+>;
+
+export const graphServiceRunContract: GraphServiceRunContract = eoc
+  .errors(habitatServiceErrorMap)
+  .input(GraphServiceRunInputStandardSchema)
+  .output(GraphServiceRunOutputStandardSchema);
+
+export type GraphServiceContract = Readonly<{
+  run: GraphServiceRunContract;
+}>;
+
+export const graphServiceContract: GraphServiceContract = {
+  run: graphServiceRunContract,
+};

--- a/tools/habitat-harness/src/service/modules/graph/module.ts
+++ b/tools/habitat-harness/src/service/modules/graph/module.ts
@@ -1,0 +1,18 @@
+import type { EffectImplementerInternal } from "effect-orpc";
+import type { HabitatServiceContext } from "../../base.js";
+import {
+  type HabitatServiceRequirements,
+  type HabitatServiceRuntimeError,
+  habitatServiceImplementer as impl,
+} from "../../impl.js";
+import type { GraphServiceContract } from "./contract.js";
+
+export type GraphServiceModule = EffectImplementerInternal<
+  GraphServiceContract,
+  HabitatServiceContext & Record<never, never>,
+  HabitatServiceContext,
+  HabitatServiceRequirements,
+  HabitatServiceRuntimeError
+>;
+
+export const module: GraphServiceModule = impl.graph;

--- a/tools/habitat-harness/src/service/modules/graph/router.ts
+++ b/tools/habitat-harness/src/service/modules/graph/router.ts
@@ -1,0 +1,8 @@
+import { module as graphModule } from "./module.js";
+import { runGraphService } from "./run.js";
+
+export const graphRouter = {
+  run: graphModule.run.effect(({ input }) => runGraphService(input)),
+};
+
+export const router = graphRouter;

--- a/tools/habitat-harness/src/service/modules/graph/run.ts
+++ b/tools/habitat-harness/src/service/modules/graph/run.ts
@@ -1,0 +1,71 @@
+import path from "node:path";
+import { ORPCError } from "@orpc/server";
+import { Effect } from "effect";
+import { JsonParseFailed } from "../../../errors/index.js";
+import {
+  NxProvider,
+  spawnResultFromCommandProviderError,
+  spawnResultFromCommandResult,
+} from "../../../providers/nx/index.js";
+import { acquireTempDirectory, HabitatFileSystem } from "../../../resources/index.js";
+import type { GraphServiceRunInput } from "./contract.js";
+
+/**
+ * Owns `habitat graph` orchestration while leaving Nx execution and file access
+ * in provider/resource layers. The CLI remains a thin caller of this service.
+ */
+export function runGraphService(input: GraphServiceRunInput = {}) {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const tempDir = yield* acquireTempDirectory("habitat-graph-").pipe(
+        Effect.mapError(graphServiceInternalError)
+      );
+      const graphPath = path.join(tempDir, "graph.json");
+      const nx = yield* NxProvider;
+      const spawnResult = yield* nx.graph({ outputPath: graphPath }).pipe(
+        Effect.match({
+          onFailure: spawnResultFromCommandProviderError,
+          onSuccess: spawnResultFromCommandResult,
+        })
+      );
+      if (spawnResult.exitCode !== 0) return spawnResult;
+
+      const fs = yield* HabitatFileSystem;
+      const graphText = yield* fs
+        .readText(graphPath)
+        .pipe(Effect.mapError(graphServiceInternalError));
+      const graphPayload = yield* parseGraphJson(graphPath, graphText).pipe(
+        Effect.mapError(graphServiceInternalError)
+      );
+      return {
+        exitCode: 0,
+        stdout: `${JSON.stringify(selectGraphPayload(graphPayload), null, input.json ? 0 : 2)}\n`,
+        stderr: "",
+      };
+    })
+  );
+}
+
+function parseGraphJson(graphPath: string, graphText: string) {
+  return Effect.try({
+    try: () => JSON.parse(graphText) as unknown,
+    catch: (cause) =>
+      new JsonParseFailed({
+        path: graphPath,
+        cause: cause instanceof Error ? cause.message : String(cause),
+      }),
+  });
+}
+
+function selectGraphPayload(payload: unknown): unknown {
+  if (payload && typeof payload === "object" && "graph" in payload) {
+    return (payload as { readonly graph: unknown }).graph ?? payload;
+  }
+  return payload;
+}
+
+function graphServiceInternalError() {
+  return new ORPCError("INTERNAL_SERVER_ERROR", {
+    message: "Habitat graph service failed.",
+  });
+}

--- a/tools/habitat-harness/src/service/router.ts
+++ b/tools/habitat-harness/src/service/router.ts
@@ -3,11 +3,13 @@ import type { HabitatServiceContext } from "./base.js";
 import { habitatServiceContract } from "./contract.js";
 import { habitatServiceImplementer } from "./impl.js";
 import { checkRouter } from "./modules/check/router.js";
+import { graphRouter } from "./modules/graph/router.js";
 import { verifyRouter } from "./modules/verify/router.js";
 
 export const habitatServiceRouter: Router<typeof habitatServiceContract, HabitatServiceContext> =
   habitatServiceImplementer.router({
     check: checkRouter,
+    graph: graphRouter,
     verify: verifyRouter,
   });
 

--- a/tools/habitat-harness/test/commands/habitat-commands.test.ts
+++ b/tools/habitat-harness/test/commands/habitat-commands.test.ts
@@ -15,6 +15,7 @@ const mockVerifyTargetPlan = vi.hoisted(() => ({
 }));
 const mockCheckRun = vi.hoisted(() => vi.fn());
 const mockCheckExpandBaseline = vi.hoisted(() => vi.fn());
+const mockGraphRun = vi.hoisted(() => vi.fn());
 const mockVerifyRun = vi.hoisted(() => vi.fn());
 
 vi.mock("../../src/lib/check-report.js", async (importOriginal) => {
@@ -85,10 +86,6 @@ vi.mock("../../src/lib/fix.js", () => ({
   runFix: vi.fn(() => ({ exitCode: 0, stdout: "biome ok\n", stderr: "" })),
 }));
 
-vi.mock("../../src/lib/graph.js", () => ({
-  runGraph: vi.fn(() => ({ exitCode: 0, stdout: '{"nodes":{}}\n', stderr: "" })),
-}));
-
 vi.mock("../../src/lib/hooks.js", () => ({
   runHook: vi.fn(() => ({ exitCode: 0, stdout: "hook ok\n", stderr: "" })),
 }));
@@ -104,6 +101,7 @@ vi.mock("../../src/lib/verify/index.js", async (importOriginal) => {
 vi.mock("../../src/service/client.js", () => ({
   createHabitatServiceClient: vi.fn(() => ({
     check: { expandBaseline: mockCheckExpandBaseline, run: mockCheckRun },
+    graph: { run: mockGraphRun },
     verify: { run: mockVerifyRun },
   })),
 }));
@@ -117,7 +115,6 @@ import Verify from "../../src/commands/verify.js";
 import * as checkReport from "../../src/lib/check-report.js";
 import * as classify from "../../src/lib/classify.js";
 import * as fix from "../../src/lib/fix.js";
-import * as graph from "../../src/lib/graph.js";
 import * as hooks from "../../src/lib/hooks.js";
 import * as verifyReceipt from "../../src/lib/verify/index.js";
 import * as serviceClient from "../../src/service/client.js";
@@ -140,6 +137,7 @@ describe("Habitat oclif commands", () => {
       kind: "expanded",
       messages: ["baseline written: demo-rule (1 entry)"],
     });
+    mockGraphRun.mockResolvedValue({ exitCode: 0, stdout: '{"nodes":{}}\n', stderr: "" });
     mockVerifyRun.mockImplementation(async (input: { base?: string; commandArgs?: string[] }) => {
       const base = input.base ?? "merge-base";
       return {
@@ -285,7 +283,8 @@ describe("Habitat oclif commands", () => {
   test("graph forwards compact JSON output", async () => {
     await Graph.run(["--json"]);
 
-    expect(graph.runGraph).toHaveBeenCalledWith({ json: true });
+    expect(serviceClient.createHabitatServiceClient).toHaveBeenCalled();
+    expect(mockGraphRun).toHaveBeenCalledWith({ json: true });
     expect(stdout.join("")).toContain('{"nodes":{}}');
   });
 

--- a/tools/habitat-harness/test/lib/vendor-providers.test.ts
+++ b/tools/habitat-harness/test/lib/vendor-providers.test.ts
@@ -10,7 +10,12 @@ import { captureOutput, makeHabitatCommandResult } from "../../src/providers/com
 import { GitProvider, makeFakeGitProviderLayer } from "../../src/providers/git/index.js";
 import { GritProvider, makeFakeGritProviderLayer } from "../../src/providers/grit/index.js";
 import { huskyDelegator } from "../../src/providers/husky/index.js";
-import { affectedArgv, makeFakeNxProviderLayer, NxProvider } from "../../src/providers/nx/index.js";
+import {
+  affectedArgv,
+  graphArgv,
+  makeFakeNxProviderLayer,
+  NxProvider,
+} from "../../src/providers/nx/index.js";
 import { runHabitatEffect } from "../../src/runtime/index.js";
 
 describe("vendor providers", () => {
@@ -86,6 +91,15 @@ describe("vendor providers", () => {
 
     expect(result.commandId).toBe("workspace-tool-nx");
     expect(result.stdout.text).toBe("ok\n");
+  });
+
+  test("NxProvider owns graph argv construction", () => {
+    expect(graphArgv({ outputPath: "/tmp/habitat-graph-fake/graph.json" })).toEqual([
+      "target-check",
+      "graph",
+      "--file",
+      "/tmp/habitat-graph-fake/graph.json",
+    ]);
   });
 
   test("BiomeProvider owns safe command-vector construction", async () => {

--- a/tools/habitat-harness/test/service/graph-service.test.ts
+++ b/tools/habitat-harness/test/service/graph-service.test.ts
@@ -1,0 +1,161 @@
+import path from "node:path";
+import { Effect, Layer } from "effect";
+import { describe, expect, test } from "vitest";
+import { CommandUnavailable } from "../../src/errors/index.js";
+import { repoRoot } from "../../src/lib/paths.js";
+import { captureOutput, makeHabitatCommandResult } from "../../src/providers/command/index.js";
+import {
+  affectedArgv,
+  graphArgv,
+  makeFakeNxProviderLayer,
+  type NxGraphRequest,
+  NxProvider,
+} from "../../src/providers/nx/index.js";
+import { makeFakeHabitatFileSystemLayer } from "../../src/resources/index.js";
+import { runGraphService } from "../../src/service/modules/graph/run.js";
+
+describe("Habitat graph service", () => {
+  test("runs Nx graph through providers and returns compact CLI JSON", async () => {
+    const events: string[] = [];
+    const graphRequests: NxGraphRequest[] = [];
+    const graphPath = path.join("/tmp/habitat-graph-fake", "graph.json");
+    const layer = Layer.mergeAll(
+      makeFakeNxProviderLayer({
+        graph: (request) => {
+          graphRequests.push(request);
+          return makeHabitatCommandResult(
+            {
+              commandId: "nx-project-graph",
+              kind: "workspace-tool",
+              executable: "target-check",
+              argv: ["graph", "--file", request.outputPath],
+              cwd: repoRoot,
+              captureGitState: false,
+            },
+            { stdout: captureOutput("graph written\n") }
+          );
+        },
+      }),
+      makeFakeHabitatFileSystemLayer(
+        events,
+        new Map([[graphPath, JSON.stringify({ graph: { nodes: { app: {} } } })]])
+      )
+    );
+
+    const result = await Effect.runPromise(
+      runGraphService({ json: true }).pipe(Effect.provide(layer))
+    );
+
+    expect(result).toEqual({
+      exitCode: 0,
+      stdout: '{"nodes":{"app":{}}}\n',
+      stderr: "",
+    });
+    expect(graphRequests).toEqual([{ outputPath: graphPath }]);
+    expect(events).toEqual([
+      "mkdtemp:/tmp/habitat-graph-fake",
+      "read:/tmp/habitat-graph-fake/graph.json",
+      "remove:/tmp/habitat-graph-fake",
+    ]);
+  });
+
+  test("keeps the legacy nullish graph projection contract", async () => {
+    const graphPath = path.join("/tmp/habitat-graph-fake", "graph.json");
+    const layer = Layer.mergeAll(
+      makeFakeNxProviderLayer({
+        graph: (request) =>
+          makeHabitatCommandResult({
+            commandId: "nx-project-graph",
+            kind: "workspace-tool",
+            executable: "target-check",
+            argv: ["graph", "--file", request.outputPath],
+            cwd: repoRoot,
+            captureGitState: false,
+          }),
+      }),
+      makeFakeHabitatFileSystemLayer(
+        [],
+        new Map([[graphPath, JSON.stringify({ graph: null, nodes: { root: {} } })]])
+      )
+    );
+
+    const result = await Effect.runPromise(
+      runGraphService({ json: true }).pipe(Effect.provide(layer))
+    );
+
+    expect(result.stdout).toBe('{"graph":null,"nodes":{"root":{}}}\n');
+  });
+
+  test("returns failed Nx command streams without reading graph JSON", async () => {
+    const events: string[] = [];
+    const layer = Layer.mergeAll(
+      makeFakeNxProviderLayer({
+        graph: (request) =>
+          makeHabitatCommandResult(
+            {
+              commandId: "nx-project-graph",
+              kind: "workspace-tool",
+              executable: "target-check",
+              argv: ["graph", "--file", request.outputPath],
+              cwd: repoRoot,
+              captureGitState: false,
+            },
+            {
+              exit: { code: 2, signal: null, interrupted: false },
+              stderr: captureOutput("nx graph failed\n"),
+            }
+          ),
+      }),
+      makeFakeHabitatFileSystemLayer(events)
+    );
+
+    const result = await Effect.runPromise(runGraphService({}).pipe(Effect.provide(layer)));
+
+    expect(result).toEqual({
+      exitCode: 2,
+      stdout: "",
+      stderr: "nx graph failed\n",
+    });
+    expect(events).toEqual(["mkdtemp:/tmp/habitat-graph-fake", "remove:/tmp/habitat-graph-fake"]);
+  });
+
+  test("returns provider infrastructure failures as command streams", async () => {
+    const events: string[] = [];
+    const layer = Layer.mergeAll(
+      Layer.succeed(NxProvider, {
+        affected: (request) =>
+          Effect.fail(
+            new CommandUnavailable({
+              commandId: "nx-affected",
+              executable: "nx",
+              argv: affectedArgv(request).slice(1),
+              cwd: repoRoot,
+              cause: "nx unavailable",
+            })
+          ),
+        affectedArgv,
+        graph: (request) =>
+          Effect.fail(
+            new CommandUnavailable({
+              commandId: "nx-project-graph",
+              executable: "target-check",
+              argv: graphArgv(request).slice(1),
+              cwd: repoRoot,
+              cause: "target-check unavailable",
+            })
+          ),
+        graphArgv,
+      }),
+      makeFakeHabitatFileSystemLayer(events)
+    );
+
+    const result = await Effect.runPromise(runGraphService({}).pipe(Effect.provide(layer)));
+
+    expect(result).toEqual({
+      exitCode: 127,
+      stdout: "",
+      stderr: "target-check unavailable\n",
+    });
+    expect(events).toEqual(["mkdtemp:/tmp/habitat-graph-fake", "remove:/tmp/habitat-graph-fake"]);
+  });
+});

--- a/tools/habitat-harness/test/service/service-architecture.test.ts
+++ b/tools/habitat-harness/test/service/service-architecture.test.ts
@@ -6,7 +6,7 @@ const packageRoot = new URL("../..", import.meta.url).pathname;
 const sourceRoot = join(packageRoot, "src");
 const serviceRoot = join(sourceRoot, "service");
 const providerRoot = join(sourceRoot, "providers");
-const serviceModuleNames = ["check", "verify"] as const;
+const serviceModuleNames = ["check", "graph", "verify"] as const;
 
 describe("Habitat service architecture", () => {
   test("keeps Effect-oRPC runtime construction in the root service seam", () => {
@@ -29,9 +29,11 @@ describe("Habitat service architecture", () => {
 
     expect(router).toContain("habitatServiceImplementer.router");
     expect(router).toContain("check: checkRouter");
+    expect(router).toContain("graph: graphRouter");
     expect(router).toContain("verify: verifyRouter");
     expect(router).not.toContain(".effect(");
     expect(router).not.toContain("createCheckReport");
+    expect(router).not.toContain("runGraphService");
     expect(router).not.toContain("runVerifyService");
     expect(router).not.toContain("process.env");
   });
@@ -72,6 +74,15 @@ describe("Habitat service architecture", () => {
     expect(checkCommand).toContain("client.check.expandBaseline");
     expect(checkCommand).not.toContain("createCheckReport");
     expect(checkCommand).not.toContain("expandBaselines");
+  });
+
+  test("routes graph CLI orchestration through the service client", () => {
+    const graphCommand = source("src/commands/graph.ts");
+
+    expect(graphCommand).toContain("createHabitatServiceClient");
+    expect(graphCommand).toContain("client.graph.run");
+    expect(graphCommand).not.toContain("runGraph");
+    expect(graphCommand).not.toContain("../lib/graph.js");
   });
 });
 


### PR DESCRIPTION
Routes `habitat graph` through the Effect-oRPC service layer instead of calling `src/lib/graph` directly from the CLI.

A new `graph` service module is added under `service/modules/graph` with a contract, module binding, router, and run function. The run function acquires a scoped temp directory, delegates Nx graph command execution to `NxProvider.graph`, reads the resulting JSON through `HabitatFileSystem.readText`, projects `graph.graph ?? graph` from the payload, and returns a stable command result for the CLI to render. The CLI command becomes a thin caller of `client.graph.run`.

`NxProvider` gains a `graph` method and `graphArgv` function that constructs the `target-check graph --file <path>` invocation. `makeFakeNxProviderLayer` is extended to accept either a single affected handler (backward-compatible) or a `FakeNxProviderHandlers` object covering both `affected` and `graph`.

`HabitatFileSystem` gains a `readText` method backed by `readFileSync`, with a corresponding fake that accepts a `files` map for test fixtures.

A new `spawnResultFromCommandProviderError` helper is added to the command provider so that infrastructure-level failures (`CommandFailed`, `CommandInterrupted`, `CommandUnavailable`) are surfaced as CLI-renderable streams rather than unhandled errors.

`src/lib/graph.ts` is intentionally left untouched; removal of that legacy export is deferred to the public-surface drainage slice.

Tests added cover: successful graph projection, the nullish `graph.graph` fallback, failed Nx command passthrough, and provider infrastructure failures. Service architecture guard tests are extended to assert the graph module topology and that the graph CLI route no longer references the legacy lib path.