### PR TITLE
docs(habitat): authority-tool separation reference + structure-check runner spec

### DIFF
--- a/.habitat/AUTHORITY-TOOL-SEPARATION.md
+++ b/.habitat/AUTHORITY-TOOL-SEPARATION.md
@@ -1,0 +1,72 @@
+# Habitat Authority Tool Separation
+
+Status: active reference for authority ownership and runner selection
+
+## Purpose
+
+This document separates the enforcement tools Habitat uses so future rule work
+does not collapse back into bespoke scripts. A rule should choose the smallest
+tool that owns its proof class. If a packet mixes proof classes, split the
+assertions first.
+
+## Core Split
+
+Habitat authority lives in `.habitat`. Execution machinery lives in
+`tools/habitat` or in the external tool that owns a specific proof class.
+`rule.json` records runner metadata; it is not the ontology for the policy
+itself.
+
+## Tool Ownership
+
+| Concern | Owner | Use For | Do Not Use For |
+| --- | --- | --- | --- |
+| Source syntax and source-pattern authority | Grit / GritQL | imports, exports, calls, identifiers, object/property shape, Markdown/source text patterns, rewrite-backed diagnostics | directory topology, generated freshness, graph traversal, package runtime behavior |
+| Alternative AST/source matching | ast-grep | source structural matching if a future rule cannot be expressed cleanly in Grit and a deliberate tool decision is made | file-tree topology, task graph, formatter hygiene |
+| Workspace graph and task relationships | Nx | project graph, import/project boundaries, task dependencies, target ordering, affected execution | source AST patterns, arbitrary nested file structure, package semantic validation |
+| Format and hygiene | Biome / formatter layer | formatting, import organization, general lint hygiene owned by formatter/linter capabilities | Habitat policy, topology, project graph ownership |
+| File-tree topology | Habitat `structure-check` runner | globbed filesystem shape, allowed/required/forbidden direct children, closed/open directory scopes, retired path absence, generated artifact presence when the claim is only presence | imports/exports, source regex, graph traversal, currentness, generated equivalence |
+| Package or product semantics | package-local validators / package tests | runtime behavior, API behavior, generated artifact equivalence, derived schema correctness, live integration behavior, package-specific graph traversal | static source-pattern authority, general file-tree shape |
+
+## Decision Rules
+
+1. If the assertion is about code or Markdown syntax, use Grit first.
+2. If the assertion is about project dependencies, build ordering, or task
+   relationships, use Nx or an Nx-backed Habitat rule.
+3. If the assertion is about the shape of files and directories, use
+   `structure-check`.
+4. If the assertion requires executing package code, deriving semantic data, or
+   comparing generated output to source truth, keep it package-local.
+5. If a command-check script contains more than one proof class, split it by
+   assertion before changing owners.
+
+## Structure-Check Boundary
+
+`structure-check` is intentionally narrow. It should validate only filesystem
+topology through globbed tree patterns. It must not grow source regex matching,
+import/export analysis, graph traversal, freshness checks, or package semantic
+logic.
+
+Good `structure-check` claims:
+
+- a root glob matches the expected directory class;
+- direct children under a matched root satisfy required and forbidden glob
+  patterns;
+- a closed scope has no undeclared direct children;
+- generated artifact files exist where declared, without proving freshness or
+  equivalence;
+- retired directories or files are absent.
+
+Claims that belong elsewhere:
+
+- imports, exports, calls, identifiers, source text tokens: Grit;
+- task ordering, dependency graph, project boundaries: Nx;
+- generated artifact freshness/equivalence: package validator or Nx target;
+- derived schemas, runtime behavior, API behavior: package-local tests or
+  validators.
+
+## Anti-Riddle Rule
+
+Do not introduce a new Habitat runner because a domain has a special noun such
+as stage topology, recipe topology, or docs topology. The runner owns a proof
+class, not a domain name. "Stage topology" is just file-tree topology unless it
+requires package semantic derivation, in which case it is not `structure-check`.

