### PR TITLE
feat(foundation): cratonization + isostatic subsidence → bimodal hypsometry

### DIFF
--- a/docs/projects/crust-relief/WORKSTREAM.md
+++ b/docs/projects/crust-relief/WORKSTREAM.md
@@ -318,3 +318,57 @@ shape-verified per the brief's "necessary, not sufficient" caveat.)
 | Emergent relief on former platforms | harness + Studio + live | ☐ not started |
 | Holds across maps/seeds | multi-seed harness | ☐ not started |
 | In-game playable (closure) | live engine run + screenshots | ☐ not started |
+
+---
+
+## 12. Implementation results (as-built)
+
+**Model as built** (in `lib/crust/buoyancy.ts` + `compute-crust-evolution`):
+1. **Isostatic, thickness-gated subsidence** (supersedes M1's first-cut maturity gate). Thermal
+   subsidence acts fully on THIN crust (oceanic lithosphere → young-ridge-high/old-abyss-deep, *and*
+   thinned/young continental margins → subside into real shelves) and fades to zero as crust thickens
+   into an isostatically-supported cratonic keel (`isostaticSupport(thickness)`). This is more
+   physical than crust-type gating and is what yields a natural shelf→coast→highland spread instead of
+   a uniform high plateau. Retires the saturated-thermalAge mis-model (age now drives buoyancy only
+   through thickness-gated subsidence, where it is physical).
+2. **Cratonization** (`compute-crust-evolution` era loop): continental crust that survives quiescent
+   eras consolidates a buoyant keel (`cratonRoot01`); active/rifted eras don't, and rift recycles it.
+   Adds a high-craton tail without a wholesale lift (rate 0.08; the isostatic spread carries the
+   gradient). Uses the *quiescence* of each era (inverse of disruption) — the differentiator is how
+   many quiescent eras a cell experienced.
+
+**Shape outcome (earthlike s1018, vs baseline):**
+| metric | baseline | as-built | meaning |
+|---|---|---|---|
+| continental crustUnit min/p50/max | 0.485/0.54/0.68 (dense hump) | **0.575/0.72/0.96 (broad spread)** | no longer a dense hump at the waterline |
+| DROWNING ZONE [−15,+15] | 73.7% | 48% | crust near waterline reduced (now a gradient, not a flat slab) |
+| clearly above >+15 | 17.8% | 51% | emergent high continental land tripled |
+| submerged continental bathy p50/min | −1 / −21 (flat) | **−5 / −30 (shelf→slope)** | no longer dead-flat; real shelf-slope-abyss profile |
+| land elev p10/p50/max | −6/3/53 | 14/28/86 | continents ride high with internal relief |
+| submergedPctOfCont | 32.2% | ~33% | **unchanged — by design** (see below) |
+
+**Why `submergedPctOfCont` does not (and should not) fall.** It is structurally pinned:
+`water%(63) − oceanic%(~44) = ~19%` of all cells = ~33% of continental crust *must* sit below the
+waterline regardless of relief shape, as long as oceanic crust fills the deep mode. Critically,
+**33% submerged continental ≈ Earth's own continental-shelf fraction** (~30% of continental crust is
+submerged shelf). The brief's symptom was never "shelves exist" — it was "broad **flat** shelves with
+**nothing emergent**." That is decisively fixed: the submerged crust is now a real shelf→slope→abyss
+profile (bathy p50 −5, sparse continental slope between −70 and −10), and the emergent crust rides
+high with relief. Forcing `submergedPctOfCont` down would require shrinking the continental fraction
+(a maturity-classification change) — a **possible follow-up lever** (the model over-produces
+continental crust: 56% earthlike / 67% juicy vs Earth ~40%), but reducing it to hit a fraction would
+be the forbidden tune-to-a-ratio. Recorded as an open lever, not pursued by tuning.
+
+**Visual (earthlike s1018):** `tools/ascii-map.mjs <RUNDIR> elev` — high cratonic cores (`@`/`^`)
+grading through coastal land (`#`) and lowlands (`-`) to coherent shelves (`:`) and deep basins (`.`);
+former dead-flat platforms are now high continents with internal relief. (Baseline: vast `+` flat
+platforms interrupting low featureless land.)
+
+**Robustness (holds across seeds + configs, not one tuned seed):** continental crustUnit is a broad
+spread on every map (earthlike s1018/7/99/2024 ≈ 0.57/0.70/0.97; latest-juicy 0.57/0.74/0.97;
+shattered-ring 0.57/0.67/0.81; sundered-archipelago 0.61/0.81/0.96; desert-mountains 0.81/0.88/0.96 —
+all-land mountainous, high by design). Submerged continental bathymetry un-pinned everywhere (p50:
+earthlike −5/−12, juicy −9, shattered-ring −37, **sundered-archipelago −77**). No carpeting / empty
+maps. **OPEN (downstream slice):** sundered-archipelago submerged crust is now *deep* (p50 −77) — must
+confirm enough *shallow* cold shelf remains to restore `requireColdReefs`, else tune shelf width or
+retire by product decision.

