### PR TITLE
docs(coastal-shelf-tiling): framing, design, expectation ledger (S0)

### DIFF
--- a/docs/projects/coastal-shelf-tiling/DESIGN.md
+++ b/docs/projects/coastal-shelf-tiling/DESIGN.md
@@ -1,0 +1,84 @@
+# Coastal Shelf Tiling — Design & Slice Sequence
+
+> Step 4–5 of the mapgen-workstream loop. Reads from `FRAMING.md` (route, frame, root-cause chain).
+> Records the chosen design, the rejected structural alternative, and the OpenSpec/Graphite domino sequence.
+
+## Physics first principles (how coast *should* be assigned)
+
+The Civ7 `TERRAIN_COAST` analogue is the **continental shelf / neritic zone**: shallow (< shelf-break
+depth), nearshore water, gently sloping from the shoreline to the shelf break, beyond which the floor
+drops to abyssal `TERRAIN_OCEAN`. Its defining physical property is **width by margin type**:
+
+- **Passive margins** (trailing/divergent edges — Atlantic analogue): broad, shallow shelves
+  (sediment-loaded, no subduction). → wide coast band.
+- **Active margins** (convergent/transform/subducting — Pacific analogue): narrow, steep shelves
+  (trench close to shore). → thin coast band.
+- Every shoreline has *some* shallow nearshore water before the drop-off → a guaranteed thin ring.
+
+So the physically-correct coast = **the continental shelf**: `water ∧ shallow(bathymetry) ∧
+within margin-dependent distance of land`, plus a guaranteed 1-tile shoreline ring. This is *exactly*
+what `compute-shelf-mask` already computes (margin-aware `cap` + bathymetric `shallowCutoff`). The op
+is correct physics; it is currently flattened by config and overridden by a uniform band (see FRAMING
+root-cause chain). **The fix is to let the shelf own the coast, not to invent new physics.**
+
+## Chosen design — "Shelf-anchored coast"
+
+Final water classification in `map-morphology/plot-coasts`:
+
+```
+waterClass[i] = LAND                              if landMask[i] == 1
+              = COAST  if water ∧ ( shelfMask[i]==1            // physics shelf (margin-aware, depth-gated)
+                                  ∨ coastalWater[i]==1 )       // guaranteed shoreline ring (1-tile)
+              = COAST  if ocean ∧ adjacent-to-land             // heal late land injection / island peaks
+              = OCEAN  otherwise
+```
+
+i.e. **coast = `sourceCoastMask` (shelf ∪ shoreline ring) ∪ land-adjacent ring** — the uniform
+`coastBufferTiles` distance band is removed. Coast width now varies with margin type and bathymetry.
+
+Supporting changes:
+- **Shelf physics restored:** fix the `capTilesMax` double-clamp so margin-aware caps (active<passive)
+  survive, and correct `latest_juicy`'s shelf block (`capTilesMax:1`, `shallowQuantile:0.9`) to
+  non-degenerate values. The shelf becomes the real driver.
+- **Coast-ring as a named policy primitive:** the "every land tile has ≥1 adjacent coast" guarantee
+  moves into the policy adapter `@civ7/map-policy` as `applyCiv7CoastRingPolicy` (replacing the
+  misappropriated `applyCiv7CoastClassificationPolicy` / `oceanWaterColumns` distance band). Policy
+  lives in the policy package, not ad hoc in the projection.
+- **De-duplicate:** `ecology-features/score-layers` stops recomputing the coast policy and reads the
+  authoritative `coastClassification.waterClass` artifact, so feature scoring sees the real coast.
+- **Retire dead surface:** once unused, remove `applyCiv7CoastClassificationPolicy`, `coastBufferTiles`,
+  and the `oceanWaterColumns` misappropriation from `@civ7/map-policy`; rename artifact field
+  `policyCoastMask` → `coastRingMask` (viz/diagnostics only).
+
+Keep: `restoreProjectedCoastTerrain` (the structural locus that keeps coast MapGen-owned across
+map-rivers/placement) and the no-water-drift guards.
+
+## Rejected structural alternative (step-5 requirement)
+
+**Alt B — "Band clamped to shelf":** keep `applyCiv7CoastClassificationPolicy` but intersect the
+distance band with the shelf (`band ∩ shelfMask`) so it can only *fill within* the shelf.
+**Rejected:** it keeps the misappropriated `oceanWaterColumns` constant and a redundant distance pass
+that can only ever shrink the shelf it's intersected with — pure indirection. The shelf already *is*
+the band; layering a distance gate on top is the confusing indirection we're removing, not adding to.
+
+**Alt C — "Fix upstream bathymetry/sea-level instead":** treat the weak shelf as an upstream surface
+problem. **Rejected** (held as the FRAMING falsifier): evidence shows the shelf op is sound; the loss
+is config + override, not a missing shelf break. Out of frame exterior.
+
+## Slice sequence (OpenSpec dominoes → Graphite stack)
+
+Causally linear (coast determination is a tight chain): shelf must be correct *before* the projection
+relies on it; the policy primitive must exist *before* the projection wires it; cleanup follows.
+
+| Slice | Behavior change | Lands in | Proof (per-slice) |
+|---|---|---|---|
+| **S0** (this branch) | none — framing + design + ledger | `docs/projects/coastal-shelf-tiling/` | doc review |
+| **S1 — shelf footgun fix** | shelf becomes margin-aware + non-degenerate | `domain/morphology` clamp semantics + config audit (`latest-juicy` et al.) | tests + diag:dump (capTilesByTile varies; shallowCutoff<0; shelf share up) |
+| **S2 — coast-ring policy primitive** | none (pure addition) | `@civ7/map-policy` (`applyCiv7CoastRingPolicy`) | unit test on the primitive |
+| **S3 — shelf-anchored projection** | **coast follows shelf; uniform band removed** | `plot-coasts.ts`, `score-layers`, artifact field, tests, diagnostics | diag:dump ledger rows C1–C3; no-water-drift |
+| **S4 — retire dead policy surface** | none (refactor/cleanup) | remove `applyCiv7CoastClassificationPolicy`/`coastBufferTiles`/`oceanWaterColumns` | build + tests green; boundaries lint |
+| **S5 — live verification milestone** | none — proof | live gate + parity + placement-metrics | `studio-run-in-game-live`; ledger close |
+
+Each implementation slice = one OpenSpec change + one Graphite branch stacked on the prior; artifacts
+regenerated in-slice; architecture review (Grit/Biome boundaries) per slice. Finalization hands off to
+`civ7-open-spec-workstream`.

