### PR TITLE
feat(habitat): add hook service module

### DIFF
--- a/openspec/changes/deep-habitat-effect-hook-runtime-cutover/design.md
+++ b/openspec/changes/deep-habitat-effect-hook-runtime-cutover/design.md
@@ -1,35 +1,57 @@
-# Design: Deep Habitat Effect Hook Runtime Cutover
+# Design: Deep Habitat Effect Hook Service Module
 
 ## Domain Boundary
 
-Owner: local-feedback domain.
+Owner: hook service module, with hook runtime internals still owning the current
+local feedback workflow.
 
-Hook owns staged-worktree policy, local-only proof labels, hook trace, and stage
-ordering. Providers own tool and Git execution.
+Hook owns staged-worktree policy, local-only feedback labels, hook trace, and
+stage ordering. Providers own tool and Git execution once the next hook runtime
+drain lands. This service-module slice creates the correct callable ownership
+boundary first, without changing the user-facing hook behavior.
+
+## Target Flow
+
+```text
+Husky -> habitat hook CLI -> Habitat service client -> hook service module -> hook runtime
+```
 
 ## Write Set
 
 ```text
-tools/habitat-harness/src/domains/local-feedback/**
-tools/habitat-harness/src/lib/hooks.ts
-tools/habitat-harness/src/lib/hook-runtime/**
+tools/habitat-harness/src/service/modules/hook/**
+tools/habitat-harness/src/service/contract.ts
+tools/habitat-harness/src/service/router.ts
 tools/habitat-harness/src/commands/hook.ts
+tools/habitat-harness/src/lib/hooks.ts
+tools/habitat-harness/test/service/hook-service.test.ts
+tools/habitat-harness/test/service/service-architecture.test.ts
+tools/habitat-harness/test/commands/habitat-commands.test.ts
 tools/habitat-harness/test/lib/hooks.test.ts
 ```
 
-## Required Cutover
+## Required Cutover In This Slice
+
+- Define a contract for `hook.run`.
+- Bind the procedure through `effect-orpc` in `src/service/modules/hook`.
+- Route the CLI through `client.hook.run`.
+- Keep unknown hook name, pre-commit, and pre-push stream/exit behavior stable.
+- Add tests that fail if the CLI imports or calls `runHook` directly.
+
+## Follow-On Hook Runtime Drain
 
 - `HookRuntime.runCommand` becomes provider Layer substitution.
 - `HookRuntime.nowMs` becomes `HabitatClock`.
 - Staged path reads use `GitProvider`.
 - File hashes and existence use `HabitatFileSystem`.
 - Biome formatting/checking uses `BiomeProvider`.
-- Pattern checking uses `GritProvider` through `habitat check` or direct provider
-  according to the check/baseline packet outcome.
+- Pattern checking uses the owned check service or Grit provider according to
+  the check/baseline packet outcome.
 
 ## Stop Conditions
 
-- Hook code calls `spawnSync`, `run`, or `Effect.run*` directly after closure.
-- Hook output claims CI/product proof.
-- Partial-staging refusal or formatter restage behavior changes without explicit
-  D0/public contract update.
+- `src/commands/hook.ts` calls `src/lib/hooks.ts` directly.
+- The service module changes hook output from local workstation feedback.
+- Partial-staging refusal or formatter restage behavior changes.
+- The packet presents this service-module slice as a complete hook provider
+  drain.

--- a/openspec/changes/deep-habitat-effect-hook-runtime-cutover/proposal.md
+++ b/openspec/changes/deep-habitat-effect-hook-runtime-cutover/proposal.md
@@ -1,15 +1,18 @@
-# Proposal: Deep Habitat Effect Hook Runtime Cutover
+# Proposal: Deep Habitat Effect Hook Service Module
 
 ## Summary
 
-Move Habitat hook runtime under Effect services while preserving Husky as a
-delegator and preserving hook results as local workstation checks only.
+Make `habitat hook` an owned Habitat service capability. Husky remains a thin
+delegator, the CLI becomes a thin service client, and hook results remain local
+workstation feedback only.
 
 ## What Changes
 