--- a/docs/projects/habitat-harness/structure-check/structure-check-runner-spec-shape.md
+++ b/docs/projects/habitat-harness/structure-check/structure-check-runner-spec-shape.md
@@ -1,0 +1,220 @@
+# Structure-Check Runner Spec Shape
+
+Status: prep input for the next implementation workstream
+
+## Intent
+
+Create a small Habitat runner for declarative file-tree topology checks. The
+runner should replace bespoke command-check scripts whose only real job is to
+validate filesystem shape.
+
+This is not an AST matcher, regex scanner, package validator, graph validator,
+or build freshness checker.
+
+## Design Commitments
+
+- Use TOML for the structure authority file.
+- Keep `rule.json` as runner metadata.
+- Allow globs on roots and child patterns.
+- Model structure as scoped filesystem patterns, not `requiredPaths`.
+- Keep allowed and forbidden patterns in the same structure file.
+- Evaluate direct children per scope; use additional scopes for deeper levels.
+- Avoid a whitespace DSL and avoid raw glob ignore semantics as policy.
+
+## Files
+
+A structure-backed rule packet should contain:
+
+```text
+<packet>.rule.json
+<packet>.structure.toml
+<packet>.baseline.json
+category.md
+```
+
+`rule.json` selects the runner and points to the TOML authority file:
+
+```json
+{
+  "schemaVersion": 1,
+  "ruleId": "preserve_standard_stage_topology_and_path_invariants",
+  "ownerTool": "structure-check",
+  "detect": ["habitat", "check", "--tool", "structure-check"],
+  "structureFile": "preserve_standard_stage_topology_and_path_invariants.structure.toml",
+  "severity": "error",
+  "message": "Standard recipe file topology drifted.",
+  "remediate": "Update the structure manifest intentionally when changing standard recipe stage topology."
+}
+```
+
+## TOML Shape
+
+```toml
+schemaVersion = 1
+
+[metadata]
+description = "Standard recipe stage topology"
+notes = "File-tree shape only. Source imports/calls belong to Grit; freshness belongs to package validators."
+
+[[scopes]]
+name = "standard-stage-root"
+root = "mods/mod-swooper-maps/src/recipes/standard/stages"
+kind = "directory"
+mode = "closed"
+
+required = [
+  "foundation-mantle",
+  "foundation-lithosphere",
+  "foundation-tectonics",
+  "foundation-orogeny",
+  "foundation-projection",
+  "morphology-shelf",
+  "hydrology-basins",
+  "hydrology-rivers",
+  "terrain-elevation",
+  "terrain-features",
+]
+
+forbidden = [
+  "foundation",
+  "advanced",
+  "_legacy-*",
+]
+
+[[scopes]]
+name = "standard-stage-entrypoints"
+root = "mods/mod-swooper-maps/src/recipes/standard/stages/*"
+kind = "directory"
+mode = "open"
+
+required = [
+  "index.ts",
+]
+
+forbidden = [
+  "*.js",
+  "*.mjs",
+]
+
+[[scopes]]
+name = "standard-recipe-root"
+root = "mods/mod-swooper-maps/src/recipes/standard"
+kind = "directory"
+mode = "open"
+
+required = [
+  "recipe.ts",
+  "contract-manifest.ts",
+]
+
+forbidden = [
+  "foundation.ts",
+  "advanced.ts",
+]
+```
+
+## Semantics
+
+Each `[[scopes]]` entry is evaluated independently.
+
+| Field | Meaning |
+| --- | --- |
+| `name` | Stable diagnostic label for the scope. |
+| `root` | Repo-relative glob. Every matched root is checked independently. |
+| `kind` | Expected root kind: `directory`, `file`, or `any`. The first implementation should support `directory`; `file` can be admitted only if a canary needs it. |
+| `mode` | `open` allows undeclared direct children. `closed` requires every direct child to match `required` or `allowed` and not match `forbidden`. |
+| `required` | Direct-child glob patterns that must each match at least once under every matched root. |
+| `allowed` | Direct-child glob patterns that are admitted in a closed scope but are not required. |
+| `forbidden` | Direct-child glob patterns that must match zero children under every matched root. |
+
+Root globs are patterns too. This lets one scope apply the same child policy to
+many directories, for example every stage directory under
+`mods/mod-swooper-maps/src/recipes/standard/stages/*`.
+
+## Closed Scope Rule
+
+For a `mode = "closed"` directory scope:
+
+1. collect direct children of each matched root;
+2. fail if any required pattern has zero matches;
+3. fail if any forbidden pattern has one or more matches;
+4. fail if any direct child matches none of the required or allowed patterns.
+
+Forbidden wins over required or allowed if a child matches both. The diagnostic
+should explain the conflicting patterns.
+
+## Open Scope Rule
+
+For a `mode = "open"` directory scope:
+
+1. collect direct children of each matched root;
+2. fail if any required pattern has zero matches;
+3. fail if any forbidden pattern has one or more matches;
+4. ignore extra children.
+
+## Descendants
+
+Do not add `requiredDescendants` or `forbiddenDescendants` fields in the first
+version. Use another scope with a globbed root instead.
+
+Example:
+
+```toml
+[[scopes]]
+name = "all-stage-entrypoints"
+root = "mods/mod-swooper-maps/src/recipes/standard/stages/*"
+kind = "directory"
+mode = "open"
+required = ["index.ts"]
+```
+
+This keeps the runner model flat, parseable, and easy to reason about while
+still supporting nested structure through scoped root globs.
+
+## Diagnostics
+
+Diagnostics should identify:
+
+- rule id;
+- scope name;
+- matched root;
+- failing pattern;
+- actual child path when available;
+- failure kind: missing required match, forbidden match, unexpected child,
+  root missing, wrong root kind, or pattern conflict.
+
+## Baselines
+
+Use the existing Habitat baseline model. A structure rule can land red with
+enumerated diagnostics and later ratchet to green. Baseline contents should
+record diagnostic identities, not duplicate the TOML structure spec.
+
+## Non-Goals
+
+- No source regex matching.
+- No import/export analysis.
+- No AST parsing.
+- No package code execution.
+- No generated artifact freshness or equivalence proof.
+- No Nx graph traversal or target-order proof.
+- No recursive DSL or indentation-sensitive syntax.
+
+## Canary Candidates
+
+The first canary should prove:
+
+1. root glob matching;
+2. open and closed scopes;
+3. required direct child globs;
+4. forbidden direct child globs;
+5. unexpected-child diagnostics in closed scopes;
+6. one conversion that deletes or shrinks a bespoke command-check script.
+
+Good starting packets:
+
+- `preserve_standard_stage_topology_and_path_invariants`, for standard stage
+  directory topology;
+- a small generated-artifact presence rule, only if the assertion is presence
+  rather than freshness;
+- a retained domain topology branch from the remaining domain split work, only
+  after the source-shape assertions have been separated to Grit.


