### PR TITLE
refactor(mapgen-studio): move `isSaveDeployTerminal` + `saveDeployResultFromTerminalStatus` into `mapConfigSave/status`

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -54,6 +54,8 @@ import {
 import { saveRepoBackedConfig, toConfigId } from "../features/mapConfigSave/api";
 import {
   createMapConfigSaveDeployStatus,
+  isSaveDeployTerminal,
+  saveDeployResultFromTerminalStatus,
   updateMapConfigSaveDeployStatus,
 } from "../features/mapConfigSave/status";
 import type { PresetErrorState } from "../features/presets/dialogState";
@@ -167,41 +169,6 @@ type SaveDeployTerminalWaiter = Readonly<{
   reject(error: Error): void;
   timeoutId: ReturnType<typeof setTimeout>;
 }>;
-
-function isSaveDeployTerminal(status: MapConfigSaveDeployStatus): boolean {
-  return status.status !== "running";
-}
-
-function saveDeployResultFromTerminalStatus(
-  status: MapConfigSaveDeployStatus,
-  fallbackPath?: string
-):
-  | {
-      ok: true;
-      path?: string;
-      deploy?: MapConfigSaveDeployStatus["deploy"];
-      saved?: boolean;
-      deployed?: boolean;
-    }
-  | { ok: false; error: string; saved?: boolean; deployed?: boolean; path?: string } {
-  const path = status.path ?? fallbackPath;
-  if (!status.ok || status.status === "failed") {
-    return {
-      ok: false,
-      error: status.error ?? "Save/deploy failed",
-      saved: status.saved,
-      deployed: status.deployed,
-      path,
-    };
-  }
-  return {
-    ok: true,
-    path,
-    deploy: status.deploy,
-    saved: status.saved,
-    deployed: status.deployed,
-  };
-}
 
 /**
  * `StudioShell` — the layout + orchestration container (architecture/10 §4).

--- a/apps/mapgen-studio/src/features/mapConfigSave/status.ts
+++ b/apps/mapgen-studio/src/features/mapConfigSave/status.ts
@@ -95,3 +95,43 @@ export function updateMapConfigSaveDeployStatus(
     ...(patch.recoveryActions === undefined ? {} : { recoveryActions: [...patch.recoveryActions] }),
   };
 }
+
+/** A save/deploy operation is terminal once it is no longer `running`. */
+export function isSaveDeployTerminal(status: MapConfigSaveDeployStatus): boolean {
+  return status.status !== "running";
+}
+
+/**
+ * Project a terminal save/deploy status into the `{ ok, ... }` result shape the
+ * save handlers consume. `fallbackPath` is used when the status carries no path.
+ */
+export function saveDeployResultFromTerminalStatus(
+  status: MapConfigSaveDeployStatus,
+  fallbackPath?: string
+):
+  | {
+      ok: true;
+      path?: string;
+      deploy?: MapConfigSaveDeployStatus["deploy"];
+      saved?: boolean;
+      deployed?: boolean;
+    }
+  | { ok: false; error: string; saved?: boolean; deployed?: boolean; path?: string } {
+  const path = status.path ?? fallbackPath;
+  if (!status.ok || status.status === "failed") {
+    return {
+      ok: false,
+      error: status.error ?? "Save/deploy failed",
+      saved: status.saved,
+      deployed: status.deployed,
+      path,
+    };
+  }
+  return {
+    ok: true,
+    path,
+    deploy: status.deploy,
+    saved: status.saved,
+    deployed: status.deployed,
+  };
+}

--- a/apps/mapgen-studio/test/mapConfigSave/status.test.ts
+++ b/apps/mapgen-studio/test/mapConfigSave/status.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   createMapConfigSaveDeployStatus,
   formatMapConfigSaveDeployPhaseLabel,
+  isSaveDeployTerminal,
   kindForMapConfigSaveDeployPhase,
+  saveDeployResultFromTerminalStatus,
   updateMapConfigSaveDeployStatus,
 } from "../../src/features/mapConfigSave/status";
 
@@ -36,5 +38,64 @@ describe("Map config save/deploy status helpers", () => {
     expect(next.path).toContain("studio-current.config.json");
     expect(next.startedAt).toBe("2026-06-01T00:00:00.000Z");
     expect(next.updatedAt).toBe("2026-06-01T00:00:01.000Z");
+  });
+});
+
+// H0 (Phase-8 slice): pure helpers moved out of StudioShell into this module.
+describe("isSaveDeployTerminal", () => {
+  it("treats only `running` as non-terminal", () => {
+    const running = createMapConfigSaveDeployStatus({ requestId: "r", phase: "saving" });
+    expect(isSaveDeployTerminal(running)).toBe(false);
+    expect(isSaveDeployTerminal({ ...running, status: "complete" })).toBe(true);
+    expect(isSaveDeployTerminal({ ...running, status: "failed" })).toBe(true);
+    expect(isSaveDeployTerminal({ ...running, status: "idle" })).toBe(true);
+  });
+});
+
+describe("saveDeployResultFromTerminalStatus", () => {
+  it("maps a successful terminal status to ok:true with path + deploy flags", () => {
+    const status = createMapConfigSaveDeployStatus({
+      requestId: "r",
+      phase: "complete",
+      path: "configs/a.config.json",
+      saved: true,
+      deployed: true,
+    });
+    expect(saveDeployResultFromTerminalStatus(status)).toMatchObject({
+      ok: true,
+      path: "configs/a.config.json",
+      saved: true,
+      deployed: true,
+    });
+  });
+
+  it("uses fallbackPath when the status carries no path", () => {
+    const status = createMapConfigSaveDeployStatus({ requestId: "r", phase: "complete", saved: true });
+    const result = saveDeployResultFromTerminalStatus(status, "configs/fallback.config.json");
+    expect(result.ok).toBe(true);
+    expect(result.path).toBe("configs/fallback.config.json");
+  });
+
+  it("maps a failed status to ok:false, preserving the error + saved/deployed flags", () => {
+    const status = createMapConfigSaveDeployStatus({
+      requestId: "r",
+      phase: "failed",
+      error: "deploy blew up",
+      saved: true,
+      deployed: false,
+    });
+    expect(saveDeployResultFromTerminalStatus(status)).toMatchObject({
+      ok: false,
+      error: "deploy blew up",
+      saved: true,
+      deployed: false,
+    });
+  });
+
+  it("falls back to a default error message when ok is false but no error is set", () => {
+    const status = createMapConfigSaveDeployStatus({ requestId: "r", phase: "failed" });
+    const result = saveDeployResultFromTerminalStatus({ ...status, error: undefined });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("Save/deploy failed");
   });
 });

