### PR TITLE
feat(map-policy): add coast-ring policy primitive (S2)

### DIFF
--- a/packages/civ7-map-policy/src/coast-ring.ts
+++ b/packages/civ7-map-policy/src/coast-ring.ts
@@ -1,0 +1,74 @@
+import { WATER_CLASS_COAST, WATER_CLASS_LAND, WATER_CLASS_OCEAN } from "./coast-classification.js";
+import { forEachHexNeighborOddQ } from "./policy-grid.js";
+
+/**
+ * Coast-ring policy evidence.
+ *
+ * This is the minimal Civ7 gameplay/engine guarantee the retired coastBufferTiles
+ * distance band conflated with cosmetic coast width:
+ * - the live engine renders land bordering deep ocean as floating cliff plateaus;
+ * - coastal settlement and many coast-adjacent content rules require a land tile to
+ *   actually touch a coast tile.
+ *
+ * It is NOT a coast-width control. Coast width is the physically-derived continental
+ * shelf (see compute-shelf-mask); this only guarantees the shoreline ring exists.
+ */
+export const CIV7_COAST_RING_POLICY_V0 = {
+  version: 0,
+  source: ["Base/modules/base-standard/maps/elevation-terrain-generator.js"],
+  rationale:
+    "Civ7 requires every land tile to border coast (no land against deep ocean). MapGen stamps a single deterministic coast ring around land using engine odd-R adjacency, independent of the physically-derived shelf that sets coast width.",
+} as const;
+
+export type CoastRingPolicyResult = Readonly<{
+  waterClass: Uint8Array;
+  coastRingMask: Uint8Array;
+  promotedOceanToCoast: number;
+}>;
+
+/**
+ * Promotes every OCEAN tile directly adjacent to land to COAST, using the engine's
+ * odd-R adjacency. Land adjacency is read against the ORIGINAL classification, so a
+ * freshly promoted ring tile cannot chain a second ring outward — this is exactly a
+ * one-tile shoreline ring, never a distance band.
+ *
+ * Source coast (shelf ∪ shoreline metrics) normally already covers the ring; this
+ * heals the residue, e.g. ocean around island peaks injected after coastline metrics.
+ */
+export function applyCiv7CoastRingPolicy(params: {
+  width: number;
+  height: number;
+  waterClass: Uint8Array;
+}): CoastRingPolicyResult {
+  const width = Math.max(0, params.width | 0);
+  const height = Math.max(0, params.height | 0);
+  const size = width * height;
+  if (params.waterClass.length !== size) {
+    throw new Error(
+      `[coastRing] waterClass length ${params.waterClass.length} does not match ${size}.`
+    );
+  }
+
+  const original = params.waterClass;
+  const waterClass = new Uint8Array(original);
+  const coastRingMask = new Uint8Array(size);
+  let promotedOceanToCoast = 0;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = y * width + x;
+      if ((waterClass[idx] | 0) !== WATER_CLASS_OCEAN) continue;
+      let adjacentToLand = false;
+      forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+        if (adjacentToLand) return;
+        if ((original[ny * width + nx] | 0) === WATER_CLASS_LAND) adjacentToLand = true;
+      });
+      if (!adjacentToLand) continue;
+      waterClass[idx] = WATER_CLASS_COAST;
+      coastRingMask[idx] = 1;
+      promotedOceanToCoast += 1;
+    }
+  }
+
+  return { waterClass, coastRingMask, promotedOceanToCoast };
+}

--- a/packages/civ7-map-policy/src/index.ts
+++ b/packages/civ7-map-policy/src/index.ts
@@ -16,6 +16,8 @@ export {
   WATER_CLASS_LAND,
   WATER_CLASS_OCEAN,
 } from "./coast-classification.js";
+export type { CoastRingPolicyResult } from "./coast-ring.js";
+export { applyCiv7CoastRingPolicy, CIV7_COAST_RING_POLICY_V0 } from "./coast-ring.js";
 export type {
   NaturalWonderFootprintOffset,
   NaturalWonderFootprintOffsetsByParity,

--- a/packages/civ7-map-policy/test/map-policy.test.ts
+++ b/packages/civ7-map-policy/test/map-policy.test.ts
@@ -4,8 +4,10 @@ import { join } from "node:path";
 
 import {
   applyCiv7CoastClassificationPolicy,
+  applyCiv7CoastRingPolicy,
   CIV7_BROWSER_TABLES_V0,
   CIV7_COAST_CLASSIFICATION_POLICY_V0,
+  CIV7_COAST_RING_POLICY_V0,
   CIV7_DEFAULT_RIVER_MODELING_ARGS,
   CIV7_RIVER_MODELING_POLICY_V0,
   CIV7_RIVER_TYPE_METADATA_SOURCE,
@@ -22,6 +24,7 @@ import {
   resolveNaturalWonderMaterializationDirection,
   resolveNaturalWonderPlacementDirection,
   WATER_CLASS_COAST,
+  WATER_CLASS_LAND,
   WATER_CLASS_OCEAN,
 } from "../src/index.js";
 
@@ -181,6 +184,32 @@ describe("@civ7/map-policy", () => {
     expect(CIV7_COAST_CLASSIFICATION_POLICY_V0.source).toContain(
       "Base/modules/base-standard/maps/map-globals.js"
     );
+  });
+
+  it("stamps a single land-adjacent coast ring (not a distance band) via odd-R adjacency", () => {
+    const width = 7;
+    const height = 5;
+    const waterClass = new Uint8Array(width * height).fill(WATER_CLASS_OCEAN);
+    const landX = 3;
+    const landY = 2; // even row
+    waterClass[landY * width + landX] = WATER_CLASS_LAND;
+
+    const result = applyCiv7CoastRingPolicy({ width, height, waterClass });
+
+    // All six odd-R neighbours of the land tile (even row) become coast — exactly one ring.
+    expect(result.promotedOceanToCoast).toBe(6);
+    expect(result.waterClass[landY * width + (landX - 1)]).toBe(WATER_CLASS_COAST); // (2,2)
+    expect(result.waterClass[landY * width + (landX + 1)]).toBe(WATER_CLASS_COAST); // (4,2)
+    // The land tile itself is never reclassified.
+    expect(result.waterClass[landY * width + landX]).toBe(WATER_CLASS_LAND);
+    // A tile two rows away is NOT adjacent to land → stays ocean (proves no distance band).
+    expect(result.waterClass[(landY + 2) * width + landX]).toBe(WATER_CLASS_OCEAN); // (3,4)
+    // The input is not mutated.
+    expect(waterClass[landY * width + (landX + 1)]).toBe(WATER_CLASS_OCEAN);
+    let ringCount = 0;
+    for (const v of result.coastRingMask) ringCount += v;
+    expect(ringCount).toBe(6);
+    expect(CIV7_COAST_RING_POLICY_V0.version).toBe(0);
   });
 
   it("models supported natural-wonder footprints and filters unsupported catalog entries", () => {


### PR DESCRIPTION
Adds applyCiv7CoastRingPolicy to @civ7/map-policy: the minimal Civ7 guarantee that
every land tile borders at least one coast tile (no land against deep ocean -> the
engine renders floating cliff plateaus; coastal settlement legality needs it).

Unlike the retired coastBufferTiles distance band, this promotes ONLY ocean tiles
directly adjacent to land (engine odd-R adjacency, read against the original
classification so it cannot chain), so it is a single shoreline ring and never
overrides the physically-derived shelf that sets coast width. Pure addition; wired
into the projection in S3.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>