### PR DESCRIPTION
This PR introduces two reference documents that establish clear boundaries for Habitat's enforcement tooling.

**Authority Tool Separation** (`.habitat/AUTHORITY-TOOL-SEPARATION.md`) defines which tool owns each proof class — Grit for source syntax and AST patterns, Nx for workspace graph and task relationships, Biome for formatting and hygiene, `structure-check` for file-tree topology, and package-local validators for runtime and semantic behavior. It includes decision rules for selecting the right tool, an explicit boundary definition for `structure-check` to prevent scope creep, and an anti-riddle rule preventing new runners from being introduced based on domain names rather than proof class ownership.

**Structure-Check Runner Spec** (`docs/projects/habitat-harness/structure-check/structure-check-runner-spec-shape.md`) defines the design and semantics for a new declarative file-tree topology runner intended to replace bespoke command-check scripts. Key design decisions include:

- TOML as the authority file format with `rule.json` holding only runner metadata
- A scope-based model using globbed roots and direct-child patterns rather than `requiredPaths`
- `open` and `closed` scope modes controlling whether undeclared children are permitted
- `required`, `allowed`, and `forbidden` child glob patterns evaluated per matched root
- Flat scope composition via globbed roots instead of recursive DSL constructs for deeper levels
- Diagnostics identifying rule ID, scope name, matched root, failing pattern, and failure kind
- Explicit non-goals excluding source regex, AST parsing, graph traversal, and freshness checks

Canary candidates are identified, with `preserve_standard_stage_topology_and_path_invariants` as the recommended first implementation target.