--- a/docs/projects/coastal-shelf-tiling/EXPECTATIONS.md
+++ b/docs/projects/coastal-shelf-tiling/EXPECTATIONS.md
@@ -78,5 +78,13 @@ bun ./src/dev/diagnostics/run-standard-dump.ts -- 106 66 1337 --label coast-juic
 
 **Overall mock verdict:** _pending_  ·  **Live verification:** _pending_
 
+## 5a. Interim — after S1 (shelf footgun fix; uniform band STILL present)
+runId `3efbb0139ba2c71f227dbc367a2c421e479bd387ccffa0fe9c8cfa87cb770993` (latest_juicy 106×66 s1337):
+- **C1 (margin variation):** `capTilesByTile` = {4 (active, 394 tiles), 8 (passive, 4084)} — restored ✓ (was flat {1}).
+- **C2 (depth gate):** `shallowCutoff` = −7 m — restored ✓ (was 0 m).
+- shelfMask 480→1511 (3.1×); sourceCoast 760→1682; landShare 0.36 unchanged.
+- policy-band-only coast still 2356 (band intact → removed in S3); coast share inflated to 0.902 (band+wider shelf).
+- Projection for post-S3: coast ≈ sourceCoast (1682) → coast share ≈ 0.38 (within C5).
+
 ## 6. Amendments (append-only; runId + date required)
 - _(none yet)_

