### PR TITLE
feat(habitat): add classify service module

### DIFF
--- a/openspec/changes/deep-habitat-effect-classify-service-module/design.md
+++ b/openspec/changes/deep-habitat-effect-classify-service-module/design.md
@@ -1,0 +1,70 @@
+# Design: Deep Habitat Effect Classify Service Module
+
+## Boundary
+
+`classify` is an owned Habitat orientation capability. It answers: "what does
+Habitat know about this path or diff, and which rule/target guidance can an
+agent use before editing?"
+
+The service module owns the procedure boundary and command orchestration. It
+imports current implementation material directly from `classify-core`, not from
+the legacy `src/lib/classify.ts` aggregate facade. `classify-core` remains
+implementation material until the
+`deep-habitat-effect-orientation-workspace-graph` packet drains it into the
+workspace graph integration domain.
+
+## Target Flow
+
+```text
+Classify CLI -> Habitat service client -> classify service module -> classify-core workspace graph integration material
+```
+
+## Target Files
+
+```text
+tools/habitat-harness/src/service/modules/classify/contract.ts
+tools/habitat-harness/src/service/modules/classify/context.ts
+tools/habitat-harness/src/service/modules/classify/module.ts
+tools/habitat-harness/src/service/modules/classify/router.ts
+tools/habitat-harness/src/service/modules/classify/run.ts
+tools/habitat-harness/src/service/contract.ts
+tools/habitat-harness/src/service/router.ts
+tools/habitat-harness/src/service/base.ts
+tools/habitat-harness/src/commands/classify.ts
+tools/habitat-harness/test/service/classify-service.test.ts
+tools/habitat-harness/test/service/service-architecture.test.ts
+tools/habitat-harness/test/commands/habitat-commands.test.ts
+```
+
+## Contract
+
+The service procedure is `classify.run`.
+
+- Input: `{ target: string }`
+- Output: existing `ClassifyResultSchema`
+
+The output schema remains the D4 command JSON authority. The service module
+does not invent a new DTO or alternate result shape.
+
+## Public Surface Handling
+
+This slice keeps the current classify package helper and DTO exports intact
+because the D0 matrix currently preserves them. It removes command dependence
+on those helpers for owned orchestration. The public-surface facade packet owns
+final export placement after the service/domain drain is complete.
+
+## Follow-On Drain
+
+- `src/lib/classify-core/**` moves into
+  `src/domains/workspace-graph-integration/**`.
+- `src/lib/classify.ts` becomes a public facade or is removed by the
+  public-surface facade packet; service modules must not depend on it.
+- Workspace graph reads move through the Nx/workspace providers and resources.
+- Direct filesystem checks in classify path/diff handling move behind resource
+  capabilities.
+
+## Verification Boundary
+
+Service tests prove the procedure path and context-injected workspace graph
+reader. Command tests prove CLI-to-service routing. Existing classify tests
+continue to prove the D4 result model and serializer.

