### PR TITLE
fix(placement): source start slopeClass from riverNetworkMetrics (heal tsc + NW group E)

### DIFF
--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/contract.ts
@@ -39,6 +39,7 @@ const DerivePlacementInputsContract = defineStep({
     requires: [
       morphologyArtifacts.topography,
       hydrologyHydrographyArtifacts.hydrography,
+      hydrologyHydrographyArtifacts.riverNetworkMetrics,
       hydrologyHydrographyArtifacts.lakePlan,
       ecologyArtifacts.biomeClassification,
       ecologyArtifacts.biomeBindings,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/index.ts
@@ -27,6 +27,10 @@ export default createStep(DerivePlacementInputsContract, {
   run: (context, config, ops, deps) => {
     const topography = deps.artifacts.topography.read(context);
     const hydrography = deps.artifacts.hydrography.read(context);
+    // slopeClass is a Hydrology river-network diagnostic owned by the
+    // riverNetworkMetrics artifact, not hydrography. Read it from its canonical
+    // source (published by the upstream hydrology-hydrography `lakes` step).
+    const riverNetworkMetrics = deps.artifacts.riverNetworkMetrics.read(context);
     // Lake placement constraints use the deterministic Hydrology plan. Engine
     // projection artifacts remain diagnostics for materialization drift.
     const lakePlan = deps.artifacts.lakePlan.read(context);
@@ -43,7 +47,7 @@ export default createStep(DerivePlacementInputsContract, {
       hydrography: {
         riverClass: hydrography.riverClass as Uint8Array,
         discharge: hydrography.discharge as Float32Array,
-        slopeClass: hydrography.slopeClass as Uint8Array,
+        slopeClass: riverNetworkMetrics.slopeClass as Uint8Array,
       },
       lakePlan: { lakeMask: lakePlan.lakeMask as Uint8Array },
       biomeClassification: {


### PR DESCRIPTION
derive-placement-inputs read `hydrography.slopeClass`, but slopeClass is owned
exclusively by the `riverNetworkMetrics` artifact (the hydrography schema is
additionalProperties:false with riverClass/discharge but no slopeClass). The
`as Uint8Array` cast hid that the value was undefined at type-check time, and the
plan-natural-wonders op's optionalU8 neutral fallback hid it at runtime — so
`tsc --noEmit` was red AND natural-wonder group E (features 32/34) silently
ranked on relief instead of true slope.

Fix (option a, lowest blast radius): require the riverNetworkMetrics artifact in
the derive-placement-inputs step contract and read `riverNetworkMetrics.slopeClass`.
No schema change, no producer change, no new computation, no ordering change
(riverNetworkMetrics is published by the upstream hydrology-hydrography lakes
step and already transitively required via map.riversPlotted). The cast is now
honest and group E scores real slope.

This is a pre-existing error on the natural-wonders base (commit 7191f31ff,
PR #1852); it lands as its own commit at that base. tsc --noEmit clean; 77
placement tests pass (incl. natural-wonder-placement). Behavioral note: NW group
E placement for features 32/34 now uses real Hydrology slopeClass — a correctness
restoration, not a regression; the NW lane should re-run live verification if it
adopts this onto the NW branch.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>