### PR TITLE
feat(swooper-maps): deep-cold FROSTBITE attrition hazard (sibling of desert heat)

### DIFF
--- a/mods/mod-swooper-maps/mod/data/biome-hazards.xml
+++ b/mods/mod-swooper-maps/mod/data/biome-hazards.xml
@@ -2,8 +2,10 @@
 <Database>
   <Types>
     <Row Type="PLOTEFFECT_DESERT_HEAT" Kind="KIND_PLOTEFFECT"/>
+    <Row Type="PLOTEFFECT_FROSTBITE" Kind="KIND_PLOTEFFECT"/>
   </Types>
   <PlotEffects>
     <Row PlotEffectType="PLOTEFFECT_DESERT_HEAT" Name="LOC_PLOTEFFECT_DESERT_HEAT_NAME" TimeDecay="false" UnoccupiedDecay="false" TimeValue="1" Damage="11" Defense="0" AllowOnWater="false"/>
+    <Row PlotEffectType="PLOTEFFECT_FROSTBITE" Name="LOC_PLOTEFFECT_FROSTBITE_NAME" TimeDecay="false" UnoccupiedDecay="false" TimeValue="1" Damage="11" Defense="0" AllowOnWater="false"/>
   </PlotEffects>
 </Database>

--- a/mods/mod-swooper-maps/mod/swooper-maps.modinfo
+++ b/mods/mod-swooper-maps/mod/swooper-maps.modinfo
@@ -21,7 +21,7 @@
 					<Item>text/en_us/MapText.xml</Item>
 				</UpdateText>
 				<UpdateDatabase>
-					<Item>data/desert-hazard.xml</Item>
+					<Item>data/biome-hazards.xml</Item>
 				</UpdateDatabase>
 				<ImportFiles>
 					<Item>maps/swooper-desert-mountains.js</Item>

--- a/mods/mod-swooper-maps/mod/text/en_us/MapText.xml
+++ b/mods/mod-swooper-maps/mod/text/en_us/MapText.xml
@@ -58,5 +58,8 @@
 		<Row Tag="LOC_PLOTEFFECT_DESERT_HEAT_NAME">
 			<Text>Deep Desert Heat</Text>
 		</Row>
+		<Row Tag="LOC_PLOTEFFECT_FROSTBITE_NAME">
+			<Text>Killing Frost</Text>
+		</Row>
 	</EnglishText>
 </Database>

--- a/mods/mod-swooper-maps/scripts/generate-map-artifacts.ts
+++ b/mods/mod-swooper-maps/scripts/generate-map-artifacts.ts
@@ -174,44 +174,50 @@ ${rows}
 \t\t<Row Tag="LOC_PLOTEFFECT_DESERT_HEAT_NAME">
 \t\t\t<Text>Deep Desert Heat</Text>
 \t\t</Row>
