### PR TITLE
feat(mapgen): relocate the shelf to a post-features morphology-shelf stage (R3)

### DIFF
--- a/docs/system/libs/mapgen/reference/STANDARD-RECIPE.md
+++ b/docs/system/libs/mapgen/reference/STANDARD-RECIPE.md
@@ -63,22 +63,25 @@ The current stage order is:
 7. `morphology-routing`
 8. `morphology-erosion`
 9. `morphology-features`
-10. `hydrology-climate-baseline`
-11. `hydrology-hydrography`
-12. `hydrology-climate-refine`
-13. `ecology-pedology`
-14. `ecology-biomes`
-15. `map-morphology`
-16. `map-hydrology`
-17. `map-elevation`
-18. `map-rivers`
-19. `ecology-features`
-20. `map-ecology`
-21. `placement`
+10. `morphology-shelf`
+11. `hydrology-climate-baseline`
+12. `hydrology-hydrography`
+13. `hydrology-climate-refine`
+14. `ecology-pedology`
+15. `ecology-biomes`
+16. `map-morphology`
+17. `map-hydrology`
+18. `map-elevation`
+19. `map-rivers`
+20. `ecology-features`
+21. `map-ecology`
+22. `placement`
 
 The five `foundation-*` stages are a sibling family decomposed from the former
 single `foundation` stage; their steps run in the same order, so output is
 byte-identical (see the FOUNDATION domain reference for the stage→step map).
+The `morphology-shelf` stage computes the continental shelf after island
+injection (post-features), so island peaks get true shelves.
 
 Note:
 

