### PR TITLE
refactor(mapgen): extract shared compute-distance-to-coast op (R1)

### DIFF
--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-distance-to-coast/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-distance-to-coast/contract.ts
@@ -1,0 +1,45 @@
+import { defineOp, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+
+/**
+ * Shared multi-source BFS that labels every tile with its hex-distance to the
+ * nearest coastal tile.
+ *
+ * "Coastal" is caller-defined via the `coastal` seed mask (1 = a distance-0
+ * source). The op is geometry-only: it has no physics and no config — it simply
+ * floods outward over the odd-Q hex grid. It is reused at two points in the
+ * pipeline that previously each carried their own copy of the BFS:
+ *  - stage-2 coast carving (distance from the carved coastline), and
+ *  - the post-features shelf stage (distance from the post-island coastline).
+ *
+ * Tiles unreachable from any seed (or every tile, when the seed mask is empty)
+ * retain the sentinel 65535.
+ */
+const ComputeDistanceToCoastContract = defineOp({
+  kind: "compute",
+  id: "morphology/compute-distance-to-coast",
+  input: Type.Object({
+    width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+    height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+    coastal: TypedArraySchemas.u8({
+      description:
+        "Seed mask (1/0): tiles at distance 0 (the coastline) from which the BFS floods.",
+    }),
+  }),
+  output: Type.Object({
+    distanceToCoast: TypedArraySchemas.u16({
+      description:
+        "Hex-distance to the nearest coastal seed per tile (0 = coastal). Unreachable tiles are 65535.",
+    }),
+  }),
+  strategies: {
+    default: Type.Object(
+      {},
+      {
+        additionalProperties: false,
+        description: "Parameter-free multi-source hex BFS from the coastal seed mask.",
+      }
+    ),
+  },
+});
+
+export default ComputeDistanceToCoastContract;

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-distance-to-coast/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-distance-to-coast/index.ts
@@ -1,0 +1,14 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import ComputeDistanceToCoastContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const computeDistanceToCoast = createOp(ComputeDistanceToCoastContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+
+export default computeDistanceToCoast;

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-distance-to-coast/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-distance-to-coast/strategies/default.ts
@@ -1,0 +1,51 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
+
+import ComputeDistanceToCoastContract from "../contract.js";
+
+const UNREACHED = 65535;
+
+export const defaultStrategy = createStrategy(ComputeDistanceToCoastContract, "default", {
+  run: (input) => {
+    const { width, height } = input;
+    const size = Math.max(0, (width | 0) * (height | 0));
+    const coastal = input.coastal as Uint8Array;
+    if (coastal.length !== size) {
+      throw new Error("[DistanceToCoast] coastal mask must match width*height.");
+    }
+
+    const distance = new Uint16Array(size);
+    distance.fill(UNREACHED);
+
+    // Multi-source BFS: every coastal seed starts at distance 0; the frontier
+    // floods outward one hex ring at a time. Because all seeds enter the queue
+    // up front and edge weights are uniform, the first time a tile is written it
+    // already holds its minimum distance.
+    const queue = new Int32Array(size);
+    let head = 0;
+    let tail = 0;
+
+    for (let i = 0; i < size; i++) {
+      if ((coastal[i] | 0) !== 1) continue;
+      distance[i] = 0;
+      queue[tail++] = i;
+    }
+
+    while (head < tail) {
+      const idx = queue[head++]!;
+      const y = (idx / width) | 0;
+      const x = idx - y * width;
+      const dist = distance[idx] ?? 0;
+
+      forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+        const ni = ny * width + nx;
+        const next = (dist + 1) as number;
+        if (distance[ni] <= next) return;
+        distance[ni] = next;
+        queue[tail++] = ni;
+      });
+    }
+
+    return { distanceToCoast: distance };
+  },
+});

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-distance-to-coast/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-distance-to-coast/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/contracts.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/contracts.ts
@@ -1,6 +1,7 @@
 import ComputeBaseTopographyContract from "./compute-base-topography/contract.js";
 import ComputeBeltDriversContract from "./compute-belt-drivers/contract.js";
 import ComputeCoastlineMetricsContract from "./compute-coastline-metrics/contract.js";
+import ComputeDistanceToCoastContract from "./compute-distance-to-coast/contract.js";
 import ComputeFlowRoutingContract from "./compute-flow-routing/contract.js";
 import ComputeGeomorphicCycleContract from "./compute-geomorphic-cycle/contract.js";
 import ComputeLandmaskContract from "./compute-landmask/contract.js";
