### PR TITLE
docs(margin-bathy): archive superseded Thread-2 statistical analysis

### DIFF
--- a/docs/projects/margin-aware-bathymetry/ANALYSIS.md
+++ b/docs/projects/margin-aware-bathymetry/ANALYSIS.md
@@ -1,0 +1,126 @@
+# Thread 2 — Analysis: margin contrast & shelf-break locality
+
+> Empirical record for the ANALYSIS phase. All numbers are reproducible and were **adversarially
+> re-derived** (see §5). Conclusions feed [FRAMING.md](./FRAMING.md) and [EXPECTATIONS.md](./EXPECTATIONS.md).
+
+## 1. Question
+
+Thread 1 closed the erosion question and handed Thread 2 a quantified lever: the single **global**
+shelf-break cutoff couples island density to continental shelf width (~+400 tiles on latest-juicy).
+The prior docs also claimed the active-narrow / passive-wide contrast was muted because the generated
+bathymetry is "only weakly margin-correlated." This analysis asks, with numbers:
+
+1. **How real and reliable is the margin-width contrast today?** (M1)
+2. **Does the seafloor carry a margin signal — and in which direction?** (M2) — decides whether
+   localizing the cutoff alone can ever produce contrast, or whether margin-aware seafloor depth is required.
+3. **How non-local is the global cutoff, and what does localizing it do?** (M3)
+
+## 2. Method (reproducible, self-validating)
+
+- **Harness:** `mods/mod-swooper-maps/scripts/diag/analyze-margin-contrast.ts` — replays the real shelf
+  physics (`compute-shelf-mask`) offline over a `diag:dump`, anchored on the live shelf-stage bins
+  (`bathymetryInput`, `landmaskInput`, `distancetocoast`, `breakdepth`, `depthgatemask`,
+  `shelfmask`, `activemarginmask`) plus the `morphology-belts` boundary signals.
+- **Self-validation (every run):** the harness recovers the op's exact `(shallowCutoff, effScale)` by
+  fitting against the live `breakdepth` bin and asserts three diffs are **0**: recomputed break depth
+  vs live, offline flood vs live shelf, margin classification vs live. All 10 runs: **0 / 0 / 0**.
+  (The recovered cutoff is the faithful op value — `cutoffOffsetFromRecompute = 0` in 10/10.)
+- **Corpus:** `latest-juicy` and `swooper-earthlike`, Huge **106×66**, seeds **1337, 1018, 207, 99, 451**
+  (10 runs). Per-run JSON + aggregate table in `dist/visualization/t2-results/` (gitignored).
+- **Repro:**
+  ```bash
+  cd mods/mod-swooper-maps
+  bun ./src/dev/diagnostics/run-standard-dump.ts -- 106 66 1337 --label t2 \
+    --configFile "$PWD/src/maps/configs/latest-juicy.config.json"
+  bun scripts/diag/analyze-margin-contrast.ts dist/visualization/t2/<runId> \
+    "$PWD/src/maps/configs/latest-juicy.config.json"
+  ```
+
+## 3. Findings
+
+### M1 — the width contrast is directionally reliable on continents, but compressed (and the naive metric lies)
+
+- **On continents** (shelf tiles attributed to a land component ≥ 100 tiles — the honest population):
+  active shelf is narrower than passive in **9/10 runs**. Mean active width 0.4–2.1 rings vs passive
+  1.8–2.6; per-config continent-restricted mean ratio ≈ **2.3 (latest-juicy)** / **2.7 (earthlike)**.
+- **The contrast is compressed/saturated, not wide.** Active continental shelf is frequently pinned at
+  the **0–1 ring floor** (shore-clamped); the active median width is 0 or 1 across runs. The break-depth
+  **lever works** (realized passive/active break-depth ratio is a clean 2.0–2.29 on all 10 runs, matching
+  the designed 1.25/0.6 = 2.08) but its **reach into realized width is small** — it cannot widen a shelf
+  the seafloor won't allow.
+- **The "all-tiles" metric is artifact-prone — do not trust it.** Splitting *all* shelf tiles by margin
+  gives a per-map-noisy ratio (0.81–3.40) because the active sample is tiny (n often < 100) and, on
+  island-heavy seeds, is dominated by single-tile island "dots" whose ring distance is structurally
+  inflated. The headline "earthlike s451 inverts to 0.81" is **a counting artifact**: 218 of 343 active
+  shelf tiles there are size-1 island dots; restricted to continents s451 is **1.06 mean / 2.0 median**
+  — not inverted at all. → Use the **continent-restricted, median-aware** metric (now in the harness).
+
+### M2 — the seafloor carries a STRONG margin signal (refutes "weakly correlated"), but it is an orogenic-relief proxy that produces an inverted WIDTH consequence
+
+- **Strong, robust signal.** Nearshore (rings 1..8) active-minus-passive bathymetry delta is
+  **+11.5 units mean [+8.5..+13.2], positive in 10/10 runs**; boundary-closeness↔depth Pearson
+  **+0.29 [+0.20..+0.45], positive in 10/10**, with a monotonic ladder (low closeness ≈ −13.6 →
+  high closeness ≈ −0.3). It **survives island removal** (continent-only delta +9.6 to +10.7). So the
+  prior "**only weakly margin-correlated**" premise is **empirically false** on the strength dimension.
+- **Direction: active nearshore is SHALLOW (median 0/−1), passive DEEP (~−13).** Mechanism:
+  `bathymetry = min(0, elevation − seaLevel)`, so it is an **orogenic-relief proxy** — high-relief
+  convergent/transform (active) coasts push the adjacent water shallow; passive coasts stay deep
+  (≈ the baseline seafloor). Active is the *special elevated case*, passive is just *typical seafloor*.
+- **Precise statement (scrutiny correction): "inverted *width consequence*," not "inverted seafloor."**
+  Real active margins *are* shallow at a high-relief coast and the data shows active bathymetry *does*
+  deepen offshore (thinly sampled). What is genuinely backwards is the **shelf-width outcome**: shallow
+  active nearshore water clears the depth gate over *more* rings → the lever wants narrow active shelves,
+  the seafloor pushes them wider. No cutoff trick can manufacture true Pacific-narrow/Atlantic-wide
+  contrast against a seafloor whose depth signal runs counter to margin steepness. **This is the case for
+  layer (b).**
+
+### M3 — the global cutoff couples island density to continental shelf width; localizing per-landmass retires it
+
+- **Coupling confirmed, robust.** Per-landmass cutoffs reveal a systematic ordering
+  **continentCutoff > globalCutoff > islandCutoff** (shallower → deeper) in **10/10 runs**
+  (latest-juicy −5 / −9 / −12; earthlike −11 / −14 / −17). Islands sit in deeper seas and **drag the
+  single global quantile deep**, so continents inherit a deeper-than-warranted gate and gain shelf — the
+  Thread-1 +400 coupling, from the other direction. The global cutoff varies enormously in space: ~85–95%
+  of 16-tile windows differ from it by ≥1 step.
+- **Localizing shrinks continental shelf in 10/10**, magnitude **method- and config-dependent**:
+  per-landmass Voronoi ≈ **−25% (latest-juicy) / −14% (earthlike)**; a simpler 16-tile spatial window
+  ≈ **−10%** (about half). The honest range is **~5–25%**, *not* a fixed "18–25%."
+- **Total shelf area holds (≈ ±5–10%) — but contingently.** The continental loss is **redistributed to
+  islands** (island shelf +9% to +46%) as islands adopt their own deeper local cutoffs. This holds for
+  Voronoi/window schemes; **continent-only** localization loses total area outright (−101..−413). The
+  **redistribution-to-islands mechanism is the real headline**, not the percentage.
+- **Caveat:** continent cutoff rests on **tiny N** (1–3 continents/run; n=1 on both s1337). A naive
+  per-component quantile is weakly sampled for exactly the landmasses that matter most → localization
+  needs a sample-count floor with blend-to-global, or the window fallback.
+
+## 4. What this means for the layers
+
+| | What the data says | Implication |
+|---|---|---|
+| **(a) localize the cutoff** | M3 is the strongest claim (10/10, self-validated). Localizing retires the coupling and *also* nudges contrast right, at near-zero blast radius (self-contained in `compute-shelf-mask`). | **Do it.** Robust, low-risk, and a **measurement prerequisite** — it removes the island-density confound so (b) is measurable on a per-landmass gate. |
+| **(b) margin-aware seafloor** | M2 proves (a) cannot make the contrast physically honest or give it dynamic range — the seafloor is orogenic-shallow on active margins. But M1 (continent-restricted) shows the contrast *direction* is already reliable, just compressed. | **Necessary for realism depth + per-map dynamic range, not a correctness emergency.** Higher scope (reefs/ecology read bathymetry) → sequence after (a); guard marine adequacy + live gate. |
+
+Decision and rejected alternatives: [FRAMING.md](./FRAMING.md). Pre-declared bounds: [EXPECTATIONS.md](./EXPECTATIONS.md).
+
+## 5. Adversarial verification
+
+A 5-agent workflow independently scrutinized M1/M2/M3 against the raw bins (not the harness aggregation):
+
+- **Bins are byte-faithful:** every run validates 0/0/0; the offline shelf rebuild matched the live
+  `shelfmask` with diff 0; key numbers (nsDelta, Pearson, cutoffs, counterfactuals) were re-derived from
+  scratch in independent Python and matched the harness exactly.
+- **Corrections folded in above:** M1's all-tiles metric is artifact-prone (→ continent-restricted added
+  to the harness); M2's "inverted seafloor" downgraded to "orogenic-shallow nearshore → inverted width
+  consequence"; M3's "18–25%" widened to "~5–25%, scheme-dependent" with redistribution-to-islands as the
+  load-bearing mechanism.
+- **All three headline verdicts: confirmed/partially-confirmed.** None reversed the a-then-b decision.
+
+## 6. Known limits of this evidence
+
+- One map size (106×66), two configs; all reads of the **same dumps** — independence is in
+  re-computation, not fresh generation. Effect sizes may shift at other sizes/configs (open question).
+- Harness + live op both use **odd-Q** adjacency; per project memory the engine is **odd-R** (differs by
+  1 of 6 neighbors per tile). The analysis is self-consistent with the op that produced the bins, but any
+  localization inherits the op's odd-Q/odd-R mismatch — flag for a future correctness pass.
+- Active offshore sample is **thin** (n drops to single digits by ring 5); deep-ring active behavior is
+  poorly constrained.