--- a/docs/projects/coastal-shelf-tiling/EXPECTATIONS.md
+++ b/docs/projects/coastal-shelf-tiling/EXPECTATIONS.md
@@ -1,0 +1,82 @@
+# Earth-like Expectation Ledger — Coastal Shelf Tiling
+
+> Step-5 GATE. Declared BEFORE tuning/implementation. Amendments are append-only (§6) with runId+date.
+> Grounding config `latest_juicy`; reference size Huge **106×66, seed 1337** (matches the baseline dump).
+
+## 0. Change under test
+- **Request:** make coastal tiles follow the physics shelf (margin-aware, depth-gated) instead of a
+  uniform fixed-distance band.
+- **Arm:** behavioral / generation-logic. **Domains:** morphology (shelf), projection (`map-morphology`),
+  policy adapter (`@civ7/map-policy`).
+- **Structural alternative chosen:** shelf-anchored coast (`coast = shelfMask ∪ shoreline-ring`, uniform
+  band removed). Rejected: band∩shelf (Alt B), upstream bathymetry (Alt C). See `DESIGN.md`.
+- **Hypothesis (falsifiable):** coast width is currently set by a uniform `coastBufferTiles` band that
+  overrides the margin-aware shelf; removing it + un-flattening the shelf yields physically varying
+  coast (passive-margin-wide, active-margin-narrow) while preserving Civ7 coast-ring + marine adequacy.
+- **Baseline run:** runId `1f0df895725b5e6640a66ee0fc13049f23c35fb5d9406a9e6402834c5733bc7f`
+  (latest_juicy, 106×66, seed 1337).
+
+## 1. Baseline (measured, BEFORE)
+| Metric | Baseline (latest_juicy 106×66 s1337) |
+|---|---|
+| coast tiles / ocean tiles | 2594 / 1884 |
+| coast share of water | 0.579 |
+| **policy-band-only coast** (band, not physics) | **1834 (70.7% of coast)** |
+| shelf-derived coast | 480 (18.5% of coast) |
+| `capTilesByTile` distinct values (water) | **{1} — flat** |
+| `shallowCutoff` | 0 m |
+| shelfMask count | 480 |
+
+## 2. Pre-declared expectations (targets, AFTER — measured at the same size/seed; report mean[min..max] over ≥5 seeds)
+
+| ID | Metric | Direction | Pre-declared bound | Physical / gameplay rationale |
+|---|---|---|---|---|
+| **C1** | `capTilesByTile` distinct values | UP | ≥ 2 distinct; mean(active-margin cap) < mean(passive-margin cap) | margin-aware shelf restored (Atlantic-wide vs Pacific-narrow) |
+| **C2** | `shallowCutoff` | DOWN (more negative) | < 0 m (strictly; not collapsed to 0) | a real shelf-break depth gate exists |
+| **C3** | uniform-band-only coast (ocean promoted purely by fixed distance) | DOWN | **= 0** | the uniform distance band is gone |
+| **C4** | shelf-anchored share of coast (coast tiles in shelfMask ∪ shoreline-ring ∪ minimal land-ring) | UP | ≥ 0.95 | coast is now physics-driven, not band-driven |
+| **C5** | coast share of water | DOWN then HOLD | within [0.20, 0.55] | shelf is narrower than the bloated band but still a substantial neritic zone |
+| **C6** | land-tile coast-ring coverage | HOLD | **= 100%** of land tiles have ≥1 adjacent coast | no floating cliffs; coastal settlement legality |
+| **C7** | `landShare` | HOLD | within ±0.005 of baseline | coast change must not move land/water |
+| **C8** | no-water-drift assertion | HOLD | passes at every guard (`map-morphology`, `map-elevation`) | engine ownership invariant intact |
+| **C9** | marine resource count (placement-metrics) | HOLD/floor | ≥ baseline − 10% AND within official feasible band | shelf must still support marine resources/reefs (REPORT concern: 1-ring too thin) |
+| **C10** | player starts placed | HOLD | all 10 players placed; island starts within `maxIslandStartCoastDistance` | start legality + island/mainland connectivity preserved |
+
+Guard rows (HOLD) C6–C10 are not optional — the most likely failure is a coast that is prettier but
+under-produces marine sites or breaks the coast ring.
+
+## 3. Pass / fail rule (declared now)
+- **PASS** = C1–C5 land inside declared bounds AND every HOLD guard (C6–C10) holds, over the seed set.
+- **FAIL (target miss)** = C1–C5 miss → hypothesis/implementation wrong; loop to step 4.
+- **FAIL (collateral)** = any C6–C10 breaks → coverage/legality regression; loop to step 4/6.
+- **AMEND** = a bound was mis-set but direction+mechanism held → record in §6 with runId+date, re-judge.
+- Mock metrics gate entry to live; **closure requires the step-7 live in-game gate** (`studio-run-in-game-live`)
+  on latest_juicy, plus marine/start adequacy (placement-metrics) and parity.
+
+## 4. Diagnostic command (reproducible)
+```bash
+cd mods/mod-swooper-maps
+bun ./src/dev/diagnostics/run-standard-dump.ts -- 106 66 1337 --label coast-juicy \
+  --configFile "$PWD/src/maps/configs/latest-juicy.config.json"
+# then read manifest.json + data/*.bin u8 layers: map.morphology.coasts.{waterClass,sourceCoastMask,
+#   policyCoastMask→coastRingMask,shelfMask,coastalWater}, morphology.coastlineMetrics.shelfMask, capTilesByTile
+```
+
+## 5. Results (fill AFTER)
+| ID | Predicted | Observed (mean[min..max], N) | runId | Verdict |
+|---|---|---|---|---|
+| C1 | ≥2 distinct; active<passive | _pending_ | | |
+| C2 | < 0 m | _pending_ | | |
+| C3 | = 0 | _pending_ | | |
+| C4 | ≥ 0.95 | _pending_ | | |
+| C5 | [0.20, 0.55] | _pending_ | | |
+| C6 | 100% | _pending_ | | |
+| C7 | ±0.005 | _pending_ | | |
+| C8 | passes | _pending_ | | |
+| C9 | ≥ baseline−10% | _pending_ | | |
+| C10 | 10/10 placed | _pending_ | | |
+
+**Overall mock verdict:** _pending_  ·  **Live verification:** _pending_
+
+## 6. Amendments (append-only; runId + date required)
+- _(none yet)_

