### PR TITLE
feat(habitat): add transactions service module and move pattern-apply execution out of src/lib

### DIFF
--- a/openspec/changes/deep-habitat-effect-owned-service-modules/design.md
+++ b/openspec/changes/deep-habitat-effect-owned-service-modules/design.md
@@ -47,14 +47,21 @@ Initial owned service modules:
 - `fix`: repair/codemod orchestration.
 - `graph`: workspace graph/orientation views.
 - `hook`: hook runtime orchestration.
+- `transactions`: admitted transformation transaction lifecycle.
 
 Required follow-on service modules:
 
 - `patterns`: pattern/generator/scaffolding authoring surfaces.
-- `transactions`: transformation transaction lifecycle.
 
 `src/lib/**` remains implementation material only while it is drained into
 named modules/domains. New owned orchestration must not be added there.
+
+Pattern-apply schema, rendering, and worktree observation may remain under
+`src/lib/pattern-apply/**` until the transformation-domain split moves those
+DTOs and presenters into their final homes. Pattern-apply execution must not
+live there: transaction application is owned by
+`src/service/modules/transactions/run.ts` and exposed through the
+`transactions.apply` Effect-oRPC procedure.
 
 ## Provider Relationship
 
@@ -80,3 +87,5 @@ inside service modules.
 - Root service router must contain composition only, with no handler logic.
 - CLI command handlers should call `createHabitatServiceClient()` for any
   capability that has a service module.
+- `src/lib/pattern-apply/run.ts` must not exist; `fix` must call the
+  transactions service module instead of a lib runner.

--- a/openspec/changes/deep-habitat-effect-owned-service-modules/proposal.md
+++ b/openspec/changes/deep-habitat-effect-owned-service-modules/proposal.md
@@ -16,6 +16,8 @@ transformation orchestration.
   modules, not as product modules.
 - Add the `check` service module and route `habitat check` through the
   in-process Habitat service client.
+- Add the `transactions` service module and move pattern-apply execution out of
+  `src/lib` into the owned service-module layer.
 - Add service architecture tests that keep runtime construction, module
   bindings, and provider imports in their assigned homes.
 
@@ -32,6 +34,7 @@ transformation orchestration.
 - `tools/habitat-harness/src/service/**`
 - `tools/habitat-harness/src/commands/check.ts`
 - `tools/habitat-harness/src/lib/check/**` as implementation material only
+- `tools/habitat-harness/src/lib/pattern-apply/**` as DTO/render material only
 - `tools/habitat-harness/test/service/**`
 
 ## Stop Conditions

--- a/openspec/changes/deep-habitat-effect-owned-service-modules/specs/habitat-harness/spec.md
+++ b/openspec/changes/deep-habitat-effect-owned-service-modules/specs/habitat-harness/spec.md
@@ -34,3 +34,12 @@ Effect-oRPC service modules rather than provider-shaped APIs or incidental
 - **AND** its procedure bindings live under a module router or procedure files
 - **AND** root service files compose module contracts and routers without
   handler logic
+
+#### Scenario: Transformation application runs as an owned service module
+
+- **WHEN** `habitat fix` applies an admitted transformation transaction
+- **THEN** the apply lifecycle runs through the `transactions.apply` service
+  module capability
+- **AND** `fix` does not call a `src/lib/pattern-apply` execution runner
+- **AND** `src/lib/pattern-apply` may only retain DTO, parser, presenter, or
+  observation material until the transformation-domain split moves it

--- a/openspec/changes/deep-habitat-effect-owned-service-modules/tasks.md
+++ b/openspec/changes/deep-habitat-effect-owned-service-modules/tasks.md
@@ -6,16 +6,21 @@
 - [x] 1.2 Add architecture tests for runtime, router, module, and provider boundaries.
 - [x] 1.3 Add the `check` service contract, module binding, router, and run functions.
 - [x] 1.4 Compose `check` into the root Habitat service contract/router/client.
