### PR TITLE
refactor(mapgen): extract pure reconcile-heightfield-from-coast op (R5)

### DIFF
--- a/mods/mod-swooper-maps/src/domain/morphology/ops/contracts.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/contracts.ts
@@ -14,6 +14,7 @@ import PlanIslandChainsContract from "./plan-island-chains/contract.js";
 import PlanRidgesContract from "./plan-ridges/contract.js";
 import PlanRoughLandsContract from "./plan-rough-lands/contract.js";
 import PlanVolcanoesContract from "./plan-volcanoes/contract.js";
+import ReconcileHeightfieldFromCoastContract from "./reconcile-heightfield-from-coast/contract.js";
 
 export const contracts = {
   computeBaseTopography: ComputeBaseTopographyContract,
@@ -32,6 +33,7 @@ export const contracts = {
   planRidges: PlanRidgesContract,
   planRoughLands: PlanRoughLandsContract,
   planVolcanoes: PlanVolcanoesContract,
+  reconcileHeightfieldFromCoast: ReconcileHeightfieldFromCoastContract,
 } as const;
 
 export default contracts;

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/index.ts
@@ -16,6 +16,7 @@ import planIslandChains from "./plan-island-chains/index.js";
 import planRidges from "./plan-ridges/index.js";
 import planRoughLands from "./plan-rough-lands/index.js";
 import planVolcanoes from "./plan-volcanoes/index.js";
+import reconcileHeightfieldFromCoast from "./reconcile-heightfield-from-coast/index.js";
 
 const implementations = {
   computeBaseTopography,
@@ -34,6 +35,7 @@ const implementations = {
   planRidges,
   planRoughLands,
   planVolcanoes,
+  reconcileHeightfieldFromCoast,
 } as const satisfies DomainOpImplementationsForContracts<typeof contracts>;
 
 export default implementations;
@@ -56,4 +58,5 @@ export {
   planRidges,
   planRoughLands,
   planVolcanoes,
+  reconcileHeightfieldFromCoast,
 };

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/reconcile-heightfield-from-coast/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/reconcile-heightfield-from-coast/contract.ts
@@ -1,0 +1,61 @@
+import { defineOp, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+
+/**
+ * Reconciles the heightfield with a freshly-carved coastline.
+ *
+ * Coast carving turns some land into water (the coast ring), so land/water,
+ * elevation, and bathymetry must be brought back into a consistent state:
+ *  - carved coast tiles become water; every other tile keeps its carved class;
+ *  - land below sea level is lifted to a minimal land elevation, water above
+ *    sea level is dropped to sea level (so elevation agrees with the class);
+ *  - bathymetry is re-derived as min(0, elevation - seaLevel) on water, 0 on land.
+ *
+ * This is the pure core of the side effect that the carving step performs on the
+ * shared heightfield. The op returns NEW {landMask, elevation, bathymetry} arrays
+ * and never mutates its inputs; the step is the only place allowed to copy the
+ * result back into the shared `context.buffers.heightfield` + topography buffers.
+ */
+const ReconcileHeightfieldFromCoastContract = defineOp({
+  kind: "compute",
+  id: "morphology/reconcile-heightfield-from-coast",
+  input: Type.Object({
+    width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+    height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+    landMask: TypedArraySchemas.u8({
+      description:
+        "Carved candidate land mask (1=land, 0=water) before coast tiles are subtracted.",
+    }),
+    coastMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): water tiles carved as coast; these are forced to water.",
+    }),
+    elevation: TypedArraySchemas.i16({
+      description: "Current elevation per tile (integer engine units). Read-only; never mutated.",
+    }),
+    seaLevel: Type.Number({
+      description: "Global sea-level threshold in the same datum/units as elevation.",
+    }),
+  }),
+  output: Type.Object({
+    landMask: TypedArraySchemas.u8({
+      description: "Reconciled land mask (1=land, 0=water) after subtracting carved coast.",
+    }),
+    elevation: TypedArraySchemas.i16({
+      description:
+        "Reconciled elevation: land lifted to >= seaLevel+1, water clamped to <= seaLevel.",
+    }),
+    bathymetry: TypedArraySchemas.i16({
+      description: "Reconciled bathymetry: 0 on land; min(0, elevation - seaLevel) in water.",
+    }),
+  }),
+  strategies: {
+    default: Type.Object(
+      {},
+      {
+        additionalProperties: false,
+        description: "Parameter-free heightfield reconciliation from the carved coastline.",
+      }
+    ),
+  },
+});
+
+export default ReconcileHeightfieldFromCoastContract;

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/reconcile-heightfield-from-coast/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/reconcile-heightfield-from-coast/index.ts
@@ -1,0 +1,14 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import ReconcileHeightfieldFromCoastContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const reconcileHeightfieldFromCoast = createOp(ReconcileHeightfieldFromCoastContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+
+export default reconcileHeightfieldFromCoast;

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/reconcile-heightfield-from-coast/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/reconcile-heightfield-from-coast/strategies/default.ts
@@ -1,0 +1,52 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+import { clampInt16, roundHalfAwayFromZero } from "@swooper/mapgen-core/lib/math";
+
+import ReconcileHeightfieldFromCoastContract from "../contract.js";
+
+export const defaultStrategy = createStrategy(ReconcileHeightfieldFromCoastContract, "default", {
+  run: (input) => {
+    const { width, height } = input;
+    const size = Math.max(0, (width | 0) * (height | 0));
+
+    const inputLandMask = input.landMask as Uint8Array;
+    const coastMask = input.coastMask as Uint8Array;
+    const inputElevation = input.elevation as Int16Array;
+    const seaLevel = input.seaLevel;
+
+    if (
+      inputLandMask.length !== size ||
+      coastMask.length !== size ||
+      inputElevation.length !== size
+    ) {
+      throw new Error("[ReconcileHeightfield] Input tensors must match width*height.");
+    }
+
+    // Pure: derive fresh outputs from a copy of the input elevation; never mutate inputs.
+    const landMask = new Uint8Array(size);
+    const elevation = Int16Array.from(inputElevation);
+    const bathymetry = new Int16Array(size);
+
+    // Carved coast tiles drop to water; every other tile keeps its carved class. Then
+    // snap elevation to its class (land >= seaLevel+1, water <= seaLevel) and re-derive
+    // bathymetry from the post-snap elevation so depth and class always agree.
+    const waterElevation = clampInt16(Math.floor(seaLevel));
+    const landElevation = clampInt16(Math.floor(seaLevel) + 1);
+
+    for (let i = 0; i < size; i++) {
+      const desiredLand = coastMask[i] === 1 ? 0 : inputLandMask[i] === 1 ? 1 : 0;
+      landMask[i] = desiredLand;
+
+      const elev = elevation[i] ?? 0;
+      if (desiredLand === 1) {
+        if (elev <= seaLevel) elevation[i] = landElevation;
+        bathymetry[i] = 0;
+      } else {
+        if (elev > seaLevel) elevation[i] = waterElevation;
+        const delta = Math.min(0, (elevation[i] ?? 0) - seaLevel);
+        bathymetry[i] = clampInt16(roundHalfAwayFromZero(delta));
+      }
+    }
+
+    return { landMask, elevation, bathymetry };
+  },
+});

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/reconcile-heightfield-from-coast/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/reconcile-heightfield-from-coast/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.contract.ts
@@ -17,6 +17,10 @@ const RuggedCoastsStepContract = defineStep({
   },
   ops: {
     coastlines: morphology.ops.computeCoastlineMetrics,
+    reconcileHeightfield: {
+      contract: morphology.ops.reconcileHeightfieldFromCoast,
+      defaultStrategy: "default",
+    },
     distanceToCoast: {
       contract: morphology.ops.computeDistanceToCoast,
       defaultStrategy: "default",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.ts
@@ -14,7 +14,7 @@ import {
   renderAsciiGrid,
 } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { clampFinite, clampInt16, roundHalfAwayFromZero } from "@swooper/mapgen-core/lib/math";
+import { clampFinite } from "@swooper/mapgen-core/lib/math";
 import RuggedCoastsStepContract from "./ruggedCoasts.contract.js";
 
 type ArtifactValidationIssue = Readonly<{ message: string }>;
@@ -182,30 +182,23 @@ export default createStep(RuggedCoastsStepContract, {
       throw new Error("Morphology topography bathymetry buffer missing or shape-mismatched.");
     }
 
-    const waterElevation = clampInt16(Math.floor(seaLevelValue));
-    const landElevation = clampInt16(Math.floor(seaLevelValue) + 1);
-
-    for (let y = 0; y < height; y++) {
-      for (let x = 0; x < width; x++) {
-        const i = y * width + x;
-        const desiredLand = coastMask[i] === 1 ? 0 : updatedLandMask[i] === 1 ? 1 : 0;
-        if (coastMask[i] === 1) {
-          heightfield.landMask[i] = 0;
-        } else {
-          heightfield.landMask[i] = updatedLandMask[i] === 1 ? 1 : 0;
-        }
-
-        const elevation = heightfield.elevation[i] ?? 0;
-        if (desiredLand === 1) {
-          if (elevation <= seaLevelValue) heightfield.elevation[i] = landElevation;
-          bathymetry[i] = 0;
-        } else {
-          if (elevation > seaLevelValue) heightfield.elevation[i] = waterElevation;
-          const delta = Math.min(0, (heightfield.elevation[i] ?? 0) - seaLevelValue);
-          bathymetry[i] = clampInt16(roundHalfAwayFromZero(delta));
-        }
-      }
-    }
+    // Reconcile land/water + elevation + bathymetry with the carved coastline. The op is
+    // pure (returns fresh arrays); the step owns the only legitimate side effect: copying the
+    // result back into the shared heightfield + topography bathymetry buffers in place.
+    const reconciled = ops.reconcileHeightfield(
+      {
+        width,
+        height,
+        landMask: updatedLandMask,
+        coastMask,
+        elevation: heightfield.elevation,
+        seaLevel: seaLevelValue,
+      },
+      config.reconcileHeightfield
+    );
+    heightfield.landMask.set(reconciled.landMask);
+    heightfield.elevation.set(reconciled.elevation);
+    bathymetry.set(reconciled.bathymetry);
 
     context.trace.event(() => {
       const size = Math.max(0, (width | 0) * (height | 0));


### PR DESCRIPTION
Thin-step / fat-op: the carving step's land/water + elevation + bathymetry
reconciliation (the double loop that snapped each tile to its class after
coast carving) is now a pure morphology op, reconcile-heightfield-from-coast.

The op takes the carved landMask + coastMask + current elevation + seaLevel
and returns FRESH {landMask, elevation, bathymetry} arrays; it never mutates
its inputs. The step keeps the one legitimate side effect — copying the result
back into the shared context.buffers.heightfield + topography bathymetry via
.set(). This is the "never mutate a shared buffer inside an op" rule from the
redesign: ops stay pure, the step owns the writeback.

- new op: domain/morphology/ops/reconcile-heightfield-from-coast (contract +
  default strategy + index), registered in ops/contracts.ts + ops/index.ts.
- ruggedCoasts.contract.ts: declare the reconcileHeightfield op dep.
- ruggedCoasts.ts: replace the inline reconciliation loop with the op call +
  three .set() copies; drop the now-unused clampInt16/roundHalfAwayFromZero
  imports.

Byte-identical: same per-tile math, same post-snap bathymetry derivation.
Proven end-to-end — shipped-map-identity + ecology baseline fingerprints +
morphology/map-morphology/diagnostics/viz unchanged (172 pass); mod build
green; biome clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>