--- a/docs/projects/coastal-shelf-tiling/FRAMING.md
+++ b/docs/projects/coastal-shelf-tiling/FRAMING.md
@@ -1,0 +1,179 @@
+# Coastal Shelf Tiling — Framing & Investigation (working doc)
+
+> Status: **active investigation**. This is the preparatory working document for the
+> coastal-tile-placement workstream. It carries the route, frame, investigation brief,
+> evidence ledger, and current understanding. It is kept current as the loop runs.
+> Closure artifacts (expectation ledger, phase record, slices) branch off this.
+
+Workstream skill: `civ7-mapgen-workstream` · Loop arm: **Behavioral / generation-logic**
+· Grounding config: `latest_juicy` (`mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json`)
+· Worktree: `wt-agent-coast-coastal-tiling-frame` (off `main`) · gt parent: `main`
+
+---
+
+## 0. Intake & route
+
+- **Request (user's words):** Coastal tiles are placed "too naively: roughly uniform
+  expansion around land out to a fixed distance, regardless of physical context… ignores
+  or underuses the shelf mask… does not feel natural." Trace the whole coastal-determination
+  path; design + implement a physically-grounded coast placement; verify live in Civ7.
+- **Arm:** Behavioral (physical realism of generated terrain). **Problem class:** generation-logic.
+- **Lead facets:** facet-physics (continental-margin shelf physics), facet-verification
+  (Earth-like ledger + live gate), facet-civ7-domain (coast → start/resource/reef legality).
+- **Prior art (directly relevant):** `docs/projects/coasts-by-erosion/` (Option D margin-aware
+  shelf design) and commit `621658f3c` (coast drift-at-boundary fix). This workstream is the
+  **completion/repair** of that work: the physics was built but is currently defeated.
+
+---
+
+## 1. Frame
+
+**Hard core (load-bearing commitments):**
+- Coast (`TERRAIN_COAST`) is the **continental shelf** — shallow, nearshore, neritic water —
+  not "any water within a fixed distance of land." Its width is a *physical output*
+  (bathymetry + tectonic margin type), not a global constant.
+- MapGen **owns** the coast/ocean split deterministically (engine `expandCoasts` is neutralized;
+  `restoreProjectedCoastTerrain` re-asserts the declared `waterClass`). So coast shape is ours
+  to define, not the engine's to impose.
+- The map serves the player: coast must remain **Civ-playable** — every land tile keeps a coast
+  ring, marine resources/reefs have adequate eligible water, island/mainland relationships and
+  start legality hold.
+
+**Selection / salience:**
+- **In / foreground:** the coast *projection* (`map-morphology/plot-coasts`), the coast *policy*
+  (`@civ7/map-policy` coast-classification), the *shelf* truth (`compute-shelf-mask` +
+  `compute-coastline-metrics`), and the `latest_juicy` config knobs that drive them.
+- **Exterior (out of scope this workstream):** landmass/continent shaping, sea-level %, erosion
+  model, river/lake projection, biome classification. We consume their truth; we do not retune them.
+  (Bathymetry quality is upstream — flagged only if it proves to be the limiting signal.)
+
+**Falsifier (what forces a reframe):** If empirical dumps show the final coast is *already*
+shelf-driven with real margin variation (i.e. the uniform-band hypothesis is wrong), or if removing
+the uniform band cannot satisfy Civ7 marine-resource/coast-ring adequacy, the "uniform band defeats
+physics" frame is wrong and we reframe toward the shelf *generator* (bathymetry/sea-level) instead.
+
+**Structural alternative considered (and why not chosen as the frame):** Treat this as a *bathymetry*
+problem (the shelf is weak because the upstream surface lacks a real shelf break) and fix it in
+`compute-geomorphic-cycle` / `compute-sea-level`. Rejected as the *primary* frame because the shelf
+op already encodes margin-aware depth-gated structure; evidence points at it being **flattened by
+config and overridden by a uniform band downstream**, not absent upstream. Held as the falsifier branch.
+
+---
+
+## 2. Investigation brief (rail = codebase deep dive + diagnostic dump)
+
+**Primary questions:**
+1. What actually determines a tile's final `TERRAIN_COAST` vs `TERRAIN_OCEAN` classification, end to end?
+2. Where, if anywhere, is the shelf mask's physical structure lost?
+3. Is the "uniform fixed-distance" behavior a config problem, a wrong/missing strategy, an
+   implementation issue, stale/duplicated logic, or a structural mismatch? (The prompt's taxonomy.)
+
+**Secondary:** How does `latest_juicy` configure the shelf/coast? What does the engine require
+(no-water-drift)? What downstream gameplay depends on coast (starts, marine resources, reefs)?
+
+**Exclusion (preserve exterior):** not retuning landmass/sea-level/erosion; not redesigning the
+Studio viz; not touching unrelated placement logic.
+
+**Evidence policy:** Live source is authoritative for code/path/schema claims (re-read, don't trust
+docs). Behavioral claims require a `diag:dump` runId + measured counts, not a screenshot. Closure
+requires the live in-game gate (`studio-run-in-game-live`).
+
+**Stop conditions:** stop analysis when (a) the full coast-determination chain is traced with
+file:line evidence, AND (b) empirical dumps quantify how much of the coast is shelf-derived vs
+uniform-band, AND (c) the no-water-drift / engine-ownership question is settled.
+
+---
+
+## 3. Findings — the coast-determination chain (traced, file:line)
+
+**The pipeline (truth → projection):**
+1. `compute-shelf-mask` (`domain/morphology/ops/compute-shelf-mask/strategies/default.ts`) —
+   **genuine physics.** Per water tile: active margin (convergent/transform + boundaryCloseness ≥
+   threshold) → `capActive`; else passive → `capPassive`. Tile is shelf iff `dist ≤ cap` AND
+   `bathymetry ≥ shallowCutoff` (a nearshore-bathymetry quantile). Margin-aware + depth-gated.
+2. `compute-coastline-metrics` (`…/compute-coastline-metrics/strategies/default.ts`) — produces
+   `coastalLand`, `coastalWater` (1-ring), `coastMask` (rugged bays/fjords). Does **not** itself
+   produce `shelfMask`.
+3. `morphology-coasts/steps/ruggedCoasts.ts` assembles the `coastlineMetrics` artifact, calling the
+   shelf-mask op and packing `shelfMask` + `distanceToCoast` alongside the coastline metrics.
+4. `map-morphology/steps/plotCoasts.ts` (the projection / stamp):
+   - `sourceCoastMask[i] = water && (coastalWater[i]==1 || shelfMask[i]==1)` — shelf truth + 1-ring. ✅
+   - **THEN** `applyCiv7CoastClassificationPolicy({ waterClass: base })` adds a uniform band. ⚠️
+   - THEN land-adjacent coast-ring promotion (heals islands / late land). ✅ (minimal, legit)
+   - Publishes `coastClassification {baseWaterClass, sourceCoastMask, waterClass, policyCoastMask}`;
+     stamps engine terrain from `waterClass`.
+5. `restoreProjectedCoastTerrain` (`projection-policies/coastProjectionParity.ts`) re-asserts
+   `waterClass` after engine maintenance at **3 boundaries**: `plotContinents` (map-morphology),
+   `plotRivers` (map-rivers), `prepare-placement-surface` (placement). → MapGen owns coast pipeline-wide.
+
+**The policy (`@civ7/map-policy/src/coast-classification.ts`):**
+`applyCiv7CoastClassificationPolicy` seeds from existing COAST tiles, BFS hex-distance, and promotes
+**every** ocean tile with `0 < distance ≤ coastBufferTiles` to coast. `coastBufferTiles =
+mapGlobals.oceanWaterColumns ?? 4`. This is a **uniform fixed-distance band**.
+
+### Root-cause chain (the "naive uniform coast")
+- **RC1 — Config footgun (latest_juicy):** `shelf.capTilesMax: 1` while `capTilesActive: 3,
+  capTilesPassive: 4`. The shelf cap is **double-clamped** to `capTilesMax`: once in
+  `ruggedCoasts.ts` normalize (`min(capTilesMax, round(cap×shelfMultiplier))`, lines ~176–189) and
+  again in the strategy (`clampInt(capActive,0,capMax)`). With `capTilesMax:1`, both caps → **1**,
+  and the `shelfWidth: "wide"` knob (`shelfMultiplier>1`) is silently defeated. → shelf collapses to
+  a degenerate ~1-tile depth-gated ring with **zero margin variation**.
+- **RC2 — Structural override (all configs):** the uniform `coastBufferTiles` band (default 4)
+  promotes every ocean within 4 hex of coast → coast. This **subsumes/dominates** the shelf; the
+  shelf physics is computed and dumped to viz but does not drive the final `waterClass`.
+- **RC3 — Misappropriated constant / indirection:** `coastBufferTiles` is sourced from
+  `mapGlobals.oceanWaterColumns` — the **map-edge forced-ocean column count** — which has no relation
+  to coast width or to actual engine coast behavior (`expandCoasts` is neutralized; the mod's map
+  class overrides it and the projection test asserts it's never called). It is a "4 looks fine"
+  coincidence dressed as Civ7 policy.
+- **RC4 — Design regression vs accepted prior art:** `coasts-by-erosion/REPORT.md` accepted Option D
+  ("shelfMask → COAST, **no engine helpers, no uniform band**"). The shipped projection contradicts
+  it; the uniform band was layered on later (≈ the 621658f3c coast-ring/drift work), defeating the
+  physics that was deliberately built.
+
+**Verdict on the prompt's taxonomy:** it is a *combination* — primarily a **structural mismatch**
+(RC2/RC4: a uniform band overriding shelf truth) compounded by a **config footgun** (RC1) and
+**stale/misappropriated indirection** (RC3). It is *not* missing physics: the shelf op is good.
+
+---
+
+## 4. Target design (physics-first) — provisional, pending step-5 gate
+
+**Coast = continental shelf (margin-aware, depth-gated) ∪ guaranteed 1-tile coastal ring. Deep water elsewhere.**
+
+- Make the **shelf mask the coast driver** (it already is the `sourceCoastMask` input) and stop
+  overriding it with a uniform distance band.
+- **Fix RC1:** make `capTilesMax` a sane hard ceiling (not a flattener); reconcile the `shelfWidth`
+  knob; correct `latest_juicy` so margin-aware caps actually apply (Atlantic-broad vs Pacific-narrow).
+- **Fix RC2/RC3:** retire the uniform `coastBufferTiles` band; replace with a minimal, named coast
+  policy primitive — **"every land tile has ≥1 coast ring"** (the land-adjacent ring already exists
+  inline; promote it to the policy adapter `@civ7/map-policy` and delete the distance-band + the
+  `oceanWaterColumns` misappropriation).
+- Keep `restoreProjectedCoastTerrain` (the structural locus that makes coast MapGen-owned).
+
+**Gameplay invariants to preserve (verify, don't assume):** coast ring on every land tile; adequate
+coast for marine resources & reefs; island/mainland connectivity & island starts
+(`maxIslandStartCoastDistance: 8`); start legality; **no water drift**.
+
+**Structural alternative for the design (step 5 will record ≥1 rejected):** keep the policy band but
+clamp it to the shelf (band ∩ shelf) — rejected-leaning because it keeps the misappropriated constant
+and the indirection; the cleaner move is shelf-owns-coast + minimal ring guarantee.
+
+---
+
+## 5. Evidence ledger (append as gathered)
+
+| Date | Claim | Evidence | Class |
+|---|---|---|---|
+| 2026-06-20 | Shelf op is margin-aware + depth-gated | `compute-shelf-mask/strategies/default.ts:25-108` | source-read |
+| 2026-06-20 | Uniform band promotes ocean within `coastBufferTiles` | `coast-classification.ts:45-106` | source-read |
+| 2026-06-20 | `coastBufferTiles` = `oceanWaterColumns ?? 4` | `coast-classification.ts:29-36` | source-read |
+| 2026-06-20 | latest_juicy `capTilesMax:1` flattens caps; double-clamp | `latest-juicy.config.json:154-161`, `ruggedCoasts.ts:170-192`, `compute-shelf-mask/strategies/default.ts:47-49` | source-read |
+| 2026-06-20 | engine `expandCoasts` neutralized; MapGen owns coast | `plot-coasts.test.ts:83-84`; restore at 3 boundaries | source-read |
+| 2026-06-20 | Prior art chose Option D (no uniform band) | `coasts-by-erosion/REPORT.md:63-90,143-148` | source-read |
+| 2026-06-20 | latest_juicy: **70.7%** of coast (1834/2594) is policy-band-only; only **18.5%** (480) shelf-derived; `capTilesByTile` flat=1; `shallowCutoff`=0m | diag:dump runId `1f0df895…` (106×66 s1337) | generated |
+| 2026-06-20 | swooper-earthlike: shelf machinery works (caps {5,13}, cutoff −12m, 52% shelf-derived) when `capTilesMax:14` | diag:dump runId `a856e371…` | generated |
+| 2026-06-20 | `applyCiv7CoastClassificationPolicy` called in 2 prod sites: `plotCoasts.ts` + `ecology-features/score-layers` (duplicate) | structural lane | source-read |
+| 2026-06-20 | `policyCoastMask` is viz/diagnostics/test-only (no gameplay consumer) → safe to retire | structural lane | source-read |
+| 2026-06-20 | `shelfMask` widely consumed (reefs, ocean-geometry/thermal, resources, starts, climate) → load-bearing; coast should align to it | structural lane | source-read |
+| 2026-06-20 | `capTilesMax` double-clamp footgun invisible to tests (they use capTilesMax:8) | structural lane | source-read |

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
@@ -44,9 +44,16 @@ export const defaultStrategy = createStrategy(ComputeShelfMaskContract, "default
     }
 
     const nearshoreDistance = clampInt(config.nearshoreDistance, 0, 65535);
-    const capMax = clampInt(config.capTilesMax, 0, 65535);
-    const capActive = clampInt(config.capTilesActive, 0, capMax);
-    const capPassive = clampInt(config.capTilesPassive, 0, capMax);
+    const capActiveReq = clampInt(config.capTilesActive, 0, 65535);
+    const capPassiveReq = clampInt(config.capTilesPassive, 0, 65535);
+    // capTilesMax is an ABSOLUTE safety ceiling on shelf reach, not a per-margin cap.
+    // Floor it to the larger configured margin cap so a too-low capTilesMax can never
+    // silently collapse the margin-aware distinction (passive > active). A bare
+    // `min(cap, capTilesMax)` is the footgun that flattened the juicy configs to a
+    // 1-tile ring (capTilesMax:1 clamped both active=3 and passive=4 to 1).
+    const capMax = Math.max(clampInt(config.capTilesMax, 0, 65535), capActiveReq, capPassiveReq);
+    const capActive = Math.min(capActiveReq, capMax);
+    const capPassive = Math.min(capPassiveReq, capMax);
 
     // Sample nearshore bathymetry over candidate nearshore water tiles.
     // We store into a fixed array then quantile over the filled prefix.

--- a/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
@@ -158,11 +158,11 @@
       },
       "shelf": {
         "nearshoreDistance": 8,
-        "shallowQuantile": 0.9,
+        "shallowQuantile": 0.6,
         "activeClosenessThreshold": 0.35,
         "capTilesActive": 3,
-        "capTilesPassive": 4,
-        "capTilesMax": 1
+        "capTilesPassive": 6,
+        "capTilesMax": 8
       }
     },
     "morphology-routing": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-earthlike.config.json
@@ -158,11 +158,11 @@
       },
       "shelf": {
         "nearshoreDistance": 8,
-        "shallowQuantile": 0.9,
+        "shallowQuantile": 0.6,
         "activeClosenessThreshold": 0.35,
         "capTilesActive": 3,
-        "capTilesPassive": 4,
-        "capTilesMax": 1
+        "capTilesPassive": 6,
+        "capTilesMax": 8
       }
     },
     "morphology-routing": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-original.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-original.config.json
