### PR TITLE
docs(desert-attrition): feasibility + Path A selective deep-desert/deep-cold hazard design

### DIFF
--- a/docs/projects/desert-ocean-attrition/REPORT.md
+++ b/docs/projects/desert-ocean-attrition/REPORT.md
@@ -1,0 +1,91 @@
+# Desert “ocean damage” — feasibility + design
+
+**Question:** Can a Civ7 mod apply the ocean / deep‑water damage effect (the attrition that kills units ending their turn on deep ocean) to units on **desert** tiles — and, per the design decision below, only to the *deep / dangerous* parts of deserts (and, symmetrically, deep‑cold zones)?
+
+**Bottom line:** **Yes — feasible, via data, and the base game already ships a near‑exact precedent.** The literal “ocean damage” effect cannot be retargeted (its only data surface is *immunity*; the trigger is engine‑internal to the deep‑water plot property). But Civ7’s **PlotEffects** system is a data‑defined, per‑turn, per‑tile HP‑damage mechanism — structurally identical to ocean damage — and this repo’s map‑gen pipeline already scores and stamps sand/snow plot effects from physical signals. The selective “deep desert / deep cold hazard” is therefore a **surgical extension of an existing op**, not new machinery.
+
+Evidence tiers: **T1** = base‑game data the engine ships/loads · **T2** = SDK source that authors such data · **T3** = repo prior art · **T4** = inference. Project rule: *data‑validity ≠ live‑engine acceptance* — anything not already exercised by base data is flagged as an **open live‑proof item**.
+
+---
+
+## 1. What “ocean damage” actually is (T1)
+
+- The **only** data lever for water damage is *protection*: `MODIFIER_PLAYER_UNITS_ADJUST_WATER_DAMAGE` → `EFFECT_ADJUST_UNIT_WATER_DAMAGE_PROTECTION` (`base-standard/data/modifiers.xml:56`). Every use **grants immunity** (`MOD_TECH_EX_NO_OCEAN_DAMAGE` via Shipbuilding, `progression-trees-tech-gameeffects.xml:39`; Tonga’s `NO_OCEAN_DAMAGE`).
+- The **magnitude** is a global parameter: `PLOT_WATER_DAMAGE_BASE=11`, `PLOT_WATER_DAMAGE_RAND=10` (`age-exploration/data/gameplay-systems.xml:19-20`), scaled by `HANDICAP_WATER_DAMAGE` (`difficulties.xml`).
+- **There is no terrain argument and no “deal water damage” effect.** The damage *trigger* is engine‑internal to the deep‑ocean plot property. ⇒ **Ocean damage cannot be re‑pointed at desert directly.**
+
+## 2. The precedent that makes it easy (T1)
+
+The base game **already damages units on desert**, via two distinct systems:
+
+1. **Desert dust storms.** `RANDOM_EVENT_DUST_STORM_GRADIENT/HABOOB` are `EventClass=CLASS_DUSTSTORM`, **`BiomeType="BIOME_DESERT"`** (`random-events.xml:69-70`); they deal `DamageType="UNIT_DAMAGED" MinHP=30..MaxHP=60` (`random-events.xml:173-174`) and lay `PLOTEFFECT_SAND` (`:186-187`). Immunity is data‑expressible: `EFFECT_UNITS_IMMUNE_TO_RANDOM_EVENTS` + `RandomEventClass=CLASS_DUSTSTORM` (cf. Gen. Moroz blizzard immunity).
+2. **PlotEffects with a `Damage` column** (`plot-effects.xml`, schema `01_GameplaySchema.sql:3013-3027`):
+
+   | PlotEffect | Damage | Notes |
+   |---|---|---|
+   | `PLOTEFFECT_IS_BURNING` | 15 | `TimeDecay`, `AllowOnWater=false` |
+   | `PLOTEFFECT_RADIOACTIVE_FALLOUT` | 50 | `TimeValue=10` |
+   | `PLOTEFFECT_PLAGUE` | 25 | decays |
+   | `PLOTEFFECT_STONE_TRAP`/`DIGSITE` | 25 | `TriggerOnEnter`, `RemoveOnEnter` |
+   | **`PLOTEFFECT_SAND`** | **0** | already exists, desert‑themed, currently harmless |
+
+   The DDL: `Damage INTEGER NOT NULL DEFAULT 0`, with `TriggerOnEnter` (default **0** ⇒ damage applies *while occupied*, i.e. per turn, not only on entry), `TimeDecay`/`TimeValue` (auto‑decay), `UnoccupiedDecay`, `AllowOnWater`. A **permanent** hazard = `Damage=N, TimeDecay=0, UnoccupiedDecay=0, TriggerOnEnter=0`.
+
+## 3. Feasibility of the data paths
+
+| Path | Mechanism | Effort | Fidelity | Key open live‑proof |
+|---|---|---|---|---|
+| **A. Permanent PlotEffect hazard (CHOSEN)** | new/overridden `PlotEffects` row with `Damage`, stamped on selected tiles via the repo’s existing `addPlotEffect` map‑gen step | Low–Med | High (tile deals per‑turn HP, like ocean) | Does a non‑decaying damaging plot‑effect harm a **land** occupant every turn? |
+| A2. Amplify dust storms | data override of `random-events.xml` (freq/HP) | Low | Med (random/transient) | none major; has native immunity hook |
+| B. Modifier + biome gate | `ModifierBuilder` → `EFFECT_UNIT_ADJUST_DAMAGE` (`run-once="false"`) gated by `REQUIREMENT_PLOT_BIOME_TYPE_MATCHES`/`BIOME_DESERT` on `COLLECTION_PLAYER_UNITS` | Low (SDK; Dacia template) | High | exact per‑turn cadence of `run-once="false"` |
+| C. Gameplay‑script DOT | JS on‑turn/move hook → desert check → damage | High | Highest control | whether Civ7 exposes the hook+damage API to mods |
+| ~~`ADJUST_UNIT_AREA_DAMAGE` / `ARMY_ADJUST_ATTRITION_DAMAGE`~~ | offensive splash ability / **0 base‑game uses** | — | — | rejected (not terrain hazards) |
+
+Supporting facts: biome gate is proven (`REQUIREMENT_PLOT_BIOME_TYPE_MATCHES` used by Dai Viet `BIOME_TROPICAL`, water‑wonders `BIOME_MARINE`); `EFFECT_UNIT_ADJUST_DAMAGE` is the signed HP lever (Amount=25/50 or `Destroy=TRUE`; Iceland uses it for healing) with `run-once="false"` precedent (`narrative-stories-gameeffects.xml:2059,2287`). `ImmuneDamage` is a **Constructibles** (wonder) column, **not** a unit lever — so per‑unit immunity to a *custom* plot effect has no clean generic data hook (limitation, see §6).
+
+---
+
+## 4. Chosen design — selective, physically‑grounded hazard (Path A)
+
+Not every desert tile; only **deep / dangerous** desert (and symmetric **deep cold**), emerging deterministically from the map’s physics. This drops straight onto the repo’s existing ecology plot‑effect pipeline.
+
+**The pipeline already exists** (`mods/mod-swooper-maps/src/domain/ecology/ops/`):
+- `plot-effects-score-sand` → per‑tile `score01` = mean of normalized `aridityIndex`, `surfaceTemperature`, inverse `freezeIndex`, inverse `vegetationDensity`, inverse `effectiveMoisture` (eligible: aridity ≥ 0.55, temp ≥ 18 °C, freeze ≤ 0.25, veg ≤ 0.2, moisture ≤ 90, biome ∈ {desert, temperateDry}). **High score = hottest/driest interior = “deep desert.”**
+- `plot-effects-score-snow` → `score01` = weighted `freezeIndex` + `elevation` + `moisture`, eligible at `surfaceTemperature ≤ 4 °C`. **High score = deepest cold — directly temperature‑tied.**
+- `plan-plot-effects` → deterministic **top‑coverage by score** with **tiered thresholds** (snow already: `light 0.35 / medium 0.6 / heavy 0.8`, `coveragePct 80`; “M3 posture: deterministic, seeded tie‑break only”).
+- `map-ecology/steps/plot-effects` → projects the plan to the engine via `adapter.addPlotEffect(x,y,type)` (`civ7-adapter/src/types.ts:576`). `DESERT_BIOME` is already resolved in `mapgen-core` (`core/terrain-constants.ts:86`).
+
+**The extension = a hazard tier + a “massive/interior” gate.**
+
+- **Deep cold:** add an `extreme` band above `heavyThreshold` in the snow plan whose selector is a *damaging* plot effect. Coldest/highest tiles only.
+- **Deep desert:** give the (currently single‑tier) sand plan the same multi‑tier treatment — `hazardThreshold` band → damaging `PLOTEFFECT_DESERT_HEAT`; below → cosmetic `PLOTEFFECT_SAND`. Add a **contiguous‑mass + interior‑distance gate** so the hazard only appears in *large* desert interiors (“crossing is clearly dangerous”), not isolated dunes:
+  - connected‑component over `sandEligibleMask`; keep components ≥ `minMassTiles`;
+  - distance transform → require `interiorDistance ≥ minInteriorDist` (tiles far from the desert edge).
+  - This is a new pure rule alongside the existing `plan-plot-effects/rules/snow-elevation.ts`.
+
+All deterministic (pure function of physical fields; RNG only as exact‑tie break) — consistent with the natural‑wonders “physically‑grounded suitability, not random” decision.
+
+---
+
+## 5. Implementation plan (file‑by‑file)
+
+1. **Data — damaging plot effects.** Author a raw SQL/XML file via `ImportFileBuilder` (T2): `PLOTEFFECT_DESERT_HEAT` (`Damage=11` to match `PLOT_WATER_DAMAGE_BASE`, `TimeDecay=0, UnoccupiedDecay=0, TriggerOnEnter=0, AllowOnWater=0`) and `PLOTEFFECT_DEEP_COLD` (e.g. `Damage=8`), each with a `Name` LOC row. Ship via an `ACTION_GROUP_ACTION` UPDATE/IMPORT.
+2. **Types/viz.** Register the two keys in `@mapgen/domain/ecology` `PlotEffectKey` and add viz categories (mirror `plot-effects/viz.ts`, which already lists `PLOTEFFECT_SAND`).
+3. **Contract — `plan-plot-effects/contract.ts`.** Extend `PlotEffectsSandPlanSchema` to multi‑tier (add `hazardThreshold`, `hazard` selector, `minMassTiles`, `minInteriorDist`); add an `extreme`/`hazard` band + selector to `PlotEffectsSnowSelectorsSchema`/plan.
+4. **Strategy — `plan-plot-effects/strategies/default.ts`.** Assign hazard vs cosmetic by score band (mirror the snow band logic), after applying the mass/interior gate; keep the deterministic `selectTopCoverage`.
+5. **Rule — `plan-plot-effects/rules/desert-mass.ts`** (new). Connected components + distance transform over `sandEligibleMask`. Pure, tested.
+6. **Config.** Enable sand (`sand.enabled=true`) and set thresholds/coverage in the relevant `mods/mod-swooper-maps/src/maps/configs/*.config.json` (desert‑heavy maps: `swooper-desert-mountains`, etc.); set the cold extreme band.
+7. **Tests + parity.** Unit‑test the new rule + band assignment; **regenerate the ecology‑parity fingerprint fixtures** (`test/fixtures/ecology-parity/…`) — placements change deterministically, so the fixture delta is expected and reviewable.
+8. **Live‑proof.** Launch Civ7, park a land unit in a deep‑desert hazard tile, confirm per‑turn HP loss in `Scripting.log`; repeat for deep cold. (See §6.)
+
+## 6. Open live‑proof items & risks
+
+- **★ Per‑turn damage on land (the one real unknown).** Every base damaging plot effect either decays (`IS_BURNING`, `PLAGUE`) or is `TriggerOnEnter` (`STONE_TRAP`). A **permanent, non‑decaying** damaging plot effect on land is structurally supported by the schema but not directly precedented → must be confirmed in `Scripting.log`. Fallback if the engine won’t per‑turn‑damage a permanent effect: Path A2 (amplified dust storms) or Path B (`run-once="false"` modifier).
+- **Map‑gen persistence.** `addPlotEffect` at gen is proven (the existing step), but persistence of a *custom permanent* effect into live turns is the test.
+- **Per‑unit immunity** has no clean data hook for custom plot effects (`ImmuneDamage` is wonders‑only). The dust‑storm path (A2) *does* have `EFFECT_UNITS_IMMUNE_TO_RANDOM_EVENTS` — relevant if we want “camel/desert units cross safely.”
+- **Balance/AI.** AI pathing may not avoid the hazard; tune `Damage`, `coveragePct`, `minMassTiles` conservatively. UX: hazard must be legible (viz/tooltip + the storm‑style notification).
+
+## 7. Status / provenance
+
+- Branch `desert-ocean-attrition-feasibility` (off `start-dist-homeland-rebalance`).
+- Evidence gathered via narsil code‑intel over the vendored base‑game dump (`.civ7/outputs/resources`) + repo SDK/mapgen source. The original background feasibility workflow stalled mid‑`Understand` on the large gameeffects XML; the findings here were produced by direct structural search and supersede it.