--- a/openspec/changes/deep-habitat-effect-classify-service-module/proposal.md
+++ b/openspec/changes/deep-habitat-effect-classify-service-module/proposal.md
@@ -1,0 +1,58 @@
+# Change: Deep Habitat Effect Classify Service Module
+
+## Why
+
+`habitat classify` is an owned Habitat orientation capability. It helps humans
+and agents decide where a path, diff, or target belongs before editing. That
+product behavior should sit behind the same Effect-oRPC service surface as the
+other owned commands instead of having the CLI call `src/lib/classify` directly.
+
+## What Changes
+
+- Add a `classify` Habitat service module under
+  `src/service/modules/classify/**`.
+- Compose `classify` into the root Habitat service contract and router.
+- Route `src/commands/classify.ts` through the in-process Habitat service
+  client.
+- Preserve the current `ClassifyResult` JSON contract and serializer.
+- Add service and architecture tests that pin classify as owned service-module
+  orchestration.
+
+## What Does Not Change
+
+- No classify output schema or command help contract change.
+- No workspace graph domain migration in this slice.
+- No public package export deletion in this slice; D0 public-surface drainage
+  owns final export placement for classify DTOs/helpers.
+- No provider owns classify product wording or target guidance decisions.
+
+## Affected Owners
+
+- `tools/habitat-harness/src/service/modules/classify/**`
+- `tools/habitat-harness/src/service/{base,contract,router}.ts`
+- `tools/habitat-harness/src/commands/classify.ts`
+- `tools/habitat-harness/src/lib/classify-core/**` as implementation material
+  only
+- `tools/habitat-harness/test/service/**`
+- `tools/habitat-harness/test/commands/habitat-commands.test.ts`
+
+## Stop Conditions
+
+- The classify CLI calls `classifyTargetResult` directly.
+- The root service router contains classify handler logic instead of module
+  composition.
+- The service module changes classify JSON output shape.
+- A provider imports classify service modules or owns Habitat orientation
+  wording.
+- This packet claims the deeper workspace-graph/domain/provider drain is
+  complete.
+
+## Verification
+
+- Focused classify service and command tests.
+- `bun run --cwd tools/habitat-harness check`
+- `bun run --cwd tools/habitat-harness test`
+- `bun run biome:ci`
+- `bun run openspec -- validate deep-habitat-effect-classify-service-module --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/deep-habitat-effect-classify-service-module/specs/habitat-harness/spec.md
+++ b/openspec/changes/deep-habitat-effect-classify-service-module/specs/habitat-harness/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Classify Runs Through Habitat Service
+
+Habitat SHALL expose classify/orientation as an owned Habitat service module
+while preserving the existing classify command JSON contract.
+
+#### Scenario: Classify CLI runs
+
+- **WHEN** a user runs `habitat classify <path-or-diff>`
+- **THEN** the command calls the in-process Habitat service client
+- **AND** the classify service module owns the procedure boundary and target
+  classification orchestration
+- **AND** the CLI handles only argument parsing and output rendering
+- **AND** the emitted payload conforms to `ClassifyResultSchema`
+
+#### Scenario: Classify service uses current implementation material
+
+- **WHEN** the classify service needs workspace graph orientation data
+- **THEN** it calls the current classify implementation material
+- **AND** it preserves path, diff, malformed-diff, unresolved-owner, and
+  graph-refusal states
+- **AND** it does not make providers own Habitat orientation wording

--- a/openspec/changes/deep-habitat-effect-classify-service-module/tasks.md
+++ b/openspec/changes/deep-habitat-effect-classify-service-module/tasks.md
@@ -1,0 +1,33 @@
+# Tasks
+
+## 1. Classify Service Module
+
+- [x] 1.1 Add classify service contract, context, module binding, router, and
+      run function.
+- [x] 1.2 Compose `classify` into the root Habitat service contract and router.
+- [x] 1.3 Route `habitat classify` through the Habitat service client.
+
+## 2. Preserve Behavior
+
+- [x] 2.1 Preserve `ClassifyResult` command JSON output.
+- [x] 2.2 Preserve package helper and DTO exports for the current public-surface
+      phase.
+- [x] 2.3 Keep workspace graph/domain provider drainage outside this service
+      ownership slice.
+
+## 3. Guardrails And Verification
+
+- [x] 3.1 Add classify service tests with a fake workspace graph project reader.
+- [x] 3.2 Extend service architecture tests for the classify module and CLI
+      route.
+- [x] 3.3 Update command tests to assert classify CLI service usage.
+- [x] 3.3a Repair review finding: service module and CLI rendering no longer
+      import through the legacy `src/lib/classify.ts` aggregate facade, and the
+      architecture guard blocks classify helper alias reintroduction in the CLI.
+- [x] 3.4 Run `bun run --cwd tools/habitat-harness check`.
+- [x] 3.5 Run focused classify service/command tests.
+- [x] 3.6 Run `bun run --cwd tools/habitat-harness test`.
+- [x] 3.7 Run `bun run biome:ci`.
+- [x] 3.8 Run `bun run openspec -- validate deep-habitat-effect-classify-service-module --strict`.
+- [x] 3.9 Run `bun run openspec:validate`.
+- [x] 3.10 Run `git diff --check`.

--- a/openspec/changes/deep-habitat-effect-classify-service-module/workstream/phase-record.md
+++ b/openspec/changes/deep-habitat-effect-classify-service-module/workstream/phase-record.md
@@ -1,0 +1,57 @@
+# Phase Record
+
+## Phase
+
+- Project: Habitat Harness deep refactor
+- Phase: Classify service module
+- Owner: Effect-first implementation lane
+- Branch/Graphite stack: `agent-DRA-effect-classify-service-module` stacked on
+  `agent-DRA-effect-hook-service-ownership`
+- Started: 2026-06-20
+- Last updated: 2026-06-20
+- Status: implementation complete; review and Graphite submit pending
+
+## Objective
+
+- Target movement: make `habitat classify` an owned Effect-oRPC service module
+  so the command participates in Habitat's service surface instead of calling
+  `src/lib/classify` directly.
+- Non-goals: workspace graph integration domain drain, provider/resource drain
+  for classify-core filesystem/graph reads, or public classify export deletion.
+- Done condition: classify CLI routes through the service client, classify
+  service returns the existing D4 result model, and tests pin the ownership
+  boundary.
+
+## Authority Inputs
+
+- Active goal: Habitat must be a coherent service/domain/provider composition
+  rather than ad hoc scripts.
+- `deep-habitat-effect-owned-service-modules`
+- `deep-habitat-effect-orientation-workspace-graph`
+- `deep-habitat-effect-substrate-architecture`
+- D0 public-surface matrix classify rows.
+- `civ7-open-spec-workstream`
+
+## Verification
+
+- `bun run --cwd tools/habitat-harness test -- test/service/classify-service.test.ts test/service/service-architecture.test.ts test/commands/habitat-commands.test.ts test/lib/classify.test.ts` - passed; 40 tests.
+- `bun run --cwd tools/habitat-harness check` - passed.
+- `bun run --cwd tools/habitat-harness test` - passed; 30 files, 283 tests.
+- `bun run biome:ci` - passed after Biome organized imports in the new classify service run file.
+- `bun run habitat classify tools/habitat-harness/src/commands/classify.ts` - passed; emitted `schemaVersion:1` and `state:project-path`.
+- `bun run openspec -- validate deep-habitat-effect-classify-service-module --strict` - passed.
+- `bun run openspec:validate` - passed; 272 items.
+- `git diff --check` - passed.
+- Review repair: service module and CLI rendering imports now target
+  `src/lib/classify-core/**` directly instead of the legacy
+  `src/lib/classify.ts` aggregate facade, and the architecture guard blocks
+  direct classify helper aliases in the CLI.
+- Review repair: classify service tests now exercise project-path, diff,
+  malformed-or-pathless-diff, unresolved-owner, and graph-refusal states through
+  the service/client boundary.
+- Review repair: existing heavy service/provider tests now avoid dynamic
+  imports inside timeout-bound test bodies where possible, and known live/Nx/Grit
+  tests declare realistic per-test budgets so the full package suite can run
+  honestly under project load.
+- Evidence boundary: service-module slice only; workspace graph integration
+  domain and provider/resource drainage remain follow-on implementation units.

--- a/openspec/changes/deep-habitat-effect-owned-service-modules/design.md
+++ b/openspec/changes/deep-habitat-effect-owned-service-modules/design.md
@@ -43,13 +43,13 @@ Initial owned service modules:
 - `verify`: verification orchestration and receipt creation.
 - `check`: structural check report orchestration and baseline expansion command
   behavior.
-
-Required follow-on service modules:
-
+- `classify`: orientation/classification procedure boundary and command route.
 - `fix`: repair/codemod orchestration.
 - `graph`: workspace graph/orientation views.
 - `hook`: hook runtime orchestration.
-- `classify`: routing/classification views.
+
+Required follow-on service modules:
+
 - `patterns`: pattern/generator/scaffolding authoring surfaces.
 - `transactions`: transformation transaction lifecycle.
 

--- a/tools/habitat-harness/src/commands/classify.ts
+++ b/tools/habitat-harness/src/commands/classify.ts
@@ -1,6 +1,7 @@
 import { Args } from "@oclif/core";
 import { HabitatCommand } from "../base/HabitatCommand.js";
-import { classifyTargetResult, stringifyClassifyResult } from "../lib/classify.js";
+import { stringifyClassifyResult } from "../lib/classify-core/schema.js";
+import { createHabitatServiceClient } from "../service/client.js";
 
 export default class Classify extends HabitatCommand {
   static override summary = "Classify a repo path or diff into Habitat orientation";
@@ -18,6 +19,7 @@ export default class Classify extends HabitatCommand {
 
   async run(): Promise<void> {
     const { args } = await this.parse(Classify);
-    this.log(stringifyClassifyResult(await classifyTargetResult(args.path)));
+    const client = createHabitatServiceClient();
+    this.log(stringifyClassifyResult(await client.classify.run({ target: args.path })));
   }
 }

--- a/tools/habitat-harness/src/service/base.ts
+++ b/tools/habitat-harness/src/service/base.ts
@@ -1,8 +1,12 @@
 import { Context } from "effect";
+import type { ClassifyServiceContext } from "./modules/classify/context.js";
 import type { FixServiceContext } from "./modules/fix/context.js";
 import type { HookServiceContext } from "./modules/hook/context.js";
 
-export interface HabitatServiceContext extends FixServiceContext, HookServiceContext {
+export interface HabitatServiceContext
+  extends ClassifyServiceContext,
+    FixServiceContext,
+    HookServiceContext {
   readonly correlationId?: string;
 }
 

--- a/tools/habitat-harness/src/service/contract.ts
+++ b/tools/habitat-harness/src/service/contract.ts
@@ -1,5 +1,9 @@
 import { eoc } from "effect-orpc";
 import { type CheckServiceContract, checkServiceContract } from "./modules/check/contract.js";
+import {
+  type ClassifyServiceContract,
+  classifyServiceContract,
+} from "./modules/classify/contract.js";
 import { type FixServiceContract, fixServiceContract } from "./modules/fix/contract.js";
 import { type GraphServiceContract, graphServiceContract } from "./modules/graph/contract.js";
 import { type HookServiceContract, hookServiceContract } from "./modules/hook/contract.js";
@@ -7,6 +11,7 @@ import { type VerifyServiceContract, verifyServiceContract } from "./modules/ver
 
 export type HabitatServiceContract = Readonly<{
   check: CheckServiceContract;
+  classify: ClassifyServiceContract;
   fix: FixServiceContract;
   graph: GraphServiceContract;
   hook: HookServiceContract;
@@ -15,6 +20,7 @@ export type HabitatServiceContract = Readonly<{
 
 export const habitatServiceContract: HabitatServiceContract = eoc.router({
   check: checkServiceContract,
+  classify: classifyServiceContract,
   fix: fixServiceContract,
   graph: graphServiceContract,
   hook: hookServiceContract,

--- a/tools/habitat-harness/src/service/modules/classify/context.ts
+++ b/tools/habitat-harness/src/service/modules/classify/context.ts
@@ -1,0 +1,9 @@
+import type { ClassifyOptions } from "../../../lib/classify-core/index.js";
+
+export interface ClassifyServiceContext {
+  readonly classify?: ClassifyServiceOptions;
+}
+
+export interface ClassifyServiceOptions {
+  readonly options?: ClassifyOptions;
+}

--- a/tools/habitat-harness/src/service/modules/classify/contract.ts
+++ b/tools/habitat-harness/src/service/modules/classify/contract.ts
@@ -1,0 +1,38 @@
+import type { ContractProcedure } from "@orpc/contract";
+import { eoc } from "effect-orpc";
+import { type Static, Type } from "typebox";
+import { ClassifyResultSchema } from "../../../lib/classify-core/schema.js";
+import { type HabitatServiceErrorMap, habitatServiceErrorMap } from "../../errors.js";
+import type { HabitatServiceProcedureMeta } from "../../metadata.js";
+import { toStandardSchema } from "../../typebox-standard-schema.js";
+
+const ClassifyServiceRunInputSchema = Type.Object(
+  {
+    target: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: false, description: "Habitat classify service run request." }
+);
+export type ClassifyServiceRunInput = Static<typeof ClassifyServiceRunInputSchema>;
+
+const ClassifyServiceRunInputStandardSchema = toStandardSchema(ClassifyServiceRunInputSchema);
+const ClassifyServiceRunOutputStandardSchema = toStandardSchema(ClassifyResultSchema);
+
+export type ClassifyServiceRunContract = ContractProcedure<
+  typeof ClassifyServiceRunInputStandardSchema,
+  typeof ClassifyServiceRunOutputStandardSchema,
+  HabitatServiceErrorMap,
+  HabitatServiceProcedureMeta
+>;
+
+export const classifyServiceRunContract: ClassifyServiceRunContract = eoc
+  .errors(habitatServiceErrorMap)
+  .input(ClassifyServiceRunInputStandardSchema)
+  .output(ClassifyServiceRunOutputStandardSchema);
+
+export type ClassifyServiceContract = Readonly<{
+  run: ClassifyServiceRunContract;
+}>;
+
+export const classifyServiceContract: ClassifyServiceContract = {
+  run: classifyServiceRunContract,
+};

--- a/tools/habitat-harness/src/service/modules/classify/module.ts
+++ b/tools/habitat-harness/src/service/modules/classify/module.ts
@@ -1,0 +1,18 @@
+import type { EffectImplementerInternal } from "effect-orpc";
+import type { HabitatServiceContext } from "../../base.js";
+import {
+  type HabitatServiceRequirements,
+  type HabitatServiceRuntimeError,
+  habitatServiceImplementer as impl,
+} from "../../impl.js";
+import type { ClassifyServiceContract } from "./contract.js";
+
+export type ClassifyServiceModule = EffectImplementerInternal<
+  ClassifyServiceContract,
+  HabitatServiceContext & Record<never, never>,
+  HabitatServiceContext,
+  HabitatServiceRequirements,
+  HabitatServiceRuntimeError
+>;
+
+export const module: ClassifyServiceModule = impl.classify;

--- a/tools/habitat-harness/src/service/modules/classify/router.ts
+++ b/tools/habitat-harness/src/service/modules/classify/router.ts
@@ -1,0 +1,10 @@
+import { module as classifyModule } from "./module.js";
+import { runClassifyService } from "./run.js";
+
+export const classifyRouter = {
+  run: classifyModule.run.effect(({ context, input }) =>
+    runClassifyService(input, context.classify)
+  ),
+};
+
+export const router = classifyRouter;

--- a/tools/habitat-harness/src/service/modules/classify/run.ts
+++ b/tools/habitat-harness/src/service/modules/classify/run.ts
@@ -1,0 +1,11 @@
+import { Effect } from "effect";
+import { classifyTargetResult } from "../../../lib/classify-core/index.js";
+import type { ClassifyServiceOptions } from "./context.js";
+import type { ClassifyServiceRunInput } from "./contract.js";
+
+export function runClassifyService(
+  input: ClassifyServiceRunInput,
+  serviceOptions: ClassifyServiceOptions = {}
+) {
+  return Effect.promise(() => classifyTargetResult(input.target, serviceOptions.options));
+}

--- a/tools/habitat-harness/src/service/router.ts
+++ b/tools/habitat-harness/src/service/router.ts
@@ -3,6 +3,7 @@ import type { HabitatServiceContext } from "./base.js";
 import { habitatServiceContract } from "./contract.js";
 import { habitatServiceImplementer } from "./impl.js";
 import { checkRouter } from "./modules/check/router.js";
+import { classifyRouter } from "./modules/classify/router.js";
 import { fixRouter } from "./modules/fix/router.js";
 import { graphRouter } from "./modules/graph/router.js";
 import { hookRouter } from "./modules/hook/router.js";
@@ -11,6 +12,7 @@ import { verifyRouter } from "./modules/verify/router.js";
 export const habitatServiceRouter: Router<typeof habitatServiceContract, HabitatServiceContext> =
   habitatServiceImplementer.router({
     check: checkRouter,
+    classify: classifyRouter,
     fix: fixRouter,
     graph: graphRouter,
     hook: hookRouter,

--- a/tools/habitat-harness/test/commands/habitat-commands.test.ts
+++ b/tools/habitat-harness/test/commands/habitat-commands.test.ts
@@ -15,6 +15,7 @@ const mockVerifyTargetPlan = vi.hoisted(() => ({
 }));
 const mockCheckRun = vi.hoisted(() => vi.fn());
 const mockCheckExpandBaseline = vi.hoisted(() => vi.fn());
+const mockClassifyRun = vi.hoisted(() => vi.fn());
 const mockFixRun = vi.hoisted(() => vi.fn());
 const mockGraphRun = vi.hoisted(() => vi.fn());
 const mockHookRun = vi.hoisted(() => vi.fn());
@@ -53,37 +54,6 @@ vi.mock("../../src/lib/check-report.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../../src/lib/classify.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../src/lib/classify.js")>();
-  return {
-    ...actual,
-    classifyTargetResult: vi.fn((target: string) => ({
-      schemaVersion: 1,
-      state: "project-path",
-      input: target,
-      path: target,
-      owner: {
-        project: "@internal/habitat-harness",
-        projectRoot: "tools/habitat-harness",
-        tags: ["kind:tooling"],
-      },
-      ruleRouting: [
-        {
-          ruleId: "adapter-boundary",
-          ownerTool: "command-check",
-          ownerProject: "@internal/habitat-harness",
-          coverageKind: "workspace-gate",
-          reason: "Workspace-level Habitat gate relevant beyond a single owning project.",
-        },
-      ],
-      runnableTargets: [],
-      unavailableTargets: [],
-      recoveryInstructions: [],
-    })),
-    stringifyClassifyResult: vi.fn(actual.stringifyClassifyResult),
-  };
-});
-
 vi.mock("../../src/lib/verify/index.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/lib/verify/index.js")>();
   return {
@@ -95,6 +65,7 @@ vi.mock("../../src/lib/verify/index.js", async (importOriginal) => {
 vi.mock("../../src/service/client.js", () => ({
   createHabitatServiceClient: vi.fn(() => ({
     check: { expandBaseline: mockCheckExpandBaseline, run: mockCheckRun },
+    classify: { run: mockClassifyRun },
     fix: { run: mockFixRun },
     graph: { run: mockGraphRun },
     hook: { run: mockHookRun },
@@ -131,6 +102,29 @@ describe("Habitat oclif commands", () => {
       kind: "expanded",
       messages: ["baseline written: demo-rule (1 entry)"],
     });
+    mockClassifyRun.mockImplementation(async (input: { target: string }) => ({
+      schemaVersion: 1,
+      state: "project-path",
+      input: input.target,
+      path: input.target,
+      owner: {
+        project: "@internal/habitat-harness",
+        projectRoot: "tools/habitat-harness",
+        tags: ["kind:tooling"],
+      },
+      ruleRouting: [
+        {
+          ruleId: "adapter-boundary",
+          ownerTool: "command-check",
+          ownerProject: "@internal/habitat-harness",
+          coverageKind: "workspace-gate",
+          reason: "Workspace-level Habitat gate relevant beyond a single owning project.",
+        },
+      ],
+      runnableTargets: [],
+      unavailableTargets: [],
+      recoveryInstructions: [],
+    }));
     mockFixRun.mockResolvedValue({ exitCode: 0, stdout: "biome ok\n", stderr: "" });
     mockGraphRun.mockResolvedValue({ exitCode: 0, stdout: '{"nodes":{}}\n', stderr: "" });
     mockHookRun.mockResolvedValue({ exitCode: 0, stdout: "hook ok\n", stderr: "" });
@@ -317,9 +311,10 @@ describe("Habitat oclif commands", () => {
     if (result.state !== "project-path") throw new Error("expected project-path");
     expect(result.owner.project).toBe("@internal/habitat-harness");
     expect(result.owner.tags).toEqual(["kind:tooling"]);
-    expect(classify.classifyTargetResult).toHaveBeenCalledWith(
-      "tools/habitat-harness/src/commands/check.ts"
-    );
+    expect(serviceClient.createHabitatServiceClient).toHaveBeenCalled();
+    expect(mockClassifyRun).toHaveBeenCalledWith({
+      target: "tools/habitat-harness/src/commands/check.ts",
+    });
   });
 
   test("hook dispatches through the Habitat service client", async () => {

--- a/tools/habitat-harness/test/lib/boundary-taxonomy.test.ts
+++ b/tools/habitat-harness/test/lib/boundary-taxonomy.test.ts
@@ -61,7 +61,7 @@ describe("boundary taxonomy verifier", () => {
       project: "civ7-modding-tools",
       root: ".",
     });
-  });
+  }, 90_000);
 
   test("uses all matching source tags so dual-tag control-to-sdk edges fail", async () => {
     const taxonomy = parseBoundaryTaxonomy(await readTaxonomyMarkdown());

--- a/tools/habitat-harness/test/lib/command-runner.test.ts
+++ b/tools/habitat-harness/test/lib/command-runner.test.ts
@@ -95,5 +95,5 @@ describe("CommandRunner", () => {
       commandId: "generic-timeout",
       timeoutMs: 75,
     } satisfies Partial<CommandInterrupted>);
-  }, 2_000);
+  }, 10_000);
 });

--- a/tools/habitat-harness/test/lib/rule-selection.test.ts
+++ b/tools/habitat-harness/test/lib/rule-selection.test.ts
@@ -203,7 +203,7 @@ describe("rule selector boundary", () => {
       )
     ).toBe(true);
     expect(report.ok).toBe(false);
-  });
+  }, 90_000);
 
   test("staged Grit scan roots preserve exact approved file paths", () => {
     expect(

--- a/tools/habitat-harness/test/service/check-service.test.ts
+++ b/tools/habitat-harness/test/service/check-service.test.ts
@@ -28,11 +28,14 @@ vi.mock("../../src/lib/check-report.js", async (importOriginal) => {
   };
 });
 
+import * as checkReport from "../../src/lib/check-report.js";
+import {
+  expandCheckBaselinesService,
+  runCheckService,
+} from "../../src/service/modules/check/run.js";
+
 describe("Habitat check service", () => {
   test("runs owned check orchestration from service input", async () => {
-    const checkReport = await import("../../src/lib/check-report.js");
-    const { runCheckService } = await import("../../src/service/modules/check/run.js");
-
     const result = await Effect.runPromise(
       runCheckService({
         selectors: { rule: "format-ci", tool: "biome" },
@@ -62,9 +65,6 @@ describe("Habitat check service", () => {
   });
 
   test("projects baseline expansion into service output states", async () => {
-    const checkReport = await import("../../src/lib/check-report.js");
-    const { expandCheckBaselinesService } = await import("../../src/service/modules/check/run.js");
-
     const expanded = await Effect.runPromise(
       expandCheckBaselinesService({
         selectors: { owner: "tools-habitat-harness" },

--- a/tools/habitat-harness/test/service/classify-service.test.ts
+++ b/tools/habitat-harness/test/service/classify-service.test.ts
@@ -1,0 +1,182 @@
+import { Effect } from "effect";
+import { describe, expect, test } from "vitest";
+import type { WorkspaceGraphProjectReader } from "../../src/lib/workspace-graph/index.js";
+import type { WorkspaceProject } from "../../src/lib/workspace-graph/schema.js";
+import { createHabitatServiceClient } from "../../src/service/client.js";
+import { runClassifyService } from "../../src/service/modules/classify/run.js";
+
+const nxProjects: WorkspaceGraphProjectReader = {
+  async readProjects() {
+    return [
+      project("@internal/habitat-harness", "tools/habitat-harness", "kind:tooling", [
+        "biome:ci",
+        "boundaries",
+        "check",
+        "generated:check",
+        "grit:check",
+        "test",
+      ]),
+      project("@civ7/adapter", "packages/civ7-adapter", "kind:adapter", ["build", "check"]),
+      project("@civ7/config", "packages/config", "kind:foundation", ["build", "check", "test"]),
+      project("@civ7/plugin-graph", "packages/plugins/plugin-graph", "kind:plugin", [
+        "check",
+        "test",
+      ]),
+      project("@civ7/types", "packages/civ7-types", "kind:foundation", ["check", "test"]),
+      project("@swooper/mapgen-core", "packages/mapgen-core", "kind:foundation", [
+        "check",
+        "test",
+        "test:architecture-core-purity",
+      ]),
+      project("mapgen-studio", "apps/mapgen-studio", "kind:app", ["check", "test"]),
+      project("mod-civ7-intelligence-bridge", "mods/mod-civ7-intelligence-bridge", "kind:mod", [
+        "test:architecture-bundle-runtime-imports",
+      ]),
+      project("mod-swooper-maps", "mods/mod-swooper-maps", "kind:mod", [
+        "check",
+        "test",
+        "test:architecture-cutover",
+        "test:architecture-ecology-step-imports",
+        "test:architecture-m11-projection-band",
+        "test:architecture-map-bundle-runtime-imports",
+        "test:architecture-rng-authority",
+      ]),
+    ];
+  },
+};
+
+describe("Habitat classify service", () => {
+  test("classifies targets through the owned service run function", async () => {
+    const result = await Effect.runPromise(
+      runClassifyService(
+        { target: "tools/habitat-harness/src/commands/classify.ts" },
+        { options: { nxProjects } }
+      )
+    );
+
+    expect(result.state).toBe("project-path");
+    if (result.state !== "project-path") throw new Error("expected project-path");
+    expect(result.owner.project).toBe("@internal/habitat-harness");
+    expect(result.runnableTargets.map((target) => target.command)).toContain(
+      "nx run @internal/habitat-harness:check"
+    );
+  });
+
+  test("routes classify through the in-process Habitat service client", async () => {
+    const client = createHabitatServiceClient({ classify: { options: { nxProjects } } });
+
+    const result = await client.classify.run({
+      target: "tools/habitat-harness/src/commands/classify.ts",
+    });
+
+    expect(result.state).toBe("project-path");
+    if (result.state !== "project-path") throw new Error("expected project-path");
+    expect(result.owner.tags).toEqual(["kind:tooling"]);
+  });
+
+  test("preserves diff classification through the service contract boundary", async () => {
+    const client = createHabitatServiceClient({ classify: { options: { nxProjects } } });
+
+    const result = await client.classify.run({
+      target: `diff --git a/apps/mapgen-studio/src/main.tsx b/apps/mapgen-studio/src/main.tsx
+index 1111111..2222222 100644
+--- a/apps/mapgen-studio/src/main.tsx
++++ b/apps/mapgen-studio/src/main.tsx
+@@ -1 +1 @@
+-export const app = 1;
++export const app = 2;
+diff --git a/packages/plugins/plugin-graph/src/index.ts b/packages/plugins/plugin-graph/src/index.ts
+index 3333333..4444444 100644
+--- a/packages/plugins/plugin-graph/src/index.ts
++++ b/packages/plugins/plugin-graph/src/index.ts
+@@ -1 +1 @@
+-export const plugin = 1;
++export const plugin = 2;
+`,
+    });
+
+    expect(result.state).toBe("diff");
+    if (result.state !== "diff") throw new Error("expected diff");
+    expect(result.paths.map((classification) => classification.path)).toEqual([
+      "apps/mapgen-studio/src/main.tsx",
+      "packages/plugins/plugin-graph/src/index.ts",
+    ]);
+  });
+
+  test("preserves malformed diff refusal before graph reads", async () => {
+    const client = createHabitatServiceClient({
+      classify: {
+        options: {
+          nxProjects: {
+            async readProjects() {
+              throw new Error("graph should not be read for malformed diff refusal");
+            },
+          },
+        },
+      },
+    });
+
+    const result = await client.classify.run({ target: "not a diff\njust text" });
+
+    expect(result.state).toBe("malformed-or-pathless-diff");
+    if (result.state !== "malformed-or-pathless-diff") {
+      throw new Error("expected malformed-or-pathless-diff");
+    }
+    expect(result.reason).toBe("no-classifiable-diff-paths");
+  });
+
+  test("preserves unresolved-owner path states through the service boundary", async () => {
+    const client = createHabitatServiceClient({ classify: { options: { nxProjects } } });
+
+    const result = await client.classify.run({ target: "notes/not-yet-created.md" });
+
+    expect(result.state).toBe("unresolved-owner");
+    if (result.state !== "unresolved-owner") throw new Error("expected unresolved-owner");
+    expect(result.reason).toBe("no-project-or-workspace-owner");
+  });
+
+  test("preserves graph-refusal states through the service boundary", async () => {
+    const client = createHabitatServiceClient({
+      classify: {
+        options: {
+          nxProjects: {
+            async readProjects() {
+              return [
+                {
+                  name: "",
+                  root: "",
+                  sourceRoot: null,
+                  tags: [],
+                  targets: [],
+                },
+              ];
+            },
+          },
+        },
+      },
+    });
+
+    const result = await client.classify.run({
+      target: "tools/habitat-harness/src/commands/classify.ts",
+    });
+
+    expect(result.state).toBe("graph-refusal");
+    if (result.state !== "graph-refusal") throw new Error("expected graph-refusal");
+    expect(result.refusal.reason).toBe("malformed-graph-json");
+  });
+});
+
+function project(
+  name: string,
+  root: string,
+  tag: string,
+  targets: readonly string[]
+): WorkspaceProject {
+  return {
+    name,
+    root,
+    sourceRoot: null,
+    tags: [tag],
+    targets: targets.map((targetName) => ({ name: targetName })),
+  };
+}

--- a/tools/habitat-harness/test/service/fix-service.test.ts
+++ b/tools/habitat-harness/test/service/fix-service.test.ts
@@ -6,10 +6,11 @@ import {
   makeHabitatCommandResult,
 } from "../../src/lib/habitat-process.js";
 import type { ApplyAdmission, ApplyTransactionInput } from "../../src/rules/patterns/index.js";
+import { createHabitatServiceClient } from "../../src/service/client.js";
+import { runFixService } from "../../src/service/modules/fix/run.js";
 
 describe("Habitat fix service", () => {
   test("runs dry-run intent through admitted pattern transactions", async () => {
-    const { runFixService } = await import("../../src/service/modules/fix/run.js");
     const requests: HabitatProcessRequest[] = [];
     const processLayer = makeFakeHabitatProcessLayer((request) => {
       requests.push(request);
@@ -45,8 +46,6 @@ describe("Habitat fix service", () => {
   });
 
   test("runs live-write intent into protected-zone refusal", async () => {
-    const { runFixService } = await import("../../src/service/modules/fix/run.js");
-
     const result = await Effect.runPromise(
       runFixService(
         { kind: "live-write-intent" },
@@ -66,8 +65,6 @@ describe("Habitat fix service", () => {
   });
 
   test("refuses before planning when no apply admissions are present", async () => {
-    const { runFixService } = await import("../../src/service/modules/fix/run.js");
-
     const result = await Effect.runPromise(
       runFixService({ kind: "dry-run-intent" }, { admissions: [] })
     );
@@ -80,7 +77,6 @@ describe("Habitat fix service", () => {
   });
 
   test("runs through the in-process Habitat service client", async () => {
-    const { createHabitatServiceClient } = await import("../../src/service/client.js");
     const requests: HabitatProcessRequest[] = [];
     const processLayer = makeFakeHabitatProcessLayer((request) => {
       requests.push(request);

--- a/tools/habitat-harness/test/service/hook-service.test.ts
+++ b/tools/habitat-harness/test/service/hook-service.test.ts
@@ -1,10 +1,11 @@
 import { Effect } from "effect";
 import { describe, expect, test } from "vitest";
 import type { HookRuntime } from "../../src/lib/hook-runtime/runtime.js";
+import { createHabitatServiceClient } from "../../src/service/client.js";
+import { runHookService } from "../../src/service/modules/hook/run.js";
 
 describe("Habitat hook service", () => {
   test("runs owned hook orchestration from service input", async () => {
-    const { runHookService } = await import("../../src/service/modules/hook/run.js");
     const fake = makePrePushRuntime();
 
     const result = await Effect.runPromise(
@@ -23,8 +24,6 @@ describe("Habitat hook service", () => {
   });
 
   test("preserves unknown hook stream behavior", async () => {
-    const { runHookService } = await import("../../src/service/modules/hook/run.js");
-
     const result = await Effect.runPromise(runHookService({}));
 
     expect(result).toEqual({
@@ -35,7 +34,6 @@ describe("Habitat hook service", () => {
   });
 
   test("preserves empty base as hook runtime input", async () => {
-    const { runHookService } = await import("../../src/service/modules/hook/run.js");
     const fake = makePrePushRuntime({ graphiteParent: "agent-parent" });
 
     const result = await Effect.runPromise(
@@ -50,7 +48,6 @@ describe("Habitat hook service", () => {
   });
 
   test("runs through the in-process Habitat service client", async () => {
-    const { createHabitatServiceClient } = await import("../../src/service/client.js");
     const fake = makePrePushRuntime();
 
     const result = await createHabitatServiceClient({
@@ -65,7 +62,6 @@ describe("Habitat hook service", () => {
   });
 
   test("runs pre-commit through the in-process Habitat service client", async () => {
-    const { createHabitatServiceClient } = await import("../../src/service/client.js");
     const fake = makePreCommitRuntime();
 
     const result = await createHabitatServiceClient({

--- a/tools/habitat-harness/test/service/service-architecture.test.ts
+++ b/tools/habitat-harness/test/service/service-architecture.test.ts
@@ -6,7 +6,7 @@ const packageRoot = new URL("../..", import.meta.url).pathname;
 const sourceRoot = join(packageRoot, "src");
 const serviceRoot = join(sourceRoot, "service");
 const providerRoot = join(sourceRoot, "providers");
-const serviceModuleNames = ["check", "fix", "graph", "hook", "verify"] as const;
+const serviceModuleNames = ["check", "classify", "fix", "graph", "hook", "verify"] as const;
 
 describe("Habitat service architecture", () => {
   test("keeps Effect-oRPC runtime construction in the root service seam", () => {
@@ -29,12 +29,14 @@ describe("Habitat service architecture", () => {
 
     expect(router).toContain("habitatServiceImplementer.router");
     expect(router).toContain("check: checkRouter");
+    expect(router).toContain("classify: classifyRouter");
     expect(router).toContain("fix: fixRouter");
     expect(router).toContain("graph: graphRouter");
     expect(router).toContain("hook: hookRouter");
     expect(router).toContain("verify: verifyRouter");
     expect(router).not.toContain(".effect(");
     expect(router).not.toContain("createCheckReport");
+    expect(router).not.toContain("runClassifyService");
     expect(router).not.toContain("runFixService");
     expect(router).not.toContain("runGraphService");
     expect(router).not.toContain("runHookService");
@@ -78,6 +80,18 @@ describe("Habitat service architecture", () => {
     expect(checkCommand).toContain("client.check.expandBaseline");
     expect(checkCommand).not.toContain("createCheckReport");
     expect(checkCommand).not.toContain("expandBaselines");
+  });
+
+  test("routes classify CLI orchestration through the service client", () => {
+    const classifyCommand = source("src/commands/classify.ts");
+
+    expect(classifyCommand).toContain("createHabitatServiceClient");
+    expect(classifyCommand).toContain("client.classify.run");
+    expect(classifyCommand).not.toContain("classifyTargetResult");
+    expect(classifyCommand).not.toContain("classifyTarget(");
+    expect(classifyCommand).not.toContain("classifyPathResult");
+    expect(classifyCommand).not.toContain("classifyPath(");
+    expect(classifyCommand).not.toContain("../lib/classify.js");
   });
 
   test("routes graph CLI orchestration through the service client", () => {


### PR DESCRIPTION
This PR introduces `classify` as an owned Habitat Effect-oRPC service module, bringing `habitat classify` into the same service surface as the other owned commands rather than having the CLI call `src/lib/classify` directly.

A new `classify` service module is added under `src/service/modules/classify/`, consisting of a contract, context, module binding, router, and run function. The contract accepts `{ target: string }` and returns the existing `ClassifyResultSchema` without altering the D4 result model or command JSON output. The run function delegates to `classifyTargetResult` from `classify-core`, bypassing the legacy `src/lib/classify.ts` aggregate facade. The classify module is composed into the root Habitat service contract, context, and router alongside the existing modules.

The `habitat classify` CLI command is updated to call `createHabitatServiceClient` and invoke `client.classify.run`, with argument parsing and output rendering remaining in the command layer. The `stringifyClassifyResult` import is sourced directly from `classify-core/schema` rather than the legacy facade.

A dedicated classify service test suite covers project-path, diff, malformed-or-pathless-diff, unresolved-owner, and graph-refusal states through the service/client boundary using a fake workspace graph project reader. Service architecture tests are extended to assert that the classify router is composed correctly, that the root router contains no inline handler logic for classify, and that the CLI command does not import classify helpers directly or reference the legacy facade. Command tests are updated to mock `client.classify.run` through the service client mock rather than mocking `src/lib/classify.js`.

Dynamic imports inside timeout-bound test bodies in the fix, hook, and check service tests are replaced with static imports. Test timeout budgets for boundary taxonomy and rule selection tests that exercise live Nx or Grit reads are set to realistic values. The `classify` module is moved from the required follow-on list to the initial owned service modules list in the owned service modules design document.