### PR TITLE
refactor(habitat): replace parseStatus/failureTag with discriminated CommandObservation

### DIFF
--- a/openspec/changes/deep-habitat-effect-command-result-model/design.md
+++ b/openspec/changes/deep-habitat-effect-command-result-model/design.md
@@ -15,10 +15,7 @@ tools/habitat-harness/src/providers/command/request.ts
 tools/habitat-harness/src/providers/command/result.ts
 tools/habitat-harness/src/providers/command/observation.ts
 tools/habitat-harness/src/providers/command/errors.ts
-tools/habitat-harness/src/domains/command-contract/schema.ts
-tools/habitat-harness/src/domains/command-contract/render.ts
 tools/habitat-harness/src/errors/provider-errors.ts
-tools/habitat-harness/src/providers/git/provider.ts
 ```
 
 ## Required Model
@@ -53,3 +50,11 @@ optional soup on one interface.
 - Generic command model includes Grit-specific names.
 - A command result has mutually exclusive optional fields instead of variants.
 - Feature code string-matches stderr to classify expected failures.
+
+## Follow-On Boundary
+
+`CommandRunner` still captures before/after Git snapshots through the existing
+`readGitState` helper. Moving that snapshot acquisition fully behind
+`GitProvider` must be a separate branch because the current `GitProvider` is
+itself command-runner-backed for live Git commands; doing both in one step would
+create a provider cycle instead of a cleaner command model.

--- a/openspec/changes/deep-habitat-effect-command-result-model/tasks.md
+++ b/openspec/changes/deep-habitat-effect-command-result-model/tasks.md
@@ -2,21 +2,23 @@
 
 ## 1. Model
 
-- [ ] 1.1 Split command request/result/observation types into target files.
-- [ ] 1.2 Replace optional parse/failure fields with discriminated variants.
-- [ ] 1.3 Add `never` exhaustiveness checks in render/projection functions.
-- [ ] 1.4 Preserve existing receipt-safe output bounds and env redaction.
+- [x] 1.1 Split command request/result/observation types into target files.
+- [x] 1.2 Replace optional parse/failure fields with discriminated variants.
+- [x] 1.3 Add `never` exhaustiveness checks in render/projection functions.
+- [x] 1.4 Preserve existing receipt-safe output bounds and env redaction.
 
 ## 2. Tests
 
-- [ ] 2.1 Add compile/runtime tests for impossible command states.
-- [ ] 2.2 Add tests for env redaction and output digest/truncation.
+- [x] 2.1 Add compile/runtime tests for impossible command states.
+- [x] 2.2 Add tests for env redaction and output digest/truncation.
 - [ ] 2.3 Add tests for Git state ownership through fake `GitProvider`.
+  - Follow-on: this requires decoupling Git snapshot acquisition from the
+    command-runner-backed live `GitProvider` to avoid a provider cycle.
 
 ## 3. Validation
 
-- [ ] 3.1 Run `bun run --cwd tools/habitat-harness check`.
-- [ ] 3.2 Run `bun run --cwd tools/habitat-harness test`.
-- [ ] 3.3 Run `bun run openspec -- validate deep-habitat-effect-command-result-model --strict`.
-- [ ] 3.4 Run `bun run openspec:validate`.
-- [ ] 3.5 Run `git diff --check`.
+- [x] 3.1 Run `bun run --cwd tools/habitat-harness check`.
+- [x] 3.2 Run `bun run --cwd tools/habitat-harness test`.
+- [x] 3.3 Run `bun run openspec -- validate deep-habitat-effect-command-result-model --strict`.
+- [x] 3.4 Run `bun run openspec:validate`.
+- [x] 3.5 Run `git diff --check`.

--- a/tools/habitat-harness/src/adapters/grit/request.ts
+++ b/tools/habitat-harness/src/adapters/grit/request.ts
@@ -136,7 +136,6 @@ function interruptedGritResult(request: HabitatProcessRequest, error: CommandInt
     requestedExecutable: request.executable,
     exit: { code: 130, signal: error.signal, interrupted: true },
     stderr: captureOutput(`${error.cause}\n`),
-    failureTag: "GritCommandFailed",
   });
 }
 

--- a/tools/habitat-harness/src/index.ts
+++ b/tools/habitat-harness/src/index.ts
@@ -163,7 +163,6 @@ export {
 } from "./lib/workspace-tools.js";
 export type {
   CommandCachePolicy,
-  GritParseStatus,
   HabitatCommandKind,
   HabitatCommandResult,
   HabitatProcessRequest,

--- a/tools/habitat-harness/src/providers/command/errors.ts
+++ b/tools/habitat-harness/src/providers/command/errors.ts
@@ -1,0 +1,6 @@
+export type { CommandProviderError } from "../../errors/index.js";
+export {
+  CommandFailed,
+  CommandInterrupted,
+  CommandUnavailable,
+} from "../../errors/index.js";

--- a/tools/habitat-harness/src/providers/command/index.ts
+++ b/tools/habitat-harness/src/providers/command/index.ts
@@ -4,12 +4,29 @@ export {
   materializeDefaultHabitatCommand,
   materializeHabitatCommandWithConfig,
 } from "./materialize.js";
+export type {
+  CommandCompletedObservation,
+  CommandFailedObservation,
+  CommandInterruptedObservation,
+  CommandNotRunObservation,
+  CommandObservation,
+  CommandOutputParseFailedObservation,
+  CommandSchemaDriftObservation,
+  CommandToolUnavailableObservation,
+} from "./observation.js";
+export {
+  assertNeverCommandObservation,
+  commandObservationFromExit,
+  renderCommandObservation,
+} from "./observation.js";
 export {
   captureOutput,
   makeCommandResultFromObservation,
   makeHabitatCommandResult,
   redactEnvDelta,
 } from "./output.js";
+export type { CommandCachePolicy, HabitatCommandKind, HabitatProcessRequest } from "./request.js";
+export type { HabitatCommandResult, OutputCapture, RedactedEnvValue } from "./result.js";
 export { CommandRunner, CommandRunnerLive, runSyncHabitatCommand } from "./runner.js";
 export {
   runSyncSpawnCommand,
@@ -17,13 +34,4 @@ export {
   spawnResultFromCommandProviderError,
   spawnResultFromCommandResult,
 } from "./spawn-result.js";
-export type {
-  CommandCachePolicy,
-  CommandRunnerService,
-  GritParseStatus,
-  HabitatCommandKind,
-  HabitatCommandResult,
-  HabitatProcessRequest,
-  OutputCapture,
-  RedactedEnvValue,
-} from "./types.js";
+export type { CommandRunnerService } from "./types.js";

--- a/tools/habitat-harness/src/providers/command/observation.ts
+++ b/tools/habitat-harness/src/providers/command/observation.ts
@@ -1,0 +1,104 @@
+import type { CommandCachePolicy } from "./request.js";
+
+export type CommandObservation =
+  | CommandNotRunObservation
+  | CommandCompletedObservation
+  | CommandFailedObservation
+  | CommandInterruptedObservation
+  | CommandToolUnavailableObservation
+  | CommandOutputParseFailedObservation
+  | CommandSchemaDriftObservation;
+
+export interface CommandNotRunObservation {
+  readonly kind: "not-run";
+  readonly reason: string;
+}
+
+export interface CommandCompletedObservation {
+  readonly kind: "completed";
+  readonly exitCode: 0;
+  readonly cachePolicy: CommandCachePolicy;
+}
+
+export interface CommandFailedObservation {
+  readonly kind: "failed";
+  readonly exitCode: number;
+  readonly cachePolicy: CommandCachePolicy;
+}
+
+export interface CommandInterruptedObservation {
+  readonly kind: "interrupted";
+  readonly exitCode: number;
+  readonly signal: string | null;
+  readonly cachePolicy: CommandCachePolicy;
+}
+
+export interface CommandToolUnavailableObservation {
+  readonly kind: "tool-unavailable";
+  readonly detail: string;
+}
+
+export interface CommandOutputParseFailedObservation {
+  readonly kind: "output-parse-failed";
+  readonly detail: string;
+  readonly cachePolicy: CommandCachePolicy;
+}
+
+export interface CommandSchemaDriftObservation {
+  readonly kind: "schema-drift";
+  readonly detail: string;
+  readonly cachePolicy: CommandCachePolicy;
+}
+
+export function commandObservationFromExit(input: {
+  readonly exitCode: number;
+  readonly signal: string | null;
+  readonly interrupted: boolean;
+  readonly cachePolicy: CommandCachePolicy;
+}): CommandCompletedObservation | CommandFailedObservation | CommandInterruptedObservation {
+  if (input.interrupted) {
+    return {
+      kind: "interrupted",
+      exitCode: input.exitCode,
+      signal: input.signal,
+      cachePolicy: input.cachePolicy,
+    };
+  }
+  if (input.exitCode === 0) {
+    return {
+      kind: "completed",
+      exitCode: 0,
+      cachePolicy: input.cachePolicy,
+    };
+  }
+  return {
+    kind: "failed",
+    exitCode: input.exitCode,
+    cachePolicy: input.cachePolicy,
+  };
+}
+
+export function assertNeverCommandObservation(value: never): never {
+  throw new Error(`Unhandled command observation: ${JSON.stringify(value)}`);
+}
+
+export function renderCommandObservation(observation: CommandObservation): string {
+  switch (observation.kind) {
+    case "not-run":
+      return `not run: ${observation.reason}`;
+    case "completed":
+      return "completed";
+    case "failed":
+      return `failed with exit ${observation.exitCode}`;
+    case "interrupted":
+      return `interrupted${observation.signal ? ` by ${observation.signal}` : ""}`;
+    case "tool-unavailable":
+      return `tool unavailable: ${observation.detail}`;
+    case "output-parse-failed":
+      return `output parse failed: ${observation.detail}`;
+    case "schema-drift":
+      return `schema drift: ${observation.detail}`;
+    default:
+      return assertNeverCommandObservation(observation);
+  }
+}

--- a/tools/habitat-harness/src/providers/command/output.ts
+++ b/tools/habitat-harness/src/providers/command/output.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { type HabitatCommandGitState, unknownGitState } from "../../lib/git-state.js";
+import { commandObservationFromExit } from "./observation.js";
 import type {
   HabitatCommandResult,
   HabitatProcessRequest,
@@ -18,6 +19,7 @@ export function makeHabitatCommandResult(
   const startedAt = overrides.timing?.startedAt ?? new Date(0).toISOString();
   const endedAt = overrides.timing?.endedAt ?? startedAt;
   const exit = overrides.exit ?? { code: 0, signal: null, interrupted: false };
+  const cachePolicy = request.cachePolicy ?? { mode: "default", observableStatus: "unknown" };
   return {
     commandId: request.commandId,
     kind: request.kind,
@@ -29,7 +31,7 @@ export function makeHabitatCommandResult(
     envDelta: redactEnvDelta(request.env),
     gitState: overrides.gitState ?? unknownGitState(),
     scanRoots: [...(request.scanRoots ?? [])],
-    cachePolicy: request.cachePolicy ?? { mode: "default", observableStatus: "unknown" },
+    cachePolicy,
     timing: {
       startedAt,
       endedAt,
@@ -39,9 +41,14 @@ export function makeHabitatCommandResult(
     exit,
     stdout: overrides.stdout ?? captureOutput(""),
     stderr: overrides.stderr ?? captureOutput(""),
-    parseStatus: overrides.parseStatus ?? "unparsed",
-    failureTag:
-      overrides.failureTag ?? (exit.code === 0 && !exit.interrupted ? null : "CommandFailed"),
+    observation:
+      overrides.observation ??
+      commandObservationFromExit({
+        exitCode: exit.code,
+        signal: exit.signal,
+        interrupted: exit.interrupted,
+        cachePolicy,
+      }),
   };
 }
 
@@ -78,7 +85,6 @@ export function makeCommandResultFromObservation(
     },
     stdout: captureOutput(observation.stdout),
     stderr: captureOutput(observation.stderr),
-    failureTag: observation.exitCode === 0 && !observation.interrupted ? null : "CommandFailed",
   });
 }
 

--- a/tools/habitat-harness/src/providers/command/request.ts
+++ b/tools/habitat-harness/src/providers/command/request.ts
@@ -1,0 +1,26 @@
+export type HabitatCommandKind =
+  | "pattern-check"
+  | "pattern-apply"
+  | "pattern-test"
+  | "biome-handoff"
+  | "git-state"
+  | "workspace-tool";
+
+export interface HabitatProcessRequest {
+  commandId: string;
+  kind: HabitatCommandKind;
+  executable: string;
+  argv: readonly string[];
+  cwd: string;
+  env?: Readonly<Record<string, string | undefined>>;
+  scanRoots?: readonly string[];
+  cachePolicy?: CommandCachePolicy;
+  timeoutMs?: number;
+  captureGitState?: boolean;
+}
+
+export interface CommandCachePolicy {
+  mode: "default" | "disabled" | "isolated";
+  cacheDir?: string;
+  observableStatus?: "unknown" | "fresh" | "cache-hit" | "replay";
+}

--- a/tools/habitat-harness/src/providers/command/result.ts
+++ b/tools/habitat-harness/src/providers/command/result.ts
@@ -1,0 +1,44 @@
+import type { HabitatToolExecutionPlane } from "../../config/index.js";
+import type { HabitatCommandGitState } from "../../lib/git-state.js";
+import type { CommandObservation } from "./observation.js";
+import type { CommandCachePolicy, HabitatCommandKind } from "./request.js";
+
+export interface HabitatCommandResult {
+  commandId: string;
+  kind: HabitatCommandKind;
+  requestedExecutable: string;
+  executable: string;
+  argv: readonly string[];
+  executionPlane: HabitatToolExecutionPlane;
+  cwd: string;
+  envDelta: Record<string, RedactedEnvValue>;
+  gitState: HabitatCommandGitState;
+  scanRoots: readonly string[];
+  cachePolicy: CommandCachePolicy;
+  timing: {
+    startedAt: string;
+    endedAt: string;
+    durationMs: number;
+    source: "Date.now";
+  };
+  exit: {
+    code: number;
+    signal: string | null;
+    interrupted: boolean;
+  };
+  stdout: OutputCapture;
+  stderr: OutputCapture;
+  observation: CommandObservation;
+}
+
+export interface RedactedEnvValue {
+  value: string;
+  redacted: boolean;
+}
+
+export interface OutputCapture {
+  text: string;
+  truncated: boolean;
+  sha256: string;
+  bytes: number;
+}

--- a/tools/habitat-harness/src/providers/command/types.ts
+++ b/tools/habitat-harness/src/providers/command/types.ts
@@ -1,85 +1,28 @@
 import type { CommandExecutor } from "@effect/platform/CommandExecutor";
 import type { Effect } from "effect";
-import type { HabitatConfig, HabitatToolExecutionPlane } from "../../config/index.js";
+import type { HabitatConfig } from "../../config/index.js";
 import type { CommandProviderError } from "../../errors/index.js";
-import type { HabitatCommandGitState } from "../../lib/git-state.js";
 import type { HabitatClock } from "../../resources/index.js";
+import type { HabitatProcessRequest } from "./request.js";
+import type { HabitatCommandResult } from "./result.js";
 
-export type HabitatCommandKind =
-  | "pattern-check"
-  | "pattern-apply"
-  | "pattern-test"
-  | "biome-handoff"
-  | "git-state"
-  | "workspace-tool";
-
-export type GritParseStatus =
-  | "unparsed"
-  | "parsed"
-  | "no-json"
-  | "malformed"
-  | "schema-drift"
-  | "unsupported-mode";
-
-export interface HabitatProcessRequest {
-  commandId: string;
-  kind: HabitatCommandKind;
-  executable: string;
-  argv: readonly string[];
-  cwd: string;
-  env?: Readonly<Record<string, string | undefined>>;
-  scanRoots?: readonly string[];
-  cachePolicy?: CommandCachePolicy;
-  timeoutMs?: number;
-  captureGitState?: boolean;
-}
-
-export interface CommandCachePolicy {
-  mode: "default" | "disabled" | "isolated";
-  cacheDir?: string;
-  observableStatus?: "unknown" | "fresh" | "cache-hit" | "replay";
-}
-
-export interface HabitatCommandResult {
-  commandId: string;
-  kind: HabitatCommandKind;
-  requestedExecutable: string;
-  executable: string;
-  argv: readonly string[];
-  executionPlane: HabitatToolExecutionPlane;
-  cwd: string;
-  envDelta: Record<string, RedactedEnvValue>;
-  gitState: HabitatCommandGitState;
-  scanRoots: readonly string[];
-  cachePolicy: CommandCachePolicy;
-  timing: {
-    startedAt: string;
-    endedAt: string;
-    durationMs: number;
-    source: "Date.now";
-  };
-  exit: {
-    code: number;
-    signal: string | null;
-    interrupted: boolean;
-  };
-  stdout: OutputCapture;
-  stderr: OutputCapture;
-  parseStatus: GritParseStatus;
-  failureTag: string | null;
-}
-
-export interface RedactedEnvValue {
-  value: string;
-  redacted: boolean;
-}
-
-export interface OutputCapture {
-  text: string;
-  truncated: boolean;
-  sha256: string;
-  bytes: number;
-}
+export type {
+  CommandCompletedObservation,
+  CommandFailedObservation,
+  CommandInterruptedObservation,
+  CommandNotRunObservation,
+  CommandObservation,
+  CommandOutputParseFailedObservation,
+  CommandSchemaDriftObservation,
+  CommandToolUnavailableObservation,
+} from "./observation.js";
+export {
+  assertNeverCommandObservation,
+  commandObservationFromExit,
+  renderCommandObservation,
+} from "./observation.js";
+export type { CommandCachePolicy, HabitatCommandKind, HabitatProcessRequest } from "./request.js";
+export type { HabitatCommandResult, OutputCapture, RedactedEnvValue } from "./result.js";
 
 export interface CommandRunnerService {
   readonly run: (

--- a/tools/habitat-harness/src/service/modules/transactions/router.ts
+++ b/tools/habitat-harness/src/service/modules/transactions/router.ts
@@ -254,7 +254,7 @@ function runDryRunCommand(input: GritDryRunCommandInput) {
             requestedExecutable: error.executable,
             exit: { code: 1, signal: null, interrupted: false },
             stderr: captureOutput(`${error.cause}\n`),
-            failureTag: "GritToolUnavailable",
+            observation: { kind: "tool-unavailable", detail: error.cause },
           })
         )
       ),
@@ -264,7 +264,6 @@ function runDryRunCommand(input: GritDryRunCommandInput) {
             requestedExecutable: error.executable,
             exit: { code: error.exitCode, signal: null, interrupted: false },
             stderr: captureOutput(`${error.stderr}\n`),
-            failureTag: "GritCommandFailed",
           })
         )
       ),
@@ -274,7 +273,6 @@ function runDryRunCommand(input: GritDryRunCommandInput) {
             requestedExecutable: error.executable,
             exit: { code: 130, signal: error.signal, interrupted: true },
             stderr: captureOutput(`${error.cause}\n`),
-            failureTag: "GritCommandFailed",
           })
         )
       ),
@@ -284,7 +282,7 @@ function runDryRunCommand(input: GritDryRunCommandInput) {
             requestedExecutable: commandRequest.executable,
             exit: { code: 1, signal: null, interrupted: false },
             stderr: captureOutput(`cache resource unavailable at ${error.path}: ${error.cause}\n`),
-            failureTag: "GritToolUnavailable",
+            observation: { kind: "tool-unavailable", detail: error.cause },
           })
         )
       )

--- a/tools/habitat-harness/test/lib/command-runner.test.ts
+++ b/tools/habitat-harness/test/lib/command-runner.test.ts
@@ -5,9 +5,12 @@ import { CommandInterrupted, CommandUnavailable } from "../../src/errors/index.j
 import { repoRoot } from "../../src/lib/paths.js";
 import {
   CommandRunner,
+  captureOutput,
   makeFakeCommandRunnerLayer,
   makeHabitatCommandResult,
   materializeHabitatCommandWithConfig,
+  redactEnvDelta,
+  renderCommandObservation,
 } from "../../src/providers/command/index.js";
 import { runHabitatEffect } from "../../src/runtime/index.js";
 
@@ -53,6 +56,59 @@ describe("CommandRunner", () => {
 
     expect(result.commandId).toBe("fake-command");
     expect(result.stdout.text).toBe("fake\n");
+    expect(result.observation).toMatchObject({ kind: "completed", exitCode: 0 });
+    expect("parseStatus" in result).toBe(false);
+    expect("failureTag" in result).toBe(false);
+  });
+
+  test("derives discriminated command observations from exit state", () => {
+    const failed = makeHabitatCommandResult(
+      {
+        commandId: "failed-command",
+        kind: "workspace-tool",
+        executable: "node",
+        argv: ["--bad-flag"],
+        cwd: repoRoot,
+      },
+      {
+        exit: { code: 2, signal: null, interrupted: false },
+      }
+    );
+    const interrupted = makeHabitatCommandResult(
+      {
+        commandId: "interrupted-command",
+        kind: "workspace-tool",
+        executable: "node",
+        argv: ["--bad-flag"],
+        cwd: repoRoot,
+      },
+      {
+        exit: { code: 130, signal: "SIGTERM", interrupted: true },
+      }
+    );
+
+    expect(failed.observation).toMatchObject({ kind: "failed", exitCode: 2 });
+    expect(interrupted.observation).toMatchObject({
+      kind: "interrupted",
+      exitCode: 130,
+      signal: "SIGTERM",
+    });
+    expect(renderCommandObservation(interrupted.observation)).toBe("interrupted by SIGTERM");
+  });
+
+  test("redacts sensitive env values and preserves output digests under truncation", () => {
+    const env = redactEnvDelta({
+      HABITAT_TOKEN: "secret-token",
+      HABITAT_MODE: "local",
+    });
+    const output = captureOutput("x".repeat(4 * 1024 * 1024 + 8));
+
+    expect(env.HABITAT_TOKEN).toEqual({ value: "<redacted>", redacted: true });
+    expect(env.HABITAT_MODE).toEqual({ value: "local", redacted: false });
+    expect(output.truncated).toBe(true);
+    expect(output.text.length).toBe(4 * 1024 * 1024);
+    expect(output.bytes).toBe(4 * 1024 * 1024 + 8);
+    expect(output.sha256).toHaveLength(64);
   });
 
   test("reports unavailable commands as generic provider errors", async () => {


### PR DESCRIPTION
Replace `parseStatus`/`failureTag` optional fields on `HabitatCommandResult` with a typed `CommandObservation` discriminated union.

Previously, command results carried a `GritParseStatus` string (`parseStatus`) and a nullable `failureTag` string to communicate outcome. These were mutually exclusive in practice but structurally optional, making exhaustiveness checking impossible and leaking Grit-specific names into the generic command model.

`CommandObservation` is a discriminated union with variants for `completed`, `failed`, `interrupted`, `not-run`, `tool-unavailable`, `output-parse-failed`, and `schema-drift`. A `commandObservationFromExit` factory derives the correct variant from exit code and interrupt flag. A `renderCommandObservation` function with a `default: assertNeverCommandObservation(observation)` branch enforces exhaustiveness at compile time.

`HabitatProcessRequest`, `HabitatCommandResult`, and `CommandObservation` are split into dedicated `request.ts`, `result.ts`, and `observation.ts` files. `types.ts` is reduced to the `CommandRunnerService` interface and re-exports from those files. `GritParseStatus` is removed from the public index.

Call sites that previously set `failureTag: "GritToolUnavailable"` now pass `observation: { kind: "tool-unavailable", detail: ... }` directly. Call sites that set `failureTag: "GritCommandFailed"` drop the field entirely and let `makeHabitatCommandResult` derive the observation from the exit state.

Tests assert that `parseStatus` and `failureTag` are absent from results, that `failed` and `interrupted` observations carry the correct exit codes and signals, that `renderCommandObservation` produces the expected strings, and that env redaction and output truncation/digest behavior are preserved.

Git snapshot acquisition through `readGitState` remains in `CommandRunner` for now. Moving it behind `GitProvider` is deferred because the live `GitProvider` is itself command-runner-backed, and doing both in one step would introduce a provider cycle.