@@ -158,11 +158,11 @@
       },
       "shelf": {
         "nearshoreDistance": 8,
-        "shallowQuantile": 0.9,
+        "shallowQuantile": 0.6,
         "activeClosenessThreshold": 0.35,
         "capTilesActive": 3,
-        "capTilesPassive": 4,
-        "capTilesMax": 1
+        "capTilesPassive": 6,
+        "capTilesMax": 8
       }
     },
     "morphology-routing": {

--- a/mods/mod-swooper-maps/src/maps/generated/latest-juicy.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/latest-juicy.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "latest-juicy",
-  configHash: "e434032d4a88d6fb98f6ec3d484e3d57bdf2ac70af14f825d95903b5d5dbac3b",
-  envelopeHash: "95f6c2a53e2ea1b393e104b9bdf52a402f37527c3dd89cc698dc5964c2f2d821",
+  configHash: "ac28fb93c92fac629b4458fe7cb5acf8b38826420d8e0a9cc5ea2df2406162eb",
+  envelopeHash: "8b86651a25e5c9b07a2240db76d52f265b5901ac58213a032d97dab162323b16",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/mountains-of-time-earthlike.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/mountains-of-time-earthlike.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "mountains-of-time-earthlike",
-  configHash: "7458226c838d96ebf0b30541a4b9449ea552dada09b112faab3710bb886817d7",
-  envelopeHash: "2996f3392c95674fad8eac96a60d6ac61858e679143a53f3b5282b0db595ec6a",
+  configHash: "9fc7649137c45093f41c5865a1627ed060e93d64267c26de627ccfe742d3111d",
+  envelopeHash: "83f74b84a0a74b55ce7f15033785c00b4f96540e81ea77bec4602433ddabf8c8",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/mountains-of-time-original.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/mountains-of-time-original.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "mountains-of-time-original",
-  configHash: "119012f8cd5f8b65f0a63355d12b0b99a7effe7578ac140369261488a5c6b107",
-  envelopeHash: "a5c158a07738e494c9b3b65e811606c179156496ca8b4f804c43b16177fb31f2",
+  configHash: "9d3757a239617d3e1aab0ae7fd90000e36f6950b0fb02a62d2a6e04084f28bf7",
+  envelopeHash: "5c5abf2332a306cca8d9c344f7d4a969164b763652f50b89e1d26a6e696a0e21",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.ts
@@ -169,26 +169,27 @@ export default createStep(RuggedCoastsStepContract, {
 
     const shelfMaskSelection =
       config.shelfMask.strategy === "default"
-        ? {
-            ...config.shelfMask,
-            config: {
-              ...config.shelfMask.config,
-              capTilesActive: Math.max(
-                0,
-                Math.min(
-                  config.shelfMask.config.capTilesMax,
-                  Math.round(config.shelfMask.config.capTilesActive * shelfMultiplier)
-                )
-              ),
-              capTilesPassive: Math.max(
-                0,
-                Math.min(
-                  config.shelfMask.config.capTilesMax,
-                  Math.round(config.shelfMask.config.capTilesPassive * shelfMultiplier)
-                )
-              ),
-            },
-          }
+        ? (() => {
+            const { capTilesActive, capTilesPassive, capTilesMax } = config.shelfMask.config;
+            // Ceiling never sits below the configured margin caps, so a low capTilesMax
+            // cannot silently erase the passive>active distinction when the shelfWidth
+            // knob scales them (see compute-shelf-mask footgun note).
+            const capCeiling = Math.max(capTilesMax, capTilesActive, capTilesPassive);
+            return {
+              ...config.shelfMask,
+              config: {
+                ...config.shelfMask.config,
+                capTilesActive: Math.max(
+                  0,
+                  Math.min(capCeiling, Math.round(capTilesActive * shelfMultiplier))
+                ),
+                capTilesPassive: Math.max(
+                  0,
+                  Math.min(capCeiling, Math.round(capTilesPassive * shelfMultiplier))
+                ),
+              },
+            };
+          })()
         : config.shelfMask;
 
     return { ...config, coastlines: coastlinesSelection, shelfMask: shelfMaskSelection };

--- a/mods/mod-swooper-maps/test/morphology/shelf-width-knob.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/shelf-width-knob.test.ts
@@ -43,4 +43,43 @@ describe("morphology-coasts shelfWidth knob", () => {
     expect(narrow.shelfMask.config.capTilesActive).toBe(2);
     expect(narrow.shelfMask.config.capTilesPassive).toBe(3);
   });
+
+  it("does not let a too-low capTilesMax silently collapse the passive>active distinction (footgun guard)", () => {
+    const base = (
+      standardRecipe.compileConfig(
+        {
+          seed: 123,
+          dimensions: { width: 80, height: 60 },
+          latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
+        },
+        standardConfig
+      ) as any
+    )["morphology-coasts"]?.["rugged-coasts"];
+
+    // capTilesMax below the configured margin caps used to clamp both active and
+    // passive down to capTilesMax (the latest_juicy capTilesMax:1 footgun).
+    const shelfMask = {
+      strategy: "default",
+      config: {
+        nearshoreDistance: 8,
+        shallowQuantile: 0.6,
+        activeClosenessThreshold: 0.35,
+        capTilesActive: 3,
+        capTilesPassive: 6,
+        capTilesMax: 1,
+      },
+    };
+
+    const wide = (ruggedCoasts as any).normalize(
+      { ...base, shelfMask },
+      { knobs: { shelfWidth: "wide" } }
+    );
+    // Ceiling floors to max(capTilesMax, active, passive) = 6, so the scaled caps
+    // survive: active = min(6, round(3*1.25)) = 4, passive = min(6, round(6*1.25)) = 6.
+    expect(wide.shelfMask.config.capTilesActive).toBe(4);
+    expect(wide.shelfMask.config.capTilesPassive).toBe(6);
+    expect(wide.shelfMask.config.capTilesPassive).toBeGreaterThan(
+      wide.shelfMask.config.capTilesActive
+    );
+  });
 });


### PR DESCRIPTION
docs(coastal-shelf-tiling): framing, design, expectation ledger (S0)

Investigation of coastal tile placement grounded in latest_juicy. Root cause is a
combination: the margin-aware shelf mask is (1) flattened by a capTilesMax double-clamp
footgun and (2) overridden by a uniform coastBufferTiles distance band (an
oceanWaterColumns misappropriation). Empirically 70.7% of latest_juicy coast tiles are
uniform-band-only; only 18.5% are shelf-derived; capTilesByTile is flat at 1.

Design: shelf-anchored coast (coast = shelf mask union shoreline ring), uniform band
retired, coast-ring guarantee promoted to a @civ7/map-policy primitive. Includes the
pre-declared Earth-like expectation ledger (step-5 gate) and the S1-S5 slice sequence.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

fix(mapgen): restore margin-aware shelf; guard capTilesMax footgun (S1)

The continental-shelf mask is genuine margin-aware, depth-gated physics, but a
capTilesMax double-clamp let a too-low capTilesMax silently collapse the per-margin
caps to a single value. The juicy configs set capTilesMax:1, flattening active=3/
passive=4 to 1 and forcing a degenerate 1-tile shelf (shallowCutoff pinned to 0m,
capTilesByTile flat at 1) regardless of the shelfWidth knob.

- compute-shelf-mask + ruggedCoasts normalize: floor the capTilesMax ceiling to
  max(capTilesMax, active, passive) so it can never erase the passive>active
  distinction; it stays a true safety ceiling when set sanely.
- fix the three footgun configs (latest-juicy, mountains-of-time-earthlike,
  mountains-of-time-original): capTilesMax 1->8, shallowQuantile 0.9->0.6,
  capTilesPassive 4->6; regenerate their entrypoints in-slice.
- regression test: a low capTilesMax + wide knob no longer collapses variation.

diag:dump latest_juicy 106x66 s1337: capTilesByTile {1}->{4,8}, shallowCutoff
0->-7m, shelfMask 480->1511. Margin-aware shelf restored (uniform band removal is S3).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>