--- a/docs/projects/desert-ocean-attrition/REPORT.md
+++ b/docs/projects/desert-ocean-attrition/REPORT.md
@@ -122,3 +122,16 @@ Permanence is governed by two flags: **`TimeDecay`** (counts down `TimeValue` tu
 - **`BURNED` is NOT permanent** — it is fully transient (both decay flags true, like `SAND`). The explicit permanence signal in the data is the **`_PERMANENT` vs `_TRANSIENT` name suffix** on the snow effects.
 - The permanent **damaging** effects (`STONE_TRAP`, `DIGSITE`) are **one-shot traps** (`RemoveOnEnter`), not continuous attrition.
 - ⇒ **No base plot effect is permanent AND deals continuous per-turn damage to occupants.** That niche was empty — which is exactly what `PLOTEFFECT_DESERT_HEAT` (permanent, `Damage=11`, no `TriggerOnEnter`) was created to fill, and is now proven to work.
+
+---
+
+## 9. Future directions (documented, not pursued now)
+
+**World-visual marker** (the hazard currently surfaces via the plot tooltip only). Three avenues, in rough order of effort/reliability:
+1. **Persistent-art Feature.** Place a feature with real, persistent 3-D art on hazard tiles as the marker. Most reliable on-map signal, but features affect movement/yields and a thematically-fitting art-backed feature must be found per biome.
+2. **JS override of `world-vfx.js`.** A mod can replace the UI script and, for our types, call the *persistent* `WorldUI.addVFXAtPlot(...)` (as `PLOTEFFECT_FLOODED` does) instead of the one-shot `triggerVFXAtPlot`. Speculative — base "appears" assets aren't authored to loop/persist — and it would also need a re-add on game-start since mapgen placements don't fire the add-event.
+3. **Custom VFX/decal asset.** Author a real ground decal through the art pipeline and point `VFX_ADDED_TO_MAP_<TYPE>` at it. Cleanest visually, but outside data-only modding.
+
+**Placement refinement.** Replace the score-based top-coverage selection with a deterministic **interior-depth gate**: a tile gets the hazard only if it is deep interior (every tile within a 3-tile hex radius is the same hazard biome/feature). This makes "only massive interiors are dangerous" geometric and explicit, and generalizes cleanly to other biomes.
+
+**Sibling hazards (same pattern).** `PLOTEFFECT_FROSTBITE` on deep snow/cold (rides the snow channel; anchor `BIOME_TUNDRA`) and `PLOTEFFECT_JUNGLE_FEVER` on deep rainforest (anchor `FEATURE_RAINFOREST`). Each is the same permanent-damaging-PlotEffect mechanism gated by the interior-depth rule above.

--- a/docs/projects/desert-ocean-attrition/REPORT.md
+++ b/docs/projects/desert-ocean-attrition/REPORT.md
@@ -89,3 +89,36 @@ All deterministic (pure function of physical fields; RNG only as exact‑tie bre
 
 - Branch `desert-ocean-attrition-feasibility` (off `start-dist-homeland-rebalance`).
 - Evidence gathered via narsil code‑intel over the vendored base‑game dump (`.civ7/outputs/resources`) + repo SDK/mapgen source. The original background feasibility workflow stalled mid‑`Understand` on the large gameeffects XML; the findings here were produced by direct structural search and supersede it.
+
+---
+
+## 8. RESULTS — implemented & PROVEN LIVE (2026-06-20)
+
+The one real unknown from §6 is **resolved: yes.** A permanent, non-decaying plot effect **does** damage a land occupant every turn.
+
+**Live proof (latest-juicy, driven via the `civ7` CLI):** `PLOTEFFECT_DESERT_HEAT` (`Damage=11, TimeDecay=false, UnoccupiedDecay=false, AllowOnWater=false`) loads with **no rollback**, registers at runtime, and was **placed on 36 deepest-desert tiles** (24% sand coverage). A stationary unit on a DESERT_HEAT tile lost **exactly 11 HP across one turn** (0 → 11, turn 1 → 2). This is the genuine ocean-damage twin.
+
+**What shipped (simpler than the §5 plan):**
+- `mod/data/desert-hazard.xml` — ROOT `<Database>` with `Types` + `PlotEffects` rows for `PLOTEFFECT_DESERT_HEAT`. Loaded via a game-scope `UpdateDatabase`. LOC name in `MapText.xml`.
+- `plan-plot-effects` — the sand channel gained an **optional `hazard` companion selector** (`sand.hazard`) that co-places the hazard on the same top-coverage deep-desert tiles the cosmetic sand selects. (Lighter than the full multi-tier + connected-mass/interior-distance gate of §4–5; coverage % already constrains it to the deepest tiles. The mass/interior gate remains available as a future refinement.) Wired via `ecology-public-config.ts` `PLOT_EFFECT_SELECTORS.sandHazard`; viz category added; tests in `test/ecology/plot-effects-sand-hazard.test.ts`.
+- The global `EFFECT_UNIT_ADJUST_DAMAGE` modifier path (§3 Path B) was **dropped**: it is one-shot in 100% of base usage (`run-once="true"`) and a biome modifier hits *all* desert, contradicting the "deep parts only" design.
+
+**Corrected finding — the "art-gated / unplaceable" fear was wrong.** A missing world-VFX does **not** block placement: the engine builds the visual as `WorldUI.triggerVFXAtPlot("VFX_ADDED_TO_MAP_"+PlotEffectType)` in `onPlotEffectAddedToMap` (`world-vfx.js:77`) and silently no-ops when the asset is absent; the gameplay placement + `Damage` still apply. The earlier "0 placements" was a data-load rollback, not art.
+
+**Open: the world-visual.** There is **no data-only way to render a persistent ground marker.** A custom type has no art, and even base `PLOTEFFECT_SAND` has *no persistent decal* — its only visual is a one-shot "appears" animation (`triggerVFXAtPlot`, vs the persistent `addVFXAtPlot` used only by `PLOTEFFECT_FLOODED`), which mapgen placement never fires (verified: SAND added to 7 tundra tiles at runtime showed zero overlay). The hazard is surfaced via the **plot tooltip** ("Deep Desert Heat") + the terrain already reading as harsh desert. A real overlay would need the art pipeline or a persistent-art **feature** — future work.
+
+### 8.1 Plot-effect permanence survey (all 15 base effects, `plot-effects.xml` — the only definition file)
+
+Permanence is governed by two flags: **`TimeDecay`** (counts down `TimeValue` turns) and **`UnoccupiedDecay`** (vanishes when no unit occupies the tile). "Permanent" = **both false**.
+
+| Class (TimeDecay / UnoccupiedDecay) | Effects | Damage | Notes |
+|---|---|---|---|
+| **PERMANENT** (false / false) | `FLOODED` (0); `SNOW_LIGHT/MEDIUM/HEAVY_PERMANENT` (0); `STONE_TRAP` (25), `DIGSITE` (25) | 0, except traps=25 | FLOODED has the *only* persistent VFX (`addVFXAtPlot`); SNOW_*_PERMANENT render via terrain material. STONE_TRAP/DIGSITE are permanent **but** `TriggerOnEnter`+`RemoveOnEnter` → one-shot, removed when stepped on (not continuous). |
+| **OCCUPANCY-HELD** (false / true) | `UNIT_FORTIFICATIONS` (0, Defense=3) | 0 | Persists only while a unit sits on it. |
+| **TIME-DECAY** (true / false) | `IS_BURNING` (15, 2t), `PLAGUE` (25, 1t), `RADIOACTIVE_FALLOUT` (50, 10t) | 15–50 | The per-turn damagers — but all expire after `TimeValue` turns. |
+| **FULLY TRANSIENT** (true / true) | `SAND` (0), **`BURNED` (0)**, `SNOW_LIGHT/MEDIUM/HEAVY_TRANSIENT` (0) | 0 | Weather/cosmetic; decay fast. |
+
+**Key takeaways:**
+- **`BURNED` is NOT permanent** — it is fully transient (both decay flags true, like `SAND`). The explicit permanence signal in the data is the **`_PERMANENT` vs `_TRANSIENT` name suffix** on the snow effects.
+- The permanent **damaging** effects (`STONE_TRAP`, `DIGSITE`) are **one-shot traps** (`RemoveOnEnter`), not continuous attrition.
+- ⇒ **No base plot effect is permanent AND deals continuous per-turn damage to occupants.** That niche was empty — which is exactly what `PLOTEFFECT_DESERT_HEAT` (permanent, `Damage=11`, no `TriggerOnEnter`) was created to fill, and is now proven to work.

--- a/mods/mod-swooper-maps/mod/data/desert-hazard.xml
+++ b/mods/mod-swooper-maps/mod/data/desert-hazard.xml
@@ -4,6 +4,6 @@
     <Row Type="PLOTEFFECT_DESERT_HEAT" Kind="KIND_PLOTEFFECT"/>
   </Types>
   <PlotEffects>
-    <Row PlotEffectType="PLOTEFFECT_DESERT_HEAT" Name="LOC_PLOTEFFECT_DESERT_HEAT_NAME" Damage="11" Defense="0" TimeDecay="false" UnoccupiedDecay="false" TriggerOnEnter="false" AllowOnWater="false" AllowConstructWhileDamaged="false"/>
+    <Row PlotEffectType="PLOTEFFECT_DESERT_HEAT" Name="LOC_PLOTEFFECT_DESERT_HEAT_NAME" TimeDecay="false" UnoccupiedDecay="false" TimeValue="1" Damage="11" Defense="0" AllowOnWater="false"/>
   </PlotEffects>
 </Database>

--- a/mods/mod-swooper-maps/mod/data/desert-hazard.xml
+++ b/mods/mod-swooper-maps/mod/data/desert-hazard.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Database>
+  <Types>
+    <Row Type="PLOTEFFECT_DESERT_HEAT" Kind="KIND_PLOTEFFECT"/>
+  </Types>
+  <PlotEffects>
+    <Row PlotEffectType="PLOTEFFECT_DESERT_HEAT" Name="LOC_PLOTEFFECT_DESERT_HEAT_NAME" Damage="11" Defense="0" TimeDecay="false" UnoccupiedDecay="false" TriggerOnEnter="false" AllowOnWater="false" AllowConstructWhileDamaged="false"/>
+  </PlotEffects>
+  <EnglishText>
+    <Row Tag="LOC_PLOTEFFECT_DESERT_HEAT_NAME">
+      <Text>Deep Desert Heat</Text>
+    </Row>
+  </EnglishText>
+</Database>

--- a/mods/mod-swooper-maps/mod/data/desert-hazard.xml
+++ b/mods/mod-swooper-maps/mod/data/desert-hazard.xml
@@ -6,9 +6,4 @@
   <PlotEffects>
     <Row PlotEffectType="PLOTEFFECT_DESERT_HEAT" Name="LOC_PLOTEFFECT_DESERT_HEAT_NAME" Damage="11" Defense="0" TimeDecay="false" UnoccupiedDecay="false" TriggerOnEnter="false" AllowOnWater="false" AllowConstructWhileDamaged="false"/>
   </PlotEffects>
-  <EnglishText>
-    <Row Tag="LOC_PLOTEFFECT_DESERT_HEAT_NAME">
-      <Text>Deep Desert Heat</Text>
-    </Row>
-  </EnglishText>
 </Database>

--- a/mods/mod-swooper-maps/mod/swooper-maps.modinfo
+++ b/mods/mod-swooper-maps/mod/swooper-maps.modinfo
@@ -20,6 +20,9 @@
 				<UpdateText>
 					<Item>text/en_us/MapText.xml</Item>
 				</UpdateText>
+				<UpdateDatabase>
+					<Item>data/desert-hazard.xml</Item>
+				</UpdateDatabase>
 				<ImportFiles>
 					<Item>maps/swooper-desert-mountains.js</Item>
 					<Item>maps/swooper-earthlike.js</Item>

--- a/mods/mod-swooper-maps/mod/text/en_us/MapText.xml
+++ b/mods/mod-swooper-maps/mod/text/en_us/MapText.xml
@@ -55,5 +55,8 @@
 		<Row Tag="LOC_MAP_MOUNTAIN_RIVERS_PATCH_DESCRIPTION">
 			<Text>Mountain Patch terrain configuration with the current visible-river projection settings applied for Studio comparison.</Text>
 		</Row>
+		<Row Tag="LOC_PLOTEFFECT_DESERT_HEAT_NAME">
+			<Text>Deep Desert Heat</Text>
+		</Row>
 	</EnglishText>
 </Database>

--- a/mods/mod-swooper-maps/scripts/generate-map-artifacts.ts
+++ b/mods/mod-swooper-maps/scripts/generate-map-artifacts.ts
@@ -171,6 +171,9 @@ function renderMapText(configs: readonly ValidatedMapConfig[]): string {
 <Database>
 \t<EnglishText>
 ${rows}
+\t\t<Row Tag="LOC_PLOTEFFECT_DESERT_HEAT_NAME">
+\t\t\t<Text>Deep Desert Heat</Text>
+\t\t</Row>
 \t</EnglishText>
 </Database>
 `;
@@ -189,11 +192,6 @@ function renderDesertHazardData(): string {
   <PlotEffects>
     <Row PlotEffectType="PLOTEFFECT_DESERT_HEAT" Name="LOC_PLOTEFFECT_DESERT_HEAT_NAME" Damage="11" Defense="0" TimeDecay="false" UnoccupiedDecay="false" TriggerOnEnter="false" AllowOnWater="false" AllowConstructWhileDamaged="false"/>
   </PlotEffects>
-  <EnglishText>
-    <Row Tag="LOC_PLOTEFFECT_DESERT_HEAT_NAME">
-      <Text>Deep Desert Heat</Text>
-    </Row>
-  </EnglishText>
 </Database>
 `;
 }

--- a/mods/mod-swooper-maps/scripts/generate-map-artifacts.ts
+++ b/mods/mod-swooper-maps/scripts/generate-map-artifacts.ts
@@ -21,6 +21,7 @@ const configsDir = resolve(pkgRoot, "src/maps/configs");
 const generatedEntriesDir = resolve(pkgRoot, "src/maps/generated");
 const modConfigDir = resolve(pkgRoot, "mod/config");
 const modTextDir = resolve(pkgRoot, "mod/text/en_us");
+const modDataDir = resolve(pkgRoot, "mod/data");
 const distRecipesDir = resolve(pkgRoot, "dist/recipes");
 const transientStudioCurrentConfig = "studio-current.config.json";
 const includeTransientStudioCurrent = process.env.SWOOPER_INCLUDE_STUDIO_CURRENT === "1";
@@ -175,6 +176,28 @@ ${rows}
 `;
 }
 
+// Deep-desert hazard (Path A de-risk slice): a permanent, non-decaying plot effect
+// that damages occupying units each turn (the structural analog of ocean damage).
+// Placed on the deepest-scoring desert tiles by the ecology plot-effects planner.
+// Loaded via a gameplay-scope UpdateDatabase action in the modinfo.
+function renderDesertHazardData(): string {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<Database>
+  <Types>
+    <Row Type="PLOTEFFECT_DESERT_HEAT" Kind="KIND_PLOTEFFECT"/>
+  </Types>
+  <PlotEffects>
+    <Row PlotEffectType="PLOTEFFECT_DESERT_HEAT" Name="LOC_PLOTEFFECT_DESERT_HEAT_NAME" Damage="11" Defense="0" TimeDecay="false" UnoccupiedDecay="false" TriggerOnEnter="false" AllowOnWater="false" AllowConstructWhileDamaged="false"/>
+  </PlotEffects>
+  <EnglishText>
+    <Row Tag="LOC_PLOTEFFECT_DESERT_HEAT_NAME">
+      <Text>Deep Desert Heat</Text>
+    </Row>
+  </EnglishText>
+</Database>
+`;
+}
+
 function renderModInfo(configs: readonly ValidatedMapConfig[]): string {
   const imports = configs
     .map((config) => `\t\t\t\t\t<Item>maps/${config.outputFile}</Item>`)
@@ -201,6 +224,9 @@ function renderModInfo(configs: readonly ValidatedMapConfig[]): string {
 \t\t\t\t<UpdateText>
 \t\t\t\t\t<Item>text/en_us/MapText.xml</Item>
 \t\t\t\t</UpdateText>
+\t\t\t\t<UpdateDatabase>
+\t\t\t\t\t<Item>data/desert-hazard.xml</Item>
+\t\t\t\t</UpdateDatabase>
 \t\t\t\t<ImportFiles>
 ${imports}
 \t\t\t\t</ImportFiles>
@@ -278,6 +304,7 @@ async function main(): Promise<void> {
   await mkdir(generatedEntriesDir, { recursive: true });
   await mkdir(modConfigDir, { recursive: true });
   await mkdir(modTextDir, { recursive: true });
+  await mkdir(modDataDir, { recursive: true });
   await mkdir(distRecipesDir, { recursive: true });
 
   for (const entry of await readdir(generatedEntriesDir, { withFileTypes: true }).catch(() => [])) {
@@ -292,6 +319,7 @@ async function main(): Promise<void> {
 
   await writeFile(resolve(modConfigDir, "config.xml"), renderConfigXml(configs));
   await writeFile(resolve(pkgRoot, "mod/swooper-maps.modinfo"), renderModInfo(configs));
+  await writeFile(resolve(modDataDir, "desert-hazard.xml"), renderDesertHazardData());
   await writeFile(resolve(modTextDir, "MapText.xml"), renderMapText(configs));
   await writeFile(
     resolve(distRecipesDir, "standard-map-config.schema.json"),

--- a/mods/mod-swooper-maps/scripts/generate-map-artifacts.ts
+++ b/mods/mod-swooper-maps/scripts/generate-map-artifacts.ts
@@ -179,10 +179,31 @@ ${rows}
 `;
 }
 
-// Deep-desert hazard (Path A de-risk slice): a permanent, non-decaying plot effect
-// that damages occupying units each turn (the structural analog of ocean damage).
-// Placed on the deepest-scoring desert tiles by the ecology plot-effects planner.
-// Loaded via a gameplay-scope UpdateDatabase action in the modinfo.
+// Deep-desert attrition. A custom, permanent, damaging PlotEffect — the data-defined
+// twin of the engine-internal ocean damage. PROVEN LIVE (a stationary unit on a DESERT_HEAT
+// tile took exactly 11 HP across one turn): a PlotEffects row with Damage>0 and no
+// TriggerOnEnter inflicts that Damage on ANY unit occupying the tile, every turn — exactly
+// the "crossing here is dangerous" model. DESERT_HEAT is permanent (TimeDecay/
+// UnoccupiedDecay=false) so it persists for the whole game, and AllowOnWater=false so it
+// only lives on land. This fills a real gap: NO base plot effect is both permanent AND
+// damages occupants per turn (the permanent ones — FLOODED, SNOW_*_PERMANENT — deal 0;
+// STONE_TRAP/DIGSITE are permanent but RemoveOnEnter one-shots; the per-turn damagers —
+// IS_BURNING/PLAGUE/FALLOUT — all TimeDecay away).
+//
+// NO WORLD-VISUAL: a custom type has no engine art (the visual name is
+// "VFX_ADDED_TO_MAP_"+PlotEffectType, with no asset for ours), and even base PLOTEFFECT_SAND
+// has no PERSISTENT decal — its only visual is a one-shot "appears" animation
+// (WorldUI.triggerVFXAtPlot, world-vfx.js:77), which mapgen placement never fires. A missing
+// VFX does NOT gate gameplay placement, so the damage still applies; the hazard is surfaced
+// in-game via the plot TOOLTIP (the PlotEffects Name) + the terrain already reading as harsh
+// desert. The ecology plan still co-places base PLOTEFFECT_SAND on these tiles (transient,
+// flavor only); a guaranteed world-overlay would need the art pipeline / a feature, tracked
+// as future work.
+//
+// Gameplay-DB table form: a ROOT <Database> with raw <Row> entries (Types + PlotEffects).
+// Loaded via a gameplay-scope UpdateDatabase action in the modinfo. (Contrast the high-level
+// <GameEffects xmlns="GameEffects"> <Modifier> form — a DIFFERENT root that rolls back if
+// nested in <Database>. No modifier needed here: PlotEffects.Damage is the whole mechanism.)
 function renderDesertHazardData(): string {
   return `<?xml version="1.0" encoding="utf-8"?>
 <Database>
@@ -190,7 +211,7 @@ function renderDesertHazardData(): string {
     <Row Type="PLOTEFFECT_DESERT_HEAT" Kind="KIND_PLOTEFFECT"/>
   </Types>
   <PlotEffects>
-    <Row PlotEffectType="PLOTEFFECT_DESERT_HEAT" Name="LOC_PLOTEFFECT_DESERT_HEAT_NAME" Damage="11" Defense="0" TimeDecay="false" UnoccupiedDecay="false" TriggerOnEnter="false" AllowOnWater="false" AllowConstructWhileDamaged="false"/>
+    <Row PlotEffectType="PLOTEFFECT_DESERT_HEAT" Name="LOC_PLOTEFFECT_DESERT_HEAT_NAME" TimeDecay="false" UnoccupiedDecay="false" TimeValue="1" Damage="11" Defense="0" AllowOnWater="false"/>
   </PlotEffects>
 </Database>
 `;

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/contract.ts
@@ -53,6 +53,20 @@ const PlotEffectsSnowPlanSchema = Type.Object({
 const PlotEffectsSandPlanSchema = Type.Object({
   enabled: Type.Boolean({ default: false, description: "Enable planning of sand plot effects." }),
   selector: createPlotEffectSelectorSchema({ typeName: "PLOTEFFECT_SAND" }),
+  // Optional companion effect CO-PLACED on the SAME selected sand tiles. The `selector`
+  // (PLOTEFFECT_SAND) is cosmetic (Damage=0) and provides the visible marker; the hazard
+  // carries the per-turn Damage (e.g. PLOTEFFECT_DESERT_HEAT). Genuinely opt-in (no schema
+  // default): when omitted, sand is placed alone (pure cosmetic). Both effects coexist on
+  // the tile — the engine supports multiple plot effects per plot.
+  hazard: Type.Optional(
+    Type.Object({
+      typeName: Type.Unsafe<PlotEffectKey>(
+        Type.String({
+          description: "Companion damaging plot effect type (ex: PLOTEFFECT_DESERT_HEAT).",
+        })
+      ),
+    })
+  ),
   coveragePct: Type.Number({
     default: 18,
     minimum: 0,

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/strategies/default.ts
@@ -44,6 +44,7 @@ function normalizeConfig(config: Config): Config {
     sand: {
       ...config.sand,
       selector: normalizeSelector(config.sand.selector),
+      hazard: config.sand.hazard ? normalizeSelector(config.sand.hazard) : config.sand.hazard,
     },
     burned: {
       ...config.burned,
@@ -153,13 +154,16 @@ export const defaultStrategy = createStrategy(PlanPlotEffectsContract, "default"
         plotEffect,
       }))
     );
-    placements.push(
-      ...selectTopCoverage(sandCandidates, sand.coveragePct).map(({ x, y, plotEffect }) => ({
-        x,
-        y,
-        plotEffect,
-      }))
-    );
+    // Sand: place the cosmetic selector, and CO-PLACE the optional hazard effect on the
+    // SAME tile (visible sand marker + per-turn damage). Multiple plot effects per plot
+    // are supported by the engine.
+    const sandHazardType = sand.hazard?.typeName;
+    for (const { x, y, plotEffect } of selectTopCoverage(sandCandidates, sand.coveragePct)) {
+      placements.push({ x, y, plotEffect });
+      if (sandHazardType) {
+        placements.push({ x, y, plotEffect: sandHazardType });
+      }
+    }
     placements.push(
       ...selectTopCoverage(burnedCandidates, burned.coveragePct).map(({ x, y, plotEffect }) => ({
         x,

--- a/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
@@ -230,7 +230,7 @@
     },
     "hydrology-climate-baseline": {
       "knobs": {
-        "dryness": "mix",
+        "dryness": "dry",
         "temperature": "hot",
         "seasonality": "high",
         "oceanCoupling": "earthlike"
@@ -298,7 +298,7 @@
         "secondaryWeightMin": 0.2
       },
       "precipitation": {
-        "rainfallScale": 184,
+        "rainfallScale": 150,
         "humidityExponent": 1.15,
         "noiseAmplitude": 14,
         "noiseScale": 0.16,
@@ -340,7 +340,7 @@
     },
     "hydrology-climate-refine": {
       "knobs": {
-        "dryness": "mix",
+        "dryness": "dry",
         "temperature": "hot",
         "cryosphere": "on"
       },

--- a/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
@@ -625,11 +625,11 @@
           "moistureMax": 170
         },
         "sand": {
-          "minAridity": 0.5,
-          "minTemperature": 15,
-          "maxFreeze": 0.3,
-          "maxVegetation": 0.23,
-          "maxMoisture": 90,
+          "minAridity": 0.3,
+          "minTemperature": 5,
+          "maxFreeze": 0.5,
+          "maxVegetation": 0.5,
+          "maxMoisture": 200,
           "allowedBiomes": ["desert", "temperateDry"]
         },
         "burned": {

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.json
@@ -591,7 +591,7 @@
         },
         "sand": {
           "enabled": true,
-          "coveragePct": 42
+          "coveragePct": 15
         },
         "burned": {
           "enabled": true,

--- a/mods/mod-swooper-maps/src/maps/generated/latest-juicy.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/latest-juicy.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "latest-juicy",
-  configHash: "10297444373d48ac7b1bbe0fbd51548794aa162aa759b3a44c0227b585d26040",
-  envelopeHash: "60d0cb1be3c78fe21c50c201bdf3628f49de768cd022f2afdccfe87db81bb8fc",
+  configHash: "f024fc651c704a008be59973884b89abeffd97faef8a272fbca5d2819ec3b1de",
+  envelopeHash: "265f5338295e485c5576f23551da0c96f3fb08d6e9e47aa1e376121c3553d9e3",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/latest-juicy.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/latest-juicy.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "latest-juicy",
-  configHash: "f024fc651c704a008be59973884b89abeffd97faef8a272fbca5d2819ec3b1de",
-  envelopeHash: "265f5338295e485c5576f23551da0c96f3fb08d6e9e47aa1e376121c3553d9e3",
+  configHash: "3d53f6de153db8bafc0d3c12a56efbdf45a57f1911f8880a74271081ed873d88",
+  envelopeHash: "402675c4c3cbaa8ab5d27f4e1c622fb252bc3e5990ccd4f789af565498fd138a",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/swooper-desert-mountains.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/swooper-desert-mountains.ts
@@ -21,7 +21,7 @@ export default createMap({
     "bottomLatitude": -40
   },
   sourceConfigId: "swooper-desert-mountains",
-  configHash: "62c2b04668acebe4b0acdb380a47b348f0ec2544b8544fb19e77b9997bc26599",
-  envelopeHash: "345922cf8928b4a23ae04d781c4fce9ad2952c425076092b41b4aa6ec2c96e9a",
+  configHash: "264025767c2cfaff8bacdb744c7d87376cce0116fea27590eb0cd39412e9802a",
+  envelopeHash: "b69b239d27f95d1d489c832a9d83305b70f76a14203a54ab3e55bd24cb2d30aa",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-public-config.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-public-config.ts
@@ -574,11 +574,14 @@ const PLOT_EFFECT_SELECTORS = {
     medium: { typeName: "PLOTEFFECT_SNOW_MEDIUM_PERMANENT" },
     heavy: { typeName: "PLOTEFFECT_SNOW_HEAVY_PERMANENT" },
   },
-  // Deep-desert hazard (Path A slice): sand placements project the permanent,
-  // damaging PLOTEFFECT_DESERT_HEAT (authored in mod/data/desert-hazard.xml) rather
-  // than the cosmetic, decaying PLOTEFFECT_SAND. The sand coverage % (public config)
-  // keeps it to the deepest-scoring desert tiles. Cosmetic/tiered split is future work.
-  sand: { typeName: "PLOTEFFECT_DESERT_HEAT" },
+  // Deep-desert hazard. The sand channel places the cosmetic, art-backed PLOTEFFECT_SAND
+  // (visible marker) AND co-places the permanent, damaging PLOTEFFECT_DESERT_HEAT
+  // (authored in mod/data/desert-hazard.xml; Damage=11/turn, no decay) on the SAME
+  // deepest-scoring desert tiles. DESERT_HEAT has no world-VFX of its own (custom type),
+  // so the SAND provides the visual while DESERT_HEAT provides the attrition. The sand
+  // coverage % (public config) keeps the hazard to the deepest desert only.
+  sand: { typeName: "PLOTEFFECT_SAND" },
+  sandHazard: { typeName: "PLOTEFFECT_DESERT_HEAT" },
   burned: { typeName: "PLOTEFFECT_BURNED" },
 } as const;
 
@@ -595,6 +598,7 @@ function plotEffectCoverageConfig(value: unknown) {
     sand: {
       ...sand,
       selector: PLOT_EFFECT_SELECTORS.sand,
+      hazard: PLOT_EFFECT_SELECTORS.sandHazard,
     },
     burned: {
       ...burned,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-public-config.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-public-config.ts
@@ -574,7 +574,11 @@ const PLOT_EFFECT_SELECTORS = {
     medium: { typeName: "PLOTEFFECT_SNOW_MEDIUM_PERMANENT" },
     heavy: { typeName: "PLOTEFFECT_SNOW_HEAVY_PERMANENT" },
   },
-  sand: { typeName: "PLOTEFFECT_SAND" },
+  // Deep-desert hazard (Path A slice): sand placements project the permanent,
+  // damaging PLOTEFFECT_DESERT_HEAT (authored in mod/data/desert-hazard.xml) rather
+  // than the cosmetic, decaying PLOTEFFECT_SAND. The sand coverage % (public config)
+  // keeps it to the deepest-scoring desert tiles. Cosmetic/tiered split is future work.
+  sand: { typeName: "PLOTEFFECT_DESERT_HEAT" },
   burned: { typeName: "PLOTEFFECT_BURNED" },
 } as const;
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-effects/viz.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-effects/viz.ts
@@ -6,6 +6,7 @@ export const PLOT_EFFECT_VIZ_VALUE_BY_KEY: Readonly<Record<string, number>> = {
   PLOTEFFECT_SNOW_HEAVY_PERMANENT: 3,
   PLOTEFFECT_SAND: 4,
   PLOTEFFECT_BURNED: 5,
+  PLOTEFFECT_DESERT_HEAT: 6,
 } as const;
 
 export const PLOT_EFFECT_VIZ_CATEGORIES = [
@@ -31,6 +32,11 @@ export const PLOT_EFFECT_VIZ_CATEGORIES = [
   },
   { value: 4, label: "Sand", color: [245, 158, 11, 240] as [number, number, number, number] },
   { value: 5, label: "Burned", color: [71, 85, 105, 240] as [number, number, number, number] },
+  {
+    value: 6,
+    label: "Desert Heat (Hazard)",
+    color: [220, 38, 38, 240] as [number, number, number, number],
+  },
 ];
 
 export function plotEffectVizValueOrThrow(key: PlotEffectKey): number {

--- a/mods/mod-swooper-maps/test/ecology/no-fudging-static-scan.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/no-fudging-static-scan.test.ts
@@ -39,6 +39,11 @@ function scanFile(
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i] ?? "";
+    // Skip comment lines: a legacy/RNG name appearing in a comment never executes, so it
+    // must not count as a real call. (Without this, doc comments that *describe* a banned
+    // call — e.g. "as Civ7's base maps call generateDiscoveries()" — would false-positive.)
+    const trimmed = line.trim();
+    if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) continue;
     for (const { name, re } of patterns) {
       if (!re.test(line)) continue;
       findings.push({ file: relFile, line: i + 1, pattern: name, text: line.trim() });

--- a/mods/mod-swooper-maps/test/ecology/plot-effects-sand-hazard.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/plot-effects-sand-hazard.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import ecology from "@mapgen/domain/ecology/ops";
+import { normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
+
+// Deep-desert hazard: the sand channel places the cosmetic, art-backed PLOTEFFECT_SAND
+// AND co-places the permanent damaging PLOTEFFECT_DESERT_HEAT on the SAME selected tiles
+// (visible marker + per-turn attrition). This guards that co-placement wiring.
+const WIDTH = 2;
+const HEIGHT = 2;
+const SIZE = WIDTH * HEIGHT;
+
+const env = {
+  seed: 0,
+  dimensions: { width: WIDTH, height: HEIGHT },
+  latitudeBounds: { topLatitude: 0, bottomLatitude: 0 },
+};
+
+const runSandPlan = (config: Record<string, unknown>) => {
+  const planSelection = normalizeOpSelectionOrThrow(
+    ecology.ops.planPlotEffects,
+    { strategy: "default", config },
+    { ctx: { env, knobs: {} }, path: "/ops/planPlotEffects" }
+  );
+
+  // All four tiles sand-eligible with descending scores.
+  const sandScore01 = new Float32Array([0.9, 0.8, 0.7, 0.6]);
+  const sandEligibleMask = new Uint8Array(SIZE).fill(1);
+
+  return ecology.ops.planPlotEffects.run(
+    {
+      width: WIDTH,
+      height: HEIGHT,
+      seed: 0,
+      snowScore01: new Float32Array(SIZE),
+      snowEligibleMask: new Uint8Array(SIZE),
+      sandScore01,
+      sandEligibleMask,
+      burnedScore01: new Float32Array(SIZE),
+      burnedEligibleMask: new Uint8Array(SIZE),
+    },
+    planSelection
+  );
+};
+
+describe("plot effects (sand hazard co-placement)", () => {
+  it("co-places PLOTEFFECT_DESERT_HEAT on every sand tile when a hazard is configured", () => {
+    const result = runSandPlan({
+      snow: { enabled: false },
+      sand: {
+        enabled: true,
+        coveragePct: 100,
+        selector: { typeName: "PLOTEFFECT_SAND" },
+        hazard: { typeName: "PLOTEFFECT_DESERT_HEAT" },
+      },
+      burned: { enabled: false },
+    });
+
+    const sand = result.placements.filter((p) => p.plotEffect === "PLOTEFFECT_SAND");
+    const heat = result.placements.filter((p) => p.plotEffect === "PLOTEFFECT_DESERT_HEAT");
+
+    // One SAND + one DESERT_HEAT per eligible tile, on identical coordinates.
+    expect(sand.length).toBe(SIZE);
+    expect(heat.length).toBe(SIZE);
+    const key = (p: { x: number; y: number }) => `${p.x},${p.y}`;
+    expect(new Set(heat.map(key))).toEqual(new Set(sand.map(key)));
+  });
+
+  it("places only cosmetic sand when no hazard is configured", () => {
+    const result = runSandPlan({
+      snow: { enabled: false },
+      sand: { enabled: true, coveragePct: 100, selector: { typeName: "PLOTEFFECT_SAND" } },
+      burned: { enabled: false },
+    });
+
+    expect(result.placements.every((p) => p.plotEffect === "PLOTEFFECT_SAND")).toBe(true);
+    expect(result.placements.length).toBe(SIZE);
+  });
+});

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -226,6 +226,10 @@ export const DEFAULT_PLOT_EFFECT_TYPES: MockPlotEffectType[] = [
   { id: 2, name: "PLOTEFFECT_SNOW_HEAVY_PERMANENT", tags: ["SNOW", "HEAVY", "PERMANENT"] },
   { id: 3, name: "PLOTEFFECT_SAND", tags: ["SAND"] },
   { id: 4, name: "PLOTEFFECT_BURNED", tags: ["BURNED"] },
+  // Authored by mod-swooper-maps (data/desert-hazard.xml): a permanent, damaging
+  // deep-desert plot effect. Registered here so mock runs of the standard recipe
+  // can resolve it via getPlotEffectTypeIndex during the map-ecology apply step.
+  { id: 5, name: "PLOTEFFECT_DESERT_HEAT", tags: ["DESERT", "HEAT", "HAZARD"] },
 ];
 
 const DEFAULT_NATURAL_WONDER_CATALOG: NaturalWonderCatalogEntry[] = NATURAL_WONDER_CATALOG;


### PR DESCRIPTION
docs(desert-attrition): feasibility + Path A selective deep-desert/deep-cold hazard design

Investigate applying Civ7 ocean/deep-water unit damage to desert tiles.
Verdict: feasible via the data-defined PlotEffects system (per-turn Damage
column), not by retargeting ocean damage (immunity-only data surface).
Design = selective hazard tier on the existing ecology plot-effects scoring
pipeline (deep-desert via sand score + contiguous-mass/interior gate;
deep-cold via snow score, temperature-tied). Includes file-by-file impl plan
and open live-proof items.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

feat(swooper-maps): deep-desert heat hazard (Path A de-risk slice)

Add PLOTEFFECT_DESERT_HEAT: a permanent, non-decaying plot effect that damages
occupying units 11 HP/turn (the structural analog of ocean damage), authored via
mod/data/desert-hazard.xml and loaded by a gameplay-scope UpdateDatabase action.
The ecology sand plot-effect plan now projects it onto the deepest-scoring desert
tiles (swooper-desert-mountains: sand coveragePct 42->15). Mock adapter registers
the type so the standard-run pipeline resolves it during map-ecology apply.

Goal: live-proof that a permanent damaging plot effect harms a land unit per turn
before building the full selective system (contiguous-mass/interior gate + cold tier).

Verified: tsc --noEmit clean; standard-run 4/4 pass; gen:maps + migrate:configs:check
pass; tsup build ok (desert bundle bakes coveragePct=15 + PLOTEFFECT_DESERT_HEAT).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

fix(swooper-maps): load PLOTEFFECT_DESERT_HEAT cleanly (drop inline EnglishText)

Live-proof revealed the gameplay-scope UpdateDatabase rolled back: inline
<EnglishText> in a gameplay data file is rejected ('In XMLSerializer while
updating table EnglishText'). Move the name LOC to MapText.xml (UpdateText is
the correct localization mechanism); desert-hazard.xml now ships only Types +
PlotEffects.

Verified live (Civ7 tuner): GameInfo.PlotEffects.lookup('PLOTEFFECT_DESERT_HEAT')
=> Damage=11, TimeDecay=false; Modding.log shows UpdateDatabase load with no
rollback. (Note: requires app relaunch to re-scan the modinfo action + rebuild
the gameplay DB — Civ7 caches both.)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

feat(swooper-maps): increase latest-juicy desert potential (dryness mix->dry, rainfall 184->150)

Live-proof showed swooper-desert-mountains @ seed 1337 classified zero
BIOME_DESERT, so the sand-based hazard had nothing to place on. Per direction,
move the testbed to latest-juicy and nudge aridity up so deep desert appears:
hydrology-climate baseline+refine dryness mix->dry, precipitation rainfallScale
184->150. latest-juicy already enables the sand plot-effect plan, so (via the
global PLOT_EFFECT_SELECTORS.sand) it projects PLOTEFFECT_DESERT_HEAT onto the
deepest desert.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

feat(swooper-maps): deep-desert attrition hazard via permanent PlotEffect

Apply the engine's "ocean damage" model to deep desert as a mod: units
crossing the deepest desert take per-turn HP loss, scoped to the deepest-
scoring tiles (not all desert), matching the natural-wonders philosophy of
physically-grounded deterministic placement.

Mechanism (proven live on latest-juicy via the civ7 CLI):
- New PLOTEFFECT_DESERT_HEAT (Damage=11, TimeDecay/UnoccupiedDecay=false,
  AllowOnWater=false) in mod/data/desert-hazard.xml, loaded via a game-scope
  UpdateDatabase. A permanent PlotEffects row with Damage>0 and no
  TriggerOnEnter inflicts that Damage on any occupying unit every turn —
  confirmed: a stationary unit went 0 -> 11 HP across one turn; the effect
  placed on 36 deepest-desert tiles with no DB rollback.
- plan-plot-effects: the sand channel gains an optional `hazard` companion
  selector that co-places the hazard on the same top-coverage deep-desert
  tiles the cosmetic sand selects (engine allows multiple effects per plot).
  Wired via ecology-public-config PLOT_EFFECT_SELECTORS.sandHazard; viz
  category added; new test test/ecology/plot-effects-sand-hazard.test.ts.

Why a PlotEffect and not a modifier: EFFECT_UNIT_ADJUST_DAMAGE is one-shot in
100% of base usage (run-once=true), and a biome modifier would hit all desert.
PlotEffects.Damage is the only data mechanism that is both per-turn-on-occupant
and positional. (No base plot effect is permanent AND continuously damaging —
that niche, documented in the report's permanence survey, is what this fills.)

Also: latest-juicy desert tuning (dryness=dry, rainfallScale->150, loosened
sand scorer) so the deep-desert biome actually appears as a testbed.

Known limitation: no persistent world-overlay. Custom types have no art, and
even base PLOTEFFECT_SAND has no persistent decal (one-shot triggerVFXAtPlot
only). The hazard surfaces via the plot tooltip ("Deep Desert Heat") + terrain
reading as harsh desert; a real overlay needs the art pipeline / a feature.

Full writeup + plot-effect permanence survey: docs/projects/desert-ocean-attrition/REPORT.md

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

docs(desert-hazard): document future directions (visual marker, interior-depth gate, sibling hazards)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

test(ecology): no-fudging static scan ignores comment lines

A banned legacy/RNG name appearing in a COMMENT never executes, so it must not
count as a real call. Skip comment lines in the scan. Fixes a pre-existing false
positive: a doc comment in place-discoveries/contract.ts ("...base maps call
generateDiscoveries()") tripped the legacy.generateDiscoveries pattern.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>