--- a/docs/projects/studio-shell-decomposition/OWNER-FRAME.md
+++ b/docs/projects/studio-shell-decomposition/OWNER-FRAME.md
@@ -200,6 +200,20 @@ features/mapConfigSave/status.ts   # P0: move isSaveDeployTerminal + saveDeployR
 
 **Open design decisions for Phase 7 (resolve explicitly, no "maybe"):** (1) does `useStudioOperations` also hold `browserRunning` (i.e. own browserRunner) or receive it — keep error/status/busy all synchronous either way; (2) exact home of `provedRunInGameSource`/`livePresets`/`displayedPresetOptions`/`materializationMode` host-vs-hook (§7.6 says host); (3) whether `useVizSelection` is one hook or one hook + extracted pure `selectFromModel`/era/overlay helpers (prefer pure helpers for testability).
 
+## 10. Verification reality (CORRECTED 2026-06-28 — load-bearing for every Phase-8 slice)
+
+**Verification method (do not regress):**
+- **NEVER pipe a test run to `tail`/`head`** — the pipe's exit code is `tail`'s (0), which MASKS vitest failures. Capture the real result: `… > out.txt 2>&1; echo "exit=$?"` then grep `out.txt`, OR run as a background task (its completion reports the command's real exit code).
+- **Fresh worktree needs built dists** for tests to run: workspace subpaths (e.g. `@civ7/studio-server/contract`) resolve only from built `dist`. Run `bunx nx run mapgen-studio:test --outputStyle=static` once (builds `^deps` + regenerates studio recipes; nx-cached after). **Once dists exist, fast filtered runs work:** `cd apps/mapgen-studio && bunx vitest run --config ../../vitest.config.ts --project mapgen-studio <filter>; echo "exit=$?"`.
+
+**Parity baseline = NOT "all green." There are 6 PRE-EXISTING failures (EXTERIOR to this workstream):**
+- `test/config/defaultConfigSchema.test.ts` (5) + `test/config/standardRecipeArtifactGuards.test.ts` (1).
+- Cause: the `mod-swooper-maps` recipe evolved (foundation split into `foundation-mantle`/`foundation-lithosphere`/…; morphology `shelf` → `continentalMargin`) but the studio config-schema tests were not updated. Confirmed pre-existing: `git diff 5aa6ccf7c..<my stack>` shows ZERO changes under `test/config/` or `mod-swooper-maps`/`mapgen-core`; the recipe source already uses the new structure.
+- **Exterior:** recipe artifacts are a stable input per the brief; not StudioShell orchestration. Flagged to the user as a separate repo-health item; NOT fixed inside this decomposition.
+- **A slice is green iff the failure set stays EXACTLY these 6** (same files/tests), with all controller/parity tests passing. Track the failure SET, not a zero count.
+
+**Dependency posture (per user directive 2026-06-28):** use latest modern versions within the min-age policy; if a conflict arises, upgrade across the board + normalize. Test deps added are the current latest (`@testing-library/react@16.3.2`, `@testing-library/dom@10.4.1`, `jsdom@29.1.1`), installed via `bun add` (lockfile tool-managed), no peer conflict, no `trustedDependencies` change. No across-the-board upgrade is triggered by this work; broader monorepo dep normalization is a separate initiative (flag, don't fold into the parity gate).
+
 ## 7. Reusable precedent (Pass 2 review machinery)
 
 Pass 2's review loop = 6 lanes (architecture-boundary · direct-control · product/runtime-parity · typescript/schema · dev-platform · adversarial-orphan) + always-on proof gates (frozen lockfile → baseline build/check → `openspec validate --strict` → `habitat classify` → `git diff --check`/`gt status` → one logical change per branch). I will adapt these lanes to my parity-focused review (behavior / architecture-boundary / maintainability) and reuse the proof-gate spine.


### PR DESCRIPTION
`isSaveDeployTerminal` and `saveDeployResultFromTerminalStatus` were private functions living inside `StudioShell.tsx` with no test coverage. This moves both into `features/mapConfigSave/status.ts`, where they belong alongside the rest of the save/deploy status logic, and exports them from there.

`StudioShell.tsx` now imports them from the module rather than defining them inline. The functions themselves are unchanged.

Unit tests for both helpers are added to `test/mapConfigSave/status.test.ts`, covering the terminal/non-terminal distinction, successful result projection, fallback path handling, failed status mapping, and the default error message fallback.

The `OWNER-FRAME.md` decomposition doc is updated to record the verification approach for Phase 8 slices, the six pre-existing test failures that are exterior to this workstream, and the dependency posture established for this phase.