### PR TITLE
feat(swooper-maps): deep-rainforest JUNGLE_FEVER attrition hazard (3rd biome hazard)

### DIFF
--- a/docs/projects/desert-ocean-attrition/REPORT.md
+++ b/docs/projects/desert-ocean-attrition/REPORT.md
@@ -99,7 +99,7 @@ The one real unknown from §6 is **resolved: yes.** A permanent, non-decaying pl
 **Live proof (latest-juicy, driven via the `civ7` CLI):** `PLOTEFFECT_DESERT_HEAT` (`Damage=11, TimeDecay=false, UnoccupiedDecay=false, AllowOnWater=false`) loads with **no rollback**, registers at runtime, and was **placed on 36 deepest-desert tiles** (24% sand coverage). A stationary unit on a DESERT_HEAT tile lost **exactly 11 HP across one turn** (0 → 11, turn 1 → 2). This is the genuine ocean-damage twin.
 
 **What shipped (simpler than the §5 plan):**
-- `mod/data/desert-hazard.xml` — ROOT `<Database>` with `Types` + `PlotEffects` rows for `PLOTEFFECT_DESERT_HEAT`. Loaded via a game-scope `UpdateDatabase`. LOC name in `MapText.xml`.
+- `mod/data/biome-hazards.xml` (originally `desert-hazard.xml`; renamed when frostbite/jungle joined) — ROOT `<Database>` with `Types` + `PlotEffects` rows for `PLOTEFFECT_DESERT_HEAT`. Loaded via a game-scope `UpdateDatabase`. LOC name in `MapText.xml`.
 - `plan-plot-effects` — the sand channel gained an **optional `hazard` companion selector** (`sand.hazard`) that co-places the hazard on the same top-coverage deep-desert tiles the cosmetic sand selects. (Lighter than the full multi-tier + connected-mass/interior-distance gate of §4–5; coverage % already constrains it to the deepest tiles. The mass/interior gate remains available as a future refinement.) Wired via `ecology-public-config.ts` `PLOT_EFFECT_SELECTORS.sandHazard`; viz category added; tests in `test/ecology/plot-effects-sand-hazard.test.ts`.
 - The global `EFFECT_UNIT_ADJUST_DAMAGE` modifier path (§3 Path B) was **dropped**: it is one-shot in 100% of base usage (`run-once="true"`) and a biome modifier hits *all* desert, contradicting the "deep parts only" design.
 
