### PR TITLE
docs(foundation): realign canonical refs to the 5-stage decomposition

### DIFF
--- a/docs/projects/foundation-stage-decomposition/FRAMING.md
+++ b/docs/projects/foundation-stage-decomposition/FRAMING.md
@@ -368,4 +368,46 @@ split). The decomposition stands; refinements below.
   agents' bad advice to regenerate identity snapshots.
 - Design doc written: [DESIGN.md](DESIGN.md). One fork deferred to user: 5 vs 6
   stages (plate-topology as projection step vs own stage).
-- Status: **awaiting user confirmation of the shape before implementation.**
+- Shape decided (2026-06-20): **5 stages** — `plate-topology` lives as a step in
+  `foundation-projection` (not its own stage). Stage authoring is **boring +
+  declarative**: each `index.ts` lists knobs + advanced op config and hooks ops
+  directly (no helper machinery), matching mapgen-core/ecology precedent.
+- Slice 2 committed (`agent-fnd-foundation-plate-topology-op`, 9ea480c9d):
+  extracted `compute-plate-topology` domain op (repair of the op-less step).
+- Slice 3 committed (`agent-fnd-foundation-split-stages`, b2ee13038): the split
+  into foundation-mantle/-plates/-tectonics/-crust/-projection + shared
+  `foundation/{artifacts,validation,viz}.ts` hub; configs/presets/generated/type-
+  test/tests migrated.
+- Identity **proven end-to-end for every shipped/dev config** (2026-06-21), not
+  argued: ran `run-standard-dump` (full standard pipeline, MockAdapter) for **all
+  9 `.config.json` maps** in the split worktree (migrated 5-block configs) and on
+  clean `main` (original 1-block configs), same dims/seed (106×66/1337). The
+  surface digests + resource `placedHash32` are byte-identical for all 9 — `diff`
+  of the digest sets is empty. Example (swooper-earthlike): elevation `65ca6e28`,
+  terrain `9163b556`, biome `8c599ae2`, feature `f30a074e`, resource `a0c8f110`
+  on both sides. (The config-shape change is a lossless re-grouping: ops, op
+  order, and the `foundation` phase label are unchanged, so each op gets an
+  identical compiled envelope + RNG stream. `runId` legitimately differs — it
+  fingerprints config shape, not output.) The test-config path (biomes-latcutoff)
+  matched too.
+- Verification (2026-06-21): full mod suite **581 pass / 2 skip / 0 fail** (583
+  tests); `tsc --noEmit` exit 0; 4 `test:architecture-*` targets pass;
+  `domain-refactor-guardrails` pass; biome clean. Boundaries via the active
+  habitat/DRA-stack CLI pointed at this worktree (~7.5s vs 14+ min legacy grit):
+  49 rules, all pattern-check/grit rules pass incl. `recipe-imports-in-domain`,
+  `sibling-stage-step-imports`, `viz-contract-ownership`,
+  `wrapper-advanced-stage-config`, `rng-authority-static`; eslint
+  `import-boundaries` pass. (`format-ci` fails only as a cross-worktree
+  biome-spawn artifact; biome verified clean directly.)
+- Failure triage (2026-06-21): of 8 pre-finalization fails — 1 preset-schema
+  (mine; fixed by migrating realism presets), 4 resource-corpus (environmental:
+  fresh worktree lacked extracted base-game data under `.civ7/outputs/resources`;
+  pass on seeded checkout + clean main 9/0), 1 biomes-latcutoff (full-suite
+  parallel-load timeout flake; passes isolated in 3.7s). 2 further issues found +
+  fixed: `contract-guard`/`map-stamping` guards re-pointed to scan the
+  `foundation-*` family dynamically; `standard-artifacts` dist built via
+  `build:studio-recipes`.
+- Slice 4 (docs): FOUNDATION.md stage-composition → 5-stage table + step-path
+  anchors migrated; STANDARD-RECIPE.md stage order updated.
+- Status: **implemented + verified green; identity proven against main.** Remaining
+  closure: live in-game smoke run (the engine is the final closure test).

--- a/docs/system/libs/mapgen/reference/STANDARD-RECIPE.md
+++ b/docs/system/libs/mapgen/reference/STANDARD-RECIPE.md
@@ -54,27 +54,35 @@ The standard recipe is **content-owned** (not SDK-owned):
 
 The current stage order is:
 
