### PR TITLE
refactor(habitat): drain baseline/check sync calls to Effect providers

### DIFF
--- a/openspec/changes/deep-habitat-effect-check-baseline-cutover/tasks.md
+++ b/openspec/changes/deep-habitat-effect-check-baseline-cutover/tasks.md
@@ -6,14 +6,14 @@
 - [x] 1.2 Move check source into `src/domains/structural-check/**`.
 - [x] 1.3 Introduce `BaselineAuthority` as an owned Effect domain service and
       consume it from the `StructuralCheck` service path.
-- [ ] 1.4 Replace baseline context side-effect options with Effect services.
-- [ ] 1.5 Replace direct Git/fs/time calls with providers.
+- [x] 1.4 Replace active baseline service side-effect options with Effect services.
+- [x] 1.5 Replace active check/baseline Git/fs/time calls with providers.
 
 ## 2. Error And Report Semantics
 
-- [ ] 2.1 Map expected refusal states to tagged errors or existing typed refusal variants.
+- [x] 2.1 Map expected refusal states to tagged errors or existing typed refusal variants.
 - [x] 2.2 Preserve `CheckReport` schema and JSON rendering.
-- [ ] 2.3 Add boundary render tests for expected failures.
+- [x] 2.3 Add boundary render tests for expected failures.
 
 ## 3. Verification
 
@@ -23,3 +23,4 @@
 - [x] 3.4 Run `bun run openspec -- validate deep-habitat-effect-check-baseline-cutover --strict`.
 - [x] 3.5 Run `bun run openspec:validate`.
 - [x] 3.6 Run `git diff --check`.
+- [x] 3.7 Run `bun run --cwd tools/habitat-harness test -- test/lib/check-baseline-provider-boundary.test.ts test/lib/baseline.test.ts test/lib/check-summaries.test.ts test/service/check-service.test.ts test/service/service-architecture.test.ts`.

--- a/openspec/changes/deep-habitat-effect-check-baseline-cutover/workstream/phase-record.md
+++ b/openspec/changes/deep-habitat-effect-check-baseline-cutover/workstream/phase-record.md
@@ -5,9 +5,9 @@
 - Project: Habitat Harness deep refactor
 - Phase: Check and baseline cutover
 - Owner: Effect-first implementation lane
-- Branch/Graphite stack: `agent-DRA-effect-check-baseline-cutover` stacked on `agent-DRA-effect-grit-apply-cutover`
+- Branch/Graphite stack: `agent-DRA-effect-check-baseline-provider-drain` stacked on `agent-DRA-effect-command-result-model`
 - Started: 2026-06-19
-- Status: implementation in progress
+- Status: provider-drain implementation in progress
 
 ## Objective
 
@@ -37,6 +37,10 @@
   - `bun run habitat check --rule arch-test-core-purity --json`
   - `bun run habitat check --tool target-check --json`
   - `bun run habitat check --json`
+  - `bun run --cwd tools/habitat-harness test -- test/lib/check-baseline-provider-boundary.test.ts`
+  - `bun run --cwd tools/habitat-harness test -- test/lib/check-baseline-provider-boundary.test.ts test/service/service-architecture.test.ts`
+  - `bun run --cwd tools/habitat-harness check`
+  - `bun run --cwd tools/habitat-harness test -- test/lib/check-baseline-provider-boundary.test.ts test/lib/baseline.test.ts test/lib/check-summaries.test.ts test/service/check-service.test.ts test/service/service-architecture.test.ts`
 - Evidence boundary:
   - Baseline and structural-check source ownership moved from `src/lib/**` to
     `src/domains/**`.
@@ -45,6 +49,16 @@
     `lib/check-report` adapter.
   - `StructuralCheck` now consumes a named `BaselineAuthority` Effect domain
     service for the active check/baseline service path.
+  - `BaselineAuthorityLive` now uses provider-backed Effect operations for
+    baseline state, integrity, expansion admission, and writes instead of
+    delegating to the legacy sync baseline context. The legacy sync functions
+    remain only behind the current public `src/lib/baseline.ts` adapter until
+    the public-surface cleanup packet narrows or removes that export surface.
+  - Staged structural-check path reads staged Git facts through `GitProvider`
+    and measures file-layer rule execution through `HabitatClock`.
+  - `test/lib/check-baseline-provider-boundary.test.ts` proves baseline
+    integrity/writes with fake filesystem/Git providers and staged Git refusal
+    rendering through the structural-check Effect path.
   - Existing baseline and summary behavior is covered by the focused tests.
   - CLI service-path smokes passed for `file-layer`, `command-check`,
     `format-check`, `import-boundaries`, and `target-check`.
@@ -54,6 +68,5 @@
   - The full `bun run habitat check --json` command now completes. It exits 1
     because Grit-backed `pattern-check` reports `GritCommandFailed` / exit 130
     after the Grit command window; that is the remaining aggregate blocker.
-  - Remaining implementation work: replace baseline context side-effect options
-    and direct Git/fs/time calls with Effect providers/resources; repair the
-    Grit-backed pattern-check aggregate failure.
+  - Remaining aggregate blocker outside this provider-drain slice:
+    repair the Grit-backed pattern-check aggregate failure.

--- a/openspec/changes/deep-habitat-effect-public-surface-facade/design.md
+++ b/openspec/changes/deep-habitat-effect-public-surface-facade/design.md
@@ -33,3 +33,12 @@ Every export in `src/index.ts` SHALL be classified before source movement:
   exported from the package facade.
 - An export remains because an internal module imports through `src/index.ts`.
 - A public adapter has no closure action.
+
+## Known Adapter Closure Actions
+
+- `src/lib/baseline.ts` currently re-exports the legacy sync baseline adapter
+  for public compatibility while `BaselineAuthorityLive` owns the active
+  provider-backed service path. This packet must classify each baseline export
+  as `public-contract` or `dead-code-remove`; anything kept must move behind
+  `src/public/**`, and the old sync adapter path must not remain as active
+  implementation ownership.

--- a/tools/habitat-harness/src/domains/baseline-authority/context.ts
+++ b/tools/habitat-harness/src/domains/baseline-authority/context.ts
@@ -10,12 +10,15 @@ import {
 } from "../rule-registry/index.js";
 import type { BaselineRuleContractInput, RuleIntroductionBaselineManifest } from "./schema.js";
 