@@ -127,11 +127,42 @@ Permanence is governed by two flags: **`TimeDecay`** (counts down `TimeValue` tu
 
 ## 9. Future directions (documented, not pursued now)
 
-**World-visual marker** (the hazard currently surfaces via the plot tooltip only). Three avenues, in rough order of effort/reliability:
+**Sibling hazards — DELIVERED.** Frostbite (deep cold) and Jungle Fever (deep rainforest) shipped as siblings of desert heat; see **§10**.
+
+**World-visual marker** (custom-type hazards surface via the plot tooltip only; frostbite reads naturally via snow terrain). Three avenues, in rough order of effort/reliability:
 1. **Persistent-art Feature.** Place a feature with real, persistent 3-D art on hazard tiles as the marker. Most reliable on-map signal, but features affect movement/yields and a thematically-fitting art-backed feature must be found per biome.
 2. **JS override of `world-vfx.js`.** A mod can replace the UI script and, for our types, call the *persistent* `WorldUI.addVFXAtPlot(...)` (as `PLOTEFFECT_FLOODED` does) instead of the one-shot `triggerVFXAtPlot`. Speculative — base "appears" assets aren't authored to loop/persist — and it would also need a re-add on game-start since mapgen placements don't fire the add-event.
 3. **Custom VFX/decal asset.** Author a real ground decal through the art pipeline and point `VFX_ADDED_TO_MAP_<TYPE>` at it. Cleanest visually, but outside data-only modding.
 
-**Placement refinement.** Replace the score-based top-coverage selection with a deterministic **interior-depth gate**: a tile gets the hazard only if it is deep interior (every tile within a 3-tile hex radius is the same hazard biome/feature). This makes "only massive interiors are dangerous" geometric and explicit, and generalizes cleanly to other biomes.
+**Placement philosophy — physically grounded, not geometric.** A strict geometric "interior-depth gate" (hazard only if every tile within a 3-hex radius is the same biome) was considered and **deliberately set aside**: placement is driven by the **existing climate-stress scorers** (aridity+heat for desert, cold+freeze for frostbite, heat+humidity+vegetation for jungle), which already concentrate on the deepest/most-extreme interiors. A radius/contiguous-mass term remains available as a *secondary* input if a future map shows the climate signal placing hazards too shallow, but it should not be the primary driver. Intensity-scaled damage (more extreme stress → higher `Damage`) is a natural extension of the same scores.
 
-**Sibling hazards (same pattern).** `PLOTEFFECT_FROSTBITE` on deep snow/cold (rides the snow channel; anchor `BIOME_TUNDRA`) and `PLOTEFFECT_JUNGLE_FEVER` on deep rainforest (anchor `FEATURE_RAINFOREST`). Each is the same permanent-damaging-PlotEffect mechanism gated by the interior-depth rule above.
+---
+
+## 10. The three-biome hazard family (DELIVERED + live-proven)
+
+The desert mechanism generalized to **three biome attrition hazards**, each a permanent, damaging `PlotEffect` (`Damage=11`, `TimeDecay=false`, `UnoccupiedDecay=false`, `AllowOnWater=false`) placed by its biome channel on the most climate-**extreme** tiles. Placement is **physically grounded** in the existing climate-stress scorers — not a geometric radius (see §9). All three are authored in one multi-hazard data file `mod/data/biome-hazards.xml` (renamed from `desert-hazard.xml`).
+
+Shipped as a Graphite stack:
+
+| Hazard | LOC name | Channel / stress signal | Branch |
+|---|---|---|---|
+| `PLOTEFFECT_DESERT_HEAT` | Deep Desert Heat | sand — aridity + heat | `desert-ocean-attrition-feasibility` (`018e60230`, docs `faf573675`) |
+| `PLOTEFFECT_FROSTBITE` | Killing Frost | snow — cold + freeze (coldest only, `hazardThreshold` 0.85) | `snow-frostbite` (`140d28e4e`) |
+| `PLOTEFFECT_JUNGLE_FEVER` | Jungle Fever | jungle — heat + humidity + vegetation density | `rainforest-jungle-fever` (`fad906943`) |
+
+**Live proof — one map, all three (latest-juicy, seed 12345, 84×54, 1,645 land tiles):** no rollback; all three register (`Damage=11`); each inflicts **exactly 11 HP across one turn** on a stationary unit (0 → 11). Placement counts and density:
+
+| Hazard | Damage tiles | Biome | Biome total | Share of biome | Ratio (hazard : normal) |
+|---|---|---|---|---|---|
+| DESERT_HEAT | 36 | desert | 364 | 9.9 % | ~1 : 9 |
+| FROSTBITE | 8 | tundra | 581 | 1.4 % | ~1 : 72 |
+| JUNGLE_FEVER | 22 | tropical | 288 | 7.6 % | ~1 : 12 |
+
+Total 66 hazard tiles = 4.0 % of land. The per-biome share is lower than the configured `coveragePct` because coverage applies to the *eligible* (climate-extreme) subset, not the whole biome. Frostbite is deliberately rarest — gated to the very coldest tundra. All tunable via `plotEffectCoverage.{sand,jungle}.coveragePct` and the snow `hazardThreshold`.
+
+**Channel patterns (how the three differ):**
+- **sand** → co-places cosmetic `PLOTEFFECT_SAND` (flavor) **+** the hazard, on the same arid-stress top-coverage tiles.
+- **snow** → co-places cosmetic permanent-snow tiers **+** the hazard, but the hazard only on tiles with `snowScore01 ≥ hazardThreshold` (deepest cold). Snow renders via the terrain material, so frostbite reads naturally in-world.
+- **jungle** → a **new** scoring channel (`plot-effects-score-jungle`): places the hazard **alone** (no cosmetic — the rainforest feature is the visual) on heat+humidity+vegetation top-coverage.
+
+**Engineering note — adding a new scoring channel** (jungle) touches, in order: the op (`contract` + `strategies/default` + `index`), the ecology registries (`ops/index.ts` implementations + named exports, `ops/contracts.ts`), the domain `plan-plot-effects` (new `*Score01`/`*EligibleMask` inputs + a plan block in `contract.ts`, candidate-collection + placement in `strategies/default.ts`), the recipe step (`steps/plan-plot-effects/contract.ts` op + `index.ts` compute/feed), the **strict** public schemas (`PlotEffectScoringPublicSchema` + `PlotEffectCoveragePublicSchema`, `additionalProperties:false` — the key must be added or configs fail validation) + the compile mapping, the data file + `MapText` LOC, the mock-adapter registry, the viz categories, and the per-map config. Reusing an existing channel (frostbite on snow) is far lighter — just the optional `hazard` selector + threshold.

--- a/mods/mod-swooper-maps/mod/data/biome-hazards.xml
+++ b/mods/mod-swooper-maps/mod/data/biome-hazards.xml
@@ -3,9 +3,11 @@
   <Types>
     <Row Type="PLOTEFFECT_DESERT_HEAT" Kind="KIND_PLOTEFFECT"/>
     <Row Type="PLOTEFFECT_FROSTBITE" Kind="KIND_PLOTEFFECT"/>
+    <Row Type="PLOTEFFECT_JUNGLE_FEVER" Kind="KIND_PLOTEFFECT"/>
   </Types>
   <PlotEffects>
     <Row PlotEffectType="PLOTEFFECT_DESERT_HEAT" Name="LOC_PLOTEFFECT_DESERT_HEAT_NAME" TimeDecay="false" UnoccupiedDecay="false" TimeValue="1" Damage="11" Defense="0" AllowOnWater="false"/>
     <Row PlotEffectType="PLOTEFFECT_FROSTBITE" Name="LOC_PLOTEFFECT_FROSTBITE_NAME" TimeDecay="false" UnoccupiedDecay="false" TimeValue="1" Damage="11" Defense="0" AllowOnWater="false"/>
+    <Row PlotEffectType="PLOTEFFECT_JUNGLE_FEVER" Name="LOC_PLOTEFFECT_JUNGLE_FEVER_NAME" TimeDecay="false" UnoccupiedDecay="false" TimeValue="1" Damage="11" Defense="0" AllowOnWater="false"/>
   </PlotEffects>
 </Database>

--- a/mods/mod-swooper-maps/mod/text/en_us/MapText.xml
+++ b/mods/mod-swooper-maps/mod/text/en_us/MapText.xml
@@ -61,5 +61,8 @@
 		<Row Tag="LOC_PLOTEFFECT_FROSTBITE_NAME">
 			<Text>Killing Frost</Text>
 		</Row>
+		<Row Tag="LOC_PLOTEFFECT_JUNGLE_FEVER_NAME">
+			<Text>Jungle Fever</Text>
+		</Row>
 	</EnglishText>
 </Database>

--- a/mods/mod-swooper-maps/scripts/generate-map-artifacts.ts
+++ b/mods/mod-swooper-maps/scripts/generate-map-artifacts.ts
@@ -177,6 +177,9 @@ ${rows}
 \t\t<Row Tag="LOC_PLOTEFFECT_FROSTBITE_NAME">
 \t\t\t<Text>Killing Frost</Text>
 \t\t</Row>
+\t\t<Row Tag="LOC_PLOTEFFECT_JUNGLE_FEVER_NAME">
+\t\t\t<Text>Jungle Fever</Text>
+\t\t</Row>
 \t</EnglishText>
 </Database>
 `;
@@ -214,10 +217,12 @@ function renderBiomeHazardData(): string {
   <Types>
     <Row Type="PLOTEFFECT_DESERT_HEAT" Kind="KIND_PLOTEFFECT"/>
     <Row Type="PLOTEFFECT_FROSTBITE" Kind="KIND_PLOTEFFECT"/>
+    <Row Type="PLOTEFFECT_JUNGLE_FEVER" Kind="KIND_PLOTEFFECT"/>
   </Types>
   <PlotEffects>
     <Row PlotEffectType="PLOTEFFECT_DESERT_HEAT" Name="LOC_PLOTEFFECT_DESERT_HEAT_NAME" TimeDecay="false" UnoccupiedDecay="false" TimeValue="1" Damage="11" Defense="0" AllowOnWater="false"/>
     <Row PlotEffectType="PLOTEFFECT_FROSTBITE" Name="LOC_PLOTEFFECT_FROSTBITE_NAME" TimeDecay="false" UnoccupiedDecay="false" TimeValue="1" Damage="11" Defense="0" AllowOnWater="false"/>
+    <Row PlotEffectType="PLOTEFFECT_JUNGLE_FEVER" Name="LOC_PLOTEFFECT_JUNGLE_FEVER_NAME" TimeDecay="false" UnoccupiedDecay="false" TimeValue="1" Damage="11" Defense="0" AllowOnWater="false"/>
   </PlotEffects>
 </Database>
 `;

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/contracts.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/contracts.ts
@@ -12,6 +12,7 @@ import AggregatePedologyContract from "./pedology-aggregate/contract.js";
 import PedologyClassifyContract from "./pedology-classify/contract.js";
 import PlanPlotEffectsContract from "./plan-plot-effects/contract.js";
 import PlotEffectsScoreBurnedContract from "./plot-effects-score-burned/contract.js";
+import PlotEffectsScoreJungleContract from "./plot-effects-score-jungle/contract.js";
 import PlotEffectsScoreSandContract from "./plot-effects-score-sand/contract.js";
 import PlotEffectsScoreSnowContract from "./plot-effects-score-snow/contract.js";
 import ScoreAtollContract from "./reef-score-atoll/contract.js";
@@ -61,6 +62,7 @@ export const contracts = {
   scorePlotEffectsSnow: PlotEffectsScoreSnowContract,
   scorePlotEffectsSand: PlotEffectsScoreSandContract,
   scorePlotEffectsBurned: PlotEffectsScoreBurnedContract,
+  scorePlotEffectsJungle: PlotEffectsScoreJungleContract,
   planPlotEffects: PlanPlotEffectsContract,
 
   planFloodplains: PlanFloodplainsContract,
@@ -88,6 +90,7 @@ export {
   PlanVegetationContract,
   PlanWetlandsContract,
   PlotEffectsScoreBurnedContract,
+  PlotEffectsScoreJungleContract,
   PlotEffectsScoreSandContract,
   PlotEffectsScoreSnowContract,
   RefineBiomeEdgesContract,

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/index.ts
@@ -14,6 +14,7 @@ import aggregatePedology from "./pedology-aggregate/index.js";
 import classifyPedology from "./pedology-classify/index.js";
 import planPlotEffects from "./plan-plot-effects/index.js";
 import scorePlotEffectsBurned from "./plot-effects-score-burned/index.js";
+import scorePlotEffectsJungle from "./plot-effects-score-jungle/index.js";
 import scorePlotEffectsSand from "./plot-effects-score-sand/index.js";
 import scorePlotEffectsSnow from "./plot-effects-score-snow/index.js";
 import scoreReefAtoll from "./reef-score-atoll/index.js";
@@ -63,6 +64,7 @@ const implementations = {
   scorePlotEffectsSnow,
   scorePlotEffectsSand,
   scorePlotEffectsBurned,
+  scorePlotEffectsJungle,
   planPlotEffects,
 
   planFloodplains,
@@ -94,6 +96,7 @@ export {
   scoreColdReef,
   scoreIce,
   scorePlotEffectsBurned,
+  scorePlotEffectsJungle,
   scorePlotEffectsSand,
   scorePlotEffectsSnow,
   scoreReef,

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/contract.ts
@@ -107,6 +107,22 @@ const PlotEffectsBurnedPlanSchema = Type.Object({
   }),
 });
 
+// Jungle hazard channel. Unlike sand (cosmetic + companion hazard), jungle places ONLY the
+// hazard (e.g. PLOTEFFECT_JUNGLE_FEVER) — the rainforest FEATURE is the visual, so no cosmetic
+// co-placement is needed. The `selector` IS the damaging effect, placed on the hottest/wettest/
+// densest rainforest tiles (jungle stress top-coverage).
+const PlotEffectsJunglePlanSchema = Type.Object({
+  enabled: Type.Boolean({ default: false, description: "Enable planning of jungle plot effects." }),
+  selector: createPlotEffectSelectorSchema({ typeName: "PLOTEFFECT_JUNGLE_FEVER" }),
+  coveragePct: Type.Number({
+    default: 12,
+    minimum: 0,
+    maximum: 100,
+    description:
+      "Percent of eligible jungle tiles to place (deterministic top-coverage selection).",
+  }),
+});
+
 const PlotEffectKeySchema = Type.Unsafe<PlotEffectKey>(
   Type.String({
     description: "Plot effect key (PLOTEFFECT_*).",
@@ -145,6 +161,12 @@ const PlanPlotEffectsContract = defineOp({
     burnedEligibleMask: TypedArraySchemas.u8({
       description: "Burned eligibility mask per tile (1=eligible, 0=ineligible).",
     }),
+    jungleScore01: TypedArraySchemas.f32({
+      description: "Jungle stress score per tile (0..1).",
+    }),
+    jungleEligibleMask: TypedArraySchemas.u8({
+      description: "Jungle eligibility mask per tile (1=eligible, 0=ineligible).",
+    }),
   }),
   output: Type.Object({
     placements: Type.Array(PlotEffectPlacementSchema),
@@ -154,6 +176,7 @@ const PlanPlotEffectsContract = defineOp({
       snow: PlotEffectsSnowPlanSchema,
       sand: PlotEffectsSandPlanSchema,
       burned: PlotEffectsBurnedPlanSchema,
+      jungle: PlotEffectsJunglePlanSchema,
     }),
   },
 });

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/strategies/default.ts
@@ -51,6 +51,10 @@ function normalizeConfig(config: Config): Config {
       ...config.burned,
       selector: normalizeSelector(config.burned.selector),
     },
+    jungle: {
+      ...config.jungle,
+      selector: normalizeSelector(config.jungle.selector),
+    },
   };
 }
 
@@ -85,18 +89,22 @@ export const defaultStrategy = createStrategy(PlanPlotEffectsContract, "default"
     const snow = config.snow;
     const sand = config.sand;
     const burned = config.burned;
+    const jungle = config.jungle;
 
     const snowSelectors = snow.selectors;
     const sandSelector = sand.selector;
     const burnedSelector = burned.selector;
+    const jungleSelector = jungle.selector;
 
     const snowEnabled = snow.enabled;
     const sandEnabled = sand.enabled;
     const burnedEnabled = burned.enabled;
+    const jungleEnabled = jungle.enabled;
 
     const snowCandidates: Candidate[] = [];
     const sandCandidates: Candidate[] = [];
     const burnedCandidates: Candidate[] = [];
+    const jungleCandidates: Candidate[] = [];
 
     const tileCount = width * height;
     for (let idx = 0; idx < tileCount; idx++) {
@@ -146,6 +154,18 @@ export const defaultStrategy = createStrategy(PlanPlotEffectsContract, "default"
           tie: rng(0x7fffffff, `plot-effects:burned:${idx}`),
         });
       }
+
+      if (jungleEnabled && input.jungleEligibleMask[idx] === 1) {
+        const score = input.jungleScore01[idx]!;
+        jungleCandidates.push({
+          idx,
+          x,
+          y,
+          plotEffect: jungleSelector.typeName,
+          score,
+          tie: rng(0x7fffffff, `plot-effects:jungle:${idx}`),
+        });
+      }
     }
 
     // Snow: place the cosmetic tier selector, and CO-PLACE the optional hazard (e.g.
@@ -170,6 +190,14 @@ export const defaultStrategy = createStrategy(PlanPlotEffectsContract, "default"
     }
     placements.push(
       ...selectTopCoverage(burnedCandidates, burned.coveragePct).map(({ x, y, plotEffect }) => ({
+        x,
+        y,
+        plotEffect,
+      }))
+    );
+    // Jungle: place ONLY the hazard selector (no cosmetic) on the deepest-stress rainforest.
+    placements.push(
+      ...selectTopCoverage(jungleCandidates, jungle.coveragePct).map(({ x, y, plotEffect }) => ({
         x,
         y,
         plotEffect,

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-jungle/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-jungle/contract.ts
@@ -1,0 +1,73 @@
+import { defineOp, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+
+const BiomeSymbolSchema = Type.Union(
+  [
+    Type.Literal("snow"),
+    Type.Literal("tundra"),
+    Type.Literal("boreal"),
+    Type.Literal("temperateDry"),
+    Type.Literal("temperateHumid"),
+    Type.Literal("tropicalSeasonal"),
+    Type.Literal("tropicalRainforest"),
+    Type.Literal("desert"),
+  ],
+  {
+    description:
+      "Biome symbol names used by the ecology classifier (maps to engine biome bindings).",
+  }
+);
+
+// Jungle stress = the physical "deep rainforest is dangerous" signal: HOT + HUMID + DENSE.
+// Mirrors the sand scorer's shape but inverts the climate axes (sand wants arid/sparse; jungle
+// wants wet/lush). High score = hottest, wettest, most overgrown interior rainforest — where
+// JUNGLE_FEVER (heat exhaustion + disease) belongs.
+const PlotEffectsScoreJungleConfigSchema = Type.Object({
+  minTemperature: Type.Number({
+    default: 22,
+    description: "Jungle is eligible when surfaceTemperature >= minTemperature (C).",
+  }),
+  minMoisture: Type.Number({
+    default: 110,
+    minimum: 0,
+    description: "Jungle is eligible when effectiveMoisture >= minMoisture.",
+  }),
+  minVegetation: Type.Number({
+    default: 0.45,
+    minimum: 0,
+    maximum: 1,
+    description: "Jungle is eligible when vegetationDensity >= minVegetation (0..1).",
+  }),
+  allowedBiomes: Type.Array(BiomeSymbolSchema, {
+    default: ["tropicalRainforest"],
+    description: "Biome symbols allowed to emit jungle plot effects (allowlist).",
+  }),
+});
+
+const PlotEffectsScoreJungleContract = defineOp({
+  kind: "compute",
+  id: "ecology/plot-effects/score/jungle",
+  input: Type.Object({
+    width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+    height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+    landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
+    biomeIndex: TypedArraySchemas.u8({ description: "Biome symbol indices per tile." }),
+    vegetationDensity: TypedArraySchemas.f32({
+      description: "Vegetation density per tile (0..1).",
+    }),
+    effectiveMoisture: TypedArraySchemas.f32({ description: "Effective moisture per tile." }),
+    surfaceTemperature: TypedArraySchemas.f32({
+      description: "Surface temperature per tile (C).",
+    }),
+  }),
+  output: Type.Object({
+    score01: TypedArraySchemas.f32({ description: "Jungle stress score per tile (0..1)." }),
+    eligibleMask: TypedArraySchemas.u8({
+      description: "Eligibility mask per tile (1=eligible for selection, 0=ineligible).",
+    }),
+  }),
+  strategies: {
+    default: PlotEffectsScoreJungleConfigSchema,
+  },
+});
+
+export default PlotEffectsScoreJungleContract;

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-jungle/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-jungle/index.ts
@@ -1,0 +1,14 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import PlotEffectsScoreJungleContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const scorePlotEffectsJungle = createOp(PlotEffectsScoreJungleContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+
+export default scorePlotEffectsJungle;

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-jungle/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-jungle/strategies/default.ts
@@ -1,0 +1,52 @@
+import { biomeSymbolFromIndex } from "@mapgen/domain/ecology/types.js";
+import { clamp01, normalizeRange } from "@swooper/mapgen-core";
+import { createStrategy, type Static } from "@swooper/mapgen-core/authoring";
+
+import PlotEffectsScoreJungleContract from "../contract.js";
+
+type Config = Static<(typeof PlotEffectsScoreJungleContract)["strategies"]["default"]>;
+
+export const defaultStrategy = createStrategy(PlotEffectsScoreJungleContract, "default", {
+  run: (input, config) => {
+    const { width, height, landMask } = input;
+    const tileCount = width * height;
+
+    const score01 = new Float32Array(tileCount);
+    const eligibleMask = new Uint8Array(tileCount);
+
+    const allowedBiomes = new Set(config.allowedBiomes);
+
+    for (let y = 0; y < height; y++) {
+      const rowOffset = y * width;
+      for (let x = 0; x < width; x++) {
+        const idx = rowOffset + x;
+        if (landMask[idx] === 0) continue;
+
+        const temp = input.surfaceTemperature[idx];
+        const moisture = input.effectiveMoisture[idx];
+        const vegetation = input.vegetationDensity[idx];
+        const symbol = biomeSymbolFromIndex(input.biomeIndex[idx]);
+
+        if (
+          temp < config.minTemperature ||
+          moisture < config.minMoisture ||
+          vegetation < config.minVegetation ||
+          !allowedBiomes.has(symbol)
+        ) {
+          continue;
+        }
+
+        eligibleMask[idx] = 1;
+
+        // Hotter, wetter, denser = deeper jungle = higher stress.
+        const tempFactor = normalizeRange(temp, config.minTemperature, config.minTemperature + 10);
+        const moistureFactor = normalizeRange(moisture, config.minMoisture, config.minMoisture + 80);
+        const vegetationFactor = normalizeRange(vegetation, config.minVegetation, 1);
+        const score = clamp01((tempFactor + moistureFactor + vegetationFactor) / 3);
+        score01[idx] = score;
+      }
+    }
+
+    return { score01, eligibleMask };
+  },
+});

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-jungle/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-jungle/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
@@ -653,6 +653,10 @@
           "enabled": true,
           "coveragePct": 24
         },
+        "jungle": {
+          "enabled": true,
+          "coveragePct": 14
+        },
         "burned": {
           "enabled": true,
           "coveragePct": 6

--- a/mods/mod-swooper-maps/src/maps/generated/latest-juicy.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/latest-juicy.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "latest-juicy",
-  configHash: "3d53f6de153db8bafc0d3c12a56efbdf45a57f1911f8880a74271081ed873d88",
-  envelopeHash: "402675c4c3cbaa8ab5d27f4e1c622fb252bc3e5990ccd4f789af565498fd138a",
+  configHash: "3aed01df63f572a94f7cc7e438ef6bebf90d49f7fcc7ddd65fc8ac68d38ce602",
+  envelopeHash: "fdcbed52adf7367ac43f93f8fb7704a8a6af0bdb5ff15dcf53e644138eccddb4",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-plot-effects/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-plot-effects/contract.ts
@@ -24,6 +24,7 @@ const PlanPlotEffectsStepContract = defineStep({
     scoreSnow: ecology.ops.scorePlotEffectsSnow,
     scoreSand: ecology.ops.scorePlotEffectsSand,
     scoreBurned: ecology.ops.scorePlotEffectsBurned,
+    scoreJungle: ecology.ops.scorePlotEffectsJungle,
     plotEffects: ecology.ops.planPlotEffects,
   },
   schema: Type.Object(

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-plot-effects/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-plot-effects/index.ts
@@ -56,6 +56,18 @@ export default createStep(PlanPlotEffectsStepContract, {
       },
       config.scoreBurned
     );
+    const scoreJungle = ops.scoreJungle(
+      {
+        width: input.width,
+        height: input.height,
+        landMask: input.landMask,
+        biomeIndex: input.biomeIndex,
+        vegetationDensity: input.vegetationDensity,
+        effectiveMoisture: input.effectiveMoisture,
+        surfaceTemperature: input.surfaceTemperature,
+      },
+      config.scoreJungle
+    );
 
     const result = ops.plotEffects(
       {
@@ -68,6 +80,8 @@ export default createStep(PlanPlotEffectsStepContract, {
         sandEligibleMask: scoreSand.eligibleMask,
         burnedScore01: scoreBurned.score01,
         burnedEligibleMask: scoreBurned.eligibleMask,
+        jungleScore01: scoreJungle.score01,
+        jungleEligibleMask: scoreJungle.eligibleMask,
       },
       config.plotEffects
     );

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-public-config.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-public-config.ts
@@ -486,11 +486,12 @@ const PlotEffectCoveragePublicSchema = Type.Object(
     snow: Type.Optional(PlotEffectSnowCoveragePublicSchema),
     sand: Type.Optional(PlotEffectSimpleCoveragePublicSchema("sand", false, 18)),
     burned: Type.Optional(PlotEffectSimpleCoveragePublicSchema("burned", false, 8)),
+    jungle: Type.Optional(PlotEffectSimpleCoveragePublicSchema("jungle", false, 12)),
   },
   {
     additionalProperties: false,
     description:
-      "Controls plot-effect coverage for snow, sand, and burned effects without exposing engine selector identifiers.",
+      "Controls plot-effect coverage for snow, sand, burned, and jungle effects without exposing engine selector identifiers.",
   }
 );
 
@@ -508,11 +509,15 @@ const PlotEffectScoringPublicSchema = Type.Object(
       ecologyOps.scorePlotEffectsBurned.strategies.default,
       "burned effect scoring"
     ),
+    jungle: optionalAuthorSchema(
+      ecologyOps.scorePlotEffectsJungle.strategies.default,
+      "jungle effect scoring"
+    ),
   },
   {
     additionalProperties: false,
     description:
-      "Controls snow, sand, and burned plot-effect suitability scoring before coverage selection.",
+      "Controls snow, sand, burned, and jungle plot-effect suitability scoring before coverage selection.",
   }
 );
 
@@ -581,9 +586,12 @@ const PLOT_EFFECT_SELECTORS = {
   //     the cosmetic, art-backed PLOTEFFECT_SAND provides flavor (the hazard has no world-VFX).
   //   - snow channel (cold/freeze stress) → PLOTEFFECT_FROSTBITE on the coldest tiles
   //     (snowScore01 >= hazardThreshold); the permanent snow renders via terrain material.
+  //   - jungle channel (heat+humidity stress) → PLOTEFFECT_JUNGLE_FEVER on the hottest/wettest/
+  //     densest rainforest; no cosmetic — the rainforest FEATURE is the visual.
   sand: { typeName: "PLOTEFFECT_SAND" },
   sandHazard: { typeName: "PLOTEFFECT_DESERT_HEAT" },
   snowHazard: { typeName: "PLOTEFFECT_FROSTBITE" },
+  jungle: { typeName: "PLOTEFFECT_JUNGLE_FEVER" },
   burned: { typeName: "PLOTEFFECT_BURNED" },
 } as const;
 
@@ -592,6 +600,7 @@ function plotEffectCoverageConfig(value: unknown) {
   const snow = publicObject(config.snow);
   const sand = publicObject(config.sand);
   const burned = publicObject(config.burned);
+  const jungle = publicObject(config.jungle);
   return {
     snow: {
       ...snow,
@@ -602,6 +611,10 @@ function plotEffectCoverageConfig(value: unknown) {
       ...sand,
       selector: PLOT_EFFECT_SELECTORS.sand,
       hazard: PLOT_EFFECT_SELECTORS.sandHazard,
+    },
+    jungle: {
+      ...jungle,
+      selector: PLOT_EFFECT_SELECTORS.jungle,
     },
     burned: {
       ...burned,
@@ -680,6 +693,7 @@ export function compileEcologyFeaturesPublicConfig(config: Record<string, unknow
       scoreSnow: defaultEnvelope(plotEffectScoring.snow),
       scoreSand: defaultEnvelope(plotEffectScoring.sand),
       scoreBurned: defaultEnvelope(plotEffectScoring.burned),
+      scoreJungle: defaultEnvelope(plotEffectScoring.jungle),
       plotEffects: defaultEnvelope(plotEffectCoverageConfig(config.plotEffectCoverage)),
     },
   };

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-effects/viz.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-effects/viz.ts
@@ -8,6 +8,7 @@ export const PLOT_EFFECT_VIZ_VALUE_BY_KEY: Readonly<Record<string, number>> = {
   PLOTEFFECT_BURNED: 5,
   PLOTEFFECT_DESERT_HEAT: 6,
   PLOTEFFECT_FROSTBITE: 7,
+  PLOTEFFECT_JUNGLE_FEVER: 8,
 } as const;
 
 export const PLOT_EFFECT_VIZ_CATEGORIES = [
@@ -42,6 +43,11 @@ export const PLOT_EFFECT_VIZ_CATEGORIES = [
     value: 7,
     label: "Frostbite (Hazard)",
     color: [37, 99, 235, 240] as [number, number, number, number],
+  },
+  {
+    value: 8,
+    label: "Jungle Fever (Hazard)",
+    color: [22, 163, 74, 240] as [number, number, number, number],
   },
 ];
 

--- a/mods/mod-swooper-maps/test/ecology/plot-effects-jungle-hazard.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/plot-effects-jungle-hazard.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import ecology from "@mapgen/domain/ecology/ops";
+import { normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
+
+// Deep-rainforest hazard: the jungle channel places ONLY the damaging PLOTEFFECT_JUNGLE_FEVER
+// (no cosmetic — the rainforest feature is the visual) on the hottest/wettest/densest tiles,
+// selected by top-coverage of the jungle stress score.
+const WIDTH = 2;
+const HEIGHT = 2;
+const SIZE = WIDTH * HEIGHT;
+
+const env = {
+  seed: 0,
+  dimensions: { width: WIDTH, height: HEIGHT },
+  latitudeBounds: { topLatitude: 0, bottomLatitude: 0 },
+};
+
+describe("plot effects (jungle / jungle fever hazard)", () => {
+  it("places PLOTEFFECT_JUNGLE_FEVER on eligible jungle tiles by top-coverage", () => {
+    const planSelection = normalizeOpSelectionOrThrow(
+      ecology.ops.planPlotEffects,
+      {
+        strategy: "default",
+        config: {
+          snow: { enabled: false },
+          sand: { enabled: false },
+          burned: { enabled: false },
+          jungle: { enabled: true, coveragePct: 100, selector: { typeName: "PLOTEFFECT_JUNGLE_FEVER" } },
+        },
+      },
+      { ctx: { env, knobs: {} }, path: "/ops/planPlotEffects" }
+    );
+
+    const jungleScore01 = new Float32Array([0.9, 0.8, 0.7, 0.6]);
+    const jungleEligibleMask = new Uint8Array(SIZE).fill(1);
+
+    const result = ecology.ops.planPlotEffects.run(
+      {
+        width: WIDTH,
+        height: HEIGHT,
+        seed: 0,
+        snowScore01: new Float32Array(SIZE),
+        snowEligibleMask: new Uint8Array(SIZE),
+        sandScore01: new Float32Array(SIZE),
+        sandEligibleMask: new Uint8Array(SIZE),
+        burnedScore01: new Float32Array(SIZE),
+        burnedEligibleMask: new Uint8Array(SIZE),
+        jungleScore01,
+        jungleEligibleMask,
+      },
+      planSelection
+    );
+
+    expect(result.placements.length).toBe(SIZE);
+    expect(result.placements.every((p) => p.plotEffect === "PLOTEFFECT_JUNGLE_FEVER")).toBe(true);
+  });
+});

--- a/mods/mod-swooper-maps/test/ecology/plot-effects-owned-snow.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/plot-effects-owned-snow.test.ts
@@ -97,6 +97,8 @@ describe("plot effects (owned)", () => {
         sandEligibleMask: new Uint8Array(input.width * input.height),
         burnedScore01: new Float32Array(input.width * input.height),
         burnedEligibleMask: new Uint8Array(input.width * input.height),
+        jungleScore01: new Float32Array(input.width * input.height),
+        jungleEligibleMask: new Uint8Array(input.width * input.height),
       },
       planSelection
     );

--- a/mods/mod-swooper-maps/test/ecology/plot-effects-sand-hazard.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/plot-effects-sand-hazard.test.ts
@@ -37,6 +37,8 @@ const runSandPlan = (config: Record<string, unknown>) => {
       sandEligibleMask,
       burnedScore01: new Float32Array(SIZE),
       burnedEligibleMask: new Uint8Array(SIZE),
+      jungleScore01: new Float32Array(SIZE),
+      jungleEligibleMask: new Uint8Array(SIZE),
     },
     planSelection
   );

--- a/mods/mod-swooper-maps/test/ecology/plot-effects-snow-hazard.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/plot-effects-snow-hazard.test.ts
@@ -37,6 +37,8 @@ const runSnowPlan = (snowConfig: Record<string, unknown>) => {
       sandEligibleMask: new Uint8Array(SIZE),
       burnedScore01: new Float32Array(SIZE),
       burnedEligibleMask: new Uint8Array(SIZE),
+      jungleScore01: new Float32Array(SIZE),
+      jungleEligibleMask: new Uint8Array(SIZE),
     },
     planSelection
   );

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -232,6 +232,7 @@ export const DEFAULT_PLOT_EFFECT_TYPES: MockPlotEffectType[] = [
   // the map-ecology apply step.
   { id: 5, name: "PLOTEFFECT_DESERT_HEAT", tags: ["DESERT", "HEAT", "HAZARD"] },
   { id: 6, name: "PLOTEFFECT_FROSTBITE", tags: ["COLD", "FROST", "HAZARD"] },
+  { id: 7, name: "PLOTEFFECT_JUNGLE_FEVER", tags: ["JUNGLE", "FEVER", "HAZARD"] },
 ];
 
 const DEFAULT_NATURAL_WONDER_CATALOG: NaturalWonderCatalogEntry[] = NATURAL_WONDER_CATALOG;


### PR DESCRIPTION
feat(swooper-maps): deep-rainforest JUNGLE_FEVER attrition hazard (3rd biome hazard)

Replicate the permanent-damaging-PlotEffect hazard for deep rainforest, placed on
the hottest/wettest/densest jungle by a new climate-stress score — physically
grounded. Proven live on latest-juicy: PLOTEFFECT_JUNGLE_FEVER (Damage=11,
permanent, land-only) loads with no rollback, registers, places on 22 tiles all
BIOME_TROPICAL, and a stationary unit took 0 -> 11 HP across one turn. With the
sibling desert/cold hazards, one map now carries all three (36 / 8 / 22 tiles).

New `jungle` plot-effect channel (the rainforest analogue of sand/snow):
- ops/plot-effects-score-jungle — jungle stress = HOT + HUMID + DENSE
  (surfaceTemperature + effectiveMoisture + vegetationDensity), eligible on the
  tropicalRainforest biome symbol. Registered in ecology ops + contracts.
- plan-plot-effects: a `jungle` plan block that places ONLY the hazard selector
  (no cosmetic — the rainforest FEATURE is the visual) on top-coverage of the
  jungle score. New jungleScore01/jungleEligibleMask inputs.
- recipe step computes scoreJungle and feeds the plan; public config exposes
  plotEffectScoring.jungle + plotEffectCoverage.jungle (strict schemas extended).
- data/biome-hazards.xml adds PLOTEFFECT_JUNGLE_FEVER; LOC "Jungle Fever";
  mock-adapter id 7; viz category; latest-juicy enables jungle (coveragePct 14).
- test/ecology/plot-effects-jungle-hazard.test.ts; existing plan tests updated
  for the new required inputs.

Stacked on snow-frostbite. Same permanent-PlotEffect mechanism, third climate signal.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

docs(biome-hazards): fold frostbite + jungle fever into REPORT (delivered family, live ratios)

Document the three-biome attrition family (desert heat / frostbite / jungle fever),
the physically-grounded placement philosophy (geometric interior-gate set aside),
live placement ratios per biome on latest-juicy, and the per-channel patterns +
the engineering cost of adding a new scoring channel.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>