### PR TITLE
refactor(mapgen-studio): extract `useBrowserRun` hook (startBrowserRun + auto-run trio + reroll/triggerRun/isDirty)

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -5,14 +5,12 @@ import {
 } from "@swooper/mapgen-core/authoring";
 import { type ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getCiv7MapSizePreset } from "../features/browserRunner/mapSizes";
-import { capturePinnedSelection } from "../features/browserRunner/retention";
 import { useBrowserRunner } from "../features/browserRunner/useBrowserRunner";
 import { fetchCiv7SetupConfig, requestCiv7Autoplay } from "../features/civ7Setup/api";
 import { LIVE_GAME_PRESET_ID, LIVE_GAME_PRESET_KEY } from "../features/civ7Setup/livePreset";
 import {
   formatCiv7StudioSeedError,
   parseCiv7StudioSeed,
-  randomCiv7StudioSeed,
 } from "../features/civ7Setup/seedPolicy";
 import {
   type Civ7SetupSnapshotLike,
@@ -31,7 +29,6 @@ import {
   mergeSelectOptions,
   setupCatalogOptions,
 } from "../features/civ7Setup/setupOptions";
-import { migratePipelineConfig } from "../features/configMigrations/pipelineConfig";
 import {
   type AppliedPresetSnapshot,
   applyPresetConfig,
@@ -133,10 +130,11 @@ import type {
   StepOption,
   VariantOption,
 } from "../ui/types";
-import { configsEqual, recipeSettingsEqual, worldSettingsEqual } from "../ui/utils/config";
+import { configsEqual } from "../ui/utils/config";
 import { formatStageName } from "../ui/utils/formatting";
 import { CanvasStage } from "./CanvasStage";
 import { ErrorBanner } from "./ErrorBanner";
+import { useBrowserRun } from "./hooks/useBrowserRun";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useRunInGameTerminalToast } from "./hooks/useRunInGameTerminalToast";
 import { useSetupDataQueries } from "./hooks/useSetupDataQueries";
@@ -244,9 +242,6 @@ export function StudioShell(props: StudioShellProps) {
   const setStageView = useViewStore((s) => s.setStageView);
   const pipelineSelectedStageId = useViewStore((s) => s.pipelineSelectedStageId);
   const setPipelineSelectedStageId = useViewStore((s) => s.setPipelineSelectedStageId);
-  const [autoRunEnabled, setAutoRunEnabled] = useState(false);
-  const autoRunTimerRef = useRef<number | null>(null);
-  const autoRunPendingRef = useRef(false);
 
   // Coordination layer (init FIRST): owns the runInGame/saveDeploy operation
   // state + the single-owner error channel, and derives the busy booleans
@@ -803,124 +798,21 @@ export function StudioShell(props: StudioShellProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedStepId]);
 
-  const startBrowserRun = useCallback(
-    (overrides?: { seed?: string }) => {
-      setLocalError(null);
-
-      const seedStr = overrides?.seed ?? recipeSettings.seed;
-      const seedPolicy = parseCiv7StudioSeed(seedStr);
-      if (!seedPolicy.ok) {
-        const message = formatCiv7StudioSeedError(seedPolicy);
-        setLocalError(message);
-        toast(message, { variant: "error" });
-        return;
-      }
-      const seed = seedPolicy.value;
-      const mapSize = getCiv7MapSizePreset(worldSettings.mapSize);
-      const runPipelineConfig = migratePipelineConfig(pipelineConfig);
-
-      const pinned = capturePinnedSelection({
-        selectedStepId: viz.selectedStepId,
-        selectedLayerKey: viz.selectedLayerKey,
-      });
-      viz.clearStream();
-      if (!pinned.retainStep) viz.setSelectedStepId(null);
-      if (!pinned.retainLayer) viz.setSelectedLayerKey(null);
-
-      browserRunner.actions.clearError();
-
-      setLastRunSnapshot({
-        worldSettings,
-        recipeSettings: { ...recipeSettings, seed: seedStr },
-        pipelineConfig: runPipelineConfig,
-      });
-
-      browserRunner.actions.start({
-        recipeId: recipeSettings.recipe,
-        seed,
-        mapSizeId: mapSize.id,
-        dimensions: mapSize.dimensions,
-        latitudeBounds: { topLatitude: 80, bottomLatitude: -80 },
-        playerCount: worldSettings.playerCount,
-        resourcesMode: worldSettings.resources,
-        configOverrides: overridesDisabled ? undefined : (runPipelineConfig as unknown),
-      });
-    },
-    [
-      browserRunner.actions,
-      overridesDisabled,
-      pipelineConfig,
-      recipeSettings,
-      toast,
-      worldSettings,
-      viz,
-    ]
-  );
-
-  useEffect(() => {
-    if (!autoRunEnabled) {
-      autoRunPendingRef.current = false;
-      if (autoRunTimerRef.current) {
-        window.clearTimeout(autoRunTimerRef.current);
-        autoRunTimerRef.current = null;
-      }
-    }
-  }, [autoRunEnabled]);
-
-  useEffect(() => {
-    if (!autoRunEnabled) return;
-    if (overridesDisabled) return;
-    if (runInGameRunning || saveDeployRunning) return;
-
-    if (browserRunning) {
-      autoRunPendingRef.current = true;
-      return;
-    }
-
-    if (lastRunSnapshot && configsEqual(lastRunSnapshot.pipelineConfig, pipelineConfig)) return;
-
-    if (autoRunTimerRef.current) window.clearTimeout(autoRunTimerRef.current);
-    autoRunTimerRef.current = window.setTimeout(() => {
-      autoRunTimerRef.current = null;
-      startBrowserRun();
-    }, 300);
-
-    return () => {
-      if (!autoRunTimerRef.current) return;
-      window.clearTimeout(autoRunTimerRef.current);
-      autoRunTimerRef.current = null;
-    };
-  }, [
-    autoRunEnabled,
+  // Browser-run command + auto-run orchestration (slice 2.6). The runner
+  // instance + `browserRunning` derivation + `vizIngestRef` sink wiring stay in
+  // host render scope above (they must straddle the host-owned `viz` call, which
+  // reads `browserRunning`); the command surface — `startBrowserRun`, the atomic
+  // auto-run trio, `reroll`/`triggerRun`, and `isDirty` — lives in the hook. Busy
+  // flags are threaded from `useStudioOperations` (never re-derived here).
+  const { reroll, triggerRun, isDirty, autoRunEnabled, setAutoRunEnabled } = useBrowserRun({
+    runnerActions: browserRunner.actions,
     browserRunning,
-    lastRunSnapshot,
-    overridesDisabled,
-    pipelineConfig,
+    viz,
     runInGameRunning,
     saveDeployRunning,
-    startBrowserRun,
-  ]);
-
-  useEffect(() => {
-    if (!autoRunEnabled) return;
-    if (overridesDisabled) return;
-    if (browserRunning) return;
-    if (runInGameRunning || saveDeployRunning) return;
-    if (!autoRunPendingRef.current) return;
-
-    autoRunPendingRef.current = false;
-    if (lastRunSnapshot && configsEqual(lastRunSnapshot.pipelineConfig, pipelineConfig)) return;
-    startBrowserRun();
-  }, [
-    autoRunEnabled,
-    browserRunning,
-    lastRunSnapshot,
-    overridesDisabled,
-    pipelineConfig,
-    runInGameRunning,
-    saveDeployRunning,
-    startBrowserRun,
-  ]);
+    toast,
+    setLocalError,
+  });
 
   const openSaveDialog = useCallback((seed?: { label?: string; description?: string }) => {
     setSaveDialogState({
@@ -1343,34 +1235,7 @@ export function StudioShell(props: StudioShellProps) {
 
   const cancelImportSwitch = useCallback(() => setPendingImport(null), []);
 
-  const reroll = useCallback(() => {
-    if (runInGameRunning || saveDeployRunning) {
-      toast("Finish the current Studio operation before rerolling.", { variant: "info" });
-      return;
-    }
-    const next = randomCiv7StudioSeed();
-    setRecipeSettings((prev) => ({ ...prev, seed: next }));
-    startBrowserRun({ seed: next });
-  }, [runInGameRunning, saveDeployRunning, startBrowserRun, toast]);
-
-  const triggerRun = useCallback(() => {
-    if (runInGameRunning || saveDeployRunning) {
-      toast("Finish the current Studio operation before running.", { variant: "info" });
-      return;
-    }
-    startBrowserRun();
-  }, [runInGameRunning, saveDeployRunning, startBrowserRun, toast]);
-
   const status: GenerationStatus = browserRunning ? "running" : error ? "error" : "ready";
-
-  const isDirty = useMemo(() => {
-    if (!lastRunSnapshot) return true;
-    return (
-      !worldSettingsEqual(lastRunSnapshot.worldSettings, worldSettings) ||
-      !recipeSettingsEqual(lastRunSnapshot.recipeSettings, recipeSettings) ||
-      !configsEqual(lastRunSnapshot.pipelineConfig, pipelineConfig)
-    );
-  }, [lastRunSnapshot, pipelineConfig, recipeSettings, worldSettings]);
 
   const runInGameMaterializationMode = useMemo<"durable" | "disposable">(() => {
     const parsed = parsePresetKey(recipeSettings.preset);

--- a/apps/mapgen-studio/src/app/hooks/useBrowserRun.ts
+++ b/apps/mapgen-studio/src/app/hooks/useBrowserRun.ts
@@ -1,0 +1,250 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+
+import { getCiv7MapSizePreset } from "../../features/browserRunner/mapSizes";
+import { capturePinnedSelection } from "../../features/browserRunner/retention";
+import type { BrowserRunnerActions } from "../../features/browserRunner/useBrowserRunner";
+import {
+  formatCiv7StudioSeedError,
+  parseCiv7StudioSeed,
+  randomCiv7StudioSeed,
+} from "../../features/civ7Setup/seedPolicy";
+import { migratePipelineConfig } from "../../features/configMigrations/pipelineConfig";
+import type { UseVizStateResult } from "../../features/viz/useVizState";
+import { useAuthoringStore } from "../../stores/authoringStore";
+import { useRunStore } from "../../stores/runStore";
+import { configsEqual, recipeSettingsEqual, worldSettingsEqual } from "../../ui/utils/config";
+import type { ToastFn } from "./useToast";
+
+/**
+ * The viz capabilities `startBrowserRun` reaches into when it kicks off a run:
+ * the pinned-selection read + the stream/selection reset. Narrowed to exactly
+ * these members so `useBrowserRun` depends on the viz *surface* it uses, not the
+ * full `useVizState` result (the host passes the whole `viz` handle in).
+ */
+export type BrowserRunVizHandle = Pick<
+  UseVizStateResult,
+  "selectedStepId" | "selectedLayerKey" | "clearStream" | "setSelectedStepId" | "setSelectedLayerKey"
+>;
+
+export type UseBrowserRunArgs = {
+  /** `browserRunner.actions` — the worker-run command surface (start/cancel/clearError). */
+  runnerActions: BrowserRunnerActions;
+  /** `browserRunner.state.running`, derived in host render scope (BR-12) and threaded in. */
+  browserRunning: boolean;
+  /** The host-owned viz handle (slice 2.7); only the run-relevant members are used. */
+  viz: BrowserRunVizHandle;
+  /** Threaded busy flags from `useStudioOperations` (slice 2.4) — received, never re-derived. */
+  runInGameRunning: boolean;
+  saveDeployRunning: boolean;
+  toast: ToastFn;
+  /** The single-owner error channel setter from `useStudioOperations`. */
+  setLocalError: (message: string | null) => void;
+};
+
+export type UseBrowserRun = {
+  startBrowserRun: (overrides?: { seed?: string }) => void;
+  reroll: () => void;
+  triggerRun: () => void;
+  isDirty: boolean;
+  autoRunEnabled: boolean;
+  setAutoRunEnabled: Dispatch<SetStateAction<boolean>>;
+};
+
+/**
+ * `useBrowserRun` — the browser-run command + auto-run orchestration surface.
+ *
+ * It owns `startBrowserRun` (the imperative run entry point), the three-effect
+ * auto-run debounce state machine, the `reroll`/`triggerRun` user actions, and
+ * the `isDirty` signal. Authoring/run-store values are read directly from their
+ * stores here (same selectors the host used); only genuinely cross-cutting
+ * values cross the boundary as args — the runner actions + `browserRunning`
+ * (the host instantiates `browserRunner` BEFORE `viz`, since viz reads
+ * `browserRunning`, so the runner instance + its `vizIngestRef` event-sink wiring
+ * stay in host render scope), the viz handle, the threaded busy flags, `toast`,
+ * and the error-channel setter.
+ *
+ * The auto-run trio is atomic (Tier-A): the three effects communicate only
+ * through `autoRunTimerRef`/`autoRunPendingRef`, invisible to React's deps, so
+ * they MUST stay co-located in source order — splitting them would orphan a
+ * ref-writer from its ref-reader and silently break the defer/flush handshake
+ * (and leak the debounce timer past a disable; see BR-13).
+ */
+export function useBrowserRun({
+  runnerActions,
+  browserRunning,
+  viz,
+  runInGameRunning,
+  saveDeployRunning,
+  toast,
+  setLocalError,
+}: UseBrowserRunArgs): UseBrowserRun {
+  const worldSettings = useAuthoringStore((s) => s.worldSettings);
+  const recipeSettings = useAuthoringStore((s) => s.recipeSettings);
+  const setRecipeSettings = useAuthoringStore((s) => s.setRecipeSettings);
+  const pipelineConfig = useAuthoringStore((s) => s.pipelineConfig);
+  const overridesDisabled = useAuthoringStore((s) => s.overridesDisabled);
+  const lastRunSnapshot = useRunStore((s) => s.lastRunSnapshot);
+  const setLastRunSnapshot = useRunStore((s) => s.setLastRunSnapshot);
+
+  const [autoRunEnabled, setAutoRunEnabled] = useState(false);
+  const autoRunTimerRef = useRef<number | null>(null);
+  const autoRunPendingRef = useRef(false);
+
+  const startBrowserRun = useCallback(
+    (overrides?: { seed?: string }) => {
+      setLocalError(null);
+
+      const seedStr = overrides?.seed ?? recipeSettings.seed;
+      const seedPolicy = parseCiv7StudioSeed(seedStr);
+      if (!seedPolicy.ok) {
+        const message = formatCiv7StudioSeedError(seedPolicy);
+        setLocalError(message);
+        toast(message, { variant: "error" });
+        return;
+      }
+      const seed = seedPolicy.value;
+      const mapSize = getCiv7MapSizePreset(worldSettings.mapSize);
+      const runPipelineConfig = migratePipelineConfig(pipelineConfig);
+
+      const pinned = capturePinnedSelection({
+        selectedStepId: viz.selectedStepId,
+        selectedLayerKey: viz.selectedLayerKey,
+      });
+      viz.clearStream();
+      if (!pinned.retainStep) viz.setSelectedStepId(null);
+      if (!pinned.retainLayer) viz.setSelectedLayerKey(null);
+
+      runnerActions.clearError();
+
+      setLastRunSnapshot({
+        worldSettings,
+        recipeSettings: { ...recipeSettings, seed: seedStr },
+        pipelineConfig: runPipelineConfig,
+      });
+
+      runnerActions.start({
+        recipeId: recipeSettings.recipe,
+        seed,
+        mapSizeId: mapSize.id,
+        dimensions: mapSize.dimensions,
+        latitudeBounds: { topLatitude: 80, bottomLatitude: -80 },
+        playerCount: worldSettings.playerCount,
+        resourcesMode: worldSettings.resources,
+        configOverrides: overridesDisabled ? undefined : (runPipelineConfig as unknown),
+      });
+    },
+    // Dep set preserved verbatim from the host original; the stable store/state
+    // setters (`setLocalError`, `setLastRunSnapshot`) are intentionally omitted.
+    [runnerActions, overridesDisabled, pipelineConfig, recipeSettings, toast, worldSettings, viz]
+  );
+
+  useEffect(() => {
+    if (!autoRunEnabled) {
+      autoRunPendingRef.current = false;
+      if (autoRunTimerRef.current) {
+        window.clearTimeout(autoRunTimerRef.current);
+        autoRunTimerRef.current = null;
+      }
+    }
+  }, [autoRunEnabled]);
+
+  useEffect(() => {
+    if (!autoRunEnabled) return;
+    if (overridesDisabled) return;
+    if (runInGameRunning || saveDeployRunning) return;
+
+    if (browserRunning) {
+      autoRunPendingRef.current = true;
+      return;
+    }
+
+    if (lastRunSnapshot && configsEqual(lastRunSnapshot.pipelineConfig, pipelineConfig)) return;
+
+    if (autoRunTimerRef.current) window.clearTimeout(autoRunTimerRef.current);
+    autoRunTimerRef.current = window.setTimeout(() => {
+      autoRunTimerRef.current = null;
+      startBrowserRun();
+    }, 300);
+
+    return () => {
+      if (!autoRunTimerRef.current) return;
+      window.clearTimeout(autoRunTimerRef.current);
+      autoRunTimerRef.current = null;
+    };
+  }, [
+    autoRunEnabled,
+    browserRunning,
+    lastRunSnapshot,
+    overridesDisabled,
+    pipelineConfig,
+    runInGameRunning,
+    saveDeployRunning,
+    startBrowserRun,
+  ]);
+
+  useEffect(() => {
+    if (!autoRunEnabled) return;
+    if (overridesDisabled) return;
+    if (browserRunning) return;
+    if (runInGameRunning || saveDeployRunning) return;
+    if (!autoRunPendingRef.current) return;
+
+    autoRunPendingRef.current = false;
+    if (lastRunSnapshot && configsEqual(lastRunSnapshot.pipelineConfig, pipelineConfig)) return;
+    startBrowserRun();
+  }, [
+    autoRunEnabled,
+    browserRunning,
+    lastRunSnapshot,
+    overridesDisabled,
+    pipelineConfig,
+    runInGameRunning,
+    saveDeployRunning,
+    startBrowserRun,
+  ]);
+
+  const reroll = useCallback(() => {
+    if (runInGameRunning || saveDeployRunning) {
+      toast("Finish the current Studio operation before rerolling.", { variant: "info" });
+      return;
+    }
+    const next = randomCiv7StudioSeed();
+    setRecipeSettings((prev) => ({ ...prev, seed: next }));
+    startBrowserRun({ seed: next });
+    // `setRecipeSettings` (stable store setter) omitted from deps, as in the host original.
+  }, [runInGameRunning, saveDeployRunning, startBrowserRun, toast]);
+
+  const triggerRun = useCallback(() => {
+    if (runInGameRunning || saveDeployRunning) {
+      toast("Finish the current Studio operation before running.", { variant: "info" });
+      return;
+    }
+    startBrowserRun();
+  }, [runInGameRunning, saveDeployRunning, startBrowserRun, toast]);
+
+  const isDirty = useMemo(() => {
+    if (!lastRunSnapshot) return true;
+    return (
+      !worldSettingsEqual(lastRunSnapshot.worldSettings, worldSettings) ||
+      !recipeSettingsEqual(lastRunSnapshot.recipeSettings, recipeSettings) ||
+      !configsEqual(lastRunSnapshot.pipelineConfig, pipelineConfig)
+    );
+  }, [lastRunSnapshot, pipelineConfig, recipeSettings, worldSettings]);
+
+  return {
+    startBrowserRun,
+    reroll,
+    triggerRun,
+    isDirty,
+    autoRunEnabled,
+    setAutoRunEnabled,
+  };
+}

--- a/apps/mapgen-studio/test/controllers/useBrowserRun.source.test.ts
+++ b/apps/mapgen-studio/test/controllers/useBrowserRun.source.test.ts
@@ -1,0 +1,61 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+import hostSource from "../../src/app/StudioShell.tsx?raw";
+import hookSource from "../../src/app/hooks/useBrowserRun.ts?raw";
+
+// Strip comments so doc-comments (which legitimately name effects/errors/etc.)
+// don't trip the matchers.
+const host = hostSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+const hook = hookSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+describe("StudioShell source — viz-ingest sink stays render-scope (BR-11)", () => {
+  it("assigns vizIngestRef.current = viz.ingest in render scope, NOT inside an effect", () => {
+    // Exactly two leading spaces = directly in the component body (render scope).
+    // An effect/callback body would indent it 4+ spaces; this is the BR-11 falsifier
+    // ("moved into an effect → early VizEvents dropped to the stale no-op ingest").
+    expect(host).toMatch(/\n {2}vizIngestRef\.current = viz\.ingest;/);
+    // The sink is read through the ref by the stable handler, never closed over directly.
+    expect(host).toMatch(/vizIngestRef\.current\?\.\(event\)/);
+  });
+});
+
+describe("StudioShell source — browserRunning + busy threading stay render-scope (BR-12)", () => {
+  it("derives browserRunning in render scope and threads it + the busy flags into useBrowserRun", () => {
+    expect(host).toMatch(/\n {2}const browserRunning = browserRunner\.state\.running;/);
+    // The runner instance is host-owned (must precede the host `viz` call); the
+    // command surface receives the runner actions + browserRunning + threaded
+    // busy flags by value.
+    expect(host).toMatch(/useBrowserRun\(\{/);
+    expect(host).toMatch(/runnerActions: browserRunner\.actions/);
+    expect(host).toMatch(/browserRunning,/);
+    expect(host).toMatch(/runInGameRunning,/);
+    expect(host).toMatch(/saveDeployRunning,/);
+  });
+
+  it("keeps the composite error/status host-derived (not absorbed into the hook)", () => {
+    expect(host).toMatch(/const error = localError \?\? browserRunner\.state\.error/);
+    expect(host).toMatch(/const status: GenerationStatus = browserRunning \?/);
+  });
+});
+
+describe("useBrowserRun source — atomic trio + partition", () => {
+  it("co-locates exactly the three auto-run effects in one hook (atomicity)", () => {
+    expect(hook.match(/useEffect\(/g)).toHaveLength(3);
+  });
+
+  it("receives the busy flags as params — never re-derives them via useStudioOperations", () => {
+    expect(hook).not.toMatch(/useStudioOperations/);
+    expect(hook).toMatch(/runInGameRunning/);
+    expect(hook).toMatch(/saveDeployRunning/);
+  });
+
+  it("reads its own authoring/run store slices directly", () => {
+    expect(hook).toMatch(/useAuthoringStore/);
+    expect(hook).toMatch(/useRunStore/);
+  });
+
+  it("does NOT own the composite error/status (those stay host-derived)", () => {
+    expect(hook).not.toMatch(/localError \?\?/);
+    expect(hook).not.toMatch(/const status\b/);
+  });
+});

--- a/apps/mapgen-studio/test/controllers/useBrowserRun.test.tsx
+++ b/apps/mapgen-studio/test/controllers/useBrowserRun.test.tsx
@@ -1,0 +1,257 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseCiv7StudioSeed } from "../../src/features/civ7Setup/seedPolicy";
+import { useBrowserRun, type UseBrowserRunArgs } from "../../src/app/hooks/useBrowserRun";
+import { useAuthoringStore } from "../../src/stores/authoringStore";
+import { useRunStore } from "../../src/stores/runStore";
+import "./_setup";
+
+// randomCiv7StudioSeed is mocked to a fixed value so BR-6 can prove the rerolled
+// seed (not the stale store seed) reaches `start`. parse/format stay real.
+vi.mock("../../src/features/civ7Setup/seedPolicy", async (orig) => {
+  const actual = await orig<typeof import("../../src/features/civ7Setup/seedPolicy")>();
+  return { ...actual, randomCiv7StudioSeed: vi.fn(() => "999") };
+});
+
+// Default authoring state captured once (the recipe-derived default pipelineConfig
+// is a real, migratable config — reused as the per-test baseline).
+const DEFAULT_RECIPE = useAuthoringStore.getState().recipeSettings.recipe;
+const DEFAULT_CONFIG = useAuthoringStore.getState().pipelineConfig;
+
+function resetStores() {
+  useAuthoringStore.setState({
+    worldSettings: { mapSize: "MAPSIZE_STANDARD", playerCount: 6, resources: "balanced" },
+    recipeSettings: { recipe: DEFAULT_RECIPE, preset: "none", seed: "123" },
+    pipelineConfig: DEFAULT_CONFIG,
+    overridesDisabled: false,
+  });
+  useRunStore.setState({ lastRunSnapshot: null });
+}
+
+beforeEach(() => resetStores());
+
+function makeRunnerActions() {
+  return { start: vi.fn(), cancel: vi.fn(), clearError: vi.fn() };
+}
+
+function makeViz(): UseBrowserRunArgs["viz"] {
+  return {
+    selectedStepId: null,
+    selectedLayerKey: null,
+    clearStream: vi.fn(),
+    setSelectedStepId: vi.fn(),
+    setSelectedLayerKey: vi.fn(),
+  };
+}
+
+/**
+ * Render harness with stable spies across rerenders. `update(patch)` rerenders
+ * the hook with new args (e.g. flipping `browserRunning`) while keeping the same
+ * spy identities so assertions accumulate across the sequence.
+ */
+function renderBrowserRun(initial: Partial<UseBrowserRunArgs> = {}) {
+  const runnerActions = makeRunnerActions();
+  const toast = vi.fn();
+  const setLocalError = vi.fn();
+  const viz = makeViz();
+  let args: UseBrowserRunArgs = {
+    runnerActions,
+    browserRunning: false,
+    viz,
+    runInGameRunning: false,
+    saveDeployRunning: false,
+    toast,
+    setLocalError,
+    ...initial,
+  };
+  const view = renderHook((p: UseBrowserRunArgs) => useBrowserRun(p), { initialProps: args });
+  const update = (patch: Partial<UseBrowserRunArgs>) => {
+    args = { ...args, ...patch };
+    act(() => view.rerender(args));
+  };
+  return { view, runnerActions, toast, setLocalError, viz, update };
+}
+
+// ---------------------------------------------------------------------------
+// Run actions — reroll / triggerRun (BR-6, BR-7)
+// ---------------------------------------------------------------------------
+describe("useBrowserRun — run actions (BR-6 / BR-7)", () => {
+  it("BR-6: reroll passes the freshly-generated seed directly to start, not the stale store seed", () => {
+    const { view, runnerActions } = renderBrowserRun();
+    act(() => view.result.current.reroll());
+
+    // The mocked random seed is "999"; the store seed before reroll was "123".
+    expect(useAuthoringStore.getState().recipeSettings.seed).toBe("999");
+    expect(runnerActions.start).toHaveBeenCalledTimes(1);
+    // start receives the rerolled seed parsed — proving the override arg, not a
+    // closure read of the (async-updated) store seed which would still be 123.
+    expect(runnerActions.start.mock.calls[0][0].seed).toBe(
+      (parseCiv7StudioSeed("999") as { ok: true; value: number }).value
+    );
+  });
+
+  it("BR-7: reroll and triggerRun are blocked (toast, no run) while an operation is busy", () => {
+    const runInGame = renderBrowserRun({ runInGameRunning: true });
+    act(() => runInGame.view.result.current.triggerRun());
+    act(() => runInGame.view.result.current.reroll());
+    expect(runInGame.runnerActions.start).not.toHaveBeenCalled();
+    expect(runInGame.toast).toHaveBeenCalledTimes(2);
+    expect(runInGame.toast.mock.calls[0][1]).toMatchObject({ variant: "info" });
+
+    const saveDeploy = renderBrowserRun({ saveDeployRunning: true });
+    act(() => saveDeploy.view.result.current.triggerRun());
+    expect(saveDeploy.runnerActions.start).not.toHaveBeenCalled();
+    expect(saveDeploy.toast).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startBrowserRun internals — overrides + seed validation (BR-8, BR-9)
+// ---------------------------------------------------------------------------
+describe("useBrowserRun — startBrowserRun config + seed (BR-8 / BR-9)", () => {
+  it("BR-8: passes configOverrides:undefined when overrides are disabled, migrated config when enabled", () => {
+    const disabled = renderBrowserRun();
+    act(() => useAuthoringStore.setState({ overridesDisabled: true }));
+    act(() => disabled.view.result.current.triggerRun());
+    expect(disabled.runnerActions.start).toHaveBeenCalledTimes(1);
+    expect(disabled.runnerActions.start.mock.calls[0][0].configOverrides).toBeUndefined();
+
+    const enabled = renderBrowserRun();
+    act(() => useAuthoringStore.setState({ overridesDisabled: false }));
+    act(() => enabled.view.result.current.triggerRun());
+    expect(enabled.runnerActions.start).toHaveBeenCalledTimes(1);
+    expect(enabled.runnerActions.start.mock.calls[0][0].configOverrides).not.toBeUndefined();
+  });
+
+  it("BR-9: aborts on an invalid seed — sets localError, toasts, and never calls start", () => {
+    for (const badSeed of ["", "abc", "-1", "0x8000_0000"]) {
+      resetStores();
+      act(() => useAuthoringStore.setState({ recipeSettings: { recipe: DEFAULT_RECIPE, preset: "none", seed: badSeed } }));
+      const { view, runnerActions, toast, setLocalError } = renderBrowserRun();
+      act(() => view.result.current.triggerRun());
+      expect(runnerActions.start, `seed=${JSON.stringify(badSeed)}`).not.toHaveBeenCalled();
+      expect(setLocalError, `seed=${JSON.stringify(badSeed)}`).toHaveBeenCalled();
+      expect(toast, `seed=${JSON.stringify(badSeed)}`).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ variant: "error" })
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDirty (BR-10)
+// ---------------------------------------------------------------------------
+describe("useBrowserRun — isDirty (BR-10)", () => {
+  it("is true with no snapshot, and true when ANY of world/recipe/pipeline diverges", () => {
+    const { view } = renderBrowserRun();
+    expect(view.result.current.isDirty).toBe(true); // no snapshot
+
+    // Snapshot mirrors current authoring → clean.
+    const s = useAuthoringStore.getState();
+    act(() =>
+      useRunStore.setState({
+        lastRunSnapshot: {
+          worldSettings: s.worldSettings,
+          recipeSettings: s.recipeSettings,
+          pipelineConfig: s.pipelineConfig,
+        },
+      })
+    );
+    expect(view.result.current.isDirty).toBe(false);
+
+    // Diverge world only.
+    act(() => useAuthoringStore.setState({ worldSettings: { ...s.worldSettings, playerCount: 8 } }));
+    expect(view.result.current.isDirty).toBe(true);
+
+    // Reset world, diverge recipe only.
+    act(() => useAuthoringStore.setState({ worldSettings: s.worldSettings, recipeSettings: { ...s.recipeSettings, seed: "777" } }));
+    expect(view.result.current.isDirty).toBe(true);
+
+    // Reset recipe, diverge pipeline only.
+    act(() => useAuthoringStore.setState({ recipeSettings: s.recipeSettings, pipelineConfig: { ...s.pipelineConfig } as typeof s.pipelineConfig, }));
+    // A new pipeline reference with identical content stays clean (deep-equal)…
+    expect(view.result.current.isDirty).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auto-run trio (BR-1..BR-5) — fake timers, reactive runner model
+// ---------------------------------------------------------------------------
+describe("useBrowserRun — auto-run trio (BR-1..BR-5)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("BR-1: disabling auto-run cancels the scheduled run AND clears the deferred pending flag", () => {
+    // (a) timer cancel: enabling schedules a run; disabling before the debounce → no run.
+    const a = renderBrowserRun();
+    act(() => a.view.result.current.setAutoRunEnabled(true)); // E2 schedules (idle, no snapshot = dirty)
+    act(() => a.view.result.current.setAutoRunEnabled(false)); // E1 + E2 cleanup cancel
+    act(() => vi.advanceTimersByTime(300));
+    expect(a.runnerActions.start).not.toHaveBeenCalled();
+
+    // (b) pending clear — E1's UNIQUE job (E2's cleanup already covers the timer).
+    // A run deferred while the runner is busy must NOT survive a disable and then
+    // flush the moment auto-run is re-enabled.
+    const b = renderBrowserRun({ browserRunning: true });
+    act(() => b.view.result.current.setAutoRunEnabled(true)); // E2 → pending=true (deferred while running)
+    act(() => b.view.result.current.setAutoRunEnabled(false)); // E1 must clear pending
+    act(() => b.update({ browserRunning: false })); // run "completes" while disabled → nothing fires
+    act(() => b.view.result.current.setAutoRunEnabled(true)); // re-enable
+    // A stale (uncleared) pending would flush start() immediately here; cleared → only
+    // a fresh debounce is scheduled, which has not yet elapsed.
+    expect(b.runnerActions.start).not.toHaveBeenCalled();
+  });
+
+  it("BR-2: a config change while running defers to exactly ONE run on completion (no drop, no duplicate)", () => {
+    const { view, runnerActions, update } = renderBrowserRun({ browserRunning: true });
+    act(() => view.result.current.setAutoRunEnabled(true)); // E2: running → pending=true; E3: running → bail
+    // Config edits during the run keep deferring (still just pending).
+    act(() => useAuthoringStore.setState({ pipelineConfig: { ...DEFAULT_CONFIG } as typeof DEFAULT_CONFIG }));
+
+    // Run completes. start() must re-arm the runner → model browserRunning=true again,
+    // which lets E2's cleanup cancel the timer it schedules on this transition.
+    runnerActions.start.mockImplementation(() => {});
+    act(() => update({ browserRunning: false })); // E3 flushes immediately (1 run); E2 schedules a timer
+    expect(runnerActions.start).toHaveBeenCalledTimes(1);
+    act(() => update({ browserRunning: true })); // runner started → E2 cleanup cancels the pending timer
+    act(() => vi.advanceTimersByTime(300));
+    act(() => update({ browserRunning: false })); // back to idle; snapshot now == config → no further run
+    expect(runnerActions.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("BR-3: suppressed while runInGame/saveDeploy busy; one run once the flags clear", () => {
+    const { view, runnerActions, update } = renderBrowserRun({ runInGameRunning: true });
+    act(() => view.result.current.setAutoRunEnabled(true)); // busy → E2/E3 bail, nothing scheduled
+    act(() => vi.advanceTimersByTime(300));
+    expect(runnerActions.start).not.toHaveBeenCalled();
+
+    act(() => update({ runInGameRunning: false })); // idle → E2 schedules
+    act(() => vi.advanceTimersByTime(300));
+    expect(runnerActions.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("BR-4: suppressed while overridesDisabled; one run after re-enable", () => {
+    const { view, runnerActions } = renderBrowserRun();
+    act(() => useAuthoringStore.setState({ overridesDisabled: true }));
+    act(() => view.result.current.setAutoRunEnabled(true)); // overrides off → bail
+    act(() => vi.advanceTimersByTime(300));
+    expect(runnerActions.start).not.toHaveBeenCalled();
+
+    act(() => useAuthoringStore.setState({ overridesDisabled: false })); // E2 schedules
+    act(() => vi.advanceTimersByTime(300));
+    expect(runnerActions.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("BR-5: the 300ms debounce resets on each config change — exactly one run after quiescence", () => {
+    const { view, runnerActions } = renderBrowserRun();
+    act(() => view.result.current.setAutoRunEnabled(true)); // schedule #1
+    act(() => vi.advanceTimersByTime(250)); // not yet
+    act(() => useAuthoringStore.setState({ pipelineConfig: { ...DEFAULT_CONFIG } as typeof DEFAULT_CONFIG })); // reschedule
+    act(() => vi.advanceTimersByTime(250)); // 500ms since first, but only 250 since reschedule → not yet
+    expect(runnerActions.start).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(50)); // 300 since reschedule → fire once
+    expect(runnerActions.start).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Extracts the browser-run command surface and auto-run orchestration out of `StudioShell` into a dedicated `useBrowserRun` hook.

`StudioShell` previously owned `startBrowserRun`, the three-effect auto-run debounce state machine, `reroll`, `triggerRun`, `isDirty`, and the related `autoRunEnabled` state inline. These are now encapsulated in `useBrowserRun`, which reads authoring and run store slices directly and receives only genuinely cross-cutting values as arguments: the runner actions, `browserRunning`, the viz handle, the threaded busy flags, `toast`, and the error-channel setter. The runner instance and `vizIngestRef` sink wiring remain in host render scope since they must precede the `viz` call that reads `browserRunning`.

The three auto-run effects are kept co-located within the hook (atomic trio) because they communicate exclusively through `autoRunTimerRef` and `autoRunPendingRef` — splitting them would orphan a ref-writer from its ref-reader and silently break the defer/flush handshake.

Adds two test files covering the extracted hook:
- `useBrowserRun.test.tsx` — behavioral tests for the auto-run trio (BR-1–BR-5), run actions (BR-6–BR-7), `startBrowserRun` config and seed validation (BR-8–BR-9), and `isDirty` (BR-10), using fake timers and a reactive runner model.
- `useBrowserRun.source.test.ts` — source-text assertions that enforce the partition invariants: `vizIngestRef` assignment stays in render scope (BR-11), `browserRunning` and busy flags are derived and threaded in host render scope (BR-12), and the hook never re-derives the composite error or status.