### PR TITLE
feat(diagnostics): region-balance start metrics (E5.1-E5.4) + pre-fix baseline

### DIFF
--- a/docs/projects/start-distribution-homeland-rebalance/evidence/baseline-2026-06-20.md
+++ b/docs/projects/start-distribution-homeland-rebalance/evidence/baseline-2026-06-20.md
@@ -1,0 +1,53 @@
+# Baseline — Region Distribution (S2, pre-fix)
+
+Instrument: `mods/mod-swooper-maps/src/dev/diagnostics/placement-metrics.ts`
+metrics **E5.1–E5.4** (added in slice S2). Run: standard recipe + shipped
+swooper-earthlike config on the mock adapter, `84×54`, `playersLandmass1=4 /
+playersLandmass2=4` (8 players — reproduces "half of 8 in one area"), seeds
+`1337–1341`. This is the **pre-fix** baseline that D1–D4 are measured against.
+
+## The proof
+
+The fixed 4/4 split puts **exactly half** the civs West on **every** seed
+(`westStartShare = 0.5` invariant) while the actual settleable land West swings
+from **9.8% to 96.6%**. Players are allocated with **zero** regard for where the
+land is — the headline failure.
+
+| seed | westStartShare | westLandShare | E5.1 allocationGap | E5.2 maxLandmassShare (capShare) | clusteredHalfSmall | E5.3 spreadIndex | E5.4 reassignRate | E1.5 minSpacing |
+|---|---|---|---|---|---|---|---|---|
+| 1337 | 0.50 | 0.371 | 0.129 | 0.50 (0.361) | false | 0.893 | 0 | 9 |
+| 1338 | 0.50 | 0.108 | 0.392 | 0.50 (0.881) | false | 0.855 | 0 | 7 |
+| 1339 | 0.50 | 0.099 | 0.401 | 0.50 (0.083) | **true** | 0.962 | 0 | 8 |
+| 1340 | 0.50 | 0.966 | 0.466 | **0.75** (0.947) | false | 0.672 | 0 | 6 |
+| 1341 | 0.50 | 0.121 | 0.379 | 0.50 (0.838) | false | 0.807 | 0 | 6 |
+| **mean** | **0.50** | 0.333 | **0.353** | 0.55 | 1/5 seeds | 0.838 | **0** | 7.2 |
+
+## Reading
+
+- **E5.1 (ER1) — primary signal.** `westStartShare` is the constant 0.5 on every
+  seed; `westLandShare` ranges 0.10–0.97. Mean gap **0.353**, max **0.466**. On
+  seed 1340 half the civs are forced East onto **3.4%** of the land; on seeds
+  1338/1339/1341 half are forced West onto ~10% of the land. This is the
+  reported "half the civs in one small land area," quantified.
+- **E5.2 (ER2).** Max single-landmass start share averages 0.55 (up to 0.75).
+  The strict failure pattern (≥50% on a <25%-capacity landmass) fires on seed
+  1339; the region-level failure (E5.1) is broader and fires on all seeds.
+- **E5.3 (ER3).** Spread index 0.67–0.96 — the pairwise floor does some local
+  spreading, so spread is not the dominant defect; **region allocation is**.
+- **E5.4 (ER4).** Reassignment rate **0** on every seed — confirms RC3: the
+  zero-only valve never fires even when a region holds <10% of the land
+  (it still has *some* candidates), so the starved region keeps its 4 seats.
+- **E1.5.** Min pairwise spacing passes (6–9) on every seed — confirms the bug
+  is **invisible** to the existing gate set; E5.x is the missing instrument.
+
+## Targets after D1–D4 (see expectations.md)
+
+- ER1: `allocationCapacityGap` mean → small (≈ ≤ 0.15 after balance-bias rounding).
+- ER2: `clusteredHalfInSmallLandmass` false on all seeds; `startShareExcess` small.
+- ER3: spread index ≥ baseline (no regression; aim ≥ 0.85 mean).
+- ER4: reassignment becomes capacity-aware (may rise from 0 where it should,
+  but ≤ 5% on balanced maps and always recorded).
+- E1.x: no regression (E1.5 floor stays ≥ 6).
+
+> Reproduce: `runPlacementMetrics({ seed, width: 84, height: 54,
+> playersLandmass1: 4, playersLandmass2: 4 })` then read `metrics["E5.*"]`.