--- a/docs/projects/margin-aware-bathymetry/DESIGN.md
+++ b/docs/projects/margin-aware-bathymetry/DESIGN.md
@@ -1,0 +1,135 @@
+# Thread 2 — Layer (a) design: per-landmass shelf-break cutoff localization
+
+> The "how." Empirical grounding: [ANALYSIS.md](./ANALYSIS.md). Decision + rejected layers:
+> [FRAMING.md](./FRAMING.md). Pre-declared success bounds: [EXPECTATIONS.md](./EXPECTATIONS.md).
+> Chosen by a 3-draft + 2-judge design panel (both judges 9/9 on draft A, "Voronoi + blend-to-global").
+
+## 0. What changes (one sentence)
+
+Replace the single **global** `shallowCutoff` quantile in `compute-shelf-mask` with a **per-water-tile
+local cutoff field** derived from nearest-land-component (Voronoi) attribution, blended toward the global
+cutoff for under-sampled components — self-contained in the op, **output shape unchanged**, gated by a
+`localizeCutoff` flag for clean A/B + zero-risk rollback.
+
+## 1. Mechanism (the chosen scheme)
+
+The op already computes a global nearshore quantile (`shallowCutoff`). Keep that pass verbatim — it stays
+the returned output, the trace-summary value, and the **blend anchor**. Add localization on top:
+
+1. **Land components** — `collectMaskComponentsOddQ({ mask: landMask, width, height })` (existing
+   `@mapgen/lib/grid/components.ts`); write each component's 1-based `id` into `landIdByTile: Int32Array`.
+2. **Nearest-land Voronoi** — multi-source odd-Q BFS seeded from every land tile (dist 0,
+   `nearestLand=landIdByTile[i]`), propagating the source's component id to every water tile. Port the
+   harness's exact loop (`analyze-margin-contrast.ts` 174–201) **verbatim**, including land-tile **seeding
+   order (index order)** so the op and harness break ties identically.
+3. **Per-component nearshore buckets** — re-walk water tiles with `dist ∈ [1, sampleRadius]` (same predicate
+   as the global pass), push `min(0, bathymetry[i])` into `compSamples.get(nearestLand[i])`.
+4. **Per-component cutoff + blend** — for each component with `n` attributed samples:
+   `rawQ = quantile(samples, shallowQuantile)`; `w = clamp01(n / localCutoffMinSamples)`;
+   `effCut = min(0, w * rawQ + (1 − w) * shallowCutoff)`. Store in `effCutoffById`.
+5. **Per-tile accessor** — `effCutoffByTile(i) = effCutoffById.get(nearestLand[i]) ?? shallowCutoff`. The
+   `?? shallowCutoff` is an **explicit, tested terminal branch** (zero-sample component / no-land map), not
+   an incidental coalesce (graft from B).
+6. **Gate pass** — the *only* line that changes in the existing loop:
+   `rawBreak = effCutoffByTile(i) * breakDepthScale * marginFactor` (was the scalar `shallowCutoff`).
+   `clampInt16`, the `absoluteMaxShelfDepth` floor, `min(0, …)`, the depth gate, `shelfBreakDepthByTile`,
+   the active/passive `marginFactor`, and the connectivity flood are **all unchanged**.
+
+`localizeCutoff === false` ⇒ `effCutoffByTile` returns the scalar `shallowCutoff` and the op is
+**byte-identical to today** (the A/B baseline + rollback path).
+
+### Why blend, not window-fallback or hard-discard
+
+- **Blend-to-global** degrades gracefully on **one code path**; the Voronoi label covers every tile, so
+  there is never an unattributed region needing a window. A continent (n in the hundreds) gets `w=1` ⇒ full
+  localization exactly where A2/A4 need it; a single-tile island dot (n ≈ 3–8) gets `w ≈ 0.13–0.33` ⇒
+  ~70–87 % blended to global, neutralizing its unstable 0.6-quantile **without a hard discard** (no spatial
+  seam at `n = floor`).
+- The **[global, islandCutoff) invariant** for continents holds by construction: a full-weight continent
+  cutoff is `rawQ` (≈ −5 juicy / −10.7 earthlike), strictly between global (≈ −8.8 / −14.2) and island
+  (≈ −12.1 / −17.3) — measured 10/10 at baseline; the blend only pulls an under-sampled component **toward**
+  global, never past it.
+
+## 2. New config keys (in `ShelfMaskConfigSchema`, canonicalized in `normalize()`)
+
+| key | type | default | range | normalize clamp | purpose |
+|---|---|---|---|---|---|
+| `localizeCutoff` | boolean | `true` | true/false | `config.localizeCutoff === false ? false : true` | master on/off; false ⇒ byte-identical global-cutoff op (A/B + rollback) |
+| `localCutoffMinSamples` | integer | `24` | 1..4096 | `Math.max(1, Math.min(4096, Math.trunc(clampNonNegative(v, 24))))` | sample-count **floor**: components with ≥ this many attributed nearshore samples are fully localized; fewer ⇒ linear blend toward global |
+
+Backward-compatible: configs omitting the keys get defaults via `normalize()`. **A frozen pre-Thread-2
+baseline run must set `localizeCutoff: false` explicitly.**
+
+## 3. Resolved open questions (EXPECTATIONS §6)
+
+- **OQ3 — floor value + blend formula:** `localCutoffMinSamples = 24` (≈ 3 odd-Q frontage rings at
+  `sampleRadius = 8`; the smallest pool whose `shallowQuantile=0.6` order statistic `floor(0.6·(n−1))` is
+  stable to ±1 unit). **Provisional → SWEEP {16, 24, 40}** against the A3 [−5%,+10%] band in DEV before
+  locking (config-only, no code change). Blend = linear ramp `w = clamp01(n/floor)`, convex combo to global.
+  Reject floor=8 (trusts noisy island quantiles); reject weighting by land **area** (sample count is the
+  direct measure of quantile stability, not area — a thin vs blob continent of equal area differ in frontage).
+- **OQ2 — odd-Q vs engine odd-R:** **DEFER, do not co-fix in (a).** The op + harness + `components.ts` are
+  all odd-Q; the engine is odd-R (differs by 1 of 6 neighbors). Co-fixing would alter Voronoi labels, sample
+  membership, the depth-gate neighbor checks, AND the flood across the *entire* shelf — confounding the A2/A3/A4
+  measurement — and would force the harness off the live odd-Q bins, breaking G6's 0/0/0. Documented as a
+  deliberately-carried-forward correctness item, not a regression introduced here.
+- **Harness fidelity (G6):** keep the harness an **independent replica** — it still solves `effScale` by
+  brute-force fitting the live `breakdepth` bin (it cannot see the `shelfWidth` knob) but re-derives the
+  per-component cutoff field with its **own** Voronoi+blend code (NOT an import of the op's function —
+  rejected by all three drafts as tautological). 0/0/0 then requires three independent derivations to agree:
+  the recomputed global quantile, the harness's own field, and the fitted scale.
+
+## 4. Adversarial risks the design must beat (the two judge leader-rejections)
+
+These are **load-bearing** — they convert "looks right" into measured-right:
+
+1. **A4 injection-stability (residual coupling through Voronoi pool-membership).** Nearest-land Voronoi
+   assigns each near-coast water tile to its *closest* land component. Injecting an island near a continent's
+   coast **steals** near-coast water tiles into the new island's cell, changing the continent's attributed
+   pool — a residual coupling **even though no island sample enters the continent's quantile**. Static-land
+   G6=0/0/0 proves field-faithfulness but proves **nothing** about injection-stability.
+   → **Resolution:** add an **island-injection counterfactual mode** to the harness (mutate `landMask` to
+   inject N islands near a continent, recompute Voronoi + per-component field, measure continental-shelf
+   delta). A4 passes iff that delta < 5 %. This is the headline A4-DECOUPLE test and is currently unproven.
+2. **A3 redistribution must be MEASURED, not assumed.** Blend-to-global gives deep-basin micro-island dots a
+   too-shallow gate ⇒ they lose their own deep island shelf ⇒ weakens redistribution-to-islands ⇒ total area
+   could drift below the −5 % floor on island-heavy seeds (earthlike s451: 218/343 active tiles were size-1
+   dots). → **Resolution:** report **per-seed island-shelf delta AND total-area delta** across all 10 runs;
+   confirm total ∈ [−5%,+10%] specifically on island-heavy seeds. Keep B's **16-tile window estimator** as a
+   pre-specified, **flag-gated contingency** (one extra config key) — if the sweep shows dots over-blending,
+   the fix is a config switch for below-floor components, not a redesign.
+
+## 5. Implementation gating discipline (do not trust any A-row until these hold)
+
+- **Quantile bit-identity across 3 call sites** — op `computeQuantileCutoff(Int16Array,count,q)`, the op's
+  new `number[]` overload, and harness `quantileCutoff(number[])` must be bit-identical (same ascending sort,
+  `idx = floor(q·(n−1))`, `min(0, x ?? 0)`, and empty/n=1/ties behavior). **Pin with a unit equivalence
+  test** — do not rely on inspection.
+- **Harness `breakDiffFor` → per-component-FIELD fit** (sweep `effScale` only; `raw = localCutoffOf(i) ·
+  effScale · marginFactor`). A scalar-cutoff fit can no longer hit 0 against the localized live bin.
+- **1-based (op `collectMaskComponentsOddQ`) vs 0-based (harness `landId`) component ids** — harmless (ids
+  are opaque keys; the compared quantity is the cutoff *field*) but must be called out; the BFS **seeding +
+  scan order** must be identical so contested *shallow* tiles don't flip components between op and harness.
+- **Op-edit + harness-edit land in the SAME commit** and re-validate **0/0/0 in 10/10** before any A-row.
+- **G1-COASTRING** explicit re-check (no land tile loses its sole dist-1 coastal-water neighbor — mechanically
+  the dist-1 ring is shallowest and clears any cutoff ≥ global, but assert it).
+- **G4-MARINE** flag (out of (a)'s strict pass rule, but shelf is the marine substrate; the ~−25 % continental
+  shrink goes to the `placement-metrics` re-check during DEV).
+
+## 6. Predicted ledger (to be confirmed in DEV, ≥5 seeds × 2 configs)
+
+| row | prediction | basis |
+|---|---|---|
+| A1 | HOLD (continentCutoff > islandCutoff ≥ 9/10) | baseline already 10/10 |
+| A2 | DOWN, ~−25 % juicy / ~−14 % earthlike (∈ [−5%,−27%]) | M3 Voronoi counterfactual; re-confirmed live: s1337 −26.5 %, s451 −8.7 % |
+| A3 | HOLD (∈ [−5%,+10%]), redistribution measured | re-confirmed live: s1337 total +0.05 %, s451 +3.4 % |
+| A4 | DECOUPLE → 0 (Pearson ≤ 0.2 AND injection < 5 %) | **the headline test — injection mode must be added** |
+| A5 | HOLD (graceful degrade; n=1-continent seeds pass on large per-component pool) | construction + s1337 baseline (continent n=1, w=1, no degeneracy) |
+
+## 7. Output / blast radius
+
+Output shape **identical** (no new bin): `shelfMask, activeMarginMask, depthGateMask,
+nearshoreCandidateMask, shelfBreakDepthByTile, shallowCutoff`. `shallowCutoff` stays the global quantile;
+the per-component field is internal and fully observable through the existing `shelfBreakDepthByTile`
+(`morphology.shelf.breakDepth`) bin. `computeShelf.ts` (`validateShelf`, trace summary, viz dumps) and all
+consumers are **untouched**. Net contract/step/viz delta: **two optional config keys**.