--- a/mods/mod-swooper-maps/src/domain/foundation/lib/crust/buoyancy.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/lib/crust/buoyancy.ts
@@ -32,13 +32,13 @@ export const THICKNESS_BUOYANCY_BOOST = 0.25;
 export const MATURITY_CONTINENT_THRESHOLD = 0.55;
 
 /**
- * Continentality ramp: maturity at which crust begins / finishes behaving as felsic continental
- * lithosphere (thick-rooted, buoyant) rather than mafic oceanic lithosphere (dense, subsiding).
- * Brackets {@link MATURITY_CONTINENT_THRESHOLD} so the oceanic↔continental transition is smooth,
- * not a hard discontinuity at the type cut.
+ * Isostatic-support ramp over crustal thickness. Thin crust (basaltic oceanic lithosphere; thinned
+ * or young continental margins) is poorly supported and subsides as it cools; thick crust (cratonic
+ * keels / orogenic roots) is isostatically buoyant and does not subside. Brackets the basaltic floor
+ * (~0.25–0.35 → full subsidence) and a consolidated keel (~0.75+ → none).
  */
-export const CONTINENTAL_FADE_LO = 0.4;
-export const CONTINENTAL_FADE_HI = 0.6;
+export const ISOSTASY_THIN_THICKNESS = 0.35;
+export const ISOSTASY_THICK_THICKNESS = 0.75;
 
 /** Lithospheric-strength factor floors (thermalAge / maturity / thickness). */
 export const STRENGTH_BASE_MIN = 0.45;
@@ -59,34 +59,35 @@ function smoothstep(edge0: number, edge1: number, x: number): number {
 }
 
 /**
- * Continentality in [0,1]: 0 = oceanic (mafic, dense, subsides with age), 1 = continental
- * (felsic, thick-rooted, buoyant), ramping across the continent threshold. Gates processes
- * that physically act on only one crust type.
+ * Isostatic support in [0,1] from crustal thickness: 0 = thin / poorly supported (subsides with
+ * age), 1 = thick / buoyant (does not subside).
  */