--- a/mods/mod-swooper-maps/src/dev/diagnostics/placement-metrics.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/placement-metrics.ts
@@ -32,6 +32,7 @@ import {
 import swooperEarthlikeConfigRaw from "../../maps/configs/swooper-earthlike.config.json";
 import standardRecipe from "../../recipes/standard/recipe.js";
 import { initializeStandardRuntime } from "../../recipes/standard/runtime.js";
+import { mapArtifacts } from "../../recipes/standard/map-artifacts.js";
 import { ecologyArtifacts } from "../../recipes/standard/stages/ecology/artifacts.js";
 import { hydrologyClimateRefineArtifacts } from "../../recipes/standard/stages/hydrology-climate-refine/artifacts.js";
 import { hydrologyHydrographyArtifacts } from "../../recipes/standard/stages/hydrology-hydrography/artifacts.js";
@@ -116,6 +117,7 @@ type StartAssignmentArtifact = {
     seatIndex: number;
     playerId: number;
     playerIdSource: "alive-majors" | "slot-index";
+    regionSlot: number;
     plotIndex: number;
     rung: "regional" | "open-pool" | "quality-relaxed" | "spacing-relaxed";
     status: "full" | "degraded";
@@ -751,6 +753,161 @@ export function computePlacementMetricsFromRun(
         aridityP90,
         temperatureP10,
         temperatureP90,
+      }
+    );
+  }
+
+  // --- E5.1–E5.4 start distribution (homeland rebalance) ------------------------------------------
+  // WHY: the pairwise-spacing gate (E1.5) passes even when half the civs clump
+  // into one small landmass — it has no notion of region balance or spread.
+  // These metrics make the reported clustering measurable and give the D1–D4
+  // slices a before/after signal (docs/projects/start-distribution-homeland-rebalance).
+  {
+    const regionSlotByTile = (
+      context.artifacts.get(mapArtifacts.landmassRegionSlotByTile.id) as
+        | { slotByTile?: Uint8Array }
+        | undefined
+    )?.slotByTile;
+    const landmassIdByTile = landmasses?.landmassIdByTile;
+    const landmassRows = landmasses?.landmasses ?? [];
+
+    // Settleable proxy for the baseline = land tiles. The exact feasibility
+    // ceiling arrives with the S3 capacity primitive; region/landmass capacity
+    // shares here use land tiles as the denominator.
+    let totalLand = 0;
+    for (let i = 0; i < size; i++) if (landMask[i] === 1) totalLand += 1;
+
+    // E5.1 — region balance: seated starts per slot vs that slot's land share.
+    const regionLand: Record<number, number> = { 1: 0, 2: 0 };
+    if (regionSlotByTile instanceof Uint8Array && regionSlotByTile.length === size) {
+      for (let i = 0; i < size; i++) {
+        const slot = regionSlotByTile[i] ?? 0;
+        if (slot === 1 || slot === 2) regionLand[slot] += 1;
+      }
+    }
+    const regionStarts: Record<number, number> = { 1: 0, 2: 0 };
+    for (const seat of startAssignment.seats) {
+      if (seat.plotIndex < 0) continue;
+      if (seat.regionSlot === 1 || seat.regionSlot === 2) regionStarts[seat.regionSlot] += 1;
+    }
+    const seatedTotal = startPlots.length;
+    const regionLandTotal = regionLand[1] + regionLand[2];
+    const westLandShare = regionLandTotal ? regionLand[1] / regionLandTotal : null;
+    const westStartShare = seatedTotal ? regionStarts[1] / seatedTotal : null;
+    const eastStartShare = seatedTotal ? regionStarts[2] / seatedTotal : null;
+    const allocationGap =
+      westLandShare != null && westStartShare != null && eastStartShare != null
+        ? Math.max(
+            Math.abs(westStartShare - westLandShare),
+            Math.abs(eastStartShare - (1 - westLandShare))
+          )
+        : null;
+    metrics["E5.1"] = metric(
+      "E5.1",
+      "Region start share tracks region settleable (land) share (ER1)",
+      "computed",
+      {
+        westLandShare,
+        eastLandShare: westLandShare != null ? 1 - westLandShare : null,
+        westStartShare,
+        eastStartShare,
+        westStarts: regionStarts[1],
+        eastStarts: regionStarts[2],
+        allocationCapacityGap: allocationGap,
+      }
+    );
+
+    // E5.2 — the headline: does one landmass hoard a disproportionate start share?
+    const startsByLandmass = new Map<number, number>();
+    if (landmassIdByTile instanceof Int32Array && landmassIdByTile.length === size) {
+      for (const plotIndex of startPlots) {
+        const lm = landmassIdByTile[plotIndex] ?? -1;
+        if (lm >= 0) startsByLandmass.set(lm, (startsByLandmass.get(lm) ?? 0) + 1);
+      }
+    }
+    let maxStartShare: number | null = null;
+    let capacityShareOfMax: number | null = null;
+    let maxLandmassId = -1;
+    for (const [lm, count] of startsByLandmass) {
+      const share = seatedTotal ? count / seatedTotal : 0;
+      if (maxStartShare == null || share > maxStartShare) {
+        maxStartShare = share;
+        maxLandmassId = lm;
+        const tiles = landmassRows[lm]?.tileCount ?? 0;
+        capacityShareOfMax = totalLand ? tiles / totalLand : null;
+      }
+    }
+    // The reported failure pattern: >=50% of civs on a landmass holding <25% of capacity.
+    const clusteredHalfInSmallLandmass =
+      maxStartShare != null &&
+      capacityShareOfMax != null &&
+      maxStartShare >= 0.5 &&
+      capacityShareOfMax < 0.25;
+    metrics["E5.2"] = metric(
+      "E5.2",
+      "No landmass holds start share far above its settleable share; not >=50% on a <25%-capacity landmass (ER2)",
+      "computed",
+      {
+        maxSingleLandmassStartShare: maxStartShare,
+        capacityShareOfMaxLandmass: capacityShareOfMax,
+        startShareExcess:
+          maxStartShare != null && capacityShareOfMax != null
+            ? maxStartShare - capacityShareOfMax
+            : null,
+        clusteredHalfInSmallLandmass,
+        distinctLandmassesWithStarts: startsByLandmass.size,
+      },
+      { detail: { maxLandmassId } }
+    );
+
+    // E5.3 — spatial spread: mean nearest-neighbor spacing vs even-dispersion ideal.
+    // Even dispersion of N points over land area A on a hex grid: spacing ~ sqrt(A/N).
+    let nnSum = 0;
+    let nnCount = 0;
+    let minNN: number | null = null;
+    for (let i = 0; i < startPlots.length; i++) {
+      let best: number | null = null;
+      for (let j = 0; j < startPlots.length; j++) {
+        if (i === j) continue;
+        const d = hexDistanceOddQPeriodicX(startPlots[i]!, startPlots[j]!, width);
+        if (best == null || d < best) best = d;
+      }
+      if (best != null) {
+        nnSum += best;
+        nnCount += 1;
+        if (minNN == null || best < minNN) minNN = best;
+      }
+    }
+    const meanNN = nnCount ? nnSum / nnCount : null;
+    const idealNN = seatedTotal > 0 && totalLand > 0 ? Math.sqrt(totalLand / seatedTotal) : null;
+    const spreadIndex = meanNN != null && idealNN ? meanNN / idealNN : null;
+    metrics["E5.3"] = metric(
+      "E5.3",
+      "Starts spatially dispersed: mean nearest-neighbor spacing near/above even-dispersion ideal (ER3)",
+      "computed",
+      {
+        meanNearestNeighborSpacing: meanNN,
+        minNearestNeighborSpacing: minNN,
+        idealEvenSpacing: idealNN,
+        spreadIndex,
+      }
+    );
+
+    // E5.4 — region reassignment rate: capacity reconciliation should be rare and loud.
+    const regionReassigned = startAssignment.seats.filter((seat) =>
+      seat.imputedFlags.includes("region-reassigned")
+    ).length;
+    const recordedRegionRelaxations = startAssignment.fairnessReport.relaxations.filter(
+      (relaxation) => relaxation.kind === "region"
+    ).length;
+    metrics["E5.4"] = metric(
+      "E5.4",
+      "Region reassignment rare (<=5% of seats) and recorded as relaxations (ER4)",
+      "computed",
+      {
+        regionReassignedCount: regionReassigned,
+        regionReassignedRate: seatedTotal ? regionReassigned / seatedTotal : null,
+        recordedRegionRelaxations,
       }
     );
   }