-- Move hook runtime source into `src/domains/local-feedback/**`.
-- Replace local `HookRuntime` ad hoc seams with Effect services and fake Layers.
-- Route Biome, Grit, Git, and Habitat command invocations through providers.
+- Add a `hook` Habitat service module under `src/service/modules/hook/**`.
+- Compose `hook` into the root Habitat service contract and router.
+- Route `src/commands/hook.ts` through the in-process Habitat service client.
+- Preserve the current hook result contract: `{ exitCode, stdout, stderr }`.
+- Update architecture tests so hook joins the owned service-module surface.
 
 ## What Does Not Change
 
@@ -17,10 +20,14 @@ delegator and preserving hook results as local workstation checks only.
   `bun run habitat hook`.
 - Pre-commit may restage formatter-touched files only.
 - CI remains authoritative.
+- Full hook runtime provider/resource drainage is the next hook implementation
+  unit: Git, Biome, Grit, filesystem, clock, and command execution remain owned
+  by the hook runtime internals until that unit lands.
 
 ## Verification Gates
 
 - `bun run --cwd tools/habitat-harness test -- test/lib/hooks.test.ts`
+- `bun run --cwd tools/habitat-harness test -- test/service/hook-service.test.ts test/service/service-architecture.test.ts test/commands/habitat-commands.test.ts`
 - `bun run habitat hook pre-commit`
 - `bun run openspec -- validate deep-habitat-effect-hook-runtime-cutover --strict`
 - `git diff --check`

--- a/openspec/changes/deep-habitat-effect-hook-runtime-cutover/specs/habitat-harness/spec.md
+++ b/openspec/changes/deep-habitat-effect-hook-runtime-cutover/specs/habitat-harness/spec.md
@@ -1,21 +1,25 @@
 ## ADDED Requirements
 
-### Requirement: Hook Runtime Uses Effect Services And Remains Local Feedback
+### Requirement: Hook Runs Through Habitat Service And Remains Local Feedback
 
-Habitat SHALL migrate hook runtime behavior onto Effect services while keeping
-Husky as a delegator and hook results as local workstation feedback only.
+Habitat SHALL expose hook execution as an owned Habitat service module while
+keeping Husky as a delegator and hook results as local workstation feedback
+only.
 
 #### Scenario: Pre-commit runs
 
 - **WHEN** `bun run habitat hook pre-commit` runs
-- **THEN** staged path discovery, partial-staging refusal, Biome formatting,
-  formatter restage, Grit staged scan, and resource policy are typed steps
+- **THEN** the CLI calls the in-process Habitat service client
+- **AND** the hook service module owns the hook procedure boundary
+- **AND** staged path discovery, partial-staging refusal, Biome formatting,
+  formatter restage, Grit staged scan, and resource policy behavior remain
+  stable
 - **AND** formatter restage touches formatter-changed files only
 - **AND** the hook record states local-only non-claims
 
 #### Scenario: Pre-push runs
 
 - **WHEN** `bun run habitat hook pre-push` runs
-- **THEN** base selection and Nx affected execution consume Git and Nx provider
-  data
+- **THEN** the CLI calls the in-process Habitat service client
+- **AND** base selection and Nx affected execution behavior remain stable
 - **AND** CI remains authoritative

--- a/openspec/changes/deep-habitat-effect-hook-runtime-cutover/tasks.md
+++ b/openspec/changes/deep-habitat-effect-hook-runtime-cutover/tasks.md
@@ -1,24 +1,33 @@
 # Tasks
 
-## 1. Move And Replace Seams
+## 1. Hook Service Module
 
-- [ ] 1.1 Move hook runtime source to `src/domains/local-feedback/**`.
-- [ ] 1.2 Replace `runCommand`, `nowMs`, `pathExists`, and `fileHash` options with service requirements.
-- [ ] 1.3 Route staged Git reads through `GitProvider`.
-- [ ] 1.4 Route Biome and pattern checks through providers.
+- [x] 1.1 Add hook service contract, module binding, router, and run function.
+- [x] 1.2 Compose `hook` into the root Habitat service contract and router.
+- [x] 1.3 Route `habitat hook` CLI through the Habitat service client.
 
 ## 2. Preserve Behavior
 
