### PR TITLE
polish(mapgen): shelf-op robustness + doc accuracy (adversarial-review findings)

### DIFF
--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/contract.ts
@@ -52,7 +52,7 @@ export const ShelfMaskConfigSchema = Type.Object(
       minimum: -1000,
       maximum: 0,
       description:
-        "Deepest (most negative, metres) the shelf-break depth may reach: a physical safety floor so the depth gate cannot flood a degenerately-flat sea. A metric depth, NOT a tile-distance cap.",
+        "Deepest (most negative) the shelf-break depth may reach, in engine elevation units (elevation - seaLevel), NOT real metres. A depth floor: it bounds how DEEP the gate can reach so a steep margin/scale cannot push the break into true deep ocean. It does NOT bound a uniformly-shallow sea, where admitting the whole connected basin is the intended outcome. A metric depth, NOT a tile-distance cap.",
     }),
     breakDepthScale: Type.Number({
       default: 1,
@@ -86,7 +86,7 @@ const ComputeShelfMaskContract = defineOp({
     landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
     bathymetry: TypedArraySchemas.i16({
       description:
-        "Bathymetry per tile (metres): 0 on land; <=0 in water; closer to 0 is shallower.",
+        "Bathymetry per tile in engine elevation units (elevation - seaLevel), not real metres: 0 on land; <=0 in water; closer to 0 is shallower.",
     }),
     distanceToCoast: TypedArraySchemas.u16({
       description:
@@ -118,11 +118,11 @@ const ComputeShelfMaskContract = defineOp({
     }),
     shelfBreakDepthByTile: TypedArraySchemas.i16({
       description:
-        "Per-tile shelf-break depth (metres, <=0) after margin modulation; deeper (more negative) => wider local shelf.",
+        "Per-tile shelf-break depth (engine elevation units, <=0) after margin modulation; deeper (more negative) => wider local shelf.",
     }),
     shallowCutoff: Type.Number({
       description:
-        "Base shelf-break depth (metres, <=0): the nearshore bathymetry quantile before margin modulation.",
+        "Base shelf-break depth (engine elevation units, <=0): the nearshore bathymetry quantile before margin modulation.",
     }),
   }),
   strategies: {

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
@@ -79,7 +79,10 @@ export const defaultStrategy = createStrategy(ComputeShelfMaskContract, "default
       if (landMask[i] === 1) continue;
       const dist = distanceToCoast[i] | 0;
       if (dist <= 0 || dist > sampleRadius) continue;
-      nearshoreSamples[sampleCount++] = bathymetry[i] ?? 0;
+      // Clamp on ingest: bathymetry is <=0 in water by contract, but a single
+      // contract-violating positive sample would skew the whole-map quantile
+      // toward shallower (narrowing every shelf), so guard the estimator here too.
+      nearshoreSamples[sampleCount++] = Math.min(0, bathymetry[i] ?? 0);
     }
     const shallowCutoff = computeQuantileCutoff(
       nearshoreSamples,
@@ -88,8 +91,10 @@ export const defaultStrategy = createStrategy(ComputeShelfMaskContract, "default
     );
 
     // 2) Per-tile, margin-modulated break depth + depth gate. Active margins use a shallower
-    //    break (narrower shelf); passive margins a deeper one (wider). The absolute floor caps
-    //    how deep the gate can reach — a physical depth, not a tile-distance cap.
+    //    break (narrower shelf); passive margins a deeper one (wider). The absolute floor bounds
+    //    how DEEP the break may reach — it stops a steep margin/scale from pushing the gate into
+    //    true deep ocean. It does NOT (and cannot) bound a uniformly-shallow sea, where the gate
+    //    legitimately admits the whole connected basin. A physical depth, not a tile-distance cap.
     const activeMarginMask = new Uint8Array(size);
     const depthGateMask = new Uint8Array(size);
     const nearshoreCandidateMask = new Uint8Array(size);


### PR DESCRIPTION
Apply the three findings from the physics adversarial reviewer over the
cap-free shelf op (all minor/nit; no blockers, no behavior change for
valid inputs):

- compute-shelf-mask/strategies/default.ts: clamp nearshore bathymetry
  samples to <=0 on ingest. A single contract-violating positive sample
  would otherwise skew the whole-map break-depth quantile shallower and
  silently narrow every shelf. Byte-identical for contract-valid input.
- default.ts + contract.ts: reword the absoluteMaxShelfDepth floor docs.
  The floor bounds how DEEP the break may reach (stops a steep
  margin/scale from pushing the gate into true deep ocean); it does not
  and cannot bound a uniformly-shallow sea, where admitting the whole
  connected basin is the intended physical outcome.
- contract.ts: relabel bathymetry/break-depth units from "metres" to
  engine elevation units (elevation - seaLevel), so the -30 floor is
  reasoned about in the units it is actually expressed in.

morphology + map-morphology suites: 50 pass / 0 fail.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>