-1. `foundation`
-2. `morphology-coasts`
-3. `morphology-routing`
-4. `morphology-erosion`
-5. `morphology-features`
-6. `hydrology-climate-baseline`
-7. `hydrology-hydrography`
-8. `hydrology-climate-refine`
-9. `ecology-pedology`
-10. `ecology-biomes`
-11. `map-morphology`
-12. `map-hydrology`
-13. `map-elevation`
-14. `map-rivers`
-15. `ecology-features`
-16. `map-ecology`
-17. `placement`
+1. `foundation-mantle`
+2. `foundation-plates`
+3. `foundation-tectonics`
+4. `foundation-crust`
+5. `foundation-projection`
+6. `morphology-coasts`
+7. `morphology-routing`
+8. `morphology-erosion`
+9. `morphology-features`
+10. `hydrology-climate-baseline`
+11. `hydrology-hydrography`
+12. `hydrology-climate-refine`
+13. `ecology-pedology`
+14. `ecology-biomes`
+15. `map-morphology`
+16. `map-hydrology`
+17. `map-elevation`
+18. `map-rivers`
+19. `ecology-features`
+20. `map-ecology`
+21. `placement`
+
+The five `foundation-*` stages are a sibling family decomposed from the former
+single `foundation` stage; their steps run in the same order, so output is
+byte-identical (see the FOUNDATION domain reference for the stage→step map).
 
 Note:
 
-- “foundation/morphology-\*/hydrology/ecology-\*” stages are primarily **truth** producers.
+- “foundation-\*/morphology-\*/hydrology/ecology-\*” stages are primarily **truth** producers.
 - “map-\*” and “placement” stages are primarily **projection** / engine-facing surfaces.
 
 ## Config surface (schema + posture)
@@ -129,6 +137,6 @@ Domain contract references:
 ## Ground truth anchors
 
 - Standard recipe composition: `mods/mod-swooper-maps/src/recipes/standard/recipe.ts`
-- Example stage schema/knobs posture: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts`
+- Example stage schema/knobs posture: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/index.ts`
 - Stage authoring contract: `packages/mapgen-core/src/authoring/stage.ts`
 - Policy: truth vs projection: `docs/system/libs/mapgen/policies/TRUTH-VS-PROJECTION.md`