-- [ ] 2.1 Keep local hook notice in human output.
-- [ ] 2.2 Preserve partial-staging refusal.
-- [ ] 2.3 Preserve formatter restage-only behavior.
-- [ ] 2.4 Preserve pre-push target sequence unless changed by verify/Nx packet.
+- [x] 2.1 Keep local hook notice in human output.
+- [x] 2.2 Preserve partial-staging refusal.
+- [x] 2.3 Preserve formatter restage-only behavior.
+- [x] 2.4 Preserve pre-push target sequence unless changed by verify/Nx packet.
+- [x] 2.5 Preserve unknown hook name exit and stderr behavior.
 
-## 3. Verification
+## 3. Explicit Remaining Drain
 
-- [ ] 3.1 Run `bun run --cwd tools/habitat-harness test -- test/lib/hooks.test.ts`.
-- [ ] 3.2 Run `bun run habitat hook pre-commit`.
-- [ ] 3.3 Run `bun run --cwd tools/habitat-harness check`.
-- [ ] 3.4 Run `bun run openspec -- validate deep-habitat-effect-hook-runtime-cutover --strict`.
-- [ ] 3.5 Run `bun run openspec:validate`.
-- [ ] 3.6 Run `git diff --check`.
+- [x] 3.1 Record that Git, Biome, Grit, filesystem, clock, and command execution
+      are still inside hook runtime internals after this service-module slice.
+- [x] 3.2 Keep hook runtime provider drainage as the next hook implementation unit.
+
+## 4. Verification
+
+- [x] 4.1 Run `bun run --cwd tools/habitat-harness test -- test/lib/hooks.test.ts`.
+- [x] 4.2 Run focused hook service/command/architecture tests.
+- [x] 4.3 Run `bun run habitat hook pre-commit`.
+- [x] 4.4 Run `bun run --cwd tools/habitat-harness check`.
+- [x] 4.5 Run `bun run --cwd tools/habitat-harness test`.
+- [x] 4.6 Run `bun run biome:ci`.
+- [x] 4.7 Run `bun run openspec -- validate deep-habitat-effect-hook-runtime-cutover --strict`.
+- [x] 4.8 Run `bun run openspec:validate`.
+- [x] 4.9 Run `git diff --check`.

--- a/openspec/changes/deep-habitat-effect-hook-runtime-cutover/workstream/phase-record.md
+++ b/openspec/changes/deep-habitat-effect-hook-runtime-cutover/workstream/phase-record.md
@@ -3,19 +3,36 @@
 ## Phase
 
 - Project: Habitat Harness deep refactor
-- Phase: Hook runtime cutover
-- Owner: Effect-first planning lane
-- Branch/Graphite stack: `agent-DRA-effect-first-openspec-domino-plan` stacked on `agent-DRA-effect-first-repair-backlog`
+- Phase: Hook service module
+- Owner: Effect-first implementation lane
+- Branch/Graphite stack: `agent-DRA-effect-hook-service-module` stacked on `agent-DRA-effect-graph-service-module`
 - Started: 2026-06-19
-- Status: packet completed to OpenSpec shape
+- Last updated: 2026-06-20
+- Status: implementation complete; review and Graphite submit pending
 
 ## Objective
 
-- Target movement: migrate hooks to Effect-scoped local feedback transactions.
+- Target movement: make `habitat hook` an owned Effect-oRPC service module so
+  Husky and the CLI call Habitat’s service surface instead of direct lib
+  orchestration.
 - Non-goals: making hooks authoritative proof.
-- Done condition: staged/partial/restage/pre-push matrices pass.
+- Done condition: hook CLI routes through the service client, hook service
+  preserves current stream/exit behavior, and tests pin local-only hook output
+  plus architecture boundaries.
 
 ## Verification
 
