### PR TITLE
feat(mapgen): shelf-anchored coast projection; retire the uniform band (R4)

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -838,8 +838,7 @@ function buildTerrainProjectionEvidence(
       "baseWaterClass",
       "sourceCoastMask",
       "waterClass",
-      "policyCoastMask",
-      "coastBufferTiles",
+      "coastRingMask",
       "promotedOceanToCoast",
     ]),
     mapMorphologyCoastTerrainSnapshot: pickSerializableFields(mapMorphologyCoastTerrainSnapshot, [

--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -404,8 +404,7 @@ export type TerrainMapMorphologyCoastPolicyRowContext = Readonly<{
   baseWaterClass: number | null;
   sourceCoastMask: number | null;
   waterClass: number | null;
-  policyCoastMask: number | null;
-  coastBufferTiles: number | null;
+  coastRingMask: number | null;
   promotedOceanToCoast: number | null;
 }>;
 
@@ -1743,8 +1742,7 @@ function terrainProjectionRowContext(
           baseWaterClass: indexedInteger(mapMorphologyCoastPolicy.baseWaterClass, plotIndex),
           sourceCoastMask: indexedInteger(mapMorphologyCoastPolicy.sourceCoastMask, plotIndex),
           waterClass: indexedInteger(mapMorphologyCoastPolicy.waterClass, plotIndex),
-          policyCoastMask: indexedInteger(mapMorphologyCoastPolicy.policyCoastMask, plotIndex),
-          coastBufferTiles: finiteInteger(mapMorphologyCoastPolicy.coastBufferTiles),
+          coastRingMask: indexedInteger(mapMorphologyCoastPolicy.coastRingMask, plotIndex),
           promotedOceanToCoast: finiteInteger(mapMorphologyCoastPolicy.promotedOceanToCoast),
         }
       : null,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/contract.ts
@@ -3,6 +3,7 @@ import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 import { ecologyArtifacts } from "../../../ecology/artifacts.js";
 import { hydrologyHydrographyArtifacts } from "../../../hydrology-hydrography/artifacts.js";
+import { mapMorphologyArtifacts } from "../../../map-morphology/artifacts.js";
 import { mapRiversArtifacts } from "../../../map-rivers/artifacts.js";
 import { morphologyArtifacts } from "../../../morphology/artifacts.js";
 
@@ -20,6 +21,7 @@ const ScoreLayersStepContract = defineStep({
       mapRiversArtifacts.projectedNavigableRivers,
       morphologyArtifacts.topography,
       morphologyArtifacts.coastlineMetrics,
+      mapMorphologyArtifacts.coastClassification,
       morphologyArtifacts.mountains,
       morphologyArtifacts.volcanoes,
     ],

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/index.ts
@@ -1,9 +1,4 @@
-import {
-  applyCiv7CoastClassificationPolicy,
-  WATER_CLASS_COAST,
-  WATER_CLASS_LAND,
-  WATER_CLASS_OCEAN,
-} from "@civ7/map-policy";
+import { WATER_CLASS_OCEAN } from "@civ7/map-policy";
 import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology";
 import { clamp01, ctxStepSeed, defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
@@ -72,6 +67,7 @@ export default createStep(ScoreLayersStepContract, {
     const pedology = deps.artifacts.pedology.read(context);
     const topography = deps.artifacts.topography.read(context);
     const coastline = deps.artifacts.coastlineMetrics.read(context);
+    const coastClassification = deps.artifacts.coastClassification.read(context);
     const hydrography = deps.artifacts.hydrography.read(context);
     const lakePlan = deps.artifacts.lakePlan.read(context);
     const riverProjection = deps.artifacts.projectedNavigableRivers.read(context);
@@ -81,22 +77,12 @@ export default createStep(ScoreLayersStepContract, {
     const { width, height } = context.dimensions;
     const size = Math.max(0, (width | 0) * (height | 0));
     const ecologyLandMask = new Uint8Array(size);
-    const baseWaterClass = new Uint8Array(size);
     for (let i = 0; i < size; i++) {
       ecologyLandMask[i] = topography.landMask[i] === 1 && lakePlan.lakeMask[i] !== 1 ? 1 : 0;
-      const isLand = topography.landMask[i] === 1;
-      const isCoast = !isLand && (coastline.coastalWater[i] === 1 || coastline.shelfMask[i] === 1);
-      baseWaterClass[i] = isLand
-        ? WATER_CLASS_LAND
-        : isCoast
-          ? WATER_CLASS_COAST
-          : WATER_CLASS_OCEAN;
     }
-    const projectedWaterClass = applyCiv7CoastClassificationPolicy({
-      width,
-      height,
-      waterClass: baseWaterClass,
-    }).waterClass;
+    // Open ocean is the authoritative engine projection (shelf + coast ring), not a local
+    // recomputation: read the coastClassification waterClass stamped by map-morphology/plot-coasts.
+    const projectedWaterClass = coastClassification.waterClass;
     const openOceanMask = new Uint8Array(size);
     for (let i = 0; i < size; i++) {
       openOceanMask[i] = projectedWaterClass[i] === WATER_CLASS_OCEAN ? 1 : 0;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/artifacts.ts
@@ -10,22 +10,19 @@ const MapMorphologyCoastClassificationArtifactSchema = Type.Object(
     }),
     sourceCoastMask: TypedArraySchemas.u8({
       description:
-        "Pre-policy mask of water tiles selected for coast projection from coastlineMetrics coastalWater or shelfMask.",
+        "Mask of water tiles selected for coast projection from the continental shelf (coastlineMetrics shelfMask) or the shoreline ring (coastalWater), before the coast-ring guarantee.",
     }),
     waterClass: TypedArraySchemas.u8({
       description:
-        "Post-policy water class stamped into engine terrain (0=land, 1=coast, 2=ocean).",
+        "Water class stamped into engine terrain (0=land, 1=coast, 2=ocean): the shelf plus the guaranteed land-adjacent coast ring.",
     }),
-    policyCoastMask: TypedArraySchemas.u8({
-      description: "Mask of ocean tiles promoted to coast by the Civ7 compliance policy.",
-    }),
-    coastBufferTiles: Type.Integer({
-      minimum: 0,
-      description: "Policy coast buffer distance used for deterministic coast widening.",
+    coastRingMask: TypedArraySchemas.u8({
+      description:
+        "Mask of ocean tiles promoted to coast by the land-adjacent coast-ring guarantee (residue not already covered by the shelf).",
     }),
     promotedOceanToCoast: Type.Integer({
       minimum: 0,
-      description: "Count of ocean tiles promoted to coast by the policy.",
+      description: "Count of ocean tiles promoted to coast by the coast-ring guarantee.",
     }),
   },
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.ts
@@ -1,6 +1,6 @@
 import {
-  applyCiv7CoastClassificationPolicy,
-  CIV7_COAST_CLASSIFICATION_POLICY_V0,
+  applyCiv7CoastRingPolicy,
+  CIV7_COAST_RING_POLICY_V0,
   WATER_CLASS_COAST,
   WATER_CLASS_LAND,
   WATER_CLASS_OCEAN,
@@ -14,7 +14,6 @@ import {
   snapshotEngineHeightfield,
 } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { getHexNeighborIndicesOddQ } from "@swooper/mapgen-core/lib/grid";
 import { assertWaterDriftWithinPolicy } from "../../../projection-policies/noWaterDrift.js";
 import { mapMorphologyArtifacts } from "../artifacts.js";
 import PlotCoastsStepContract from "./plotCoasts.contract.js";
@@ -42,7 +41,8 @@ export default createStep(PlotCoastsStepContract, {
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
         const idx = y * width + x;
-        // The source mask is Morphology truth; the later policy pass is a separate engine-compatibility band.
+        // Coast is the physically-derived continental shelf (margin-aware, depth-gated)
+        // plus the guaranteed shoreline ring. No uniform distance band overrides it.
         const isLand = topography.landMask[idx] === 1;
         const isCoast =
           !isLand &&
@@ -56,43 +56,20 @@ export default createStep(PlotCoastsStepContract, {
       }
     }
 
-    const coastPolicy = applyCiv7CoastClassificationPolicy({
+    // Coast-ring invariant: every land tile must border at least one coast tile — no land
+    // may sit against deep ocean (the live engine renders floating cliff plateaus) and
+    // coastal settlement legality requires the adjacency. The shelf covers most of this
+    // already; the ring policy heals the residue (e.g. ocean around island peaks injected
+    // after coastline metrics) with a single land-adjacent ring using engine odd-R adjacency.
+    // This is NOT a coast-width control — width is the shelf (see compute-shelf-mask).
+    const coastRing = applyCiv7CoastRingPolicy({
       width,
       height,
       waterClass: baseWaterClass,
     });
-    const waterClass = coastPolicy.waterClass;
-    const policyCoastMask = coastPolicy.policyCoastMask;
-    let promotedOceanToCoast = coastPolicy.promotedOceanToCoast;
-
-    // Coast-ring invariant: every land tile must have a coast ring — no land may
-    // border deep ocean, or the live engine renders floating cliff plateaus.
-    // The Civ7 coast policy seeds expansion from existing COAST tiles (not land),
-    // so land injected after coastline metrics (e.g. island peaks) gets no ring.
-    // Promote any deep-ocean tile adjacent to land to coast, using the canonical
-    // engine adjacency (odd-R). This is source-agnostic — it heals islands and
-    // any future late land injection — so the no-water-drift policy stops
-    // fighting the engine's coast repair. The earlier eight-offset superset
-    // workaround is unnecessary now that the adjacency model matches the engine.
-    let landAdjacentCoastRingPromotions = 0;
-    for (let y = 0; y < height; y++) {
-      for (let x = 0; x < width; x++) {
-        const idx = y * width + x;
-        if ((waterClass[idx] | 0) !== WATER_CLASS_OCEAN) continue;
-        let adjacentToLand = false;
-        for (const neighbor of getHexNeighborIndicesOddQ(x, y, width, height)) {
-          if ((waterClass[neighbor] | 0) === WATER_CLASS_LAND) {
-            adjacentToLand = true;
-            break;
-          }
-        }
-        if (!adjacentToLand) continue;
-        waterClass[idx] = WATER_CLASS_COAST;
-        policyCoastMask[idx] = 1;
-        landAdjacentCoastRingPromotions += 1;
-      }
-    }
-    promotedOceanToCoast += landAdjacentCoastRingPromotions;
+    const waterClass = coastRing.waterClass;
+    const coastRingMask = coastRing.coastRingMask;
+    const promotedOceanToCoast = coastRing.promotedOceanToCoast;
 
     deps.artifacts.coastClassification.publish(context, {
       width,
@@ -100,25 +77,16 @@ export default createStep(PlotCoastsStepContract, {
       baseWaterClass,
       sourceCoastMask,
       waterClass,
-      policyCoastMask,
-      coastBufferTiles: coastPolicy.coastBufferTiles,
+      coastRingMask,
       promotedOceanToCoast,
     });
 
     context.trace.event(() => ({
       type: "map.morphology.coasts.policy",
-      policy: "civ7.coastClassification.v0",
-      coastBufferTiles: coastPolicy.coastBufferTiles,
+      policy: "civ7.coastRing.v0",
       promotedOceanToCoast,
-      source: CIV7_COAST_CLASSIFICATION_POLICY_V0.source,
+      source: CIV7_COAST_RING_POLICY_V0.source,
     }));
-
-    if (landAdjacentCoastRingPromotions > 0) {
-      context.trace.event(() => ({
-        type: "map.morphology.coasts.landAdjacentCoastRing",
-        promoted: landAdjacentCoastRingPromotions,
-      }));
-    }
 
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
@@ -155,10 +123,10 @@ export default createStep(PlotCoastsStepContract, {
       format: "u8",
       values: waterClass,
       meta: defineVizMeta("map.morphology.coasts.waterClass", {
-        label: "Water Class (Engine Policy)",
+        label: "Water Class (Engine)",
         group: GROUP_MAP_MORPHOLOGY,
         description:
-          "Post-policy water class stamped into engine terrain (0=land, 1=coast, 2=ocean). This includes source coast tiles plus Civ7 compatibility coast-band promotions.",
+          "Water class stamped into engine terrain (0=land, 1=coast, 2=ocean): the continental shelf plus the guaranteed land-adjacent coast ring.",
         role: "membership",
         palette: "categorical",
         categories: [
@@ -189,22 +157,22 @@ export default createStep(PlotCoastsStepContract, {
       }),
     });
     context.viz?.dumpGrid(context.trace, {
-      dataTypeKey: "map.morphology.coasts.policyCoastMask",
+      dataTypeKey: "map.morphology.coasts.coastRingMask",
       spaceId: TILE_SPACE_ID,
       dims: { width, height },
       format: "u8",
-      values: coastPolicy.policyCoastMask,
-      meta: defineVizMeta("map.morphology.coasts.policyCoastMask", {
-        label: "Policy Coast Additions",
+      values: coastRingMask,
+      meta: defineVizMeta("map.morphology.coasts.coastRingMask", {
+        label: "Coast Ring Additions",
         group: GROUP_MAP_MORPHOLOGY,
         description:
-          "Ocean tiles promoted to coast by the Civ7 compatibility policy after source coast selection.",
+          "Ocean tiles promoted to coast by the land-adjacent coast-ring guarantee (the residue not already covered by the shelf).",
         visibility: "debug",
         role: "membership",
         palette: "categorical",
         categories: [
-          { value: 0, label: "Not policy-added", color: [15, 23, 42, 40] },
-          { value: 1, label: "Policy-added coast", color: [125, 211, 252, 235] },
+          { value: 0, label: "Not ring-added", color: [15, 23, 42, 40] },
+          { value: 1, label: "Ring-added coast", color: [125, 211, 252, 235] },
         ],
       }),
     });

--- a/mods/mod-swooper-maps/test/map-morphology/plot-coasts.test.ts
+++ b/mods/mod-swooper-maps/test/map-morphology/plot-coasts.test.ts
@@ -14,7 +14,7 @@ import plotContinents from "../../src/recipes/standard/stages/map-morphology/ste
 import { buildTestDeps } from "../support/step-deps.js";
 
 describe("map-morphology/plot-coasts", () => {
-  it("separates source coast selection from policy-expanded engine coast terrain", () => {
+  it("stamps coast from the shelf + shoreline ring; ring promotes only land-adjacent ocean (no distance band)", () => {
     const width = 4;
     const height = 3;
     const seed = 1234;
@@ -35,13 +35,14 @@ describe("map-morphology/plot-coasts", () => {
     const context = createExtendedMapContext({ width, height }, adapter, env);
 
     const size = width * height;
+    // Land only at (0,0). Source coast = a shoreline-ring water tile (1,0) + a shelf tile (2,1).
     const landMask = new Uint8Array(size).fill(0);
     landMask[0] = 1;
 
     const coastalWater = new Uint8Array(size).fill(0);
-    coastalWater[1] = 1;
+    coastalWater[1] = 1; // (1,0)
     const shelfMask = new Uint8Array(size).fill(0);
-    shelfMask[6] = 1;
+    shelfMask[6] = 1; // (2,1)
 
     context.artifacts.set("artifact:morphology.topography", { landMask });
     context.artifacts.set("artifact:morphology.coastlineMetrics", {
@@ -53,15 +54,16 @@ describe("map-morphology/plot-coasts", () => {
 
     plotCoasts.run(context as any, {}, {} as any, buildTestDeps(plotCoasts));
 
-    // land stays land
+    // Land stays land; source coast (shoreline ring + shelf) becomes COAST.
     expect(adapter.getTerrainType(0, 0)).toBe(FLAT_TERRAIN);
-    // coastalWater becomes COAST terrain
-    expect(adapter.getTerrainType(1, 0)).toBe(COAST_TERRAIN);
-    // shelfMask becomes COAST terrain
-    expect(adapter.getTerrainType(2, 1)).toBe(COAST_TERRAIN);
-    // Civ7 coast classification policy can promote neighboring ocean to coast
-    // without making that tile part of the Morphology source coast mask.
-    expect(adapter.getTerrainType(2, 0)).toBe(COAST_TERRAIN);
+    expect(adapter.getTerrainType(1, 0)).toBe(COAST_TERRAIN); // coastalWater (1,0)
+    expect(adapter.getTerrainType(2, 1)).toBe(COAST_TERRAIN); // shelfMask (2,1)
+    // The coast-ring guarantee promotes a land-adjacent ocean tile (0,1) to coast.
+    expect(adapter.getTerrainType(0, 1)).toBe(COAST_TERRAIN);
+    // But an ocean tile two tiles from land (2,0) is NOT promoted -- there is no distance band,
+    // even though it neighbours coast tiles (1,0) and (2,1). This is the key regression guard.
+    expect(adapter.getTerrainType(2, 0)).toBe(OCEAN_TERRAIN);
+
     const coastClassification = context.artifacts.get(
       mapMorphologyArtifacts.coastClassification.id
     ) as
@@ -69,16 +71,20 @@ describe("map-morphology/plot-coasts", () => {
           baseWaterClass?: Uint8Array;
           sourceCoastMask?: Uint8Array;
           waterClass?: Uint8Array;
-          policyCoastMask?: Uint8Array;
+          coastRingMask?: Uint8Array;
         }
       | undefined;
-    expect(coastClassification?.baseWaterClass?.[2]).toBe(2);
+    // Source coast = shelf ∪ shoreline ring; the ring tile (0,1)=idx4 is NOT a source coast tile.
     expect(coastClassification?.sourceCoastMask?.[1]).toBe(1);
     expect(coastClassification?.sourceCoastMask?.[6]).toBe(1);
+    expect(coastClassification?.sourceCoastMask?.[4]).toBe(0);
     expect(coastClassification?.sourceCoastMask?.[2]).toBe(0);
-    expect(coastClassification?.waterClass?.[2]).toBe(1);
-    expect(coastClassification?.policyCoastMask?.[2]).toBe(1);
-    expect([...(coastClassification?.baseWaterClass ?? [])]).toContain(2);
+    // Final water class: ring tile (0,1) is coast; the non-adjacent tile (2,0) stays ocean.
+    expect(coastClassification?.waterClass?.[4]).toBe(1);
+    expect(coastClassification?.waterClass?.[2]).toBe(2);
+    // The ring mask marks the land-adjacent promotion, not the source coast.
+    expect(coastClassification?.coastRingMask?.[4]).toBe(1);
+    expect(coastClassification?.coastRingMask?.[2]).toBe(0);
 
     // expandCoasts is intentionally not invoked by this step.
     expect((adapter as any).calls?.expandCoasts?.length ?? 0).toBe(0);


### PR DESCRIPTION
The coast is now the continental shelf plus the guaranteed shoreline ring, instead of
a uniform fixed-distance band that overrode the shelf. This fixes the original symptom
(coasts expanded uniformly around land regardless of physical context).

- plotCoasts: coast = shelf (coastlineMetrics.shelfMask) union shoreline ring
  (coastalWater), then applyCiv7CoastRingPolicy guarantees every land tile borders coast.
  Removes the applyCiv7CoastClassificationPolicy uniform coastBufferTiles band and the
  duplicate inline ring loop.
- coastClassification artifact: policyCoastMask -> coastRingMask; drop coastBufferTiles.
- score-layers: stop recomputing the coast policy; read the authoritative
  coastClassification.waterClass (de-duplicates the second policy call).
- diagnostics (surface-delta-context, live-parity): policyCoastMask -> coastRingMask.
- plot-coasts test: assert ring promotes only land-adjacent ocean; a tile two from land
  stays ocean (regression guard against a distance band).

diag:dump latest_juicy 106x66 s1337: coast share of water 0.878 -> 0.466; 85.4% of coast
is shelf-derived (was band-dominated); 0 land tiles border deep ocean (coast-ring holds);
landShare unchanged. Uniform band eliminated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>