### PR TITLE
docs(placement): homeland-rebalance design + dominoes for start-distribution clustering

### DIFF
--- a/docs/projects/start-distribution-homeland-rebalance/design.md
+++ b/docs/projects/start-distribution-homeland-rebalance/design.md
@@ -1,0 +1,197 @@
+# Start Distribution — Redesign (from the ground up)
+
+> Companion to [`diagnosis.md`](./diagnosis.md) and
+> [`expectations.md`](./expectations.md). This is the algorithm design and the
+> domino plan. The OpenSpec control record is
+> `openspec/changes/start-distribution-homeland-rebalance/`.
+
+## 1. Design principle — match the homeland model to the land that exists
+
+Civ7's gameplay model is **two homeland hemispheres** (West / East), with
+*Distant Lands* across the ocean reserved for the Exploration Age. Every major
+civ starts on a homeland; the engine tracks this with `LandmassRegionId`
+(`WEST`/`EAST`/`NONE`). The 2-region model is therefore **correct and kept**.
+
+The defect (see diagnosis) is that the mod imposes the West/East split
+**geometrically on whatever morphology produced** and then allocates a **fixed**
+player count to each half **blind to capacity**. Real Civ7 instead *builds*
+two balanced homeland continents sized for their player counts. We cannot resize
+continents from placement (that is morphology), so we do the next best,
+physics-honest thing:
+
+> **Partition the settleable land into two balanced homelands, allocate players
+> to each homeland in proportion to its real capacity, and disperse seats within
+> a homeland across its constituent landmasses and its full extent.**
+
+Three rules govern every move below:
+
+- **Physics-informed:** decisions read the *actual* land distribution and the
+  pipeline's existing truth artifacts (`morphology.landmasses`, `topography`,
+  `pedology.fertility`, candidate viability) — never a fixed geometric guess.
+- **Gameplay-anchored:** every hard Civ7 requirement is preserved — one start
+  per major civ, starts on settleable land only, the official 6/12 spacing
+  buffers, fertility/freshwater/climate preference, per-civ StartBias, and the
+  worst-pair fairness gap ≤ 0.3. See `expectations.md`.
+- **Degrade as data:** when geography cannot satisfy a target, the shortfall is
+  recorded loudly (per-seat flags, fairness report, diagnostics) — never forced
+  silently and never thrown.
+
+## 2. The four moves
+
+Each move targets a specific root cause and is independently verifiable against
+the region-balance metric (move D0). Together they are the homeland rebalance.
+
+### D1 — Land-aware homeland partition (fixes RC1)
+
+Replace `centerX < width/2` with an **area-balanced split of the cylinder**.
+The map wraps in X, so "West vs East" is a rotation choice, not a fixed seam.
+
+1. Build a per-column settleable-land weight histogram `w[x]`
+   (`w[x] = settleable land tiles in column x`, settleable = land minus
+   mountain/volcano/lake/wonder).
+2. Slide a half-map window (`width/2` wide, circular) and pick the rotation
+   offset `m*` that **minimizes |W(window) − W_total/2|** — the meridian pair
+   that best halves settleable land. O(width), deterministic.
+3. Assign each **landmass whole** (by its area-weighted centroid relative to
+   `m*`) to West or East. Keeping landmasses intact preserves "homeland =
+   continent" coherence; the residual imbalance when one landmass exceeds half
+   the capacity is absorbed by D2.
+
+This keeps the published 2-slot output, the engine `WEST`/`EAST` region stamping,
+and the cross-ocean Distant-Lands geometry — it only changes *where the line is*.
+
+### D2 — Capacity-proportional player allocation (fixes RC2)
+
+Replace the fixed positional 4/4 split. Total players `N` comes from the
+adapter's alive-major count (`getAliveMajorIds().length`), with `MapInfo`
+`PlayersLandmass1+2` as fallback only.
+
+1. **Capacity** per region = a feasibility-aware measure of how many
+   well-spaced starts the region can actually hold:
+   `feasibleCeiling_r = floor(settleableTiles_r / tilesPerStart)` where
+   `tilesPerStart` derives from the spacing floor (a hex disk footprint), and a
+   quality-weighted `capacity_r` (settleable tiles weighted by viability) ranks
+   regions when both are feasible.
+2. **Apportion** `N` across the two regions by largest-remainder (Hamilton)
+   proportional to `capacity_r`, then **clamp to `feasibleCeiling_r`** and
+   redistribute any overflow to the region with spare ceiling.
+3. **Balance bias:** blend the proportional result toward an equal split by
+   `balanceBias ∈ [0,1]` (Civ7 prefers near-equal hemispheres *when feasible*).
+   Feasibility always wins over balance — we never assign a region more starts
+   than it can space.
+
+Result: a land-poor homeland receives *fewer* (or zero) players instead of a
+forced 4; a land-rich homeland absorbs the rest. No more "half crammed into a
+sliver."
+
+### D3 — Intra-region dispersion objective (fixes RC4)
+
+Within a region holding `q_r` players across possibly several landmasses:
+
+1. **Per-landmass quotas:** apportion `q_r` across the region's landmasses by
+   their capacity (reuse the D2 apportionment primitive). Multi-landmass
+   homelands now seat starts on *each* viable landmass, not just the best one.
+2. **Farthest-point seeding:** seed the first seat at the highest-quality
+   candidate, then each subsequent seat maximizes a blend of **viability AND
+   distance to the nearest already-seated start** (a max-min spread objective),
+   subject to its landmass quota and the spacing floor. This generalizes the
+   current pairwise relaxation into an explicit dispersion pass.
+3. **Adaptive spread weight:** when a region is capacity-tight, raise the
+   dispersion share of the ranking so seats fan out rather than clump in the
+   single best basin.
+
+### D4 — Imbalance-aware reconciliation + verification (fixes RC3, closes the loop)
+
+1. **Reconciliation:** because D2 allocates within feasibility, the zero-only
+   valve becomes a true capacity rebalance — if selection still cannot space a
+   region's quota, surplus seats move to the region with spare capacity,
+   recorded as a region relaxation (loud, per-seat).
+2. **Region-balance metric (D0 instrument, landed early):** add diagnostics that
+   make clustering *measurable* — starts-per-region vs capacity, max
+   single-landmass start share, and a normalized spatial-spread index. This is
+   the gate the bug currently evades; it provides the before/after proof.
+
+## 3. Policy primitives → `packages/civ7-map-policy`
+
+The package is `@civ7/map-policy` — "pure Civ7 map policy facts and deterministic
+compliance helpers", zero runtime deps. The Civ7 start-distribution *policy*
+(homeland model, official spacing buffers, capacity/feasibility model, balance
+bias) is exactly that charter. New module `src/starts/`:
+
+| Primitive | Signature (shape) | Purpose | Purity |
+|---|---|---|---|
+| `CIV7_START_PLACEMENT_POLICY_V0` | const fact table | Official spacing buffers (required 6 / desired 12), homeland region count + ids, default `balanceBias`, `tilesPerStart` derivation | data |
+| `balancedHemisphereSplit` | `({ columnWeights, landmassCentroids, width }) → { meridianOffset, slotByLandmass }` | D1 area-balanced partition | pure |
+| `feasibleStartCeiling` | `(settleableTiles, spacingFloor) → number` | D2 hard capacity ceiling | pure |
+| `apportionStartsByCapacity` | `({ capacities, ceilings, total, balanceBias }) → number[]` | D2 + D3 quotas (largest-remainder + clamp + redistribute) | pure |
+| `dispersionScore` | `(plotIndex, seatedPlots, width) → 0..1` | D3 max-min spread term (odd-R distance) | pure |
+
+The grid-distance dependency uses the package's existing
+`src/policy-grid.ts` hex helpers (currently unexported — export what `src/starts/`
+needs). **Odd-R caveat:** this branch sits above the odd-R adjacency migration
+(#1812/#1851); any distance/footprint math must use the engine **odd-R** model.
+Verify the live helper name before use — historical names may still read `OddQ`
+pending the rename packet (`docs(openspec): record OddQ->OddR rename scope`).
+
+Start-specific *orchestration* (reading artifacts, building candidate pools,
+wiring quotas into the ladder) stays in the mod under
+`domain/placement/ops/plan-starts/policy/` and the `plot-landmass-regions` step —
+it *consumes* the pure primitives. This keeps `@civ7/map-policy` a pure policy
+layer and the mod the composition layer (Nx boundary: `kind:mod` may import
+`kind:foundation`).
+
+## 4. Non-goals (explicit scope boundaries)
+
+- **No N-region generalization.** The Civ7 homeland model is two hemispheres;
+  the published `plan-starts` output stays 2-region (`playersLandmass1/2`,
+  `regionSlot ∈ {1,2}`). N-region would break the schema, the engine region-id
+  space, and Studio — out of scope, recorded as a future option only.
+- **No morphology change.** We do not make morphology generate balanced
+  continents; we adapt placement to the land that exists.
+- **No scorer redesign.** Viability scoring and candidate screening are kept.
+- **No engine-positioner revival.** The mod keeps owning `setStartPosition`.
+
+## 5. Dominoes, sequencing, and complexity × parallelism
+
+Graphite is a linear stack; the table records the dependency DAG so independent
+dominoes can be split into parallel worktrees if desired. Each slice is one
+OpenSpec task group and one Graphite branch on top of
+`start-dist-homeland-rebalance`.
+
+| Slice | Domino | Touches | Depends on | Complexity | Parallel with |
+|---|---|---|---|---|---|
+| S1 | **Design** (this packet + OpenSpec) | `docs/`, `openspec/` | — | low | — |
+| S2 | **D0 metric + baseline** (region balance, spread, max-landmass-share; measure current) | `dev/diagnostics/placement-metrics.ts`, evidence | S1 | low–med | **S3** |
+| S3 | **Policy primitives** (`@civ7/map-policy/src/starts/` + unit tests) | `packages/civ7-map-policy` | S1 | med (isolated, fully unit-tested) | **S2** |
+| S4 | **D1 land-aware partition** | `plot-landmass-regions` (+ optional capacity surface) | S3 | med | — |
+| S5 | **D2 capacity allocation** (replace fixed split; seat-identity; N from alive-majors) | `plan-starts` (`seat-identity`, `default.ts`), `runtime`/`derive-placement-inputs` | S3, S4 | med–high | — |
+| S6 | **D3 dispersion** (per-landmass quotas + farthest-point in ladder) | `selection-ladder.ts`, `default.ts` | S3, S5 | med–high | — |
+| S7 | **D4 reconciliation + verification + closure** (rebalance valve, ledger results, in-game proof) | `default.ts`, diagnostics, evidence | S4–S6 | med | — |
+
+**Critical path:** S1 → S3 → S4 → S5 → S6 → S7. **Parallel opportunity:** S2 ∥ S3
+(metric and pure primitives are independent — two worktrees could land them
+before S4). After S3, the behavior spine S4→S5→S6 is sequential by data
+dependency (each consumes the previous region/allocation state) and each
+*monotonically* improves the D0 metric, so every slice is independently
+verifiable. S7 confirms no regression on the kept E1.x gates and adds in-game
+proof (the closure test — MockAdapter-valid maps can still SIGSEGV live).
+
+**Why this order (outside-in refinement):** first fix *where* the homelands are
+(D1), then *how many* players each gets (D2), then *where within* a homeland they
+sit (D3), then *prove + reconcile* (D4). Each layer assumes the previous is
+correct, and each can be measured in isolation against the D0 metric — so a
+regression is attributable to exactly one slice.
+
+## 6. Open risks / decisions (recorded, not silent)
+
+- **Odd-R distance helpers** — verify live name on this branch before use (above).
+- **`tilesPerStart` constant** — the feasibility ceiling needs a defensible
+  tiles-per-start footprint tied to the 6-tile floor; calibrate against the D0
+  baseline rather than guessing. Recorded as a tuning task in S3/S7.
+- **`balanceBias` default** — Civ7 prefers near-equal hemispheres, but there is
+  no authored constant; pick a default that keeps equal splits on balanced maps
+  and only diverges when feasibility forces it. Tune in S7.
+- **Single-dominant-continent (pangaea) maps** — D1's meridian cuts *through*
+  the continent, giving two nominal homelands on one landmass. This is desirable
+  (8 players spread across the continent) and strictly better than today's
+  collapse; documented expected behavior, not a defect.

--- a/docs/projects/start-distribution-homeland-rebalance/diagnosis.md
+++ b/docs/projects/start-distribution-homeland-rebalance/diagnosis.md
@@ -1,0 +1,137 @@
+# Start Distribution — Diagnosis
+
+> **Symptom (user-reported).** On generated maps, start positions are badly
+> distributed: roughly **half of all civilizations are always crowded into a
+> single small land area**, instead of being spread across the map's landmasses.
+> The failure is severe and near-deterministic for a given map shape.
+
+This document records the verified root cause. Evidence was gathered by a
+four-lane systematic investigation (planner algorithm, input derivation, policy
+adapter + engine boundary, gameplay/base-game reference) and then confirmed by
+direct reads of live source. Every claim cites `file:line` on the
+`start-dist-homeland-rebalance` branch (built on the natural-wonders + odd-R
+stack).
+
+## Where starts are actually decided
+
+The mod **fully owns** final start assignment. The engine positioner
+(`assignStartPositions` / `chooseStartSectors`, `packages/civ7-adapter/src/types.ts:805-882`)
+is wrapped but **never called** — it is dead code (the official sector grid was
+intentionally retired, ADR-008). Seats are stamped one-by-one via
+`adapter.setStartPosition(...)` (`assign-starts/materialize.ts:170`). So the
+clustering is ours to fix, entirely inside the recipe.
+
+Placement stage order (`contract-manifest.ts:119-131`):
+
+```
+derive-placement-inputs → plot-landmass-regions → place-natural-wonders
+  → prepare-placement-surface → plan-resources → assign-starts (plan-starts op)
+  → adjust/place-resources → place-discoveries → assign-advanced-starts → placement
+```
+
+## Root cause — the REGION MODEL, not the scorer
+
+The viability scorer (fertility / freshwater / climate / roughness / start-bias)
+is fine. Clustering is produced by four compounding defects in how the map is
+partitioned into start regions and how players are allocated to them.
+
+### RC1 — Geometric midline partition ignores land area
+`plot-landmass-regions/index.ts:42-45`
+
+```ts
+const slotByLandmass = new Uint8Array(landmasses.length);
+for (const mass of landmasses) {
+  const centerX = computeWrappedIntervalCenter(mass.bbox.west, mass.bbox.east, width);
+  slotByLandmass[mass.id] = centerX < width / 2 ? 1 : 2;   // 1=west, 2=east
+}
+```
+
+Every landmass is bucketed **West (1)** or **East (2)** purely by whether its
+bounding-box center sits left or right of `width/2`. There is **no balancing of
+settleable land area** between the two halves. When real geography is
+asymmetric — one dominant continent, or most land on one side of the seam — one
+region holds the overwhelming majority of settleable land and the other holds a
+sliver (or only sub-threshold islands).
+
+### RC2 — Capacity-blind, fixed player split
+`runtime.ts:31-32` → `derive-placement-inputs/inputs.ts:152-155` → `seat-identity.ts:27-35`
+
+```ts
+// runtime.ts
+const playersLandmass1 = mapInfo.PlayersLandmass1 ?? 4;   // default 4
+const playersLandmass2 = mapInfo.PlayersLandmass2 ?? 4;   // default 4
+// seat-identity.ts (positional bind)
+regionSlot: seatIndex < args.playersWest ? 1 : 2,
+```
+
+Player counts are taken verbatim from static `MapInfo` (default **4/4**) and
+mapped **positionally** onto the two slots — the first 4 seats are West, the
+rest East — **regardless of where the land actually is**. So a region that RC1
+made tiny is still handed a fixed batch of 4 seats. Those 4 seats (half of 8)
+are forced into a small area: this is the precise mechanism of "half the civs in
+one small land area."
+
+### RC3 — Reconciliation only triggers at *zero* candidates
+`plan-starts/strategies/default.ts:702-719`
+
+```ts
+const candidatesBySlot = { 1: 0, 2: 0 };
+for (const candidate of candidates) candidatesBySlot[candidate.regionSlot] += 1;
+for (const seat of seatIdentities) {
+  const own = candidatesBySlot[seat.regionSlot];
+  const other = (seat.regionSlot === 1 ? 2 : 1) as 1 | 2;
+  if (own === 0 && candidatesBySlot[other] > 0) { /* reassign to other */ }
+}
+```
+
+The only safety valve fires **only when a region has exactly zero candidates**.
+The common bad case — a region with *few-but-nonzero* candidates but assigned far
+more seats than it can space — is never rebalanced. The starved region's seats
+stay put and pack to the spacing floor. (And when it *does* fire, all of that
+region's seats collapse onto the other continent, producing the
+"all-on-one-continent" variant.)
+
+### RC4 — No intra-region dispersion objective
+`plan-starts/strategies/default.ts:685` (`candidates.sort(compareSelectableTiles)`),
+`selection-ladder.ts` (greedy pick within region pool)
+
+Selection is a **quality-sorted greedy** pass. The only force separating seats
+is a **pairwise** min-distance that is *relaxed per-seat down to the floor*
+(spacing weight is just `1 - rankingBlend = 0.14`). High-quality tiles are
+spatially correlated (same fertile basin), so seats pile into the best
+neighborhood as long as they clear the floor. There is no objective spreading
+seats **across distinct landmasses or across the region's extent**.
+
+## Why this hid for so long
+
+The existing spacing metric (E1.5, `placement-metrics.ts:632-659`) measures only
+the **pairwise minimum** distance. Eight starts can all clear a 6-tile floor
+while sitting inside one small landmass — so E1.5 passes while the map is visibly
+crowded. **There is no metric for region balance or spatial spread of starts**
+(`placement-metrics.ts` E2.8 "regional equity" is about *resource* density, not
+starts). The bug is invisible to the current gate set.
+
+## What is sound (do not change)
+
+- The candidate **screening** (impassable / wonder / lake exclusions) and the
+  **viability scorer** (fertility/freshwater/climate/roughness/start-bias) — keep.
+- The **2-region homeland model** itself (WEST/EAST `LandmassRegionId`) is the
+  *correct* Civ7 model (Homelands vs Distant-Lands; see `design.md`). The bug is
+  not "2 regions"; it is "regions defined geometrically + allocated blindly."
+- The **degrade-as-data** discipline (four-rung ladder, per-seat flags, fairness
+  report) — keep and extend.
+
+## Reference index
+
+| Concern | File:line |
+|---|---|
+| Midline partition (RC1) | `mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plot-landmass-regions/index.ts:42-45` |
+| Fixed player counts (RC2) | `mods/mod-swooper-maps/src/recipes/standard/runtime.ts:31-32` |
+| Positional seat→slot bind (RC2) | `mods/mod-swooper-maps/src/domain/placement/ops/plan-starts/policy/seat-identity.ts:27-35` |
+| Input assembly | `mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/inputs.ts:152-155` |
+| Zero-only reconciliation (RC3) | `mods/mod-swooper-maps/src/domain/placement/ops/plan-starts/strategies/default.ts:702-719` |
+| Greedy selection / no spread (RC4) | `mods/mod-swooper-maps/src/domain/placement/ops/plan-starts/strategies/default.ts:685`, `.../policy/selection-ladder.ts` |
+| Published 2-region contract | `mods/mod-swooper-maps/src/domain/placement/ops/plan-starts/contract.ts:5-19,301-315,352` |
+| Spacing metric (blind to clustering) | `mods/mod-swooper-maps/src/dev/diagnostics/placement-metrics.ts:632-705` |
+| Engine positioner (dead) | `packages/civ7-adapter/src/types.ts:805-882` |
+| Policy adapter package (no start primitives) | `packages/civ7-map-policy/src/index.ts:1-55` |

--- a/docs/projects/start-distribution-homeland-rebalance/expectations.md
+++ b/docs/projects/start-distribution-homeland-rebalance/expectations.md
@@ -1,0 +1,76 @@
+# Start Distribution — Predeclared Expectations
+
+> Systematic-workstream gate 6: declare expected behavior **before** tuning, so
+> verification cannot be retrofitted to the result. Baselines marked `TBD` are
+> measured in slice S2 (the D0 region-balance metric) on fixed seeds before any
+> behavior change lands. These extend — they do not replace — the existing
+> placement ledger (`docs/projects/placement-realignment/expectations.md`,
+> E1.x).
+
+Measurement harness: the placement metrics diagnostic
+(`mods/mod-swooper-maps/src/dev/diagnostics/placement-metrics.ts`) over a fixed
+seed set at standard size, plus `.bin` u8 layer dumps
+(`diag run-standard-dump --configFile`) for spatial inspection.
+
+## New expectations (this workstream)
+
+### ER1 — Player allocation tracks region capacity
+A homeland region's seated start count is proportional to its settleable
+capacity and never exceeds its feasibility ceiling.
+- **Metric:** per-region `seatedStarts` vs `feasibleCeiling` and vs
+  capacity-proportional target.
+- **Target:** `seatedStarts_r ≤ feasibleCeiling_r` for every region (hard); and
+  `|seatedStarts_r − proportionalTarget_r| ≤ 1` after balance-bias + rounding.
+- **Baseline:** TBD (today: fixed 4/4 regardless of capacity).
+
+### ER2 — No single small landmass hoards half the civs (the headline bug)
+No single landmass holds a disproportionate share of starts relative to its
+share of settleable capacity.
+- **Metric:** `maxSingleLandmassStartShare` = max over landmasses of
+  (starts on landmass / total starts), reported alongside that landmass's
+  capacity share.
+- **Target:** `maxSingleLandmassStartShare ≤ landmassCapacityShare + tolerance`
+  (tolerance ≈ one start). Concretely, the failing pattern "≥ 50% of civs on a
+  landmass holding < 25% of capacity" must not occur on any baseline seed.
+- **Baseline:** TBD (expected to FAIL today — this is the reported symptom).
+
+### ER3 — Starts are spatially dispersed, not clumped
+Beyond the pairwise floor, starts spread across each region's extent.
+- **Metric:** normalized spatial-spread index — mean nearest-neighbor start
+  distance ÷ the ideal even-dispersion distance for `N` starts over the
+  settleable area (1.0 = perfectly even; → 0 = clumped). Reported per region and
+  global.
+- **Target:** global spread index ≥ a threshold calibrated at S2 baseline (aim:
+  materially above baseline; provisional ≥ 0.6), with no region < 0.4.
+- **Baseline:** TBD (today: greedy quality-first, only pairwise floor).
+
+### ER4 — Reconciliation is rare and loud
+Capacity rebalancing across regions is a recorded exception, not the norm.
+- **Metric:** `regionReassignedRate` = reassigned seats / total, all surfaced as
+  region relaxations in the fairness report.
+- **Target:** ≤ 5% of seats on balanced maps; every reassignment recorded
+  per-seat (never silent). Mirrors E1.7.
+- **Baseline:** TBD.
+
+## Preserved expectations (must not regress)
+
+The kept gates from the existing ledger — the redesign changes *where* and *how
+many*, not the per-tile quality bar:
+
+- **E1.1** 0% starts on water / lake / mountain / volcano / natural-wonder.
+- **E1.2** Exactly the configured alive-player count seated, correct ids
+  (now sourced from `getAliveMajorIds()`, not slot index).
+- **E1.3** ≥ 80% of starts with freshwater (river/lake) within ≤ 1 tile.
+- **E1.4** Mean start fertility ≥ 1.05× local land mean (radius 2).
+- **E1.5** Min pairwise start spacing ≥ 6 tiles (official floor); score tapers
+  to 12. *Spread (ER3) is additive to — not a replacement for — this floor.*
+- **E1.6** Worst-pair fairness gap on `StartRecord.score` ≤ 0.3.
+- **E1.8** ≤ 10% of starts in climate extremes.
+
+## Falsifier
+
+If, after D1–D4, a baseline seed still places ≥ 50% of civs on a landmass
+holding < 25% of settleable capacity (ER2 fail) **and** that landmass had a
+feasible alternative region with spare capacity, the homeland model is still
+mis-allocating and the design is wrong — stop and re-frame rather than tune
+weights.

--- a/openspec/changes/start-distribution-homeland-rebalance/.openspec.yaml
+++ b/openspec/changes/start-distribution-homeland-rebalance/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-06-20
+status: draft

--- a/openspec/changes/start-distribution-homeland-rebalance/design.md
+++ b/openspec/changes/start-distribution-homeland-rebalance/design.md
@@ -1,0 +1,70 @@
+# Design — Dominoes, Graphite Slices, Integration Points
+
+> Full algorithm + rationale: `docs/projects/start-distribution-homeland-rebalance/design.md`.
+> This file is the **sequencing control record**: how the dominoes map to
+> Graphite branches, where each touches the pipeline, and the parallelism plan.
+
+## Graphite stack (on top of the natural-wonders stack)
+
+```
+agent-A-natural-wonders-full-set-parity-suitability   (PR #1852, NW stack top)
+└── start-dist-homeland-rebalance        S1  design + OpenSpec (this branch)
+    └── start-dist-2-region-metric       S2  D0 region-balance metric + baseline   ┐ parallelizable
+    └── start-dist-3-policy-primitives   S3  @civ7/map-policy src/starts/ + tests   ┘ (S2 ∥ S3)
+        └── start-dist-4-partition       S4  D1 land-aware homeland partition
+            └── start-dist-5-allocation  S5  D2 capacity-proportional allocation
+                └── start-dist-6-dispersion  S6  D3 per-landmass quotas + farthest-point
+                    └── start-dist-7-verify  S7  D4 reconciliation + ER1–ER4 + in-game + closure
+```
+
+Graphite is linear; S2 and S3 are dependency-independent and may be developed in
+separate worktrees, then ordered into the stack before S4. The behavioral spine
+S4→S5→S6 is sequential by data dependency and each slice monotonically improves
+the D0 metric, so a regression is attributable to one slice.
+
+## Complexity × parallelism (not effort/time)
+
+| Slice | Coupling | Independently testable | Parallel lane |
+|---|---|---|---|
+| S2 metric | reads existing artifacts only; no behavior change | yes (diagnostics harness) | A |
+| S3 primitives | pure functions, zero consumers yet | yes (unit tests, isolated) | B |
+| S4 partition | one step (`plot-landmass-regions`) | yes (metric + step test) | spine |
+| S5 allocation | `plan-starts` allocation + `runtime`/inputs wiring | yes (metric + plan-ops tests) | spine |
+| S6 dispersion | selection ladder | yes (metric + ladder tests) | spine |
+| S7 verify | diagnostics + closure | yes (full gate set + live) | tail |
+
+## Integration points (where each domino plugs in)
+
+- **D0 / S2** — `mods/mod-swooper-maps/src/dev/diagnostics/placement-metrics.ts`.
+  Add region-balance metric ids (E-series) reading the published `plan-starts`
+  output (`seats[].regionSlot`, `plotIndex`) + `landmasses` + `topography`.
+- **S3 primitives** — `packages/civ7-map-policy/src/starts/{index,policy,partition,apportion,dispersion}.ts`;
+  re-export from `packages/civ7-map-policy/src/index.ts`; export needed helpers
+  from `src/policy-grid.ts`.
+- **D1 / S4** — `plot-landmass-regions/index.ts:resolveSlotByTile` replaces the
+  `centerX < width/2` loop with `balancedHemisphereSplit(...)`. Output artifact
+  `map.landmassRegionSlotByTile` and engine `WEST`/`EAST` stamping unchanged.
+- **D2 / S5** — `runtime.ts` stops fixing the per-region split; total `N` from
+  `getAliveMajorIds()`. `plan-starts/strategies/default.ts` computes per-region
+  capacity/ceilings from screened candidates and calls
+  `apportionStartsByCapacity`; `seat-identity.ts buildSeatIdentities` takes the
+  computed per-region counts instead of `playersWest/playersEast` from `MapInfo`.
+- **D3 / S6** — `default.ts` builds per-landmass quotas (apportion within region)
+  and `selection-ladder.ts` adds a farthest-point/dispersion term + quota
+  constraint to the regional rung.
+- **D4 / S7** — `default.ts:702-719` reconciliation becomes capacity-aware;
+  evidence recorded; live run.
+
+## Contracts touched
+
+- `plan-starts` **input/output schema unchanged** on the region surface
+  (decision log). Allocation is internal. If a future need forces an output
+  field (e.g. per-region capacity for Studio), it is additive and recorded here.
+- New `@civ7/map-policy` exports are additive (`kind:foundation`; `kind:mod` may
+  import it — Nx boundary respected).
+
+## Spec capability
+
+Behavioral requirements land under the `mapgen-normalization-workstreams`
+capability (`specs/mapgen-normalization-workstreams/spec.md`), consistent with
+the placement-realignment series.

--- a/openspec/changes/start-distribution-homeland-rebalance/proposal.md
+++ b/openspec/changes/start-distribution-homeland-rebalance/proposal.md
@@ -1,0 +1,136 @@
+## Why
+
+Generated maps badly distribute starts: roughly **half of all civs are always
+crowded into one small land area**, near-deterministically. A four-lane
+systematic investigation (recorded in
+`docs/projects/start-distribution-homeland-rebalance/diagnosis.md`) proves the
+cause is the **region model**, not the scorer:
+
+- **RC1** the West/East partition is purely geometric — each landmass is bucketed
+  by `bbox-center < width/2` with no land-area balancing
+  (`plot-landmass-regions/index.ts:42-45`);
+- **RC2** player counts are a fixed, capacity-blind `4/4` from `MapInfo`, mapped
+  positionally onto the two slots (`runtime.ts:31-32`, `seat-identity.ts:35`);
+- **RC3** the only reconciliation valve fires at *zero* candidates, never for an
+  under-supplied region (`default.ts:702-719`);
+- **RC4** selection is greedy quality-first with only a relaxable pairwise floor —
+  no objective spreading seats across landmasses (`selection-ladder.ts`).
+
+The current spacing gate (E1.5) measures only the pairwise minimum, so eight
+starts can clump inside one small landmass and still pass — the bug is invisible
+to the gate set. This change keeps Civ7's correct **two-homeland** model and
+makes the partition + allocation **capacity-aware** with an explicit
+**dispersion** objective.
+
+## Target Authority Refs
+
+- `docs/projects/start-distribution-homeland-rebalance/diagnosis.md` (root cause, file:line)
+- `docs/projects/start-distribution-homeland-rebalance/design.md` (algorithm + dominoes + sequencing)
+- `docs/projects/start-distribution-homeland-rebalance/expectations.md` (predeclared ER1–ER4 + preserved E1.x)
+- `docs/projects/placement-realignment/expectations.md` (E1.x ledger this preserves)
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md` (controlling baseline)
+
+## What Changes
+
+Five dominoes (full algorithm in the project `design.md`; slice→branch map in
+this change's `design.md`):
+
+- **D0 — Region-balance metric.** New placement diagnostics: starts-per-region
+  vs capacity, `maxSingleLandmassStartShare`, and a normalized spatial-spread
+  index. Lands first to baseline the bug and prove before/after. No behavior
+  change.
+- **Policy primitives.** New `@civ7/map-policy` module `src/starts/`:
+  `CIV7_START_PLACEMENT_POLICY_V0` (official 6/12 buffers, homeland model,
+  `balanceBias`, `tilesPerStart`), `balancedHemisphereSplit`,
+  `feasibleStartCeiling`, `apportionStartsByCapacity`, `dispersionScore` — pure,
+  zero-dep, unit-tested. Exports the needed `policy-grid` hex helpers (odd-R).
+- **D1 — Land-aware partition.** `plot-landmass-regions` replaces
+  `centerX < width/2` with `balancedHemisphereSplit` (area-balanced meridian over
+  settleable land; landmasses kept whole). Output slot space unchanged.
+- **D2 — Capacity allocation.** `plan-starts` replaces the fixed positional split
+  with `apportionStartsByCapacity` over per-region capacity + feasibility
+  ceilings; total players `N` sourced from `getAliveMajorIds()`. `seat-identity`
+  binds seats to the computed allocation.
+- **D3 — Dispersion.** Per-landmass quotas + farthest-point (max-min) seeding in
+  the selection ladder, with adaptive spread weight under capacity pressure.
+- **D4 — Reconciliation + verification.** Zero-only valve becomes a true
+  capacity rebalance (recorded loudly); ER1–ER4 measured; in-game proof; closure.
+
+## Decision Log (recorded, not decided silently)
+
+- **Keep 2 regions.** Civ7's homeland model is two hemispheres (`WEST`/`EAST`
+  `LandmassRegionId`). The published `plan-starts` output stays 2-region — no
+  schema break, no Studio/engine region-id churn. N-region is a documented
+  non-goal.
+- **West/East is a rotation, not a fixed seam.** The map wraps in X, so the
+  balanced split chooses the meridian pair that halves settleable land; the
+  `WEST`/`EAST` labels remain valid region ids.
+- **Landmasses kept whole** in the partition (homeland = continent); residual
+  imbalance when one landmass exceeds half the capacity is absorbed by D2
+  allocation, not by splitting a continent.
+- **Feasibility beats balance.** `balanceBias` nudges toward equal hemispheres,
+  but a region is never allocated more starts than its `feasibleStartCeiling`.
+- **Primitives are pure policy.** Algorithmic-but-pure helpers (apportionment,
+  balanced split, dispersion, official buffers) fit `@civ7/map-policy`'s
+  "deterministic compliance helpers" charter; start-specific orchestration stays
+  in the mod.
+- **Odd-R distance.** This branch is above the odd-R migration; all new
+  distance/footprint math uses engine odd-R — verify the live helper name before
+  use (historical names may still read `OddQ`).
+
+## Requires
+
+- Natural-wonders + odd-R stack (this change branches on
+  `agent-A-natural-wonders-full-set-parity-suitability`).
+
+## Enables Parallel Work
+
+- The D0 metric slice and the policy-primitives slice are independent and can be
+  developed in parallel worktrees before the D1 partition slice.
+- After primitives land, the D1→D2→D3 spine is sequential (each consumes the
+  prior region/allocation state) but each is independently measurable against the
+  D0 metric.
+
+## Affected Owners
+
+- `packages/civ7-map-policy/**` (new `src/starts/` module + tests).
+- `mods/mod-swooper-maps/**` placement: `plot-landmass-regions`,
+  `domain/placement/ops/plan-starts/**`, `recipes/standard/runtime.ts`,
+  `derive-placement-inputs`, `dev/diagnostics/placement-metrics.ts`.
+- `docs/projects/start-distribution-homeland-rebalance/**` (evidence).
+
+## Forbidden Owners
+
+- No edits to generated files (`*.gen.ts`, `dist/**`, `mod/**`,
+  `.civ7/outputs/**`, `src/maps/generated/**`).
+- No scorer/screening redesign, no morphology change, no engine-positioner
+  revival, no `plan-starts` output schema change (region space stays `{1,2}`).
+
+## Consumer Impact
+
+- `plan-starts` **input/output schemas unchanged** for the region surface
+  (`playersLandmass1/2`, `regionSlot ∈ {1,2}`); allocation semantics change
+  (counts derived from land, not `MapInfo`).
+- `@civ7/map-policy` gains an additive `src/starts/` export surface.
+- New diagnostics metric ids (additive) in `placement-metrics.ts`.
+- Visible behavior change: starts spread across homelands instead of clustering.
+
+## Stop Conditions
+
+- Any domino turning out to require a `plan-starts` output schema change or a
+  morphology change — stop, record why, keep the slice shippable or re-scope.
+- ER2 still failing after D1–D2 where a feasible alternative region had spare
+  capacity (the design `falsifier`) — re-frame, do not tune weights.
+
+## Verification Gates
+
+- `bun run --cwd packages/civ7-map-policy test` (primitive unit tests).
+- `bun --cwd mods/mod-swooper-maps test test/placement` (planner tests).
+- `bun run --cwd mods/mod-swooper-maps check` (Biome + types).
+- `nx run mod-swooper-maps:build` (schema-compile gate).
+- Region-balance metric (D0) over the fixed seed set: ER1–ER4 pass, E1.x no
+  regression — results recorded under
+  `docs/projects/start-distribution-homeland-rebalance/evidence/`.
+- In-game live verification (closure test) per
+  `.agents/skills/civ7-mapgen-workstream/assets/live-verification-runbook.md`.
+- `bun run openspec -- validate start-distribution-homeland-rebalance --strict`.

--- a/openspec/changes/start-distribution-homeland-rebalance/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/start-distribution-homeland-rebalance/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: Homeland Partition Balances Settleable Land Area
+
+The `plot-landmass-regions` step SHALL partition landmasses into the two
+homeland regions by an area-balanced split of the settleable-land distribution
+(the meridian pair that best halves settleable land on the X-wrapping map),
+assigning each landmass whole, instead of by a fixed `bbox-center < width/2`
+geometric midline.
+
+#### Scenario: Asymmetric land is split near-evenly by capacity
+- **WHEN** settleable land is concentrated on one side of the fixed `width/2`
+  midline
+- **THEN** the chosen split assigns landmasses so the two regions' settleable
+  capacities are as balanced as keeping landmasses whole allows
+- **AND** the published region slot space remains `0=none,1=west,2=east` and the
+  engine `WEST`/`EAST`/`NONE` region ids are still stamped
+
+#### Scenario: A single dominant continent is split, not collapsed
+- **WHEN** one landmass spans more than half the map's settleable capacity
+- **THEN** the balanced split cuts the cylinder through that continent so both
+  regions contain settleable land (rather than leaving one region empty)
+
+### Requirement: Player Allocation Is Proportional To Region Capacity Within Feasibility
+
+The `plan-starts` op SHALL allocate the total player count across the two
+homeland regions in proportion to each region's settleable capacity, clamped to
+a per-region feasibility ceiling derived from the official spacing floor, instead
+of using fixed per-hemisphere counts from `MapInfo`. The total player count
+SHALL be sourced from the adapter alive-major read surface.
+
+#### Scenario: A land-poor region receives fewer players
+- **WHEN** one homeland region has materially less settleable capacity than the
+  other
+- **THEN** it is allocated proportionally fewer starts, never more than its
+  feasibility ceiling
+- **AND** the other region absorbs the remainder
+
+#### Scenario: Allocation honors feasibility over balance
+- **WHEN** a capacity-proportional or balance-biased allocation would assign a
+  region more starts than its feasibility ceiling allows
+- **THEN** the surplus is redistributed to a region with spare ceiling, and the
+  redistribution is recorded as a region relaxation
+
+#### Scenario: Total seats equal the alive major count
+- **WHEN** the adapter reports the alive major player ids
+- **THEN** the number of seats equals that count and player ids come from the
+  alive-major surface (slot-index fallback recorded per seat, never silent)
+
+### Requirement: Starts Disperse Across Landmasses And Space Within A Region
+
+The `plan-starts` selection SHALL spread a region's seats across its constituent
+landmasses (per-landmass quotas proportional to capacity) and across the
+region's extent (a max-min / farthest-point dispersion objective), in addition to
+the existing pairwise spacing floor.
+
+#### Scenario: Multiple landmasses in a region each receive starts
+- **WHEN** a homeland region contains more than one viable landmass and is
+  allocated more starts than one landmass's quota
+- **THEN** starts are seated on each viable landmass according to its quota
+  rather than all on the single highest-scoring landmass
+
+#### Scenario: Seats fan out under capacity pressure
+- **WHEN** a region is capacity-tight
+- **THEN** the selection raises the dispersion weight so seats maximize mutual
+  distance rather than clumping in the single best basin, while still respecting
+  the spacing floor
+
+### Requirement: Region Rebalancing Is Capacity-Aware And Recorded
+
+Cross-region seat reassignment SHALL trigger on capacity infeasibility (a region
+cannot space its allocated seats), not only on a region having zero candidates,
+and SHALL record every reassignment as a region relaxation in the fairness
+report and per-seat flags.
+
+#### Scenario: An under-supplied region rebalances before clustering
+- **WHEN** a region is allocated seats it cannot space at the floor and another
+  region has spare capacity
+- **THEN** the surplus seats are reassigned to the region with spare capacity and
+  each reassignment is recorded (never silent)
+
+### Requirement: Start Region Balance And Spread Are Measurable
+
+Placement diagnostics SHALL report start region balance and spatial spread:
+seated starts per region against region capacity, the maximum single-landmass
+start share against that landmass's capacity share, and a normalized spatial
+spread index.
+
+#### Scenario: Clustering is detectable by a metric
+- **WHEN** a generated map seats a disproportionate share of starts on one small
+  landmass
+- **THEN** the region-balance metric reports `maxSingleLandmassStartShare`
+  exceeding that landmass's capacity share (a failing signal the pairwise
+  spacing metric alone cannot detect)
+
+### Requirement: Start-Distribution Policy Primitives Are Pure Deterministic Helpers
+
+The Civ7 start-distribution policy SHALL be expressed as pure, deterministic,
+zero-dependency primitives in the `@civ7/map-policy` package (`src/starts/`):
+the official spacing buffers and homeland model as fact data, a balanced
+hemisphere split, a feasibility ceiling, a capacity apportionment, and a
+dispersion score. Start-specific orchestration consuming these primitives stays
+in the mod.
+
+#### Scenario: Apportionment is deterministic and total-preserving
+- **WHEN** `apportionStartsByCapacity` is given region capacities, ceilings, a
+  total, and a balance bias
+- **THEN** it returns integer per-region counts that sum to the total (or to the
+  sum of ceilings when the total exceeds total capacity) and is identical across
+  runs for identical inputs
+
+#### Scenario: Primitives carry no Civ7 engine or mod dependency
+- **WHEN** the `src/starts/` primitives are imported
+- **THEN** they depend only on pure data and the package's own grid helpers (no
+  adapter, no mod, no engine state), consistent with `kind:foundation`

--- a/openspec/changes/start-distribution-homeland-rebalance/tasks.md
+++ b/openspec/changes/start-distribution-homeland-rebalance/tasks.md
@@ -1,0 +1,66 @@
+# Tasks
+
+Grouped by domino = Graphite slice. `[ ]` open, `[x]` done. Each slice is one
+branch stacked on `start-dist-homeland-rebalance`. Verify the odd-R distance
+helper name on this branch before any distance math.
+
+## S1 — Design + OpenSpec (this branch)
+- [x] Four-lane systematic diagnosis (planner, inputs, policy/engine, gameplay)
+- [x] Project packet: `diagnosis.md`, `design.md`, `expectations.md`
+- [x] OpenSpec change: proposal, design, spec delta, tasks
+- [ ] `bun run openspec -- validate start-distribution-homeland-rebalance --strict`
+- [ ] Pre-code review gate (authority/owners/scope/no-shortcut language)
+
+## S2 — D0 region-balance metric + baseline (parallel with S3)
+- [ ] Add metric ids to `dev/diagnostics/placement-metrics.ts`: starts-per-region
+  vs capacity (ER1), `maxSingleLandmassStartShare` vs capacity share (ER2),
+  normalized spatial-spread index (ER3), `regionReassignedRate` (ER4)
+- [ ] Harness-works test (metric reported with valid status), not behavior assert
+- [ ] Measure + record baseline over the fixed seed set →
+  `docs/projects/start-distribution-homeland-rebalance/evidence/baseline-2026-06-20.md`
+- [ ] Confirm ER2 FAILS at baseline (reproduces the reported symptom)
+
+## S3 — Policy primitives (`@civ7/map-policy/src/starts/`) (parallel with S2)
+- [ ] `CIV7_START_PLACEMENT_POLICY_V0` (6/12 buffers, homeland model,
+  `balanceBias`, `tilesPerStart` derivation)
+- [ ] `balancedHemisphereSplit({ columnWeights, landmassCentroids, width })`
+- [ ] `feasibleStartCeiling(settleableTiles, spacingFloor)`
+- [ ] `apportionStartsByCapacity({ capacities, ceilings, total, balanceBias })`
+  (largest-remainder + clamp + redistribute)
+- [ ] `dispersionScore(plotIndex, seatedPlots, width)` (odd-R distance)
+- [ ] Export `src/starts/` from `src/index.ts`; export needed `policy-grid` helpers
+- [ ] Unit tests (determinism, total-preservation, feasibility clamp, balanced vs
+  lopsided inputs, seam wrap)
+- [ ] `bun run --cwd packages/civ7-map-policy test`
+
+## S4 — D1 land-aware partition
+- [ ] `plot-landmass-regions/index.ts:resolveSlotByTile` → `balancedHemisphereSplit`
+  (settleable-land column weights; landmasses kept whole by centroid)
+- [ ] Preserve artifact + engine `WEST`/`EAST`/`NONE` stamping + viz
+- [ ] Step/unit test: asymmetric land splits near-evenly; dominant continent is cut
+- [ ] Metric delta: region capacity balance improves vs S2 baseline
+
+## S5 — D2 capacity-proportional allocation
+- [ ] `runtime.ts` / `derive-placement-inputs`: stop fixing per-region split;
+  total `N` from `getAliveMajorIds()` (MapInfo sum as fallback)
+- [ ] `plan-starts/strategies/default.ts`: compute per-region capacity + ceilings
+  from screened candidates; call `apportionStartsByCapacity`
+- [ ] `seat-identity.ts buildSeatIdentities`: bind seats to computed per-region counts
+- [ ] Tests: land-poor region gets fewer; feasibility beats balance; seats == alive count
+- [ ] Metric delta: ER1 passes; ER2 improves
+
+## S6 — D3 dispersion
+- [ ] Per-landmass quotas within region (reuse `apportionStartsByCapacity`)
+- [ ] `selection-ladder.ts`: farthest-point/dispersion term + quota constraint on
+  the regional rung; adaptive spread weight under capacity pressure
+- [ ] Tests: multi-landmass regions seat each landmass; seats fan out; floor held
+- [ ] Metric delta: ER3 passes
+
+## S7 — D4 reconciliation + verification + closure
+- [ ] `default.ts:702-719`: capacity-aware rebalance (recorded), replaces zero-only
+- [ ] Calibrate `tilesPerStart` + `balanceBias` against baseline
+- [ ] Full gate run: ER1–ER4 pass, E1.1/E1.2/E1.3/E1.4/E1.5/E1.6/E1.8 no regression
+  → `evidence/s-results-2026-06-20.md`
+- [ ] `bun run --cwd mods/mod-swooper-maps check` + `nx run mod-swooper-maps:build`
+- [ ] In-game live verification (closure test) + screenshots
+- [ ] OpenSpec validate; hand off to `civ7-open-spec-workstream` / `civ7-systematic-workstream` closure


### PR DESCRIPTION
Systematic diagnosis (4 lanes) + ground-up redesign for the "half the civs crowd
into one small land area" start-distribution bug. Root cause verified: the region
model, not the scorer -- geometric width/2 partition (RC1), fixed capacity-blind
4/4 split (RC2), zero-only reconciliation (RC3), no intra-region dispersion (RC4).

Design keeps the Civ7 two-homeland model and makes partition + allocation
capacity-aware with a dispersion objective: D1 area-balanced meridian, D2
capacity-proportional allocation, D3 per-landmass quotas + farthest-point, D4
imbalance-aware reconciliation + region-balance metric. New pure policy
primitives land in @civ7/map-policy. Dominoes sequenced as graphite slices
S2..S7 with complexity x parallelism (S2 metric || S3 primitives, then the
behavioral spine). OpenSpec change validates --strict.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>