--- a/docs/projects/margin-aware-bathymetry/EXPECTATIONS.md
+++ b/docs/projects/margin-aware-bathymetry/EXPECTATIONS.md
@@ -1,0 +1,173 @@
+# Thread 2 Expectation Ledger — Margin-aware bathymetry
+
+> **Step-5 GATE. Declared BEFORE design/tuning.** Amendments are append-only (§6) with runId+date.
+> Grounding configs `latest-juicy` + `swooper-earthlike`; reference size Huge **106×66**, seeds
+> 1337/1018/207/99/451. Baseline = the analysis corpus ([ANALYSIS.md](./ANALYSIS.md)). Decision +
+> rationale: [FRAMING.md](./FRAMING.md).
+
+## 0. Change under test
+
+- **Request:** decouple continental shelf width from island density, and make the active-narrow /
+  passive-wide margin contrast physically grounded, contiguous, and per-map reliable.
+- **Domains:** morphology (shelf, layer a) and morphology/foundation seafloor (heightfield, layer b);
+  projection (`map-morphology`); guards from the coast workstream carry forward.
+- **Structural plan (chosen):** **a-then-b**. (a) replace the single global `shallowCutoff` with a
+  per-landmass local cutoff in `compute-shelf-mask`; (b) add a margin-aware sub-sea depth term upstream
+  of `bathymetry = min(0, elevation − seaLevel)`. Rejected: b-only, a-only-final, both-now, neither
+  (see FRAMING).
+- **Hypotheses (falsifiable):**
+  - (a) Continental shelf width is coupled to island density because the break gate uses one global
+    cutoff that island nearshore samples drag deep. A per-landmass cutoff makes per-landmass width
+    independent of island count, shrinks continental shelf, and redistributes (not deletes) area to
+    islands — while preserving byte-faithful self-validation. It preserves/slightly sharpens contrast but
+    does **not** reach a reliable per-map floor (the seafloor is still orogenic-shallow on active margins).
+  - (b) The active-narrow width inversion originates in bathymetry (an orogenic-relief proxy). A
+    margin-aware subsidence term that deepens convergent/transform nearshore seafloor (steeper drop-off)
+    while keeping passive gentle/shallow lifts the per-map width ratio to a reliable floor **without**
+    regressing coast-ring / land-share / marine-adequacy and **without** double-counting relief.
+
+## 1. Baseline (measured, BEFORE — mean [min..max] over the 10-run corpus)
+
+| Metric | latest-juicy | swooper-earthlike |
+|---|---|---|
+| cutoff ordering continent / global / island | −5.1 / −8.8 / −12.1 | −10.7 / −14.2 / −17.3 |
+| ordering continent>global>island holds | 5/5 runs | 5/5 runs |
+| continental shelf tiles (global → per-landmass-local) | ≈ −25% | ≈ −14% |
+| total shelf change (Voronoi local) | ≈ flat (−3%..+10%) | ≈ flat |
+| nearshore active−passive bathy delta | +11.7 [+10.0..+13.2] | +11.4 [+8.5..+12.4] |
+| closeness↔depth Pearson | +0.28 [+0.23..+0.33] | +0.30 [+0.20..+0.45] |
+| continent-restricted active mean width (rings) | 0.5..1.9 | 0.4..2.1 |
+| continent-restricted passive mean width (rings) | 1.8..2.2 | 2.2..2.6 |
+| active continental shelf direction (active < passive) | 5/5 | 4/5 (s451 ≈ equal, not inverted) |
+| harness self-validation (break/flood/margin diff) | 0/0/0 | 0/0/0 |
+
+## 2. Pre-declared expectations (targets, AFTER — same size/seeds; report mean[min..max] over ≥5 seeds × 2 configs)
+
+### Layer (a) — localize the cutoff
+
+| ID | Metric | Direction | Pre-declared bound | Rationale |
+|---|---|---|---|---|
+| **A1** | per-landmass cutoff ordering (continent vs island, per component over its attributed nearshore) | HOLD (precondition) | continentCutoff > islandCutoff in ≥ 9/10 runs | the coupling (a) exploits must persist or there is nothing to decouple |
+| **A2** | continental shelf tiles, per-landmass vs global cutoff | DOWN | drops in 10/10; magnitude in **[−5%, −27%]** (do NOT promise "18–25%" — that's the latest-juicy/Voronoi corner) | removing island-borrowed depth retires the +400 coupling; magnitude is method/config-dependent by design |
+| **A3** | total shelf area change, global → per-landmass | HOLD | within **[−5%, +10%]**; redistribution-to-islands (island shelf +9%..+46%) **measured, not assumed**. Continent-only attribution REJECTED for primary (loses area −101..−413) | localization redistributes, it doesn't delete; the HOLD is contingent on islands absorbing |
+| **A4‑DECOUPLE** | sensitivity of per-continent shelf width to island count across the corpus | TARGET → 0 | \|Pearson(continentWidth, islandCount)\| ≤ 0.2 AND a controlled island-injection counterfactual moves continental shelf < 5% (vs current +400) | **the headline Thread-1 target**: a continent's shelf break must not be set by island density elsewhere |
+| **A5‑STABILITY** | continental cutoff well-defined when continents are few (1–3/run; n=1 on s1337) | HOLD (graceful degrade) | no degenerate (n<floor) raw quantile; below floor blend→global or 16-tile window fallback; no NaN/0-collapse; localized continental cutoff stays in [global, islandCutoff) | the landmasses that matter most have the smallest count; naive per-component quantile is weakly sampled |
+
+### Layer (b) — margin-aware seafloor
+
+| ID | Metric | Direction | Pre-declared bound | Rationale |
+|---|---|---|---|---|
+| **B1** | active-margin nearshore median bathymetry (rings 1..R) | DOWN (deeper) | active median moves from ~0/−1 to **deeper than passive median** in ≥ 8/10 runs | real active margins are steep/deep; the gate must then admit fewer active rings (narrower) |
+| **B2** | per-map width ratio passive/active (**median, continent-restricted, area-weighted** — NOT per-tile active.mean) | UP toward a reliable floor | passive/active ≥ **1.0 in 10/10** (eliminate the s451-class artifact); mean in **[1.3, 2.5]** without island-dot inflation | Pacific-narrow / Atlantic-wide, per-map reliable, with real dynamic range |
+| **B3‑NO‑DOUBLECOUNT** | subsidence is an independent depth term, not re-applied orogenic relief | HOLD | passive nearshore median changes by ≤ \|2\| units; active deepening respects absoluteMaxShelfDepth (−30) and never breaks the connectivity flood; closeness↔depth must not become more monotonic in the same direction | bathymetry is already a relief proxy; a margin term that re-weights relief would double-count |
+
+### Guards (HOLD) — carry forward from the coast workstream; not optional
+
+| ID | Metric | Bound | Rationale |
+|---|---|---|---|
+| **G1‑COASTRING** | land-tile coast-ring coverage | = 100% in every run, after (a) and (b); zero land bordering deep ocean with no coast ring | no floating cliffs; coastal settlement legality |
+| **G2‑LANDSHARE** | landShare | within ±0.005 of baseline | neither layer may move the land/water boundary (both operate strictly in water) |
+| **G3‑WATERDRIFT** | no-water-drift assertion (map-morphology, map-elevation) | passes after (a) and (b); bathymetry ≤ 0 in water (no positive leak) | (b) writes sub-sea elevation; must keep the contract + engine no-drift invariant |
+| **G4‑MARINE** | marine resource / reef-family adequacy (placement-metrics; coast C9) | ≥ baseline − 10% AND within official feasible band; explicitly re-check atoll-eligible warm shallow **open**-ocean area | shelf is the marine substrate; deepening active + redistributing shelf must not starve marine sites; atoll/shelf tradeoff is delicate (EXPECTATIONS §6 R3) |
+| **G5‑STARTS** | player starts + island-start coast distance (coast C10) | all 10 placed; island starts within `maxIslandStartCoastDistance`; live Huge gen completes | start legality + connectivity; (b) is map-affecting → live gate required |
+| **G6‑SELFVALIDATE** | harness self-validation (break/flood/margin diff vs live bins) | = 0/0/0 in 10/10 after each layer | every Thread-2 number rests on the harness mirroring the live op exactly |
+
+## 3. Pass / fail rule (declared now)
+
+- **PASS (layer a)** = A2 ∧ A3 ∧ A4‑DECOUPLE in bounds, with A1/A5 preconditions met, AND every guard
+  G1–G6 holds over the ≥5-seed × 2-config set. **Ship (a) on this alone** — robust, self-contained,
+  near-zero blast radius.
+- **PASS (layer b)** = B1 ∧ B2 ∧ B3 in bounds, AND every guard G1–G6 holds, AND the **step-7 live
+  in-game gate** passes on latest-juicy (b is map-affecting).
+- **FAIL (target miss)** = A2/A4 (a) or B1/B2 (b) miss while direction/mechanism held → hypothesis/tuning
+  wrong; loop. If a bound was mis-set but direction+mechanism held → **AMEND** append-only (§6) + re-judge.
+- **FAIL (collateral)** = any guard G1–G6 breaks → coverage/legality/measurement regression; loop. The
+  most likely (b) failure is a prettier seafloor that under-produces marine sites (G4) or strands land (G1).
+- **SEQUENCING GATE** = (b) does not start until (a) PASSES (removes the island-density confound so (b)'s
+  contrast is measured on a clean per-landmass gate). both-now is rejected.
+- **DOWNGRADE / ESCALATE triggers:** see FRAMING "What would change the call." If (a) alone lifts the
+  continent-restricted ratio to a reliable floor, (b) → "realism polish." If the mis-aimed shelves break
+  start/marine balance live, (b) → first/urgent.
+
+## 4. Diagnostic command (reproducible)
+
+```bash
+cd mods/mod-swooper-maps
+bun ./src/dev/diagnostics/run-standard-dump.ts -- 106 66 1337 --label t2 \
+  --configFile "$PWD/src/maps/configs/latest-juicy.config.json"
+bun scripts/diag/analyze-margin-contrast.ts dist/visualization/t2/<runId> \
+  "$PWD/src/maps/configs/latest-juicy.config.json"
+# self-validation must read 0/0/0; M1.continentRestricted is the honest width metric;
+# M3.counterfactualLocalVsGlobal is the layer-(a) preview.
+```
+
+## 5. Results — Layer (a), measured
+
+> Corpus: 10 fresh **localized** dumps (`localizeCutoff=true`, `localCutoffMinSamples=24`, the default),
+> Huge 106×66, `latest-juicy` + `swooper-earthlike` × seeds 1337/1018/207/99/451. Harness
+> `analyze-margin-contrast.ts`; A2/A3 = M3 dual-arm (local field vs global field, same dump/effScale);
+> A4 = M4 exclusion counterfactual + Pearson; floor sweep = M5. Design: [DESIGN.md](./DESIGN.md).
+
+| ID | Bound | Measured (10 runs) | Verdict |
+|---|---|---|---|
+| **G6** | break/flood/margin diff = 0/0/0 in 10/10 | **0/0/0 in 10/10** | ✅ PASS |
+| **A1** | continentCutoff > islandCutoff ≥ 9/10 | **10/10** (cont −3..−11 vs island −13..−17) | ✅ PASS |
+| **A2** | continental shelf DOWN 10/10, ∈ [−5%,−27%] | down 10/10, range **[−26.5%, −7.0%]** | ✅ PASS |
+| **A3** | total shelf ∈ [−5%,+10%]; redistribution measured | **9/10 in band [−2.7%,+4.9%]**; outlier latest-juicy/451 **+18.1%**; island shelf +11%..+57% (redistribution measured) | ⚠️ PROVISIONAL — see §6 A3-AMEND (diagnosed; gated on G4 + live) |
+| **A4** | \|Pearson(contWidth, islandCount)\| ≤ 0.2 AND injection < 5% | exclusion counterfactual **local 0% (10/10)** vs global +3%..+46%; Pearson local −0.64/−0.55 vs global −0.73/−0.67 | ✅ PASS via causal test — see §6 A4-AMEND (Pearson is geography-confounded) |
+| **A5** | no degenerate quantile; cont cutoff ∈ [global, islandCut); blend below floor | **continentsBelowFloor = 0 in 10/10** (median cont samples 229–1604, w=1); pool-robustness max cutoff shift **1 unit** | ✅ PASS |
+
+**Floor sweep (M5, offline-exact):** at floors {16,24,32,40,48,64} the continental drop is ~floor-invariant
+(continents are full-weight at every floor) and 9/10 totals stay in band at all floors; latest-juicy/451
+stays +14%..+19% at every floor (its excess is **full-weight deep-water islands**, not under-sampled dots,
+so the floor neither causes nor cures it). **Floor = 24 retained** (the analysis default; 16–40 equivalent
+on this corpus).
+
+**Run IDs (localized, floor 24):** latest-juicy 1337 `f9ee2948…`, 1018 `84ca414e…`, 207 `dd7130ad…`,
+99 `ed0e7e10…`, 451 `9f2900e1…`; swooper-earthlike 1337 `702acf65…`, 1018 `d9a817de…`, 207 `32b16a2d…`,
+99 `79fe7a06…`, 451 `f81325fc…` (under `dist/visualization/t2asw_*`, gitignored).
+
+**Layer-(a) verdict (headless):** A1/A2/A4/A5/G6 **PASS**; A3 **PROVISIONAL** (one island-dense seed over
+the pre-declared ceiling, diagnosed as a low-global-baseline artifact, not anomalous localized coast).
+Final PASS pending the §4 guards (esp. G4 marine adequacy) and the step-7 live in-game gate.
+
+## 6. Amendments, limitations, deferrals (append-only)
+
+- **Premise correction (2026-06-21):** the coastal-shelf-tiling "weakly margin-correlated" premise is
+  refuted on the strength dimension (signal is strong: delta +11.5, Pearson +0.29, 10/10). The defect is
+  the **sign of the width consequence**, not signal strength. See ANALYSIS §M2.
+- **B2 metric not yet implemented as area-weighted:** the harness now reports continent-restricted
+  mean+median width by margin (`M1.continentRestricted`). The full **area-weighted** B2 metric must be
+  added + re-validated (G6 = 0/0/0) before (b) tuning begins. (Open question.)
+- **A4-AMEND — Pearson sub-criterion is geography-confounded (2026-06-21, layer-a sweep):** the
+  pre-declared A4 test had two parts: `|Pearson(continentWidth, islandCount)| ≤ 0.2` AND
+  `injection counterfactual < 5%`. Measured: the **causal** test passes decisively — the exclusion
+  counterfactual (recompute the cutoff with vs WITHOUT island nearshore samples) moves continental shelf
+  **0% under the local gate in 10/10** vs **+3%..+46% under the global gate**. But the Pearson stays high
+  (local −0.64/−0.55 vs global −0.73/−0.67). Diagnosis: `islandCount` and `continentWidth` share an
+  irreducible **geographic confounder** — a seed with more islands has less continental land, hence less
+  continental shelf — that localization neither can nor should remove. The Pearson conflates that
+  confounder with the cutoff-coupling; the exclusion counterfactual isolates the cutoff-coupling and is
+  the confound-free measure. **Re-judge A4 PASS** on `exclusion-local < 5% (got 0%)` AND
+  `|Pearson_local| < |Pearson_global|` (coupling reduced, holds both configs); retire the `≤ 0.2`
+  absolute Pearson bound as mis-specified. (Mechanism + direction held; this is a bound correction.)
+- **A3-AMEND (PROVISIONAL) — island-dense ceiling (2026-06-21, layer-a sweep):** 9/10 totals are in
+  [−5%,+10%]; latest-juicy/451 (the most island-dense seed, 48 islands) is **+18.1%**. Diagnosis: NOT
+  small-island over-blending (floor-invariant: +18% even at floor 64) but **proper shelving of deep-water
+  islands** the single global cutoff under-shelfs. Single-tile specks get a large attributed deep-ocean
+  Voronoi pool (80–135 samples) → a confident deep cutoff → a shelf calibrated to their deep surroundings.
+  Crucially the **local absolute total (2509) is consistent with the other juicy seeds (2338–2525)**; it is
+  s451's **global baseline (2124) that is anomalously low**, so the high % reflects a low comparison
+  baseline, not anomalous localized coast. Redistribution held (continents −15.3%, islands +57.5%; no
+  deletion). **Proposed amendment:** widen the A3 ceiling to **+20%** for island-dense seeds (or restate
+  A3 as "local absolute coast consistent across the corpus + no deletion"). **CONTINGENT** on G4 marine
+  adequacy + the live in-game gate confirming the extra island shelves are benign (not flooding marine
+  balance or producing pathological speck-aprons). If the live gate flags speck-aprons as a coast-quality
+  regression, revisit with a near-tile-weighted sample window (a SEPARATE change, not layer (a)).
+- **Open questions (carried from analysis):** (1) does the M3 coupling + (a) magnitude survive a
+  fresh-generation sweep at other map sizes/configs? (2) odd-Q vs engine odd-R adjacency — note for a
+  future correctness pass or co-fix in (a)? (3) (a) attribution scheme (per-component-with-blend vs
+  window) and the sample-count floor value are untuned. (4) (b) how to add tectonic subsidence keyed on
+  margin without double-counting the orogenic relief already in bathymetry. (5) (b) reef/ecology retune
+  budget — bound to config, not code? (6) active offshore sampling is thin — denser sample before
+  trusting B1/B2 deep-ring claims?

--- a/docs/projects/margin-aware-bathymetry/FRAMING.md
+++ b/docs/projects/margin-aware-bathymetry/FRAMING.md
@@ -1,0 +1,87 @@
+# Thread 2 — Framing & decision: margin-aware seafloor bathymetry
+
+> The "why" and the "what we're doing about it." Empirical grounding: [ANALYSIS.md](./ANALYSIS.md).
+> Pre-declared success bounds: [EXPECTATIONS.md](./EXPECTATIONS.md).
+
+## The premise was wrong (and the analysis corrected it)
+
+[coastal-shelf-tiling EXPECTATIONS §6](../coastal-shelf-tiling/EXPECTATIONS.md) deferred margin-aware
+seafloor as polish, on the premise that "the generated bathymetry is only **weakly margin-correlated**."
+Thread 2 measurement (10 self-validated runs, byte-faithful vs the live op) **refutes that adjective**:
+
+- The nearshore seafloor carries a **strong, robust margin signal** — active−passive depth delta
+  ≈ **+11.5** (positive in 10/10), closeness↔depth Pearson **+0.29** (positive in 10/10), survives
+  island removal. Not "weak."
+- The real defect is the **sign of the consequence, not the strength.** Because
+  `bathymetry = min(0, elevation − seaLevel)`, the seafloor is an **orogenic-relief proxy**: high-relief
+  active (convergent/transform) coasts make the adjacent water **shallow**, passive coasts stay **deep**.
+  Shallow active nearshore water clears the depth gate over *more* rings → it tends to **widen** active
+  shelves, the opposite of the intended Pacific-narrow / Atlantic-wide contrast.
+
+So the prior doc and this analysis **agree on the mechanism and disagree only on the adjective**: the
+bathymetry does not translate into the *desired* width contrast — but because the signal is *strong and
+mis-aimed*, not weak. (Honest scope: "inverted *width consequence*," not a flatly non-physical seafloor —
+real active margins are shallow at the coast too.)
+
+## Two layers, sequenced: **a-then-b**
+
+### (a) Localize the shelf-break cutoff — do now, low-risk
+
+Today `shallowCutoff` is **one global quantile** over all nearshore water tiles. Abundant island samples
+(island local cutoff ≈ −13) drag it deep, so continents (local cutoff ≈ −4) inherit a deeper-than-warranted
+gate and gain ~+400 shelf tiles — **Thread-1's quantified island→continent coupling**. The ordering
+continentCutoff > globalCutoff > islandCutoff holds in 10/10 runs.
+
+**Fix:** compute the cutoff **per-landmass** (nearest-land Voronoi attribution + blend-to-global below a
+sample-count floor; 16-tile spatial window as the graceful fallback). Self-contained in
+`compute-shelf-mask`; **no bathymetry consumer changes**; near-zero blast radius. It shrinks continental
+shelf in 10/10 (≈ −25% latest-juicy / −14% earthlike) while redistributing to islands so total area holds.
+It is also a **measurement prerequisite**: removing the island-density confound lets (b) be measured on a
+per-landmass gate free of the +400 contamination.
+
+### (b) Margin-aware seafloor subsidence — necessary for realism depth, sequence after (a)
+
+M2 proves (a) alone cannot make the contrast physically honest or give it **dynamic range** — against an
+orogenic-shallow active nearshore, the break-depth lever (a clean 2.0 ratio on every run) saturates and
+active continental shelves pin at the 0–1 ring floor. (b) adds a **margin-aware sub-sea depth term** so
+convergent/transform nearshore seafloor **deepens** (steeper drop-off → genuinely narrow active shelf) and
+passive nearshore stays gentle/shallow → wider. This is the seafloor analogue of the foundation's existing
+land **forcing→elevation coupling** (top-uplift-decile → top-30% land elevation; see
+`pipeline-realism/.../morphology-contract.md`), which has **no seafloor equivalent today** — that gap is (b).
+
+Entry point: `reconcile-heightfield-from-coast` (and whatever sets sub-sea elevation). **Risk surface:**
+reefs (atoll/reef scoring keys on warm shallow *open* ocean beyond the shelf — already a delicate tradeoff,
+EXPECTATIONS §6 R3) and ecology (sand/snow, marine resources, the C9 marine-adequacy guard). So (b) is a
+foundation/heightfield change that **must follow (a)**, re-verify marine adequacy, and re-run the live
+in-game gate (it is map-affecting).
+
+**Urgency note (honest):** the continent-restricted metric shows the contrast *direction* is already
+reliable on continents (active narrower in 9/10) — it is only the artifact-laden all-tiles metric that
+looked "inverted." So (b) is **realism depth + per-map dynamic range**, not a correctness emergency. This
+matches the ledger's downgrade/escalate triggers.
+
+## Rejected alternatives
+
+- **b-only (skip cutoff localization):** leaves the robust +400 coupling in place, so any seafloor change
+  is measured through a global cutoff still dragged deep by island density — you can't attribute the
+  improvement to the seafloor fix. Worst ordering; also forgoes a near-zero-risk win.
+- **a-only (localize and declare done):** M2 is decisive that the seafloor itself is mis-aimed; (a)
+  de-confounds and sharpens but cannot give the contrast dynamic range or physical honesty. Acceptable as
+  an interim if the downgrade trigger fires, but not the end state.
+- **both-now (parallel a+b):** couples a low-risk self-contained op change to a high-scope foundation
+  change that reefs+ecology read — destroys effect isolation and inflates the live-verification surface.
+  (a) is a measurement prerequisite for evaluating (b); sequence, don't merge.
+- **neither:** refuted by all three confirmed findings (robust coupling, artifact-laden + compressed
+  contrast, mis-aimed seafloor signal).
+
+## What would change the call
+
+- **Downgrade (b) to "realism polish":** if a cheap experiment shows (a) alone lifts the per-map
+  continent-restricted width ratio to a reliable floor across all runs — the direction is already there,
+  so this is plausible.
+- **Escalate (b) to first/urgent:** only if a live/gameplay check shows the compressed/mis-aimed active
+  shelves break **start or marine balance** (a concrete C9/G4 or C10/G5 consequence), not merely a realism gap.
+- **Reconsider both-now:** only if (b) can be proven bathymetry-isolated (reef/ecology fingerprints
+  demonstrably unaffected), removing the scope-coupling that motivates sequencing.
+- **Drop (a) priority:** if a fresh-generation sweep at other map sizes shows the M3 coupling does not
+  survive.

--- a/docs/projects/margin-aware-bathymetry/README.md
+++ b/docs/projects/margin-aware-bathymetry/README.md
@@ -1,0 +1,38 @@
+# Margin-aware bathymetry (Thread 2)
+
+The realism follow-on to [coastal-shelf-tiling](../coastal-shelf-tiling/README.md). That workstream
+made coastal tiles follow a margin-aware, depth-gated continental shelf instead of a uniform band, and
+shipped it live. It closed with two honest hand-offs:
+
+- **Thread 1** ([erosion](../coastal-shelf-tiling/EROSION-THREAD.md)): erosion does **not** shape the
+  seafloor; the R3 shelf growth is dominated by a **global-cutoff coupling** — a single global
+  shelf-break quantile lets island density set continental shelf width map-wide.
+- **Margin-contrast limitation** ([EXPECTATIONS §6](../coastal-shelf-tiling/EXPECTATIONS.md)): the
+  active-narrow / passive-wide contrast was thought muted because "bathymetry is only weakly
+  margin-correlated."
+
+**Thread 2 tests both claims empirically and acts on them.** The analysis (10 self-validated runs)
+refutes the "weakly correlated" premise and quantifies the coupling, then scopes a two-layer fix.
+
+## Docs
+
+- [ANALYSIS.md](./ANALYSIS.md) — the empirical findings (M1/M2/M3), method, data, adversarial verification.
+- [FRAMING.md](./FRAMING.md) — corrected premise + the **a-then-b** decision and rejected alternatives.
+- [EXPECTATIONS.md](./EXPECTATIONS.md) — the pre-declared expectation ledger (Step-5 gate) for both layers.
+
+## One-line status
+
+Analysis complete and adversarially verified. Decision: **(a) localize the shelf-break cutoff**
+(self-contained, low-risk, retires the Thread-1 coupling), **then (b) margin-aware seafloor depth**
+(foundation/heightfield change; realism depth + per-map dynamic range). Design phase not started.
+
+## Ground-truth artifacts
+
+- Measurement harness (self-validating, byte-faithful vs the live op):
+  `mods/mod-swooper-maps/scripts/diag/analyze-margin-contrast.ts`
+- Layer (a) entry point (the single global cutoff):
+  `mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts`
+- Layer (b) entry point (bathymetry = min(0, elevation − seaLevel)):
+  `mods/mod-swooper-maps/src/domain/morphology/ops/reconcile-heightfield-from-coast/strategies/default.ts`
+- Foundation forcing→elevation coupling reference (the land analogue (b) extends to the seafloor):
+  `docs/projects/pipeline-realism/resources/spec/sections/morphology-contract.md`

--- a/mods/mod-swooper-maps/scripts/diag/analyze-margin-contrast.ts
+++ b/mods/mod-swooper-maps/scripts/diag/analyze-margin-contrast.ts
@@ -1,0 +1,784 @@
+#!/usr/bin/env bun
+// THREAD 2 HARNESS — quantify the margin-contrast gap and the global-cutoff locality, and (layer a)
+// SELF-VALIDATE the per-landmass cutoff localization byte-for-byte against the live shelf bins.
+// Reads ONE diag:dump and the map config, anchors on live shelf artifacts, and self-validates three
+// replicas (diff 0) before reporting:
+//
+//   M1  width-by-margin     : is the active-narrow / passive-wide shelf contrast real or muted?
+//   M2  bathy <-> margin     : does the underwater seafloor already carry a margin signal?
+//   M3  cutoff locality      : per-landmass vs global cutoff — the A2/A3 dual-arm counterfactual
+//                              (continental shelf DOWN, total area HOLD via redistribution-to-islands)
+//   M4  decoupling           : the A4-DECOUPLE causal test — an EXCLUSION counterfactual (recompute the
+//                              cutoff with vs WITHOUT island nearshore samples): continental shelf moves
+//                              ~0% under the LOCAL gate vs a large % under the GLOBAL gate (the Thread-1
+//                              island->continent coupling). Plus a continent cutoff pool-robustness probe.
+//   M5  floor sweep          : island-shelf (A3) sensitivity to localCutoffMinSamples, offline-exact.
+//
+// The harness stays an INDEPENDENT replica of compute-shelf-mask: it re-derives the per-component cutoff
+// field from the raw bins with its OWN code (NOT an import of the op) and still solves the knob-folded
+// effScale by fitting the live breakdepth bin. A diff of 0 then requires three independent derivations
+// to agree (recomputed global quantile, harness Voronoi+blend field, fitted scale).
+//
+// Usage: bun scripts/diag/analyze-margin-contrast.ts <dumpDir> <configFile> [--json]
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
+
+const BOUNDARY_CONVERGENT = 1;
+const BOUNDARY_TRANSFORM = 3;
+const CONTINENT_MIN = 100; // land-component tiles at/above which it is a "continent"
+const WINDOW = 16; // spatial-window edge (tiles) for the regional-cutoff cross-check
+
+const dumpDir = process.argv[2];
+const configFile = process.argv[3];
+const asJson = process.argv.includes("--json");
+if (!dumpDir || !configFile) {
+  console.error("usage: analyze-margin-contrast <dumpDir> <configFile> [--json]");
+  process.exit(1);
+}
+
+const dataDir = join(dumpDir, "data");
+const files = readdirSync(dataDir);
+function pickPath(sub: string): string {
+  const matches = files.filter((x) => x.toLowerCase().includes(sub) && x.endsWith(".bin"));
+  if (!matches.length) throw new Error(`no bin matching ${sub}`);
+  if (matches.length > 1) throw new Error(`ambiguous bin for ${sub}: ${matches.join(", ")}`);
+  return join(dataDir, matches[0]!);
+}
+const readU8 = (sub: string): Uint8Array => Uint8Array.from(readFileSync(pickPath(sub)));
+const readI16 = (sub: string): Int16Array =>
+  new Int16Array(Uint8Array.from(readFileSync(pickPath(sub))).buffer);
+
+// dims from manifest
+const manifest = JSON.parse(readFileSync(join(dumpDir, "manifest.json"), "utf8")) as any;
+let width = 0;
+let height = 0;
+const findDims = (o: any): void => {
+  if (o && typeof o === "object") {
+    if (typeof o.width === "number" && typeof o.height === "number" && !width) {
+      width = o.width;
+      height = o.height;
+    }
+    for (const v of Object.values(o)) findDims(v);
+  }
+};
+findDims(manifest);
+const size = width * height;
+
+// shelf config from the map config (knob-agnostic for the structural params; the
+// shelfWidth knob folds into an EFFECTIVE breakDepthScale we solve from live data).
+const cfgJson = JSON.parse(readFileSync(configFile, "utf8")) as any;
+const shelfCfg = cfgJson?.config?.["morphology-shelf"]?.shelf ?? {};
+const sampleRadius: number = Math.max(1, Math.trunc(shelfCfg.breakDepthSampleRadius ?? 8));
+const shallowQuantile: number = Math.max(0, Math.min(1, shelfCfg.shallowQuantile ?? 0.6));
+const activeClosenessThreshold: number = Math.max(
+  0,
+  Math.min(1, shelfCfg.activeClosenessThreshold ?? 0.35)
+);
+const activeBreakDepthFactor: number = shelfCfg.activeBreakDepthFactor ?? 0.6;
+const passiveBreakDepthFactor: number = shelfCfg.passiveBreakDepthFactor ?? 1.25;
+const absoluteMaxShelfDepth: number = Math.min(
+  0,
+  Math.trunc(shelfCfg.absoluteMaxShelfDepth ?? -30)
+);
+const activeThresholdU8 = Math.floor(activeClosenessThreshold * 255);
+// Layer (a) localization params (must mirror compute-shelf-mask normalize()).
+const localizeCutoff: boolean = shelfCfg.localizeCutoff === false ? false : true;
+const localCutoffMinSamples: number = Math.max(
+  1,
+  Math.min(4096, Math.trunc(shelfCfg.localCutoffMinSamples ?? 24))
+);
+
+// --- live shelf-stage artifacts (the exact state the op read + produced) ---
+const bathy = readI16("shelf-bathymetryinput-tile");
+const landMask = readU8("shelf-landmaskinput-tile");
+const distLive = new Uint16Array(
+  Uint8Array.from(readFileSync(pickPath("compute-shelf-morphology-shelf-distancetocoast-tile")))
+    .buffer
+);
+const boundaryType = readU8("morphology-belts-boundarytype-tile");
+const boundaryCloseness = readU8("morphology-belts-boundarycloseness-tile");
+const liveShelf = readU8("compute-shelf-morphology-shelf-shelfmask-tile");
+const liveBreak = readI16("shelf-breakdepth-tile");
+const liveGate = readU8("shelf-depthgatemask-tile");
+const liveActive = readU8("shelf-activemarginmask-tile");
+
+for (const [n, a] of [
+  ["bathy", bathy],
+  ["landMask", landMask],
+  ["distLive", distLive],
+  ["boundaryType", boundaryType],
+  ["boundaryCloseness", boundaryCloseness],
+  ["liveShelf", liveShelf],
+  ["liveBreak", liveBreak],
+  ["liveGate", liveGate],
+  ["liveActive", liveActive],
+] as const) {
+  if (a.length !== size) throw new Error(`${n} length ${a.length} != ${size} (${width}x${height})`);
+}
+
+function clampInt16(v: number): number {
+  return Math.max(-32768, Math.min(32767, v | 0));
+}
+function clamp01(v: number): number {
+  if (!Number.isFinite(v)) return 0;
+  return Math.max(0, Math.min(1, v));
+}
+const isWater = (i: number) => landMask[i] !== 1;
+const isActive = (i: number) =>
+  (boundaryType[i] === BOUNDARY_CONVERGENT || boundaryType[i] === BOUNDARY_TRANSFORM) &&
+  (boundaryCloseness[i] | 0) >= activeThresholdU8;
+
+// ---------- stats helpers ----------
+function summary(values: number[]): { n: number; mean: number; median: number; p90: number } {
+  if (!values.length) return { n: 0, mean: 0, median: 0, p90: 0 };
+  const v = values.slice().sort((a, b) => a - b);
+  const mean = v.reduce((a, b) => a + b, 0) / v.length;
+  const at = (q: number) => v[Math.min(v.length - 1, Math.floor(q * (v.length - 1)))]!;
+  return { n: v.length, mean: +mean.toFixed(3), median: at(0.5), p90: at(0.9) };
+}
+function pearson(xs: number[], ys: number[]): number {
+  const n = xs.length;
+  if (n < 2) return 0;
+  let sx = 0,
+    sy = 0,
+    sxx = 0,
+    syy = 0,
+    sxy = 0;
+  for (let i = 0; i < n; i++) {
+    sx += xs[i]!;
+    sy += ys[i]!;
+    sxx += xs[i]! * xs[i]!;
+    syy += ys[i]! * ys[i]!;
+    sxy += xs[i]! * ys[i]!;
+  }
+  const cov = sxy - (sx * sy) / n;
+  const vx = sxx - (sx * sx) / n;
+  const vy = syy - (sy * sy) / n;
+  if (vx <= 0 || vy <= 0) return 0;
+  return +(cov / Math.sqrt(vx * vy)).toFixed(3);
+}
+// Quantile estimator — MUST stay bit-identical to compute-shelf-mask's computeQuantileCutoff /
+// computeQuantileCutoffFromArray (pinned by shelf-cutoff-quantile-equivalence.test.ts).
+function quantileCutoff(samples: number[]): number {
+  if (!samples.length) return 0;
+  const v = samples.slice().sort((a, b) => a - b);
+  return Math.min(0, v[Math.floor(shallowQuantile * (v.length - 1))] ?? 0);
+}
+
+// ---------- land components (odd-Q) + nearest-land Voronoi over water ----------
+const landId = new Int32Array(size).fill(-1);
+const landSizes: number[] = [];
+{
+  const stack: number[] = [];
+  for (let i = 0; i < size; i++) {
+    if (landMask[i] !== 1 || landId[i] !== -1) continue;
+    const id = landSizes.length;
+    let count = 0;
+    stack.length = 0;
+    stack.push(i);
+    landId[i] = id;
+    while (stack.length) {
+      const idx = stack.pop()!;
+      count++;
+      const y = (idx / width) | 0;
+      const x = idx - y * width;
+      forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+        const ni = ny * width + nx;
+        if (landMask[ni] === 1 && landId[ni] === -1) {
+          landId[ni] = id;
+          stack.push(ni);
+        }
+      });
+    }
+    landSizes.push(count);
+  }
+}
+const isContinent = (id: number) => id >= 0 && landSizes[id]! >= CONTINENT_MIN;
+
+// nearest-land-component label over water (multi-source BFS from all land tiles)
+const nearestLand = new Int32Array(size).fill(-1);
+{
+  const dist = new Uint16Array(size).fill(65535);
+  const queue = new Int32Array(size);
+  let head = 0,
+    tail = 0;
+  for (let i = 0; i < size; i++) {
+    if (landMask[i] === 1) {
+      dist[i] = 0;
+      nearestLand[i] = landId[i];
+      queue[tail++] = i;
+    }
+  }
+  while (head < tail) {
+    const idx = queue[head++]!;
+    const y = (idx / width) | 0;
+    const x = idx - y * width;
+    const nd = dist[idx] + 1;
+    forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+      const ni = ny * width + nx;
+      if (dist[ni] > nd) {
+        dist[ni] = nd;
+        nearestLand[ni] = nearestLand[idx];
+        queue[tail++] = ni;
+      }
+    });
+  }
+}
+
+// ---------- shared shelf primitives ----------
+function floodFromGate(gate: Uint8Array): Uint8Array {
+  const shelf = new Uint8Array(size);
+  const queue = new Int32Array(size);
+  let head = 0,
+    tail = 0;
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = y * width + x;
+      if (landMask[i] === 1 || gate[i] !== 1) continue;
+      let adj = false;
+      forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+        if (adj) return;
+        if (landMask[ny * width + nx] === 1) adj = true;
+      });
+      if (!adj) continue;
+      shelf[i] = 1;
+      queue[tail++] = i;
+    }
+  }
+  while (head < tail) {
+    const idx = queue[head++]!;
+    const y = (idx / width) | 0;
+    const x = idx - y * width;
+    forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+      const ni = ny * width + nx;
+      if (landMask[ni] === 1 || shelf[ni] === 1 || gate[ni] !== 1) return;
+      shelf[ni] = 1;
+      queue[tail++] = ni;
+    });
+  }
+  return shelf;
+}
+// breakDepth gate per tile from a per-tile cutoff field + effective scale.
+function gateFromCutoffField(cutoffOf: (i: number) => number, effScale: number): Uint8Array {
+  const gate = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    if (landMask[i] === 1) continue;
+    const marginFactor = isActive(i) ? activeBreakDepthFactor : passiveBreakDepthFactor;
+    const raw = cutoffOf(i) * effScale * marginFactor;
+    const breakDepth = clampInt16(Math.max(absoluteMaxShelfDepth, Math.min(0, Math.round(raw))));
+    if ((bathy[i] ?? 0) >= breakDepth) gate[i] = 1;
+  }
+  return gate;
+}
+const countOf = (m: Uint8Array): number => {
+  let c = 0;
+  for (let i = 0; i < size; i++) if (m[i]) c++;
+  return c;
+};
+
+// ---------- layer (a): per-component nearshore samples -> blended cutoff field ----------
+// (independent re-derivation of compute-shelf-mask's buildLocalCutoffField, over the live nearestLand)
+const compNearshoreSamples = new Map<number, number[]>();
+for (let i = 0; i < size; i++) {
+  if (!isWater(i)) continue;
+  const d = distLive[i] | 0;
+  if (d <= 0 || d > sampleRadius) continue;
+  const id = nearestLand[i];
+  if (id < 0) continue;
+  let arr = compNearshoreSamples.get(id);
+  if (!arr) {
+    arr = [];
+    compNearshoreSamples.set(id, arr);
+  }
+  arr.push(Math.min(0, bathy[i] ?? 0));
+}
+function buildEffCutoffById(
+  globalAnchor: number,
+  floor: number = localCutoffMinSamples
+): Map<number, number> {
+  const m = new Map<number, number>();
+  for (const [id, samples] of compNearshoreSamples) {
+    const rawQ = quantileCutoff(samples);
+    const w = clamp01(samples.length / floor);
+    m.set(id, Math.min(0, w * rawQ + (1 - w) * globalAnchor));
+  }
+  return m;
+}
+function fieldFromEff(eff: Map<number, number>, globalAnchor: number): (i: number) => number {
+  return (i: number) => {
+    const id = nearestLand[i];
+    const c = id >= 0 ? eff.get(id) : undefined;
+    return c ?? globalAnchor;
+  };
+}
+
+// ---------- global cutoff (recomputed) + effScale solve + FIELD self-validation ----------
+const nearshore: number[] = [];
+for (let i = 0; i < size; i++) {
+  if (!isWater(i)) continue;
+  const d = distLive[i] | 0;
+  if (d <= 0 || d > sampleRadius) continue;
+  nearshore.push(Math.min(0, bathy[i] ?? 0));
+}
+const recomputedCutoff = quantileCutoff(nearshore);
+
+// Reconstruct (globalAnchor, effScale) the live op used by minimizing the break-depth diff against the
+// live breakdepth bin. The cutoff FIELD matches the live op (local if localizeCutoff else global); the
+// shelfWidth knob folds into effScale, solved by a brute-force sweep; the recomputed quantile can sit
+// +/- a step from the op's anchor. self-validating: a diff of 0 proves the field reconstruction is
+// byte-faithful, and downstream counterfactuals reuse the same (anchor, scale).
+function liveFieldFor(globalAnchor: number): (i: number) => number {
+  return localizeCutoff
+    ? fieldFromEff(buildEffCutoffById(globalAnchor), globalAnchor)
+    : (_i: number) => globalAnchor;
+}
+function breakDiffForField(cutoffOf: (i: number) => number, effScale: number): number {
+  let diff = 0;
+  for (let i = 0; i < size; i++) {
+    if (landMask[i] === 1) continue;
+    const marginFactor = isActive(i) ? activeBreakDepthFactor : passiveBreakDepthFactor;
+    const raw = cutoffOf(i) * effScale * marginFactor;
+    const bd = clampInt16(Math.max(absoluteMaxShelfDepth, Math.min(0, Math.round(raw))));
+    if ((bd | 0) !== (liveBreak[i] | 0)) diff++;
+  }
+  return diff;
+}
+let globalCutoff = recomputedCutoff;
+let effScale = shelfCfg.breakDepthScale ?? 1;
+let breakDiff = Number.POSITIVE_INFINITY;
+// Prefer the faithful recomputed anchor (offset 0); only fall back to +/-offsets if no effScale
+// reproduces the live breakdepth at offset 0 (rounding can make pairs degenerate).
+for (const co of [0, -1, 1, -2, 2, -3, 3]) {
+  const anchor = Math.min(0, recomputedCutoff + co);
+  const field = liveFieldFor(anchor);
+  for (let s = 50; s <= 200; s++) {
+    const sc = s / 100;
+    const d = breakDiffForField(field, sc);
+    if (d < breakDiff) {
+      breakDiff = d;
+      globalCutoff = anchor;
+      effScale = sc;
+    }
+    if (breakDiff === 0) break;
+  }
+  if (breakDiff === 0) break;
+}
+const cutoffOffsetFromRecompute = globalCutoff - recomputedCutoff;
+
+// validation B: offline flood from live gate == live shelf bin
+const floodLive = floodFromGate(liveGate);
+let floodDiff = 0;
+for (let i = 0; i < size; i++) if ((floodLive[i] ? 1 : 0) !== (liveShelf[i] ? 1 : 0)) floodDiff++;
+
+// validation C: my activeMargin classification == live activemarginmask bin (water only;
+// the live op never labels land, so restrict the comparison to the water domain it owns).
+let activeDiff = 0;
+for (let i = 0; i < size; i++)
+  if (isWater(i) && (isActive(i) ? 1 : 0) !== (liveActive[i] ? 1 : 0)) activeDiff++;
+
+// ================= M1 — width by margin =================
+const shelfActiveDist: number[] = [];
+const shelfPassiveDist: number[] = [];
+const shelfActiveBreak: number[] = [];
+const shelfPassiveBreak: number[] = [];
+for (let i = 0; i < size; i++) {
+  if (!liveShelf[i]) continue;
+  const d = distLive[i] | 0;
+  if (liveActive[i]) {
+    shelfActiveDist.push(d);
+    shelfActiveBreak.push(liveBreak[i]!);
+  } else {
+    shelfPassiveDist.push(d);
+    shelfPassiveBreak.push(liveBreak[i]!);
+  }
+}
+// per-land-component apron: shelf tiles attributed to each land component (Voronoi)
+type Comp = {
+  id: number;
+  landSize: number;
+  continent: boolean;
+  shelf: number;
+  activeFrac: number;
+  meanWidth: number;
+  p90Width: number;
+};
+const compShelf = new Map<number, { dists: number[]; active: number }>();
+for (let i = 0; i < size; i++) {
+  if (!liveShelf[i]) continue;
+  const id = nearestLand[i];
+  if (id < 0) continue;
+  const e = compShelf.get(id) ?? { dists: [], active: 0 };
+  e.dists.push(distLive[i] | 0);
+  if (liveActive[i]) e.active++;
+  compShelf.set(id, e);
+}
+const comps: Comp[] = [];
+for (const [id, e] of compShelf) {
+  const s = summary(e.dists);
+  comps.push({
+    id,
+    landSize: landSizes[id]!,
+    continent: isContinent(id),
+    shelf: e.dists.length,
+    activeFrac: +(e.active / e.dists.length).toFixed(3),
+    meanWidth: s.mean,
+    p90Width: s.p90,
+  });
+}
+comps.sort((a, b) => b.shelf - a.shelf);
+// correlation across components (weighted by shelf tiles via repetition is overkill; use per-comp)
+const compActiveFrac = comps.filter((c) => c.shelf >= 20).map((c) => c.activeFrac);
+const compMeanWidth = comps.filter((c) => c.shelf >= 20).map((c) => c.meanWidth);
+
+// CONTINENT-RESTRICTED width by margin: the per-tile active.mean above is artifact-prone —
+// the active sample is tiny (n often <100) and on island-heavy seeds is dominated by single-tile
+// island "dots" whose ring distance is structurally inflated. Restricting to shelf tiles
+// attributed to a CONTINENT (landSize >= CONTINENT_MIN) is the honest margin-contrast metric.
+const contActiveDist: number[] = [];
+const contPassiveDist: number[] = [];
+for (let i = 0; i < size; i++) {
+  if (!liveShelf[i] || !isContinent(nearestLand[i])) continue;
+  (liveActive[i] ? contActiveDist : contPassiveDist).push(distLive[i] | 0);
+}
+const caD = summary(contActiveDist);
+const cpD = summary(contPassiveDist);
+
+const aD = summary(shelfActiveDist);
+const pD = summary(shelfPassiveDist);
+const m1 = {
+  designedLever: {
+    breakDepthRatioPassiveOverActive: +(passiveBreakDepthFactor / activeBreakDepthFactor).toFixed(
+      2
+    ),
+    note: "passive break is this many x deeper than active by config; realized width ratio below should track it if bathymetry translated the lever",
+  },
+  shelfWidthByMargin: {
+    active: aD,
+    passive: pD,
+    widthRatioPassiveOverActive: aD.mean ? +(pD.mean / aD.mean).toFixed(2) : 0,
+    note: "per-tile mean over ALL shelf tiles; active sample is small + island-dot-biased. Prefer continentRestricted below.",
+  },
+  continentRestricted: {
+    active: caD,
+    passive: cpD,
+    widthRatioMeanPassiveOverActive: caD.mean ? +(cpD.mean / caD.mean).toFixed(2) : 0,
+    widthRatioMedianPassiveOverActive: caD.median ? +(cpD.median / caD.median).toFixed(2) : 0,
+    note: "honest margin contrast: shelf tiles on continents only (landSize >= 100), removes the single-tile-island inflation",
+  },
+  breakDepthByMargin: {
+    activeMean: summary(shelfActiveBreak).mean,
+    passiveMean: summary(shelfPassiveBreak).mean,
+  },
+  perComponent: {
+    nComponents: comps.length,
+    continents: comps.filter((c) => c.continent).length,
+    islands: comps.filter((c) => !c.continent).length,
+    activeFracVsMeanWidthPearson: pearson(compActiveFrac, compMeanWidth),
+    top: comps.slice(0, 8).map((c) => ({
+      landSize: c.landSize,
+      kind: c.continent ? "continent" : "island",
+      shelf: c.shelf,
+      activeFrac: c.activeFrac,
+      meanWidth: c.meanWidth,
+      p90Width: c.p90Width,
+    })),
+  },
+};
+
+// ================= M2 — bathymetry <-> margin =================
+const nsActive: number[] = [];
+const nsPassive: number[] = [];
+const corrCloseness: number[] = [];
+const corrBathy: number[] = [];
+const profByMargin: Record<string, { active: number[]; passive: number[] }> = {};
+for (let i = 0; i < size; i++) {
+  if (!isWater(i)) continue;
+  const d = distLive[i] | 0;
+  if (d <= 0 || d > sampleRadius) continue;
+  const b = Math.min(0, bathy[i] ?? 0);
+  if (liveActive[i]) nsActive.push(b);
+  else nsPassive.push(b);
+  const k = String(d);
+  (profByMargin[k] ??= { active: [], passive: [] })[liveActive[i] ? "active" : "passive"].push(b);
+  // correlation over convergent/transform tiles: does closeness predict depth?
+  if (boundaryType[i] === BOUNDARY_CONVERGENT || boundaryType[i] === BOUNDARY_TRANSFORM) {
+    corrCloseness.push(boundaryCloseness[i] | 0);
+    corrBathy.push(b);
+  }
+}
+const nsA = summary(nsActive);
+const nsP = summary(nsPassive);
+const m2 = {
+  nearshoreBathymetryByMargin: {
+    active: nsA,
+    passive: nsP,
+    meanDeltaActiveMinusPassive: +(nsA.mean - nsP.mean).toFixed(3),
+    note: "≈0 => seafloor carries no margin signal => localizing the cutoff alone (a) cannot create contrast; margin-aware seafloor depth (b) is required",
+  },
+  closenessVsDepthPearson_onActiveBoundaries: pearson(corrCloseness, corrBathy),
+  profileByDistanceAndMargin: Object.fromEntries(
+    Array.from({ length: sampleRadius }, (_, k) => String(k + 1)).map((k) => [
+      k,
+      {
+        active: summary(profByMargin[k]?.active ?? []),
+        passive: summary(profByMargin[k]?.passive ?? []),
+      },
+    ])
+  ),
+};
+
+// ================= M3 — cutoff locality (A2/A3 dual-arm counterfactual) =================
+// (i) spatial windows
+const windowCutoffs: number[] = [];
+{
+  const wx = Math.ceil(width / WINDOW);
+  const wy = Math.ceil(height / WINDOW);
+  const buckets: number[][] = Array.from({ length: wx * wy }, () => []);
+  for (let i = 0; i < size; i++) {
+    if (!isWater(i)) continue;
+    const d = distLive[i] | 0;
+    if (d <= 0 || d > sampleRadius) continue;
+    const y = (i / width) | 0;
+    const x = i - y * width;
+    buckets[((y / WINDOW) | 0) * wx + ((x / WINDOW) | 0)]!.push(Math.min(0, bathy[i] ?? 0));
+  }
+  for (const b of buckets) if (b.length >= 8) windowCutoffs.push(quantileCutoff(b));
+}
+// (ii) per-land-component cutoff: RAW quantile + BLENDED (the cutoff the live op actually gates on),
+//      plus attributed sample counts (A5 clearance: every continent must clear the floor).
+const effById = buildEffCutoffById(globalCutoff);
+const compCutoffs: {
+  id: number;
+  continent: boolean;
+  landSize: number;
+  samples: number;
+  rawCutoff: number;
+  blendedCutoff: number;
+  weight: number;
+}[] = [];
+for (const [id, samples] of compNearshoreSamples) {
+  compCutoffs.push({
+    id,
+    continent: isContinent(id),
+    landSize: landSizes[id]!,
+    samples: samples.length,
+    rawCutoff: quantileCutoff(samples),
+    blendedCutoff: effById.get(id)!,
+    weight: +clamp01(samples.length / localCutoffMinSamples).toFixed(3),
+  });
+}
+compCutoffs.sort((a, b) => b.samples - a.samples);
+const continentCutoffs = compCutoffs.filter((c) => c.continent).map((c) => c.rawCutoff);
+const islandCutoffs = compCutoffs.filter((c) => !c.continent).map((c) => c.rawCutoff);
+const continentSampleCounts = compCutoffs.filter((c) => c.continent).map((c) => c.samples);
+const continentsBelowFloor = compCutoffs.filter(
+  (c) => c.continent && c.samples < localCutoffMinSamples
+).length;
+
+// (iii) A2/A3 dual-arm counterfactual: GLOBAL field vs LOCAL (Voronoi+blend) field, same effScale.
+const globalField = (_i: number) => globalCutoff;
+const localField = fieldFromEff(effById, globalCutoff);
+const globalShelf = floodFromGate(gateFromCutoffField(globalField, effScale));
+const localShelf = floodFromGate(gateFromCutoffField(localField, effScale));
+const continentalShelf = (m: Uint8Array): number => {
+  let c = 0;
+  for (let i = 0; i < size; i++) if (m[i] && isContinent(nearestLand[i])) c++;
+  return c;
+};
+const islandShelf = (m: Uint8Array): number => {
+  let c = 0;
+  for (let i = 0; i < size; i++)
+    if (m[i] && nearestLand[i] >= 0 && !isContinent(nearestLand[i])) c++;
+  return c;
+};
+const pct = (a: number, b: number): number => (b ? +(((a - b) / b) * 100).toFixed(1) : 0);
+const gTot = countOf(globalShelf);
+const lTot = countOf(localShelf);
+const gCont = continentalShelf(globalShelf);
+const lCont = continentalShelf(localShelf);
+const gIsl = islandShelf(globalShelf);
+const lIsl = islandShelf(localShelf);
+// width-by-margin under the local field
+const cfActiveDist: number[] = [];
+const cfPassiveDist: number[] = [];
+for (let i = 0; i < size; i++) {
+  if (!localShelf[i]) continue;
+  if (liveActive[i]) cfActiveDist.push(distLive[i] | 0);
+  else cfPassiveDist.push(distLive[i] | 0);
+}
+const cfA = summary(cfActiveDist);
+const cfP = summary(cfPassiveDist);
+
+const m3 = {
+  globalCutoff,
+  recomputedQuantileCutoff: recomputedCutoff,
+  cutoffOffsetFromRecompute, // 0 == recomputed quantile is the op's exact anchor
+  effectiveBreakDepthScale: effScale,
+  localizeCutoff,
+  localCutoffMinSamples,
+  spatialWindows: {
+    edgeTiles: WINDOW,
+    nWindows: windowCutoffs.length,
+    ...summary(windowCutoffs),
+    min: windowCutoffs.length ? Math.min(...windowCutoffs) : 0,
+    max: windowCutoffs.length ? Math.max(...windowCutoffs) : 0,
+    windowsDifferingFromGlobalBy1Plus: windowCutoffs.filter((c) => Math.abs(c - globalCutoff) >= 1)
+      .length,
+  },
+  perComponentCutoff: {
+    nComponents: compCutoffs.length,
+    continentCutoff: summary(continentCutoffs),
+    islandCutoff: summary(islandCutoffs),
+    continentSampleCounts: summary(continentSampleCounts),
+    continentsBelowFloor, // A5: must be 0 for full-weight localization on every continent
+    note: "rawCutoff = per-component quantile; blendedCutoff = what the live op gates on; if continentsBelowFloor>0 some continent is partially blended to global",
+    top: compCutoffs.slice(0, 8).map((c) => ({
+      kind: c.continent ? "continent" : "island",
+      landSize: c.landSize,
+      samples: c.samples,
+      weight: c.weight,
+      rawCutoff: c.rawCutoff,
+      blendedCutoff: c.blendedCutoff,
+    })),
+  },
+  counterfactualLocalVsGlobal: {
+    shelfTiles: { global: gTot, local: lTot, totalDeltaPct: pct(lTot, gTot) },
+    continentalShelfTiles: { global: gCont, local: lCont, deltaPct: pct(lCont, gCont) },
+    islandShelfTiles: { global: gIsl, local: lIsl, deltaPct: pct(lIsl, gIsl) },
+    note: "A2 = continentalShelfTiles.deltaPct (DOWN, [-5%,-27%]); A3 = shelfTiles.totalDeltaPct (HOLD, [-5%,+10%]); redistribution = islandShelfTiles.deltaPct (UP)",
+    widthByMargin_local: {
+      active: cfA,
+      passive: cfP,
+      widthRatioPassiveOverActive: cfA.mean ? +(cfP.mean / cfA.mean).toFixed(2) : 0,
+    },
+  },
+};
+
+// ================= M4 — A4-DECOUPLE: island-density sensitivity of continental shelf =================
+// PRIMARY (exclusion counterfactual — EXACT, no geometry recompute, no attribution drift): would
+// continental shelf change if island nearshore samples did NOT contribute to the cutoff? Under the
+// GLOBAL gate, island samples drag the single cutoff => continental shelf moves (the Thread-1
+// island->continent coupling). Under the LOCAL gate, every full-weight continent reads ONLY its own
+// pool, so excluding island samples changes nothing (delta ~0). This is the clean causal test for
+// "does island density set continental shelf width"; it reuses the same effScale + flood as the live
+// self-validation, so it is not a fragile perturbation.
+const nearshoreContinentOnly: number[] = [];
+for (let i = 0; i < size; i++) {
+  if (!isWater(i)) continue;
+  const d = distLive[i] | 0;
+  if (d <= 0 || d > sampleRadius) continue;
+  if (!isContinent(nearestLand[i])) continue;
+  nearshoreContinentOnly.push(Math.min(0, bathy[i] ?? 0));
+}
+const gCutContinentsOnly = quantileCutoff(nearshoreContinentOnly);
+const contShelfUnder = (cutoffOf: (i: number) => number): number =>
+  continentalShelf(floodFromGate(gateFromCutoffField(cutoffOf, effScale)));
+const exclGlobalAll = contShelfUnder(() => globalCutoff);
+const exclGlobalContOnly = contShelfUnder(() => gCutContinentsOnly);
+const exclLocalAll = contShelfUnder(fieldFromEff(buildEffCutoffById(globalCutoff), globalCutoff));
+const exclLocalContOnly = contShelfUnder(
+  fieldFromEff(buildEffCutoffById(gCutContinentsOnly), gCutContinentsOnly)
+);
+const exclusion = {
+  globalCutoff,
+  globalCutoffContinentsOnly: gCutContinentsOnly,
+  global: {
+    withIslandSamples: exclGlobalAll,
+    withoutIslandSamples: exclGlobalContOnly,
+    deltaPct: pct(exclGlobalAll, exclGlobalContOnly),
+  },
+  local: {
+    withIslandSamples: exclLocalAll,
+    withoutIslandSamples: exclLocalContOnly,
+    deltaPct: pct(exclLocalAll, exclLocalContOnly),
+  },
+  note: "A4: |local.deltaPct| ~0 (continental cutoffs ignore island samples) while global.deltaPct shows the island->continent coupling. local can be nonzero only if a continent is below the sample floor (then its blend reads the island-influenced global anchor) — cross-check perComponentCutoff.continentsBelowFloor.",
+};
+
+// SECONDARY — continent cutoff pool-robustness (addresses the judge's Voronoi pool-membership concern
+// WITHOUT the injected-island new-shelf artifact). If a near-coast island stole part of a continent's
+// attributed nearshore pool, would the continent's quantile (and thus its gate depth) move? Drop a
+// deterministic 25% of each continent's samples and report the cutoff shift; a large pool (samples >>
+// floor) must keep the quantile stable, so pool-membership reassignment cannot move continental shelf.
+const poolRobustness: {
+  landSize: number;
+  samples: number;
+  fullCutoff: number;
+  droppedCutoff: number;
+  shift: number;
+}[] = [];
+for (const [id, samples] of compNearshoreSamples) {
+  if (!isContinent(id)) continue;
+  const full = quantileCutoff(samples);
+  const kept = samples.filter((_, k) => k % 4 !== 0); // drop every 4th sample (~25%)
+  const dropped = quantileCutoff(kept);
+  poolRobustness.push({
+    landSize: landSizes[id]!,
+    samples: samples.length,
+    fullCutoff: full,
+    droppedCutoff: dropped,
+    shift: dropped - full,
+  });
+}
+const maxContinentCutoffShift = poolRobustness.reduce((m, r) => Math.max(m, Math.abs(r.shift)), 0);
+const m4 = {
+  primaryExclusionCounterfactual: exclusion,
+  secondaryPoolRobustness: {
+    maxContinentCutoffShift,
+    perContinent: poolRobustness,
+    note: "drop 25% of each continent's attributed nearshore pool; maxContinentCutoffShift ~0-1 unit => a continent's gate is robust to losing near-coast samples to an injected island (its pool >> the sample floor), so Voronoi pool-membership reassignment cannot meaningfully move continental shelf.",
+  },
+};
+
+// ================= M5 — floor sweep (offline, EXACT) =================
+// The sample-count floor only affects ISLAND shelf (continents are always full-weight), so it is a
+// pure A3 knob: a higher floor blends more small islands toward the (shallower) global cutoff =>
+// less island shelf => lower total. The local field is geometry-determined (nearestLand + samples
+// are floor-independent; only the blend weight changes) and effScale is the floor-independent knob,
+// so recomputing the counterfactual at floor X here is EXACTLY what regenerating the live op at
+// floor X would produce. Continental% is ~floor-invariant; totalPct is the A3-relevant series.
+const m5: { floor: number; continentalPct: number; totalPct: number; islandPct: number }[] = [];
+for (const fl of [16, 24, 32, 40, 48, 64]) {
+  const lf = fieldFromEff(buildEffCutoffById(globalCutoff, fl), globalCutoff);
+  const sh = floodFromGate(gateFromCutoffField(lf, effScale));
+  m5.push({
+    floor: fl,
+    continentalPct: pct(continentalShelf(sh), gCont),
+    totalPct: pct(countOf(sh), gTot),
+    islandPct: pct(islandShelf(sh), gIsl),
+  });
+}
+
+const out = {
+  meta: {
+    dumpDir,
+    configFile,
+    dims: { width, height, size },
+    shelfConfig: {
+      sampleRadius,
+      shallowQuantile,
+      activeClosenessThreshold,
+      activeBreakDepthFactor,
+      passiveBreakDepthFactor,
+      absoluteMaxShelfDepth,
+      rawBreakDepthScale: shelfCfg.breakDepthScale ?? 1,
+      solvedEffectiveScale: effScale,
+      localizeCutoff,
+      localCutoffMinSamples,
+    },
+  },
+  validation: {
+    breakDepthDiffVsLive: breakDiff, // 0 == per-component field reconstruction faithful (+ effScale correct)
+    floodDiffVsLive: floodDiff, // 0 == flood replica faithful
+    activeMarginDiffVsLive: activeDiff, // 0 == margin classification faithful
+  },
+  M1_widthByMargin: m1,
+  M2_bathyVsMargin: m2,
+  M3_cutoffLocality: m3,
+  M4_injectionStability: m4,
+  M5_floorSweep: m5,
+};
+
+console.log(JSON.stringify(out, null, asJson ? 0 : 2));


### PR DESCRIPTION
Preserves the margin-aware-bathymetry analytical record (ANALYSIS/DESIGN/
FRAMING/EXPECTATIONS/README) and the self-contained analyze-margin-contrast.ts
measurement harness from the abandoned statistical nearshore-bathymetry thread
(branches agent-bathy-t2-analysis / -t2a-localize-cutoff / -t2a-localize-impl),
which was superseded by the Path-A physical continental-margin sculpt.

Files-only cherry-pick: the dead compute-shelf-mask quantile strategy + its
shelf-cutoff-quantile-equivalence test are intentionally EXCLUDED (they would
regress the shipped gradient-break shelf). The harness imports only node +
mapgen-core/lib/grid (not the removed op), so it remains runnable. Kept for the
analytical record (why statistical was rejected; the margin-contrast
measurements) ahead of deleting the three source branches.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>