-- Commands run: pending implementation.
-- Evidence boundary: design packet.
+- `bun run --cwd tools/habitat-harness check` - passed.
+- `bun run --cwd tools/habitat-harness test -- test/service/hook-service.test.ts test/service/service-architecture.test.ts test/commands/habitat-commands.test.ts test/lib/hooks.test.ts` - passed.
+- `bun run --cwd tools/habitat-harness test` - passed.
+- `bun run biome:ci` - passed.
+- `bun run habitat hook pre-commit` - passed; emitted local-only workstation
+  feedback notice and no staged Biome/pattern work in the current tree.
+- `bun run openspec -- validate deep-habitat-effect-hook-runtime-cutover --strict` - passed.
+- `bun run openspec:validate` - passed.
+- `git diff --check` - passed.
+- Review repair: the hook service contract accepts empty `base` strings so the
+  existing hook runtime semantics for empty `--base` are preserved instead of
+  failing service input validation.
+- Evidence boundary: service-module slice; hook provider/resource drainage
+  remains the next hook runtime implementation unit.

--- a/tools/habitat-harness/src/commands/hook.ts
+++ b/tools/habitat-harness/src/commands/hook.ts
@@ -1,6 +1,6 @@
 import { Args, Flags } from "@oclif/core";
 import { HabitatCommand } from "../base/HabitatCommand.js";