@@ -18,6 +19,7 @@ export const contracts = {
   computeBaseTopography: ComputeBaseTopographyContract,
   computeBeltDrivers: ComputeBeltDriversContract,
   computeCoastlineMetrics: ComputeCoastlineMetricsContract,
+  computeDistanceToCoast: ComputeDistanceToCoastContract,
   computeFlowRouting: ComputeFlowRoutingContract,
   computeGeomorphicCycle: ComputeGeomorphicCycleContract,
   computeLandmask: ComputeLandmaskContract,

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/index.ts
@@ -2,6 +2,7 @@ import type { DomainOpImplementationsForContracts } from "@swooper/mapgen-core/a
 import computeBaseTopography from "./compute-base-topography/index.js";
 import computeBeltDrivers from "./compute-belt-drivers/index.js";
 import computeCoastlineMetrics from "./compute-coastline-metrics/index.js";
+import computeDistanceToCoast from "./compute-distance-to-coast/index.js";
 import computeFlowRouting from "./compute-flow-routing/index.js";
 import computeGeomorphicCycle from "./compute-geomorphic-cycle/index.js";
 import computeLandmask from "./compute-landmask/index.js";
@@ -20,6 +21,7 @@ const implementations = {
   computeBaseTopography,
   computeBeltDrivers,
   computeCoastlineMetrics,
+  computeDistanceToCoast,
   computeFlowRouting,
   computeGeomorphicCycle,
   computeLandmask,
@@ -41,6 +43,7 @@ export {
   computeBaseTopography,
   computeBeltDrivers,
   computeCoastlineMetrics,
+  computeDistanceToCoast,
   computeFlowRouting,
   computeGeomorphicCycle,
   computeLandmask,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.contract.ts
@@ -17,6 +17,10 @@ const RuggedCoastsStepContract = defineStep({
   },
   ops: {
     coastlines: morphology.ops.computeCoastlineMetrics,
+    distanceToCoast: {
+      contract: morphology.ops.computeDistanceToCoast,
+      defaultStrategy: "default",
+    },
     shelfMask: { contract: morphology.ops.computeShelfMask, defaultStrategy: "default" },
   },
   schema: Type.Object({}),

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.ts
@@ -14,7 +14,6 @@ import {
   renderAsciiGrid,
 } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
 import { clampFinite, clampInt16, roundHalfAwayFromZero } from "@swooper/mapgen-core/lib/math";
 import RuggedCoastsStepContract from "./ruggedCoasts.contract.js";
 
@@ -90,39 +89,6 @@ function validateCoastlineMetrics(
     size
   );
   return errors;
-}
-
-function computeDistanceToCoast(width: number, height: number, coastal: Uint8Array): Uint16Array {
-  const size = Math.max(0, (width | 0) * (height | 0));
-  const distance = new Uint16Array(size);
-  distance.fill(65535);
-
-  const queue = new Int32Array(size);
-  let head = 0;
-  let tail = 0;
-
-  for (let i = 0; i < size; i++) {
-    if ((coastal[i] | 0) !== 1) continue;
-    distance[i] = 0;
-    queue[tail++] = i;
-  }
-
-  while (head < tail) {
-    const idx = queue[head++]!;
-    const y = (idx / width) | 0;
-    const x = idx - y * width;
-    const dist = distance[idx] ?? 0;
-
-    forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
-      const ni = ny * width + nx;
-      const next = (dist + 1) as number;
-      if (distance[ni] <= next) return;
-      distance[ni] = next;
-      queue[tail++] = ni;
-    });
-  }
-
-  return distance;
 }
 
 export default createStep(RuggedCoastsStepContract, {
@@ -281,7 +247,10 @@ export default createStep(RuggedCoastsStepContract, {
     for (let i = 0; i < coastal.length; i++) {
       coastal[i] = result.coastalLand[i] === 1 || result.coastalWater[i] === 1 ? 1 : 0;
     }
-    const distanceToCoast = computeDistanceToCoast(width, height, coastal);
+    const { distanceToCoast } = ops.distanceToCoast(
+      { width, height, coastal },
+      config.distanceToCoast
+    );
 
     const shelfResult = ops.shelfMask(
       {


### PR DESCRIPTION
Thin-step / fat-op: the multi-source coast BFS that lived inline in the
stage-2 carving step (ruggedCoasts) is now a shared morphology domain op,
compute-distance-to-coast. The step calls ops.distanceToCoast instead of a
private function; the op is geometry-only (no physics, empty config) and is
the single home for "label every tile with its hex-distance to the coastline".

Why: the BFS was op-grade computation living in a step (violating thin
steps / fat ops), and the post-features shelf stage (R3) needs the same BFS
over the post-island coastline. Extracting it once lets both sites share it
instead of carrying duplicate copies.

- new op: domain/morphology/ops/compute-distance-to-coast (contract +
  default strategy + index), registered in ops/contracts.ts + ops/index.ts.
- ruggedCoasts.contract.ts: declare the distanceToCoast op dep.
- ruggedCoasts.ts: drop the inline computeDistanceToCoast + now-unused
  forEachHexNeighborOddQ import; call ops.distanceToCoast.

Byte-identical: same BFS logic. Proven end-to-end — shipped-map-identity +
all ecology baseline fingerprints unchanged (119 pass); morphology +
map-morphology + viz-emissions (53 pass); mod build green; biome clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>