### PR TITLE
refactor(foundation): extract shared crust-buoyancy model; de-duplicate relief rule

### DIFF
--- a/mods/mod-swooper-maps/src/domain/foundation/lib/crust/buoyancy.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/lib/crust/buoyancy.ts
@@ -1,0 +1,73 @@
+import { clamp01 } from "@swooper/mapgen-core/lib/math";
+
+/**
+ * Shared crust buoyancy / strength / classification model — the SINGLE SOURCE OF
+ * TRUTH for how crust-history state (maturity, thickness, thermal age) maps to
+ * isostatic buoyancy. Consumed by both the t=0 basaltic-lid seed (`compute-crust`)
+ * and the era-integrated evolution (`compute-crust-evolution`) so the two can no
+ * longer silently diverge (they previously carried byte-identical private copies).
+ *
+ * WHY here: foundation-internal physical constants live under `domain/foundation/lib`
+ * (cf. `lib/tectonics/constants.ts`). Buoyancy is NOT author-configurable — crust
+ * evolution follows the tectonic history — so these are physical coefficients, never
+ * authoring knobs, and must never be tuned to a downstream land/ocean output ratio.
+ */
+
+/**
+ * Isostatic buoyancy floor every crust cell inherits before history differentiates it
+ * (the basaltic oceanic lid at t=0). This is the baseline for ALL crust — the
+ * oceanic-vs-continental split emerges from the maturity / thickness / age terms below,
+ * not from this constant. (Formerly mis-named `OCEANIC_BASE_ELEVATION`.)
+ */
+export const CRUST_BASE_BUOYANCY = 0.32;
+
+/** Thermal subsidence depth: cooling lithosphere sinks with thermal age. */
+export const OCEANIC_AGE_DEPTH = 0.22;
+/** Differentiated (mature) crust is more buoyant. */
+export const MATURITY_BUOYANCY_BOOST = 0.45;
+/** Thicker crust floats higher (isostasy). */
+export const THICKNESS_BUOYANCY_BOOST = 0.25;
+
+/** Maturity at/above which a cell is classified continental crust. */
+export const MATURITY_CONTINENT_THRESHOLD = 0.55;
+
+/** Lithospheric-strength factor floors (thermalAge / maturity / thickness). */
+export const STRENGTH_BASE_MIN = 0.45;
+export const STRENGTH_MATURITY_MIN = 0.5;
+export const STRENGTH_THICKNESS_MIN = 0.55;
+
+export interface CrustBuoyancyInputs {
+  maturity: number;
+  thickness: number;
+  thermalAge01: number;
+}
+
+/**
+ * Isostatic crust buoyancy in [0,1] from crust-history state. Higher rides higher
+ * (emerges as land / shallow shelf); lower sinks (deep ocean). `baseElevation := this`,
+ * and base-topography linearly remaps it into the absolute relief band — so the SHAPE
+ * of this function's output distribution is the hypsometry.
+ */
+export function deriveBuoyancy(params: CrustBuoyancyInputs): number {
+  const maturityBoost = MATURITY_BUOYANCY_BOOST * clamp01(params.maturity);
+  const thicknessBoost = THICKNESS_BUOYANCY_BOOST * clamp01(params.thickness);
+  const subsidence = OCEANIC_AGE_DEPTH * clamp01(params.thermalAge01);
+  return clamp01(CRUST_BASE_BUOYANCY + maturityBoost + thicknessBoost - subsidence);
+}
+
+/** Continental-crust classification from maturity. */
+export function isContinentalMaturity(maturity: number): boolean {
+  return maturity >= MATURITY_CONTINENT_THRESHOLD;
+}
+
+export function strengthFromThermalAge(age01: number): number {
+  return STRENGTH_BASE_MIN + (1 - STRENGTH_BASE_MIN) * clamp01(age01);
+}
+
+export function strengthFromMaturity(maturity: number): number {
+  return STRENGTH_MATURITY_MIN + (1 - STRENGTH_MATURITY_MIN) * clamp01(maturity);
+}
+
+export function strengthFromThickness(thickness: number): number {
+  return STRENGTH_THICKNESS_MIN + (1 - STRENGTH_THICKNESS_MIN) * clamp01(thickness);
+}

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts
@@ -2,6 +2,13 @@ import { createOp } from "@swooper/mapgen-core/authoring";
 import { clamp01, clampU8 } from "@swooper/mapgen-core/lib/math";
 
 import {
+  deriveBuoyancy,
+  isContinentalMaturity,
+  strengthFromMaturity,
+  strengthFromThermalAge,
+  strengthFromThickness,
+} from "../../lib/crust/buoyancy.js";
+import {
   requireCrust,
   requireMesh,
   requireTectonicHistory,
@@ -9,21 +16,10 @@ import {
 } from "../../lib/require.js";
 import ComputeCrustEvolutionContract from "./contract.js";
 
-const MATURITY_CONTINENT_THRESHOLD = 0.55;
-
-const OCEANIC_BASE_ELEVATION = 0.32;
-const OCEANIC_AGE_DEPTH = 0.22;
-const MATURITY_BUOYANCY_BOOST = 0.45;
-const THICKNESS_BUOYANCY_BOOST = 0.25;
-
 // Thickening is driven by differentiated (mature) crust; maturity integrates uplift/volcanism and
 // is suppressed by disruption, so a maturity-based mapping keeps thickness coherent with the
 // rest of the evolution model.
 const THICKNESS_FROM_MATURITY_GAIN = 0.5;
-
-const STRENGTH_BASE_MIN = 0.45;
-const STRENGTH_MATURITY_MIN = 0.5;
-const STRENGTH_THICKNESS_MIN = 0.55;
 
 // Baseline damage proxy (normalized weighted sum) coefficients.
 const DAMAGE_COEFF_SUM = 0.55 + 0.6 + 0.45;
@@ -42,29 +38,6 @@ const RIFT_RECYCLE_THRESHOLD = 0.35;
 const RIFT_RECYCLE_MATURITY_CAP = 0.08;
 const RIFT_THERMAL_AGE_MUL = 0.4;
 const THERMAL_AGE_RIFT_SLOWDOWN = 0.6;
-
-function strengthFromThermalAge(age01: number): number {
-  return STRENGTH_BASE_MIN + (1 - STRENGTH_BASE_MIN) * clamp01(age01);
-}
-
-function strengthFromMaturity(maturity: number): number {
-  return STRENGTH_MATURITY_MIN + (1 - STRENGTH_MATURITY_MIN) * clamp01(maturity);
-}
-
-function strengthFromThickness(thickness: number): number {
-  return STRENGTH_THICKNESS_MIN + (1 - STRENGTH_THICKNESS_MIN) * clamp01(thickness);
-}
-
-function deriveBuoyancy(params: {
-  maturity: number;
-  thickness: number;
-  thermalAge01: number;
-}): number {
-  const maturityBoost = MATURITY_BUOYANCY_BOOST * clamp01(params.maturity);
-  const thicknessBoost = THICKNESS_BUOYANCY_BOOST * clamp01(params.thickness);
-  const subsidence = OCEANIC_AGE_DEPTH * clamp01(params.thermalAge01);
-  return clamp01(OCEANIC_BASE_ELEVATION + maturityBoost + thicknessBoost - subsidence);
-}
 
 const computeCrustEvolution = createOp(ComputeCrustEvolutionContract, {
   strategies: {
@@ -166,7 +139,7 @@ const computeCrustEvolution = createOp(ComputeCrustEvolutionContract, {
           thermalAge[i] = clampU8(thermalAge01 * 255);
           damage[i] = clampU8(damage01 * 255);
 
-          const isContinent = maturity01 >= MATURITY_CONTINENT_THRESHOLD ? 1 : 0;
+          const isContinent = isContinentalMaturity(maturity01) ? 1 : 0;
           type[i] = isContinent;
           age[i] = thermalAge[i];
 

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust/index.ts
@@ -1,49 +1,15 @@
 import { createOp } from "@swooper/mapgen-core/authoring";
-import { clamp01 } from "@swooper/mapgen-core/lib/math";
+import { clamp01, clampU8 } from "@swooper/mapgen-core/lib/math";
 
+import {
+  deriveBuoyancy,
+  isContinentalMaturity,
+  strengthFromMaturity,
+  strengthFromThermalAge,
+  strengthFromThickness,
+} from "../../lib/crust/buoyancy.js";
 import { requireMantleForcing, requireMesh } from "../../lib/require.js";
 import ComputeCrustContract from "./contract.js";
-
-const MATURITY_CONTINENT_THRESHOLD = 0.55;
-
-const OCEANIC_BASE_ELEVATION = 0.32;
-const OCEANIC_AGE_DEPTH = 0.22;
-const MATURITY_BUOYANCY_BOOST = 0.45;
-const THICKNESS_BUOYANCY_BOOST = 0.25;
-
-const STRENGTH_BASE_MIN = 0.45;
-const STRENGTH_MATURITY_MIN = 0.5;
-const STRENGTH_THICKNESS_MIN = 0.55;
-
-function clampU8(value: number): number {
-  if (!Number.isFinite(value)) return 0;
-  if (value <= 0) return 0;
-  if (value >= 255) return 255;
-  return value | 0;
-}
-
-function strengthFromThermalAge(age01: number): number {
-  return STRENGTH_BASE_MIN + (1 - STRENGTH_BASE_MIN) * clamp01(age01);
-}
-
-function strengthFromMaturity(maturity: number): number {
-  return STRENGTH_MATURITY_MIN + (1 - STRENGTH_MATURITY_MIN) * clamp01(maturity);
-}
-
-function strengthFromThickness(thickness: number): number {
-  return STRENGTH_THICKNESS_MIN + (1 - STRENGTH_THICKNESS_MIN) * clamp01(thickness);
-}
-
-function deriveBuoyancy(params: {
-  maturity: number;
-  thickness: number;
-  thermalAge01: number;
-}): number {
-  const maturityBoost = MATURITY_BUOYANCY_BOOST * clamp01(params.maturity);
-  const thicknessBoost = THICKNESS_BUOYANCY_BOOST * clamp01(params.thickness);
-  const subsidence = OCEANIC_AGE_DEPTH * clamp01(params.thermalAge01);
-  return clamp01(OCEANIC_BASE_ELEVATION + maturityBoost + thicknessBoost - subsidence);
-}
 
 const computeCrust = createOp(ComputeCrustContract, {
   strategies: {
@@ -100,7 +66,7 @@ const computeCrust = createOp(ComputeCrustContract, {
           const age01 = 0;
           const damage01 = clamp01((damage[i] ?? 0) / 255);
 
-          type[i] = m >= MATURITY_CONTINENT_THRESHOLD ? 1 : 0;
+          type[i] = isContinentalMaturity(m) ? 1 : 0;
           age[i] = 0;
 
           const buoy = deriveBuoyancy({ maturity: m, thickness: t, thermalAge01: age01 });


### PR DESCRIPTION
compute-crust (t=0 seed) and compute-crust-evolution each carried byte-identical
private copies of deriveBuoyancy, the four buoyancy constants, the strengthFrom*
helpers, and MATURITY_CONTINENT_THRESHOLD — a copy that had already drifted (local
clampU8 vs the core one). Extract them into a single
domain/foundation/lib/crust/buoyancy.ts primitive imported by both, so the upcoming
bimodal-hypsometry reshape lands in ONE place and the two ops cannot diverge again.
Rename the misleading OCEANIC_BASE_ELEVATION -> CRUST_BASE_BUOYANCY (it is the
buoyancy floor for ALL crust, not an oceanic-only datum).

No behavior change: earthlike s1018 dump is byte-identical (same runId 2103cc19…,
landMask/elevation surface hashes unchanged, drowned 2708 / 32.2% / -1,0,0). mod
build (tsup) + biome + 46 foundation/crust tests all pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>