-import { runHook } from "../lib/hooks.js";
+import { createHabitatServiceClient } from "../service/client.js";
 
 export default class Hook extends HabitatCommand {
   static override summary = "Run a Habitat git-hook entrypoint";
@@ -20,7 +20,8 @@ export default class Hook extends HabitatCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(Hook);
-    const result = runHook(args.name, { base: flags.base });
+    const client = createHabitatServiceClient();
+    const result = await client.hook.run({ name: args.name, base: flags.base });
     process.stdout.write(result.stdout);
     process.stderr.write(result.stderr);
     this.exitWith(result.exitCode);

--- a/tools/habitat-harness/src/service/contract.ts
+++ b/tools/habitat-harness/src/service/contract.ts
@@ -1,16 +1,19 @@
 import { eoc } from "effect-orpc";
 import { type CheckServiceContract, checkServiceContract } from "./modules/check/contract.js";
 import { type GraphServiceContract, graphServiceContract } from "./modules/graph/contract.js";
+import { type HookServiceContract, hookServiceContract } from "./modules/hook/contract.js";
 import { type VerifyServiceContract, verifyServiceContract } from "./modules/verify/contract.js";
 
 export type HabitatServiceContract = Readonly<{
   check: CheckServiceContract;
   graph: GraphServiceContract;
+  hook: HookServiceContract;
   verify: VerifyServiceContract;
 }>;
 
 export const habitatServiceContract: HabitatServiceContract = eoc.router({
   check: checkServiceContract,
   graph: graphServiceContract,
+  hook: hookServiceContract,
   verify: verifyServiceContract,
 });

--- a/tools/habitat-harness/src/service/modules/hook/contract.ts
+++ b/tools/habitat-harness/src/service/modules/hook/contract.ts
@@ -1,0 +1,48 @@
+import type { ContractProcedure } from "@orpc/contract";
+import { eoc } from "effect-orpc";
+import { type Static, Type } from "typebox";
+import { type HabitatServiceErrorMap, habitatServiceErrorMap } from "../../errors.js";
+import type { HabitatServiceProcedureMeta } from "../../metadata.js";
+import { toStandardSchema } from "../../typebox-standard-schema.js";
+
+const HookServiceRunInputSchema = Type.Object(
+  {
+    name: Type.Optional(Type.String()),
+    base: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false, description: "Habitat hook service run request." }
+);
+export type HookServiceRunInput = Static<typeof HookServiceRunInputSchema>;
+
+const HookServiceRunOutputSchema = Type.Object(
+  {
+    exitCode: Type.Integer(),
+    stdout: Type.String(),
+    stderr: Type.String(),
+  },
+  { additionalProperties: false, description: "Raw hook command streams for CLI handoff." }
+);
+export type HookServiceRunOutput = Static<typeof HookServiceRunOutputSchema>;
+
+const HookServiceRunInputStandardSchema = toStandardSchema(HookServiceRunInputSchema);
+const HookServiceRunOutputStandardSchema = toStandardSchema(HookServiceRunOutputSchema);
+
+export type HookServiceRunContract = ContractProcedure<
+  typeof HookServiceRunInputStandardSchema,
+  typeof HookServiceRunOutputStandardSchema,
+  HabitatServiceErrorMap,
+  HabitatServiceProcedureMeta
+>;
+
+export const hookServiceRunContract: HookServiceRunContract = eoc
+  .errors(habitatServiceErrorMap)
+  .input(HookServiceRunInputStandardSchema)
+  .output(HookServiceRunOutputStandardSchema);
+
+export type HookServiceContract = Readonly<{
+  run: HookServiceRunContract;
+}>;
+
+export const hookServiceContract: HookServiceContract = {
+  run: hookServiceRunContract,
+};

--- a/tools/habitat-harness/src/service/modules/hook/module.ts
+++ b/tools/habitat-harness/src/service/modules/hook/module.ts
@@ -1,0 +1,18 @@
+import type { EffectImplementerInternal } from "effect-orpc";
+import type { HabitatServiceContext } from "../../base.js";
+import {
+  type HabitatServiceRequirements,
+  type HabitatServiceRuntimeError,
+  habitatServiceImplementer as impl,
+} from "../../impl.js";
+import type { HookServiceContract } from "./contract.js";
+
+export type HookServiceModule = EffectImplementerInternal<
+  HookServiceContract,
+  HabitatServiceContext & Record<never, never>,
+  HabitatServiceContext,
+  HabitatServiceRequirements,
+  HabitatServiceRuntimeError
+>;
+
+export const module: HookServiceModule = impl.hook;

--- a/tools/habitat-harness/src/service/modules/hook/router.ts
+++ b/tools/habitat-harness/src/service/modules/hook/router.ts
@@ -1,0 +1,8 @@
+import { module as hookModule } from "./module.js";
+import { runHookService } from "./run.js";
+
+export const hookRouter = {
+  run: hookModule.run.effect(({ input }) => runHookService(input)),
+};
+
+export const router = hookRouter;

--- a/tools/habitat-harness/src/service/modules/hook/run.ts
+++ b/tools/habitat-harness/src/service/modules/hook/run.ts
@@ -1,0 +1,11 @@
+import { Effect } from "effect";
+import { runHook } from "../../../lib/hooks.js";
+import type { HookServiceRunInput } from "./contract.js";
+
+/**
+ * Owns the `habitat hook` callable boundary. The hook runtime internals keep
+ * their current behavior while the CLI and Husky enter through the service.
+ */
+export function runHookService(input: HookServiceRunInput = {}) {
+  return Effect.sync(() => runHook(input.name, { base: input.base }));
+}

--- a/tools/habitat-harness/src/service/router.ts
+++ b/tools/habitat-harness/src/service/router.ts
@@ -4,12 +4,14 @@ import { habitatServiceContract } from "./contract.js";
 import { habitatServiceImplementer } from "./impl.js";
 import { checkRouter } from "./modules/check/router.js";
 import { graphRouter } from "./modules/graph/router.js";
+import { hookRouter } from "./modules/hook/router.js";
 import { verifyRouter } from "./modules/verify/router.js";
 
 export const habitatServiceRouter: Router<typeof habitatServiceContract, HabitatServiceContext> =
   habitatServiceImplementer.router({
     check: checkRouter,
     graph: graphRouter,
+    hook: hookRouter,
     verify: verifyRouter,
   });
 

--- a/tools/habitat-harness/test/commands/habitat-commands.test.ts
+++ b/tools/habitat-harness/test/commands/habitat-commands.test.ts
@@ -16,6 +16,7 @@ const mockVerifyTargetPlan = vi.hoisted(() => ({
 const mockCheckRun = vi.hoisted(() => vi.fn());
 const mockCheckExpandBaseline = vi.hoisted(() => vi.fn());
 const mockGraphRun = vi.hoisted(() => vi.fn());
+const mockHookRun = vi.hoisted(() => vi.fn());
 const mockVerifyRun = vi.hoisted(() => vi.fn());
 
 vi.mock("../../src/lib/check-report.js", async (importOriginal) => {
@@ -86,10 +87,6 @@ vi.mock("../../src/lib/fix.js", () => ({
   runFix: vi.fn(() => ({ exitCode: 0, stdout: "biome ok\n", stderr: "" })),
 }));
 
-vi.mock("../../src/lib/hooks.js", () => ({
-  runHook: vi.fn(() => ({ exitCode: 0, stdout: "hook ok\n", stderr: "" })),
-}));
-
 vi.mock("../../src/lib/verify/index.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/lib/verify/index.js")>();
   return {
@@ -102,6 +99,7 @@ vi.mock("../../src/service/client.js", () => ({
   createHabitatServiceClient: vi.fn(() => ({
     check: { expandBaseline: mockCheckExpandBaseline, run: mockCheckRun },
     graph: { run: mockGraphRun },
+    hook: { run: mockHookRun },
     verify: { run: mockVerifyRun },
   })),
 }));
@@ -115,7 +113,6 @@ import Verify from "../../src/commands/verify.js";
 import * as checkReport from "../../src/lib/check-report.js";
 import * as classify from "../../src/lib/classify.js";
 import * as fix from "../../src/lib/fix.js";
-import * as hooks from "../../src/lib/hooks.js";
 import * as verifyReceipt from "../../src/lib/verify/index.js";
 import * as serviceClient from "../../src/service/client.js";
 
@@ -138,6 +135,7 @@ describe("Habitat oclif commands", () => {
       messages: ["baseline written: demo-rule (1 entry)"],
     });
     mockGraphRun.mockResolvedValue({ exitCode: 0, stdout: '{"nodes":{}}\n', stderr: "" });
+    mockHookRun.mockResolvedValue({ exitCode: 0, stdout: "hook ok\n", stderr: "" });
     mockVerifyRun.mockImplementation(async (input: { base?: string; commandArgs?: string[] }) => {
       const base = input.base ?? "merge-base";
       return {
@@ -303,10 +301,11 @@ describe("Habitat oclif commands", () => {
     );
   });
 
-  test("hook dispatches to the Habitat hook runner", async () => {
+  test("hook dispatches through the Habitat service client", async () => {
     await Hook.run(["pre-push", "--base", "HEAD~1"]);
 
-    expect(hooks.runHook).toHaveBeenCalledWith("pre-push", { base: "HEAD~1" });
+    expect(serviceClient.createHabitatServiceClient).toHaveBeenCalled();
+    expect(mockHookRun).toHaveBeenCalledWith({ name: "pre-push", base: "HEAD~1" });
     expect(stdout.join("")).toContain("hook ok");
   });
 

--- a/tools/habitat-harness/test/service/hook-service.test.ts
+++ b/tools/habitat-harness/test/service/hook-service.test.ts
@@ -1,0 +1,52 @@
+import { Effect } from "effect";
+import { describe, expect, test, vi } from "vitest";
+
+const mockRunHook = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/lib/hooks.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/lib/hooks.js")>();
+  return {
+    ...actual,
+    runHook: mockRunHook,
+  };
+});
+
+describe("Habitat hook service", () => {
+  test("runs owned hook orchestration from service input", async () => {
+    const { runHookService } = await import("../../src/service/modules/hook/run.js");
+    mockRunHook.mockReturnValueOnce({ exitCode: 0, stdout: "hook ok\n", stderr: "" });
+
+    const result = await Effect.runPromise(runHookService({ name: "pre-push", base: "HEAD~1" }));
+
+    expect(result).toEqual({ exitCode: 0, stdout: "hook ok\n", stderr: "" });
+    expect(mockRunHook).toHaveBeenCalledWith("pre-push", { base: "HEAD~1" });
+  });
+
+  test("preserves unknown hook stream behavior", async () => {
+    const { runHookService } = await import("../../src/service/modules/hook/run.js");
+    mockRunHook.mockReturnValueOnce({
+      exitCode: 2,
+      stdout: "",
+      stderr: "Unknown Habitat hook '(missing)'. Expected pre-commit or pre-push.\n",
+    });
+
+    const result = await Effect.runPromise(runHookService({}));
+
+    expect(result).toEqual({
+      exitCode: 2,
+      stdout: "",
+      stderr: "Unknown Habitat hook '(missing)'. Expected pre-commit or pre-push.\n",
+    });
+    expect(mockRunHook).toHaveBeenCalledWith(undefined, { base: undefined });
+  });
+
+  test("preserves empty base as hook runtime input", async () => {
+    const { runHookService } = await import("../../src/service/modules/hook/run.js");
+    mockRunHook.mockReturnValueOnce({ exitCode: 0, stdout: "resolved default base\n", stderr: "" });
+
+    const result = await Effect.runPromise(runHookService({ name: "pre-push", base: "" }));
+
+    expect(result).toEqual({ exitCode: 0, stdout: "resolved default base\n", stderr: "" });
+    expect(mockRunHook).toHaveBeenCalledWith("pre-push", { base: "" });
+  });
+});

--- a/tools/habitat-harness/test/service/service-architecture.test.ts
+++ b/tools/habitat-harness/test/service/service-architecture.test.ts
@@ -6,7 +6,7 @@ const packageRoot = new URL("../..", import.meta.url).pathname;
 const sourceRoot = join(packageRoot, "src");
 const serviceRoot = join(sourceRoot, "service");
 const providerRoot = join(sourceRoot, "providers");
-const serviceModuleNames = ["check", "graph", "verify"] as const;
+const serviceModuleNames = ["check", "graph", "hook", "verify"] as const;
 
 describe("Habitat service architecture", () => {
   test("keeps Effect-oRPC runtime construction in the root service seam", () => {
@@ -30,10 +30,12 @@ describe("Habitat service architecture", () => {
     expect(router).toContain("habitatServiceImplementer.router");
     expect(router).toContain("check: checkRouter");
     expect(router).toContain("graph: graphRouter");
+    expect(router).toContain("hook: hookRouter");
     expect(router).toContain("verify: verifyRouter");
     expect(router).not.toContain(".effect(");
     expect(router).not.toContain("createCheckReport");
     expect(router).not.toContain("runGraphService");
+    expect(router).not.toContain("runHookService");
     expect(router).not.toContain("runVerifyService");
     expect(router).not.toContain("process.env");
   });
@@ -83,6 +85,15 @@ describe("Habitat service architecture", () => {
     expect(graphCommand).toContain("client.graph.run");
     expect(graphCommand).not.toContain("runGraph");
     expect(graphCommand).not.toContain("../lib/graph.js");
+  });
+
+  test("routes hook CLI orchestration through the service client", () => {
+    const hookCommand = source("src/commands/hook.ts");
+
+    expect(hookCommand).toContain("createHabitatServiceClient");
+    expect(hookCommand).toContain("client.hook.run");
+    expect(hookCommand).not.toContain("runHook");
+    expect(hookCommand).not.toContain("../lib/hooks.js");
   });
 });
 


### PR DESCRIPTION
Expose `habitat hook` as an owned Habitat service module so Husky and the CLI enter through the service surface rather than calling `runHook` directly.

`src/commands/hook.ts` now creates a Habitat service client and calls `client.hook.run` instead of importing `runHook` from `src/lib/hooks.ts`. The hook service module (`src/service/modules/hook`) defines the contract, module binding, router, and a `runHookService` function that wraps the existing hook runtime in an `Effect.sync` call. The `hook` module is composed into the root service contract and router alongside `check`, `graph`, and `verify`.

Hook runtime internals (Git, Biome, Grit, filesystem, clock, and command execution) are intentionally left unchanged. Full provider and resource drainage of the hook runtime is deferred to the next hook implementation unit.

New tests pin the architecture boundaries: the hook CLI must not import or call `runHook` directly, the service router must not inline `runHookService`, and the hook service must preserve current stream and exit behavior for pre-commit, pre-push, unknown hook names, and empty `--base` values.