### PR TITLE
docs(foundation): frame + design for foundation stage decomposition

### DIFF
--- a/docs/projects/foundation-stage-decomposition/DESIGN.md
+++ b/docs/projects/foundation-stage-decomposition/DESIGN.md
@@ -1,0 +1,244 @@
+# Foundation Stage Decomposition — Design
+
+> The proposed end-state for `foundation`: what each stage is, what it needs and
+> produces, the file layout, and how the realignment stays byte-identical.
+> Companion to [FRAMING.md](FRAMING.md). Read that for the evidence + decisions.
+
+**Nature of the change:** a **behavior-preserving structural refactor**. The single
+`foundation` recipe stage (10 steps) becomes a sequence of small,
+physically-grounded stages. Same ops, same execution order, same resolved configs,
+**byte-identical generated maps** (guarded by `shipped-map-identity.test.ts`). The
+`foundation` *domain* (17 ops) is unchanged. This mirrors how `morphology`,
+`hydrology`, and `ecology` are already **one domain → many stages**.
+
+---
+
+## 1. The decomposition
+
+Physically-grounded cut along the earth-science dependency chain (= the
+architecture packet's "generative layers"): **mantle convection → lithosphere &
+plates → tectonic boundary history → crustal evolution → tile projection**.
+
+| # | Stage | Steps (in order) | Unit of work | Produces (artifacts) | Knob |
+|---|---|---|---|---|---|
+| 1 | `foundation-mantle` | mesh, mantle-potential, mantle-forcing | Computational mesh + mantle convection forcing field — the deep-earth driver | `foundation.{mesh, mantlePotential, mantleForcing}` | `plateCount` (mesh sizing) |
+| 2 | `foundation-plates` | crust (init), plate-graph, plate-motion | Initial lithosphere, partitioned into rigid plates with kinematics | `foundation.{crustInit, plateGraph, plateMotion}` | `plateCount` (partition) |
+| 3 | `foundation-tectonics` | tectonics | Plate-boundary dynamics + geological history (segments, era loop, events, fields, rollups, current drivers, tracers, provenance) | `foundation.{tectonicSegments, tectonicHistory, tectonicProvenance, tectonics}` | — |
+| 4 | `foundation-crust` | crust-evolution | **Merge:** initial crust ⊕ tectonic history → final crustal material state | `foundation.crust` | — |
+| 5 | `foundation-projection` | projection **[+ plate-topology]** | Resample mesh-space truth → Civ7 tile grid **[+ plate adjacency graph]** | `map.foundation{Plates, TileToCellIndex, CrustTiles, TectonicHistoryTiles, TectonicProvenanceTiles}` **[+ `foundation.plateTopology`]** | `plateActivity` |
+
+**Open fork (for the user):** `plate-topology` lands either as the **2nd step of
+`foundation-projection`** (5 stages — recommended) or as its **own
+`foundation-topology` stage** (6 stages). See §6.
+
+### Dependency DAG (after the split)
+
+```
+foundation-mantle ─▶ foundation-plates ─▶ foundation-tectonics ─▶ foundation-crust ─▶ foundation-projection ─▶ (morphology-coasts …)
+   mesh,                crustInit,            segments, history,       crust(final)        map.foundation*  (the cross-domain surface)
+   mantlePotential,     plateGraph,           provenance, tectonics
+   mantleForcing        plateMotion
+```
+
+Mesh-space truth flows down the chain; only the tile-space `map.foundation*`
+products cross into morphology (unchanged artifact ids → **near-zero downstream
+churn**: consumers still read `mapArtifacts.foundation*`).
+
+### Why these boundaries (physical grounding)
+
+- **mantle | plates** — convective *forcing* (a field on the mesh) vs the *rigid
+  lithosphere* it produces and moves. Different objects (continuous field vs
+  discrete plates).
+- **plates | tectonics** — plate *formation/kinematics* vs what happens *at their
+  boundaries over geological time*. tectonics requires fully-formed moving plates.
+- **tectonics | crust** — boundary *history* (a process record) vs the *material
+  state* that history produces. `crust-evolution` is the one step that merges
+  `crustInit` lineage with `tectonicHistory` → the user's "combination/merge
+  stage" and the packet's distinct material layer.
+- **truth | projection** — all of 1–4 are mesh-space **truth** (never touch the
+  adapter); stage 5 is the explicit, labeled **mesh→tile resampling** bridge
+  (still truth-space — it does NOT write engine terrain; that is the later `map-*`
+  stages). This keeps the load-bearing truth/projection invariant crisp.
+
+---
+
+## 2. File structure (scale-continuous; nothing loose)
+
+Each stage is a **structurally identical, self-contained directory**:
+
+```
+recipes/standard/stages/
+  foundation-mantle/
+    index.ts            createStage({ id:"foundation-mantle", knobsSchema:{plateCount}, public:{meshResolution,mantleSources,mantleForcing}, steps, compile })
+    artifacts.ts        defineArtifact for mesh, mantlePotential, mantleForcing
+    validation.ts       validators for this stage's artifacts (+ shared wrapper from domain lib)
+    viz.ts              viz meta/colors owned by this stage (imports shared geometry from domain lib)
+    steps/{index.ts, mesh.ts, mesh.contract.ts, mantlePotential.ts, …, mantleForcing.contract.ts}
+  foundation-plates/      … crust(init), plate-graph, plate-motion ; public:{lithosphere,platePartition,plateMotion} ; knob plateCount
+  foundation-tectonics/   … tectonics ; public:{tectonicSegmentation,tectonicEras,tectonicFields,tectonicRollups}
+  foundation-crust/       … crust-evolution ; public:{} ; no knob
+  foundation-projection/  … projection [+ plate-topology] ; public:{} ; knob plateActivity
+```
+
+**Shared primitives** (genuinely cross-stage) move to the domain's natural home so
+no `stages/foundation/` hub lingers:
+- `domain/foundation/lib/viz-geometry.ts` ← the pure geometry converters from
+  today's `viz.ts` (`interleaveXY`, `segmentsFromCellPairs`, `segmentsFromMeshNeighbors`,
+  `pointsFromPlateSeeds`, `pointsFromTileCentroids`, `segmentsFromTileTopologyNeighbors`).
+- `domain/foundation/lib/artifact-validation.ts` ← `wrapFoundationValidate` /
+  `wrapFoundationValidateNoDims` (per-artifact validators move into each stage's
+  `validation.ts`, beside the artifacts they guard).
+- The shared **crust artifact schema** (`FoundationCrustArtifactSchema`, used by
+  `crustInit` and `crust`) → defined once (in `foundation-plates/artifacts.ts`,
+  owner of `crustInit`) and imported by `foundation-crust/artifacts.ts`.
+- The **tile-space schemas** (consumed by `recipes/standard/map-artifacts.ts`) live
+  in `foundation-projection/artifacts.ts`; `map-artifacts.ts` imports from there.
+
+The old `stages/foundation/{index.ts, artifacts.ts, validation.ts, viz.ts, steps/}`
+is fully removed — its content is distributed, nothing is orphaned.
+
+---
+
+## 3. Artifact ownership & quality
+
+Audit result: **16 artifacts are meaningful + usable + atomic → publish all; 0 are
+bad/meaningless → remove none** (honors the "publish meaningful artifacts even if
+unconsumed" directive). Per-stage ownership:
+
+- **mantle:** `mesh`, `mantlePotential`, `mantleForcing`.
+- **plates:** `crustInit`, `plateGraph`, `plateMotion`.
+- **tectonics:** `tectonicSegments` (boundary topology — kept; meaningful + atomic
+  even though consumed only by tests/viz today), `tectonicHistory`,
+  `tectonicProvenance`, `tectonics`.
+- **crust:** `crust` (final).
+- **projection:** the 5 `map.foundation*` tile products [+ `plateTopology`].
+
+**One repair (not a removal):** `plate-topology` currently has `ops:{}` and calls
+`buildPlateTopology` inline — the only loose-code step. Extract a real
+`foundation/compute-plate-topology` domain op (identity-preserving: same function,
+same inputs). It stays tile-derived for this slice; going mesh-native (→ move into
+`foundation-plates`) is the flagged follow-on.
+
+---
+
+## 4. Knobs
+
+- `plateCount` (shared `FoundationPlateCountKnobSchema`) is declared on **both**
+  `foundation-mantle` (→ mesh `cellCount`) and `foundation-plates` (→ partition
+  count). Identity-safe: no default; configs set it on both blocks; omission →
+  both ops default to 32. (Single-source "derive from mesh artifact" = clean
+  follow-on, not this slice.)
+- `plateActivity` (shared `FoundationPlateActivityKnobSchema`) → `foundation-projection`
+  only (projection `normalize`). Clean, single stage.
+
+---
+
+## 5. Visualization (intentional)
+
+Viz is co-located in each step (`context.viz?.dump*` + `defineVizMeta`); there is no
+separate registry. The split moves each step's viz with it, so groups stay coherent
+and intentional per stage:
+- `Foundation / Mesh`, `Foundation / Mantle*` → mantle stage.
+- `Foundation / Crust` (cell type/age/maturity), `Foundation / Plates` (seeds/graph),
+  plate-motion fields → plates stage.
+- `Foundation / Tectonics`, `Foundation / Tectonic History` (per-era) → tectonics stage.
+- `Foundation / Crust` (final) → crust stage (shares the `Foundation / Crust` group
+  with crustInit — deliberate: init vs evolved crust read as one family; colors/labels
+  reviewed so the two are distinguishable).
+- `Foundation / Plates` (tile), `… Crust Tiles`, `… Tectonic History/Provenance Tiles`,
+  `Foundation / Plate Topology` → projection stage. Spaces: mesh steps emit in
+  `world.xy`; projection/topology in `tile.hexOddQ` — preserved.
+
+Shared geometry converters move to `domain/foundation/lib/viz-geometry.ts`; the
+color/label/`defineVizMeta` choices stay with the owning step. Boundary-type colors
+(convergent=red, divergent=blue, transform=amber, none=grey) and crust-type colors
+(oceanic=blue, continental=green) are preserved and applied consistently.
+
+---
+
+## 6. The one open fork: 5 vs 6 stages (plate-topology placement)
+
+`plate-topology` is, this slice, tile-derived (reads `map.foundationPlates`), so it
+must run **after** projection. Two clean placements:
+
+- **5 stages (recommended):** `plate-topology` is the **2nd step of
+  `foundation-projection`**. Cohesive "tile-facing outputs" stage; doesn't mint a
+  whole stage for a transitional, currently-viz-only diagnostic; folds cleanly into
+  `foundation-plates` when it later goes mesh-native. (Architecture/packet lens.)
+- **6 stages:** `plate-topology` is its **own `foundation-topology` stage** after
+  projection. Maximizes composability (a consumer of plate adjacency depends only
+  on this node) and keeps `foundation-projection` purely mesh→tile resampling.
+  (Physics / gameplay / naming lenses.)
+
+Either is identity-safe and structurally uniform. Recommendation: **5**.
+
+---
+
+## 7. Identity-safety invariants (the guard rails)
+
+1. Every step keeps `phase: "foundation"` → RNG labels (`${phase}/${stepId}`) are
+   unchanged. **The single most important invariant.**
+2. Op execution order preserved exactly (manifest order = mesh → … → plate-topology).
+3. Artifact ids, op ids, op configs, knob schemas/defaults — all unchanged.
+4. Step contracts' `requires`/`provides` unchanged (only the owning stage changes).
+5. Identity test passes **without** regenerating golden output. If it fails, the
+   refactor changed behavior — fix the refactor, never the snapshot.
+
+---
+
+## 8. Realignment edit set (blast radius)
+
+| Surface | Change |
+|---|---|
+| `contract-manifest.ts` | Replace the one `stage("foundation", […10])` with 5(/6) `stage("foundation-*", […])` entries in order; `StandardStageId` union expands. |
+| `recipe.ts` | Import 5(/6) stages; pass them to `orderStandardStages({…})`. Domain wiring (`collectCompileOps(foundationDomain,…)`) unchanged. |
+| `stages/foundation/**` | Removed; redistributed into `stages/foundation-*/**` + `domain/foundation/lib/*` (shared primitives). |
+| `map-artifacts.ts` | Import the 5 tile-space schemas from `foundation-projection/artifacts.ts` (was `foundation/artifacts.ts`). `mapArtifacts.*` ids unchanged. |
+| `studio-contracts/index.ts` | Auto-derives from the manifest → updates for free. |
+| **Map configs** (`maps/configs/*.json`, `canonical.ts`, `studio-current.config.json`) | Split each `foundation: {…}` block into `foundation-mantle/-plates/-tectonics/-crust/-projection` blocks; `plateCount` knob duplicated to mantle+plates, `plateActivity` to projection. (~10 configs.) |
+| **Presets** (`maps/presets/realism/*.ts`) | Same block split (young-tectonics, old-erosion). |
+| `maps/__type_tests__/createMap-config.inference.ts` | Update `_FoundationKnobs` references to the new stage keys. |
+| **Tests** (`test/foundation/**`, `test/pipeline/**`, `test/config/**`, `test/standard-*.ts`, `test/m11-config-knobs-and-presets.ts`, `test/support/**`, morphology consumer tests) | Update any hardcoded stage id `"foundation"`, full step id `"foundation/<step>"`, or `foundation` config block. Identity/topology-lock/gates tests must stay green unchanged-in-spirit. |
+| **Docs** | `FOUNDATION.md` stage-composition section → 5(/6) stages; `STANDARD-RECIPE.md`; backlink the packet + this design. |
+
+Downstream domain code (morphology consumers) needs **no change** — it reads
+`mapArtifacts.foundation*`, whose ids are unchanged.
+
+---
+
+## 9. Slice sequence (Graphite stack on `main`)
+
+1. **`frame+design`** — this doc + FRAMING + decisions. *(docs-only; current branch)*
+2. **`compute-plate-topology op`** — extract the inlined `buildPlateTopology` into a
+   domain op; rewire the existing `plate-topology` step to call it. Identity-preserving,
+   self-contained, independently reviewable. Removes the last `ops:{}` step.
+3. **`foundation stage split`** — the structural cutover: scaffold the 5(/6) stages,
+   distribute artifacts/validation/viz, relocate shared primitives to `domain/foundation/lib`,
+   update manifest + recipe + map-artifacts + knob plumbing, migrate all configs/presets,
+   update tests, remove the monolith. Identity-guarded. *(internally ordered commits:
+   scaffold → migrate configs → update tests → delete monolith, each kept green.)*
+4. **`docs realignment`** — FOUNDATION.md + STANDARD-RECIPE.md to the new shape.
+
+Each slice ends green (build + identity + targeted suites) before the next stacks.
+
+---
+
+## 10. Verification per slice
+
+`nx run mod-swooper-maps:build` · `bun test test/config/shipped-map-identity.test.ts`
+(primary) · `test/pipeline/{foundation-gates,foundation-topology-lock,artifacts,viz-emissions,determinism-suite}` ·
+`test/foundation/**` · `test/standard-recipe.test.ts` · `test/m11-config-knobs-and-presets.ts` ·
+`nx run-many -t boundaries` (Nx) + Grit checks · Studio DAG build. Closure: a live
+in-game smoke run (identity ⇒ parity, but the live engine is the closure test).
+
+---
+
+## 11. Explicitly out of scope (enabled follow-ons)
+
+These are made *possible* by the decomposition but are **not** part of this
+behavior-preserving refactor (they change output):
+- `foundation-material-history-contract` (per-era crust snapshots / material deltas).
+- `plate-topology` → mesh-native (from `plateGraph`+`mesh`), moved into `foundation-plates`.
+- `plateCount` → single-source (derive from mesh artifact instead of duplicate knob).
+- `foundation-projection-provenance-confidence`, `morphology-landform-intents`, etc.
+  (from the architecture packet's candidate slices).

--- a/docs/projects/foundation-stage-decomposition/FRAMING.md
+++ b/docs/projects/foundation-stage-decomposition/FRAMING.md
@@ -1,0 +1,371 @@
+# Foundation Stage Decomposition — Framing & Investigation
+
+> Living working document. Maintained from first discovery through design and into
+> implementation. Grounds the whole workstream: skills + repo context gathered,
+> domain constraints, prior artifacts, assumptions, hypotheses, evidence, current
+> understanding, and the proposed design. Not a status log — the durable frame.
+
+**Branch:** `agent-fnd-foundation-stage-split` (worktree, off `main` @ `a061eec65`)
+**Date opened:** 2026-06-20
+**Owner stance:** steward/driver of the workstream (own investigation, design, slice sequence, verification, follow-through).
+
+---
+
+## 1. Mission
+
+Decompose the monolithic `foundation` **recipe stage** into multiple well-defined,
+physically-grounded **stages** — each a composable, self-contained node in the
+pipeline graph with explicit input/output artifacts — and realign every producer
+and consumer accordingly. Clean up loose/orphaned artifacts and make all
+visualization intentional.
+
+The right model is **physical / algorithmic grounding**: the stage boundaries
+should reflect the real dependency graph of the earth-science processes
+(mantle convection → lithosphere/plates → tectonic history → crustal evolution →
+tile projection), not arbitrary groupings or the patterns of other stages.
+
+### Hard constraint discovered: behavior-preserving structural refactor
+
+`mods/mod-swooper-maps/test/config/shipped-map-identity.test.ts` asserts shipped
+maps generate identically. This decomposition is therefore a **pure structural
+refactor**: same ops, same execution order, same resolved configs, **byte-identical
+generated maps**. No behavioral/physics change rides along. The identity test is
+the safety net for the whole refactor. (Material-history / landform-intent /
+provenance-confidence enrichments proposed by the architecture packet are
+explicitly *out of scope* here — they are follow-on slices that become possible
+*because* of this decomposition.)
+
+---
+
+## 2. The lens: gameplay and physics must agree
+
+- **Physics:** the world must hold together as a simulated place — plates,
+  convection, crust, tectonic history causally consistent. The decomposition is
+  judged by whether each stage is a coherent earth-science unit.
+- **Gameplay:** foundation is upstream of everything the player stands in
+  (coasts, mountains, fair starts, naval geography). Decomposition value is
+  **composability + legibility**: a downstream consumer should depend on exactly
+  the foundation stage it needs, and any author/dev should immediately see what
+  each stage needs and produces.
+- Reason in **complexity vs. parallelism**, never effort/time. Within foundation
+  the earth-science dependency graph is largely linear (each layer feeds the
+  next), so the gain is in *composability and clarity*, not intra-foundation
+  parallelism. That is the honest representation of the physics.
+
+---
+
+## 3. Skills & context gathered (read in full)
+
+Anchor skills (entry → relevant references, read fully):
+- `civ7-mapgen-workstream` SKILL + `references/pipeline-map.md` + `references/facet-physics.md`
+  + `templates/mapgen-workstream-starting-frame.md`.
+- `civ7-systematic-workstream` SKILL (12-gate evidence loop).
+- `civ7-open-spec-workstream` SKILL (phase loop, dominoes → OpenSpec changes).
+- `dev:graphite` SKILL + `dev:git-worktrees` SKILL (worktree + stack mechanics).
+- `mapgen:foundation` (philosophy-only / outdated arch — used for domain
+  philosophy, never for current paths).
+
+Authoritative repo grounding (live source + canonical docs):
+- Recipe wiring: `recipes/standard/recipe.ts`, `recipes/standard/contract-manifest.ts`.
+- The monolith: `recipes/standard/stages/foundation/**`.
+- Domain (unchanged target): `domain/foundation/**` (one `foundation` domain, 17 ops).
+- Canonical reference: `docs/system/libs/mapgen/reference/domains/FOUNDATION.md` (updated 2026-06-05).
+
+### Decisive prior artifact — the architecture packet
+
+`docs/projects/pipeline-realism/resources/packets/foundation-architecture-generative-pipeline/README.md`
+(merged via PR #1422, 2026-06-07). An independent, source-cited review of the
+*current* Foundation architecture. It is not yet an implementation spec, but it:
+- Names the structural problems this workstream targets:
+  - **#2** `tectonics` is a broad layer aggregator (segments + era loop + events +
+    fields + rollups + current + tracers + provenance in one step).
+  - **#3** Material evolution collapsed into final crust (`crust-evolution` publishes
+    only `foundation.crust`).
+  - **#4** Projection is still inside Foundation (publishes `map.foundation*`).
+  - **#5** `plateTopology` is projection-adjacent, named as Foundation, has **no op**.
+- Gives a **"Generative Layers Over Time"** model (layers 1–12) = the
+  physically-grounded dependency graph this decomposition cuts along.
+- Proposes candidate slices incl. `foundation-tectonics-lane-split`,
+  `foundation-plate-topology-op`, projection separation — i.e. it independently
+  points at the same cuts.
+- **Hard core (load-bearing for us):** "material history, plate kinematics,
+  tectonic events, provenance, and tile projections must remain separately
+  understandable"; "downstream consumers should read explicit artifacts, not
+  recover meaning from sampled/buffer-local state"; "map projection stages
+  materialize truth, they do not own truth planning."
+
+> **Note vs packet:** the packet is conservative ("separate lanes contractually
+> *without prematurely promoting stages*"). This workstream's directive is to go
+> further and **promote to stages** (the user's explicit goal). The packet
+> supplies the layered model + problems; the user supplies the stage-promotion
+> decision.
+
+### Decisive prior artifact — the morphology precedent
+
+`docs/projects/morphology-4stage-split/` decomposed the morphology truth pipeline
+into `morphology-coasts / -routing / -erosion / -features`. This is the exact
+template: **one domain → many recipe stages**, `<domain>-<stage>` naming, artifact
+ids unchanged, op ids unchanged, viz dataTypeKeys unchanged, full step ids change
+(stage id is embedded), author legibility preserved via labels. Hydrology
+(`-climate-baseline/-hydrography/-climate-refine`) and ecology
+(`-pedology/-biomes/-features`) follow the same shape. **Foundation is the last
+single-stage truth domain; bringing it into line is scale-continuous with the
+rest of the pipeline.**
+
+### User clarifications (2026-06-20)
+
+1. **Publish meaningful artifacts even if not yet consumed downstream** — as long
+   as they are *usable, meaningful, and atomic*. Do NOT remove an artifact merely
+   because nothing consumes it yet. Only remove/repair artifacts that are *bad,
+   meaningless, or non-atomic*. → Reframes "cleanup" from "delete orphans" to
+   "audit quality; every published artifact must be meaningful + atomic."
+2. A recent Foundation architecture doc exists — found (the packet above); it
+   informs this approach.
+3. Use Narsil MCP (indexes the primary worktree = current `main`).
+
+---
+
+## 4. Current architecture (evidence-cited)
+
+### 4.1 The monolith
+
+`stages/foundation/` is one `createStage({ id: "foundation" })` with **10 steps**
+(order authority = `contract-manifest.ts`):
+
+```
+mesh → mantle-potential → mantle-forcing → crust(crustInit) → plate-graph →
+plate-motion → tectonics → crust-evolution → projection → plate-topology
+```
+
+Stage-level shared modules: `artifacts.ts` (977 L — the artifact catalog +
+tile-space schemas re-exported to `map-artifacts.ts`), `validation.ts` (792 L —
+shared per-step output validators, imported by every step's `run`), `viz.ts`
+(123 L — shared mesh/tile geometry → viz-buffer converters).
+
+### 4.2 Artifact dependency graph (the physics chain)
+
+| Step | requires (artifacts) | provides | space |
+|---|---|---|---|
+| mesh | — | `mesh` | mesh |
+| mantle-potential | mesh | `mantlePotential` | mesh |
+| mantle-forcing | mesh, mantlePotential | `mantleForcing` | mesh |
+| crust | mesh, mantleForcing | `crustInit` | mesh |
+| plate-graph | mesh, crustInit | `plateGraph` | mesh |
+| plate-motion | mesh, plateGraph, mantleForcing | `plateMotion` | mesh |
+| tectonics | mesh, mantleForcing, crustInit, plateGraph, plateMotion | `tectonicSegments`, `tectonicHistory`, `tectonicProvenance`, `tectonics` | mesh |
+| crust-evolution | mesh, crustInit, **tectonics, tectonicHistory** | `crust` (final) | mesh |
+| projection | mesh, **crust**, plateGraph, plateMotion, tectonics, tectonicHistory, tectonicProvenance | `map.foundation{Plates,TileToCellIndex,CrustTiles,TectonicHistoryTiles,TectonicProvenanceTiles}` | mesh→tile |
+| plate-topology | `map.foundationPlates` | `foundation.plateTopology` | tile-derived |
+
+Key structural facts:
+- **Crust is bimodal in time.** `crustInit` (mesh+forcing) is the precondition for
+  plate partition; `crust` (final) is `crustInit` reworked by tectonic history.
+  They are different artifacts at different causal points — `crust-evolution` is a
+  genuine **merge** (crustInit lineage ⊕ tectonic history). This matches the
+  user's "combination/merge stage" hint and packet problem #3.
+- **`projection` is mesh→tile resampling** (`computePlatesTensors`), not adapter
+  projection. It does NOT touch the adapter — it's still truth-space, producing
+  tile-space `map.foundation*` artifacts. Naming overloads the pipeline's
+  "projection" (= `map-*` adapter stages); must be documented clearly.
+- **`plate-topology` has `ops: {}`** — it calls `buildPlateTopology` from
+  `@swooper/mapgen-core/lib/plates` directly (loose code, no domain op). Packet
+  slice `foundation-plate-topology-op` wants this extracted into an op.
+
+### 4.3 Truth vs projection (the load-bearing invariant)
+
+Mesh-space `foundation.*` artifacts are **truth**; tile-space `map.foundation*` are
+**projections** (recomputable from truth, carry `tileToCellIndex` crosswalk). The
+decomposition must keep this split crisp: truth stages compute mesh artifacts;
+the projection stage is the explicit, labeled mesh→tile bridge.
+
+### 4.4 Consumers (who reads foundation across the repo)
+
+- **Mesh-space `foundation.*`**: consumed **only inside the foundation stage**
+  (intermediate truth) + tests. (Confirmed by grep: no downstream domain imports
+  `foundationArtifacts`.)
+- **Tile-space `map.foundation*`** (the cross-domain surface):
+  - `morphology-coasts/landmassPlates` ← `foundationCrustTiles`,
+    `foundationTectonicHistoryTiles`, `foundationTectonicProvenanceTiles`, `foundationPlates`.
+  - `morphology-features/islands`, `morphology-features/volcanoes` ← `foundationPlates`.
+  - `foundationTileToCellIndex` ← only foundation/projection + validation/viz (crosswalk).
+- `map-artifacts.ts` imports the 5 tile-space schemas from `foundation/artifacts.ts`
+  to define the `mapArtifacts.foundation*` registry. **Downstream consumers
+  reference `mapArtifacts.*` (unchanged), so the cross-domain churn is minimal.**
+- Studio DAG **auto-derives** from `standardStageContractManifest`
+  (`studio-contracts/index.ts`) → updates for free when the manifest changes.
+
+### 4.5 Knobs (the one real cross-stage entanglement)
+
+Knobs are **stage-scoped** (authored at `config.<stageId>.knobs`, reach steps via
+`ctx.knobs` in `normalize`). Foundation has two:
+- `plateCount` — consumed by **mesh** (`cellCount = plateCount × cellsPerPlate`)
+  AND **plate-graph** (plate partition count). These land in **different stages**
+  (mantle vs plates) → cross-stage knob. Resolution is a design decision (§6).
+- `plateActivity` — consumed by **projection only** → lands cleanly in the
+  projection stage.
+
+### 4.6 Phase field
+
+`defineStep({ phase })` = the **domain** name, not the stage id (morphology steps
+use `phase: "morphology"` across all 4 stages). So all foundation steps keep
+`phase: "foundation"` after the split — no phase change.
+
+---
+
+## 5. Proposed decomposition (5 stages) — to be stress-tested before implementing
+
+One `foundation` **domain** (17 ops) is unchanged. The single `foundation` **recipe
+stage** splits into 5, named `foundation-<stage>` per precedent. Each stage is
+structurally identical: `index.ts` (createStage), `artifacts.ts`, `validation.ts`,
+`viz.ts`, `steps/`.
+
+| # | Stage | Steps | Physical/algorithmic unit | Primary outputs | Knob |
+|---|---|---|---|---|---|
+| 1 | `foundation-mantle` | mesh, mantle-potential, mantle-forcing | Computational mesh + mantle convection forcing field | `foundation.{mesh,mantlePotential,mantleForcing}` | `plateCount`* |
+| 2 | `foundation-plates` | crust(init), plate-graph, plate-motion | Initial lithosphere + plate partition + rigid kinematics | `foundation.{crustInit,plateGraph,plateMotion}` | `plateCount`* |
+| 3 | `foundation-tectonics` | tectonics | Plate-boundary dynamics + geological history | `foundation.{tectonicSegments,tectonicHistory,tectonicProvenance,tectonics}` | — |
+| 4 | `foundation-crust` | crust-evolution | Crustal evolution (merge: crustInit ⊕ tectonic history) | `foundation.crust` | — |
+| 5 | `foundation-projection` | projection, plate-topology | Project mesh truth → Civ7 tile grid (+ plate adjacency) | `map.foundation*`, `foundation.plateTopology` | `plateActivity` |
+
+\* `plateCount` cross-stage knob — resolution pending (§6).
+
+**Downstream dependency after the split:** morphology depends on
+`foundation-projection` (the `map.foundation*` outputs). The mesh-space truth
+stages (1–4) become independently dependable nodes (e.g. a future consumer of raw
+crust truth depends on `foundation-crust`; a plate-kinematics consumer depends on
+`foundation-plates`).
+
+### Why this is the right cut (physical grounding)
+
+Maps 1:1 onto the packet's generative layers: mantle (L1–3) → plates (L4–6) →
+tectonics history (L7–10) → crust evolution (L11) → tile projection (L12). Each
+boundary is a real causal hand-off, and each stage is one coherent earth-science
+process. Tectonics and Crust are separate per the user's explicit hints and
+because boundary-dynamics (history) and crustal-material-evolution are distinct
+concerns coupled only by the history artifact.
+
+---
+
+## 6. Decisions (resolved via the 9-agent design-hardening workflow)
+
+All 4 red-team lenses → **"sound-with-refinements"** (none reject the stage
+split). The decomposition stands; refinements below.
+
+1. **Identity safety (decisive).** `ctxRandomLabel` derives from
+   `${phase}/${stepId}` and `phase` stays `"foundation"` for every step (it is the
+   domain, not the stage). So RNG label sequences are **unchanged** by the split.
+   With op order preserved (manifest) and op configs/knob schemas unchanged,
+   output is byte-identical. → The split is a safe structural refactor; the
+   identity test holds **without** snapshot regeneration (do NOT regenerate
+   golden output — two agents wrongly suggested `--update-snapshots`; rejected).
+2. **`plateCount` cross-stage knob → duplicate on both stages** (`foundation-mantle`
+   for mesh, `foundation-plates` for plate-graph), referencing the shared
+   `FoundationPlateCountKnobSchema`. Knob has no default; when omitted both ops
+   independently default to 32 (identical) → identity-safe. Configs that set
+   `plateCount` set it on **both** blocks. (Single-source "derive from mesh
+   artifact" is cleaner but a behavioral touch → deferred follow-on; duplicate is
+   the identity-safe choice for this slice.)
+3. **`plate-topology` → keep + op-ify** (unanimous). Extract a real
+   `foundation/compute-plate-topology` domain op from the inlined
+   `buildPlateTopology` (removes the only `ops:{}` loose-code step). Stays
+   tile-derived (reads `map.foundationPlates`) to preserve identity; **mesh-native
+   (from plateGraph+mesh) → foundation-plates is the flagged follow-on** (packet
+   slice `foundation-plate-topology-op` + FOUNDATION.md open question #1).
+4. **Crust as its own stage → keep separate** (3/4 lenses; physics dissents,
+   preferring merge-into-tectonics). Kept separate: it is the packet's distinct
+   "layer 11" material-evolution merge, and separating it surfaces the layer for
+   the future material-history contract. `foundation-crust` is the merge node.
+5. **Projection / topology grouping → the one open fork for the user.** 3/4 lenses
+   favor separating topology from projection (different inputs: projection reads 6
+   mesh artifacts → tiles; topology reads 1 tile artifact → adjacency); the
+   architecture/packet lens favors keeping them together (topology is
+   projection-adjacent, post-projection, no consumer yet). → Present 5-stage
+   (topology as projection's 2nd step) vs 6-stage (topology its own stage) and let
+   the user pick. Recommendation: **5** (don't mint a stage for a transitional
+   tile-derived diagnostic; it folds cleanly into foundation-plates when it goes
+   mesh-native).
+6. **Artifact-quality audit → 0 bad artifacts; remove none.** 16 artifacts are
+   meaningful/usable/atomic → publish all (honors clarification #1). `plateTopology`
+   = "repair" (op-ify, decision 3). `tectonicSegments` = meaningful + atomic
+   boundary surface, keep (published for diagnostics/tests even though no
+   cross-domain consumer). No deletions.
+7. **`crustInit` placement → `foundation-plates`** (the initial lithosphere that is
+   partitioned). Physics-lens alternative (place in `foundation-mantle` as the
+   first material response to forcing) noted; plates chosen for the coherent
+   "lithosphere + partition + motion" unit.
+8. **File structure → 5–6 self-contained stage dirs; no vestigial hub.** Genuinely
+   cross-stage primitives (viz geometry helpers, validation wrappers, the shared
+   crust artifact schema) relocate to the domain's `lib/` (their natural owner) so
+   each stage dir is structurally uniform and nothing is left "loose" in `stages/`.
+   (Cleaner than current morphology/ecology shared hubs, which the normalization
+   packet wants dissolved anyway.)
+
+---
+
+## 7. Verification plan
+
+- **Identity (primary):** `shipped-map-identity.test.ts` must stay green —
+  byte-identical maps prove behavior preservation.
+- **Build/schema gate:** `nx run mod-swooper-maps:build` (tsup compile).
+- **Targeted suites:** `test/foundation/**`, `test/pipeline/{artifacts,foundation-gates,foundation-topology-lock,viz-emissions,determinism-suite}.test.ts`, `test/config/{maps-schema-valid,shipped-map-identity,standard-authoring-surface-guards}.test.ts`, `test/standard-recipe.test.ts`, `test/m11-config-knobs-and-presets.test.ts`, morphology consumer tests.
+- **Boundaries:** `nx run-many -t boundaries` (Nx) + Grit checks.
+- **Studio DAG:** auto-derives from manifest; assert it still builds.
+- **In-game (closure):** a live run is the closure test for any mapgen change
+  (per workstream skill). For a pure structural refactor with identity preserved,
+  in-game parity should follow from identity, but a live smoke run is the honest
+  closure gate before "done."
+
+---
+
+## 8. Slice sequence (dominoes → Graphite stack) — draft
+
+1. **Frame + design** (this doc + design doc + decision record). [docs-only]
+2. **Plate-topology op** — extract `compute-plate-topology` domain op (no stage
+   change yet); identity-preserving. (Unblocks clean projection stage.)
+3. **Stage split** — the structural cutover: 5 stages, distribute
+   artifacts/validation/viz, update manifest + recipe + map-artifacts + knob
+   plumbing; migrate configs/presets; update tests; docs realignment. (The big
+   identity-guarded domino — may sub-split if review wants.)
+4. **Docs realignment** — FOUNDATION.md + any stage refs to the new 5-stage shape.
+
+(Sequence may be refined after design red-team / blast-radius mapping.)
+
+---
+
+## 9. Assumptions & risks
+
+- **A1:** One foundation domain stays; only the recipe stage splits (precedent:
+  morphology/hydrology/ecology). 
+- **A2:** Refactor is behavior-preserving; identity test is the guard. If identity
+  can't hold for a sub-change, that sub-change is out of scope (a follow-on).
+- **A3:** Config split (`foundation` block → per-stage blocks) across 10 configs +
+  2 presets + canonical.ts + studio-current is mechanical but must be exact.
+- **R1:** Knob plumbing change (plateCount) risks identity drift → mitigate by
+  deriving the same value; verify with identity test.
+- **R2:** Full step ids change (stage id embedded) → may break tests/Studio
+  retention that hardcode `foundation/<step>`; inventory needed (blast radius).
+- **R3:** Parallel-lane contention (busy Graphite repo) → stay on own worktree off
+  main; never global `gt sync`; `gt sync --no-restack` only if needed.
+
+---
+
+## 10. Evidence log
+
+- Baseline (2026-06-20): worktree `wt-agent-fnd-foundation-stage-split` off
+  `main@a061eec65`; `bun install` clean; `nx run mod-swooper-maps:build` → exit 0
+  (schema-compile gate green); `bun test` of `shipped-map-identity`,
+  `foundation-gates`, `foundation-topology-lock`, `standard-recipe` → **10 pass / 0
+  fail / 141 expects**. Proven green starting point established before any change.
+- Design hardening (2026-06-20): 9-agent workflow complete (~768k tokens). All 4
+  red-team lenses → "sound-with-refinements" (none reject the stage split).
+  Decisive identity finding: RNG labels derive from `phase` (stays "foundation"),
+  not stage id → split is byte-identity-safe with op order + phase preserved.
+  Artifact audit: 16 meaningful/atomic → publish all; 0 bad → remove none;
+  plate-topology → op-ify (repair, not remove). Blast radius mapped: manifest +
+  recipe + map-artifacts + ~10 configs + 2 presets + inference type-test + tests +
+  FOUNDATION.md; downstream morphology consumers need NO change (mapArtifacts.*
+  ids unchanged). Conclusions folded into §6 decisions + DESIGN.md. Rejected two
+  agents' bad advice to regenerate identity snapshots.
+- Design doc written: [DESIGN.md](DESIGN.md). One fork deferred to user: 5 vs 6
+  stages (plate-topology as projection step vs own stage).
+- Status: **awaiting user confirmation of the shape before implementation.**


### PR DESCRIPTION
Decompose the monolithic `foundation` recipe stage into physically-grounded
stages (mantle -> plates -> tectonics -> crust -> projection), one domain ->
many stages per the morphology/hydrology/ecology precedent. Behavior-preserving
structural refactor (shipped-map-identity is the guard).

FRAMING.md: skills/context gathered, current architecture (evidence-cited), the
architecture packet + morphology precedent, decisions (resolved via a 9-agent
red-team + blast-radius workflow), assumptions/risks, verification plan.
DESIGN.md: the 5-stage decomposition, file structure, artifact ownership, knob
plumbing, viz plan, identity-safety invariants, blast radius, slice sequence.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>