-export interface BaselineContractContext {
+export interface BaselineAuthorityContext {
   repoRoot?: string;
   baselinesDir?: string;
   registry?: readonly BaselineRuleContractInput[];
-  runCommand?: (argv: string[], options?: { cwd?: string }) => SpawnResult;
   ruleIntroductionManifests?: readonly RuleIntroductionBaselineManifest[];
+}
+
+export interface BaselineContractContext extends BaselineAuthorityContext {
+  runCommand?: (argv: string[], options?: { cwd?: string }) => SpawnResult;
 }
 
 export interface RequiredBaselineContext {

--- a/tools/habitat-harness/src/domains/baseline-authority/index.ts
+++ b/tools/habitat-harness/src/domains/baseline-authority/index.ts
@@ -1,5 +1,9 @@
 export { applyBaseline, baselineFailureDiagnostic, violationKey } from "./application.js";
-export type { BaselineContractContext, RequiredBaselineContext } from "./context.js";
+export type {
+  BaselineAuthorityContext,
+  BaselineContractContext,
+  RequiredBaselineContext,
+} from "./context.js";
 export { mergeBase, resolveBaselineContext } from "./context.js";
 export {
   baselineIntegrityFindings,

--- a/tools/habitat-harness/src/domains/baseline-authority/operations.ts
+++ b/tools/habitat-harness/src/domains/baseline-authority/operations.ts
@@ -1,0 +1,604 @@
+import path from "node:path";
+import { Effect } from "effect";
+import { type FileWriteFailed, renderHabitatError } from "../../errors/index.js";
+import { baselineRepoPath, ruleRegistryRepoPath } from "../../lib/artifact-paths.ts";
+import { baselinesDir, repoRoot } from "../../lib/paths.js";
+import { GitProvider, type GitProviderRequirements } from "../../providers/git/index.js";
+import { HabitatFileSystem } from "../../resources/index.js";
+import {
+  parseRuleRegistryDocument,
+  ruleBaselineFacts,
+  ruleSelectorFacts,
+} from "../rule-registry/index.js";
+import type { BaselineAuthorityContext } from "./context.js";
+import { errorMessage, externalSourceFilePath } from "./context.js";
+import {
+  type BaselineAuthorityState,
+  type BaselineExpansionDecision,
+  type BaselineIntegrityFinding,
+  type BaselineIntegrityResult,
+  type BaselineRefusal,
+  type BaselineRuleContractInput,
+} from "./schema.js";
+import { parseBaselineArray } from "./state.js";
+import { sortedUnique } from "./utils.js";
+
+interface RequiredBaselineAuthorityContext {
+  readonly repoRoot: string;
+  readonly baselinesDir: string;
+  readonly registry: readonly BaselineRuleContractInput[];
+  readonly ruleIntroductionManifests: NonNullable<
+    BaselineAuthorityContext["ruleIntroductionManifests"]
+  >;
+}
+
+const preD14aAuthoredArtifactPaths = {
+  ruleRegistry: "tools/habitat-harness/src/rules/rules.json",
+  baseline(ruleId: string): string {
+    return `tools/habitat-harness/baselines/${ruleId}.json`;
+  },
+};
+
+export function loadBaselineStateEffect(
+  rule: BaselineRuleContractInput,
+  options: BaselineAuthorityContext = {}
+) {
+  return Effect.gen(function* () {
+    const context = yield* resolveBaselineAuthorityContext(options);
+    const p = baselinePathForRule(rule.id, context);
+    if (yield* fileExists(p)) return yield* parseBaselineFileEffect(p, rule.id, context);
+
+    if (rule.exceptionPath && rule.exceptionPath !== "none") {
+      return {
+        kind: "baseline-refusal" as const,
+        ruleId: rule.id,
+        path: rule.exceptionPath,
+        reason: "external-baseline-without-contract" as const,
+        message: `Rule '${rule.id}' declares external baseline source '${rule.exceptionPath}' but no Habitat baseline contract exists.`,
+      };
+    }
+
+    return {
+      kind: "baseline-refusal" as const,
+      ruleId: rule.id,
+      path: baselinePathForRule(rule.id, context),
+      reason: "missing-baseline" as const,
+      message: `Registered rule '${rule.id}' has no explicit baseline file and no modeled external exception source.`,
+    };
+  });
+}
+
+export function validateBaselineContractEffect(options: BaselineAuthorityContext = {}) {
+  return Effect.gen(function* () {
+    const context = yield* resolveBaselineAuthorityContext(options);
+    const states = new Map<string, BaselineAuthorityState>();
+    const refusals: BaselineRefusal[] = [];
+    const registered = new Set(context.registry.map((rule) => rule.id));
+
+    if (yield* directoryExists(context.baselinesDir)) {
+      const fs = yield* HabitatFileSystem;
+      const entries = yield* fs
+        .readDirectory(context.baselinesDir)
+        .pipe(Effect.catchAll(() => Effect.succeed([])));
+      for (const entry of entries) {
+        if (entry.kind !== "file" || !entry.name.endsWith(".json")) continue;
+        const ruleId = entry.name.replace(/\.json$/, "");
+        if (!registered.has(ruleId)) {
+          refusals.push({
+            kind: "baseline-refusal",
+            ruleId,
+            path: path.join(context.baselinesDir, entry.name),
+            reason: "orphan-baseline",
+            message: `Baseline file '${entry.name}' has no registered Habitat rule.`,
+          });
+        }
+      }
+    }
+
+    for (const rule of context.registry) {
+      const state = yield* loadBaselineStateEffect(rule, context);
+      states.set(rule.id, state);
+      if (state.kind === "baseline-refusal") refusals.push(state);
+    }
+
+    return { states, refusals };
+  });
+}
+
+export function checkBaselineIntegrityEffect(
+  base = "main",
+  options: BaselineAuthorityContext = {}
+): Effect.Effect<
+  BaselineIntegrityResult,
+  never,
+  HabitatFileSystem | GitProvider | GitProviderRequirements
+> {
+  return Effect.gen(function* () {
+    const context = yield* resolveBaselineAuthorityContext(options);
+    const contract = yield* validateBaselineContractEffect(context);
+    const refusals: BaselineRefusal[] = [...contract.refusals];
+
+    const mb = yield* mergeBaseEffect(base, context);
+    if (!mb) {
+      return refused([
+        {
+          kind: "baseline-refusal",
+          path: ".",
+          reason: "comparison-base-unavailable",
+          message: `Unable to resolve a trusted comparison base for '${base}'.`,
+        },
+        ...refusals,
+      ]);
+    }
+
+    const baseRules = yield* loadBaseRuleIdsEffect(mb, context);
+    if (!baseRules.ok) return refused([baseRules.refusal, ...refusals]);
+
+    for (const [ruleId, state] of contract.states) {
+      if (state.kind !== "explicit-empty" && state.kind !== "explicit-debt") continue;
+      const before = yield* loadBaseBaselineKeysEffect(mb, ruleId, context);
+      if (!before.ok) {
+        refusals.push(before.refusal);
+        continue;
+      }
+      const previous = new Set<string>(before.keys);
+      const added = state.keys.filter((key) => !previous.has(key));
+      if (added.length === 0) continue;
+      if (baseRules.ruleIds.has(ruleId)) {
+        refusals.push({
+          kind: "baseline-refusal",
+          ruleId,
+          path: baselineRepoPath(ruleId),
+          reason: "baseline-growth-existing-rule",
+          addedKeys: added,
+          message:
+            `baseline for existing rule '${ruleId}' grew by ${added.length} entr${added.length === 1 ? "y" : "ies"} ` +
+            `relative to merge-base ${mb.slice(0, 9)}; baselines are shrink-only outside rule-introduction changes`,
+        });
+        continue;
+      }
+
+      const manifest = acceptedRuleIntroductionManifest(ruleId, added, base, context);
+      if (!manifest.ok) refusals.push(manifest.refusal);
+    }
+
+    return refusals.length > 0 ? refused(refusals) : { status: "accepted", refusals: [] };
+  });
+}
+
+export function baselineIntegrityFindingsEffect(result: BaselineIntegrityResult) {
+  return Effect.succeed(
+    result.status === "accepted" ? [] : result.refusals.map(findingFromRefusal)
+  );
+}
+
+export function guardBaselineExpansionEffect(
+  ruleId: string,
+  keys: readonly string[],
+  base = "main",
+  options: BaselineAuthorityContext = {}
+): Effect.Effect<
+  BaselineExpansionDecision,
+  never,
+  HabitatFileSystem | GitProvider | GitProviderRequirements
+> {
+  return Effect.gen(function* () {
+    const context = yield* resolveBaselineAuthorityContext(options);
+    const uniqueKeys = sortedUnique(keys);
+    const mb = yield* mergeBaseEffect(base, context);
+    const baselinePath = baselineRepoPath(ruleId);
+    if (!mb) {
+      return expansionRefusal({
+        kind: "baseline-refusal",
+        ruleId,
+        path: baselinePath,
+        reason: "comparison-base-unavailable",
+        message: `Refusing baseline write for '${ruleId}': unable to resolve comparison base '${base}'.`,
+      });
+    }
+
+    const baseRules = yield* loadBaseRuleIdsEffect(mb, context);
+    if (!baseRules.ok) {
+      return expansionRefusal({
+        ...baseRules.refusal,
+        ruleId,
+        path: baselinePath,
+        message: `Refusing baseline write for '${ruleId}': ${baseRules.refusal.message}`,
+      });
+    }
+
+    if (baseRules.ruleIds.has(ruleId)) {
+      return expansionRefusal({
+        kind: "baseline-refusal",
+        ruleId,
+        path: baselinePath,
+        reason: "baseline-growth-existing-rule",
+        addedKeys: uniqueKeys,
+        message:
+          `Refusing baseline write for existing rule '${ruleId}': ${uniqueKeys.length} new ` +
+          `baseline key${uniqueKeys.length === 1 ? "" : "s"} would grow tracked debt relative to ${mb.slice(0, 9)}.`,
+      });
+    }
+
+    const manifest = acceptedRuleIntroductionManifest(ruleId, uniqueKeys, base, context);
+    if (!manifest.ok) return expansionRefusal(manifest.refusal);
+
+    return {
+      status: "accepted",
+      ruleId,
+      baselinePath,
+      keys: uniqueKeys,
+      comparisonBase: base,
+      message: `baseline write accepted for introduced rule '${ruleId}'`,
+    };
+  });
+}
+
+export function writeBaselineEffect(
+  ruleId: string,
+  keys: readonly string[],
+  options: BaselineAuthorityContext = {}
+): Effect.Effect<void, FileWriteFailed, HabitatFileSystem> {
+  return Effect.gen(function* () {
+    const context = yield* resolveBaselineAuthorityContext(options);
+    const fs = yield* HabitatFileSystem;
+    yield* fs.makeDirectory(context.baselinesDir);
+    yield* fs.writeText(
+      baselinePathForRule(ruleId, context),
+      `${JSON.stringify([...keys].sort(), null, 2)}\n`
+    );
+  });
+}
+
+function resolveBaselineAuthorityContext(
+  options: BaselineAuthorityContext = {}
+): Effect.Effect<RequiredBaselineAuthorityContext, never, HabitatFileSystem> {
+  const root = options.repoRoot ?? repoRoot;
+  return Effect.gen(function* () {
+    return {
+      repoRoot: root,
+      baselinesDir: options.baselinesDir ?? baselinesDir,
+      registry: options.registry ?? (yield* readCurrentRuleRegistryEffect(root)),
+      ruleIntroductionManifests: options.ruleIntroductionManifests ?? [],
+    };
+  });
+}
+
+function readCurrentRuleRegistryEffect(
+  root: string
+): Effect.Effect<BaselineRuleContractInput[], never, HabitatFileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* HabitatFileSystem;
+    const registryPath = path.join(root, ruleRegistryRepoPath, "rules.json");
+    const raw = yield* fs.readText(registryPath).pipe(Effect.catchAll(() => Effect.succeed(null)));
+    if (raw === null) return [];
+    try {
+      const parsed = parseRuleRegistryDocument(JSON.parse(raw), registryPath);
+      if (!parsed.ok) return [];
+      const selectorsByRuleId = new Map(
+        ruleSelectorFacts(parsed.document.rules).map((fact) => [fact.id, fact])
+      );
+      return ruleBaselineFacts(parsed.document.rules).map((fact) => {
+        const selector = selectorsByRuleId.get(fact.id);
+        return {
+          ...fact,
+          ...(selector
+            ? {
+                ownerProject: selector.ownerProject,
+                ownerTool: selector.ownerTool,
+              }
+            : {}),
+        };
+      });
+    } catch {
+      return [];
+    }
+  });
+}
+
+function parseBaselineFileEffect(
+  filePath: string,
+  ruleId: string,
+  context: RequiredBaselineAuthorityContext
+) {
+  return Effect.gen(function* () {
+    const fs = yield* HabitatFileSystem;
+    const raw = yield* fs.readText(filePath).pipe(Effect.either);
+    if (raw._tag === "Left") {
+      return {
+        kind: "baseline-refusal" as const,
+        ruleId,
+        path: toAuthorityRelative(filePath, context),
+        reason: "malformed-baseline" as const,
+        message: `Baseline '${toAuthorityRelative(filePath, context)}' is not readable JSON: ${renderHabitatError(raw.left)}.`,
+      };
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw.right);
+    } catch (error) {
+      return {
+        kind: "baseline-refusal" as const,
+        ruleId,
+        path: toAuthorityRelative(filePath, context),
+        reason: "malformed-baseline" as const,
+        message: `Baseline '${toAuthorityRelative(filePath, context)}' is not readable JSON: ${errorMessage(error)}.`,
+      };
+    }
+
+    const keys = parseBaselineArray(parsed, toAuthorityRelative(filePath, context), ruleId);
+    if (!keys.ok) return keys.refusal;
+    return keys.keys.length === 0
+      ? {
+          kind: "explicit-empty" as const,
+          ruleId,
+          path: toAuthorityRelative(filePath, context),
+          locked: true as const,
+          keys: [] as [],
+        }
+      : {
+          kind: "explicit-debt" as const,
+          ruleId,
+          path: toAuthorityRelative(filePath, context),
+          locked: false as const,
+          keys: keys.keys,
+        };
+  });
+}
+
+function fileExists(filePath: string): Effect.Effect<boolean, never, HabitatFileSystem> {
+  return HabitatFileSystem.pipe(
+    Effect.flatMap((fs) => fs.isFile(filePath)),
+    Effect.catchAll(() => Effect.succeed(false))
+  );
+}
+
+function directoryExists(directoryPath: string): Effect.Effect<boolean, never, HabitatFileSystem> {
+  return HabitatFileSystem.pipe(
+    Effect.flatMap((fs) => fs.isDirectory(directoryPath)),
+    Effect.catchAll(() => Effect.succeed(false))
+  );
+}
+
+function mergeBaseEffect(
+  base: string,
+  context: RequiredBaselineAuthorityContext
+): Effect.Effect<string | null, never, GitProvider | GitProviderRequirements> {
+  return Effect.gen(function* () {
+    const git = yield* GitProvider;
+    for (const ref of [base, `origin/${base}`]) {
+      const mb = yield* git.mergeBase(ref, { cwd: context.repoRoot });
+      if (mb) return mb;
+    }
+    return null;
+  });
+}
+
+function loadBaseRuleIdsEffect(
+  mb: string,
+  context: RequiredBaselineAuthorityContext
+): Effect.Effect<
+  { ok: true; ruleIds: Set<string> } | { ok: false; refusal: BaselineRefusal },
+  never,
+  GitProvider | GitProviderRequirements
+> {
+  return Effect.gen(function* () {
+    const registryPath = ruleRegistryRepoPath;
+    const rulePackAtBase = yield* gitShowMovedAuthoredArtifactEffect(
+      mb,
+      `${registryPath}/rules.json`,
+      preD14aAuthoredArtifactPaths.ruleRegistry,
+      context
+    );
+    if (rulePackAtBase === null) {
+      const ruleIds = yield* loadBaseRuleIdsFromDirectoryEffect(mb, registryPath, context);
+      if (ruleIds) return { ok: true, ruleIds };
+      return {
+        ok: false,
+        refusal: {
+          kind: "baseline-refusal",
+          path: registryPath,
+          reason: "base-rule-registry-missing",
+          message: `Unable to read base rule registry at ${mb.slice(0, 9)}.`,
+        },
+      };
+    }
+    try {
+      const parsedRaw = JSON.parse(rulePackAtBase.contents);
+      const parsed = parseRuleRegistryDocument(parsedRaw, registryPath);
+      if (!parsed.ok) {
+        const baseRuleIds = baseRuleIdsFromHistoricalRegistry(parsedRaw);
+        if (baseRuleIds) return { ok: true, ruleIds: baseRuleIds };
+        throw new Error(parsed.issues.map((issue) => `${issue.path}: ${issue.message}`).join("; "));
+      }
+      return { ok: true, ruleIds: new Set(parsed.document.rules.map((rule) => rule.id)) };
+    } catch (error) {
+      return {
+        ok: false,
+        refusal: {
+          kind: "baseline-refusal",
+          path: registryPath,
+          reason: "base-rule-registry-malformed",
+          message: `Unable to parse base rule registry at ${mb.slice(0, 9)}: ${errorMessage(error)}`,
+        },
+      };
+    }
+  });
+}
+
+function loadBaseRuleIdsFromDirectoryEffect(
+  mb: string,
+  registryPath: string,
+  context: RequiredBaselineAuthorityContext
+): Effect.Effect<Set<string> | null, never, GitProvider | GitProviderRequirements> {
+  return Effect.gen(function* () {
+    const git = yield* GitProvider;
+    const lines = yield* git.lsTreeNameOnly(mb, registryPath, { cwd: context.repoRoot });
+    if (lines === null) return null;
+    const ids = lines
+      .filter((line) => line.startsWith(`${registryPath}/`) && line.endsWith("/rule.json"))
+      .map((line) => line.slice(`${registryPath}/`.length, -"/rule.json".length))
+      .filter(Boolean)
+      .sort();
+    return ids.length === 0 ? null : new Set(ids);
+  });
+}
+
+function loadBaseBaselineKeysEffect(
+  mb: string,
+  ruleId: string,
+  context: RequiredBaselineAuthorityContext
+): Effect.Effect<
+  { ok: true; keys: string[] } | { ok: false; refusal: BaselineRefusal },
+  never,
+  GitProvider | GitProviderRequirements
+> {
+  return Effect.gen(function* () {
+    const baselinePath = baselineRepoPath(ruleId);
+    const beforeRaw = yield* gitShowMovedAuthoredArtifactEffect(
+      mb,
+      baselinePath,
+      preD14aAuthoredArtifactPaths.baseline(ruleId),
+      context
+    );
+    if (beforeRaw === null) return { ok: true, keys: [] };
+    try {
+      const parsed = parseBaselineArray(JSON.parse(beforeRaw.contents), baselinePath, ruleId);
+      return parsed.ok
+        ? { ok: true, keys: parsed.keys }
+        : { ok: false, refusal: { ...parsed.refusal, reason: "base-baseline-unreadable" } };
+    } catch (error) {
+      return {
+        ok: false,
+        refusal: {
+          kind: "baseline-refusal",
+          ruleId,
+          path: baselinePath,
+          reason: "base-baseline-unreadable",
+          message: `Unable to read base baseline for '${ruleId}' at ${mb.slice(0, 9)}: ${errorMessage(error)}`,
+        },
+      };
+    }
+  });
+}
+
+function gitShowMovedAuthoredArtifactEffect(
+  ref: string,
+  currentRepoPath: string,
+  previousRepoPath: string,
+  context: RequiredBaselineAuthorityContext
+): Effect.Effect<{ contents: string } | null, never, GitProvider | GitProviderRequirements> {
+  return Effect.gen(function* () {
+    const git = yield* GitProvider;
+    const current = yield* git.show(ref, currentRepoPath, { cwd: context.repoRoot });
+    if (current !== null) return { contents: current };
+
+    const previous = yield* git.show(ref, previousRepoPath, { cwd: context.repoRoot });
+    return previous === null ? null : { contents: previous };
+  });
+}
+
+function baseRuleIdsFromHistoricalRegistry(value: unknown): Set<string> | null {
+  if (!value || typeof value !== "object" || !("rules" in value)) return null;
+  const rules = (value as { rules: unknown }).rules;
+  if (!Array.isArray(rules)) return null;
+
+  const ruleIds: string[] = [];
+  for (const rule of rules) {
+    if (!rule || typeof rule !== "object" || !("id" in rule)) return null;
+    const id = (rule as { id: unknown }).id;
+    if (typeof id !== "string" || id.length === 0) return null;
+    ruleIds.push(id);
+  }
+  return new Set(ruleIds);
+}
+
+function acceptedRuleIntroductionManifest(
+  ruleId: string,
+  keys: readonly string[],
+  base: string,
+  context: RequiredBaselineAuthorityContext
+): { ok: true } | { ok: false; refusal: BaselineRefusal } {
+  const manifest = context.ruleIntroductionManifests.find(
+    (candidate) => candidate.ruleId === ruleId
+  );
+  const baselinePath = baselineRepoPath(ruleId);
+  if (!manifest) {
+    return {
+      ok: false,
+      refusal: {
+        kind: "baseline-refusal",
+        ruleId,
+        path: baselinePath,
+        reason: "rule-introduction-manifest-missing",
+        addedKeys: sortedUnique(keys),
+        message:
+          `baseline for introduced rule '${ruleId}' has seeded keys but no accepted rule-introduction ` +
+          "baseline manifest; refusing baseline growth",
+      },
+    };
+  }
+
+  const sortedKeys = sortedUnique(keys);
+  const manifestKeys = sortedUnique(manifest.initialBaselineKeys);
+  const currentRule = context.registry.find((rule) => rule.id === ruleId);
+  if (
+    manifest.comparisonBase !== base ||
+    manifest.baselinePath !== baselinePath ||
+    manifest.ownerProject !== currentRule?.ownerProject ||
+    manifest.ownerTool !== currentRule?.ownerTool ||
+    manifestKeys.length !== manifest.initialBaselineKeys.length ||
+    !sameLengthList(manifestKeys, sortedKeys)
+  ) {
+    return {
+      ok: false,
+      refusal: {
+        kind: "baseline-refusal",
+        ruleId,
+        path: baselinePath,
+        reason: "rule-introduction-manifest-mismatch",
+        addedKeys: sortedUnique(keys),
+        message: `rule-introduction baseline manifest for '${ruleId}' does not match the requested write`,
+      },
+    };
+  }
+  return { ok: true };
+}
+
+function refused(refusals: BaselineRefusal[]): BaselineIntegrityResult {
+  return { status: "refused", refusals };
+}
+
+function expansionRefusal(refusal: BaselineRefusal): BaselineExpansionDecision {
+  return { status: "refused", refusal, message: refusal.message };
+}
+
+function findingFromRefusal(refusal: BaselineRefusal): BaselineIntegrityFinding {
+  return {
+    file: refusal.path ?? ".",
+    ruleId: refusal.ruleId ?? "baseline-integrity",
+    addedKeys: refusal.addedKeys ?? [],
+    reason: `baseline contract failure (${refusal.reason}): ${refusal.message}`,
+  };
+}
+
+function baselinePathForRule(
+  ruleId: string,
+  context: Pick<RequiredBaselineAuthorityContext, "baselinesDir">
+): string {
+  return path.join(context.baselinesDir, `${ruleId}.json`);
+}
+
+function toAuthorityRelative(
+  filePath: string,
+  context: Pick<RequiredBaselineAuthorityContext, "repoRoot">
+): string {
+  return externalSourceFilePath(
+    path.relative(context.repoRoot, path.resolve(filePath)).split(path.sep).join("/")
+  );
+}
+
+function sameLengthList(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}

