### PR TITLE
feat(placement): capacity-proportional homeland player allocation (D2)

### DIFF
--- a/mods/mod-swooper-maps/src/domain/placement/ops/plan-starts/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/ops/plan-starts/strategies/default.ts
@@ -1,3 +1,8 @@
+import {
+  apportionStartsByCapacity,
+  CIV7_START_PLACEMENT_POLICY_V0,
+  feasibleStartCeiling,
+} from "@civ7/map-policy";
 import { clamp01 } from "@swooper/mapgen-core";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 import {
@@ -684,25 +689,62 @@ export const defaultStrategy = createStrategy(PlanStartsContract, "default", {
 
     candidates.sort(compareSelectableTiles);
 
-    // --- pass 3: seat identities + four-rung selection ladder ------------------------------
+    // --- pass 3a: capacity-proportional homeland allocation (D2) ---------------------------
+    // WHY: the legacy fixed playersLandmass1/playersLandmass2 split (default
+    // 4/4) ignored where the settleable land actually is, forcing half the civs
+    // into a land-poor homeland (the reported clustering). Apportion the SAME
+    // total across the two homelands by real capacity — admitted-candidate count
+    // (quality-aware) clamped to a spacing-feasibility ceiling from each region's
+    // land extent — then bias toward equal hemispheres when the land allows.
+    // Total seat count is preserved.
+    const candidatesBySlot = { 1: 0, 2: 0 };
+    for (const candidate of candidates) candidatesBySlot[candidate.regionSlot] += 1;
+    let landBySlot1 = 0;
+    let landBySlot2 = 0;
+    for (let i = 0; i < size; i++) {
+      if ((landMask[i] ?? 0) !== 1) continue;
+      const slot = slotByTile[i];
+      if (slot === 1) landBySlot1 += 1;
+      else if (slot === 2) landBySlot2 += 1;
+    }
+    const totalPlayers = playersLandmass1 + playersLandmass2;
+    const allocation = apportionStartsByCapacity({
+      capacities: [candidatesBySlot[1], candidatesBySlot[2]],
+      ceilings: [
+        feasibleStartCeiling(landBySlot1, spacingFloorTiles),
+        feasibleStartCeiling(landBySlot2, spacingFloorTiles),
+      ],
+      total: totalPlayers,
+      balanceBias: CIV7_START_PLACEMENT_POLICY_V0.balanceBias,
+    });
+    // Over-subscription top-up: when the map cannot feasibly hold `total`
+    // well-spaced starts, the excess still gets a seat in the homeland with the
+    // most remaining candidate headroom — degraded downstream by the ladder,
+    // never silently dropped.
+    let allocated = allocation[0]! + allocation[1]!;
+    while (allocated < totalPlayers) {
+      const headroom1 = candidatesBySlot[1] - allocation[0]!;
+      const headroom2 = candidatesBySlot[2] - allocation[1]!;
+      allocation[headroom1 >= headroom2 ? 0 : 1]! += 1;
+      allocated += 1;
+    }
+    const playersWest = allocation[0]!;
+    const playersEast = allocation[1]!;
+
+    // --- pass 3b: seat identities + four-rung selection ladder -----------------------------
     const seatIdentities = buildSeatIdentities({
-      playersWest: playersLandmass1,
-      playersEast: playersLandmass2,
+      playersWest,
+      playersEast,
       alivePlayerIds: input.alivePlayerIds,
     });
 
-    // Region reassignment (recorded, never silent): when a configured region
-    // has ZERO admitted candidates (e.g. a single-continent map whose "east"
-    // hemisphere is a few stray tiles), its seats cannot be regional by
-    // geography — they are reassigned to the other region up-front. This is a
-    // map-shape reconciliation, not a quality fallback: the seat then runs the
-    // normal ladder inside its reassigned region. Each reassignment is
-    // recorded as a region relaxation, flagged per seat, and degrades the
-    // seat's status.
+    // Region reassignment (recorded, never silent): a residual guard for any
+    // seat whose homeland still has ZERO admitted candidates after allocation
+    // (rare now that D2 allocates 0 players to a zero-capacity region). The seat
+    // is reassigned to the other region, recorded as a region relaxation, and
+    // its status degrades.
     const preLadderRelaxations: RelaxationEntry[] = [];
     const reassignedSeats = new Set<number>();
-    const candidatesBySlot = { 1: 0, 2: 0 };
-    for (const candidate of candidates) candidatesBySlot[candidate.regionSlot] += 1;
     for (const seat of seatIdentities) {
       const own = candidatesBySlot[seat.regionSlot];
       const other = (seat.regionSlot === 1 ? 2 : 1) as 1 | 2;
@@ -809,8 +851,11 @@ export const defaultStrategy = createStrategy(PlanStartsContract, "default", {
       .sort((a, b) => a.reason.localeCompare(b.reason));
 
     return {
-      playersLandmass1,
-      playersLandmass2,
+      // Report the ACTUAL capacity-proportional allocation, not the requested
+      // split (the contract defines these as "player count allocated to the
+      // west/east landmass region").
+      playersLandmass1: playersWest,
+      playersLandmass2: playersEast,
       spacingFloorTiles,
       desiredSpacingTiles,
       width,

--- a/mods/mod-swooper-maps/test/placement/start-viability.test.ts
+++ b/mods/mod-swooper-maps/test/placement/start-viability.test.ts
@@ -261,11 +261,11 @@ describe("start selection ladder (op-owned, S4)", () => {
     }
   });
 
-  it("region-reassigns seats whose configured region has zero candidates, recording the reassignment", () => {
+  it("allocates zero players to a homeland with no candidates (capacity allocation pre-empts reassignment)", () => {
     const input = makeInput(16, 10, 1, 1);
-    // All land sits in the west region; the east region does not exist on this
-    // map, so its seat is reassigned (map-shape reconciliation, not a quality
-    // fallback) — recorded as a region relaxation + per-seat flag.
+    // All land sits in the west homeland; the east homeland has no land at all.
+    // D2 apportions players by capacity, so east receives 0 players up front —
+    // both civs seat cleanly in the west with no zero-candidate reassignment.
     addLandmass(
       input,
       0,
@@ -275,29 +275,27 @@ describe("start selection ladder (op-owned, S4)", () => {
 
     const result = plan(input, { spacingFloorTiles: 2, desiredSpacingTiles: 4 });
 
-    const westSeat = result.seats[0]!;
-    const eastSeat = result.seats[1]!;
-    expect(westSeat.rung).toBe("regional");
-    expect(westSeat.status).toBe("full");
-    expect(eastSeat.rung).toBe("regional");
-    expect(eastSeat.regionSlot).toBe(1);
-    expect(eastSeat.status).toBe("degraded");
-    expect(eastSeat.imputedFlags).toContain("region-reassigned");
-    expect(result.status).toBe("degraded");
-    expect(
-      result.fairnessReport.relaxations.some(
-        (entry) =>
-          entry.seatIndex === 1 && entry.kind === "region" && entry.from === 2 && entry.to === 1
-      )
-    ).toBe(true);
+    expect(result.seats.length).toBe(2);
+    for (const seat of result.seats) {
+      expect(seat.regionSlot).toBe(1);
+      expect(seat.rung).toBe("regional");
+      expect(seat.status).toBe("full");
+      expect(seat.imputedFlags).not.toContain("region-reassigned");
+    }
+    expect(result.status).toBe("full");
+    // Allocation pre-empts the zero-candidate reassignment → no region relaxation.
+    expect(result.fairnessReport.relaxations.some((entry) => entry.kind === "region")).toBe(false);
+    // The op reports the ACTUAL allocation (both players west).
+    expect(result.playersLandmass1).toBe(2);
+    expect(result.playersLandmass2).toBe(0);
   });
 
-  it("falls back to the open-pool rung when a region has candidates but no spaced capacity left", () => {
+  it("apportions each homeland a spaceable share by feasibility instead of overloading one (D2)", () => {
     const input = makeInput(20, 10, 0, 2);
-    // East region: one compact 3x4 block — admits candidates but cannot hold
-    // two seats at a 6-tile floor. West region: a distant block. The second
-    // east seat must cross regions on the open-pool rung (a real quality
-    // ladder degradation, unlike the zero-candidate reassignment above).
+    // East homeland: a compact 3x4 block (12 tiles). West homeland: a larger
+    // distant block (36 tiles). The legacy fixed 0/2 split forced both seats
+    // into the cramped east block (an open-pool degradation); D2 apportions by
+    // feasibility so each homeland gets one spaceable, regional seat.
     addLandmass(
       input,
       0,
@@ -317,18 +315,40 @@ describe("start selection ladder (op-owned, S4)", () => {
       desiredSpacingTiles: 6,
     });
 
-    const first = result.seats[0]!;
-    const second = result.seats[1]!;
-    expect(first.rung).toBe("regional");
-    expect(first.imputedFlags).not.toContain("region-reassigned");
-    expect(second.rung).toBe("open-pool");
-    expect(second.status).toBe("degraded");
+    expect(result.seats.length).toBe(2);
+    expect(result.seats.filter((seat) => seat.regionSlot === 1).length).toBe(1);
+    expect(result.seats.filter((seat) => seat.regionSlot === 2).length).toBe(1);
+    for (const seat of result.seats) {
+      expect(seat.rung).toBe("regional");
+      expect(seat.status).toBe("full");
+    }
+    expect(result.status).toBe("full");
+  });
+
+  it("degrades over-subscribed seats when a homeland cannot space its forced allocation (degrade-as-data)", () => {
+    const input = makeInput(16, 10, 3, 0);
+    // One small 12-tile west homeland, 3 players, 6-tile floor: feasibility caps
+    // the homeland near 1 well-spaced start, but every player must still seat
+    // (never dropped) — the surplus seats degrade through the ladder.
+    addLandmass(
+      input,
+      0,
+      1,
+      Array.from({ length: 12 }, (_value, i) => [1 + (i % 3), 1 + Math.floor(i / 3)] as const)
+    );
+
+    const result = plan(input, {
+      minContiguousLandTiles: 12,
+      spacingFloorTiles: 6,
+      desiredSpacingTiles: 6,
+    });
+
+    expect(result.seats.length).toBe(3);
+    // Degrade-as-data: every player is seated, none dropped.
+    expect(result.seats.every((seat) => seat.plotIndex >= 0)).toBe(true);
+    // 12 tiles cannot hold 3 starts 6 apart → at least one seat degrades.
+    expect(result.seats.some((seat) => seat.status === "degraded")).toBe(true);
     expect(result.status).toBe("degraded");
-    expect(
-      result.fairnessReport.relaxations.some(
-        (entry) => entry.seatIndex === second.seatIndex && entry.kind === "region"
-      )
-    ).toBe(true);
   });
 
   it("uses the scored quality-relaxed rung before relaxing spacing below the floor", () => {

--- a/packages/civ7-map-policy/src/starts.ts
+++ b/packages/civ7-map-policy/src/starts.ts
@@ -72,7 +72,9 @@ export function startFootprintTiles(
 /**
  * Max well-spaced starts a region of `settleableTiles` can host at the floor.
  * An area/footprint approximation (region SHAPE is ignored): a soft ceiling the
- * selection ladder still validates exactly. 0 settleable tiles → 0.
+ * selection ladder still validates exactly. 0 settleable tiles → 0; any
+ * non-empty region → ≥ 1 (a single start needs no mutual spacing, so the
+ * footprint divisor must not zero out a small-but-real homeland).
  */
 export function feasibleStartCeiling(
   settleableTiles: number,
@@ -80,7 +82,8 @@ export function feasibleStartCeiling(
   footprintFactor?: number
 ): number {
   if (settleableTiles <= 0) return 0;
-  return Math.floor(settleableTiles / startFootprintTiles(spacingFloorTiles, footprintFactor));
+  const footprint = startFootprintTiles(spacingFloorTiles, footprintFactor);
+  return Math.max(1, Math.floor(settleableTiles / footprint));
 }
 
 /**

--- a/packages/civ7-map-policy/test/starts.test.ts
+++ b/packages/civ7-map-policy/test/starts.test.ts
@@ -32,6 +32,13 @@ describe("feasibleStartCeiling", () => {
     // Larger floor → larger footprint → fewer feasible starts for the same area.
     expect(feasibleStartCeiling(1000, 12)).toBeLessThan(feasibleStartCeiling(1000, 6));
   });
+
+  it("yields at least one start for a small but non-empty region", () => {
+    // A single start needs no mutual spacing, so a sub-footprint region still
+    // hosts one (must not zero out a small-but-real homeland).
+    expect(feasibleStartCeiling(12, 6)).toBe(1);
+    expect(feasibleStartCeiling(1, 6)).toBe(1);
+  });
 });
 
 describe("balancedHemisphereMeridian", () => {


### PR DESCRIPTION
S5 of the start-distribution homeland rebalance — the core fix. plan-starts now
apportions the SAME total players across the two homelands by real capacity
instead of the fixed playersLandmass1/playersLandmass2 (4/4) split:

- capacity = admitted-candidate count per homeland (quality-aware);
- ceilings = feasibleStartCeiling(land extent) per homeland;
- apportionStartsByCapacity blends proportional <-> equal by balanceBias and
  clamps to ceilings; over-subscription tops up the highest-headroom homeland
  (degrade-as-data: every player is seated, never dropped);
- the op now reports the ACTUAL allocation in playersLandmass1/2.

Also corrects feasibleStartCeiling to return >=1 for any non-empty homeland (a
single start needs no mutual spacing; the footprint divisor must not zero out a
small-but-real homeland) + a regression test.

Effect (84x54, 4/4, seeds 1337-1341): E5.1 allocationCapacityGap mean
0.353 (S2) -> 0.263 (D1) -> 0.088; E5.2 clusteredHalfInSmallLandmass 1/5 -> 0/5
(headline bug eliminated); startShareExcess ~0 (starts proportional to
capacity); reassignment rate 2.5% (recorded). Spread 0.80 (D3 recovers it).

Region-reassignment / open-pool unit tests updated to the new allocation
behavior; a new over-subscription test keeps degrade-as-data covered. tsc clean
(only the pre-existing hydrography.slopeClass base error), Biome clean, 78
placement tests + 18 map-policy tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>