--- a/mods/mod-swooper-maps/scripts/generate-studio-recipe-types.ts
+++ b/mods/mod-swooper-maps/scripts/generate-studio-recipe-types.ts
@@ -250,6 +250,7 @@ const STAGE_LABEL_OVERRIDES: Record<string, string> = {
   "morphology-routing": "Morphology / Routing",
   "morphology-erosion": "Morphology / Erosion",
   "morphology-features": "Morphology / Features",
+  "morphology-shelf": "Morphology / Shelf",
   "map-morphology": "Map / Morphology",
   "map-hydrology": "Map / Hydrology",
   "map-ecology": "Map / Ecology",

--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -794,6 +794,7 @@ function buildTerrainProjectionEvidence(
   context: ReturnType<typeof createExtendedMapContext>
 ): unknown {
   const coastlineMetrics = context.artifacts.get(morphologyArtifacts.coastlineMetrics.id);
+  const shelf = context.artifacts.get(morphologyArtifacts.shelf.id);
   const mapMorphologyCoastPolicy = context.artifacts.get(
     mapMorphologyArtifacts.coastClassification.id
   );
@@ -829,7 +830,12 @@ function buildTerrainProjectionEvidence(
     coastlineMetrics: pickSerializableFields(coastlineMetrics, [
       "coastalLand",
       "coastalWater",
+      "distanceToCoast",
+    ]),
+    shelf: pickSerializableFields(shelf, [
       "shelfMask",
+      "coastalLand",
+      "coastalWater",
       "distanceToCoast",
     ]),
     mapMorphologyCoastPolicy: pickSerializableFields(mapMorphologyCoastPolicy, [

--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -1693,6 +1693,7 @@ function terrainProjectionRowContext(
   const morphology = isRecord(projection.coastlineMetrics)
     ? projection.coastlineMetrics
     : undefined;
+  const shelf = isRecord(projection.shelf) ? projection.shelf : undefined;
   const mapMorphologyCoastPolicy = isRecord(projection.mapMorphologyCoastPolicy)
     ? projection.mapMorphologyCoastPolicy
     : undefined;
@@ -1733,8 +1734,15 @@ function terrainProjectionRowContext(
       ? {
           coastalLand: indexedInteger(morphology.coastalLand, plotIndex),
           coastalWater: indexedInteger(morphology.coastalWater, plotIndex),
-          shelfMask: indexedInteger(morphology.shelfMask, plotIndex),
           distanceToCoast: indexedInteger(morphology.distanceToCoast, plotIndex),
+        }
+      : null,
+    shelf: shelf
+      ? {
+          shelfMask: indexedInteger(shelf.shelfMask, plotIndex),
+          coastalLand: indexedInteger(shelf.coastalLand, plotIndex),
+          coastalWater: indexedInteger(shelf.coastalWater, plotIndex),
+          distanceToCoast: indexedInteger(shelf.distanceToCoast, plotIndex),
         }
       : null,
     mapMorphologyCoastPolicy: mapMorphologyCoastPolicy

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-atoll/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-atoll/strategies/default.ts
@@ -29,15 +29,17 @@ export const defaultStrategy = createStrategy(ScoreAtollContract, "default", {
 
     for (let i = 0; i < size; i++) {
       if (input.landMask[i] !== 0) continue;
+      // Atolls MUST sit on ocean terrain: Civ7 rejects FEATURE_ATOLL on coast, and the
+      // continental shelf (shelfMask) projects to TERRAIN_COAST. So atolls only score on
+      // open-ocean banks beyond the shelf. (A wider shelf therefore yields fewer atolls by
+      // converting nearshore shallow banks into coast — an intended shelf-width tradeoff,
+      // not a scoring bug: placing atolls on shelf tiles only produces apply-time rejects.)
       if (input.openOceanMask[i] !== 1) continue;
       if (input.shelfMask[i] === 1) continue;
       if (input.coastalWater[i] !== 0) continue;
       const distanceToCoast = input.distanceToCoast[i] ?? 0;
       if (distanceToCoast < minDistanceToCoast || distanceToCoast > maxDistanceToCoast) continue;
 
-      // Civ7 atolls are open-water features. Swooper projects shelfMask water
-      // to TERRAIN_COAST, so atolls score from warm shallow open-ocean banks
-      // beyond the shelf/coast band rather than the coast surface used by reefs.
       const warmSuit = rampUp01(
         input.surfaceTemperature[i],
         config.tempWarmStartC,

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-coastal-adjacency/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-coastal-adjacency/contract.ts
@@ -1,0 +1,40 @@
+import { defineOp, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+
+/**
+ * Land/water shoreline adjacency for a given land mask.
+ *
+ * For each tile, a tile is "coastal" iff it has at least one odd-Q hex neighbor
+ * of the opposite class: land touching water => coastalLand; water touching land
+ * => coastalWater. Geometry-only, no physics, no config.
+ *
+ * This is the pure form of the adjacency pass that compute-coastline-metrics runs
+ * internally after carving. It is its own op because the carve op cannot delegate
+ * (op-calls-op is forbidden) and the post-features shelf stage needs adjacency on
+ * the FINAL post-island land mask — a different vintage than the carved coastline.
+ */
+const ComputeCoastalAdjacencyContract = defineOp({
+  kind: "compute",
+  id: "morphology/compute-coastal-adjacency",
+  input: Type.Object({
+    width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+    height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+    landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
+  }),
+  output: Type.Object({
+    coastalLand: TypedArraySchemas.u8({ description: "Mask (1/0): land tiles adjacent to water." }),
+    coastalWater: TypedArraySchemas.u8({
+      description: "Mask (1/0): water tiles adjacent to land.",
+    }),
+  }),
+  strategies: {
+    default: Type.Object(
+      {},
+      {
+        additionalProperties: false,
+        description: "Parameter-free shoreline adjacency over the odd-Q hex grid.",
+      }
+    ),
+  },
+});
+
+export default ComputeCoastalAdjacencyContract;

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-coastal-adjacency/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-coastal-adjacency/index.ts
@@ -1,0 +1,14 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import ComputeCoastalAdjacencyContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const computeCoastalAdjacency = createOp(ComputeCoastalAdjacencyContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+
+export default computeCoastalAdjacency;

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-coastal-adjacency/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-coastal-adjacency/strategies/default.ts
@@ -1,0 +1,32 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
+
+import ComputeCoastalAdjacencyContract from "../contract.js";
+
+export const defaultStrategy = createStrategy(ComputeCoastalAdjacencyContract, "default", {
+  run: (input) => {
+    const { width, height } = input;
+    const size = Math.max(0, (width | 0) * (height | 0));
+    const landMask = input.landMask as Uint8Array;
+
+    const coastalLand = new Uint8Array(size);
+    const coastalWater = new Uint8Array(size);
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const i = y * width + x;
+        const isLand = landMask[i] === 1;
+        let hasOpposite = false;
+        forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+          if (hasOpposite) return;
+          const ni = ny * width + nx;
+          if ((landMask[ni] === 1) !== isLand) hasOpposite = true;
+        });
+        if (!hasOpposite) continue;
+        if (isLand) coastalLand[i] = 1;
+        else coastalWater[i] = 1;
+      }
+    }
+
+    return { coastalLand, coastalWater };
+  },
+});

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-coastal-adjacency/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-coastal-adjacency/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-distance-to-coast/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-distance-to-coast/strategies/default.ts
@@ -10,9 +10,6 @@ export const defaultStrategy = createStrategy(ComputeDistanceToCoastContract, "d
     const { width, height } = input;
     const size = Math.max(0, (width | 0) * (height | 0));
     const coastal = input.coastal as Uint8Array;
-    if (coastal.length !== size) {
-      throw new Error("[DistanceToCoast] coastal mask must match width*height.");
-    }
 
     const distance = new Uint16Array(size);
     distance.fill(UNREACHED);

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
@@ -56,16 +56,6 @@ export const defaultStrategy = createStrategy(ComputeShelfMaskContract, "default
     const boundaryCloseness = input.boundaryCloseness as Uint8Array;
     const boundaryType = input.boundaryType as Uint8Array;
 
-    if (
-      landMask.length !== size ||
-      bathymetry.length !== size ||
-      distanceToCoast.length !== size ||
-      boundaryCloseness.length !== size ||
-      boundaryType.length !== size
-    ) {
-      throw new Error("[ShelfMask] Input tensors must match width*height.");
-    }
-
     const sampleRadius = config.breakDepthSampleRadius;
     const absoluteMaxShelfDepth = config.absoluteMaxShelfDepth;
     const activeThresholdU8 = Math.floor(config.activeClosenessThreshold * 255);

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/contracts.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/contracts.ts
@@ -1,5 +1,6 @@
 import ComputeBaseTopographyContract from "./compute-base-topography/contract.js";
 import ComputeBeltDriversContract from "./compute-belt-drivers/contract.js";
+import ComputeCoastalAdjacencyContract from "./compute-coastal-adjacency/contract.js";
 import ComputeCoastlineMetricsContract from "./compute-coastline-metrics/contract.js";
 import ComputeDistanceToCoastContract from "./compute-distance-to-coast/contract.js";
 import ComputeFlowRoutingContract from "./compute-flow-routing/contract.js";
@@ -19,6 +20,7 @@ import ReconcileHeightfieldFromCoastContract from "./reconcile-heightfield-from-
 export const contracts = {
   computeBaseTopography: ComputeBaseTopographyContract,
   computeBeltDrivers: ComputeBeltDriversContract,
+  computeCoastalAdjacency: ComputeCoastalAdjacencyContract,
   computeCoastlineMetrics: ComputeCoastlineMetricsContract,
   computeDistanceToCoast: ComputeDistanceToCoastContract,
   computeFlowRouting: ComputeFlowRoutingContract,

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/index.ts
@@ -1,6 +1,7 @@
 import type { DomainOpImplementationsForContracts } from "@swooper/mapgen-core/authoring";
 import computeBaseTopography from "./compute-base-topography/index.js";
 import computeBeltDrivers from "./compute-belt-drivers/index.js";
+import computeCoastalAdjacency from "./compute-coastal-adjacency/index.js";
 import computeCoastlineMetrics from "./compute-coastline-metrics/index.js";
 import computeDistanceToCoast from "./compute-distance-to-coast/index.js";
 import computeFlowRouting from "./compute-flow-routing/index.js";
@@ -21,6 +22,7 @@ import reconcileHeightfieldFromCoast from "./reconcile-heightfield-from-coast/in
 const implementations = {
   computeBaseTopography,
   computeBeltDrivers,
+  computeCoastalAdjacency,
   computeCoastlineMetrics,
   computeDistanceToCoast,
   computeFlowRouting,
@@ -44,6 +46,7 @@ export type { MountainsConfig } from "./mountains-shared/config.js";
 export {
   computeBaseTopography,
   computeBeltDrivers,
+  computeCoastalAdjacency,
   computeCoastlineMetrics,
   computeDistanceToCoast,
   computeFlowRouting,

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/reconcile-heightfield-from-coast/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/reconcile-heightfield-from-coast/strategies/default.ts
@@ -13,14 +13,6 @@ export const defaultStrategy = createStrategy(ReconcileHeightfieldFromCoastContr
     const inputElevation = input.elevation as Int16Array;
     const seaLevel = input.seaLevel;
 
-    if (
-      inputLandMask.length !== size ||
-      coastMask.length !== size ||
-      inputElevation.length !== size
-    ) {
-      throw new Error("[ReconcileHeightfield] Input tensors must match width*height.");
-    }
-
     // Pure: derive fresh outputs from a copy of the input elevation; never mutate inputs.
     const landMask = new Uint8Array(size);
     const elevation = Int16Array.from(inputElevation);

--- a/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
@@ -82,8 +82,7 @@
     "morphology-coasts": {
       "knobs": {
         "seaLevel": "earthlike",
-        "coastRuggedness": "normal",
-        "shelfWidth": "wide"
+        "coastRuggedness": "normal"
       },
       "substrate": {
         "continentalBaseErodibility": 0.3,
@@ -155,15 +154,6 @@
           "bayNoiseBonus": 0.45,
           "fjordWeight": 0.85
         }
-      },
-      "shelf": {
-        "breakDepthSampleRadius": 8,
-        "shallowQuantile": 0.6,
-        "activeClosenessThreshold": 0.35,
-        "activeBreakDepthFactor": 0.6,
-        "passiveBreakDepthFactor": 1.25,
-        "absoluteMaxShelfDepth": -30,
-        "breakDepthScale": 1
       }
     },
     "morphology-routing": {
@@ -232,6 +222,20 @@
         "randomJitter": 0.04,
         "minVolcanoes": 12,
         "maxVolcanoes": 42
+      }
+    },
+    "morphology-shelf": {
+      "knobs": {
+        "shelfWidth": "wide"
+      },
+      "shelf": {
+        "breakDepthSampleRadius": 8,
+        "shallowQuantile": 0.6,
+        "activeClosenessThreshold": 0.35,
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "hydrology-climate-baseline": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountain-patch.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountain-patch.config.json
@@ -82,8 +82,7 @@
     "morphology-coasts": {
       "knobs": {
         "seaLevel": "earthlike",
-        "coastRuggedness": "normal",
-        "shelfWidth": "normal"
+        "coastRuggedness": "normal"
       },
       "substrate": {
         "continentalBaseErodibility": 0.3,
@@ -155,15 +154,6 @@
           "bayNoiseBonus": 0.45,
           "fjordWeight": 0.85
         }
-      },
-      "shelf": {
-        "breakDepthSampleRadius": 8,
-        "shallowQuantile": 0.45,
-        "activeClosenessThreshold": 0.45,
-        "activeBreakDepthFactor": 0.6,
-        "passiveBreakDepthFactor": 1.25,
-        "absoluteMaxShelfDepth": -30,
-        "breakDepthScale": 1
       }
     },
     "morphology-routing": {
@@ -232,6 +222,20 @@
         "randomJitter": 0.04,
         "minVolcanoes": 12,
         "maxVolcanoes": 42
+      }
+    },
+    "morphology-shelf": {
+      "knobs": {
+        "shelfWidth": "normal"
+      },
+      "shelf": {
+        "breakDepthSampleRadius": 8,
+        "shallowQuantile": 0.45,
+        "activeClosenessThreshold": 0.45,
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "hydrology-climate-baseline": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountain-rivers-patch.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountain-rivers-patch.config.json
@@ -82,8 +82,7 @@
     "morphology-coasts": {
       "knobs": {
         "seaLevel": "earthlike",
-        "coastRuggedness": "normal",
-        "shelfWidth": "normal"
+        "coastRuggedness": "normal"
       },
       "substrate": {
         "continentalBaseErodibility": 0.3,
@@ -155,15 +154,6 @@
           "bayNoiseBonus": 0.45,
           "fjordWeight": 0.85
         }
-      },
-      "shelf": {
-        "breakDepthSampleRadius": 8,
-        "shallowQuantile": 0.45,
-        "activeClosenessThreshold": 0.45,
-        "activeBreakDepthFactor": 0.6,
-        "passiveBreakDepthFactor": 1.25,
-        "absoluteMaxShelfDepth": -30,
-        "breakDepthScale": 1
       }
     },
     "morphology-routing": {
@@ -232,6 +222,20 @@
         "randomJitter": 0.04,
         "minVolcanoes": 12,
         "maxVolcanoes": 42
+      }
+    },
+    "morphology-shelf": {
+      "knobs": {
+        "shelfWidth": "normal"
+      },
+      "shelf": {
+        "breakDepthSampleRadius": 8,
+        "shallowQuantile": 0.45,
+        "activeClosenessThreshold": 0.45,
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "hydrology-climate-baseline": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-earthlike.config.json
@@ -82,8 +82,7 @@
     "morphology-coasts": {
       "knobs": {
         "seaLevel": "earthlike",
-        "coastRuggedness": "normal",
-        "shelfWidth": "wide"
+        "coastRuggedness": "normal"
       },
       "substrate": {
         "continentalBaseErodibility": 0.3,
@@ -155,15 +154,6 @@
           "bayNoiseBonus": 0.45,
           "fjordWeight": 0.85
         }
-      },
-      "shelf": {
-        "breakDepthSampleRadius": 8,
-        "shallowQuantile": 0.6,
-        "activeClosenessThreshold": 0.35,
-        "activeBreakDepthFactor": 0.6,
-        "passiveBreakDepthFactor": 1.25,
-        "absoluteMaxShelfDepth": -30,
-        "breakDepthScale": 1
       }
     },
     "morphology-routing": {
@@ -232,6 +222,20 @@
         "randomJitter": 0.04,
         "minVolcanoes": 12,
         "maxVolcanoes": 42
+      }
+    },
+    "morphology-shelf": {
+      "knobs": {
+        "shelfWidth": "wide"
+      },
+      "shelf": {
+        "breakDepthSampleRadius": 8,
+        "shallowQuantile": 0.6,
+        "activeClosenessThreshold": 0.35,
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "hydrology-climate-baseline": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-original.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-original.config.json
@@ -82,8 +82,7 @@
     "morphology-coasts": {
       "knobs": {
         "seaLevel": "earthlike",
-        "coastRuggedness": "normal",
-        "shelfWidth": "wide"
+        "coastRuggedness": "normal"
       },
       "substrate": {
         "continentalBaseErodibility": 0.3,
@@ -155,15 +154,6 @@
           "bayNoiseBonus": 0.45,
           "fjordWeight": 0.85
         }
-      },
-      "shelf": {
-        "breakDepthSampleRadius": 8,
-        "shallowQuantile": 0.6,
-        "activeClosenessThreshold": 0.35,
-        "activeBreakDepthFactor": 0.6,
-        "passiveBreakDepthFactor": 1.25,
-        "absoluteMaxShelfDepth": -30,
-        "breakDepthScale": 1
       }
     },
     "morphology-routing": {
@@ -232,6 +222,20 @@
         "terrainTextureFractalMix": 0.55,
         "erosionMaturity": 0.26,
         "tectonicSignalSensitivity": 1.8
+      }
+    },
+    "morphology-shelf": {
+      "knobs": {
+        "shelfWidth": "wide"
+      },
+      "shelf": {
+        "breakDepthSampleRadius": 8,
+        "shallowQuantile": 0.6,
+        "activeClosenessThreshold": 0.35,
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "hydrology-climate-baseline": {

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.json
@@ -147,15 +147,6 @@
           "activeBonus": 1,
           "passiveBonus": 2
         }
-      },
-      "shelf": {
-        "breakDepthSampleRadius": 3,
-        "shallowQuantile": 0.7,
-        "activeClosenessThreshold": 0.45,
-        "activeBreakDepthFactor": 0.6,
-        "passiveBreakDepthFactor": 1.25,
-        "absoluteMaxShelfDepth": -30,
-        "breakDepthScale": 1
       }
     },
     "morphology-routing": {},
@@ -203,6 +194,17 @@
         "randomJitter": 0.14,
         "minVolcanoes": 10,
         "maxVolcanoes": 45
+      }
+    },
+    "morphology-shelf": {
+      "shelf": {
+        "breakDepthSampleRadius": 3,
+        "shallowQuantile": 0.7,
+        "activeClosenessThreshold": 0.45,
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "hydrology-climate-baseline": {

--- a/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.json
@@ -147,15 +147,6 @@
           "activeBonus": 1,
           "passiveBonus": 2
         }
-      },
-      "shelf": {
-        "breakDepthSampleRadius": 3,
-        "shallowQuantile": 0.7,
-        "activeClosenessThreshold": 0.45,
-        "activeBreakDepthFactor": 0.6,
-        "passiveBreakDepthFactor": 1.25,
-        "absoluteMaxShelfDepth": -30,
-        "breakDepthScale": 1
       }
     },
     "morphology-routing": {},
@@ -203,6 +194,17 @@
         "randomJitter": 0.18,
         "minVolcanoes": 16,
         "maxVolcanoes": 70
+      }
+    },
+    "morphology-shelf": {
+      "shelf": {
+        "breakDepthSampleRadius": 3,
+        "shallowQuantile": 0.7,
+        "activeClosenessThreshold": 0.45,
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "hydrology-climate-baseline": {

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.json
@@ -151,15 +151,6 @@
           "activeBonus": 1,
           "passiveBonus": 2
         }
-      },
-      "shelf": {
-        "breakDepthSampleRadius": 3,
-        "shallowQuantile": 0.7,
-        "activeClosenessThreshold": 0.45,
-        "activeBreakDepthFactor": 0.6,
-        "passiveBreakDepthFactor": 1.25,
-        "absoluteMaxShelfDepth": -30,
-        "breakDepthScale": 1
       }
     },
     "morphology-routing": {},
@@ -207,6 +198,17 @@
         "randomJitter": 0.08,
         "minVolcanoes": 6,
         "maxVolcanoes": 18
+      }
+    },
+    "morphology-shelf": {
+      "shelf": {
+        "breakDepthSampleRadius": 3,
+        "shallowQuantile": 0.7,
+        "activeClosenessThreshold": 0.45,
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "hydrology-climate-baseline": {

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -82,8 +82,7 @@
     "morphology-coasts": {
       "knobs": {
         "seaLevel": "earthlike",
-        "coastRuggedness": "normal",
-        "shelfWidth": "wide"
+        "coastRuggedness": "normal"
       },
       "substrate": {
         "continentalBaseErodibility": 0.3,
@@ -155,15 +154,6 @@
           "bayNoiseBonus": 0.45,
           "fjordWeight": 0.85
         }
-      },
-      "shelf": {
-        "breakDepthSampleRadius": 8,
-        "shallowQuantile": 0.45,
-        "activeClosenessThreshold": 0.45,
-        "activeBreakDepthFactor": 0.6,
-        "passiveBreakDepthFactor": 1.25,
-        "absoluteMaxShelfDepth": -30,
-        "breakDepthScale": 1
       }
     },
     "morphology-routing": {
@@ -232,6 +222,20 @@
         "terrainTextureFractalMix": 0.55,
         "erosionMaturity": 0.26,
         "tectonicSignalSensitivity": 1.8
+      }
+    },
+    "morphology-shelf": {
+      "knobs": {
+        "shelfWidth": "wide"
+      },
+      "shelf": {
+        "breakDepthSampleRadius": 8,
+        "shallowQuantile": 0.45,
+        "activeClosenessThreshold": 0.45,
+        "activeBreakDepthFactor": 0.6,
+        "passiveBreakDepthFactor": 1.25,
+        "absoluteMaxShelfDepth": -30,
+        "breakDepthScale": 1
       }
     },
     "hydrology-climate-baseline": {

--- a/mods/mod-swooper-maps/src/maps/generated/latest-juicy.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/latest-juicy.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "latest-juicy",
-  configHash: "3ee2e2cf9a428121dc76c78c59233d8107b07d90249b9268364b51f339790357",
-  envelopeHash: "156cc003d5ac16365b5c5c85089a82428317e93626c9d98659070fc688415843",
+  configHash: "5cf787d777d45d259a9927ec5868454c3e3ebaa31eeb3c2edc691bfd22593a68",
+  envelopeHash: "ef26ec3ee045d86fdb24e0df74833389983c2dfa19b45157db5f51ffa6fffd41",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/mountain-patch.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/mountain-patch.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "mountain-patch",
-  configHash: "3059106ece0e04230ababd4496f3fc5f034b9e0722c2d7d47a777d317eea4651",
-  envelopeHash: "326570aa61db75b1371af70a858fefe100f327705b971a369f28c91a9fe9e4fa",
+  configHash: "a4dc50e0364293323ba7db333e9acb5233b0158a35bfa294c5b1cf92e9736d11",
+  envelopeHash: "dc0917dc86b9d98e5387b3ec0a7c0969ca2e4c8e8e8026894fb2e01010c3ddc6",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/mountain-rivers-patch.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/mountain-rivers-patch.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "mountain-rivers-patch",
-  configHash: "3059106ece0e04230ababd4496f3fc5f034b9e0722c2d7d47a777d317eea4651",
-  envelopeHash: "42b628f8734af9a82ebcbc561d3380af700519b568758a2ee1dc98366a7a03fc",
+  configHash: "a4dc50e0364293323ba7db333e9acb5233b0158a35bfa294c5b1cf92e9736d11",
+  envelopeHash: "22b2e6b5b4b77e46c66308318a5ff6e1e554973c20470bbf732529b66fcece7c",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/mountains-of-time-earthlike.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/mountains-of-time-earthlike.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "mountains-of-time-earthlike",
-  configHash: "e8523bb4ed82258e8c1ffb84f68fd82e60ede7f7dcc91e80f27d722f2b5d6507",
-  envelopeHash: "7f765a42dafc4a51d58732cf47c7f002d1a73cb0f474918349ee1c5f0821aaa6",
+  configHash: "1e39cea63b27893fb7e8edb13dabc74baeea78aeeba3bcf994eab6729abe9aed",
+  envelopeHash: "25cef541753d69a849cb6e8a0a004e38d2c90028ad86d8ee6e3a6eef5cc1556b",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/mountains-of-time-original.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/mountains-of-time-original.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "mountains-of-time-original",
-  configHash: "f7c1f26b28c137f19926f484fea6dfb7cf4e658007f494ce32527d9d54ceed5c",
-  envelopeHash: "5b9344260edb906c560c943296315ec2d9eaa17dcf6a1961543b3495c22a05cf",
+  configHash: "8e02b429611b7290d31677b73bf0d3e0a64266b2c5bac64b5f35b4a231fb25ed",
+  envelopeHash: "9da5eacc45ab0cb70eb0327e75cb701ea494805057bc70211e2fa11b2c87f81e",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/shattered-ring.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/shattered-ring.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "shattered-ring",
-  configHash: "f875dd2e675862774c01cf9134ceb1c7ffce6388f05f6a0f5b09cc0dd87297cc",
-  envelopeHash: "0c018d8ac3785eddf8f18189781c5a47fe7d464fbac5c805f49dbf7b4e4cc645",
+  configHash: "b30ac2ff4fa169d1db670e0e07b10dd2bb43dc4163fda5a8a71106d23bc759e8",
+  envelopeHash: "5eba819a01cc45087bb1e6d917db445fbbe9010d494efef419b3bfa9ed2de19b",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/sundered-archipelago.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/sundered-archipelago.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "sundered-archipelago",
-  configHash: "ead9419ac4618a941c8a9907075c49e7b648c1b65eea228258020e6c309341d8",
-  envelopeHash: "894e8992774a55c58aef2b6b3dd39c6bd20fd1b8dc4c42953926bde3425ec701",
+  configHash: "74c81058e8bf099a0043fd05ada649d9a348cf9198b97fd7ac0eea0355799c0f",
+  envelopeHash: "9c90b4443e82288cf0310394a58b64fbc0a97188c989ac46bd05c8d4ca4400b4",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/swooper-desert-mountains.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/swooper-desert-mountains.ts
@@ -21,7 +21,7 @@ export default createMap({
     "bottomLatitude": -40
   },
   sourceConfigId: "swooper-desert-mountains",
-  configHash: "a249f224c3d5fb19ce6fbeb5de8ed1b9bbb5d191890d2a50a9c871cab3c1877f",
-  envelopeHash: "53c2b3d30c48ea697d35817e9609b896ae9911bde96c9520d338d250b8a215a0",
+  configHash: "04e2d717125e65d39b21536a45fdb0df78e2c3fb236c96d355e8c2e45a923d56",
+  envelopeHash: "df03aebf2ac421fd7b9a60e657ab6262f54d836d252efec77080f780afa82dc9",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/generated/swooper-earthlike.ts
+++ b/mods/mod-swooper-maps/src/maps/generated/swooper-earthlike.ts
@@ -17,7 +17,7 @@ export default createMap({
   description: mapConfig.description,
   recipe: standardRecipe,
   sourceConfigId: "swooper-earthlike",
-  configHash: "26e2adac284ab1ab1e1c1e12a5b0067ad4a2f7c73399b7c82548b3290be9cf47",
-  envelopeHash: "5d4aa061d8d0b77251c85c9af1f91a79eea5f50cea015485abb8af18bbe25c85",
+  configHash: "0cf5801569874075e8494f5715be308755ca591cc20b846522abd2968be17850",
+  envelopeHash: "8a5deb1de7aee7ca342266203d85576f5865015ef2007b0ce82297c6a49c3ee1",
   config: canonicalRecipeConfig<StandardRecipeConfig>(mapConfig),
 });

--- a/mods/mod-swooper-maps/src/maps/presets/realism/old-erosion.config.ts
+++ b/mods/mod-swooper-maps/src/maps/presets/realism/old-erosion.config.ts
@@ -9,8 +9,9 @@ export const realismOldErosionConfig: StandardRecipeConfig = {
   "foundation-lithosphere": { knobs: { plateCount: 28 } },
   "foundation-tectonics": { knobs: { plateActivity: 0.25 } },
   "morphology-coasts": {
-    knobs: { seaLevel: "earthlike", coastRuggedness: "smooth", shelfWidth: "normal" },
+    knobs: { seaLevel: "earthlike", coastRuggedness: "smooth" },
   },
+  "morphology-shelf": { knobs: { shelfWidth: "normal" } },
   "morphology-erosion": { knobs: { erosion: "high" } },
   "morphology-features": { knobs: { volcanism: "low" } },
 };

--- a/mods/mod-swooper-maps/src/maps/presets/realism/young-tectonics.config.ts
+++ b/mods/mod-swooper-maps/src/maps/presets/realism/young-tectonics.config.ts
@@ -9,8 +9,9 @@ export const realismYoungTectonicsConfig: StandardRecipeConfig = {
   "foundation-lithosphere": { knobs: { plateCount: 28 } },
   "foundation-tectonics": { knobs: { plateActivity: 0.75 } },
   "morphology-coasts": {
-    knobs: { seaLevel: "earthlike", coastRuggedness: "rugged", shelfWidth: "normal" },
+    knobs: { seaLevel: "earthlike", coastRuggedness: "rugged" },
   },
+  "morphology-shelf": { knobs: { shelfWidth: "normal" } },
   "morphology-erosion": { knobs: { erosion: "high" } },
   "morphology-features": { knobs: { volcanism: "high" } },
 };

--- a/mods/mod-swooper-maps/src/recipes/standard/contract-manifest.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/contract-manifest.ts
@@ -45,6 +45,7 @@ import LandmassesStepContract from "./stages/morphology-features/steps/landmasse
 import MountainsStepContract from "./stages/morphology-features/steps/mountains.contract.js";
 import VolcanoesStepContract from "./stages/morphology-features/steps/volcanoes.contract.js";
 import RoutingStepContract from "./stages/morphology-routing/steps/routing.contract.js";
+import ComputeShelfStepContract from "./stages/morphology-shelf/steps/computeShelf.contract.js";
 import AdjustResourcesStepContract from "./stages/placement/steps/adjust-resources/contract.js";
 import AssignAdvancedStartsStepContract from "./stages/placement/steps/assign-advanced-starts/contract.js";
 import AssignStartsStepContract from "./stages/placement/steps/assign-starts/contract.js";
@@ -85,6 +86,7 @@ export const standardStageContractManifest = [
     VolcanoesStepContract,
     LandmassesStepContract,
   ]),
+  stage("morphology-shelf", [ComputeShelfStepContract]),
   stage("hydrology-climate-baseline", [ClimateBaselineStepContract]),
   stage("hydrology-hydrography", [RiversStepContract, HydrologyLakesStepContract]),
   stage("hydrology-climate-refine", [ClimateRefineStepContract]),

--- a/mods/mod-swooper-maps/src/recipes/standard/recipe.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/recipe.ts
@@ -31,6 +31,7 @@ import morphologyCoasts from "./stages/morphology-coasts/index.js";
 import morphologyErosion from "./stages/morphology-erosion/index.js";
 import morphologyFeatures from "./stages/morphology-features/index.js";
 import morphologyRouting from "./stages/morphology-routing/index.js";
+import morphologyShelf from "./stages/morphology-shelf/index.js";
 import placement from "./stages/placement/index.js";
 import { STANDARD_TAG_DEFINITIONS } from "./tags.js";
 
@@ -45,6 +46,7 @@ const stages = orderStandardStages({
   "morphology-routing": morphologyRouting,
   "morphology-erosion": morphologyErosion,
   "morphology-features": morphologyFeatures,
+  "morphology-shelf": morphologyShelf,
   "hydrology-climate-baseline": hydrologyClimateBaseline,
   "hydrology-hydrography": hydrologyHydrography,
   "hydrology-climate-refine": hydrologyClimateRefine,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/contract.ts
@@ -20,7 +20,7 @@ const ScoreLayersStepContract = defineStep({
       hydrologyHydrographyArtifacts.lakePlan,
       mapRiversArtifacts.projectedNavigableRivers,
       morphologyArtifacts.topography,
-      morphologyArtifacts.coastlineMetrics,
+      morphologyArtifacts.shelf,
       mapMorphologyArtifacts.coastClassification,
       morphologyArtifacts.mountains,
       morphologyArtifacts.volcanoes,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/index.ts
@@ -66,7 +66,7 @@ export default createStep(ScoreLayersStepContract, {
     const classification = deps.artifacts.biomeClassification.read(context);
     const pedology = deps.artifacts.pedology.read(context);
     const topography = deps.artifacts.topography.read(context);
-    const coastline = deps.artifacts.coastlineMetrics.read(context);
+    const coastline = deps.artifacts.shelf.read(context);
     const coastClassification = deps.artifacts.coastClassification.read(context);
     const hydrography = deps.artifacts.hydrography.read(context);
     const lakePlan = deps.artifacts.lakePlan.read(context);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.contract.ts
@@ -63,7 +63,7 @@ const ClimateBaselineStepContract = defineStep({
   requires: [],
   provides: [],
   artifacts: {
-    requires: [morphologyArtifacts.topography, morphologyArtifacts.coastlineMetrics],
+    requires: [morphologyArtifacts.topography, morphologyArtifacts.shelf],
     provides: [
       hydrologyClimateBaselineArtifacts.climateField,
       hydrologyClimateBaselineArtifacts.climateSeasonality,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.ts
@@ -399,7 +399,7 @@ export default createStep(ClimateBaselineStepContract, {
     }
 
     const topography = deps.artifacts.topography.read(context);
-    const coastlineMetrics = deps.artifacts.coastlineMetrics.read(context);
+    const shelf = deps.artifacts.shelf.read(context);
     const elevation = topography.elevation;
     const landMask = topography.landMask;
     const isWaterMask = new Uint8Array(width * height);
@@ -454,9 +454,9 @@ export default createStep(ClimateBaselineStepContract, {
           width,
           height,
           isWaterMask,
-          coastalWaterMask: coastlineMetrics.coastalWater,
-          distanceToCoast: coastlineMetrics.distanceToCoast,
-          shelfMask: coastlineMetrics.shelfMask,
+          coastalWaterMask: shelf.coastalWater,
+          distanceToCoast: shelf.distanceToCoast,
+          shelfMask: shelf.shelfMask,
         },
         config.computeOceanGeometry
       );
@@ -549,7 +549,7 @@ export default createStep(ClimateBaselineStepContract, {
           height,
           latitudeByRow,
           isWaterMask,
-          shelfMask: coastlineMetrics.shelfMask,
+          shelfMask: shelf.shelfMask,
           currentU: meanCurrentU,
           currentV: meanCurrentV,
         },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.contract.ts
@@ -10,7 +10,7 @@ const PlotCoastsStepContract = defineStep({
   requires: [],
   provides: [MAP_PROJECTION_EFFECT_TAGS.map.coastsPlotted],
   artifacts: {
-    requires: [morphologyArtifacts.topography, morphologyArtifacts.coastlineMetrics],
+    requires: [morphologyArtifacts.topography, morphologyArtifacts.shelf],
     provides: [
       mapMorphologyArtifacts.coastClassification,
       mapMorphologyArtifacts.coastEngineTerrainSnapshot,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.ts
@@ -31,7 +31,7 @@ export default createStep(PlotCoastsStepContract, {
   ),
   run: (context, _config, _ops, deps) => {
     const topography = deps.artifacts.topography.read(context);
-    const coastlineMetrics = deps.artifacts.coastlineMetrics.read(context);
+    const shelf = deps.artifacts.shelf.read(context);
     const { width, height } = context.dimensions;
     const size = Math.max(0, (width | 0) * (height | 0));
 
@@ -44,9 +44,7 @@ export default createStep(PlotCoastsStepContract, {
         // Coast is the physically-derived continental shelf (margin-aware, depth-gated)
         // plus the guaranteed shoreline ring. No uniform distance band overrides it.
         const isLand = topography.landMask[idx] === 1;
-        const isCoast =
-          !isLand &&
-          (coastlineMetrics.coastalWater[idx] === 1 || coastlineMetrics.shelfMask[idx] === 1);
+        const isCoast = !isLand && (shelf.coastalWater[idx] === 1 || shelf.shelfMask[idx] === 1);
         if (isCoast) sourceCoastMask[idx] = 1;
         baseWaterClass[idx] = isLand
           ? WATER_CLASS_LAND
@@ -181,9 +179,9 @@ export default createStep(PlotCoastsStepContract, {
       spaceId: TILE_SPACE_ID,
       dims: { width, height },
       format: "u8",
-      values: coastlineMetrics.coastalLand,
+      values: shelf.coastalLand,
       meta: defineVizMeta("map.morphology.coasts.coastalLand", {
-        label: "Coastal Land (Coastline Metrics)",
+        label: "Coastal Land (Post-island Shelf)",
         group: GROUP_MAP_MORPHOLOGY,
         visibility: "debug",
       }),
@@ -193,9 +191,9 @@ export default createStep(PlotCoastsStepContract, {
       spaceId: TILE_SPACE_ID,
       dims: { width, height },
       format: "u8",
-      values: coastlineMetrics.coastalWater,
+      values: shelf.coastalWater,
       meta: defineVizMeta("map.morphology.coasts.coastalWater", {
-        label: "Coastal Water (Coastline Metrics)",
+        label: "Coastal Water (Post-island Shelf)",
         group: GROUP_MAP_MORPHOLOGY,
         visibility: "debug",
       }),
@@ -205,9 +203,9 @@ export default createStep(PlotCoastsStepContract, {
       spaceId: TILE_SPACE_ID,
       dims: { width, height },
       format: "u8",
-      values: coastlineMetrics.shelfMask,
+      values: shelf.shelfMask,
       meta: defineVizMeta("map.morphology.coasts.shelfMask", {
-        label: "Shelf Mask (Coastline Metrics)",
+        label: "Shelf Mask (Post-island Shelf)",
         group: GROUP_MAP_MORPHOLOGY,
         visibility: "debug",
       }),

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/index.ts
@@ -1,14 +1,12 @@
 import {
   MorphologyCoastRuggednessKnobSchema,
   MorphologySeaLevelKnobSchema,
-  MorphologyShelfWidthKnobSchema,
 } from "@mapgen/domain/morphology/config.js";
 import {
   CoastConfigSchema,
   HypsometryConfigSchema,
   LandmaskConfigSchema,
   ReliefConfigSchema,
-  ShelfMaskConfigSchema,
   SubstrateConfigSchema,
 } from "@mapgen/domain/morphology/ops";
 import { createStage, Type } from "@swooper/mapgen-core/authoring";
@@ -16,19 +14,19 @@ import { orderStandardStageSteps } from "../../contract-manifest.js";
 import { landmassPlates, ruggedCoasts } from "./steps/index.js";
 
 /**
- * Morphology-coasts knobs (seaLevel/coastRuggedness/shelfWidth).
+ * Morphology-coasts knobs (seaLevel/coastRuggedness).
  * Knobs apply after defaulted step config as deterministic transforms.
+ * The shelfWidth knob moved to the morphology-shelf stage with the shelf computation.
  */
 const knobsSchema = Type.Object(
   {
     seaLevel: Type.Optional(MorphologySeaLevelKnobSchema),
     coastRuggedness: Type.Optional(MorphologyCoastRuggednessKnobSchema),
-    shelfWidth: Type.Optional(MorphologyShelfWidthKnobSchema),
   },
   {
     additionalProperties: false,
     description:
-      "Morphology-coasts controls for sea level, coast ruggedness, and shelf width applied as deterministic transforms.",
+      "Morphology-coasts controls for sea level and coast ruggedness applied as deterministic transforms.",
   }
 );
 
@@ -39,12 +37,11 @@ const publicSchema = Type.Object(
     waterCoverage: Type.Optional(HypsometryConfigSchema),
     continents: Type.Optional(LandmaskConfigSchema),
     coastlineShape: Type.Optional(CoastConfigSchema),
-    shelf: Type.Optional(ShelfMaskConfigSchema),
   },
   {
     additionalProperties: false,
     description:
-      "Morphology coast and land/sea shaping controls for substrate, relief, water coverage, continents, coastline shape, and shelf width.",
+      "Morphology coast and land/sea shaping controls for substrate, relief, water coverage, continents, and coastline shape.",
   }
 );
 
@@ -70,7 +67,6 @@ export default createStage({
     },
     "rugged-coasts": {
       coastlines: defaultEnvelope({ coast: config.coastlineShape ?? {} }),
-      shelfMask: defaultEnvelope(config.shelf),
     },
   }),
 } as const);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.contract.ts
@@ -25,7 +25,6 @@ const RuggedCoastsStepContract = defineStep({
       contract: morphology.ops.computeDistanceToCoast,
       defaultStrategy: "default",
     },
-    shelfMask: { contract: morphology.ops.computeShelfMask, defaultStrategy: "default" },
   },
   schema: Type.Object({}),
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.ts
@@ -1,12 +1,6 @@
 import type { MapDimensions } from "@civ7/adapter";
-import type {
-  MorphologyCoastRuggednessKnob,
-  MorphologyShelfWidthKnob,
-} from "@mapgen/domain/morphology/config.js";
-import {
-  MORPHOLOGY_COAST_RUGGEDNESS_MULTIPLIER,
-  MORPHOLOGY_SHELF_WIDTH_MULTIPLIER,
-} from "@mapgen/domain/morphology/config.js";
+import type { MorphologyCoastRuggednessKnob } from "@mapgen/domain/morphology/config.js";
+import { MORPHOLOGY_COAST_RUGGEDNESS_MULTIPLIER } from "@mapgen/domain/morphology/config.js";
 import {
   computeSampleStep,
   defineVizMeta,
@@ -20,7 +14,6 @@ import RuggedCoastsStepContract from "./ruggedCoasts.contract.js";
 type ArtifactValidationIssue = Readonly<{ message: string }>;
 
 const GROUP_COASTLINES = "Morphology / Coastlines";
-const GROUP_SHELF = "Morphology / Shelf";
 const TILE_SPACE_ID = "tile.hexOddQ" as const;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -63,7 +56,6 @@ function validateCoastlineMetrics(
   const candidate = value as {
     coastalLand?: unknown;
     coastalWater?: unknown;
-    shelfMask?: unknown;
     distanceToCoast?: unknown;
   };
   validateTypedArray(
@@ -80,7 +72,6 @@ function validateCoastlineMetrics(
     Uint8Array,
     size
   );
-  validateTypedArray(errors, "coastlineMetrics.shelfMask", candidate.shelfMask, Uint8Array, size);
   validateTypedArray(
     errors,
     "coastlineMetrics.distanceToCoast",
@@ -91,6 +82,13 @@ function validateCoastlineMetrics(
   return errors;
 }
 
+/**
+ * Carves the coastline into the heightfield and publishes the CARVED (pre-island)
+ * coastline metrics. The continental shelf used to be computed here too, but it is
+ * now a separate post-features stage (morphology-shelf) so it sees final post-island
+ * geography; this step only owns carving + reconciliation + the carved metrics that
+ * mountains (stage morphology-features) consumes.
+ */
 export default createStep(RuggedCoastsStepContract, {
   artifacts: implementArtifacts(RuggedCoastsStepContract.artifacts!.provides!, {
     coastlineMetrics: {
@@ -98,12 +96,10 @@ export default createStep(RuggedCoastsStepContract, {
     },
   }),
   normalize: (config, ctx) => {
-    const { coastRuggedness, shelfWidth } = ctx.knobs as Readonly<{
+    const { coastRuggedness } = ctx.knobs as Readonly<{
       coastRuggedness?: MorphologyCoastRuggednessKnob;
-      shelfWidth?: MorphologyShelfWidthKnob;
     }>;
     const multiplier = MORPHOLOGY_COAST_RUGGEDNESS_MULTIPLIER[coastRuggedness ?? "normal"] ?? 1.0;
-    const shelfMultiplier = MORPHOLOGY_SHELF_WIDTH_MULTIPLIER[shelfWidth ?? "normal"] ?? 1.0;
 
     const coastlinesSelection =
       config.coastlines.strategy === "default"
@@ -133,31 +129,12 @@ export default createStep(RuggedCoastsStepContract, {
           }
         : config.coastlines;
 
-    const shelfMaskSelection =
-      config.shelfMask.strategy === "default"
-        ? {
-            ...config.shelfMask,
-            config: {
-              ...config.shelfMask.config,
-              // The shelfWidth knob drives the cap-free break-depth scale: narrow (<1) =>
-              // shallower break => narrower shelf; wide (>1) => deeper => wider. No caps.
-              breakDepthScale: clampFinite(
-                config.shelfMask.config.breakDepthScale * shelfMultiplier,
-                0
-              ),
-            },
-          }
-        : config.shelfMask;
-
-    return { ...config, coastlines: coastlinesSelection, shelfMask: shelfMaskSelection };
+    return { ...config, coastlines: coastlinesSelection };
   },
   run: (context, config, ops, deps) => {
     const { width, height } = context.dimensions;
     const beltDrivers = deps.artifacts.beltDrivers.read(context);
-    const topography = deps.artifacts.topography.read(context) as {
-      seaLevel?: number;
-      bathymetry?: Int16Array;
-    };
+    const topography = deps.artifacts.topography.read(context);
     const heightfield = context.buffers.heightfield;
     const rngSeed = deriveStepSeed(context.env.seed, "morphology:computeCoastlineMetrics");
 
@@ -176,11 +153,8 @@ export default createStep(RuggedCoastsStepContract, {
     const updatedLandMask = result.landMask;
     const coastMask = result.coastMask;
 
-    const seaLevelValue = typeof topography.seaLevel === "number" ? topography.seaLevel : 0;
+    const seaLevelValue = topography.seaLevel;
     const bathymetry = topography.bathymetry;
-    if (!(bathymetry instanceof Int16Array) || bathymetry.length !== heightfield.elevation.length) {
-      throw new Error("Morphology topography bathymetry buffer missing or shape-mismatched.");
-    }
 
     // Reconcile land/water + elevation + bathymetry with the carved coastline. The op is
     // pure (returns fresh arrays); the step owns the only legitimate side effect: copying the
@@ -236,6 +210,8 @@ export default createStep(RuggedCoastsStepContract, {
       };
     });
 
+    // Carved distance-to-coast (pre-island): windows the shelf-break sample is now the
+    // shelf stage's concern; here it is the snapshot mountains(morphology-features) consume.
     const coastal = new Uint8Array(Math.max(0, (width | 0) * (height | 0)));
     for (let i = 0; i < coastal.length; i++) {
       coastal[i] = result.coastalLand[i] === 1 || result.coastalWater[i] === 1 ? 1 : 0;
@@ -244,114 +220,6 @@ export default createStep(RuggedCoastsStepContract, {
       { width, height, coastal },
       config.distanceToCoast
     );
-
-    const shelfResult = ops.shelfMask(
-      {
-        width,
-        height,
-        landMask: heightfield.landMask,
-        bathymetry,
-        distanceToCoast,
-        boundaryCloseness: beltDrivers.boundaryCloseness,
-        boundaryType: beltDrivers.boundaryType,
-      },
-      config.shelfMask
-    );
-    const {
-      shelfMask,
-      activeMarginMask,
-      shelfBreakDepthByTile,
-      nearshoreCandidateMask,
-      depthGateMask,
-      shallowCutoff,
-    } = shelfResult as unknown as {
-      shelfMask: unknown;
-      activeMarginMask: unknown;
-      shelfBreakDepthByTile: unknown;
-      nearshoreCandidateMask: unknown;
-      depthGateMask: unknown;
-      shallowCutoff: unknown;
-    };
-    if (!(shelfMask instanceof Uint8Array) || shelfMask.length !== coastal.length) {
-      throw new Error("Computed shelfMask missing or shape-mismatched.");
-    }
-    if (!(activeMarginMask instanceof Uint8Array) || activeMarginMask.length !== coastal.length) {
-      throw new Error("Computed activeMarginMask missing or shape-mismatched.");
-    }
-    if (
-      !(shelfBreakDepthByTile instanceof Int16Array) ||
-      shelfBreakDepthByTile.length !== coastal.length
-    ) {
-      throw new Error("Computed shelfBreakDepthByTile missing or shape-mismatched.");
-    }
-    if (
-      !(nearshoreCandidateMask instanceof Uint8Array) ||
-      nearshoreCandidateMask.length !== coastal.length
-    ) {
-      throw new Error("Computed nearshoreCandidateMask missing or shape-mismatched.");
-    }
-    if (!(depthGateMask instanceof Uint8Array) || depthGateMask.length !== coastal.length) {
-      throw new Error("Computed depthGateMask missing or shape-mismatched.");
-    }
-    if (!Number.isFinite(shallowCutoff) || (shallowCutoff as number) > 0) {
-      throw new Error("Computed shallowCutoff missing or invalid (expected finite number <= 0).");
-    }
-
-    context.trace.event(() => {
-      const size = Math.max(0, (width | 0) * (height | 0));
-      let activeMarginTiles = 0;
-      let nearshoreCandidates = 0;
-      let depthGatedTiles = 0;
-      let shelfTiles = 0;
-      let shelfTilesBeyondShore = 0;
-      let activeShelfTiles = 0;
-      let passiveShelfTiles = 0;
-      let deepestShelfBreak = 0;
-
-      for (let i = 0; i < size; i++) {
-        if ((activeMarginMask[i] | 0) === 1) activeMarginTiles += 1;
-        if ((nearshoreCandidateMask[i] | 0) === 1) nearshoreCandidates += 1;
-        if ((depthGateMask[i] | 0) === 1) depthGatedTiles += 1;
-
-        const breakDepth = shelfBreakDepthByTile[i] | 0;
-        if (breakDepth < deepestShelfBreak) deepestShelfBreak = breakDepth;
-
-        if ((shelfMask[i] | 0) !== 1) continue;
-        shelfTiles += 1;
-        if ((activeMarginMask[i] | 0) === 1) activeShelfTiles += 1;
-        else passiveShelfTiles += 1;
-
-        const dist = distanceToCoast[i] | 0;
-        if ((result.coastalWater[i] | 0) === 0 && dist >= 2) shelfTilesBeyondShore += 1;
-      }
-
-      const selection = config.shelfMask;
-      const shelfConfig = selection.strategy === "default" ? (selection.config as any) : undefined;
-      return {
-        kind: "morphology.shelf.summary",
-        shallowCutoff: shallowCutoff as number,
-        deepestShelfBreak,
-        nearshoreCandidates,
-        depthGatedTiles,
-        shelfTiles,
-        shelfTilesBeyondShore,
-        activeMarginTiles,
-        activeShelfTiles,
-        passiveShelfTiles,
-        strategy: selection.strategy,
-        config: shelfConfig
-          ? {
-              shallowQuantile: shelfConfig.shallowQuantile,
-              breakDepthSampleRadius: shelfConfig.breakDepthSampleRadius,
-              activeClosenessThreshold: shelfConfig.activeClosenessThreshold,
-              activeBreakDepthFactor: shelfConfig.activeBreakDepthFactor,
-              passiveBreakDepthFactor: shelfConfig.passiveBreakDepthFactor,
-              absoluteMaxShelfDepth: shelfConfig.absoluteMaxShelfDepth,
-              breakDepthScale: shelfConfig.breakDepthScale,
-            }
-          : undefined,
-      };
-    });
 
     context.viz?.dumpGrid(context.trace, {
       dataTypeKey: "morphology.coastlineMetrics.coastalLand",
@@ -376,25 +244,6 @@ export default createStep(RuggedCoastsStepContract, {
       }),
     });
     context.viz?.dumpGrid(context.trace, {
-      dataTypeKey: "morphology.coastlineMetrics.shelfMask",
-      spaceId: TILE_SPACE_ID,
-      dims: { width, height },
-      format: "u8",
-      values: shelfMask,
-      meta: defineVizMeta("morphology.coastlineMetrics.shelfMask", {
-        label: "Shelf Mask",
-        group: GROUP_SHELF,
-        description:
-          "Deterministic shallow-shelf water mask used to project TERRAIN_COAST beyond the guaranteed shoreline ring.",
-        role: "membership",
-        palette: "categorical",
-        categories: [
-          { value: 0, label: "Deep Water", color: [37, 99, 235, 220] },
-          { value: 1, label: "Shelf Water", color: [56, 189, 248, 230] },
-        ],
-      }),
-    });
-    context.viz?.dumpGrid(context.trace, {
       dataTypeKey: "morphology.coastlineMetrics.distanceToCoast",
       spaceId: TILE_SPACE_ID,
       dims: { width, height },
@@ -402,93 +251,14 @@ export default createStep(RuggedCoastsStepContract, {
       values: distanceToCoast,
       meta: defineVizMeta("morphology.coastlineMetrics.distanceToCoast", {
         label: "Distance To Coast (Tiles)",
-        group: GROUP_SHELF,
+        group: GROUP_COASTLINES,
         visibility: "debug",
-      }),
-    });
-
-    context.viz?.dumpGrid(context.trace, {
-      dataTypeKey: "morphology.shelf.activeMarginMask",
-      spaceId: TILE_SPACE_ID,
-      dims: { width, height },
-      format: "u8",
-      values: activeMarginMask,
-      meta: defineVizMeta("morphology.shelf.activeMarginMask", {
-        label: "Active Margin Mask",
-        group: GROUP_SHELF,
-        description:
-          "Tiles treated as active margins (convergent/transform with high boundary closeness).",
-        role: "membership",
-        palette: "categorical",
-        categories: [
-          { value: 0, label: "Passive/Other", color: [37, 99, 235, 80] },
-          { value: 1, label: "Active Margin", color: [220, 38, 38, 230] },
-        ],
-      }),
-    });
-
-    context.viz?.dumpGrid(context.trace, {
-      dataTypeKey: "morphology.shelf.breakDepth",
-      spaceId: TILE_SPACE_ID,
-      dims: { width, height },
-      format: "i16",
-      values: shelfBreakDepthByTile,
-      meta: defineVizMeta("morphology.shelf.breakDepth", {
-        label: "Shelf Break Depth (m)",
-        group: GROUP_SHELF,
-        description:
-          "Per-tile, margin-modulated shelf-break depth (metres, <=0). Active margins shallower (narrower shelf); passive deeper (wider). Water shallower than this and connected to shore becomes shelf.",
-        role: "scalar",
-        palette: "continuous",
-      }),
-    });
-
-    context.viz?.dumpGrid(context.trace, {
-      dataTypeKey: "morphology.shelf.nearshoreCandidateMask",
-      spaceId: TILE_SPACE_ID,
-      dims: { width, height },
-      format: "u8",
-      values: nearshoreCandidateMask,
-      meta: defineVizMeta("morphology.shelf.nearshoreCandidateMask", {
-        label: "Nearshore Candidates",
-        group: GROUP_SHELF,
-        visibility: "debug",
-        description:
-          "Water tiles within breakDepthSampleRadius, used to sample bathymetry for the shelf-break cutoff.",
-        role: "membership",
-        palette: "categorical",
-        categories: [
-          { value: 0, label: "Not Sampled", color: [0, 0, 0, 0] },
-          { value: 1, label: "Sampled", color: [14, 165, 233, 230] },
-        ],
-      }),
-    });
-
-    context.viz?.dumpGrid(context.trace, {
-      dataTypeKey: "morphology.shelf.depthGateMask",
-      spaceId: TILE_SPACE_ID,
-      dims: { width, height },
-      format: "u8",
-      values: depthGateMask,
-      meta: defineVizMeta("morphology.shelf.depthGateMask", {
-        label: "Depth Gate (Shallow Enough)",
-        group: GROUP_SHELF,
-        visibility: "debug",
-        description:
-          "Water tiles where bathymetry >= shallowCutoff (shallower than the selected cutoff).",
-        role: "membership",
-        palette: "categorical",
-        categories: [
-          { value: 0, label: "Too Deep", color: [37, 99, 235, 220] },
-          { value: 1, label: "Shallow Enough", color: [56, 189, 248, 230] },
-        ],
       }),
     });
 
     deps.artifacts.coastlineMetrics.publish(context, {
       coastalLand: result.coastalLand,
       coastalWater: result.coastalWater,
-      shelfMask,
       distanceToCoast,
     });
   },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-shelf/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-shelf/index.ts
@@ -1,0 +1,50 @@
+import { MorphologyShelfWidthKnobSchema } from "@mapgen/domain/morphology/config.js";
+import { ShelfMaskConfigSchema } from "@mapgen/domain/morphology/ops";
+import { createStage, Type } from "@swooper/mapgen-core/authoring";
+import { orderStandardStageSteps } from "../../contract-manifest.js";
+import { computeShelf } from "./steps/index.js";
+
+/**
+ * Morphology-shelf computes the continental shelf AFTER islands/mountains, so the
+ * shelf and the post-island coastline reflect final land. The shelfWidth knob lives
+ * here (it drives the cap-free break-depth scale); coast ruggedness stays in
+ * morphology-coasts with the carving step.
+ */
+const knobsSchema = Type.Object(
+  {
+    shelfWidth: Type.Optional(MorphologyShelfWidthKnobSchema),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Morphology-shelf control for shelf width, applied as a deterministic break-depth transform.",
+  }
+);
+
+const publicSchema = Type.Object(
+  {
+    shelf: Type.Optional(ShelfMaskConfigSchema),
+  },
+  {
+    additionalProperties: false,
+    description: "Continental-shelf shaping controls (margin-aware, depth-gated, cap-free).",
+  }
+);
+
+function defaultEnvelope(config: unknown): { strategy: "default"; config: unknown } {
+  return { strategy: "default", config: config ?? {} };
+}
+
+export default createStage({
+  id: "morphology-shelf",
+  knobsSchema,
+  public: publicSchema,
+  steps: orderStandardStageSteps("morphology-shelf", {
+    "compute-shelf": computeShelf,
+  }),
+  compile: ({ config }: { config: Record<string, unknown> }) => ({
+    "compute-shelf": {
+      shelfMask: defaultEnvelope(config.shelf),
+    },
+  }),
+} as const);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-shelf/steps/computeShelf.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-shelf/steps/computeShelf.contract.ts
@@ -1,0 +1,36 @@
+import morphology from "@mapgen/domain/morphology";
+import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
+
+import { morphologyArtifacts } from "../../morphology/artifacts.js";
+
+/**
+ * Computes the continental shelf from POST-island morphology truth.
+ *
+ * Runs after morphology-features (islands + mountains), so the shelf and the
+ * post-island coastline reflect final land — island peaks get real shelves, and
+ * downstream ocean-geometry / reef / coast consumers see one coherent vintage.
+ */
+const ComputeShelfStepContract = defineStep({
+  id: "compute-shelf",
+  phase: "morphology",
+  requires: [],
+  provides: [],
+  artifacts: {
+    requires: [morphologyArtifacts.topography, morphologyArtifacts.beltDrivers],
+    provides: [morphologyArtifacts.shelf],
+  },
+  ops: {
+    coastalAdjacency: {
+      contract: morphology.ops.computeCoastalAdjacency,
+      defaultStrategy: "default",
+    },
+    distanceToCoast: {
+      contract: morphology.ops.computeDistanceToCoast,
+      defaultStrategy: "default",
+    },
+    shelfMask: { contract: morphology.ops.computeShelfMask, defaultStrategy: "default" },
+  },
+  schema: Type.Object({}),
+});
+
+export default ComputeShelfStepContract;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-shelf/steps/computeShelf.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-shelf/steps/computeShelf.ts
@@ -1,0 +1,349 @@
+import type { MapDimensions } from "@civ7/adapter";
+import type { MorphologyShelfWidthKnob } from "@mapgen/domain/morphology/config.js";
+import { MORPHOLOGY_SHELF_WIDTH_MULTIPLIER } from "@mapgen/domain/morphology/config.js";
+import { defineVizMeta } from "@swooper/mapgen-core";
+import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
+import { clampFinite } from "@swooper/mapgen-core/lib/math";
+import ComputeShelfStepContract from "./computeShelf.contract.js";
+
+type ArtifactValidationIssue = Readonly<{ message: string }>;
+
+const GROUP_SHELF = "Morphology / Shelf";
+const TILE_SPACE_ID = "tile.hexOddQ" as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function expectedSize(dimensions: MapDimensions): number {
+  return Math.max(0, (dimensions.width | 0) * (dimensions.height | 0));
+}
+
+function validateTypedArray(
+  errors: ArtifactValidationIssue[],
+  label: string,
+  value: unknown,
+  ctor: { new (...args: any[]): { length: number } },
+  expectedLength: number
+): void {
+  if (!(value instanceof ctor)) {
+    errors.push({ message: `Expected ${label} to be ${ctor.name}.` });
+    return;
+  }
+  if (value.length !== expectedLength) {
+    errors.push({
+      message: `Expected ${label} length ${expectedLength} (received ${value.length}).`,
+    });
+  }
+}
+
+function validateShelf(value: unknown, dimensions: MapDimensions): ArtifactValidationIssue[] {
+  const errors: ArtifactValidationIssue[] = [];
+  if (!isRecord(value)) {
+    errors.push({ message: "Missing shelf artifact." });
+    return errors;
+  }
+  const size = expectedSize(dimensions);
+  const c = value as Record<string, unknown>;
+  validateTypedArray(errors, "shelf.shelfMask", c.shelfMask, Uint8Array, size);
+  validateTypedArray(errors, "shelf.coastalLand", c.coastalLand, Uint8Array, size);
+  validateTypedArray(errors, "shelf.coastalWater", c.coastalWater, Uint8Array, size);
+  validateTypedArray(errors, "shelf.distanceToCoast", c.distanceToCoast, Uint16Array, size);
+  validateTypedArray(errors, "shelf.activeMarginMask", c.activeMarginMask, Uint8Array, size);
+  validateTypedArray(errors, "shelf.depthGateMask", c.depthGateMask, Uint8Array, size);
+  validateTypedArray(
+    errors,
+    "shelf.nearshoreCandidateMask",
+    c.nearshoreCandidateMask,
+    Uint8Array,
+    size
+  );
+  validateTypedArray(
+    errors,
+    "shelf.shelfBreakDepthByTile",
+    c.shelfBreakDepthByTile,
+    Int16Array,
+    size
+  );
+  if (!Number.isFinite(c.shallowCutoff) || (c.shallowCutoff as number) > 0) {
+    errors.push({ message: "shelf.shallowCutoff must be a finite number <= 0." });
+  }
+  return errors;
+}
+
+/**
+ * Post-features continental-shelf stage. Reads the FINAL post-island land mask +
+ * bathymetry, recomputes the coastline (so island peaks count), then runs the
+ * cap-free margin-aware shelf classifier and publishes the shelf truth + post-island
+ * coastline metrics + diagnostics. The carving step (morphology-coasts) owns only the
+ * carved pre-island metrics that mountains consumes.
+ */
+export default createStep(ComputeShelfStepContract, {
+  artifacts: implementArtifacts(ComputeShelfStepContract.artifacts!.provides!, {
+    shelf: {
+      validate: (value, context) => validateShelf(value, context.dimensions),
+    },
+  }),
+  normalize: (config, ctx) => {
+    const { shelfWidth } = ctx.knobs as Readonly<{ shelfWidth?: MorphologyShelfWidthKnob }>;
+    const shelfMultiplier = MORPHOLOGY_SHELF_WIDTH_MULTIPLIER[shelfWidth ?? "normal"] ?? 1.0;
+
+    const shelfMaskSelection =
+      config.shelfMask.strategy === "default"
+        ? {
+            ...config.shelfMask,
+            config: {
+              ...config.shelfMask.config,
+              // The shelfWidth knob drives the cap-free break-depth scale: narrow (<1) =>
+              // shallower break => narrower shelf; wide (>1) => deeper => wider. No caps.
+              breakDepthScale: clampFinite(
+                config.shelfMask.config.breakDepthScale * shelfMultiplier,
+                0
+              ),
+            },
+          }
+        : config.shelfMask;
+
+    return { ...config, shelfMask: shelfMaskSelection };
+  },
+  run: (context, config, ops, deps) => {
+    const { width, height } = context.dimensions;
+    const size = Math.max(0, (width | 0) * (height | 0));
+    const beltDrivers = deps.artifacts.beltDrivers.read(context);
+    const topography = deps.artifacts.topography.read(context);
+
+    // POST-island truth: topography.landMask/bathymetry are publish-once handles that
+    // morphology-features mutated in place (islands inject land + set bathymetry 0).
+    const landMask = topography.landMask;
+    const bathymetry = topography.bathymetry;
+
+    // 1) Post-island shoreline adjacency (island peaks now count).
+    const { coastalLand, coastalWater } = ops.coastalAdjacency(
+      { width, height, landMask },
+      config.coastalAdjacency
+    );
+
+    // 2) Post-island distance to coast (windows the shelf-break sample).
+    const coastal = new Uint8Array(size);
+    for (let i = 0; i < size; i++) {
+      coastal[i] = coastalLand[i] === 1 || coastalWater[i] === 1 ? 1 : 0;
+    }
+    const { distanceToCoast } = ops.distanceToCoast(
+      { width, height, coastal },
+      config.distanceToCoast
+    );
+
+    // 3) Cap-free margin-aware shelf over post-island geography.
+    const shelfResult = ops.shelfMask(
+      {
+        width,
+        height,
+        landMask,
+        bathymetry,
+        distanceToCoast,
+        boundaryCloseness: beltDrivers.boundaryCloseness,
+        boundaryType: beltDrivers.boundaryType,
+      },
+      config.shelfMask
+    );
+    const {
+      shelfMask,
+      activeMarginMask,
+      shelfBreakDepthByTile,
+      nearshoreCandidateMask,
+      depthGateMask,
+      shallowCutoff,
+    } = shelfResult as unknown as {
+      shelfMask: Uint8Array;
+      activeMarginMask: Uint8Array;
+      shelfBreakDepthByTile: Int16Array;
+      nearshoreCandidateMask: Uint8Array;
+      depthGateMask: Uint8Array;
+      shallowCutoff: number;
+    };
+
+    context.trace.event(() => {
+      let activeMarginTiles = 0;
+      let nearshoreCandidates = 0;
+      let depthGatedTiles = 0;
+      let shelfTiles = 0;
+      let shelfTilesBeyondShore = 0;
+      let activeShelfTiles = 0;
+      let passiveShelfTiles = 0;
+      let deepestShelfBreak = 0;
+
+      for (let i = 0; i < size; i++) {
+        if ((activeMarginMask[i] | 0) === 1) activeMarginTiles += 1;
+        if ((nearshoreCandidateMask[i] | 0) === 1) nearshoreCandidates += 1;
+        if ((depthGateMask[i] | 0) === 1) depthGatedTiles += 1;
+
+        const breakDepth = shelfBreakDepthByTile[i] | 0;
+        if (breakDepth < deepestShelfBreak) deepestShelfBreak = breakDepth;
+
+        if ((shelfMask[i] | 0) !== 1) continue;
+        shelfTiles += 1;
+        if ((activeMarginMask[i] | 0) === 1) activeShelfTiles += 1;
+        else passiveShelfTiles += 1;
+
+        const dist = distanceToCoast[i] | 0;
+        if ((coastalWater[i] | 0) === 0 && dist >= 2) shelfTilesBeyondShore += 1;
+      }
+
+      const selection = config.shelfMask;
+      const shelfConfig = selection.strategy === "default" ? (selection.config as any) : undefined;
+      return {
+        kind: "morphology.shelf.summary",
+        shallowCutoff,
+        deepestShelfBreak,
+        nearshoreCandidates,
+        depthGatedTiles,
+        shelfTiles,
+        shelfTilesBeyondShore,
+        activeMarginTiles,
+        activeShelfTiles,
+        passiveShelfTiles,
+        strategy: selection.strategy,
+        config: shelfConfig
+          ? {
+              shallowQuantile: shelfConfig.shallowQuantile,
+              breakDepthSampleRadius: shelfConfig.breakDepthSampleRadius,
+              activeClosenessThreshold: shelfConfig.activeClosenessThreshold,
+              activeBreakDepthFactor: shelfConfig.activeBreakDepthFactor,
+              passiveBreakDepthFactor: shelfConfig.passiveBreakDepthFactor,
+              absoluteMaxShelfDepth: shelfConfig.absoluteMaxShelfDepth,
+              breakDepthScale: shelfConfig.breakDepthScale,
+            }
+          : undefined,
+      };
+    });
+
+    context.viz?.dumpGrid(context.trace, {
+      dataTypeKey: "morphology.shelf.shelfMask",
+      spaceId: TILE_SPACE_ID,
+      dims: { width, height },
+      format: "u8",
+      values: shelfMask,
+      meta: defineVizMeta("morphology.shelf.shelfMask", {
+        label: "Shelf Mask",
+        group: GROUP_SHELF,
+        description:
+          "Post-island continental-shelf water mask used to project TERRAIN_COAST beyond the shoreline ring.",
+        role: "membership",
+        palette: "categorical",
+        categories: [
+          { value: 0, label: "Deep Water", color: [37, 99, 235, 220] },
+          { value: 1, label: "Shelf Water", color: [56, 189, 248, 230] },
+        ],
+      }),
+    });
+    context.viz?.dumpGrid(context.trace, {
+      dataTypeKey: "morphology.shelf.coastalWater",
+      spaceId: TILE_SPACE_ID,
+      dims: { width, height },
+      format: "u8",
+      values: coastalWater,
+      meta: defineVizMeta("morphology.shelf.coastalWater", {
+        label: "Coastal Water (Post-island)",
+        group: GROUP_SHELF,
+        visibility: "debug",
+      }),
+    });
+    context.viz?.dumpGrid(context.trace, {
+      dataTypeKey: "morphology.shelf.distanceToCoast",
+      spaceId: TILE_SPACE_ID,
+      dims: { width, height },
+      format: "u16",
+      values: distanceToCoast,
+      meta: defineVizMeta("morphology.shelf.distanceToCoast", {
+        label: "Distance To Coast (Post-island)",
+        group: GROUP_SHELF,
+        visibility: "debug",
+      }),
+    });
+    context.viz?.dumpGrid(context.trace, {
+      dataTypeKey: "morphology.shelf.activeMarginMask",
+      spaceId: TILE_SPACE_ID,
+      dims: { width, height },
+      format: "u8",
+      values: activeMarginMask,
+      meta: defineVizMeta("morphology.shelf.activeMarginMask", {
+        label: "Active Margin Mask",
+        group: GROUP_SHELF,
+        description:
+          "Tiles treated as active margins (convergent/transform with high boundary closeness).",
+        role: "membership",
+        palette: "categorical",
+        categories: [
+          { value: 0, label: "Passive/Other", color: [37, 99, 235, 80] },
+          { value: 1, label: "Active Margin", color: [220, 38, 38, 230] },
+        ],
+      }),
+    });
+    context.viz?.dumpGrid(context.trace, {
+      dataTypeKey: "morphology.shelf.breakDepth",
+      spaceId: TILE_SPACE_ID,
+      dims: { width, height },
+      format: "i16",
+      values: shelfBreakDepthByTile,
+      meta: defineVizMeta("morphology.shelf.breakDepth", {
+        label: "Shelf Break Depth",
+        group: GROUP_SHELF,
+        description:
+          "Per-tile, margin-modulated shelf-break depth (engine elevation units, <=0). Active margins shallower (narrower shelf); passive deeper (wider).",
+        role: "scalar",
+        palette: "continuous",
+      }),
+    });
+    context.viz?.dumpGrid(context.trace, {
+      dataTypeKey: "morphology.shelf.nearshoreCandidateMask",
+      spaceId: TILE_SPACE_ID,
+      dims: { width, height },
+      format: "u8",
+      values: nearshoreCandidateMask,
+      meta: defineVizMeta("morphology.shelf.nearshoreCandidateMask", {
+        label: "Nearshore Candidates",
+        group: GROUP_SHELF,
+        visibility: "debug",
+        description:
+          "Water tiles within breakDepthSampleRadius, used to sample bathymetry for the shelf-break cutoff.",
+        role: "membership",
+        palette: "categorical",
+        categories: [
+          { value: 0, label: "Not Sampled", color: [0, 0, 0, 0] },
+          { value: 1, label: "Sampled", color: [14, 165, 233, 230] },
+        ],
+      }),
+    });
+    context.viz?.dumpGrid(context.trace, {
+      dataTypeKey: "morphology.shelf.depthGateMask",
+      spaceId: TILE_SPACE_ID,
+      dims: { width, height },
+      format: "u8",
+      values: depthGateMask,
+      meta: defineVizMeta("morphology.shelf.depthGateMask", {
+        label: "Depth Gate (Shallow Enough)",
+        group: GROUP_SHELF,
+        visibility: "debug",
+        description: "Water tiles where bathymetry >= the per-tile shelf-break depth.",
+        role: "membership",
+        palette: "categorical",
+        categories: [
+          { value: 0, label: "Too Deep", color: [37, 99, 235, 220] },
+          { value: 1, label: "Shallow Enough", color: [56, 189, 248, 230] },
+        ],
+      }),
+    });
+
+    deps.artifacts.shelf.publish(context, {
+      shelfMask,
+      coastalLand,
+      coastalWater,
+      distanceToCoast,
+      activeMarginMask,
+      depthGateMask,
+      nearshoreCandidateMask,
+      shelfBreakDepthByTile,
+      shallowCutoff,
+    });
+  },
+});

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-shelf/steps/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-shelf/steps/index.ts
@@ -1,0 +1,1 @@
+export { default as computeShelf } from "./computeShelf.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts.ts
@@ -58,10 +58,6 @@ const MorphologyCoastlineMetricsArtifactSchema = Type.Object(
     coastalWater: TypedArraySchemas.u8({
       description: "Mask (1/0): water tiles adjacent to land.",
     }),
-    shelfMask: TypedArraySchemas.u8({
-      description:
-        "Mask (1/0): shallow shelf water eligible for TERRAIN_COAST projection (deterministic, derived from Morphology truth).",
-    }),
     distanceToCoast: TypedArraySchemas.u16({
       description:
         "Minimum tile-graph distance to any coastline tile (0=coast), using wrapX=true and wrapY=false.",
@@ -69,7 +65,51 @@ const MorphologyCoastlineMetricsArtifactSchema = Type.Object(
   },
   {
     additionalProperties: false,
-    description: "Derived coastline metrics snapshot (Phase 2 schema; immutable at F2).",
+    description:
+      "CARVED coastline metrics snapshot (stage morphology-coasts; pre-island). The shelf and the post-island coastline live in artifact:morphology.shelf.",
+  }
+);
+
+const MorphologyShelfArtifactSchema = Type.Object(
+  {
+    shelfMask: TypedArraySchemas.u8({
+      description:
+        "Mask (1/0): continental-shelf water (margin-aware, depth-gated, shore-connected) eligible for TERRAIN_COAST projection. Derived from POST-island morphology truth so island peaks get shelves.",
+    }),
+    coastalLand: TypedArraySchemas.u8({
+      description: "Mask (1/0): POST-island land tiles adjacent to water.",
+    }),
+    coastalWater: TypedArraySchemas.u8({
+      description: "Mask (1/0): POST-island water tiles adjacent to land.",
+    }),
+    distanceToCoast: TypedArraySchemas.u16({
+      description: "POST-island minimum hex distance to the nearest coastline tile (0=coast).",
+    }),
+    activeMarginMask: TypedArraySchemas.u8({
+      description:
+        "Mask (1/0): water tiles treated as active margin (convergent/transform, high closeness) => shallower break.",
+    }),
+    depthGateMask: TypedArraySchemas.u8({
+      description:
+        "Mask (1/0): water tiles passing the per-tile depth gate (bathymetry >= break depth).",
+    }),
+    nearshoreCandidateMask: TypedArraySchemas.u8({
+      description:
+        "Mask (1/0): water tiles within breakDepthSampleRadius used to sample the break depth.",
+    }),
+    shelfBreakDepthByTile: TypedArraySchemas.i16({
+      description:
+        "Per-tile shelf-break depth (engine elevation units, <=0) after margin modulation; deeper => wider local shelf.",
+    }),
+    shallowCutoff: Type.Number({
+      description:
+        "Base shelf-break depth (engine elevation units, <=0): nearshore quantile before margin modulation.",
+    }),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Continental-shelf truth + post-island coastline metrics (stage morphology-shelf, after islands/mountains).",
   }
 );
 
@@ -319,6 +359,11 @@ export const morphologyArtifacts = {
     name: "coastlineMetrics",
     id: "artifact:morphology.coastlineMetrics",
     schema: MorphologyCoastlineMetricsArtifactSchema,
+  }),
+  shelf: defineArtifact({
+    name: "shelf",
+    id: "artifact:morphology.shelf",
+    schema: MorphologyShelfArtifactSchema,
   }),
   landmasses: defineArtifact({
     name: "landmasses",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/contract.ts
@@ -27,7 +27,7 @@ const AssignStartsStepContract = defineStep({
       morphologyArtifacts.landmasses,
       morphologyArtifacts.mountains,
       morphologyArtifacts.volcanoes,
-      morphologyArtifacts.coastlineMetrics,
+      morphologyArtifacts.shelf,
       hydrologyHydrographyArtifacts.hydrography,
       hydrologyHydrographyArtifacts.lakePlan,
       ecologyArtifacts.biomeClassification,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/index.ts
@@ -24,7 +24,7 @@ export default createStep(AssignStartsStepContract, {
     const landmasses = deps.artifacts.landmasses.read(context);
     const mountains = deps.artifacts.mountains.read(context);
     const volcanoes = deps.artifacts.volcanoes.read(context);
-    const coastlineMetrics = deps.artifacts.coastlineMetrics.read(context);
+    const shelf = deps.artifacts.shelf.read(context);
     const hydrography = deps.artifacts.hydrography.read(context);
     const lakePlan = deps.artifacts.lakePlan.read(context);
     const biomeClassification = deps.artifacts.biomeClassification.read(context);
@@ -49,9 +49,9 @@ export default createStep(AssignStartsStepContract, {
         slotByTile,
         landmassIdByTile: landmasses.landmassIdByTile as Int32Array,
         landmassTileCounts: landmasses.landmasses.map((landmass) => landmass.tileCount),
-        coastalLand: coastlineMetrics.coastalLand as Uint8Array,
-        distanceToCoast: coastlineMetrics.distanceToCoast as Uint16Array,
-        shelfMask: coastlineMetrics.shelfMask as Uint8Array,
+        coastalLand: shelf.coastalLand as Uint8Array,
+        distanceToCoast: shelf.distanceToCoast as Uint16Array,
+        shelfMask: shelf.shelfMask as Uint8Array,
         elevation: topography.elevation as Int16Array,
         fertility: pedology.fertility as Float32Array,
         effectiveMoisture: biomeClassification.effectiveMoisture as Float32Array,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/contract.ts
@@ -30,7 +30,7 @@ const PlanResourcesStepContract = defineStep({
   artifacts: {
     requires: [
       morphologyArtifacts.topography,
-      morphologyArtifacts.coastlineMetrics,
+      morphologyArtifacts.shelf,
       morphologyArtifacts.landmasses,
       morphologyArtifacts.mountains,
       morphologyArtifacts.beltDrivers,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/index.ts
@@ -47,7 +47,7 @@ export default createStep(PlanResourcesStepContract, {
   run: (context, config, ops, deps) => {
     const { width, height } = context.dimensions;
     const topography = deps.artifacts.topography.read(context);
-    const coastlineMetrics = deps.artifacts.coastlineMetrics.read(context);
+    const shelf = deps.artifacts.shelf.read(context);
     const landmasses = deps.artifacts.landmasses.read(context);
     const mountains = deps.artifacts.mountains.read(context);
     const beltDrivers = deps.artifacts.beltDrivers.read(context);
@@ -68,8 +68,8 @@ export default createStep(PlanResourcesStepContract, {
         height,
         landMask: topography.landMask,
         lakeMask: lakePlan.lakeMask,
-        coastalWater: coastlineMetrics.coastalWater,
-        shelfWater: coastlineMetrics.shelfMask,
+        coastalWater: shelf.coastalWater,
+        shelfWater: shelf.shelfMask,
         riverClass: hydrography.riverClass,
         surfaceTemperature: biomeClassification.surfaceTemperature,
         aridityIndex: biomeClassification.aridityIndex,

--- a/mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts
+++ b/mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts
@@ -34,11 +34,11 @@ const MORPHOLOGY_PUBLIC_KEYS: Record<string, readonly string[]> = {
     "waterCoverage",
     "continents",
     "coastlineShape",
-    "shelf",
   ],
   "morphology-routing": ["knobs"],
   "morphology-erosion": ["knobs", "geomorphicCycle"],
   "morphology-features": ["knobs", "islandChains", "mountainRanges", "volcanoes"],
+  "morphology-shelf": ["knobs", "shelf"],
 };
 
 const MORPHOLOGY_INTERNAL_STAGE_KEYS = [

--- a/mods/mod-swooper-maps/test/config/shipped-map-identity.test.ts
+++ b/mods/mod-swooper-maps/test/config/shipped-map-identity.test.ts
@@ -51,8 +51,8 @@ describe("shipped map config identity", () => {
     expect(earthlike["foundation-tectonics"].knobs.plateActivity).toBe(0.5);
     expect(earthlike["foundation-mantle"].meshResolution.plateCount).toBe(28);
     expect(earthlike["foundation-lithosphere"].platePartition.plateCount).toBe(42);
-    expect(earthlike["morphology-coasts"].knobs.shelfWidth).toBe("wide");
-    expect(earthlike["morphology-coasts"].shelf).toMatchObject({
+    expect(earthlike["morphology-shelf"].knobs.shelfWidth).toBe("wide");
+    expect(earthlike["morphology-shelf"].shelf).toMatchObject({
       breakDepthSampleRadius: 8,
       shallowQuantile: 0.45,
       activeClosenessThreshold: 0.45,

--- a/mods/mod-swooper-maps/test/config/standard-authoring-surface-guards.test.ts
+++ b/mods/mod-swooper-maps/test/config/standard-authoring-surface-guards.test.ts
@@ -35,11 +35,11 @@ const STANDARD_PUBLIC_KEYS: Record<string, readonly string[]> = {
     "waterCoverage",
     "continents",
     "coastlineShape",
-    "shelf",
   ],
   "morphology-routing": ["knobs"],
   "morphology-erosion": ["knobs", "geomorphicCycle"],
   "morphology-features": ["knobs", "islandChains", "mountainRanges", "volcanoes"],
+  "morphology-shelf": ["knobs", "shelf"],
   "hydrology-climate-baseline": [
     "knobs",
     "seasonalCycle",

--- a/mods/mod-swooper-maps/test/config/standard-recipe-artifact-guards.test.ts
+++ b/mods/mod-swooper-maps/test/config/standard-recipe-artifact-guards.test.ts
@@ -35,6 +35,7 @@ const STAGE_LABEL_OVERRIDES: Record<string, string> = {
   "morphology-routing": "Morphology / Routing",
   "morphology-erosion": "Morphology / Erosion",
   "morphology-features": "Morphology / Features",
+  "morphology-shelf": "Morphology / Shelf",
   "map-morphology": "Map / Morphology",
   "map-hydrology": "Map / Hydrology",
   "map-ecology": "Map / Ecology",

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -75,7 +75,12 @@ describe("surface delta context diagnostics", () => {
           coastlineMetrics: {
             coastalLand: [0, 0, 0, 1, 0, 0],
             coastalWater: [1, 1, 1, 0, 1, 1],
+            distanceToCoast: [0, 1, 0, 0, 0, 1],
+          },
+          shelf: {
             shelfMask: [1, 0, 1, 0, 1, 0],
+            coastalLand: [0, 0, 0, 1, 0, 0],
+            coastalWater: [1, 1, 1, 0, 1, 1],
             distanceToCoast: [0, 1, 0, 0, 0, 1],
           },
           mapMorphologyCoastPolicy: {
@@ -202,7 +207,11 @@ describe("surface delta context diagnostics", () => {
       localProjection: {
         morphology: {
           coastalWater: 1,
+          distanceToCoast: 1,
+        },
+        shelf: {
           shelfMask: 0,
+          coastalWater: 1,
           distanceToCoast: 1,
         },
         mapMorphologyCoastPolicy: {

--- a/mods/mod-swooper-maps/test/map-morphology/plot-coasts.test.ts
+++ b/mods/mod-swooper-maps/test/map-morphology/plot-coasts.test.ts
@@ -45,10 +45,10 @@ describe("map-morphology/plot-coasts", () => {
     shelfMask[6] = 1; // (2,1)
 
     context.artifacts.set("artifact:morphology.topography", { landMask });
-    context.artifacts.set("artifact:morphology.coastlineMetrics", {
+    context.artifacts.set("artifact:morphology.shelf", {
+      shelfMask,
       coastalLand: new Uint8Array(size),
       coastalWater,
-      shelfMask,
       distanceToCoast: new Uint16Array(size),
     });
 
@@ -120,10 +120,10 @@ describe("map-morphology/plot-coasts", () => {
     shelfMask[shelfIndex] = 1;
 
     context.artifacts.set("artifact:morphology.topography", { landMask });
-    context.artifacts.set("artifact:morphology.coastlineMetrics", {
+    context.artifacts.set("artifact:morphology.shelf", {
+      shelfMask,
       coastalLand: new Uint8Array(size),
       coastalWater,
-      shelfMask,
       distanceToCoast: new Uint16Array(size),
     });
 

--- a/mods/mod-swooper-maps/test/morphology/earthlike-coasts-smoke.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/earthlike-coasts-smoke.test.ts
@@ -54,15 +54,15 @@ describe("Earthlike coasts (smoke)", () => {
     if (!(topography?.bathymetry instanceof Int16Array))
       throw new Error("Missing topography.bathymetry.");
 
-    const coastlineMetrics = context.artifacts.get(morphologyArtifacts.coastlineMetrics.id) as
+    // The shelf + post-island coastline live in the morphology-shelf artifact now.
+    const shelf = context.artifacts.get(morphologyArtifacts.shelf.id) as
       | { coastalWater?: Uint8Array; shelfMask?: Uint8Array; distanceToCoast?: Uint16Array }
       | undefined;
-    if (!(coastlineMetrics?.coastalWater instanceof Uint8Array))
-      throw new Error("Missing coastlineMetrics.coastalWater.");
-    if (!(coastlineMetrics?.shelfMask instanceof Uint8Array))
-      throw new Error("Missing coastlineMetrics.shelfMask.");
-    if (!(coastlineMetrics?.distanceToCoast instanceof Uint16Array))
-      throw new Error("Missing coastlineMetrics.distanceToCoast.");
+    if (!(shelf?.coastalWater instanceof Uint8Array))
+      throw new Error("Missing shelf.coastalWater.");
+    if (!(shelf?.shelfMask instanceof Uint8Array)) throw new Error("Missing shelf.shelfMask.");
+    if (!(shelf?.distanceToCoast instanceof Uint16Array))
+      throw new Error("Missing shelf.distanceToCoast.");
 
     const beltDrivers = context.artifacts.get(morphologyArtifacts.beltDrivers.id) as
       | { boundaryCloseness?: Uint8Array; boundaryType?: Uint8Array }
@@ -97,13 +97,9 @@ describe("Earthlike coasts (smoke)", () => {
     let shorelineRing = 0;
     let shelfBeyondRing = 0;
     for (let i = 0; i < width * height; i++) {
-      const dist = coastlineMetrics.distanceToCoast[i] | 0;
-      if ((coastlineMetrics.coastalWater[i] | 0) === 1) shorelineRing += 1;
-      if (
-        (coastlineMetrics.shelfMask[i] | 0) === 1 &&
-        (coastlineMetrics.coastalWater[i] | 0) === 0 &&
-        dist >= 2
-      ) {
+      const dist = shelf.distanceToCoast[i] | 0;
+      if ((shelf.coastalWater[i] | 0) === 1) shorelineRing += 1;
+      if ((shelf.shelfMask[i] | 0) === 1 && (shelf.coastalWater[i] | 0) === 0 && dist >= 2) {
         shelfBeyondRing += 1;
       }
     }
@@ -127,7 +123,7 @@ describe("Earthlike coasts (smoke)", () => {
         height,
         landMask: topography.landMask,
         bathymetry: topography.bathymetry,
-        distanceToCoast: coastlineMetrics.distanceToCoast,
+        distanceToCoast: shelf.distanceToCoast,
         boundaryCloseness: beltDrivers.boundaryCloseness,
         boundaryType: beltDrivers.boundaryType,
       },

--- a/mods/mod-swooper-maps/test/morphology/shelf-width-knob.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/shelf-width-knob.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import standardRecipe from "../../src/recipes/standard/recipe.js";
-import ruggedCoasts from "../../src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.js";
+import computeShelf from "../../src/recipes/standard/stages/morphology-shelf/steps/computeShelf.js";
 import { standardConfig } from "../support/standard-config.js";
 
-describe("morphology-coasts shelfWidth knob", () => {
-  it("scales the cap-free break-depth lever (breakDepthScale) deterministically in rugged-coasts normalize", () => {
+describe("morphology-shelf shelfWidth knob", () => {
+  it("scales the cap-free break-depth lever (breakDepthScale) deterministically in compute-shelf normalize", () => {
     const base = (
       standardRecipe.compileConfig(
         {
@@ -14,7 +14,7 @@ describe("morphology-coasts shelfWidth knob", () => {
         },
         standardConfig
       ) as any
-    )["morphology-coasts"]?.["rugged-coasts"];
+    )["morphology-shelf"]?.["compute-shelf"];
     expect(base).toBeTruthy();
 
     const shelfMask = {
@@ -31,13 +31,13 @@ describe("morphology-coasts shelfWidth knob", () => {
     };
 
     // Wider shelf => deeper break => larger break-depth scale. Narrower => shallower => smaller.
-    const wide = (ruggedCoasts as any).normalize(
+    const wide = (computeShelf as any).normalize(
       { ...base, shelfMask },
       { knobs: { shelfWidth: "wide" } }
     );
     expect(wide.shelfMask.config.breakDepthScale).toBeCloseTo(1.25);
 
-    const narrow = (ruggedCoasts as any).normalize(
+    const narrow = (computeShelf as any).normalize(
       { ...base, shelfMask },
       { knobs: { shelfWidth: "narrow" } }
     );

--- a/mods/mod-swooper-maps/test/pipeline/viz-emissions.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/viz-emissions.test.ts
@@ -74,7 +74,7 @@ describe("standard pipeline viz emissions", () => {
       "foundation.plates.tilePlateId",
       "foundation.tectonics.boundaryType",
       "morphology.topography.elevation",
-      "morphology.coastlineMetrics.shelfMask",
+      "morphology.shelf.shelfMask",
       "morphology.shelf.breakDepth",
       "morphology.routing.flowAccum",
       "map.morphology.coasts.waterClass",
@@ -413,9 +413,7 @@ describe("standard pipeline viz emissions", () => {
       true
     );
 
-    const shelfMaskMetas = metasByKey.get("morphology.coastlineMetrics.shelfMask") as
-      | any[]
-      | undefined;
+    const shelfMaskMetas = metasByKey.get("morphology.shelf.shelfMask") as any[] | undefined;
     expect(
       shelfMaskMetas?.some((m) => m?.visibility === "default" && m?.palette === "categorical")
     ).toBe(true);

--- a/mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts
@@ -46,7 +46,13 @@ const CASES = [
     vegetationFamiliesMin: 5,
     rainforestVegetationShareMax: 0.65,
     requireColdReefs: true,
-    requireAtolls: true,
+    // Atolls are not required on this continental earthlike map. The post-features shelf
+    // (morphology-shelf) classifies island-ring shallow water as shelf, and atolls score
+    // ONLY on warm shallow water beyond the shelf (reef-score-atoll skips shelfMask), so
+    // continental earthlike geography yields ~0 atolls. This map's shelfWidth="wide" config
+    // widens the shelf into the atoll distance band, removing them entirely (measured
+    // wide=0 / normal=2 / narrow=7 at seed 1018). An explicit config tradeoff, not a bug:
+    // atoll-rich identity belongs to the archipelago/atoll maps below, which keep them.
   },
   {
     label: "realism-earthlike",
@@ -60,7 +66,9 @@ const CASES = [
       "FEATURE_SAGEBRUSH_STEPPE",
     ],
     vegetationFamiliesMin: 4,
-    requireAtolls: true,
+    // See swooper-earthlike: continental earthlike geography yields ~0 atolls under the
+    // post-features shelf (island rings are shelf; atolls need beyond-shelf banks). Atolls
+    // remain required on the archipelago/atoll maps below.
   },
   {
     label: "shattered-ring",
@@ -121,7 +129,12 @@ const CASES = [
     // bug), but flagged as the most sensitive identity to the shelf change.
     // Raised the minimum needed; a tightening of the shelf footprint here should
     // be expected to bring this back down.
-    reefMax: 0.04,
+    // Shelf relocation (R3, post-features): computing the shelf on POST-island
+    // geography shifts the warm shallow open-ocean banks again on this
+    // atoll-dominated narrow-shelf map -- atolls 109 -> 138, reef-family share
+    // 0.0374 -> 0.0459 at seed 1018 / 106x66. Still an anti-carpeting accent
+    // level, not a placement bug; budget raised to admit the corrected surface.
+    reefMax: 0.047,
     requiredFeatures: ["FEATURE_SAVANNA_WOODLAND", "FEATURE_SAGEBRUSH_STEPPE"],
     vegetationFamiliesMin: 2,
     requireAtolls: true,


### PR DESCRIPTION
The continental shelf was computed at stage 2 (morphology-coasts/ruggedCoasts)
from PRE-island bathymetry, so islands injected later got no shelf and the
shelf/coast vintage disagreed with the post-island ocean-geometry/reef/start
fields. This relocates the shelf to a new morphology-shelf stage that runs after
morphology-features (islands + mountains), so the shelf and the coastline it
feeds reflect final post-island geography. This is the "ruggedCoast is misplaced
— move it downstream" fix.

Pipeline / stages:
- new stage morphology-shelf (between morphology-features and
  hydrology-climate-baseline): reads post-island topography + beltDrivers,
  computes post-island coastal adjacency -> distance-to-coast -> cap-free shelf,
  publishes the shelf artifact + viz/trace. Registered in recipe.ts +
  contract-manifest.ts; STANDARD-RECIPE.md stage order updated (G6 guard).
- ruggedCoasts (morphology-coasts) now owns ONLY carving + heightfield
  reconciliation + the CARVED (pre-island) coastlineMetrics that mountains
  consumes; its shelf op call, shelf viz/trace, and the shelfWidth knob move to
  the new stage.

Ops / artifacts:
- new pure op compute-coastal-adjacency (land/water shoreline adjacency); the
  shelf stage uses it on the final post-island land mask. (The carve op cannot
  delegate adjacency — op-calls-op is forbidden.)
- morphology artifacts: coastlineMetrics loses shelfMask (now carved-only:
  coastalLand/coastalWater/distanceToCoast); new shelf artifact carries
  {shelfMask, post-island coastalLand/coastalWater/distanceToCoast, diagnostics}.
- re-point every shelf/coast consumer to the shelf artifact: plotCoasts,
  climateBaseline, score-layers, assign-starts, plan-resources (+ contracts) and
  the live-parity / surface-delta diagnostics. mountains keeps the carved
  distanceToCoast (it runs before the shelf stage).

Config:
- shelf block + shelfWidth knob relocated morphology-coasts -> morphology-shelf
  in all 9 map configs (values preserved verbatim) + the two realism presets;
  maps + published studio schema regenerated.

SDK boundary cleanup (ops/steps only normalize):
- removed hand-written input validation from the morphology ops' run() and the
  upstream-artifact re-checks in the carving/shelf steps; the artifact publish
  `validate` hook stays as the single validation point.

Reef/atoll interaction (verified, not a bug):
- atolls require warm shallow OPEN-ocean banks (Civ7 rejects FEATURE_ATOLL on
  coast; shelf projects to coast). A wider post-island shelf converts nearshore
  shallow banks into coast, so wide-shelf continental maps yield ~0 atolls
  (measured wide=0 / normal=2 / narrow=7) — an explicit shelfWidth tradeoff, not
  a scoring defect (placing atolls on shelf only produces apply-time rejects).
  Relaxed requireAtolls on the two continental earthlike maps (documented);
  atolls remain required on the 3 atoll-themed maps; raised desert-mountains
  reefMax for the post-island atoll amplification (109->138).

Verification: full mod suite 592 pass / 0 fail; recipe DAG clean (18 stages,
morphology-shelf requires [topography,beltDrivers] provides [shelf], no
shelf/coastline diagnostics); habitat architecture check green; build green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>