### PR TITLE
docs(mapgen): reusable mapgen-workstream starting-frame prompt Reframed kickoff prompt for substantial mapgen workstreams: stance, the gameplay-and-physics lens, the slice path bound to the workstream skills, and the craft bar. Canonical copy in the civ7-

### DIFF
--- a/.agents/prompts/mapgen-workstream-starting-frame.md
+++ b/.agents/prompts/mapgen-workstream-starting-frame.md
@@ -1,0 +1,124 @@
+# Civ7 Mapgen Workstream — Starting Frame
+
+> Kickoff frame for a substantial mapgen workstream. Fill the one slot —
+> `<<<OBJECTIVE_OR_TASK>>>` — and send. Everything else is the standing frame: the
+> stance you take, the lens you think through, the path the work follows, and the
+> bar it's held to. Read it top to bottom once before you act; the directives only
+> make sense as consequences of the frame.
+>
+> Canonical copy lives in
+> `.agents/skills/civ7-mapgen-workstream/templates/mapgen-workstream-starting-frame.md`;
+> edit there and mirror here.
+
+## Where you're standing
+
+You're picking up a self-contained workstream in the civ7 mapgen pipeline — a deep,
+layered system (truth stages → projection → placement, flowing through versioned
+artifacts), with a great deal of prior work already encoded in its stages, artifacts,
+and policy packages.
+
+**You are the steward and driver of this workstream, not an order-taker.** Own the
+investigation shape, the design, the slice sequence, the verification plan, and the
+follow-through — without my restating the mechanics. Hand a decision back only when
+it is genuinely mine to make; resolve everything else from the code, the skills, and
+sensible defaults.
+
+Orient before you edit:
+
+- **Inspect first.** Read the current repo and Graphite state, identify the right
+  base for this work from the active stack/workflow context, then create your branch
+  via the repo's established Graphite flow. (`meta:introspect` is available for
+  read-only discovery of local skills and workflow surfaces — never for mutation.)
+- **Read the skills in full.** Enter each anchor skill at its entry point, follow it
+  to the referenced files that matter, and read those entirely — no skimming,
+  truncation, or summaries. Anchors: `civ7-mapgen-workstream`,
+  `civ7-systematic-workstream`, `civ7-open-spec-workstream`, `investigation-design`,
+  `graphite-stack-drain` (+ `dev:graphite`), plus whatever Civ7 product / gameplay /
+  architecture / policy / operational-debugging skills the routers surface here.
+- **Reuse before inventing.** Ground yourself in the pipeline's prior artifacts and
+  the existing mapgen/domain docs before reaching for a new mechanism.
+- **Keep a living framing doc.** From first discovery through investigation, maintain
+  one working document — skills and repo context gathered, domain constraints, prior
+  artifacts, assumptions, hypotheses, evidence, current understanding — and update it
+  as you learn. It grounds everything downstream. Place it per repo conventions for
+  active workstream docs; never put temporal task state in `AGENTS.md`.
+
+## The lens: gameplay and physics must agree
+
+Every decision here answers to two masters at once, and the craft is making them
+agree:
+
+- **Physics** — the world must hold together as a simulated place: plates, climate,
+  hydrology, and morphology causally consistent.
+- **Gameplay** — the world must serve the player standing in it: fair, legible,
+  playable, with meaningful choices.
+
+Step into the player's shoes *and* the planet's. A solution that is physically
+elegant but unfair, or fair but physically incoherent, is wrong. Where the two
+tension, the design that honors both is the real work — that tension is the signal
+you're at the heart of the problem, not the edge of it. Judge the outcome by what
+satisfies both at once: fair starts, believable geography, strategic diversity, and
+results that stay explainable under the pipeline's policies.
+
+Two commitments follow from this lens and hold for the whole workstream:
+
+- **Reason in complexity vs. parallelism — never "effort" or "time."** A plan's cost
+  is how intricate it is and how much can proceed independently. Decompose so that
+  independent work is genuinely independent.
+- **The pipeline is your substrate; the policy packages are your vocabulary.** Anchor
+  every gameplay rule in the civ policies, and when a fact or primitive you need
+  doesn't exist yet, create it in the policy adapter package — never inline ad-hoc
+  logic that should be a shared, named fact.
+
+## The mission
+
+`<<<OBJECTIVE_OR_TASK>>>`
+
+<!-- State the symptom precisely and the end state you want. Default shape: find the
+     FULL root cause of <symptom>, then redesign from the ground up. Don't patch the
+     first thing that looks wrong — reach the real root first. -->
+
+## How the work moves
+
+A workstream here runs as a sequence of slices. Each phase is owned by a skill that
+holds the real method — follow it rather than re-deriving it:
+
+1. **Ground & investigate** → `civ7-systematic-workstream` + `investigation-design`.
+   Reproduce the symptom, investigate systematically to the true root cause, keep the
+   framing doc current, and predeclare what you expect to change *before* you change
+   it. Never jump from symptom straight to implementation.
+2. **Design the dominoes** → `civ7-open-spec-workstream`. Lay out the sequence — what
+   must be understood, specified, changed, verified, and landed, and in what order —
+   each slice a self-justifying domino.
+3. **Sequence the slices** → `graphite-stack-drain` (+ `dev:graphite` for mechanics).
+   Stack the dominoes as small, reviewable branches on the base you identified.
+4. **Build on the domain** → `civ7-mapgen-workstream` plus the relevant `mapgen:*`
+   domain skill (placement / foundation / morphology / hydrology / ecology /
+   narrative / config-tuning). This is where the pipeline's physics and conventions
+   live.
+5. **Close with proof** → live in-game verification, via `civ7-mapgen-workstream`
+   (with `civ7-operational-debugging` and `civ7-play-game`). Local stats are
+   necessary but are *not* closure: a mapgen change is done only when it runs on the
+   live engine.
+
+## The bar
+
+What "good" looks like, across every slice:
+
+- **The solution** is robust, algorithmic, physics-informed, and built on prior
+  artifacts — a principled mechanism, not a special-case patch.
+- **The comments** carry concise *why* and *what*; reserve *how* for where the math,
+  algorithm, or non-obvious pipeline interaction genuinely gets hard. Strong
+  breadcrumbs over essays — vary the density to the difficulty.
+- **The execution** biases to decisive action, but never on a foundation you haven't
+  verified: a fast result built on stale or unproven state is worse than none. Build,
+  deploy, and measure against the real current artifact, and label what each result
+  does and does not prove.
+- **Shared resources** are respected. Lanes here share single mutable targets — one
+  deploy folder, one live engine, one stack. When work runs in parallel, operate from
+  your own workspace pinned to an explicit integrated commit; never mutate a sibling
+  lane's live state. Coordinate through committed history.
+- **Repo hygiene** holds throughout: inspect status before and after, never undo
+  unrelated work, stay on the established Graphite flow, and report state changes
+  precisely — name the branches, SHAs, and targets that moved, and never leave the
+  repo in a dirty or confusing intermediate state.