+- [x] 1.5 Add the `transactions` service contract, module binding, router, and run function.
+- [x] 1.6 Compose `transactions` into the root Habitat service contract/router/client.
 
 ## 2. CLI Cutover
 
 - [x] 2.1 Route `habitat check` normal report execution through the `check` service module.
 - [x] 2.2 Route `habitat check --expand-baseline` through the `check` service module.
 - [x] 2.3 Preserve CheckReport v1 output and exit-code behavior.
+- [x] 2.4 Route `fix` transformation application through the `transactions` service module.
+- [x] 2.5 Delete the legacy `src/lib/pattern-apply/run.ts` execution entrypoint and remove its export.
 
 ## 3. Guardrails And Verification
 
 - [x] 3.1 Add focused service tests for `check` orchestration with mocked implementation material.
+- [x] 3.1a Add focused service tests for `transactions.apply` with mocked process resources.
 - [x] 3.2 Run `bun run --cwd tools/habitat-harness check`.
 - [x] 3.3 Run focused Habitat service/command tests.
 - [x] 3.4 Run `bun run --cwd tools/habitat-harness test`.

--- a/openspec/changes/deep-habitat-effect-owned-service-modules/workstream/phase-record.md
+++ b/openspec/changes/deep-habitat-effect-owned-service-modules/workstream/phase-record.md
@@ -8,7 +8,7 @@
 - Branch/Graphite stack: `agent-DRA-effect-owned-service-modules` stacked on `agent-DRA-effect-vendor-providers`
 - Started: 2026-06-20
 - Last updated: 2026-06-20
-- Status: implemented and validated
+- Status: extended for transaction service module and validated
 
 ## Objective
 
@@ -16,9 +16,10 @@
   capability surface and keep providers as resource dependencies.
 - Non-goals: full drain of every `src/lib/**` domain, command result
   observation redesign, final provider bridge deletion.
-- Done condition: `check` joins `verify` as an owned service module, CLI check
-  routes through the service client, and guard tests pin the service/provider
-  boundary for follow-on dominos.
+- Done condition: command-facing owned capabilities route through Effect-oRPC
+  service modules, transaction application is no longer an incidental
+  `src/lib` runner, and guard tests pin the service/provider boundary for
+  follow-on dominos.
 
 ## Authority Inputs
 
@@ -38,6 +39,7 @@
   - `bun run --cwd tools/habitat-harness check`
   - `bun run --cwd tools/habitat-harness test -- test/service/check-service.test.ts test/service/service-architecture.test.ts test/lib/verify-service.test.ts`
   - `bun run --cwd tools/habitat-harness test -- test/commands/habitat-commands.test.ts`
+  - `bun run --cwd tools/habitat-harness test -- test/service/transactions-service.test.ts test/service/fix-service.test.ts test/service/service-architecture.test.ts test/lib/pattern-apply.test.ts`
   - `bun run --cwd tools/habitat-harness test`
   - `bun run openspec -- validate deep-habitat-effect-owned-service-modules --strict`
   - `bun run openspec:validate`
@@ -51,6 +53,10 @@
   current domino until owned service modules are explicit.
 - Added the `check` service module and routed `habitat check` through the
   in-process service client.
+- Added the `transactions` service module, composed it into the root
+  Effect-oRPC service contract/router, routed `fix` transaction application
+  through it, and deleted the old `src/lib/pattern-apply/run.ts` execution
+  entrypoint.
 - Added architecture guard tests for service runtime construction, root router
   composition, module procedure bindings, provider direction, and CLI service
   routing.

--- a/tools/habitat-harness/src/lib/pattern-apply/index.ts
+++ b/tools/habitat-harness/src/lib/pattern-apply/index.ts
@@ -1,5 +1,4 @@
 export { renderPatternApply } from "./render.js";