--- a/tools/habitat-harness/src/domains/baseline-authority/service.ts
+++ b/tools/habitat-harness/src/domains/baseline-authority/service.ts
@@ -1,13 +1,17 @@
 import { Context, Effect, Layer } from "effect";
+import type { FileWriteFailed } from "../../errors/index.js";
 import type { HabitatDiagnostic } from "../../lib/diagnostics.js";
+import type { GitProvider, GitProviderRequirements } from "../../providers/git/index.js";
+import type { HabitatFileSystem } from "../../resources/index.js";
 import { applyBaseline, baselineFailureDiagnostic } from "./application.js";
-import type { BaselineContractContext } from "./context.js";
+import type { BaselineAuthorityContext } from "./context.js";
 import {
-  baselineIntegrityFindings,
-  checkBaselineIntegrity,
-  guardBaselineExpansion,
-  writeBaseline,
-} from "./integrity.js";
+  baselineIntegrityFindingsEffect,
+  checkBaselineIntegrityEffect,
+  guardBaselineExpansionEffect,
+  loadBaselineStateEffect,
+  writeBaselineEffect,
+} from "./operations.js";
 import type {
   BaselineApplicationResult,
   BaselineAuthorityState,
@@ -17,13 +21,13 @@ import type {
   BaselineRefusal,
   BaselineRuleContractInput,
 } from "./schema.js";
-import { isBaselineLocked, loadBaselineState } from "./state.js";
+import { isBaselineLocked } from "./state.js";
 
 export interface BaselineAuthorityService {
   readonly loadState: (
     rule: BaselineRuleContractInput,
-    options?: BaselineContractContext
-  ) => Effect.Effect<BaselineAuthorityState>;
+    options?: BaselineAuthorityContext
+  ) => Effect.Effect<BaselineAuthorityState, never, HabitatFileSystem>;
   readonly apply: (
     diagnostics: HabitatDiagnostic[],
     baseline: Set<string> | BaselineAuthorityState
@@ -35,8 +39,12 @@ export interface BaselineAuthorityService {
   ) => Effect.Effect<HabitatDiagnostic>;
   readonly checkIntegrity: (
     base?: string,
-    options?: BaselineContractContext
-  ) => Effect.Effect<BaselineIntegrityResult>;
+    options?: BaselineAuthorityContext
+  ) => Effect.Effect<
+    BaselineIntegrityResult,
+    never,
+    HabitatFileSystem | GitProvider | GitProviderRequirements
+  >;
   readonly integrityFindings: (
     result: BaselineIntegrityResult
   ) => Effect.Effect<BaselineIntegrityFinding[]>;
@@ -44,13 +52,17 @@ export interface BaselineAuthorityService {
     ruleId: string,
     keys: readonly string[],
     base?: string,
-    options?: BaselineContractContext
-  ) => Effect.Effect<BaselineExpansionDecision>;
+    options?: BaselineAuthorityContext
+  ) => Effect.Effect<
+    BaselineExpansionDecision,
+    never,
+    HabitatFileSystem | GitProvider | GitProviderRequirements
+  >;
   readonly write: (
     ruleId: string,
     keys: string[],
-    options?: BaselineContractContext
-  ) => Effect.Effect<void>;
+    options?: BaselineAuthorityContext
+  ) => Effect.Effect<void, FileWriteFailed, HabitatFileSystem>;
 }
 
 export class BaselineAuthority extends Context.Tag("@internal/habitat-harness/BaselineAuthority")<