-export function continentality(maturity: number): number {
-  return smoothstep(CONTINENTAL_FADE_LO, CONTINENTAL_FADE_HI, clamp01(maturity));
+export function isostaticSupport(thickness: number): number {
+  return smoothstep(ISOSTASY_THIN_THICKNESS, ISOSTASY_THICK_THICKNESS, clamp01(thickness));
 }
 
 /**
- * Isostatic crust buoyancy in [0,1] from crust-history state. Higher rides higher (emerges as
- * land / shallow shelf); lower sinks (deep ocean). `baseElevation := this`, and base-topography
- * linearly remaps it into the absolute relief band — so the SHAPE of this function's output
- * distribution IS the hypsometry.
+ * Isostatic crust buoyancy in [0,1] from crust-history state. Higher rides higher (emerges as land /
+ * shallow shelf); lower sinks (deep ocean). `baseElevation := this`, and base-topography linearly
+ * remaps it into the absolute relief band — so the SHAPE of this function's output distribution IS
+ * the hypsometry.
  *
- * Thermal subsidence is an OCEANIC process: cooling mafic lithosphere contracts and sinks with
- * thermal age (young ridge high → old abyss deep). Continental (felsic, thick-rooted) crust does
- * NOT thermally subside — old cratons are the highest, most stable crust. We therefore gate the
- * subsidence term by (1 − continentality): full on oceanic crust, fading to zero as the cell
- * matures continental. This lifts the aged continental band off the waterline instead of dragging
- * exactly the crust that should ride highest down onto it. (It also retires the prior mis-model
- * where a saturated, signal-free continental thermalAge applied a uniform ~−0.21 to all crust.)
+ * Thermal subsidence (cooling lithosphere contracts and sinks with age) is gated by ISOSTASY rather
+ * than crust type: it acts fully on THIN crust — basaltic oceanic lithosphere (young ridge high →
+ * old abyss deep) and thinned/young continental margins (which subside into real shelves) — and
+ * fades to zero as crust thickens into an isostatically-supported cratonic keel (old cratons ride
+ * highest, never sinking). This deepens old ocean, keeps cratons high, AND leaves thin margins low,
+ * yielding a natural shelf→coast→highland spread rather than a drowned flat band (old uniform
+ * subsidence) or a uniform high plateau. It also retires the prior mis-model where a saturated,
+ * signal-free continental thermalAge dragged all crust down uniformly.
  */
 export function deriveBuoyancy(params: CrustBuoyancyInputs): number {
   const maturity = clamp01(params.maturity);
+  const thickness = clamp01(params.thickness);
   const maturityBoost = MATURITY_BUOYANCY_BOOST * maturity;
-  const thicknessBoost = THICKNESS_BUOYANCY_BOOST * clamp01(params.thickness);
-  const oceanic = 1 - continentality(maturity);
-  const subsidence = OCEANIC_AGE_DEPTH * clamp01(params.thermalAge01) * oceanic;
+  const thicknessBoost = THICKNESS_BUOYANCY_BOOST * thickness;
+  const subsidence =
+    OCEANIC_AGE_DEPTH * clamp01(params.thermalAge01) * (1 - isostaticSupport(thickness));
   return clamp01(CRUST_BASE_BUOYANCY + maturityBoost + thicknessBoost - subsidence);
 }
 

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts
@@ -39,6 +39,16 @@ const RIFT_RECYCLE_MATURITY_CAP = 0.08;
 const RIFT_THERMAL_AGE_MUL = 0.4;
 const THERMAL_AGE_RIFT_SLOWDOWN = 0.6;
 
+// Cratonization: stable continental crust consolidates a thick, buoyant felsic keel over quiescent
+// eras — the positive feedback that grows a real high-craton elevation mode (vs. a single band
+// hugging the continent threshold) and leaves young/recently-rifted margins thin and low. Rates are
+// physical (per-era keel growth / rift recycling), never tuned to a land/ocean output ratio.
+const CRATON_MATURITY_MIN = 0.55; // keel growth begins at continental maturity…
+const CRATON_MATURITY_SPAN = 0.3; // …and reaches full rate by maturity ~0.85 (only true cratons)
+const CRATON_THICKEN_RATE = 0.08; // keel thickness gained per fully-quiescent era (adds a high tail,
+//                                   not a wholesale lift — the isostatic spread carries the gradient)
+const CRATON_RIFT_RECYCLE_MUL = 0.3; // fraction of the keel surviving a rifting era
+
 const computeCrustEvolution = createOp(ComputeCrustEvolutionContract, {
   strategies: {
     default: {
@@ -83,6 +93,7 @@ const computeCrustEvolution = createOp(ComputeCrustEvolutionContract, {
           let maturity01 = 0;
           let thickness01 = clamp01(initThickness);
           let thermalAge01 = 0;
+          let cratonRoot01 = 0;
 
           // Baseline damage proxy (existing one-shot formula).
           const fractureTotal01 = clamp01((tectonicHistory.fractureTotal[i] ?? 0) / 255);
@@ -127,11 +138,23 @@ const computeCrustEvolution = createOp(ComputeCrustEvolutionContract, {
             thermalAge01 = clamp01(
               thermalAge01 + thermalAgeStep * (1 - THERMAL_AGE_RIFT_SLOWDOWN * r)
             );
+
+            // Cratonization: a continental cell that survives a quiescent era thickens its keel; an
+            // active/rifting era adds little, and a rift recycles most of it. `cratonizing` ramps in
+            // with maturity so only continental-grade crust consolidates; `quiescence` is the inverse
+            // of this era's disruption. Cells that matured early then drifted off the active belt
+            // accumulate a deep keel (high mode); perpetually-active or rifted margins stay thin (low).
+            const cratonizing = clamp01((maturity01 - CRATON_MATURITY_MIN) / CRATON_MATURITY_SPAN);
+            const quiescence = clamp01(1 - disrupt);
+            cratonRoot01 = clamp01(cratonRoot01 + CRATON_THICKEN_RATE * cratonizing * quiescence);
+            if (r >= RIFT_RECYCLE_THRESHOLD) cratonRoot01 *= CRATON_RIFT_RECYCLE_MUL;
           }
 
-          // Thickness increases with differentiated crust, and implicitly responds to uplift/volcanism via maturity.
+          // Thickness = differentiated-crust base (from maturity) + the accumulated cratonic keel.
+          // The keel is the high-mode driver: long-quiescent cratons reach full thickness and ride
+          // highest; young/rifted margins keep only the maturity base and stay low → real shelf depth.
           thickness01 = clamp01(
-            Math.max(thickness01, initThickness + THICKNESS_FROM_MATURITY_GAIN * maturity01)
+            initThickness + THICKNESS_FROM_MATURITY_GAIN * maturity01 + cratonRoot01
           );
 
           maturity[i] = maturity01;


### PR DESCRIPTION
Completes the crust-relief reshape with two coupled, emergent mechanisms.

1. Isostatic (thickness-gated) subsidence — refines M1's first-cut maturity gate.
   Thermal subsidence acts fully on THIN crust: oceanic lithosphere
   (young-ridge-high / old-abyss-deep) AND thinned/young continental margins
   (which subside into real shelves), and fades to zero as crust thickens into an
   isostatically-supported cratonic keel. Thickness — not crust type — is the
   physical control, so old cratons stay high, old ocean deepens, and thin margins
   stay low: a natural shelf→coast→highland spread instead of a uniform high plateau.

2. Cratonization (compute-crust-evolution era loop) — continental crust that
   survives quiescent eras consolidates a buoyant keel (cratonRoot01); active/rifted
   eras do not, and rift recycles it. The differentiator is how many quiescent eras a
   cell saw, so long-stable interiors become high cratons while perpetually-active
   margins stay thin. Mild rate (0.08) adds a high-craton tail; the isostatic spread
   carries the gradient.

Shape — robust across earthlike seeds 1018/7/99/2024 + shattered-ring /
sundered-archipelago / desert-mountains / latest-juicy: continental crustUnit is a
broad spread (~0.57–0.97), not a dense hump at 0.485–0.68; submerged continental
bathymetry is no longer pinned at 0 (p50 −5 to −77 by map, was ~−1) — a real
shelf-slope-abyss profile; emergent high continental land tripled (clearly-above
17.8%→51%); water% preserved (~63%, solver untouched). submergedPctOfCont stays ~33%
by design (≈ Earth's continental-shelf fraction; structurally pinned by the
continental/water budget — never tuned to a ratio).

base-topography, the sea-level percentile solver, and the margin sculpt are
unchanged: bimodal buoyancy flows through the linear remap and the percentile cut
produces bimodal elevation automatically. Build + biome + 45 foundation tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>