--- a/mods/mod-swooper-maps/test/placement/placement-metrics-harness.test.ts
+++ b/mods/mod-swooper-maps/test/placement/placement-metrics-harness.test.ts
@@ -43,6 +43,10 @@ const EXPECTED_METRIC_IDS = [
   "E4.2",
   "E4.3",
   "E4.4",
+  "E5.1",
+  "E5.2",
+  "E5.3",
+  "E5.4",
 ] as const;
 
 const VALID_STATUSES: ReadonlySet<PlacementMetricStatus> = new Set([


### PR DESCRIPTION
S2 / D0 of the start-distribution homeland rebalance. Adds the instrument the
clustering bug currently evades: E1.5 (pairwise spacing) passes even when half
the civs clump into one small landmass.

- E5.1 region start share vs region settleable share (ER1)
- E5.2 max single-landmass start share vs capacity share (ER2, the headline)
- E5.3 normalized spatial spread index (ER3)
- E5.4 region reassignment rate (ER4)

Baseline (84x54, 4/4, seeds 1337-1341) proves the bug: westStartShare is the
constant 0.5 on every seed while westLandShare swings 0.10-0.97 (mean
allocation gap 0.353, max 0.466); reassignment rate is 0 everywhere (RC3); the
pairwise floor passes on every seed. Recorded in
docs/projects/start-distribution-homeland-rebalance/evidence/baseline-2026-06-20.md.

No behavior change. Harness self-test extended to expect E5.x.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>