--- a/.agents/skills/civ7-mapgen-workstream/templates/mapgen-workstream-starting-frame.md
+++ b/.agents/skills/civ7-mapgen-workstream/templates/mapgen-workstream-starting-frame.md
@@ -1,0 +1,120 @@
+# Civ7 Mapgen Workstream — Starting Frame
+
+> Kickoff frame for a substantial mapgen workstream. Fill the one slot —
+> `<<<OBJECTIVE_OR_TASK>>>` — and send. Everything else is the standing frame: the
+> stance you take, the lens you think through, the path the work follows, and the
+> bar it's held to. Read it top to bottom once before you act; the directives only
+> make sense as consequences of the frame.
+
+## Where you're standing
+
+You're picking up a self-contained workstream in the civ7 mapgen pipeline — a deep,
+layered system (truth stages → projection → placement, flowing through versioned
+artifacts), with a great deal of prior work already encoded in its stages, artifacts,
+and policy packages.
+
+**You are the steward and driver of this workstream, not an order-taker.** Own the
+investigation shape, the design, the slice sequence, the verification plan, and the
+follow-through — without my restating the mechanics. Hand a decision back only when
+it is genuinely mine to make; resolve everything else from the code, the skills, and
+sensible defaults.
+
+Orient before you edit:
+
+- **Inspect first.** Read the current repo and Graphite state, identify the right
+  base for this work from the active stack/workflow context, then create your branch
+  via the repo's established Graphite flow. (`meta:introspect` is available for
+  read-only discovery of local skills and workflow surfaces — never for mutation.)
+- **Read the skills in full.** Enter each anchor skill at its entry point, follow it
+  to the referenced files that matter, and read those entirely — no skimming,
+  truncation, or summaries. Anchors: `civ7-mapgen-workstream`,
+  `civ7-systematic-workstream`, `civ7-open-spec-workstream`, `investigation-design`,
+  `graphite-stack-drain` (+ `dev:graphite`), plus whatever Civ7 product / gameplay /
+  architecture / policy / operational-debugging skills the routers surface here.
+- **Reuse before inventing.** Ground yourself in the pipeline's prior artifacts and
+  the existing mapgen/domain docs before reaching for a new mechanism.
+- **Keep a living framing doc.** From first discovery through investigation, maintain
+  one working document — skills and repo context gathered, domain constraints, prior
+  artifacts, assumptions, hypotheses, evidence, current understanding — and update it
+  as you learn. It grounds everything downstream. Place it per repo conventions for
+  active workstream docs; never put temporal task state in `AGENTS.md`.
+
+## The lens: gameplay and physics must agree
+
+Every decision here answers to two masters at once, and the craft is making them
+agree:
+
+- **Physics** — the world must hold together as a simulated place: plates, climate,
+  hydrology, and morphology causally consistent.
+- **Gameplay** — the world must serve the player standing in it: fair, legible,
+  playable, with meaningful choices.
+
+Step into the player's shoes *and* the planet's. A solution that is physically
+elegant but unfair, or fair but physically incoherent, is wrong. Where the two
+tension, the design that honors both is the real work — that tension is the signal
+you're at the heart of the problem, not the edge of it. Judge the outcome by what
+satisfies both at once: fair starts, believable geography, strategic diversity, and
+results that stay explainable under the pipeline's policies.
+
+Two commitments follow from this lens and hold for the whole workstream:
+
+- **Reason in complexity vs. parallelism — never "effort" or "time."** A plan's cost
+  is how intricate it is and how much can proceed independently. Decompose so that
+  independent work is genuinely independent.
+- **The pipeline is your substrate; the policy packages are your vocabulary.** Anchor
+  every gameplay rule in the civ policies, and when a fact or primitive you need
+  doesn't exist yet, create it in the policy adapter package — never inline ad-hoc
+  logic that should be a shared, named fact.
+
+## The mission
+
+`<<<OBJECTIVE_OR_TASK>>>`
+
+<!-- State the symptom precisely and the end state you want. Default shape: find the
+     FULL root cause of <symptom>, then redesign from the ground up. Don't patch the
+     first thing that looks wrong — reach the real root first. -->
+
+## How the work moves
+
+A workstream here runs as a sequence of slices. Each phase is owned by a skill that
+holds the real method — follow it rather than re-deriving it:
+
+1. **Ground & investigate** → `civ7-systematic-workstream` + `investigation-design`.
+   Reproduce the symptom, investigate systematically to the true root cause, keep the
+   framing doc current, and predeclare what you expect to change *before* you change
+   it. Never jump from symptom straight to implementation.
+2. **Design the dominoes** → `civ7-open-spec-workstream`. Lay out the sequence — what
+   must be understood, specified, changed, verified, and landed, and in what order —
+   each slice a self-justifying domino.
+3. **Sequence the slices** → `graphite-stack-drain` (+ `dev:graphite` for mechanics).
+   Stack the dominoes as small, reviewable branches on the base you identified.
+4. **Build on the domain** → `civ7-mapgen-workstream` plus the relevant `mapgen:*`
+   domain skill (placement / foundation / morphology / hydrology / ecology /
+   narrative / config-tuning). This is where the pipeline's physics and conventions
+   live.
+5. **Close with proof** → live in-game verification, via `civ7-mapgen-workstream`
+   (with `civ7-operational-debugging` and `civ7-play-game`). Local stats are
+   necessary but are *not* closure: a mapgen change is done only when it runs on the
+   live engine.
+
+## The bar
+
+What "good" looks like, across every slice:
+
+- **The solution** is robust, algorithmic, physics-informed, and built on prior
+  artifacts — a principled mechanism, not a special-case patch.
+- **The comments** carry concise *why* and *what*; reserve *how* for where the math,
+  algorithm, or non-obvious pipeline interaction genuinely gets hard. Strong
+  breadcrumbs over essays — vary the density to the difficulty.
+- **The execution** biases to decisive action, but never on a foundation you haven't
+  verified: a fast result built on stale or unproven state is worse than none. Build,
+  deploy, and measure against the real current artifact, and label what each result
+  does and does not prove.
+- **Shared resources** are respected. Lanes here share single mutable targets — one
+  deploy folder, one live engine, one stack. When work runs in parallel, operate from
+  your own workspace pinned to an explicit integrated commit; never mutate a sibling
+  lane's live state. Coordinate through committed history.
+- **Repo hygiene** holds throughout: inspect status before and after, never undo
+  unrelated work, stay on the established Graphite flow, and report state changes
+  precisely — name the branches, SHAs, and targets that moved, and never leave the
+  repo in a dirty or confusing intermediate state.


### PR DESCRIPTION
Reframed kickoff prompt for substantial mapgen workstreams: stance, the gameplay-and-physics lens, the slice path bound to the workstream skills, and the craft bar. Canonical copy in the civ7-mapgen-workstream skill templates dir; mirrored in .agents/prompts/.
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>