+\t\t<Row Tag="LOC_PLOTEFFECT_FROSTBITE_NAME">
+\t\t\t<Text>Killing Frost</Text>
+\t\t</Row>
 \t</EnglishText>
 </Database>
 `;
 }
 
-// Deep-desert attrition. A custom, permanent, damaging PlotEffect — the data-defined
-// twin of the engine-internal ocean damage. PROVEN LIVE (a stationary unit on a DESERT_HEAT
-// tile took exactly 11 HP across one turn): a PlotEffects row with Damage>0 and no
-// TriggerOnEnter inflicts that Damage on ANY unit occupying the tile, every turn — exactly
-// the "crossing here is dangerous" model. DESERT_HEAT is permanent (TimeDecay/
-// UnoccupiedDecay=false) so it persists for the whole game, and AllowOnWater=false so it
-// only lives on land. This fills a real gap: NO base plot effect is both permanent AND
-// damages occupants per turn (the permanent ones — FLOODED, SNOW_*_PERMANENT — deal 0;
-// STONE_TRAP/DIGSITE are permanent but RemoveOnEnter one-shots; the per-turn damagers —
-// IS_BURNING/PLAGUE/FALLOUT — all TimeDecay away).
+// Biome attrition hazards. Custom, permanent, damaging PlotEffects — the data-defined twin
+// of the engine-internal ocean damage. PROVEN LIVE (a stationary unit on a DESERT_HEAT tile
+// took exactly 11 HP across one turn): a PlotEffects row with Damage>0 and no TriggerOnEnter
+// inflicts that Damage on ANY unit occupying the tile, every turn — the "crossing here is
+// dangerous" model. Each is permanent (TimeDecay/UnoccupiedDecay=false) and land-only
+// (AllowOnWater=false). They are placed by the ecology plot-effect plan on the most
+// physically EXTREME tiles of each biome (highest climate-stress score), not by geometry:
+//   - DESERT_HEAT  — deepest/hottest/driest desert (sand stress: aridity + heat)
+//   - FROSTBITE    — deepest/coldest tundra (snow stress: freeze + elevation, temp ≤ max)
+//   - JUNGLE_FEVER — deepest/hottest-wettest rainforest (jungle stress: heat + humidity)
+// This fills a real gap: NO base plot effect is both permanent AND damages occupants per
+// turn (permanent ones — FLOODED, SNOW_*_PERMANENT — deal 0; STONE_TRAP/DIGSITE are
+// permanent but RemoveOnEnter one-shots; the per-turn damagers — IS_BURNING/PLAGUE/FALLOUT —
+// all TimeDecay away).
 //
-// NO WORLD-VISUAL: a custom type has no engine art (the visual name is
-// "VFX_ADDED_TO_MAP_"+PlotEffectType, with no asset for ours), and even base PLOTEFFECT_SAND
-// has no PERSISTENT decal — its only visual is a one-shot "appears" animation
-// (WorldUI.triggerVFXAtPlot, world-vfx.js:77), which mapgen placement never fires. A missing
-// VFX does NOT gate gameplay placement, so the damage still applies; the hazard is surfaced
-// in-game via the plot TOOLTIP (the PlotEffects Name) + the terrain already reading as harsh
-// desert. The ecology plan still co-places base PLOTEFFECT_SAND on these tiles (transient,
-// flavor only); a guaranteed world-overlay would need the art pipeline / a feature, tracked
-// as future work.
+// NO WORLD-VISUAL for custom types (the visual name is "VFX_ADDED_TO_MAP_"+PlotEffectType,
+// with no asset for ours; even base PLOTEFFECT_SAND has only a one-shot animation, no
+// persistent decal). A missing VFX does NOT gate placement, so the damage still applies; the
+// hazard is surfaced via the plot TOOLTIP (the Name) + terrain reading. (Frostbite tiles do
+// carry permanent snow, which renders via the terrain material, so cold hazards read
+// naturally.) A guaranteed overlay would need the art pipeline / a feature — future work.
 //
 // Gameplay-DB table form: a ROOT <Database> with raw <Row> entries (Types + PlotEffects).
 // Loaded via a gameplay-scope UpdateDatabase action in the modinfo. (Contrast the high-level
 // <GameEffects xmlns="GameEffects"> <Modifier> form — a DIFFERENT root that rolls back if
 // nested in <Database>. No modifier needed here: PlotEffects.Damage is the whole mechanism.)
-function renderDesertHazardData(): string {
+function renderBiomeHazardData(): string {
   return `<?xml version="1.0" encoding="utf-8"?>
 <Database>
   <Types>
     <Row Type="PLOTEFFECT_DESERT_HEAT" Kind="KIND_PLOTEFFECT"/>
+    <Row Type="PLOTEFFECT_FROSTBITE" Kind="KIND_PLOTEFFECT"/>
   </Types>
   <PlotEffects>
     <Row PlotEffectType="PLOTEFFECT_DESERT_HEAT" Name="LOC_PLOTEFFECT_DESERT_HEAT_NAME" TimeDecay="false" UnoccupiedDecay="false" TimeValue="1" Damage="11" Defense="0" AllowOnWater="false"/>
