### PR TITLE
refactor(foundation): extract compute-plate-topology domain op

### DIFF
--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-topology/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-topology/contract.ts
@@ -1,0 +1,80 @@
+import { defineOp, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+
+/**
+ * Plate topology node: per-plate adjacency + centroid/area derived from the
+ * tile-space plate-id raster. `area`/`centroid` are tile-space aggregates;
+ * `neighbors` is the sorted, unique set of bordering plate ids.
+ */
+const FoundationPlateTopologyNodeSchema = Type.Object(
+  {
+    /** Plate id (0..plateCount-1). */
+    id: Type.Integer({ minimum: 0, description: "Plate id (0..plateCount-1)." }),
+    /** Plate area in tiles. */
+    area: Type.Integer({ minimum: 0, description: "Plate area in tiles." }),
+    /** Plate centroid in tile-space coordinates. */
+    centroid: Type.Object(
+      {
+        /** Plate centroid X (tile space). */
+        x: Type.Number({ description: "Plate centroid X (tile space)." }),
+        /** Plate centroid Y (tile space). */
+        y: Type.Number({ description: "Plate centroid Y (tile space)." }),
+      },
+      { description: "Plate centroid in tile-space coordinates." }
+    ),
+    /** Sorted, unique adjacent plate ids. */
+    neighbors: Type.Array(Type.Integer({ minimum: 0, description: "Neighbor plate id." }), {
+      default: [],
+      description: "Sorted, unique adjacent plate ids.",
+    }),
+  },
+  { description: "Plate topology node (adjacency + centroid/area)." }
+);
+
+/**
+ * compute-plate-topology — build the plate adjacency graph from the tile-space
+ * plate-id field. This is a tile-derived (projection-adjacent) product: it reads
+ * the projected per-tile plate ids and summarizes whole-plate adjacency so
+ * higher-level logic can reason about plates instead of tile-level boundary
+ * noise. The plate budget is derived from the raster (max id + 1).
+ *
+ * NOTE (follow-on): a mesh-native variant could derive adjacency directly from
+ * `foundation.plateGraph` + `foundation.mesh` and move to the plates stage; that
+ * changes output and is intentionally out of scope for the identity-preserving
+ * decomposition. See docs/projects/foundation-stage-decomposition.
+ */
+const ComputePlateTopologyContract = defineOp({
+  kind: "compute",
+  id: "foundation/compute-plate-topology",
+  input: Type.Object(
+    {
+      plateIds: TypedArraySchemas.i16({
+        shape: null,
+        description: "Plate id per tile (tile order).",
+      }),
+      width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+      height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+    },
+    { additionalProperties: false }
+  ),
+  output: Type.Object(
+    {
+      plateTopology: Type.Object(
+        {
+          /** Number of plates included in the topology payload. */
+          plateCount: Type.Integer({ minimum: 1, description: "Number of plates." }),
+          /** Plate topology nodes (indexed by plate id). */
+          plates: Type.Array(FoundationPlateTopologyNodeSchema, {
+            description: "Plate topology nodes (indexed by plate id).",
+          }),
+        },
+        { description: "Foundation plate topology (tile-derived adjacency + centroid/area)." }
+      ),
+    },
+    { additionalProperties: false }
+  ),
+  strategies: {
+    default: Type.Object({}, { additionalProperties: false }),
+  },
+});
+
+export default ComputePlateTopologyContract;

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-topology/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-topology/index.ts
@@ -1,0 +1,12 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import ComputePlateTopologyContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const computePlateTopology = createOp(ComputePlateTopologyContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export default computePlateTopology;

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-topology/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-topology/strategies/default.ts
@@ -1,0 +1,48 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+import { buildPlateTopology } from "@swooper/mapgen-core/lib/plates";
+
+import ComputePlateTopologyContract from "../contract.js";
+
+/**
+ * Undirected-adjacency invariant: if A lists B as a neighbor, B must list A.
+ * A break indicates a topology-build bug, not authored data, so it throws.
+ */
+function validateTopologySymmetry(
+  plates: ReadonlyArray<{ id: number; neighbors: number[] }>
+): void {
+  const neighborSets = new Map<number, Set<number>>();
+  for (const p of plates) neighborSets.set(p.id, new Set(p.neighbors));
+
+  for (const p of plates) {
+    const s = neighborSets.get(p.id);
+    if (!s) continue;
+    for (const n of s) {
+      const back = neighborSets.get(n);
+      if (!back || !back.has(p.id)) {
+        throw new Error("[Foundation] Invalid foundation plateTopology neighbor symmetry.");
+      }
+    }
+  }
+}
+
+export const defaultStrategy = createStrategy(ComputePlateTopologyContract, "default", {
+  run: (input) => {
+    const { plateIds, width, height } = input;
+
+    // Plate budget = highest plate id present + 1 (ids are dense 0..N-1).
+    let maxId = -1;
+    for (let i = 0; i < plateIds.length; i++) {
+      const v = plateIds[i] | 0;
+      if (v > maxId) maxId = v;
+    }
+    const plateCount = Math.max(0, maxId + 1);
+    if (plateCount <= 0) {
+      throw new Error("[Foundation] compute-plate-topology requires at least one plate.");
+    }
+
+    const plates = buildPlateTopology(plateIds, width, height, plateCount);
+    validateTopologySymmetry(plates);
+
+    return { plateTopology: { plateCount, plates } } as const;
+  },
+});

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-topology/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-topology/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/contracts.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/contracts.ts
@@ -8,6 +8,7 @@ import ComputeMantlePotentialContract from "./compute-mantle-potential/contract.
 import ComputeMeshContract from "./compute-mesh/contract.js";
 import ComputePlateGraphContract from "./compute-plate-graph/contract.js";
 import ComputePlateMotionContract from "./compute-plate-motion/contract.js";
+import ComputePlateTopologyContract from "./compute-plate-topology/contract.js";
 import ComputePlatesTensorsContract from "./compute-plates-tensors/contract.js";
 import ComputeSegmentEventsContract from "./compute-segment-events/contract.js";
 import ComputeTectonicHistoryRollupsContract from "./compute-tectonic-history-rollups/contract.js";
@@ -34,6 +35,7 @@ export const contracts = {
   computeTracerAdvection: ComputeTracerAdvectionContract,
   computeTectonicProvenance: ComputeTectonicProvenanceContract,
   computePlatesTensors: ComputePlatesTensorsContract,
+  computePlateTopology: ComputePlateTopologyContract,
 } as const;
 
 export default contracts;

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/index.ts
@@ -9,6 +9,7 @@ import computeMantlePotential from "./compute-mantle-potential/index.js";
 import computeMesh from "./compute-mesh/index.js";
 import computePlateGraph from "./compute-plate-graph/index.js";
 import computePlateMotion from "./compute-plate-motion/index.js";
+import computePlateTopology from "./compute-plate-topology/index.js";
 import computePlatesTensors from "./compute-plates-tensors/index.js";
 import computeSegmentEvents from "./compute-segment-events/index.js";
 import computeTectonicHistoryRollups from "./compute-tectonic-history-rollups/index.js";
@@ -36,6 +37,7 @@ const implementations = {
   computeTracerAdvection,
   computeTectonicProvenance,
   computePlatesTensors,
+  computePlateTopology,
 } as const satisfies DomainOpImplementationsForContracts<typeof contracts>;
 
 export default implementations;
@@ -52,6 +54,7 @@ export {
   computePlateGraph,
   computePlateMotion,
   computePlatesTensors,
+  computePlateTopology,
   computeSegmentEvents,
   computeTectonicHistoryRollups,
   computeTectonicProvenance,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.contract.ts
@@ -1,3 +1,4 @@
+import foundation from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import { mapArtifacts } from "../../../map-artifacts.js";
 import { foundationArtifacts } from "../artifacts.js";
@@ -11,7 +12,9 @@ const PlateTopologyStepContract = defineStep({
     requires: [mapArtifacts.foundationPlates],
     provides: [foundationArtifacts.plateTopology],
   },
-  ops: {},
+  ops: {
+    computePlateTopology: foundation.ops.computePlateTopology,
+  },
   schema: Type.Object({}, { additionalProperties: false }),
 });
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts
@@ -1,6 +1,5 @@
 import { defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { buildPlateTopology } from "@swooper/mapgen-core/lib/plates";
 
 import { foundationArtifacts } from "../artifacts.js";
 import { pointsFromTileCentroids, segmentsFromTileTopologyNeighbors } from "../viz.js";
@@ -9,24 +8,6 @@ import { validatePlateTopologyArtifact, wrapFoundationValidateNoDims } from "./v
 
 const GROUP_PLATE_TOPOLOGY = "Foundation / Plate Topology";
 
-function validateTopologySymmetry(
-  plates: ReadonlyArray<{ id: number; neighbors: number[] }>
-): void {
-  const neighborSets = new Map<number, Set<number>>();
-  for (const p of plates) neighborSets.set(p.id, new Set(p.neighbors));
-
-  for (const p of plates) {
-    const s = neighborSets.get(p.id);
-    if (!s) continue;
-    for (const n of s) {
-      const back = neighborSets.get(n);
-      if (!back || !back.has(p.id)) {
-        throw new Error("[FoundationArtifact] Invalid foundation plateTopology neighbor symmetry.");
-      }
-    }
-  }
-}
-
 export default createStep(PlateTopologyStepContract, {
   artifacts: implementArtifacts([foundationArtifacts.plateTopology], {
     foundationPlateTopology: {
@@ -34,27 +15,19 @@ export default createStep(PlateTopologyStepContract, {
     },
   }),
   run: (context, config, ops, deps) => {
-    void config;
-    void ops;
-
+    // Plate adjacency is derived from the projected tile plate-id field via the
+    // compute-plate-topology op (tile-derived; see the op contract for the
+    // mesh-native follow-on note).
     const { width, height } = context.dimensions;
     const plates = deps.artifacts.foundationPlates.read(context);
-    const plateIds = plates.id;
 
-    let maxId = -1;
-    for (let i = 0; i < plateIds.length; i++) {
-      const v = plateIds[i] | 0;
-      if (v > maxId) maxId = v;
-    }
-    const plateCount = Math.max(0, maxId + 1);
-    if (plateCount <= 0) {
-      throw new Error("[FoundationArtifact] Invalid foundation plateTopology.plateCount.");
-    }
+    const { plateTopology } = ops.computePlateTopology(
+      { plateIds: plates.id, width, height },
+      config.computePlateTopology
+    );
+    const topologyPlates = plateTopology.plates;
 
-    const topologyPlates = buildPlateTopology(plateIds, width, height, plateCount);
-    validateTopologySymmetry(topologyPlates);
-
-    deps.artifacts.foundationPlateTopology.publish(context, { plateCount, plates: topologyPlates });
+    deps.artifacts.foundationPlateTopology.publish(context, plateTopology);
 
     const centroidPoints = pointsFromTileCentroids(topologyPlates);
     context.viz?.dumpPoints(context.trace, {


### PR DESCRIPTION
The plate-topology step was the only foundation step with `ops: {}` — it called
`buildPlateTopology` from the engine lib inline (loose code, no op/contract
boundary). Extract a real `foundation/compute-plate-topology` domain op that
owns the tile-derived adjacency build + the undirected-symmetry invariant. The
step now binds and calls the op like every other step.

Behavior-preserving: same buildPlateTopology call, same inputs, same output;
plate budget still derived as max(id)+1. Identity verified (shipped-map-identity
green). Tile-derived today; mesh-native variant noted as a follow-on in the op
contract.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>