### PR TITLE
feat(mapgen): cap-free, margin-aware continental-shelf op (R2)

### DIFF
--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/contract.ts
@@ -1,61 +1,81 @@
 import { defineOp, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 
+/**
+ * Cap-free shelf classifier config.
+ *
+ * The continental shelf is shallow water connected to the shoreline and shallower than
+ * the *shelf-break depth*. There are NO tile-distance caps: shelf extent emerges from
+ * where the seafloor drops past the break depth (the depth gate) and from contiguity to
+ * shore (the flood-fill). Margin type modulates the break depth as physics — active
+ * (convergent/transform) margins drop off steeply (shallower break, narrower shelf);
+ * passive margins are gentle (deeper break, wider shelf).
+ */
 export const ShelfMaskConfigSchema = Type.Object(
   {
-    nearshoreDistance: Type.Integer({
-      default: 3,
-      minimum: 0,
-      maximum: 64,
-      description:
-        "Controls candidate nearshore water distance cap used to sample shelf bathymetry.",
-    }),
     shallowQuantile: Type.Number({
-      default: 0.7,
+      default: 0.6,
       minimum: 0,
       maximum: 1,
       description:
-        "Quantile (0..1) of nearshore bathymetry used as the shallow cutoff (higher => narrower shelf; lower => wider).",
+        "Quantile (0..1) of nearshore bathymetry used as the base shelf-break depth. Higher => shallower break => narrower shelf; lower => deeper => wider. Adapts the break to each map's depth scale.",
+    }),
+    breakDepthSampleRadius: Type.Integer({
+      default: 8,
+      minimum: 1,
+      maximum: 64,
+      description:
+        "Nearshore window (tiles from coast) over which bathymetry is sampled to estimate the break depth. This bounds which tiles INFORM the cutoff (a statistical estimator window), NOT the shelf extent.",
     }),
     activeClosenessThreshold: Type.Number({
-      default: 0.45,
+      default: 0.35,
       minimum: 0,
       maximum: 1,
       description:
-        "Controls boundary closeness threshold for treating convergent/transform margins as active for shelf narrowing.",
+        "Boundary-closeness (0..1) above which a convergent/transform margin counts as active (steeper drop-off, narrower shelf).",
     }),
-    capTilesActive: Type.Integer({
-      default: 2,
+    activeBreakDepthFactor: Type.Number({
+      default: 0.6,
       minimum: 0,
-      maximum: 64,
-      description: "Controls max distance to coast for shelf classification near active margins.",
-    }),
-    capTilesPassive: Type.Integer({
-      default: 4,
-      minimum: 0,
-      maximum: 64,
+      maximum: 4,
       description:
-        "Controls max distance to coast for shelf classification away from active margins.",
+        "Break-depth multiplier on active margins (<1 => shallower break => narrower shelf). Margin physics, not a cap.",
     }),
-    capTilesMax: Type.Integer({
-      default: 8,
+    passiveBreakDepthFactor: Type.Number({
+      default: 1.25,
       minimum: 0,
-      maximum: 64,
-      description: "Controls hard clamp on the per-tile shelf distance cap.",
+      maximum: 4,
+      description:
+        "Break-depth multiplier on passive margins (>1 => deeper break => wider shelf). Margin physics, not a cap.",
+    }),
+    absoluteMaxShelfDepth: Type.Integer({
+      default: -30,
+      minimum: -1000,
+      maximum: 0,
+      description:
+        "Deepest (most negative, metres) the shelf-break depth may reach: a physical safety floor so the depth gate cannot flood a degenerately-flat sea. A metric depth, NOT a tile-distance cap.",
+    }),
+    breakDepthScale: Type.Number({
+      default: 1,
+      minimum: 0,
+      maximum: 8,
+      description:
+        "Global break-depth scale set from the shelfWidth knob (narrow<1, wide>1). Authors use the knob; normalize() injects this value.",
     }),
   },
   {
     additionalProperties: false,
     description:
-      "Shelf classifier controls (steering inputs): nearshore sampling distance, shallow cutoff quantile, and margin-aware distance caps.",
+      "Cap-free shelf classifier: a margin-modulated bathymetric break depth (with a physical depth floor) plus connectivity to shore. No tile-distance caps.",
   }
 );
 
 /**
- * Computes a shallow-shelf water mask for projecting to Civ7 TERRAIN_COAST.
+ * Computes a continental-shelf water mask for projecting to Civ7 TERRAIN_COAST.
  *
- * Intent:
- * - Deterministic, Morphology-derived shelf band (no Civ RNG helpers).
- * - Narrow shelves near active (convergent/transform) margins; wider elsewhere.
+ * Physics: shelf = water that is (a) shallower than a margin-modulated bathymetric break
+ * depth AND (b) flood-connected to the shoreline. Passive margins yield broad shelves,
+ * active margins narrow ones. No tile-distance caps; the only bounds are the break depth
+ * (a metric depth) and shore connectivity (BFS).
  */
 const ComputeShelfMaskContract = defineOp({
   kind: "compute",
@@ -66,10 +86,11 @@ const ComputeShelfMaskContract = defineOp({
     landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
     bathymetry: TypedArraySchemas.i16({
       description:
-        "Bathymetry per tile (meters): 0 on land; <=0 in water; closer to 0 is shallower.",
+        "Bathymetry per tile (metres): 0 on land; <=0 in water; closer to 0 is shallower.",
     }),
     distanceToCoast: TypedArraySchemas.u16({
-      description: "Distance to coast per tile (0=coast).",
+      description:
+        "Distance to coast per tile (0=coast). Used only to window the break-depth sample.",
     }),
     boundaryCloseness: TypedArraySchemas.u8({
       description: "Boundary proximity per tile (0..255).",
@@ -80,27 +101,28 @@ const ComputeShelfMaskContract = defineOp({
   }),
   output: Type.Object({
     shelfMask: TypedArraySchemas.u8({
-      description: "Mask (1/0): shallow shelf water eligible for TERRAIN_COAST projection.",
+      description:
+        "Mask (1/0): shallow shelf water (shallower than the break depth AND connected to shore) eligible for TERRAIN_COAST.",
     }),
     activeMarginMask: TypedArraySchemas.u8({
       description:
-        "Mask (1/0): tiles treated as active margin for shelf narrowing (convergent/transform with high closeness).",
-    }),
-    capTilesByTile: TypedArraySchemas.u8({
-      description:
-        "Per-tile distance cap (tiles) used by the shelf classifier (active margins narrower, passive wider).",
-    }),
-    nearshoreCandidateMask: TypedArraySchemas.u8({
-      description:
-        "Mask (1/0): water tiles within nearshoreDistance used to sample bathymetry for the shallow cutoff.",
+        "Mask (1/0): water tiles treated as active margin (convergent/transform with high closeness) => shallower break depth.",
     }),
     depthGateMask: TypedArraySchemas.u8({
       description:
-        "Mask (1/0): water tiles passing the shallow bathymetry cutoff (bathymetry >= shallowCutoff).",
+        "Mask (1/0): water tiles passing the per-tile depth gate (bathymetry >= break depth).",
+    }),
+    nearshoreCandidateMask: TypedArraySchemas.u8({
+      description:
+        "Mask (1/0): water tiles within breakDepthSampleRadius used to sample bathymetry for the break-depth quantile.",
+    }),
+    shelfBreakDepthByTile: TypedArraySchemas.i16({
+      description:
+        "Per-tile shelf-break depth (metres, <=0) after margin modulation; deeper (more negative) => wider local shelf.",
     }),
     shallowCutoff: Type.Number({
       description:
-        "Bathymetry cutoff (meters, <=0) selected deterministically from nearshore samples; bathymetry >= cutoff is treated as shallow.",
+        "Base shelf-break depth (metres, <=0): the nearshore bathymetry quantile before margin modulation.",
     }),
   }),
   strategies: {

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
@@ -1,28 +1,51 @@
 import { createStrategy } from "@swooper/mapgen-core/authoring";
-import { clampInt } from "@swooper/mapgen-core/lib/math";
+import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
+import { clampInt16 } from "@swooper/mapgen-core/lib/math";
 
 import ComputeShelfMaskContract from "../contract.js";
 
 const BOUNDARY_CONVERGENT = 1;
 const BOUNDARY_TRANSFORM = 3;
 
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function clampNonNegative(value: number, fallback: number): number {
+  if (!Number.isFinite(value) || value < 0) return fallback;
+  return value;
+}
+
+/** Quantile over the filled prefix of a nearshore-bathymetry sample (ascending: deepest -> shallowest). */
 function computeQuantileCutoff(values: Int16Array, count: number, qUnit: number): number {
   if (count <= 0) return 0;
-
-  // Copy into a normal array for a simple deterministic quantile.
-  // Nearshore set is relatively small in practice; keep this maximally minimal.
   const copy: number[] = new Array(count);
   for (let i = 0; i < count; i++) copy[i] = values[i] as number;
-  copy.sort((a, b) => a - b); // ascending: deepest (more negative) -> shallowest (towards 0)
-
-  const q = Math.max(0, Math.min(1, qUnit));
+  copy.sort((a, b) => a - b);
+  const q = clamp01(qUnit);
   const idx = Math.floor(q * (count - 1));
-  const cutoff = copy[idx] ?? 0;
-  // Bathymetry contract says <= 0 in water; clamp just in case.
-  return Math.min(0, cutoff);
+  // Bathymetry is <= 0 in water by contract; clamp defensively.
+  return Math.min(0, copy[idx] ?? 0);
 }
 
 export const defaultStrategy = createStrategy(ComputeShelfMaskContract, "default", {
+  // Config canonicalization belongs here, not in run(): clamp the physical parameters into
+  // their valid ranges once so run() carries only the shelf physics.
+  normalize: (config) => ({
+    ...config,
+    shallowQuantile: clamp01(config.shallowQuantile),
+    breakDepthSampleRadius: Math.max(
+      1,
+      Math.trunc(clampNonNegative(config.breakDepthSampleRadius, 8))
+    ),
+    activeClosenessThreshold: clamp01(config.activeClosenessThreshold),
+    activeBreakDepthFactor: clampNonNegative(config.activeBreakDepthFactor, 0.6),
+    passiveBreakDepthFactor: clampNonNegative(config.passiveBreakDepthFactor, 1.25),
+    // A depth floor: must be <= 0 (bathymetry contract). Less-negative-than-0 collapses to 0.
+    absoluteMaxShelfDepth: Math.min(0, Math.trunc(config.absoluteMaxShelfDepth)),
+    breakDepthScale: clampNonNegative(config.breakDepthScale, 1),
+  }),
   run: (input, config) => {
     const { width, height } = input;
     const size = Math.max(0, (width | 0) * (height | 0));
@@ -43,73 +66,98 @@ export const defaultStrategy = createStrategy(ComputeShelfMaskContract, "default
       throw new Error("[ShelfMask] Input tensors must match width*height.");
     }
 
-    const nearshoreDistance = clampInt(config.nearshoreDistance, 0, 65535);
-    const capActiveReq = clampInt(config.capTilesActive, 0, 65535);
-    const capPassiveReq = clampInt(config.capTilesPassive, 0, 65535);
-    // capTilesMax is an ABSOLUTE safety ceiling on shelf reach, not a per-margin cap.
-    // Floor it to the larger configured margin cap so a too-low capTilesMax can never
-    // silently collapse the margin-aware distinction (passive > active). A bare
-    // `min(cap, capTilesMax)` is the footgun that flattened the juicy configs to a
-    // 1-tile ring (capTilesMax:1 clamped both active=3 and passive=4 to 1).
-    const capMax = Math.max(clampInt(config.capTilesMax, 0, 65535), capActiveReq, capPassiveReq);
-    const capActive = Math.min(capActiveReq, capMax);
-    const capPassive = Math.min(capPassiveReq, capMax);
+    const sampleRadius = config.breakDepthSampleRadius;
+    const absoluteMaxShelfDepth = config.absoluteMaxShelfDepth;
+    const activeThresholdU8 = Math.floor(config.activeClosenessThreshold * 255);
 
-    // Sample nearshore bathymetry over candidate nearshore water tiles.
-    // We store into a fixed array then quantile over the filled prefix.
+    // 1) Estimate the base shelf-break depth from nearshore bathymetry. The shoreline ring
+    //    (distance 0) is excluded from the SAMPLE only — it is clamped to sea level and would
+    //    skew the cutoff toward 0 — but it remains eligible for shelf membership below.
     const nearshoreSamples = new Int16Array(size);
     let sampleCount = 0;
     for (let i = 0; i < size; i++) {
       if (landMask[i] === 1) continue;
       const dist = distanceToCoast[i] | 0;
-      // Exclude the guaranteed shoreline ring (distance 0), which is often artificially clamped to seaLevel and would
-      // otherwise skew the shallow cutoff too close to 0m (eliminating the shelf band beyond the ring).
-      if (dist <= 0) continue;
-      if (dist > nearshoreDistance) continue;
+      if (dist <= 0 || dist > sampleRadius) continue;
       nearshoreSamples[sampleCount++] = bathymetry[i] ?? 0;
     }
-
     const shallowCutoff = computeQuantileCutoff(
       nearshoreSamples,
       sampleCount,
       config.shallowQuantile
     );
 
-    const activeThreshold = Math.max(0, Math.min(1, config.activeClosenessThreshold));
-    const activeThresholdU8 = Math.floor(activeThreshold * 255);
-
-    const shelfMask = new Uint8Array(size);
+    // 2) Per-tile, margin-modulated break depth + depth gate. Active margins use a shallower
+    //    break (narrower shelf); passive margins a deeper one (wider). The absolute floor caps
+    //    how deep the gate can reach — a physical depth, not a tile-distance cap.
     const activeMarginMask = new Uint8Array(size);
-    const capTilesByTile = new Uint8Array(size);
-    const nearshoreCandidateMask = new Uint8Array(size);
     const depthGateMask = new Uint8Array(size);
+    const nearshoreCandidateMask = new Uint8Array(size);
+    const shelfBreakDepthByTile = new Int16Array(size);
     for (let i = 0; i < size; i++) {
       if (landMask[i] === 1) continue;
 
       const dist = distanceToCoast[i] | 0;
+      if (dist > 0 && dist <= sampleRadius) nearshoreCandidateMask[i] = 1;
+
       const t = boundaryType[i] | 0;
       const isActiveMargin =
         (t === BOUNDARY_CONVERGENT || t === BOUNDARY_TRANSFORM) &&
         (boundaryCloseness[i] | 0) >= activeThresholdU8;
-      const cap = isActiveMargin ? capActive : capPassive;
-
       if (isActiveMargin) activeMarginMask[i] = 1;
-      capTilesByTile[i] = cap as number;
-      if (dist > 0 && dist <= nearshoreDistance) nearshoreCandidateMask[i] = 1;
 
-      const depth = bathymetry[i] ?? 0;
-      if (depth >= shallowCutoff) depthGateMask[i] = 1;
+      const marginFactor = isActiveMargin
+        ? config.activeBreakDepthFactor
+        : config.passiveBreakDepthFactor;
+      // shallowCutoff <= 0; scaling by positive factors keeps it <= 0. Clamp to the floor.
+      const rawBreak = shallowCutoff * config.breakDepthScale * marginFactor;
+      const breakDepth = clampInt16(
+        Math.max(absoluteMaxShelfDepth, Math.min(0, Math.round(rawBreak)))
+      );
+      shelfBreakDepthByTile[i] = breakDepth;
 
-      if (dist > cap) continue;
-      if (depth >= shallowCutoff) shelfMask[i] = 1;
+      if ((bathymetry[i] ?? 0) >= breakDepth) depthGateMask[i] = 1;
+    }
+
+    // 3) Connectivity to shore: shelf = depth-gated water reachable from a land-adjacent
+    //    water tile through contiguous depth-gated water. This bounds extent at the shelf
+    //    break without any tile-distance cap, and excludes deep isolated shallow pockets.
+    const shelfMask = new Uint8Array(size);
+    const queue = new Int32Array(size);
+    let head = 0;
+    let tail = 0;
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const i = y * width + x;
+        if (landMask[i] === 1 || depthGateMask[i] !== 1) continue;
+        let adjacentToLand = false;
+        forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+          if (adjacentToLand) return;
+          if (landMask[ny * width + nx] === 1) adjacentToLand = true;
+        });
+        if (!adjacentToLand) continue;
+        shelfMask[i] = 1;
+        queue[tail++] = i;
+      }
+    }
+    while (head < tail) {
+      const idx = queue[head++]!;
+      const y = (idx / width) | 0;
+      const x = idx - y * width;
+      forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+        const ni = ny * width + nx;
+        if (landMask[ni] === 1 || shelfMask[ni] === 1 || depthGateMask[ni] !== 1) return;
+        shelfMask[ni] = 1;
+        queue[tail++] = ni;
+      });
     }
 
     return {
       shelfMask,
       activeMarginMask,
-      capTilesByTile,
-      nearshoreCandidateMask,
       depthGateMask,
+      nearshoreCandidateMask,
+      shelfBreakDepthByTile,
       shallowCutoff,
     };
   },

--- a/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
@@ -157,12 +157,13 @@
         }
       },
       "shelf": {
-        "nearshoreDistance": 8,
+        "breakDepthSampleRadius": 8,
         "shallowQuantile": 0.6,
         "activeClosenessThreshold": 0.35,
-        "capTilesActive": 3,
-        "capTilesPassive": 6,
-        "capTilesMax": 8
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "morphology-routing": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountain-patch.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountain-patch.config.json
@@ -157,12 +157,13 @@
         }
       },
       "shelf": {
-        "nearshoreDistance": 8,
+        "breakDepthSampleRadius": 8,
         "shallowQuantile": 0.45,
         "activeClosenessThreshold": 0.45,
-        "capTilesActive": 4,
-        "capTilesPassive": 10,
-        "capTilesMax": 14
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "morphology-routing": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountain-rivers-patch.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountain-rivers-patch.config.json
@@ -157,12 +157,13 @@
         }
       },
       "shelf": {
-        "nearshoreDistance": 8,
+        "breakDepthSampleRadius": 8,
         "shallowQuantile": 0.45,
         "activeClosenessThreshold": 0.45,
-        "capTilesActive": 4,
-        "capTilesPassive": 10,
-        "capTilesMax": 14
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "morphology-routing": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-earthlike.config.json
@@ -157,12 +157,13 @@
         }
       },
       "shelf": {
-        "nearshoreDistance": 8,
+        "breakDepthSampleRadius": 8,
         "shallowQuantile": 0.6,
         "activeClosenessThreshold": 0.35,
-        "capTilesActive": 3,
-        "capTilesPassive": 6,
-        "capTilesMax": 8
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "morphology-routing": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-original.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-original.config.json
@@ -157,12 +157,13 @@
         }
       },
       "shelf": {
-        "nearshoreDistance": 8,
+        "breakDepthSampleRadius": 8,
         "shallowQuantile": 0.6,
         "activeClosenessThreshold": 0.35,
-        "capTilesActive": 3,
-        "capTilesPassive": 6,
-        "capTilesMax": 8
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "morphology-routing": {

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.json
@@ -149,12 +149,13 @@
         }
       },
       "shelf": {
-        "nearshoreDistance": 3,
+        "breakDepthSampleRadius": 3,
         "shallowQuantile": 0.7,
         "activeClosenessThreshold": 0.45,
-        "capTilesActive": 2,
-        "capTilesPassive": 4,
-        "capTilesMax": 8
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "morphology-routing": {},

--- a/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.json
@@ -149,12 +149,13 @@
         }
       },
       "shelf": {
-        "nearshoreDistance": 3,
+        "breakDepthSampleRadius": 3,
         "shallowQuantile": 0.7,
         "activeClosenessThreshold": 0.45,
-        "capTilesActive": 2,
-        "capTilesPassive": 4,
-        "capTilesMax": 8
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "morphology-routing": {},

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.json
@@ -153,12 +153,13 @@
         }
       },
       "shelf": {
-        "nearshoreDistance": 3,
+        "breakDepthSampleRadius": 3,
         "shallowQuantile": 0.7,
         "activeClosenessThreshold": 0.45,
-        "capTilesActive": 2,
-        "capTilesPassive": 4,
-        "capTilesMax": 8
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "morphology-routing": {},

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -157,12 +157,13 @@
         }
       },
       "shelf": {
-        "nearshoreDistance": 8,
+        "breakDepthSampleRadius": 8,
         "shallowQuantile": 0.45,
         "activeClosenessThreshold": 0.45,
-        "capTilesActive": 4,
-        "capTilesPassive": 10,
-        "capTilesMax": 14
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "morphology-routing": {

--- a/mods/mod-swooper-maps/src/maps/generated/latest-juicy.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/latest-juicy.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "latest-juicy",
-  configHash: "ac28fb93c92fac629b4458fe7cb5acf8b38826420d8e0a9cc5ea2df2406162eb",
-  envelopeHash: "8b86651a25e5c9b07a2240db76d52f265b5901ac58213a032d97dab162323b16",
+  configHash: "3ee2e2cf9a428121dc76c78c59233d8107b07d90249b9268364b51f339790357",
+  envelopeHash: "156cc003d5ac16365b5c5c85089a82428317e93626c9d98659070fc688415843",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/mountain-patch.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/mountain-patch.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "mountain-patch",
-  configHash: "19d22cb8d6d1f7772a36ca6ea14197808487fefc68e99fcf914b51cfed1be78c",
-  envelopeHash: "4fc5ed22aa0d84b519ce44e0b60068fc38ccd3008c639d094df5ea0a8a054568",
+  configHash: "3059106ece0e04230ababd4496f3fc5f034b9e0722c2d7d47a777d317eea4651",
+  envelopeHash: "326570aa61db75b1371af70a858fefe100f327705b971a369f28c91a9fe9e4fa",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/mountain-rivers-patch.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/mountain-rivers-patch.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "mountain-rivers-patch",
-  configHash: "19d22cb8d6d1f7772a36ca6ea14197808487fefc68e99fcf914b51cfed1be78c",
-  envelopeHash: "de245ca18d28fcaef4658a5c210eaa742c489f40ad25f0d34d19764abf8cc82d",
+  configHash: "3059106ece0e04230ababd4496f3fc5f034b9e0722c2d7d47a777d317eea4651",
+  envelopeHash: "42b628f8734af9a82ebcbc561d3380af700519b568758a2ee1dc98366a7a03fc",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/mountains-of-time-earthlike.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/mountains-of-time-earthlike.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "mountains-of-time-earthlike",
-  configHash: "9fc7649137c45093f41c5865a1627ed060e93d64267c26de627ccfe742d3111d",
-  envelopeHash: "83f74b84a0a74b55ce7f15033785c00b4f96540e81ea77bec4602433ddabf8c8",
+  configHash: "e8523bb4ed82258e8c1ffb84f68fd82e60ede7f7dcc91e80f27d722f2b5d6507",
+  envelopeHash: "7f765a42dafc4a51d58732cf47c7f002d1a73cb0f474918349ee1c5f0821aaa6",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/mountains-of-time-original.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/mountains-of-time-original.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "mountains-of-time-original",
-  configHash: "9d3757a239617d3e1aab0ae7fd90000e36f6950b0fb02a62d2a6e04084f28bf7",
-  envelopeHash: "5c5abf2332a306cca8d9c344f7d4a969164b763652f50b89e1d26a6e696a0e21",
+  configHash: "f7c1f26b28c137f19926f484fea6dfb7cf4e658007f494ce32527d9d54ceed5c",
+  envelopeHash: "5b9344260edb906c560c943296315ec2d9eaa17dcf6a1961543b3495c22a05cf",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/shattered-ring.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/shattered-ring.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "shattered-ring",
-  configHash: "81739363f534647052b47760092dcda3de652698cc8209ad621cacec739fb448",
-  envelopeHash: "fcd239a30ccac7f79da3594d867775a04dcc81599eef87d9ec04eaaf5970b628",
+  configHash: "f875dd2e675862774c01cf9134ceb1c7ffce6388f05f6a0f5b09cc0dd87297cc",
+  envelopeHash: "0c018d8ac3785eddf8f18189781c5a47fe7d464fbac5c805f49dbf7b4e4cc645",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/sundered-archipelago.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/sundered-archipelago.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "sundered-archipelago",
-  configHash: "3ff84897721485e202967deef2d97763793c7399fe707bbe36b5724eca03cdb1",
-  envelopeHash: "0d3ad2a9133e62cf34808eb172e8d2b6c353f68150902a32426ff7b4efa841f7",
+  configHash: "ead9419ac4618a941c8a9907075c49e7b648c1b65eea228258020e6c309341d8",
+  envelopeHash: "894e8992774a55c58aef2b6b3dd39c6bd20fd1b8dc4c42953926bde3425ec701",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/swooper-desert-mountains.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/swooper-desert-mountains.ts
@@ -21,7 +21,7 @@ export default createMap({
     "bottomLatitude": -40
   },
   sourceConfigId: "swooper-desert-mountains",
-  configHash: "d825bc643e2efac3e7efd6c92b758b9cfd95218d0d332510a2c70e8ff0aee370",
-  envelopeHash: "f55422e423d3fedbbcd31b5f7adfaac9b03d07d721b94c71d28851544a4e5c02",
+  configHash: "a249f224c3d5fb19ce6fbeb5de8ed1b9bbb5d191890d2a50a9c871cab3c1877f",
+  envelopeHash: "53c2b3d30c48ea697d35817e9609b896ae9911bde96c9520d338d250b8a215a0",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/swooper-earthlike.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/swooper-earthlike.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "swooper-earthlike",
-  configHash: "070a7a8fcf35a6a7c42e9f1ead8051694e332dbdadb1e6d4cbdb3881b76f7ed5",
-  envelopeHash: "2ada765aaa7352461dac754c109dd23aa860f4ebb6ce493e54be60f2b5262541",
+  configHash: "26e2adac284ab1ab1e1c1e12a5b0067ad4a2f7c73399b7c82548b3290be9cf47",
+  envelopeHash: "5d4aa061d8d0b77251c85c9af1f91a79eea5f50cea015485abb8af18bbe25c85",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.ts
@@ -169,27 +169,18 @@ export default createStep(RuggedCoastsStepContract, {
 
     const shelfMaskSelection =
       config.shelfMask.strategy === "default"
-        ? (() => {
-            const { capTilesActive, capTilesPassive, capTilesMax } = config.shelfMask.config;
-            // Ceiling never sits below the configured margin caps, so a low capTilesMax
-            // cannot silently erase the passive>active distinction when the shelfWidth
-            // knob scales them (see compute-shelf-mask footgun note).
-            const capCeiling = Math.max(capTilesMax, capTilesActive, capTilesPassive);
-            return {
-              ...config.shelfMask,
-              config: {
-                ...config.shelfMask.config,
-                capTilesActive: Math.max(
-                  0,
-                  Math.min(capCeiling, Math.round(capTilesActive * shelfMultiplier))
-                ),
-                capTilesPassive: Math.max(
-                  0,
-                  Math.min(capCeiling, Math.round(capTilesPassive * shelfMultiplier))
-                ),
-              },
-            };
-          })()
+        ? {
+            ...config.shelfMask,
+            config: {
+              ...config.shelfMask.config,
+              // The shelfWidth knob drives the cap-free break-depth scale: narrow (<1) =>
+              // shallower break => narrower shelf; wide (>1) => deeper => wider. No caps.
+              breakDepthScale: clampFinite(
+                config.shelfMask.config.breakDepthScale * shelfMultiplier,
+                0
+              ),
+            },
+          }
         : config.shelfMask;
 
     return { ...config, coastlines: coastlinesSelection, shelfMask: shelfMaskSelection };
@@ -307,14 +298,14 @@ export default createStep(RuggedCoastsStepContract, {
     const {
       shelfMask,
       activeMarginMask,
-      capTilesByTile,
+      shelfBreakDepthByTile,
       nearshoreCandidateMask,
       depthGateMask,
       shallowCutoff,
     } = shelfResult as unknown as {
       shelfMask: unknown;
       activeMarginMask: unknown;
-      capTilesByTile: unknown;
+      shelfBreakDepthByTile: unknown;
       nearshoreCandidateMask: unknown;
       depthGateMask: unknown;
       shallowCutoff: unknown;
@@ -325,8 +316,11 @@ export default createStep(RuggedCoastsStepContract, {
     if (!(activeMarginMask instanceof Uint8Array) || activeMarginMask.length !== coastal.length) {
       throw new Error("Computed activeMarginMask missing or shape-mismatched.");
     }
-    if (!(capTilesByTile instanceof Uint8Array) || capTilesByTile.length !== coastal.length) {
-      throw new Error("Computed capTilesByTile missing or shape-mismatched.");
+    if (
+      !(shelfBreakDepthByTile instanceof Int16Array) ||
+      shelfBreakDepthByTile.length !== coastal.length
+    ) {
+      throw new Error("Computed shelfBreakDepthByTile missing or shape-mismatched.");
     }
     if (
       !(nearshoreCandidateMask instanceof Uint8Array) ||
@@ -350,15 +344,15 @@ export default createStep(RuggedCoastsStepContract, {
       let shelfTilesBeyondShore = 0;
       let activeShelfTiles = 0;
       let passiveShelfTiles = 0;
-      let maxCapTiles = 0;
+      let deepestShelfBreak = 0;
 
       for (let i = 0; i < size; i++) {
         if ((activeMarginMask[i] | 0) === 1) activeMarginTiles += 1;
         if ((nearshoreCandidateMask[i] | 0) === 1) nearshoreCandidates += 1;
         if ((depthGateMask[i] | 0) === 1) depthGatedTiles += 1;
 
-        const cap = capTilesByTile[i] | 0;
-        if (cap > maxCapTiles) maxCapTiles = cap;
+        const breakDepth = shelfBreakDepthByTile[i] | 0;
+        if (breakDepth < deepestShelfBreak) deepestShelfBreak = breakDepth;
 
         if ((shelfMask[i] | 0) !== 1) continue;
         shelfTiles += 1;
@@ -374,6 +368,7 @@ export default createStep(RuggedCoastsStepContract, {
       return {
         kind: "morphology.shelf.summary",
         shallowCutoff: shallowCutoff as number,
+        deepestShelfBreak,
         nearshoreCandidates,
         depthGatedTiles,
         shelfTiles,
@@ -381,16 +376,16 @@ export default createStep(RuggedCoastsStepContract, {
         activeMarginTiles,
         activeShelfTiles,
         passiveShelfTiles,
-        maxCapTiles,
         strategy: selection.strategy,
         config: shelfConfig
           ? {
-              nearshoreDistance: shelfConfig.nearshoreDistance,
               shallowQuantile: shelfConfig.shallowQuantile,
+              breakDepthSampleRadius: shelfConfig.breakDepthSampleRadius,
               activeClosenessThreshold: shelfConfig.activeClosenessThreshold,
-              capTilesActive: shelfConfig.capTilesActive,
-              capTilesPassive: shelfConfig.capTilesPassive,
-              capTilesMax: shelfConfig.capTilesMax,
+              activeBreakDepthFactor: shelfConfig.activeBreakDepthFactor,
+              passiveBreakDepthFactor: shelfConfig.passiveBreakDepthFactor,
+              absoluteMaxShelfDepth: shelfConfig.absoluteMaxShelfDepth,
+              breakDepthScale: shelfConfig.breakDepthScale,
             }
           : undefined,
       };
@@ -471,17 +466,17 @@ export default createStep(RuggedCoastsStepContract, {
     });
 
     context.viz?.dumpGrid(context.trace, {
-      dataTypeKey: "morphology.shelf.capTiles",
+      dataTypeKey: "morphology.shelf.breakDepth",
       spaceId: TILE_SPACE_ID,
       dims: { width, height },
-      format: "u8",
-      values: capTilesByTile,
-      meta: defineVizMeta("morphology.shelf.capTiles", {
-        label: "Shelf Distance Cap (Tiles)",
+      format: "i16",
+      values: shelfBreakDepthByTile,
+      meta: defineVizMeta("morphology.shelf.breakDepth", {
+        label: "Shelf Break Depth (m)",
         group: GROUP_SHELF,
         description:
-          "Per-tile max distance to coast used by the shelf classifier (active margins narrower).",
-        role: "membership",
+          "Per-tile, margin-modulated shelf-break depth (metres, <=0). Active margins shallower (narrower shelf); passive deeper (wider). Water shallower than this and connected to shore becomes shelf.",
+        role: "scalar",
         palette: "continuous",
       }),
     });
@@ -497,7 +492,7 @@ export default createStep(RuggedCoastsStepContract, {
         group: GROUP_SHELF,
         visibility: "debug",
         description:
-          "Water tiles within nearshoreDistance, used to sample bathymetry for shallowCutoff.",
+          "Water tiles within breakDepthSampleRadius, used to sample bathymetry for the shelf-break cutoff.",
         role: "membership",
         palette: "categorical",
         categories: [

--- a/mods/mod-swooper-maps/test/morphology/ops-shelf-mask.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/ops-shelf-mask.test.ts
@@ -5,36 +5,65 @@ import { normalizeStrictOrThrow, runOpValidated } from "../support/compiler-help
 
 const { computeShelfMask } = morphologyDomain.ops;
 
-describe("morphology/compute-shelf-mask", () => {
-  it("returns shelf viz tensors and never marks land tiles", () => {
-    const width = 4;
-    const height = 3;
+describe("morphology/compute-shelf-mask (cap-free: depth gate + shore connectivity + margin break depth)", () => {
+  it("classifies shelf by depth + shore connectivity, modulates the break depth by margin, never marks land", () => {
+    // 5x5 grid. Row 0 is land; the rest is water. Mostly a shallow shelf (-4 m) with a
+    // deep abyss (-40 m) in rows 3-4, plus one isolated shallow tile (idx 22) walled off
+    // from shore by deep water to exercise the connectivity rule.
+    const width = 5;
+    const height = 5;
     const size = width * height;
+    const L = 0;
+    const land = new Uint8Array(size).fill(0);
+    for (let x = 0; x < width; x++) land[x] = 1; // row 0 = land
 
-    // One land tile in the corner, everything else water.
-    const landMask = new Uint8Array(size).fill(0);
-    landMask[0] = 1;
-
-    // Make most nearshore water relatively deep, and a few tiles shallow.
-    // Bathymetry is <= 0 in water; closer to 0 is shallower.
-    const bathymetry = new Int16Array([0, -100, -90, -80, -70, -60, -30, -20, -10, -55, -45, -5]);
-
-    // Distance-to-coast input (already computed upstream in the pipeline).
-    // We'll set a few tiles at distance 3 so passive cap includes them but active cap excludes them.
-    const distanceToCoast = new Uint16Array([0, 1, 2, 3, 1, 2, 3, 4, 2, 3, 1, 5]);
-
-    // Boundary context: make tile index 3 "active margin" (type=convergent + high closeness).
-    const boundaryType = new Uint8Array(size).fill(2); // divergent by default (passive-ish)
+    const D = -40; // abyss (fails the depth gate)
+    const S = -4; // shelf-shallow
+    // prettier-ignore
+    const bathymetry = new Int16Array([
+      L,
+      L,
+      L,
+      L,
+      L, // row 0 land
+      S,
+      S,
+      S,
+      S,
+      S, // row 1 shallow (shore)
+      S,
+      S,
+      S,
+      S,
+      S, // row 2 shallow
+      D,
+      D,
+      D,
+      D,
+      D, // row 3 abyss
+      D,
+      D,
+      S,
+      D,
+      D, // row 4 abyss with one isolated shallow tile at idx 22
+    ]);
+    // distanceToCoast only windows the break-depth sample; rough per-row values suffice.
+    // prettier-ignore
+    const distanceToCoast = new Uint16Array([
+      0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
+    ]);
+    // idx 6 = active margin (convergent + very close); idx 7 = passive. Rest passive.
+    const boundaryType = new Uint8Array(size).fill(2); // divergent (passive)
     const boundaryCloseness = new Uint8Array(size).fill(0);
-    boundaryType[3] = 1; // convergent
-    boundaryCloseness[3] = 255; // very close
+    boundaryType[6] = 1; // convergent
+    boundaryCloseness[6] = 255;
 
     const result = runOpValidated(
       computeShelfMask,
       {
         width,
         height,
-        landMask,
+        landMask: land,
         bathymetry,
         distanceToCoast,
         boundaryCloseness,
@@ -43,12 +72,13 @@ describe("morphology/compute-shelf-mask", () => {
       {
         strategy: "default",
         config: {
-          nearshoreDistance: 3,
           shallowQuantile: 0.7,
+          breakDepthSampleRadius: 8,
           activeClosenessThreshold: 0.45,
-          capTilesActive: 2,
-          capTilesPassive: 4,
-          capTilesMax: 8,
+          activeBreakDepthFactor: 0.6,
+          passiveBreakDepthFactor: 1.25,
+          absoluteMaxShelfDepth: -30,
+          breakDepthScale: 1,
         },
       }
     );
@@ -58,28 +88,41 @@ describe("morphology/compute-shelf-mask", () => {
       result,
       "/ops/morphology/compute-shelf-mask/output"
     );
-    expect(result.shelfMask).toBeInstanceOf(Uint8Array);
-    expect(result.shelfMask.length).toBe(size);
-    expect(result.activeMarginMask).toBeInstanceOf(Uint8Array);
-    expect(result.activeMarginMask.length).toBe(size);
-    expect(result.capTilesByTile).toBeInstanceOf(Uint8Array);
-    expect(result.capTilesByTile.length).toBe(size);
-    expect(result.nearshoreCandidateMask).toBeInstanceOf(Uint8Array);
-    expect(result.nearshoreCandidateMask.length).toBe(size);
-    expect(result.depthGateMask).toBeInstanceOf(Uint8Array);
-    expect(result.depthGateMask.length).toBe(size);
+    for (const key of [
+      "shelfMask",
+      "activeMarginMask",
+      "depthGateMask",
+      "nearshoreCandidateMask",
+    ] as const) {
+      expect(result[key]).toBeInstanceOf(Uint8Array);
+      expect(result[key].length).toBe(size);
+    }
+    expect(result.shelfBreakDepthByTile).toBeInstanceOf(Int16Array);
+    expect(result.shelfBreakDepthByTile.length).toBe(size);
     expect(Number.isFinite(result.shallowCutoff)).toBe(true);
     expect(result.shallowCutoff).toBeLessThanOrEqual(0);
 
-    // Land must never be marked as shelf.
-    expect(result.shelfMask[0]).toBe(0);
+    // Land is never shelf.
+    for (let x = 0; x < width; x++) expect(result.shelfMask[x]).toBe(0);
 
-    // Active margin tile at distance 3 should be excluded by capTilesActive=2.
-    expect(result.shelfMask[3]).toBe(0);
-    expect(result.activeMarginMask[3]).toBe(1);
+    // A shore-adjacent shallow tile is shelf; deep tiles fail the depth gate.
+    expect(result.shelfMask[5]).toBe(1);
+    expect(result.depthGateMask[5]).toBe(1);
+    expect(result.shelfMask[15]).toBe(0); // row-3 abyss
+    expect(result.depthGateMask[15]).toBe(0);
 
-    // A passive/neutral tile within cap and shallow enough should be included.
-    // Index 6: distance=3, bathymetry=-30 (shallow), passive cap=4 => eligible.
-    expect(result.shelfMask[6]).toBe(1);
+    // Connectivity: the isolated shallow tile passes the depth gate but is NOT reachable
+    // from shore through shallow water, so it is excluded (no distance band would do this).
+    expect(result.depthGateMask[22]).toBe(1);
+    expect(result.shelfMask[22]).toBe(0);
+
+    // Margin modulation as physics: the active-margin tile has a SHALLOWER (less negative)
+    // break depth than an otherwise-identical passive tile -> narrower shelf on active margins.
+    expect(result.shelfBreakDepthByTile[6]).toBeGreaterThan(result.shelfBreakDepthByTile[7]);
+
+    // Every shelf tile must pass the depth gate (shelf is a subset of depth-eligible water).
+    for (let i = 0; i < size; i++) {
+      if (result.shelfMask[i] === 1) expect(result.depthGateMask[i]).toBe(1);
+    }
   });
 });

--- a/mods/mod-swooper-maps/test/morphology/shelf-width-knob.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/shelf-width-knob.test.ts
@@ -4,7 +4,7 @@ import ruggedCoasts from "../../src/recipes/standard/stages/morphology-coasts/st
 import { standardConfig } from "../support/standard-config.js";
 
 describe("morphology-coasts shelfWidth knob", () => {
-  it("scales shelfMask distance caps deterministically in rugged-coasts normalize", () => {
+  it("scales the cap-free break-depth lever (breakDepthScale) deterministically in rugged-coasts normalize", () => {
     const base = (
       standardRecipe.compileConfig(
         {
@@ -20,66 +20,34 @@ describe("morphology-coasts shelfWidth knob", () => {
     const shelfMask = {
       strategy: "default",
       config: {
-        nearshoreDistance: 3,
-        shallowQuantile: 0.7,
-        activeClosenessThreshold: 0.45,
-        capTilesActive: 2,
-        capTilesPassive: 4,
-        capTilesMax: 8,
+        shallowQuantile: 0.6,
+        breakDepthSampleRadius: 8,
+        activeClosenessThreshold: 0.35,
+        activeBreakDepthFactor: 0.6,
+        passiveBreakDepthFactor: 1.25,
+        absoluteMaxShelfDepth: -30,
+        breakDepthScale: 1,
       },
     };
 
+    // Wider shelf => deeper break => larger break-depth scale. Narrower => shallower => smaller.
     const wide = (ruggedCoasts as any).normalize(
       { ...base, shelfMask },
       { knobs: { shelfWidth: "wide" } }
     );
-    expect(wide.shelfMask.config.capTilesActive).toBe(3);
-    expect(wide.shelfMask.config.capTilesPassive).toBe(5);
+    expect(wide.shelfMask.config.breakDepthScale).toBeCloseTo(1.25);
 
     const narrow = (ruggedCoasts as any).normalize(
       { ...base, shelfMask },
       { knobs: { shelfWidth: "narrow" } }
     );
-    expect(narrow.shelfMask.config.capTilesActive).toBe(2);
-    expect(narrow.shelfMask.config.capTilesPassive).toBe(3);
-  });
+    expect(narrow.shelfMask.config.breakDepthScale).toBeCloseTo(0.75);
 
-  it("does not let a too-low capTilesMax silently collapse the passive>active distinction (footgun guard)", () => {
-    const base = (
-      standardRecipe.compileConfig(
-        {
-          seed: 123,
-          dimensions: { width: 80, height: 60 },
-          latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
-        },
-        standardConfig
-      ) as any
-    )["morphology-coasts"]?.["rugged-coasts"];
-
-    // capTilesMax below the configured margin caps used to clamp both active and
-    // passive down to capTilesMax (the latest_juicy capTilesMax:1 footgun).
-    const shelfMask = {
-      strategy: "default",
-      config: {
-        nearshoreDistance: 8,
-        shallowQuantile: 0.6,
-        activeClosenessThreshold: 0.35,
-        capTilesActive: 3,
-        capTilesPassive: 6,
-        capTilesMax: 1,
-      },
-    };
-
-    const wide = (ruggedCoasts as any).normalize(
-      { ...base, shelfMask },
-      { knobs: { shelfWidth: "wide" } }
+    expect(wide.shelfMask.config.breakDepthScale).toBeGreaterThan(
+      narrow.shelfMask.config.breakDepthScale
     );
-    // Ceiling floors to max(capTilesMax, active, passive) = 6, so the scaled caps
-    // survive: active = min(6, round(3*1.25)) = 4, passive = min(6, round(6*1.25)) = 6.
-    expect(wide.shelfMask.config.capTilesActive).toBe(4);
-    expect(wide.shelfMask.config.capTilesPassive).toBe(6);
-    expect(wide.shelfMask.config.capTilesPassive).toBeGreaterThan(
-      wide.shelfMask.config.capTilesActive
-    );
+    // The cap-free shelf has no tile-distance caps to scale.
+    expect(wide.shelfMask.config.capTilesActive).toBeUndefined();
+    expect(wide.shelfMask.config.capTilesMax).toBeUndefined();
   });
 });


### PR DESCRIPTION
Replace the arbitrary tile-distance caps (capTilesActive/Passive/Max) with a
physics-based shelf classifier. The shelf is now: water shallower than a
margin-modulated bathymetric break depth AND flood-connected to the shoreline.

- compute-shelf-mask rewritten cap-free:
  - depth gate: bathymetry >= shelfBreakDepth (an adaptive nearshore quantile);
  - margin modulation: active (convergent/transform, close) margins use a shallower
    break (narrower shelf), passive a deeper one (wider) -- Atlantic vs Pacific;
  - connectivity: multi-source flood-fill from shore through depth-gated water bounds
    extent at the shelf break and drops isolated deep shallow pockets (no tile cap);
  - absoluteMaxShelfDepth: a metric depth floor (safety + the shelfWidth lever), not a cap.
  - config canonicalization moved into a normalize() hook (out of run()).
- shelfWidth knob re-wired from the deleted caps to the break-depth scale (narrow<1, wide>1).
- all 9 configs migrated to the cap-free shelf schema (caps removed); entrypoints regenerated.
- shelf op + knob tests rewritten for the new physics.

diag:dump latest_juicy 106x66 s1337: break depth {-5 active, -11 passive} (margin variation
restored), shallowCutoff -7, shelf extent bounded (max 15 / p95 10). Supersedes S1.
Uniform coast band still present here; removed in R4.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>