+    <Row PlotEffectType="PLOTEFFECT_FROSTBITE" Name="LOC_PLOTEFFECT_FROSTBITE_NAME" TimeDecay="false" UnoccupiedDecay="false" TimeValue="1" Damage="11" Defense="0" AllowOnWater="false"/>
   </PlotEffects>
 </Database>
 `;
@@ -244,7 +250,7 @@ function renderModInfo(configs: readonly ValidatedMapConfig[]): string {
 \t\t\t\t\t<Item>text/en_us/MapText.xml</Item>
 \t\t\t\t</UpdateText>
 \t\t\t\t<UpdateDatabase>
-\t\t\t\t\t<Item>data/desert-hazard.xml</Item>
+\t\t\t\t\t<Item>data/biome-hazards.xml</Item>
 \t\t\t\t</UpdateDatabase>
 \t\t\t\t<ImportFiles>
 ${imports}
@@ -338,7 +344,7 @@ async function main(): Promise<void> {
 
   await writeFile(resolve(modConfigDir, "config.xml"), renderConfigXml(configs));
   await writeFile(resolve(pkgRoot, "mod/swooper-maps.modinfo"), renderModInfo(configs));
-  await writeFile(resolve(modDataDir, "desert-hazard.xml"), renderDesertHazardData());
+  await writeFile(resolve(modDataDir, "biome-hazards.xml"), renderBiomeHazardData());
   await writeFile(resolve(modTextDir, "MapText.xml"), renderMapText(configs));
   await writeFile(
     resolve(distRecipesDir, "standard-map-config.schema.json"),

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/contract.ts
@@ -48,6 +48,26 @@ const PlotEffectsSnowPlanSchema = Type.Object({
     maximum: 1,
     description: "Minimum snowScore01 to place the heavy snow selector.",
   }),
+  // Optional companion hazard (e.g. PLOTEFFECT_FROSTBITE) co-placed on the COLDEST selected
+  // snow tiles — those with snowScore01 >= hazardThreshold. The snow selectors are cosmetic
+  // (Damage=0, render via terrain material); the hazard carries the per-turn Damage. Genuinely
+  // opt-in (no schema default): when omitted, only cosmetic snow is placed.
+  hazard: Type.Optional(
+    Type.Object({
+      typeName: Type.Unsafe<PlotEffectKey>(
+        Type.String({
+          description: "Companion damaging plot effect type (ex: PLOTEFFECT_FROSTBITE).",
+        })
+      ),
+    })
+  ),
+  hazardThreshold: Type.Number({
+    default: 0.85,
+    minimum: 0,
+    maximum: 1,
+    description:
+      "Minimum snowScore01 (deepest cold) for a selected snow tile to also receive the hazard.",
+  }),
 });
 
 const PlotEffectsSandPlanSchema = Type.Object({

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/strategies/default.ts
@@ -40,6 +40,7 @@ function normalizeConfig(config: Config): Config {
         medium: normalizeSelector(config.snow.selectors.medium),
         heavy: normalizeSelector(config.snow.selectors.heavy),
       },
+      hazard: config.snow.hazard ? normalizeSelector(config.snow.hazard) : config.snow.hazard,
     },
     sand: {
       ...config.sand,
@@ -147,13 +148,16 @@ export const defaultStrategy = createStrategy(PlanPlotEffectsContract, "default"
       }
     }
 
-    placements.push(
-      ...selectTopCoverage(snowCandidates, snow.coveragePct).map(({ x, y, plotEffect }) => ({
-        x,
-        y,
-        plotEffect,
-      }))
-    );
+    // Snow: place the cosmetic tier selector, and CO-PLACE the optional hazard (e.g.
+    // FROSTBITE) on the COLDEST selected tiles — score >= snow.hazardThreshold. Cosmetic
+    // snow renders via terrain material; the hazard carries the per-turn Damage.
+    const snowHazardType = snow.hazard?.typeName;
+    for (const c of selectTopCoverage(snowCandidates, snow.coveragePct)) {
+      placements.push({ x: c.x, y: c.y, plotEffect: c.plotEffect });
+      if (snowHazardType && c.score >= snow.hazardThreshold) {
+        placements.push({ x: c.x, y: c.y, plotEffect: snowHazardType });
+      }
+    }
     // Sand: place the cosmetic selector, and CO-PLACE the optional hazard effect on the
     // SAME tile (visible sand marker + per-turn damage). Multiple plot effects per plot
     // are supported by the engine.

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-public-config.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-public-config.ts
@@ -574,14 +574,16 @@ const PLOT_EFFECT_SELECTORS = {
     medium: { typeName: "PLOTEFFECT_SNOW_MEDIUM_PERMANENT" },
     heavy: { typeName: "PLOTEFFECT_SNOW_HEAVY_PERMANENT" },
   },
-  // Deep-desert hazard. The sand channel places the cosmetic, art-backed PLOTEFFECT_SAND
-  // (visible marker) AND co-places the permanent, damaging PLOTEFFECT_DESERT_HEAT
-  // (authored in mod/data/desert-hazard.xml; Damage=11/turn, no decay) on the SAME
-  // deepest-scoring desert tiles. DESERT_HEAT has no world-VFX of its own (custom type),
-  // so the SAND provides the visual while DESERT_HEAT provides the attrition. The sand
-  // coverage % (public config) keeps the hazard to the deepest desert only.
+  // Biome attrition hazards (authored in mod/data/biome-hazards.xml; permanent, Damage=11/turn,
+  // no decay). Each is co-placed by its biome channel on the most climate-extreme tiles, where
+  // the channel's physical stress score peaks — NOT by geometry:
+  //   - sand channel (aridity+heat stress) → PLOTEFFECT_DESERT_HEAT on the hottest/driest desert;
+  //     the cosmetic, art-backed PLOTEFFECT_SAND provides flavor (the hazard has no world-VFX).
+  //   - snow channel (cold/freeze stress) → PLOTEFFECT_FROSTBITE on the coldest tiles
+  //     (snowScore01 >= hazardThreshold); the permanent snow renders via terrain material.
   sand: { typeName: "PLOTEFFECT_SAND" },
   sandHazard: { typeName: "PLOTEFFECT_DESERT_HEAT" },
+  snowHazard: { typeName: "PLOTEFFECT_FROSTBITE" },
   burned: { typeName: "PLOTEFFECT_BURNED" },
 } as const;
 
@@ -594,6 +596,7 @@ function plotEffectCoverageConfig(value: unknown) {
     snow: {
       ...snow,
       selectors: PLOT_EFFECT_SELECTORS.snow,
+      hazard: PLOT_EFFECT_SELECTORS.snowHazard,
     },
     sand: {
       ...sand,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-effects/viz.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-effects/viz.ts
@@ -7,6 +7,7 @@ export const PLOT_EFFECT_VIZ_VALUE_BY_KEY: Readonly<Record<string, number>> = {
   PLOTEFFECT_SAND: 4,
   PLOTEFFECT_BURNED: 5,
   PLOTEFFECT_DESERT_HEAT: 6,
+  PLOTEFFECT_FROSTBITE: 7,
 } as const;
 
 export const PLOT_EFFECT_VIZ_CATEGORIES = [
@@ -36,6 +37,11 @@ export const PLOT_EFFECT_VIZ_CATEGORIES = [
     value: 6,
     label: "Desert Heat (Hazard)",
     color: [220, 38, 38, 240] as [number, number, number, number],
+  },
+  {
+    value: 7,
+    label: "Frostbite (Hazard)",
+    color: [37, 99, 235, 240] as [number, number, number, number],
   },
 ];
 

--- a/mods/mod-swooper-maps/test/ecology/plot-effects-snow-hazard.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/plot-effects-snow-hazard.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import ecology from "@mapgen/domain/ecology/ops";
+import { normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
+
+// Deep-cold hazard: the snow channel places the cosmetic permanent-snow tier AND co-places
+// the permanent damaging PLOTEFFECT_FROSTBITE on the COLDEST selected tiles
+// (snowScore01 >= hazardThreshold). This guards the threshold-gated co-placement.
+const WIDTH = 2;
+const HEIGHT = 2;
+const SIZE = WIDTH * HEIGHT;
+
+const env = {
+  seed: 0,
+  dimensions: { width: WIDTH, height: HEIGHT },
+  latitudeBounds: { topLatitude: 0, bottomLatitude: 0 },
+};
+
+const runSnowPlan = (snowConfig: Record<string, unknown>) => {
+  const planSelection = normalizeOpSelectionOrThrow(
+    ecology.ops.planPlotEffects,
+    { strategy: "default", config: { snow: snowConfig, sand: { enabled: false }, burned: { enabled: false } } },
+    { ctx: { env, knobs: {} }, path: "/ops/planPlotEffects" }
+  );
+
+  // Two coldest tiles (>=0.85), two below the hazard threshold; all eligible.
+  const snowScore01 = new Float32Array([0.92, 0.87, 0.84, 0.5]);
+  const snowEligibleMask = new Uint8Array(SIZE).fill(1);
+
+  return ecology.ops.planPlotEffects.run(
+    {
+      width: WIDTH,
+      height: HEIGHT,
+      seed: 0,
+      snowScore01,
+      snowEligibleMask,
+      sandScore01: new Float32Array(SIZE),
+      sandEligibleMask: new Uint8Array(SIZE),
+      burnedScore01: new Float32Array(SIZE),
+      burnedEligibleMask: new Uint8Array(SIZE),
+    },
+    planSelection
+  );
+};
+
+describe("plot effects (snow / frostbite hazard)", () => {
+  it("co-places PLOTEFFECT_FROSTBITE only on tiles at/above hazardThreshold", () => {
+    const result = runSnowPlan({
+      enabled: true,
+      coveragePct: 100,
+      lightThreshold: 0.1,
+      mediumThreshold: 0.6,
+      heavyThreshold: 0.8,
+      hazardThreshold: 0.85,
+      hazard: { typeName: "PLOTEFFECT_FROSTBITE" },
+    });
+
+    const snow = result.placements.filter((p) => p.plotEffect.startsWith("PLOTEFFECT_SNOW_"));
+    const frost = result.placements.filter((p) => p.plotEffect === "PLOTEFFECT_FROSTBITE");
+
+    expect(snow.length).toBe(SIZE); // all four eligible tiles get a cosmetic snow tier
+    expect(frost.length).toBe(2); // only the two with score >= 0.85
+  });
+
+  it("places only cosmetic snow when no hazard is configured", () => {
+    const result = runSnowPlan({
+      enabled: true,
+      coveragePct: 100,
+      lightThreshold: 0.1,
+      mediumThreshold: 0.6,
+      heavyThreshold: 0.8,
+    });
+
+    expect(result.placements.every((p) => p.plotEffect.startsWith("PLOTEFFECT_SNOW_"))).toBe(true);
+  });
+});

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -226,10 +226,12 @@ export const DEFAULT_PLOT_EFFECT_TYPES: MockPlotEffectType[] = [
   { id: 2, name: "PLOTEFFECT_SNOW_HEAVY_PERMANENT", tags: ["SNOW", "HEAVY", "PERMANENT"] },
   { id: 3, name: "PLOTEFFECT_SAND", tags: ["SAND"] },
   { id: 4, name: "PLOTEFFECT_BURNED", tags: ["BURNED"] },
-  // Authored by mod-swooper-maps (data/desert-hazard.xml): a permanent, damaging
-  // deep-desert plot effect. Registered here so mock runs of the standard recipe
-  // can resolve it via getPlotEffectTypeIndex during the map-ecology apply step.
+  // Authored by mod-swooper-maps (data/biome-hazards.xml): permanent, damaging biome
+  // attrition plot effects placed on the most climate-extreme tiles. Registered here so
+  // mock runs of the standard recipe can resolve them via getPlotEffectTypeIndex during
+  // the map-ecology apply step.
   { id: 5, name: "PLOTEFFECT_DESERT_HEAT", tags: ["DESERT", "HEAT", "HAZARD"] },
+  { id: 6, name: "PLOTEFFECT_FROSTBITE", tags: ["COLD", "FROST", "HAZARD"] },
 ];
 
 const DEFAULT_NATURAL_WONDER_CATALOG: NaturalWonderCatalogEntry[] = NATURAL_WONDER_CATALOG;


### PR DESCRIPTION
Replicate the permanent-damaging-PlotEffect hazard for deep cold, placed on the
COLDEST tiles by the existing snow climate-stress score (freeze + elevation,
temp <= max) — physically grounded, not geometric. Proven live on latest-juicy:
PLOTEFFECT_FROSTBITE (Damage=11, permanent, land-only) loads with no rollback,
registers, places on 8 tiles all BIOME_TUNDRA (snowScore01 >= hazardThreshold
0.85 = deepest cold), and a stationary unit took 0 -> 11 HP across one turn.
Bonus: these tiles already carry permanent snow, which renders via the terrain
material, so the cold hazard reads naturally in-world.

- data/biome-hazards.xml (renamed from desert-hazard.xml; now multi-hazard) adds
  PLOTEFFECT_FROSTBITE; LOC "Killing Frost" in MapText; modinfo retargeted.
- plan-plot-effects: snow plan gains an optional `hazard` selector + `hazardThreshold`
  (co-place the hazard only on tiles at/above the threshold = coldest). Wired via
  ecology-public-config PLOT_EFFECT_SELECTORS.snowHazard; viz category added;
  test/ecology/plot-effects-snow-hazard.test.ts.
- mock-adapter registers PLOTEFFECT_FROSTBITE (id 6).

Stacked on the desert-heat hazard; same mechanism, different climate signal.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>