--- a/docs/system/libs/mapgen/reference/domains/FOUNDATION.md
+++ b/docs/system/libs/mapgen/reference/domains/FOUNDATION.md
@@ -49,7 +49,7 @@ FOUNDATION does not require upstream domain artifacts. It requires only:
 
 **Ground truth anchors**
 - `packages/mapgen-core/src/core/types.ts` (`ctxRandom` derives from `Env.seed`, not adapter RNG)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts` (`ctxRandom`, `ctxRandomLabel`, `context.dimensions`)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mesh.ts` (`ctxRandom`, `ctxRandomLabel`, `context.dimensions`)
 - `mods/mod-swooper-maps/src/domain/foundation/lib/normalize.ts` (`requireEnvDimensions`)
 - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-mesh/contract.ts` (`ComputeMeshContract.input`)
 
@@ -80,12 +80,12 @@ FOUNDATION provides the following artifact dependency tags (all `artifact:*`).
 **Ground truth anchors**
 - `packages/mapgen-core/src/core/types.ts` (`FOUNDATION_MESH_ARTIFACT_TAG`, `FOUNDATION_MANTLE_POTENTIAL_ARTIFACT_TAG`, `FOUNDATION_MANTLE_FORCING_ARTIFACT_TAG`, `FOUNDATION_CRUST_ARTIFACT_TAG`, `FOUNDATION_PLATE_MOTION_ARTIFACT_TAG`, `FOUNDATION_PLATE_GRAPH_ARTIFACT_TAG`, `FOUNDATION_TECTONIC_PROVENANCE_ARTIFACT_TAG`, `FOUNDATION_TECTONICS_ARTIFACT_TAG`, `FOUNDATION_TILE_TO_CELL_INDEX_ARTIFACT_TAG`, `FOUNDATION_CRUST_TILES_ARTIFACT_TAG`, `FOUNDATION_TECTONIC_HISTORY_TILES_ARTIFACT_TAG`, `FOUNDATION_TECTONIC_PROVENANCE_TILES_ARTIFACT_TAG`, `FOUNDATION_PLATES_ARTIFACT_TAG`)
 - `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts` (`FOUNDATION_TECTONIC_SEGMENTS_ARTIFACT_TAG`, `FOUNDATION_TECTONIC_HISTORY_ARTIFACT_TAG`, `FOUNDATION_PLATE_TOPOLOGY_ARTIFACT_TAG`, `foundationArtifacts`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.contract.ts` (`MeshStepContract.artifacts.provides`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crust.contract.ts` (`CrustStepContract.artifacts.requires/provides`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.contract.ts` (`PlateGraphStepContract.artifacts.requires/provides`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts` (`TectonicsStepContract.artifacts.requires/provides`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts` (`ProjectionStepContract.artifacts.requires/provides`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.contract.ts` (`PlateTopologyStepContract.artifacts.requires/provides`)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mesh.contract.ts` (`MeshStepContract.artifacts.provides`)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-plates/steps/crust.contract.ts` (`CrustStepContract.artifacts.requires/provides`)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-plates/steps/plateGraph.contract.ts` (`PlateGraphStepContract.artifacts.requires/provides`)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-tectonics/steps/tectonics.contract.ts` (`TectonicsStepContract.artifacts.requires/provides`)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-projection/steps/projection.contract.ts` (`ProjectionStepContract.artifacts.requires/provides`)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-projection/steps/plateTopology.contract.ts` (`PlateTopologyStepContract.artifacts.requires/provides`)
 
 ### Value domains (enums / ranges)
 
@@ -226,7 +226,7 @@ Key fields:
 **Ground truth anchors**
 - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history-rollups/contract.ts` (`FoundationTectonicHistorySchema`)
 - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history-rollups/index.ts` (`computeTectonicHistoryRollups`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts` (`historyResult` publication)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-tectonics/steps/tectonics.ts` (`historyResult` publication)
 
 ### `artifact:foundation.tectonicProvenance` (truth; mesh space)
 
@@ -319,7 +319,7 @@ Key fields (per tile):
 Plate adjacency + centroid/area derived from the tile-space `foundation.plates.id` field.
 
 **Ground truth anchors**
-- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts` (`buildPlateTopology`, `validateTopologySymmetry`)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-projection/steps/plateTopology.ts` (`buildPlateTopology`, `validateTopologySymmetry`)
 - `packages/mapgen-core/src/lib/plates/topology.ts` (`buildPlateTopology`) (see `@swooper/mapgen-core/lib/plates` re-export)
 
 ## Operations
@@ -368,7 +368,7 @@ The standard recipe exposes two knobs that apply *after* defaulted step config, 
 **Ground truth anchors**
 - `mods/mod-swooper-maps/src/domain/foundation/shared/knobs.ts` (`FoundationPlateCountKnobSchema`, `FoundationPlateActivityKnobSchema`)
 - `mods/mod-swooper-maps/src/domain/foundation/shared/knob-multipliers.ts` (`resolvePlateActivityKinematicsMultiplier`, `resolvePlateActivityBoundaryDelta`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts` (`knobsSchema`, “Knobs apply last” docstrings)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/index.ts` and `…/foundation-plates/index.ts` (`plateCount` `knobsSchema`); `…/foundation-projection/index.ts` (`plateActivity` `knobsSchema`)
 - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-mesh/index.ts` (`normalize` deriving `cellCount`)
 - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/index.ts` (`normalize` validating selected-map-size plate count)
 
@@ -393,20 +393,32 @@ from validated runtime map dimensions:
 
 ### Stage composition
 
-In the standard recipe, the `foundation` stage runs these steps (in order):
-1. `mesh`
-2. `mantle-potential`
-3. `mantle-forcing`
-4. `crust`
-5. `plate-graph`
-6. `plate-motion`
-7. `tectonics`
-8. `crust-evolution`
-9. `projection`
-10. `plate-topology`
+In the standard recipe, FOUNDATION is authored as a **family of five sibling
+recipe stages** (not one monolithic stage). Each stage is a composable node with
+its own knobs + advanced op config; they share the `foundation/` hub for truth
+artifacts, validation, and viz contracts. The steps run in the same global order
+as before — splitting the stage boundaries does not reorder steps, so generated
+maps remain byte-identical (the RNG phase label stays `foundation`).
+
+| # | Stage | Steps (in order) | Responsibility |
+|---|-------|------------------|----------------|
+| 1 | `foundation-mantle` | `mesh`, `mantle-potential`, `mantle-forcing` | Tectonic mesh + mantle-convection forcing field |
+| 2 | `foundation-plates` | `crust`, `plate-graph`, `plate-motion` | Lithosphere crust, plate partition, plate kinematics |
+| 3 | `foundation-tectonics` | `tectonics` | Per-era tectonic history (segments + history rollups) |
+| 4 | `foundation-crust` | `crust-evolution` | Crust maturation over the tectonic history |
+| 5 | `foundation-projection` | `projection`, `plate-topology` | Resample mesh-space truth onto the tile grid + tile plate adjacency |
+
+Cross-stage knobs: `plateCount` is set on **both** `foundation-mantle` (mesh
+density) and `foundation-plates` (plate partition); `plateActivity` is a
+`foundation-projection` knob (scales projected plate kinematics/boundaries).
 
 **Ground truth anchors**
-- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts` (`createStage`, `steps`)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/index.ts` (`createStage`, mantle steps + `plateCount` knob)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-plates/index.ts` (`createStage`, plate steps + `plateCount` knob)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-tectonics/index.ts` (`createStage`, tectonics op contracts)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-crust/index.ts` (`createStage`, crust-evolution)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-projection/index.ts` (`createStage`, projection + `plateActivity` knob)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/{artifacts,validation,viz}.ts` (shared hub for the five stages)
 - `mods/mod-swooper-maps/src/recipes/standard/recipe.ts` (`STANDARD_STAGES`, `stages` ordering)
 
 ### Downstream consumption (today)
@@ -426,8 +438,8 @@ This is the minimal drift worth calling out in a domain reference:
 - **Tectonic history is not consumed cross-domain today**, even though it exists as a truth artifact.
 
 **Ground truth anchors**
-- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts` (`buildPlateTopology(plateIds, width, height, plateCount)`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts` (publishes history; no downstream reads in standard recipe)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-projection/steps/plateTopology.ts` (`buildPlateTopology(plateIds, width, height, plateCount)`)
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-tectonics/steps/tectonics.ts` (publishes history; no downstream reads in standard recipe)
 
 ## Open Questions
 
@@ -446,8 +458,8 @@ This section is a navigation aid: concrete file paths that back the contract cla
 This page contains many inline “Ground truth anchors” callouts. This section collects the canonical entrypoints:
 
 - Domain entrypoint + op ids: `mods/mod-swooper-maps/src/domain/foundation/index.ts`
-- Standard recipe stage definition (step ordering + wiring): `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts`
-- Stage artifact wiring (recipe-level tags, schemas, and helpers): `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts`
+- Standard recipe stage definitions (five sibling stages): `mods/mod-swooper-maps/src/recipes/standard/stages/foundation-{mantle,plates,tectonics,crust,projection}/index.ts`; overall step ordering + wiring: `mods/mod-swooper-maps/src/recipes/standard/recipe.ts`
+- Stage artifact wiring (recipe-level tags, schemas, and helpers; shared hub): `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts`
 - Core artifact tag constants (shared ids/types): `packages/mapgen-core/src/core/types.ts`
 
 - Mesh construction (truth root):


### PR DESCRIPTION
Update the canonical FOUNDATION domain reference and the standard-recipe
reference to reflect the foundation stage split:

- FOUNDATION.md "Stage composition" → a five-stage table
  (foundation-mantle/-plates/-tectonics/-crust/-projection) with the stage→step
  map and the cross-stage knob notes; migrate every `stages/foundation/steps/*`
  anchor to its new `foundation-<stage>/steps/*` path; the `foundation/`
  artifacts/validation/viz hub references stay.
- STANDARD-RECIPE.md stage-order list → the five `foundation-*` stages
  (renumbered), with a note that the split is byte-identical.
- FRAMING.md evidence log → implementation + verification closure (identity
  proven against main, full suite green, boundary/grit rules pass).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>