-export { runPatternApply } from "./run.js";
 export {
   type DryRunIntent,
   DryRunIntentSchema,

--- a/tools/habitat-harness/src/service/base.ts
+++ b/tools/habitat-harness/src/service/base.ts
@@ -2,11 +2,13 @@ import { Context } from "effect";
 import type { ClassifyServiceContext } from "./modules/classify/context.js";
 import type { FixServiceContext } from "./modules/fix/context.js";
 import type { HookServiceContext } from "./modules/hook/context.js";
+import type { TransactionsServiceContext } from "./modules/transactions/context.js";
 
 export interface HabitatServiceContext
   extends ClassifyServiceContext,
     FixServiceContext,
-    HookServiceContext {
+    HookServiceContext,
+    TransactionsServiceContext {
   readonly correlationId?: string;
 }
 

--- a/tools/habitat-harness/src/service/contract.ts
+++ b/tools/habitat-harness/src/service/contract.ts
@@ -7,6 +7,10 @@ import {
 import { type FixServiceContract, fixServiceContract } from "./modules/fix/contract.js";
 import { type GraphServiceContract, graphServiceContract } from "./modules/graph/contract.js";
 import { type HookServiceContract, hookServiceContract } from "./modules/hook/contract.js";
+import {
+  type TransactionsServiceContract,
+  transactionsServiceContract,
+} from "./modules/transactions/contract.js";
 import { type VerifyServiceContract, verifyServiceContract } from "./modules/verify/contract.js";
 
 export type HabitatServiceContract = Readonly<{
@@ -15,6 +19,7 @@ export type HabitatServiceContract = Readonly<{
   fix: FixServiceContract;
   graph: GraphServiceContract;
   hook: HookServiceContract;
+  transactions: TransactionsServiceContract;
   verify: VerifyServiceContract;
 }>;
 
@@ -24,5 +29,6 @@ export const habitatServiceContract: HabitatServiceContract = eoc.router({
   fix: fixServiceContract,
   graph: graphServiceContract,
   hook: hookServiceContract,
+  transactions: transactionsServiceContract,
   verify: verifyServiceContract,
 });

--- a/tools/habitat-harness/src/service/modules/fix/run.ts
+++ b/tools/habitat-harness/src/service/modules/fix/run.ts
@@ -5,7 +5,6 @@ import {
   observeWorktree,
   type PatternApplyRequest,
   renderPatternApply,
-  runPatternApply,
   type WorktreeObservation,
 } from "../../../lib/pattern-apply/index.js";
 import type { SpawnResult } from "../../../lib/spawn.js";
@@ -16,6 +15,7 @@ import {
   activeApplyTransactionInputs,
   defaultApplyAdmissions,
 } from "../../../rules/patterns/index.js";
+import { runTransactionApplyService } from "../transactions/run.js";
 import type { FixServiceOptions } from "./context.js";
 import type { FixServiceRunInput } from "./contract.js";
 import { FixCommandIntentSchema } from "./contract.js";
@@ -39,15 +39,14 @@ export function runFixService(input: FixServiceRunInput, options: FixServiceOpti
     }
 
     const transactionInputs = options.transactionInputs ?? activeApplyTransactionInputs();
-    const records = yield* Effect.promise(() =>
-      Promise.all(
-        admissions.map((admission) =>
-          runPatternApply(transactionRequest(parsed, admission, options.worktree), {
-            processLayer: options.processLayer,
-            transactionInputs,
-          })
-        )
-      )
+    const records = yield* Effect.forEach(
+      admissions,
+      (admission) =>
+        runTransactionApplyService(transactionRequest(parsed, admission, options.worktree), {
+          processLayer: options.processLayer,
+          transactionInputs,
+        }),
+      { concurrency: 1 }
     );
     const rendered = records.map(renderPatternApply);
     const failed = rendered.find((result) => result.exitCode !== 0);

--- a/tools/habitat-harness/src/service/modules/transactions/context.ts
+++ b/tools/habitat-harness/src/service/modules/transactions/context.ts
@@ -1,0 +1,12 @@
+import type { Layer } from "effect";
+import type { HabitatProcess } from "../../../lib/habitat-process.js";
+import type { ApplyTransactionInput } from "../../../rules/patterns/index.js";
+
+export interface TransactionsServiceContext {
+  readonly transactions?: TransactionsServiceOptions;
+}
+
+export interface TransactionsServiceOptions {
+  readonly processLayer?: Layer.Layer<HabitatProcess>;
+  readonly transactionInputs?: readonly ApplyTransactionInput[];
+}

--- a/tools/habitat-harness/src/service/modules/transactions/contract.ts
+++ b/tools/habitat-harness/src/service/modules/transactions/contract.ts
@@ -1,0 +1,32 @@
+import type { ContractProcedure } from "@orpc/contract";
+import { eoc } from "effect-orpc";
+import {
+  PatternApplyRecordSchema,
+  PatternApplyRequestSchema,
+} from "../../../lib/pattern-apply/schema.js";
+import { type HabitatServiceErrorMap, habitatServiceErrorMap } from "../../errors.js";
+import type { HabitatServiceProcedureMeta } from "../../metadata.js";
+import { toStandardSchema } from "../../typebox-standard-schema.js";
+
+const TransactionsApplyInputStandardSchema = toStandardSchema(PatternApplyRequestSchema);
+const TransactionsApplyOutputStandardSchema = toStandardSchema(PatternApplyRecordSchema);
+
+export type TransactionsApplyContract = ContractProcedure<
+  typeof TransactionsApplyInputStandardSchema,
+  typeof TransactionsApplyOutputStandardSchema,
+  HabitatServiceErrorMap,
+  HabitatServiceProcedureMeta
+>;
+
+export const transactionsApplyContract: TransactionsApplyContract = eoc
+  .errors(habitatServiceErrorMap)
+  .input(TransactionsApplyInputStandardSchema)
+  .output(TransactionsApplyOutputStandardSchema);
+
+export type TransactionsServiceContract = Readonly<{
+  apply: TransactionsApplyContract;
+}>;
+
+export const transactionsServiceContract: TransactionsServiceContract = {
+  apply: transactionsApplyContract,
+};

--- a/tools/habitat-harness/src/service/modules/transactions/module.ts
+++ b/tools/habitat-harness/src/service/modules/transactions/module.ts
@@ -1,0 +1,18 @@
+import type { EffectImplementerInternal } from "effect-orpc";
+import type { HabitatServiceContext } from "../../base.js";
+import {
+  type HabitatServiceRequirements,
+  type HabitatServiceRuntimeError,
+  habitatServiceImplementer as impl,
+} from "../../impl.js";
+import type { TransactionsServiceContract } from "./contract.js";
+
+export type TransactionsServiceModule = EffectImplementerInternal<
+  TransactionsServiceContract,
+  HabitatServiceContext & Record<never, never>,
+  HabitatServiceContext,
+  HabitatServiceRequirements,
+  HabitatServiceRuntimeError
+>;
+
+export const module: TransactionsServiceModule = impl.transactions;

--- a/tools/habitat-harness/src/service/modules/transactions/router.ts
+++ b/tools/habitat-harness/src/service/modules/transactions/router.ts
@@ -1,0 +1,10 @@
+import { module as transactionsModule } from "./module.js";
+import { runTransactionApplyService } from "./run.js";
+
+export const transactionsRouter = {
+  apply: transactionsModule.apply.effect(({ context, input }) =>
+    runTransactionApplyService(input, context.transactions)
+  ),
+};
+
+export const router = transactionsRouter;

--- a/tools/habitat-harness/src/service/modules/transactions/run.ts
+++ b/tools/habitat-harness/src/service/modules/transactions/run.ts
@@ -1,17 +1,15 @@
-import { Effect, Layer } from "effect";
+import { Effect } from "effect";
 import { Value } from "typebox/value";
-import { defaultGritCommandTimeoutMs } from "../../adapters/grit/constants.js";
-import type { ApplyTransactionInput } from "../../rules/patterns/index.js";
-import { runHabitatEffect } from "../effect-runtime.js";
-import { gritMachineOutputEnv } from "../grit-env.js";
+import { defaultGritCommandTimeoutMs } from "../../../adapters/grit/constants.js";
+import { gritMachineOutputEnv } from "../../../lib/grit-env.js";
 import {
   type HabitatCommandResult,
   HabitatProcess,
   HabitatProcessLive,
   type HabitatProcessRequest,
   makeHabitatCommandResult,
-} from "../habitat-process.js";
-import { repoRoot } from "../paths.js";
+} from "../../../lib/habitat-process.js";
+import { repoRoot } from "../../../lib/paths.js";
 import {
   type GritDryRunCommandInput,
   type PatternApplyRecord,
@@ -22,16 +20,25 @@ import {
   type RecoveryInstruction,
   resolveTransactionInput,
   type TransactionRefusal,
-} from "./schema.js";
+} from "../../../lib/pattern-apply/schema.js";
+import { runHabitatEffect } from "../../../runtime/index.js";
+import type { TransactionsServiceOptions } from "./context.js";
 
-export interface PatternApplyOptions {
-  processLayer?: Layer.Layer<HabitatProcess>;
-  transactionInputs?: readonly ApplyTransactionInput[];
+/**
+ * Runs an admitted Habitat transformation transaction from the owned service
+ * module. This is the service boundary for pattern application; vendor command
+ * execution is still provided by HabitatProcess until the Grit provider cutover.
+ */
+export function runTransactionApplyService(
+  input: unknown,
+  options: TransactionsServiceOptions = {}
+) {
+  return Effect.promise(() => runTransactionApply(input, options));
 }
 
-export async function runPatternApply(
+async function runTransactionApply(
   input: unknown,
-  options: PatternApplyOptions = {}
+  options: TransactionsServiceOptions
 ): Promise<PatternApplyRecord> {
   const request = parsePatternApplyRequest(input);
 
@@ -221,7 +228,7 @@ function pathInRoot(candidate: string, root: string): boolean {
 
 async function runDryRunCommands(
   commands: readonly GritDryRunCommandInput[],
-  options: PatternApplyOptions
+  options: TransactionsServiceOptions
 ): Promise<HabitatCommandResult[]> {
   const processLayer = options.processLayer ?? HabitatProcessLive;
   const program = Effect.forEach(commands, (command) => runDryRunCommand(command), {

--- a/tools/habitat-harness/src/service/router.ts
+++ b/tools/habitat-harness/src/service/router.ts
@@ -7,6 +7,7 @@ import { classifyRouter } from "./modules/classify/router.js";
 import { fixRouter } from "./modules/fix/router.js";
 import { graphRouter } from "./modules/graph/router.js";
 import { hookRouter } from "./modules/hook/router.js";
+import { transactionsRouter } from "./modules/transactions/router.js";
 import { verifyRouter } from "./modules/verify/router.js";
 
 export const habitatServiceRouter: Router<typeof habitatServiceContract, HabitatServiceContext> =
@@ -16,6 +17,7 @@ export const habitatServiceRouter: Router<typeof habitatServiceContract, Habitat
     fix: fixRouter,
     graph: graphRouter,
     hook: hookRouter,
+    transactions: transactionsRouter,
     verify: verifyRouter,
   });
 

--- a/tools/habitat-harness/test/lib/pattern-apply.test.ts
+++ b/tools/habitat-harness/test/lib/pattern-apply.test.ts
@@ -10,9 +10,10 @@ import {
   type PatternApplyRequest,
   PatternApplyRequestSchema,
   renderPatternApply,
-  runPatternApply,
 } from "../../src/lib/pattern-apply/index.js";
 import type { ApplyAdmission, ApplyTransactionInput } from "../../src/rules/patterns/index.js";
+import type { TransactionsServiceOptions } from "../../src/service/modules/transactions/context.js";
+import { runTransactionApplyService } from "../../src/service/modules/transactions/run.js";
 
 describe("pattern apply", () => {
   test("requires apply admission before a transaction request is valid", () => {
@@ -63,7 +64,7 @@ describe("pattern apply", () => {
       });
     });
 
-    const record = await runPatternApply(
+    const record = await applyTransaction(
       {
         kind: "dry-run-intent",
         worktree: cleanWorktree(),
@@ -98,7 +99,7 @@ describe("pattern apply", () => {
       })
     );
 
-    const record = await runPatternApply(
+    const record = await applyTransaction(
       {
         kind: "dry-run-intent",
         worktree: cleanWorktree(),
@@ -116,7 +117,7 @@ describe("pattern apply", () => {
   });
 
   test("missing transaction input stays a refusal after admission", async () => {
-    const record = await runPatternApply({
+    const record = await applyTransaction({
       kind: "dry-run-intent",
       worktree: cleanWorktree(),
       admission: applyAdmission({
@@ -153,7 +154,7 @@ describe("pattern apply", () => {
       ],
     } as Partial<ApplyTransactionInput>);
 
-    const record = await runPatternApply(
+    const record = await applyTransaction(
       {
         kind: "dry-run-intent",
         worktree: cleanWorktree(),
@@ -172,7 +173,7 @@ describe("pattern apply", () => {
   });
 
   test("refuses transaction input whose identity does not match the admission", async () => {
-    const record = await runPatternApply(
+    const record = await applyTransaction(
       {
         kind: "dry-run-intent",
         worktree: cleanWorktree(),
@@ -195,7 +196,7 @@ describe("pattern apply", () => {
   });
 
   test("blocks live writes without protected-zone authority", async () => {
-    const record = await runPatternApply({
+    const record = await applyTransaction({
       kind: "live-write-intent",
       worktree: cleanWorktree(),
       admission: applyAdmission(),
@@ -208,7 +209,7 @@ describe("pattern apply", () => {
   });
 
   test("blocks live writes on dirty worktrees before zone or host decisions", async () => {
-    const record = await runPatternApply({
+    const record = await applyTransaction({
       kind: "live-write-intent",
       worktree: dirtyWorktree(),
       admission: applyAdmission(),
@@ -221,7 +222,7 @@ describe("pattern apply", () => {
   });
 
   test("blocks live writes without host-policy authority", async () => {
-    const record = await runPatternApply({
+    const record = await applyTransaction({
       kind: "live-write-intent",
       worktree: cleanWorktree(),
       admission: applyAdmission(),
@@ -235,7 +236,7 @@ describe("pattern apply", () => {
   });
 
   test("consumes an allowed protected-zone write decision before live execution", async () => {
-    const record = await runPatternApply(
+    const record = await applyTransaction(
       {
         kind: "live-write-intent",
         worktree: cleanWorktree(),
@@ -254,7 +255,7 @@ describe("pattern apply", () => {
   });
 
   test("binds protected-zone write decisions to the admitted transaction roots", async () => {
-    const record = await runPatternApply(
+    const record = await applyTransaction(
       {
         kind: "live-write-intent",
         worktree: cleanWorktree(),
@@ -274,6 +275,10 @@ describe("pattern apply", () => {
     });
   });
 });
+
+function applyTransaction(input: unknown, options?: TransactionsServiceOptions) {
+  return Effect.runPromise(runTransactionApplyService(input, options));
+}
 
 function cleanWorktree() {
   return {

--- a/tools/habitat-harness/test/service/service-architecture.test.ts
+++ b/tools/habitat-harness/test/service/service-architecture.test.ts
@@ -6,7 +6,15 @@ const packageRoot = new URL("../..", import.meta.url).pathname;
 const sourceRoot = join(packageRoot, "src");
 const serviceRoot = join(sourceRoot, "service");
 const providerRoot = join(sourceRoot, "providers");
-const serviceModuleNames = ["check", "classify", "fix", "graph", "hook", "verify"] as const;
+const serviceModuleNames = [
+  "check",
+  "classify",
+  "fix",
+  "graph",
+  "hook",
+  "transactions",
+  "verify",
+] as const;
 
 describe("Habitat service architecture", () => {
   test("keeps Effect-oRPC runtime construction in the root service seam", () => {
@@ -33,6 +41,7 @@ describe("Habitat service architecture", () => {
     expect(router).toContain("fix: fixRouter");
     expect(router).toContain("graph: graphRouter");
     expect(router).toContain("hook: hookRouter");
+    expect(router).toContain("transactions: transactionsRouter");
     expect(router).toContain("verify: verifyRouter");
     expect(router).not.toContain(".effect(");
     expect(router).not.toContain("createCheckReport");
@@ -40,6 +49,7 @@ describe("Habitat service architecture", () => {
     expect(router).not.toContain("runFixService");
     expect(router).not.toContain("runGraphService");
     expect(router).not.toContain("runHookService");
+    expect(router).not.toContain("runTransactionApplyService");
     expect(router).not.toContain("runVerifyService");
     expect(router).not.toContain("process.env");
   });
@@ -113,8 +123,20 @@ describe("Habitat service architecture", () => {
     expect(fixCommand).not.toContain("runFix");
     expect(fixCommand).not.toContain("../lib/fix.js");
     expect(fixRun).not.toMatch(/from\s+["'][^"']*lib\/fix\.js["']/);
+    expect(fixRun).not.toContain("runPatternApply");
+    expect(fixRun).not.toMatch(/from\s+["'][^"']*lib\/pattern-apply\/run/);
     expect(publicIndex).not.toContain("runFix");
     expect(existsSync(join(packageRoot, "src/lib/fix.ts"))).toBe(false);
+  });
+
+  test("keeps transaction execution in the transactions service module", () => {
+    const transactionRun = source("src/service/modules/transactions/run.ts");
+    const patternApplyIndex = source("src/lib/pattern-apply/index.ts");
+
+    expect(transactionRun).toContain("runTransactionApplyService");
+    expect(transactionRun).toContain("PatternApplyRecordSchema");
+    expect(patternApplyIndex).not.toContain("runPatternApply");
+    expect(existsSync(join(packageRoot, "src/lib/pattern-apply/run.ts"))).toBe(false);
   });
 
   test("routes hook CLI orchestration through the service client", () => {

--- a/tools/habitat-harness/test/service/transactions-service.test.ts
+++ b/tools/habitat-harness/test/service/transactions-service.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "vitest";
+import {
+  type HabitatProcessRequest,
+  makeFakeHabitatProcessLayer,
+  makeHabitatCommandResult,
+} from "../../src/lib/habitat-process.js";
+import { renderPatternApply } from "../../src/lib/pattern-apply/index.js";
+import type { ApplyAdmission, ApplyTransactionInput } from "../../src/rules/patterns/index.js";
+import { createHabitatServiceClient } from "../../src/service/client.js";
+
+describe("Habitat transactions service", () => {
+  test("runs admitted dry-run transactions through the in-process service client", async () => {
+    const requests: HabitatProcessRequest[] = [];
+    const processLayer = makeFakeHabitatProcessLayer((request) => {
+      requests.push(request);
+      return makeHabitatCommandResult(request, {
+        stdout: {
+          text: "transaction dry run ok\n",
+          truncated: false,
+          sha256: "",
+          bytes: 23,
+        },
+      });
+    });
+
+    const record = await createHabitatServiceClient({
+      transactions: {
+        processLayer,
+        transactionInputs: [transactionInput()],
+      },
+    }).transactions.apply({
+      kind: "dry-run-intent",
+      worktree: cleanWorktree(),
+      admission: applyAdmission(),
+    });
+
+    expect(record.outcome).toMatchObject({
+      kind: "dry-run-completed",
+      admission: { patternId: "deep-import-to-public-surface" },
+    });
+    expect(renderPatternApply(record)).toEqual({
+      exitCode: 0,
+      stdout: "transaction dry run ok\n",
+      stderr: "",
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      commandId: "habitat-fix-deep-import-dry-run",
+      executable: "grit",
+      kind: "pattern-apply",
+    });
+  });
+
+  test("refuses unresolved transaction input before vendor execution", async () => {
+    const requests: HabitatProcessRequest[] = [];
+    const processLayer = makeFakeHabitatProcessLayer((request) => {
+      requests.push(request);
+      return makeHabitatCommandResult(request);
+    });
+
+    const record = await createHabitatServiceClient({
+      transactions: {
+        processLayer,
+        transactionInputs: [],
+      },
+    }).transactions.apply({
+      kind: "dry-run-intent",
+      worktree: cleanWorktree(),
+      admission: applyAdmission(),
+    });
+
+    expect(record.outcome).toMatchObject({
+      kind: "refused",
+      refusal: { reason: "missing-transaction-input" },
+    });
+    expect(requests).toHaveLength(0);
+  });
+});
+
+function applyAdmission(overrides: Partial<ApplyAdmission> = {}): ApplyAdmission {
+  return {
+    kind: "apply-admission",
+    patternId: "deep-import-to-public-surface",
+    manifestPath: ".habitat/patterns/apply/deep_import_to_public_surface.md",
+    transactionInputRef: "patterns:deep-import-to-public-surface:transaction-input",
+    transactionInputRuleIds: ["domain-deep-import"],
+    dryRunOutput: "compact",
+    ...overrides,
+  };
+}
+
+function transactionInput(overrides: Partial<ApplyTransactionInput> = {}): ApplyTransactionInput {
+  return {
+    kind: "apply-transaction-input",
+    patternId: "deep-import-to-public-surface",
+    manifestPath: ".habitat/patterns/apply/deep_import_to_public_surface.md",
+    transactionInputRef: "patterns:deep-import-to-public-surface:transaction-input",
+    dryRunCommands: [
+      {
+        kind: "dry-run-command",
+        commandId: "habitat-fix-deep-import-dry-run",
+        patternPath: ".habitat/patterns/apply/deep_import_to_public_surface.md",
+        roots: ["tools/habitat-harness/test/fixtures"],
+        output: "compact",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function cleanWorktree() {
+  return {
+    kind: "worktree-observation",
+    dirty: false,
+    dirtyPathCount: 0,
+    statusDigest: "e3b0c44298fc1c149afbf4c8996fb924",
+  } as const;
+}


### PR DESCRIPTION
Adds the `transactions` service module to the owned Effect-oRPC service layer and moves pattern-apply execution out of `src/lib` into that module.

The `transactions.apply` procedure is now the single service boundary for admitted transformation transaction lifecycle. `fix` no longer calls a `src/lib` execution runner directly; it delegates to `runTransactionApplyService` from the `transactions` module. The legacy `src/lib/pattern-apply/run.ts` entrypoint and its `runPatternApply` export are deleted. `src/lib/pattern-apply` is retained as DTO, parser, presenter, and worktree-observation material only.

The `transactions` contract, context, module binding, and router are composed into the root Habitat service contract and router alongside the existing `check`, `fix`, `hook`, and other modules. Architecture guard tests are extended to assert that `transactionsRouter` appears in the root router, that `runPatternApply` no longer appears in the `pattern-apply` index, and that `src/lib/pattern-apply/run.ts` does not exist. A new `transactions-service.test.ts` covers the admitted dry-run path and the refused-on-missing-input path through the in-process service client.