@@ -59,16 +71,16 @@ export class BaselineAuthority extends Context.Tag("@internal/habitat-harness/Ba
 >() {}
 
 export const BaselineAuthorityLive = Layer.succeed(BaselineAuthority, {
-  loadState: (rule, options) => Effect.sync(() => loadBaselineState(rule, options)),
+  loadState: (rule, options) => loadBaselineStateEffect(rule, options),
   apply: (diagnostics, baseline) => Effect.sync(() => applyBaseline(diagnostics, baseline)),
   isLocked: (state) => Effect.sync(() => isBaselineLocked(state)),
   failureDiagnostic: (ruleId, refusal) =>
     Effect.sync(() => baselineFailureDiagnostic(ruleId, refusal)),
-  checkIntegrity: (base, options) => Effect.sync(() => checkBaselineIntegrity(base, options)),
-  integrityFindings: (result) => Effect.sync(() => baselineIntegrityFindings(result)),
+  checkIntegrity: (base, options) => checkBaselineIntegrityEffect(base, options),
+  integrityFindings: baselineIntegrityFindingsEffect,
   guardExpansion: (ruleId, keys, base, options) =>
-    Effect.sync(() => guardBaselineExpansion(ruleId, keys, base, options)),
-  write: (ruleId, keys, options) => Effect.sync(() => writeBaseline(ruleId, keys, options)),
+    guardBaselineExpansionEffect(ruleId, keys, base, options),
+  write: (ruleId, keys, options) => writeBaselineEffect(ruleId, keys, options),
 });
 
 export function makeFakeBaselineAuthorityLayer(service: BaselineAuthorityService) {

--- a/tools/habitat-harness/src/domains/structural-check/baseline-expansion.ts
+++ b/tools/habitat-harness/src/domains/structural-check/baseline-expansion.ts
@@ -4,8 +4,10 @@ import { GritProvider, type GritProviderRequirements } from "../../adapters/grit
 import type { HabitatConfig } from "../../config/index.js";
 import type { RuleSelection } from "../../domains/rule-selection/index.js";
 import { type RuleSelectionResult, selectRules } from "../../domains/rule-selection/index.js";
+import { renderHabitatError } from "../../errors/index.js";
 import { CommandRunner } from "../../providers/command/index.js";
-import type { HabitatClock } from "../../resources/index.js";
+import type { GitProvider, GitProviderRequirements } from "../../providers/git/index.js";
+import type { HabitatClock, HabitatFileSystem } from "../../resources/index.js";
 import { BaselineAuthority, violationKey } from "../baseline-authority/index.js";
 import {
   activeRuleBaselineFacts,
@@ -36,6 +38,9 @@ export function expandBaselinesEffect(
   | GritProvider
   | GritProviderRequirements
   | HabitatConfig
+  | HabitatFileSystem
+  | GitProvider
+  | GitProviderRequirements
   | HabitatClock
 > {
   return Effect.gen(function* () {
@@ -93,7 +98,18 @@ export function expandBaselinesEffect(
             message: guard.message,
           };
         }
-        yield* baselineAuthority.write(rule.id, guard.keys);
+        const writeFailure = yield* baselineAuthority.write(rule.id, guard.keys).pipe(
+          Effect.as(null),
+          Effect.catchAll((error) => Effect.succeed(error))
+        );
+        if (writeFailure) {
+          return {
+            ok: false,
+            requested: selection,
+            reason: "baseline-contract",
+            message: `Unable to write baseline for '${rule.id}': ${renderHabitatError(writeFailure)}`,
+          };
+        }
         messages.push(`baseline written: ${rule.id} (${keys.length} entries)`);
       }
     }

--- a/tools/habitat-harness/src/domains/structural-check/execution.ts
+++ b/tools/habitat-harness/src/domains/structural-check/execution.ts
@@ -12,11 +12,8 @@ import {
   type StagedMutationPath,
   stagedPathsFromNameStatus,
 } from "../../lib/protected-zones/index.js";
-import {
-  CommandRunner,
-  type HabitatCommandResult,
-  runSyncSpawnCommand,
-} from "../../providers/command/index.js";
+import { CommandRunner, type HabitatCommandResult } from "../../providers/command/index.js";
+import { GitProvider, type GitProviderRequirements } from "../../providers/git/index.js";
 import { readWorkspaceGraph } from "../../providers/nx/graph.js";
 import { HabitatClock } from "../../resources/index.js";
 import { type RuleRunResult, ruleDiagnosticsFromCommandResult } from "../../rules/architecture.js";
@@ -89,6 +86,8 @@ export function executeSelectedRulesEffect(
   | GritProviderRequirements
   | HabitatConfig
   | HabitatClock
+  | GitProvider
+  | GitProviderRequirements
 > {
   return Effect.gen(function* () {
     const results = new Map<string, RuleExecutionRecord>();
@@ -97,7 +96,7 @@ export function executeSelectedRulesEffect(
     if (gritRules.length > 0) {
       const scanRoots = options.staged
         ? stagedPatternScanRoots(
-            options.stagedPaths ?? currentStagedPaths(),
+            options.stagedPaths ?? (yield* currentStagedPathsEffect()),
             approvedScanRootsForRules(gritRules)
           )
         : undefined;
@@ -149,7 +148,7 @@ export function executeSelectedRulesEffect(
       commandRules.filter((rule) => !graphRefusals.has(rule.id)),
       results
     );
-    executeFileLayerRules(
+    yield* executeFileLayerRulesEffect(
       factsForRuleIds(activeRuleFileLayerFacts, selectedRuleIds),
       results,
       options
@@ -268,39 +267,42 @@ function isHabitatError(error: unknown): error is HabitatError {
   return Boolean(error && typeof error === "object" && "_tag" in error);
 }
 
-function executeFileLayerRules(
+function executeFileLayerRulesEffect(
   fileLayerRules: readonly RuleFileLayerFacts[],
   results: Map<string, RuleExecutionRecord>,
   options: Pick<CheckOptions, "staged" | "stagedPaths">
-): void {
-  const stagedPathsResult =
-    options.staged && options.stagedPaths
-      ? modifiedStagedPaths(options.stagedPaths)
-      : options.staged
-        ? currentStagedPathActions()
-        : undefined;
-  for (const rule of fileLayerRules) {
-    const started = Date.now();
-    if (isStagedPathReadFailure(stagedPathsResult)) {
-      const durationMs = Date.now() - started;
-      results.set(rule.id, {
-        result: {
-          exitCode: 1,
-          diagnostics: [stagedPathReadFailureDiagnostic(rule, stagedPathsResult.message)],
-        },
-        durationMs,
-        disposition: { kind: "executed", durationMs },
+): Effect.Effect<void, never, HabitatClock | GitProvider | GitProviderRequirements> {
+  return Effect.gen(function* () {
+    const clock = yield* HabitatClock;
+    const stagedPathsResult =
+      options.staged && options.stagedPaths
+        ? modifiedStagedPaths(options.stagedPaths)
+        : options.staged
+          ? yield* currentStagedPathActionsEffect()
+          : undefined;
+    for (const rule of fileLayerRules) {
+      const started = yield* clock.currentTimeMillis;
+      if (isStagedPathReadFailure(stagedPathsResult)) {
+        const durationMs = Math.max(0, (yield* clock.currentTimeMillis) - started);
+        results.set(rule.id, {
+          result: {
+            exitCode: 1,
+            diagnostics: [stagedPathReadFailureDiagnostic(rule, stagedPathsResult.message)],
+          },
+          durationMs,
+          disposition: { kind: "executed", durationMs },
+        });
+        continue;
+      }
+      const stagedPaths = stagedPathsResult ? stagedPathsResult : undefined;
+      const result = runFileLayerProtectedMutationRule(rule, {
+        staged: options.staged,
+        ...(stagedPaths ? { stagedPaths } : {}),
       });
-      continue;
+      const durationMs = Math.max(0, (yield* clock.currentTimeMillis) - started);
+      results.set(rule.id, { result, durationMs, disposition: { kind: "executed", durationMs } });
     }
-    const stagedPaths = stagedPathsResult ? stagedPathsResult : undefined;
-    const result = runFileLayerProtectedMutationRule(rule, {
-      staged: options.staged,
-      ...(stagedPaths ? { stagedPaths } : {}),
-    });
-    const durationMs = Date.now() - started;
-    results.set(rule.id, { result, durationMs, disposition: { kind: "executed", durationMs } });
-  }
+  });
 }
 
 type StagedPathActionReadResult = StagedMutationPath[] | { ok: false; message: string };
@@ -311,20 +313,31 @@ function isStagedPathReadFailure(
   return Boolean(result && "ok" in result && !result.ok);
 }
 
-function currentStagedPathActions(): StagedPathActionReadResult {
-  const result = runSyncSpawnCommand(["git", "diff", "--cached", "--name-status", "-z"], {
-    cwd: repoRoot,
+function currentStagedPathActionsEffect(): Effect.Effect<
+  StagedPathActionReadResult,
+  never,
+  GitProvider | GitProviderRequirements
+> {
+  return Effect.gen(function* () {
+    const git = yield* GitProvider;
+    const result = yield* git.diffNameStatus({ cached: true, cwd: repoRoot }).pipe(Effect.either);
+    if (result._tag === "Left") {
+      return {
+        ok: false,
+        message: renderHabitatError(result.left),
+      };
+    }
+    if (result.right.exit.code !== 0) {
+      return {
+        ok: false,
+        message:
+          result.right.stderr.text.trim() ||
+          `Unable to read staged path actions with git diff --cached --name-status -z (exit ${result.right.exit.code}).`,
+      };
+    }
+    if (!result.right.stdout.text) return [];
+    return stagedPathsFromNameStatus(result.right.stdout.text);
   });
-  if (result.exitCode !== 0) {
-    return {
-      ok: false,
-      message:
-        result.stderr.trim() ||
-        `Unable to read staged path actions with git diff --cached --name-status -z (exit ${result.exitCode}).`,
-    };
-  }
-  if (!result.stdout) return [];
-  return stagedPathsFromNameStatus(result.stdout);
 }
 
 function stagedPathReadFailureDiagnostic(
@@ -340,12 +353,19 @@ function stagedPathReadFailureDiagnostic(
   };
 }
 
-function currentStagedPaths(): string[] {
-  const result = runSyncSpawnCommand(["git", "diff", "--cached", "--name-only", "-z"], {
-    cwd: repoRoot,
+function currentStagedPathsEffect(): Effect.Effect<
+  string[],
+  never,
+  GitProvider | GitProviderRequirements
+> {
+  return Effect.gen(function* () {
+    const git = yield* GitProvider;
+    const result = yield* git.diffNameOnly({ cached: true, cwd: repoRoot }).pipe(Effect.either);
+    if (result._tag === "Left" || result.right.exit.code !== 0 || !result.right.stdout.text) {
+      return [];
+    }
+    return result.right.stdout.text.split("\0").filter(Boolean).map(toRepoRelative);
   });
-  if (result.exitCode !== 0 || !result.stdout) return [];
-  return result.stdout.split("\0").filter(Boolean).map(toRepoRelative);
 }
 
 function sortedUnique(values: readonly string[]): string[] {

--- a/tools/habitat-harness/src/domains/structural-check/report.ts
+++ b/tools/habitat-harness/src/domains/structural-check/report.ts
@@ -5,7 +5,8 @@ import { GritProvider, type GritProviderRequirements } from "../../adapters/grit
 import type { HabitatConfig } from "../../config/index.js";
 import { selectRules } from "../../domains/rule-selection/index.js";
 import { CommandRunner } from "../../providers/command/index.js";
-import { HabitatClock } from "../../resources/index.js";
+import type { GitProvider, GitProviderRequirements } from "../../providers/git/index.js";
+import { HabitatClock, type HabitatFileSystem } from "../../resources/index.js";
 import { type BaselineApplicationResult, BaselineAuthority } from "../baseline-authority/index.js";
 import { activeRuleReportFacts, factsForRuleIds } from "../rule-registry/active-facts.js";
 import type { RuleReportFacts } from "../rule-registry/index.js";
@@ -37,6 +38,9 @@ export function createCheckReportEffect(
   | GritProvider
   | GritProviderRequirements
   | HabitatConfig
+  | HabitatFileSystem
+  | GitProvider
+  | GitProviderRequirements
   | HabitatClock
 > {
   return Effect.gen(function* () {
@@ -192,7 +196,11 @@ function ruleReportFromDiagnostics(input: {
 
 function baselineIntegrityReportEffect(
   base: string
-): Effect.Effect<RuleReport, never, BaselineAuthority | HabitatClock> {
+): Effect.Effect<
+  RuleReport,
+  never,
+  BaselineAuthority | HabitatClock | HabitatFileSystem | GitProvider | GitProviderRequirements
+> {
   return Effect.gen(function* () {
     const baselineAuthority = yield* BaselineAuthority;
     const clock = yield* HabitatClock;

--- a/tools/habitat-harness/src/domains/structural-check/service.ts
+++ b/tools/habitat-harness/src/domains/structural-check/service.ts
@@ -4,7 +4,8 @@ import type { GritProvider, GritProviderRequirements } from "../../adapters/grit
 import type { HabitatConfig } from "../../config/index.js";
 import type { RuleSelection } from "../../domains/rule-selection/index.js";
 import type { CommandRunner } from "../../providers/command/index.js";
-import type { HabitatClock } from "../../resources/index.js";
+import type { GitProvider, GitProviderRequirements } from "../../providers/git/index.js";
+import type { HabitatClock, HabitatFileSystem } from "../../resources/index.js";
 import type { BaselineAuthority } from "../baseline-authority/index.js";
 import type { BaselineExpansionResult } from "./baseline-expansion.js";
 import { expandBaselinesEffect } from "./baseline-expansion.js";
@@ -24,6 +25,9 @@ export interface StructuralCheckService {
     | GritProvider
     | GritProviderRequirements
     | HabitatConfig
+    | HabitatFileSystem
+    | GitProvider
+    | GitProviderRequirements
     | HabitatClock
   >;
   readonly expandBaselines: (
@@ -38,6 +42,9 @@ export interface StructuralCheckService {
     | GritProvider
     | GritProviderRequirements
     | HabitatConfig
+    | HabitatFileSystem
+    | GitProvider
+    | GitProviderRequirements
     | HabitatClock
   >;
 }

--- a/tools/habitat-harness/src/providers/git/index.ts
+++ b/tools/habitat-harness/src/providers/git/index.ts
@@ -7,7 +7,11 @@ import type { HabitatClock } from "../../resources/index.js";
 import { CommandRunner, spawnResultFromCommandResult } from "../command/index.js";
 import type { HabitatCommandResult } from "../command/types.js";
 
-type GitProviderRequirements = CommandExecutor | HabitatConfig | HabitatClock | CommandRunner;
+export type GitProviderRequirements =
+  | CommandExecutor
+  | HabitatConfig
+  | HabitatClock
+  | CommandRunner;
 type GitCommandEffect = Effect.Effect<
   HabitatCommandResult,
   CommandProviderError,
@@ -27,6 +31,12 @@ export interface GitProviderService {
   readonly statusShortBranch: (options?: GitCommandOptions) => GitCommandEffect;
   readonly remoteDefaultBranch: (options?: GitCommandOptions) => GitTextEffect;
   readonly mergeBase: (ref: string, options?: GitCommandOptions) => GitTextEffect;
+  readonly show: (ref: string, repoPath: string, options?: GitCommandOptions) => GitTextEffect;
+  readonly lsTreeNameOnly: (
+    ref: string,
+    repoPath: string,
+    options?: GitCommandOptions
+  ) => Effect.Effect<readonly string[] | null, never, GitProviderRequirements>;
   readonly add: (paths: readonly string[], options?: GitCommandOptions) => GitCommandEffect;
   readonly diffNameOnly: (
     input?: { cached?: boolean; paths?: readonly string[] } & GitCommandOptions
@@ -89,6 +99,18 @@ function providerFromCommand(command: GitProviderService["command"]): GitProvide
         command(["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], options)
       ),
     mergeBase: (ref, options) => textOrNull(command(["merge-base", "HEAD", ref], options)),
+    show: (ref, repoPath, options) => textOrNull(command(["show", `${ref}:${repoPath}`], options)),
+    lsTreeNameOnly: (ref, repoPath, options) =>
+      textOrNull(command(["ls-tree", "-r", "--name-only", ref, repoPath], options)).pipe(
+        Effect.map((stdout) =>
+          stdout === null
+            ? null
+            : stdout
+                .split("\n")
+                .map((line) => line.trim())
+                .filter(Boolean)
+        )
+      ),
     add: (paths, options) => command(["add", "--", ...paths], options),
     diffNameOnly: (input = {}) =>
       command(

--- a/tools/habitat-harness/src/resources/filesystem.ts
+++ b/tools/habitat-harness/src/resources/filesystem.ts
@@ -1,4 +1,12 @@
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { Context, Effect, Layer } from "effect";
@@ -18,6 +26,10 @@ export interface HabitatFileSystemService {
     targetPath: string
   ) => Effect.Effect<readonly HabitatDirectoryEntry[], FileReadFailed>;
   readonly readText: (targetPath: string) => Effect.Effect<string, FileReadFailed>;
+  readonly writeText: (
+    targetPath: string,
+    contents: string
+  ) => Effect.Effect<void, FileWriteFailed>;
   readonly remove: (targetPath: string) => Effect.Effect<void, FileWriteFailed>;
 }
 
@@ -91,6 +103,15 @@ export const HabitatFileSystemLive = Layer.succeed(HabitatFileSystem, {
           cause: cause instanceof Error ? cause.message : String(cause),
         }),
     }),
+  writeText: (targetPath, contents) =>
+    Effect.try({
+      try: () => writeFileSync(targetPath, contents),
+      catch: (cause) =>
+        new FileWriteFailed({
+          path: targetPath,
+          cause: cause instanceof Error ? cause.message : String(cause),
+        }),
+    }).pipe(Effect.asVoid),
   remove: (targetPath) =>
     Effect.try({
       try: () => rmSync(targetPath, { recursive: true, force: true }),
@@ -151,6 +172,10 @@ export function makeFakeHabitatFileSystemLayer(
             cause: "Fake Habitat filesystem has no text fixture for path.",
           })
         );
+      }),
+    writeText: (targetPath, contents) =>
+      Effect.sync(() => {
+        events.push(`write:${targetPath}:${contents}`);
       }),
     remove: (targetPath) =>
       Effect.sync(() => {

--- a/tools/habitat-harness/src/service/modules/check/router.ts
+++ b/tools/habitat-harness/src/service/modules/check/router.ts
@@ -12,7 +12,8 @@ import {
   StructuralCheck,
 } from "../../../domains/structural-check/index.js";
 import type { CommandRunner } from "../../../providers/command/index.js";
-import type { HabitatClock } from "../../../resources/index.js";
+import type { GitProvider, GitProviderRequirements } from "../../../providers/git/index.js";
+import type { HabitatClock, HabitatFileSystem } from "../../../resources/index.js";
 import type {
   CheckServiceExpandBaselineInput,
   CheckServiceExpandBaselineOutput,
@@ -54,6 +55,9 @@ export function expandCheckBaselinesService(
   | GritProvider
   | GritProviderRequirements
   | HabitatConfig
+  | HabitatFileSystem
+  | GitProvider
+  | GitProviderRequirements
   | HabitatClock
   | StructuralCheck
 > {

--- a/tools/habitat-harness/test/lib/check-baseline-provider-boundary.test.ts
+++ b/tools/habitat-harness/test/lib/check-baseline-provider-boundary.test.ts
@@ -1,0 +1,176 @@
+import { Effect, Layer } from "effect";
+import { describe, expect, test } from "vitest";
+import {
+  BaselineAuthority,
+  BaselineAuthorityLive,
+} from "../../src/domains/baseline-authority/index.js";
+import { activeRuleSelectorFacts } from "../../src/domains/rule-registry/active-facts.js";
+import { executeSelectedRulesEffect } from "../../src/domains/structural-check/execution.js";
+import { captureOutput, makeHabitatCommandResult } from "../../src/providers/command/index.js";
+import { makeFakeGitProviderLayer } from "../../src/providers/git/index.js";
+import {
+  makeFakeHabitatClockLayer,
+  makeFakeHabitatFileSystemLayer,
+} from "../../src/resources/index.js";
+
+describe("check and baseline provider boundaries", () => {
+  test("BaselineAuthorityLive reads integrity state through filesystem and git providers", async () => {
+    const root = "/repo";
+    const baselinesDir = "/repo/.habitat/baselines";
+    const events: string[] = [];
+    const gitCalls: string[][] = [];
+    const registry = [baselineRule("existing-rule")];
+    const layer = Layer.mergeAll(
+      BaselineAuthorityLive,
+      makeFakeHabitatFileSystemLayer(
+        events,
+        new Map([[`${baselinesDir}/existing-rule.json`, "[]\n"]]),
+        new Map([[baselinesDir, [{ name: "existing-rule.json", kind: "file" }]]])
+      ),
+      makeFakeGitProviderLayer((argv, options) => {
+        gitCalls.push([...argv]);
+        if (argv[0] === "merge-base") {
+          return commandResult(argv, options.cwd, "merge-base-sha\n");
+        }
+        if (argv[0] === "show" && argv[1] === "merge-base-sha:.habitat/rules/rules.json") {
+          return commandResult(argv, options.cwd, ruleRegistryJson(["existing-rule"]));
+        }
+        if (
+          argv[0] === "show" &&
+          argv[1] === "merge-base-sha:.habitat/baselines/existing-rule.json"
+        ) {
+          return commandResult(argv, options.cwd, "[]\n");
+        }
+        return commandResult(argv, options.cwd, "", 1, "not found\n");
+      })
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const baseline = yield* BaselineAuthority;
+        return yield* baseline.checkIntegrity("main", {
+          repoRoot: root,
+          baselinesDir,
+          registry,
+        });
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(result).toEqual({ status: "accepted", refusals: [] });
+    expect(events).toEqual([
+      `isDirectory:${baselinesDir}`,
+      `readdir:${baselinesDir}`,
+      `isFile:${baselinesDir}/existing-rule.json`,
+      `read:${baselinesDir}/existing-rule.json`,
+    ]);
+    expect(gitCalls).toEqual([
+      ["merge-base", "HEAD", "main"],
+      ["show", "merge-base-sha:.habitat/rules/rules.json"],
+      ["show", "merge-base-sha:.habitat/baselines/existing-rule.json"],
+    ]);
+  });
+
+  test("BaselineAuthorityLive writes baselines through HabitatFileSystem", async () => {
+    const baselinesDir = "/repo/.habitat/baselines";
+    const events: string[] = [];
+    const layer = Layer.mergeAll(BaselineAuthorityLive, makeFakeHabitatFileSystemLayer(events));
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const baseline = yield* BaselineAuthority;
+        yield* baseline.write("new-rule", ["z::last", "a::first"], {
+          repoRoot: "/repo",
+          baselinesDir,
+          registry: [],
+        });
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(events).toEqual([
+      `mkdir:${baselinesDir}`,
+      `write:${baselinesDir}/new-rule.json:${JSON.stringify(["a::first", "z::last"], null, 2)}\n`,
+    ]);
+  });
+
+  test("staged file-layer checks render GitProvider failures as diagnostics", async () => {
+    const fileLayerRule = activeRuleSelectorFacts.find((rule) => rule.ownerTool === "file-layer");
+    expect(fileLayerRule).toBeDefined();
+    const gitCalls: string[][] = [];
+    const layer = Layer.mergeAll(
+      makeFakeHabitatClockLayer(10),
+      makeFakeGitProviderLayer((argv, options) => {
+        gitCalls.push([...argv]);
+        return commandResult(argv, options.cwd, "", 1, "fake staged diff failure\n");
+      })
+    );
+
+    const results = await Effect.runPromise(
+      executeSelectedRulesEffect([fileLayerRule!], { staged: true }).pipe(Effect.provide(layer))
+    );
+    const record = results.get(fileLayerRule!.id);
+
+    expect(gitCalls).toEqual([["diff", "--cached", "--name-status", "-z"]]);
+    expect(record?.result.exitCode).toBe(1);
+    expect(record?.result.diagnostics[0]?.message).toContain("fake staged diff failure");
+  });
+});
+
+function baselineRule(id: string) {
+  return {
+    id,
+    exceptionPath: "none",
+    ownerProject: "@internal/habitat-harness",
+    ownerTool: "pattern-check",
+  } as const;
+}
+
+function ruleRegistryJson(ruleIds: readonly string[]) {
+  return JSON.stringify(
+    {
+      schemaVersion: 1,
+      ownerRoots: {
+        "@internal/habitat-harness": "tools/habitat-harness",
+      },
+      rules: ruleIds.map((id) => ({
+        id,
+        ownerProject: "@internal/habitat-harness",
+        ownerTool: "command-check",
+        lane: "enforced",
+        scope: "tools/habitat-harness/**",
+        forbids: "fixture violation",
+        why: "fixture base registry record for provider-boundary tests",
+        detect: ["fixture", id],
+        remediate: null,
+        message: "fixture baseline authority diagnostic",
+        exceptionPath: "none",
+        pathCoverage: [{ kind: "workspace-gate" }],
+      })),
+    },
+    null,
+    2
+  );
+}
+
+function commandResult(
+  argv: readonly string[],
+  cwd: string,
+  stdout: string,
+  exitCode = 0,
+  stderr = ""
+) {
+  return makeHabitatCommandResult(
+    {
+      commandId: `git-${argv.join("-")}`,
+      kind: "git-state",
+      executable: "git",
+      argv,
+      cwd,
+      captureGitState: false,
+    },
+    {
+      exit: { code: exitCode, signal: null, interrupted: false },
+      stdout: captureOutput(stdout),
+      stderr: captureOutput(stderr),
+    }
+  );
+}

--- a/tools/habitat-harness/test/service/service-architecture.test.ts
+++ b/tools/habitat-harness/test/service/service-architecture.test.ts
@@ -135,6 +135,8 @@ describe("Habitat service architecture", () => {
     const checkCommand = source("src/commands/check.ts");
     const checkRouter = source("src/service/modules/check/router.ts");
     const serviceImpl = source("src/service/impl.ts");
+    const baselineService = source("src/domains/baseline-authority/service.ts");
+    const structuralExecution = source("src/domains/structural-check/execution.ts");
 
     expect(checkCommand).toContain("createHabitatServiceClient");
     expect(checkCommand).toContain("client.check.run");
@@ -147,9 +149,16 @@ describe("Habitat service architecture", () => {
     expect(checkRouter).not.toContain('from "./run.js"');
     expect(checkRouter).not.toContain("lib/check-report");
     expect(source("src/domains/structural-check/report.ts")).toContain("BaselineAuthority");
-    expect(source("src/domains/structural-check/execution.ts")).toContain(
-      "executeSelectedRulesEffect"
-    );
+    expect(structuralExecution).toContain("executeSelectedRulesEffect");
+    expect(structuralExecution).toContain("GitProvider");
+    expect(structuralExecution).not.toContain("runSyncSpawnCommand");
+    expect(baselineService).toContain("loadBaselineStateEffect");
+    expect(baselineService).toContain("checkBaselineIntegrityEffect");
+    expect(baselineService).toContain("writeBaselineEffect");
+    expect(baselineService).not.toContain("loadBaselineState(");
+    expect(baselineService).not.toContain("checkBaselineIntegrity(");
+    expect(baselineService).not.toContain("guardBaselineExpansion(");
+    expect(baselineService).not.toContain("writeBaseline(");
     expect(serviceImpl).toContain("StructuralCheckLive");
     expect(serviceImpl).toContain("BaselineAuthorityLive");
     expect(existsSync(join(packageRoot, "src/service/modules/check/report.ts"))).toBe(false);


### PR DESCRIPTION
Drains the remaining sync side-effects from the active baseline and structural-check paths by replacing direct Git/filesystem/time calls with Effect provider operations.

`BaselineAuthorityLive` now delegates all baseline state reads, integrity checks, expansion admission decisions, and writes to a new `operations.ts` module that uses `HabitatFileSystem`, `GitProvider`, and `HabitatClock` instead of the legacy sync baseline context. The legacy sync functions remain only behind the `src/lib/baseline.ts` public adapter until the public-surface cleanup packet removes or narrows that export surface.

The staged structural-check path reads staged Git facts through `GitProvider` (`diffNameOnly`, `diffNameStatus`) and measures file-layer rule execution through `HabitatClock`, replacing the previous `runSyncSpawnCommand` and `Date.now()` calls. `executeFileLayerRulesEffect` is now an Effect and propagates `GitProvider` and `GitProviderRequirements` through the execution and report layers.

`GitProvider` gains `show` and `lsTreeNameOnly` operations used by the integrity check to read base rule registry and baseline state at a merge-base commit. `GitProviderRequirements` is now exported. `HabitatFileSystemService` gains a `writeText` operation backed by `writeFileSync` in the live layer and an event-recording stub in the fake layer.

`test/lib/check-baseline-provider-boundary.test.ts` is added to prove baseline integrity reads and writes flow through fake filesystem and Git providers, and that staged Git refusal messages surface as diagnostics through the structural-check Effect path. Service architecture assertions are extended to confirm the sync call sites have been removed from the active service path.