### PR TITLE
refactor(mapgen-studio): extract viz selection/exploration cascade into `useVizSelection` (slice 2.7)

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -8,10 +8,7 @@ import { getCiv7MapSizePreset } from "../features/browserRunner/mapSizes";
 import { useBrowserRunner } from "../features/browserRunner/useBrowserRunner";
 import { fetchCiv7SetupConfig, requestCiv7Autoplay } from "../features/civ7Setup/api";
 import { LIVE_GAME_PRESET_ID, LIVE_GAME_PRESET_KEY } from "../features/civ7Setup/livePreset";
-import {
-  formatCiv7StudioSeedError,
-  parseCiv7StudioSeed,
-} from "../features/civ7Setup/seedPolicy";
+import { formatCiv7StudioSeedError, parseCiv7StudioSeed } from "../features/civ7Setup/seedPolicy";
 import {
   type Civ7SetupSnapshotLike,
   type Civ7StudioSetupConfig,
@@ -84,19 +81,6 @@ import {
   formatRunInGameDiagnostics,
   runInGameRequiresProcessRestart,
 } from "../features/runInGame/status";
-import {
-  findVariantIdForEra,
-  findVariantKeyForEra,
-  listEraVariants,
-  parseEraVariantKey,
-  resolveFixedEraUiValue,
-} from "../features/viz/era";
-import { applyRiverLakeInspectorSelection } from "../features/viz/inspectorSelection";
-import {
-  buildRiverLakeFloodplainInspectorSummary,
-  type RiverLakeInspectorLayerRef,
-} from "../features/viz/riverLakeInspector";
-import { useVizState } from "../features/viz/useVizState";
 import { liveControlPort } from "../lib/control/liveControlPort";
 import { orpcClient } from "../lib/orpc";
 import {
@@ -105,10 +89,7 @@ import {
   getRecipeArtifacts,
   STUDIO_RECIPE_OPTIONS,
 } from "../recipes/catalog";
-import { getOverlaySuggestions } from "../recipes/overlaySuggestions";
 import { isAbortLikeError } from "../shared/async";
-import { formatErrorForUi } from "../shared/errorFormat";
-import { clampNumber } from "../shared/number";
 import type { VizEvent } from "../shared/vizEvents";
 import { useAuthoringStore } from "../stores/authoringStore";
 import { useRunStore } from "../stores/runStore";
@@ -119,19 +100,8 @@ import { ExplorePanel } from "../ui/components/ExplorePanel";
 import { GameConsole } from "../ui/components/GameConsole";
 import { RecipePanel } from "../ui/components/RecipePanel";
 import { StageViewTabs } from "../ui/components/StageViewTabs";
-import type {
-  DataTypeOption,
-  GenerationStatus,
-  OverlayOption,
-  PipelineConfig,
-  RenderModeOption,
-  SpaceOption,
-  StageOption,
-  StepOption,
-  VariantOption,
-} from "../ui/types";
+import type { GenerationStatus, PipelineConfig } from "../ui/types";
 import { configsEqual } from "../ui/utils/config";
-import { formatStageName } from "../ui/utils/formatting";
 import { CanvasStage } from "./CanvasStage";
 import { ErrorBanner } from "./ErrorBanner";
 import { useBrowserRun } from "./hooks/useBrowserRun";
@@ -142,6 +112,7 @@ import { useStudioEvents } from "./hooks/useStudioEvents";
 import { useStudioOperations } from "./hooks/useStudioOperations";
 import { useToast } from "./hooks/useToast";
 import { useViewportLayout } from "./hooks/useViewportLayout";
+import { useVizSelection } from "./hooks/useVizSelection";
 import { LeftDock } from "./LeftDock";
 import { readAndAdoptStudioOperationsCurrent } from "./operationAdoption";
 import { RightDock } from "./RightDock";
@@ -220,12 +191,10 @@ export function StudioShell(props: StudioShellProps) {
   const setOverlaySelectionId = useViewStore((s) => s.setOverlaySelectionId);
   const overlayOpacity = useViewStore((s) => s.overlayOpacity);
   const setOverlayOpacity = useViewStore((s) => s.setOverlayOpacity);
-  const overlayVariantKeyPreference = useViewStore((s) => s.overlayVariantKeyPreference);
-  const setOverlayVariantKeyPreference = useViewStore((s) => s.setOverlayVariantKeyPreference);
+  // `eraMode` is read here for the explore-panel JSX; the era/overlay *write*
+  // surface (`manualEra`/`setManualEra`/`setEraMode`/`overlayVariantKeyPreference`)
+  // is owned by `useVizSelection`.
   const eraMode = useViewStore((s) => s.eraMode);
-  const setEraMode = useViewStore((s) => s.setEraMode);
-  const manualEra = useViewStore((s) => s.manualEra);
-  const setManualEra = useViewStore((s) => s.setManualEra);
   const recipeSectionCollapsed = useViewStore((s) => s.recipeSectionCollapsed);
   const setRecipeSectionCollapsed = useViewStore((s) => s.setRecipeSectionCollapsed);
   const configSectionCollapsed = useViewStore((s) => s.configSectionCollapsed);
@@ -300,13 +269,6 @@ export function StudioShell(props: StudioShellProps) {
   // `studio.operations.current` instead.
   const lastRunInGameSource = useRunStore((s) => s.lastRunInGameSource);
   const setLastRunInGameSource = useRunStore((s) => s.setLastRunInGameSource);
-
-  const overlaySuggestions = useMemo(
-    () => getOverlaySuggestions(recipeSettings.recipe),
-    [recipeSettings.recipe]
-  );
-  const overlaySelection = overlaySuggestions.find((opt) => opt.id === overlaySelectionId) ?? null;
-  const overlayDataTypeKey = overlaySelection?.overlayDataTypeKey ?? null;
 
   const recipeArtifacts = useMemo(
     () => getRecipeArtifacts(recipeSettings.recipe),
@@ -538,14 +500,41 @@ export function StudioShell(props: StudioShellProps) {
   const [autoplayActionRunning, setAutoplayActionRunning] = useState(false);
   const [exploreActionRunning, setExploreActionRunning] = useState(false);
 
-  const viz = useVizState({
-    enabled: true,
-    showEdgeOverlay: showEdges,
-    overlayDataTypeKey,
-    overlayVariantKeyPreference,
-    overlayOpacity,
-    allowPendingSelection: browserRunning,
-    onError: (e) => setLocalError(formatErrorForUi(e)),
+  // Viz selection/exploration fixpoint (slice 2.7): owns `useVizState` + the full
+  // stage/step/dataType/space/mode/variant/era/overlay cascade and is the sole
+  // writer of the selected stage/step + the mutable `viz` object. Called here
+  // (after `browserRunning` is derived — viz reads it via `allowPendingSelection`)
+  // so the host-owned `vizIngestRef` event sink can be wired in render scope below,
+  // and the whole `viz` handle threads onward to `useBrowserRun`, deck-autofit
+  // (slice 2.7b), `backgroundGridEnabled`, and the canvas/explore JSX BY VALUE.
+  const {
+    viz,
+    stages,
+    steps,
+    dataTypeOptions,
+    spaceOptions,
+    renderModeOptions,
+    variantOptions,
+    overlayOptions,
+    selection,
+    eraEnabled,
+    eraRange,
+    eraDisplayValue,
+    riverLakeInspectorSummary,
+    handleStageChange,
+    handleStepChange,
+    handleDataTypeChange,
+    handleSpaceChange,
+    handleRenderModeChange,
+    handleVariantChange,
+    handleEraModeChange,
+    handleEraValueChange,
+    handleRiverLakeInspectorLayerSelect,
+  } = useVizSelection({
+    recipe: recipeSettings.recipe,
+    recipeArtifacts,
+    browserRunning,
+    setLocalError,
   });
   vizIngestRef.current = viz.ingest;
   const hasEverSeenVizManifestRef = useRef(false);
@@ -744,59 +733,16 @@ export function StudioShell(props: StudioShellProps) {
   // Selected stage/step are part of the view surface — owned by `viewStore`
   // (single owner; no App-local mirror), per architecture/10 §3.
   const selectedStageId = useViewStore((s) => s.selectedStageId);
-  const setSelectedStageId = useViewStore((s) => s.setSelectedStageId);
   const selectedStepId = useViewStore((s) => s.selectedStepId);
+  // `setSelectedStepId` is still threaded into `useKeyboardShortcuts` here;
+  // `setSelectedStageId` and the stage/step memos + clamp effects moved into
+  // `useVizSelection` (their sole writer).
   const setSelectedStepId = useViewStore((s) => s.setSelectedStepId);
 
   const recipeOptions = useMemo(
     () => STUDIO_RECIPE_OPTIONS.map((opt) => ({ value: opt.id, label: opt.label })),
     []
   );
-
-  const stages: StageOption[] = useMemo(() => {
-    return recipeArtifacts.uiMeta.stages.map((stage, index) => ({
-      value: stage.stageId,
-      label: stage.stageLabel ?? formatStageName(stage.stageId),
-      index: index + 1,
-    }));
-  }, [recipeArtifacts.uiMeta.stages]);
-
-  const steps: StepOption[] = useMemo(() => {
-    if (!selectedStageId) return [];
-
-    const labelByFullStepId = new Map(
-      recipeArtifacts.uiMeta.stages.flatMap((stage) =>
-        stage.steps.map((step) => [step.fullStepId, step.stepLabel] as const)
-      )
-    );
-
-    const stage = recipeArtifacts.uiMeta.stages.find((s) => s.stageId === selectedStageId);
-    return (
-      stage?.steps.map((step) => ({
-        value: step.fullStepId,
-        label: labelByFullStepId.get(step.fullStepId) ?? step.stepLabel ?? step.stepId,
-        category: selectedStageId,
-      })) ?? []
-    );
-  }, [recipeArtifacts.uiMeta.stages, selectedStageId]);
-
-  useEffect(() => {
-    if (stages.length === 0) return;
-    setSelectedStageId((prev) => (stages.some((s) => s.value === prev) ? prev : stages[0]!.value));
-  }, [stages]);
-
-  useEffect(() => {
-    if (steps.length === 0) return;
-    setSelectedStepId((prev) => (steps.some((s) => s.value === prev) ? prev : steps[0]!.value));
-  }, [steps]);
-
-  useEffect(() => {
-    if (!selectedStepId) return;
-    if (viz.selectedStepId === selectedStepId) return;
-    viz.setSelectedStepId(selectedStepId);
-    viz.setSelectedLayerKey(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedStepId]);
 
   // Browser-run command + auto-run orchestration (slice 2.6). The runner
   // instance + `browserRunning` derivation + `vizIngestRef` sink wiring stay in
@@ -1838,351 +1784,6 @@ export function StudioShell(props: StudioShellProps) {
     runInGameRunning,
     saveDeployRunning,
   });
-
-  const dataTypeModel = viz.dataTypeModel;
-  const dataTypeOptions: DataTypeOption[] = useMemo(() => {
-    if (!dataTypeModel) return [];
-    return dataTypeModel.dataTypes.map((dt) => ({
-      value: dt.dataTypeId,
-      label: dt.label,
-      group: dt.group,
-    }));
-  }, [dataTypeModel]);
-
-  const riverLakeInspectorSummary = useMemo(
-    () => buildRiverLakeFloodplainInspectorSummary(viz.manifest),
-    [viz.manifest]
-  );
-
-  const selection = useMemo(() => {
-    if (!dataTypeModel) return null;
-    for (const dt of dataTypeModel.dataTypes) {
-      for (const space of dt.spaces) {
-        for (const rm of space.renderModes) {
-          for (const variant of rm.variants) {
-            if (variant.layerKey === viz.selectedLayerKey) {
-              return {
-                dataTypeId: dt.dataTypeId,
-                spaceId: space.spaceId,
-                renderModeId: rm.renderModeId,
-                variantId: variant.variantId,
-              };
-            }
-          }
-        }
-      }
-    }
-    const firstDt = dataTypeModel.dataTypes[0];
-    const firstSpace = firstDt?.spaces[0];
-    const firstRm = firstSpace?.renderModes[0];
-    const firstVariant = firstRm?.variants[0];
-    if (!firstDt || !firstSpace || !firstRm || !firstVariant) return null;
-    return {
-      dataTypeId: firstDt.dataTypeId,
-      spaceId: firstSpace.spaceId,
-      renderModeId: firstRm.renderModeId,
-      variantId: firstVariant.variantId,
-    };
-  }, [dataTypeModel, viz.selectedLayerKey]);
-
-  const selectedDataType = useMemo(() => {
-    if (!dataTypeModel || !selection) return null;
-    return dataTypeModel.dataTypes.find((x) => x.dataTypeId === selection.dataTypeId) ?? null;
-  }, [dataTypeModel, selection]);
-
-  const selectedSpace = useMemo(() => {
-    if (!selectedDataType || !selection) return null;
-    return (
-      selectedDataType.spaces.find((s) => s.spaceId === selection.spaceId) ??
-      selectedDataType.spaces[0] ??
-      null
-    );
-  }, [selectedDataType, selection]);
-
-  const selectedRenderMode = useMemo(() => {
-    if (!selectedSpace || !selection) return null;
-    return (
-      selectedSpace.renderModes.find((rm) => rm.renderModeId === selection.renderModeId) ??
-      selectedSpace.renderModes[0] ??
-      null
-    );
-  }, [selectedSpace, selection]);
-
-  const selectedVariants = selectedRenderMode?.variants ?? [];
-  const selectedVariant = useMemo(() => {
-    if (!selection) return selectedVariants[0] ?? null;
-    return (
-      selectedVariants.find((v) => v.variantId === selection.variantId) ??
-      selectedVariants[0] ??
-      null
-    );
-  }, [selectedVariants, selection]);
-  const selectedVariantKey = selectedVariant?.layer.variantKey ?? null;
-
-  const spaceOptions: SpaceOption[] = useMemo(() => {
-    if (!selectedDataType) return [];
-    return selectedDataType.spaces.map((s) => ({ value: s.spaceId, label: s.label }));
-  }, [selectedDataType]);
-
-  const renderModeOptions: RenderModeOption[] = useMemo(() => {
-    if (!selectedSpace) return [];
-    return selectedSpace.renderModes.map((rm) => ({
-      value: rm.renderModeId,
-      label: rm.label,
-    }));
-  }, [selectedSpace]);
-
-  const variantOptions: VariantOption[] = useMemo(
-    () => selectedVariants.map((v) => ({ value: v.variantId, label: v.label })),
-    [selectedVariants]
-  );
-
-  const eraVariants = useMemo(() => listEraVariants(selectedVariants), [selectedVariants]);
-  const eraRange = useMemo(() => {
-    if (!eraVariants.length) return null;
-    const min = eraVariants[0]?.era ?? 1;
-    const max = eraVariants[eraVariants.length - 1]?.era ?? min;
-    return { min, max };
-  }, [eraVariants]);
-  const autoEra = useMemo(() => parseEraVariantKey(selectedVariantKey), [selectedVariantKey]);
-  const eraEnabled = Boolean(eraRange);
-  const fixedEraUiValue = useMemo(
-    () =>
-      resolveFixedEraUiValue({
-        variants: selectedVariants,
-        selectedVariantKey,
-        requestedEra: manualEra,
-      }),
-    [manualEra, selectedVariantKey, selectedVariants]
-  );
-  const eraDisplayValue = eraMode === "fixed" ? fixedEraUiValue : (autoEra ?? eraRange?.min ?? 1);
-
-  useEffect(() => {
-    if (!eraRange) return;
-    setManualEra((prev) => clampNumber(prev, eraRange.min, eraRange.max));
-  }, [eraRange]);
-
-  const overlayCandidates: OverlayOption[] = useMemo(() => {
-    if (!dataTypeModel || !selection) return [];
-    const out: OverlayOption[] = [];
-    for (const suggestion of overlaySuggestions) {
-      if (suggestion.primaryDataTypeKey !== selection.dataTypeId) continue;
-      const overlayDt = dataTypeModel.dataTypes.find(
-        (dt) => dt.dataTypeId === suggestion.overlayDataTypeKey
-      );
-      if (!overlayDt) continue;
-      out.push({ value: suggestion.id, label: suggestion.label });
-    }
-    return out;
-  }, [dataTypeModel, overlaySuggestions, selection]);
-
-  const overlayOptions: OverlayOption[] = useMemo(() => {
-    if (!overlayCandidates.length) return [];
-    return [{ value: "", label: "No overlay" }, ...overlayCandidates];
-  }, [overlayCandidates]);
-
-  useEffect(() => {
-    if (!overlayCandidates.length) {
-      if (overlaySelectionId) setOverlaySelectionId("");
-      return;
-    }
-    if (overlaySelectionId && !overlayCandidates.some((opt) => opt.value === overlaySelectionId)) {
-      setOverlaySelectionId("");
-    }
-  }, [overlayCandidates, overlaySelectionId]);
-
-  useEffect(() => {
-    if (eraMode !== "fixed" || !overlaySelection || !dataTypeModel || !selection) {
-      setOverlayVariantKeyPreference((prev) => (prev === null ? prev : null));
-      return;
-    }
-
-    const overlayDataType = dataTypeModel.dataTypes.find(
-      (dataType) => dataType.dataTypeId === overlaySelection.overlayDataTypeKey
-    );
-    if (!overlayDataType) {
-      setOverlayVariantKeyPreference((prev) => (prev === null ? prev : null));
-      return;
-    }
-
-    const preferredSpace =
-      overlayDataType.spaces.find((space) => space.spaceId === selection.spaceId) ??
-      overlayDataType.spaces[0] ??
-      null;
-    if (!preferredSpace) {
-      setOverlayVariantKeyPreference((prev) => (prev === null ? prev : null));
-      return;
-    }
-
-    const preferredRenderMode =
-      preferredSpace.renderModes.find(
-        (renderMode) => renderMode.renderModeId === selection.renderModeId
-      ) ??
-      preferredSpace.renderModes[0] ??
-      null;
-
-    const availableVariants = preferredRenderMode?.variants.length
-      ? preferredRenderMode.variants
-      : preferredSpace.renderModes.flatMap((renderMode) => renderMode.variants);
-    const resolvedVariantKey = findVariantKeyForEra(availableVariants, manualEra);
-    setOverlayVariantKeyPreference((prev) =>
-      prev === resolvedVariantKey ? prev : resolvedVariantKey
-    );
-  }, [dataTypeModel, eraMode, manualEra, overlaySelection, selection]);
-
-  const selectLayerFor = useCallback(
-    (
-      dataTypeId: string,
-      spaceId: string,
-      renderModeId: string,
-      opts?: { variantId?: string; variantKey?: string; era?: number }
-    ) => {
-      if (!dataTypeModel) return;
-      const dt = dataTypeModel.dataTypes.find((x) => x.dataTypeId === dataTypeId);
-      const space = dt?.spaces.find((s) => s.spaceId === spaceId) ?? dt?.spaces[0];
-      const rm =
-        space?.renderModes.find((x) => x.renderModeId === renderModeId) ?? space?.renderModes[0];
-      if (!space || !rm) return;
-      let variant = opts?.variantId
-        ? (rm.variants.find((v) => v.variantId === opts.variantId) ?? null)
-        : null;
-      if (!variant && opts?.variantKey) {
-        variant = rm.variants.find((v) => v.layer.variantKey === opts.variantKey) ?? null;
-      }
-      if (!variant && opts?.era != null) {
-        const eraVariantId = findVariantIdForEra(rm.variants, opts.era);
-        variant = eraVariantId
-          ? (rm.variants.find((v) => v.variantId === eraVariantId) ?? null)
-          : null;
-      }
-      if (!variant) variant = rm.variants[0] ?? null;
-      viz.setSelectedLayerKey(variant?.layerKey ?? null);
-    },
-    [dataTypeModel, viz]
-  );
-
-  const handleStageChange = useCallback(
-    (stageId: string) => {
-      setSelectedStageId(stageId);
-      const stage = stages.find((s) => s.value === stageId);
-      if (!stage) return;
-
-      const stageMeta = recipeArtifacts.uiMeta.stages.find((s) => s.stageId === stageId);
-      const nextStep = stageMeta?.steps[0]?.fullStepId ?? "";
-      setSelectedStepId(nextStep);
-    },
-    [recipeArtifacts.uiMeta.stages, stages]
-  );
-
-  const handleStepChange = useCallback((stepId: string) => setSelectedStepId(stepId), []);
-
-  const handleRiverLakeInspectorLayerSelect = useCallback(
-    (ref: RiverLakeInspectorLayerRef) => {
-      applyRiverLakeInspectorSelection(ref, {
-        stages: recipeArtifacts.uiMeta.stages,
-        setSelectedStageId,
-        setSelectedStepId,
-        setShowDebugLayers: viz.setShowDebugLayers,
-        setVizSelectedStepId: viz.setSelectedStepId,
-        setVizSelectedLayerKey: viz.setSelectedLayerKey,
-      });
-    },
-    [recipeArtifacts.uiMeta.stages, viz]
-  );
-
-  const handleDataTypeChange = useCallback(
-    (next: string) => {
-      if (!dataTypeModel) return;
-      const dt = dataTypeModel.dataTypes.find((x) => x.dataTypeId === next);
-      const space = dt?.spaces[0];
-      const rm = space?.renderModes[0];
-      if (!space || !rm) return;
-      if (eraMode === "fixed") {
-        selectLayerFor(next, space.spaceId, rm.renderModeId, { era: manualEra });
-        return;
-      }
-      selectLayerFor(next, space.spaceId, rm.renderModeId);
-    },
-    [dataTypeModel, eraMode, manualEra, selectLayerFor]
-  );
-
-  const handleSpaceChange = useCallback(
-    (next: string) => {
-      if (!selection) return;
-      const dataTypeId = selection.dataTypeId;
-      if (!dataTypeModel) return;
-      const dt = dataTypeModel.dataTypes.find((x) => x.dataTypeId === dataTypeId);
-      const space = dt?.spaces.find((s) => s.spaceId === next) ?? dt?.spaces[0];
-      const rm = space?.renderModes[0];
-      if (!space || !rm) return;
-      if (eraMode === "fixed") {
-        selectLayerFor(dataTypeId, space.spaceId, rm.renderModeId, { era: manualEra });
-        return;
-      }
-      selectLayerFor(dataTypeId, space.spaceId, rm.renderModeId);
-    },
-    [dataTypeModel, eraMode, manualEra, selectLayerFor, selection]
-  );
-
-  const handleRenderModeChange = useCallback(
-    (next: string) => {
-      if (!selection) return;
-      if (eraMode === "fixed") {
-        selectLayerFor(selection.dataTypeId, selection.spaceId, next, { era: manualEra });
-        return;
-      }
-      selectLayerFor(selection.dataTypeId, selection.spaceId, next);
-    },
-    [eraMode, manualEra, selectLayerFor, selection]
-  );
-
-  const handleVariantChange = useCallback(
-    (next: string) => {
-      if (!selection) return;
-      const variant = selectedVariants.find((v) => v.variantId === next) ?? null;
-      const parsedEra = parseEraVariantKey(variant?.layer.variantKey ?? null);
-      if (parsedEra != null) setManualEra(parsedEra);
-      if (parsedEra == null && eraMode === "fixed") setEraMode("auto");
-      selectLayerFor(selection.dataTypeId, selection.spaceId, selection.renderModeId, {
-        variantId: next,
-      });
-    },
-    [eraMode, selectLayerFor, selection, selectedVariants]
-  );
-
-  const handleEraModeChange = useCallback(
-    (nextMode: "auto" | "fixed") => {
-      if (nextMode === "auto") {
-        setEraMode("auto");
-        return;
-      }
-      if (!selection || !eraRange) {
-        setEraMode("fixed");
-        return;
-      }
-      const seedEra = autoEra ?? manualEra ?? eraRange.min;
-      const clampedEra = clampNumber(seedEra, eraRange.min, eraRange.max);
-      setManualEra(clampedEra);
-      setEraMode("fixed");
-      selectLayerFor(selection.dataTypeId, selection.spaceId, selection.renderModeId, {
-        era: clampedEra,
-      });
-    },
-    [autoEra, eraRange, manualEra, selectLayerFor, selection]
-  );
-
-  const handleEraValueChange = useCallback(
-    (nextEra: number) => {
-      if (!selection || !eraRange) return;
-      const clampedEra = clampNumber(nextEra, eraRange.min, eraRange.max);
-      setManualEra(clampedEra);
-      if (eraMode !== "fixed") setEraMode("fixed");
-      selectLayerFor(selection.dataTypeId, selection.spaceId, selection.renderModeId, {
-        era: clampedEra,
-      });
-    },
-    [eraMode, eraRange, selectLayerFor, selection]
-  );
 
   useKeyboardShortcuts({
     stages,

--- a/apps/mapgen-studio/src/app/hooks/useVizSelection.ts
+++ b/apps/mapgen-studio/src/app/hooks/useVizSelection.ts
@@ -1,0 +1,559 @@
+import { useCallback, useEffect, useMemo } from "react";
+
+import {
+  findVariantIdForEra,
+  findVariantKeyForEra,
+  listEraVariants,
+  parseEraVariantKey,
+  resolveFixedEraUiValue,
+} from "../../features/viz/era";
+import { applyRiverLakeInspectorSelection } from "../../features/viz/inspectorSelection";
+import {
+  buildRiverLakeFloodplainInspectorSummary,
+  type RiverLakeInspectorLayerRef,
+} from "../../features/viz/riverLakeInspector";
+import { type UseVizStateResult, useVizState } from "../../features/viz/useVizState";
+import type { RecipeArtifacts, StudioRecipeId } from "../../recipes/catalog";
+import { getOverlaySuggestions } from "../../recipes/overlaySuggestions";
+import { formatErrorForUi } from "../../shared/errorFormat";
+import { clampNumber } from "../../shared/number";
+import { useViewStore } from "../../stores/viewStore";
+import type {
+  DataTypeOption,
+  OverlayOption,
+  RenderModeOption,
+  SpaceOption,
+  StageOption,
+  StepOption,
+  VariantOption,
+} from "../../ui/types";
+import { formatStageName } from "../../ui/utils/formatting";
+
+/** The resolved (dataType, space, renderMode, variant) tuple driving the canvas. */
+export type VizSelection = {
+  dataTypeId: string;
+  spaceId: string;
+  renderModeId: string;
+  variantId: string;
+};
+
+export type UseVizSelectionArgs = {
+  /** `recipeSettings.recipe` — drives the overlay-suggestion catalog (recipe-only). */
+  recipe: StudioRecipeId;
+  /** Host-owned recipe artifacts (shared with the config-form surface), threaded in. */
+  recipeArtifacts: RecipeArtifacts;
+  /** `browserRunner.state.running`, derived in host render scope; gates pending selection. */
+  browserRunning: boolean;
+  /** The single-owner error channel setter from `useStudioOperations`. */
+  setLocalError: (message: string | null) => void;
+};
+
+export type UseVizSelectionResult = {
+  /**
+   * The raw `useVizState` handle, exposed BY VALUE (no new memoization) so its
+   * per-render fresh-object identity is preserved for the host consumers that
+   * still read it (the `vizIngestRef` sink, deck-autofit (slice 2.7b),
+   * `backgroundGridEnabled`, `useBrowserRun`, and the canvas/explore JSX).
+   */
+  viz: UseVizStateResult;
+  stages: StageOption[];
+  steps: StepOption[];
+  dataTypeOptions: DataTypeOption[];
+  spaceOptions: SpaceOption[];
+  renderModeOptions: RenderModeOption[];
+  variantOptions: VariantOption[];
+  overlayOptions: OverlayOption[];
+  selection: VizSelection | null;
+  eraEnabled: boolean;
+  eraRange: { min: number; max: number } | null;
+  eraDisplayValue: number;
+  riverLakeInspectorSummary: ReturnType<typeof buildRiverLakeFloodplainInspectorSummary>;
+  handleStageChange: (stageId: string) => void;
+  handleStepChange: (stepId: string) => void;
+  handleDataTypeChange: (next: string) => void;
+  handleSpaceChange: (next: string) => void;
+  handleRenderModeChange: (next: string) => void;
+  handleVariantChange: (next: string) => void;
+  handleEraModeChange: (nextMode: "auto" | "fixed") => void;
+  handleEraValueChange: (nextEra: number) => void;
+  handleRiverLakeInspectorLayerSelect: (ref: RiverLakeInspectorLayerRef) => void;
+};
+
+/**
+ * `useVizSelection` — the visualization selection/exploration fixpoint.
+ *
+ * It owns `useVizState` plus the full stage → step → dataType → space →
+ * renderMode → variant → era → overlay cascade, and is the SOLE writer of the
+ * selected stage/step and the mutable `viz` object; only the viz read-projection
+ * is threaded back out (architecture/10 §7.1/§7.2).
+ *
+ * Three structural invariants make this one indivisible hook:
+ *  1. `overlayDataTypeKey` is derived in render phase BEFORE the internal
+ *     `useVizState` (the forward edge of a genuine cycle: `overlayDataTypeKey` →
+ *     `useVizState`, and `overlayVariantKeyPreference` ← back-edge). Moving it
+ *     into state/effect would feed `useVizState` a stale `null` for one render
+ *     (LS-6).
+ *  2. The stage → step → viz-sync trio (stage-clamp / step-clamp / viz-sync) is
+ *     Tier-A atomic and MUST stay in source order; the viz-sync effect keeps its
+ *     `exhaustive-deps` suppression (deps `[selectedStepId]` only) — it reads
+ *     `viz.selectedStepId` purely as a dedupe guard, and listing it would create
+ *     an echo loop (SS-4).
+ *  3. The era/overlay group (manualEra-clamp → overlay-prune → overlay-variant-
+ *     pref) writes `setManualEra` / `setOverlaySelectionId` /
+ *     `setOverlayVariantKeyPreference`, whose output PERSISTS (not self-healing),
+ *     so the source order is load-bearing (EO-1).
+ */
+export function useVizSelection({
+  recipe,
+  recipeArtifacts,
+  browserRunning,
+  setLocalError,
+}: UseVizSelectionArgs): UseVizSelectionResult {
+  const showEdges = useViewStore((s) => s.showEdges);
+  const overlaySelectionId = useViewStore((s) => s.overlaySelectionId);
+  const setOverlaySelectionId = useViewStore((s) => s.setOverlaySelectionId);
+  const overlayOpacity = useViewStore((s) => s.overlayOpacity);
+  const overlayVariantKeyPreference = useViewStore((s) => s.overlayVariantKeyPreference);
+  const setOverlayVariantKeyPreference = useViewStore((s) => s.setOverlayVariantKeyPreference);
+  const eraMode = useViewStore((s) => s.eraMode);
+  const setEraMode = useViewStore((s) => s.setEraMode);
+  const manualEra = useViewStore((s) => s.manualEra);
+  const setManualEra = useViewStore((s) => s.setManualEra);
+  const selectedStageId = useViewStore((s) => s.selectedStageId);
+  const setSelectedStageId = useViewStore((s) => s.setSelectedStageId);
+  const selectedStepId = useViewStore((s) => s.selectedStepId);
+  const setSelectedStepId = useViewStore((s) => s.setSelectedStepId);
+
+  // Overlay suggestions are recipe-derived ONLY; `overlayDataTypeKey` must be
+  // resolved in render phase before `useVizState` below (the forward edge of the
+  // overlay cycle — see invariant 1).
+  const overlaySuggestions = useMemo(() => getOverlaySuggestions(recipe), [recipe]);
+  const overlaySelection = overlaySuggestions.find((opt) => opt.id === overlaySelectionId) ?? null;
+  const overlayDataTypeKey = overlaySelection?.overlayDataTypeKey ?? null;
+
+  const viz = useVizState({
+    enabled: true,
+    showEdgeOverlay: showEdges,
+    overlayDataTypeKey,
+    overlayVariantKeyPreference,
+    overlayOpacity,
+    allowPendingSelection: browserRunning,
+    onError: (e) => setLocalError(formatErrorForUi(e)),
+  });
+
+  const dataTypeModel = viz.dataTypeModel;
+
+  const stages: StageOption[] = useMemo(() => {
+    return recipeArtifacts.uiMeta.stages.map((stage, index) => ({
+      value: stage.stageId,
+      label: stage.stageLabel ?? formatStageName(stage.stageId),
+      index: index + 1,
+    }));
+  }, [recipeArtifacts.uiMeta.stages]);
+
+  const steps: StepOption[] = useMemo(() => {
+    if (!selectedStageId) return [];
+
+    const labelByFullStepId = new Map(
+      recipeArtifacts.uiMeta.stages.flatMap((stage) =>
+        stage.steps.map((step) => [step.fullStepId, step.stepLabel] as const)
+      )
+    );
+
+    const stage = recipeArtifacts.uiMeta.stages.find((s) => s.stageId === selectedStageId);
+    return (
+      stage?.steps.map((step) => ({
+        value: step.fullStepId,
+        label: labelByFullStepId.get(step.fullStepId) ?? step.stepLabel ?? step.stepId,
+        category: selectedStageId,
+      })) ?? []
+    );
+  }, [recipeArtifacts.uiMeta.stages, selectedStageId]);
+
+  useEffect(() => {
+    if (stages.length === 0) return;
+    setSelectedStageId((prev) => (stages.some((s) => s.value === prev) ? prev : stages[0]!.value));
+  }, [stages]);
+
+  useEffect(() => {
+    if (steps.length === 0) return;
+    setSelectedStepId((prev) => (steps.some((s) => s.value === prev) ? prev : steps[0]!.value));
+  }, [steps]);
+
+  useEffect(() => {
+    if (!selectedStepId) return;
+    if (viz.selectedStepId === selectedStepId) return;
+    viz.setSelectedStepId(selectedStepId);
+    viz.setSelectedLayerKey(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedStepId]);
+
+  const dataTypeOptions: DataTypeOption[] = useMemo(() => {
+    if (!dataTypeModel) return [];
+    return dataTypeModel.dataTypes.map((dt) => ({
+      value: dt.dataTypeId,
+      label: dt.label,
+      group: dt.group,
+    }));
+  }, [dataTypeModel]);
+
+  const riverLakeInspectorSummary = useMemo(
+    () => buildRiverLakeFloodplainInspectorSummary(viz.manifest),
+    [viz.manifest]
+  );
+
+  const selection = useMemo(() => {
+    if (!dataTypeModel) return null;
+    for (const dt of dataTypeModel.dataTypes) {
+      for (const space of dt.spaces) {
+        for (const rm of space.renderModes) {
+          for (const variant of rm.variants) {
+            if (variant.layerKey === viz.selectedLayerKey) {
+              return {
+                dataTypeId: dt.dataTypeId,
+                spaceId: space.spaceId,
+                renderModeId: rm.renderModeId,
+                variantId: variant.variantId,
+              };
+            }
+          }
+        }
+      }
+    }
+    const firstDt = dataTypeModel.dataTypes[0];
+    const firstSpace = firstDt?.spaces[0];
+    const firstRm = firstSpace?.renderModes[0];
+    const firstVariant = firstRm?.variants[0];
+    if (!firstDt || !firstSpace || !firstRm || !firstVariant) return null;
+    return {
+      dataTypeId: firstDt.dataTypeId,
+      spaceId: firstSpace.spaceId,
+      renderModeId: firstRm.renderModeId,
+      variantId: firstVariant.variantId,
+    };
+  }, [dataTypeModel, viz.selectedLayerKey]);
+
+  const selectedDataType = useMemo(() => {
+    if (!dataTypeModel || !selection) return null;
+    return dataTypeModel.dataTypes.find((x) => x.dataTypeId === selection.dataTypeId) ?? null;
+  }, [dataTypeModel, selection]);
+
+  const selectedSpace = useMemo(() => {
+    if (!selectedDataType || !selection) return null;
+    return (
+      selectedDataType.spaces.find((s) => s.spaceId === selection.spaceId) ??
+      selectedDataType.spaces[0] ??
+      null
+    );
+  }, [selectedDataType, selection]);
+
+  const selectedRenderMode = useMemo(() => {
+    if (!selectedSpace || !selection) return null;
+    return (
+      selectedSpace.renderModes.find((rm) => rm.renderModeId === selection.renderModeId) ??
+      selectedSpace.renderModes[0] ??
+      null
+    );
+  }, [selectedSpace, selection]);
+
+  const selectedVariants = selectedRenderMode?.variants ?? [];
+  const selectedVariant = useMemo(() => {
+    if (!selection) return selectedVariants[0] ?? null;
+    return (
+      selectedVariants.find((v) => v.variantId === selection.variantId) ??
+      selectedVariants[0] ??
+      null
+    );
+  }, [selectedVariants, selection]);
+  const selectedVariantKey = selectedVariant?.layer.variantKey ?? null;
+
+  const spaceOptions: SpaceOption[] = useMemo(() => {
+    if (!selectedDataType) return [];
+    return selectedDataType.spaces.map((s) => ({ value: s.spaceId, label: s.label }));
+  }, [selectedDataType]);
+
+  const renderModeOptions: RenderModeOption[] = useMemo(() => {
+    if (!selectedSpace) return [];
+    return selectedSpace.renderModes.map((rm) => ({
+      value: rm.renderModeId,
+      label: rm.label,
+    }));
+  }, [selectedSpace]);
+
+  const variantOptions: VariantOption[] = useMemo(
+    () => selectedVariants.map((v) => ({ value: v.variantId, label: v.label })),
+    [selectedVariants]
+  );
+
+  const eraVariants = useMemo(() => listEraVariants(selectedVariants), [selectedVariants]);
+  const eraRange = useMemo(() => {
+    if (!eraVariants.length) return null;
+    const min = eraVariants[0]?.era ?? 1;
+    const max = eraVariants[eraVariants.length - 1]?.era ?? min;
+    return { min, max };
+  }, [eraVariants]);
+  const autoEra = useMemo(() => parseEraVariantKey(selectedVariantKey), [selectedVariantKey]);
+  const eraEnabled = Boolean(eraRange);
+  const fixedEraUiValue = useMemo(
+    () =>
+      resolveFixedEraUiValue({
+        variants: selectedVariants,
+        selectedVariantKey,
+        requestedEra: manualEra,
+      }),
+    [manualEra, selectedVariantKey, selectedVariants]
+  );
+  const eraDisplayValue = eraMode === "fixed" ? fixedEraUiValue : (autoEra ?? eraRange?.min ?? 1);
+
+  useEffect(() => {
+    if (!eraRange) return;
+    setManualEra((prev) => clampNumber(prev, eraRange.min, eraRange.max));
+  }, [eraRange]);
+
+  const overlayCandidates: OverlayOption[] = useMemo(() => {
+    if (!dataTypeModel || !selection) return [];
+    const out: OverlayOption[] = [];
+    for (const suggestion of overlaySuggestions) {
+      if (suggestion.primaryDataTypeKey !== selection.dataTypeId) continue;
+      const overlayDt = dataTypeModel.dataTypes.find(
+        (dt) => dt.dataTypeId === suggestion.overlayDataTypeKey
+      );
+      if (!overlayDt) continue;
+      out.push({ value: suggestion.id, label: suggestion.label });
+    }
+    return out;
+  }, [dataTypeModel, overlaySuggestions, selection]);
+
+  const overlayOptions: OverlayOption[] = useMemo(() => {
+    if (!overlayCandidates.length) return [];
+    return [{ value: "", label: "No overlay" }, ...overlayCandidates];
+  }, [overlayCandidates]);
+
+  useEffect(() => {
+    if (!overlayCandidates.length) {
+      if (overlaySelectionId) setOverlaySelectionId("");
+      return;
+    }
+    if (overlaySelectionId && !overlayCandidates.some((opt) => opt.value === overlaySelectionId)) {
+      setOverlaySelectionId("");
+    }
+  }, [overlayCandidates, overlaySelectionId]);
+
+  useEffect(() => {
+    if (eraMode !== "fixed" || !overlaySelection || !dataTypeModel || !selection) {
+      setOverlayVariantKeyPreference((prev) => (prev === null ? prev : null));
+      return;
+    }
+
+    const overlayDataType = dataTypeModel.dataTypes.find(
+      (dataType) => dataType.dataTypeId === overlaySelection.overlayDataTypeKey
+    );
+    if (!overlayDataType) {
+      setOverlayVariantKeyPreference((prev) => (prev === null ? prev : null));
+      return;
+    }
+
+    const preferredSpace =
+      overlayDataType.spaces.find((space) => space.spaceId === selection.spaceId) ??
+      overlayDataType.spaces[0] ??
+      null;
+    if (!preferredSpace) {
+      setOverlayVariantKeyPreference((prev) => (prev === null ? prev : null));
+      return;
+    }
+
+    const preferredRenderMode =
+      preferredSpace.renderModes.find(
+        (renderMode) => renderMode.renderModeId === selection.renderModeId
+      ) ??
+      preferredSpace.renderModes[0] ??
+      null;
+
+    const availableVariants = preferredRenderMode?.variants.length
+      ? preferredRenderMode.variants
+      : preferredSpace.renderModes.flatMap((renderMode) => renderMode.variants);
+    const resolvedVariantKey = findVariantKeyForEra(availableVariants, manualEra);
+    setOverlayVariantKeyPreference((prev) =>
+      prev === resolvedVariantKey ? prev : resolvedVariantKey
+    );
+  }, [dataTypeModel, eraMode, manualEra, overlaySelection, selection]);
+
+  const selectLayerFor = useCallback(
+    (
+      dataTypeId: string,
+      spaceId: string,
+      renderModeId: string,
+      opts?: { variantId?: string; variantKey?: string; era?: number }
+    ) => {
+      if (!dataTypeModel) return;
+      const dt = dataTypeModel.dataTypes.find((x) => x.dataTypeId === dataTypeId);
+      const space = dt?.spaces.find((s) => s.spaceId === spaceId) ?? dt?.spaces[0];
+      const rm =
+        space?.renderModes.find((x) => x.renderModeId === renderModeId) ?? space?.renderModes[0];
+      if (!space || !rm) return;
+      let variant = opts?.variantId
+        ? (rm.variants.find((v) => v.variantId === opts.variantId) ?? null)
+        : null;
+      if (!variant && opts?.variantKey) {
+        variant = rm.variants.find((v) => v.layer.variantKey === opts.variantKey) ?? null;
+      }
+      if (!variant && opts?.era != null) {
+        const eraVariantId = findVariantIdForEra(rm.variants, opts.era);
+        variant = eraVariantId
+          ? (rm.variants.find((v) => v.variantId === eraVariantId) ?? null)
+          : null;
+      }
+      if (!variant) variant = rm.variants[0] ?? null;
+      viz.setSelectedLayerKey(variant?.layerKey ?? null);
+    },
+    [dataTypeModel, viz]
+  );
+
+  const handleStageChange = useCallback(
+    (stageId: string) => {
+      setSelectedStageId(stageId);
+      const stage = stages.find((s) => s.value === stageId);
+      if (!stage) return;
+
+      const stageMeta = recipeArtifacts.uiMeta.stages.find((s) => s.stageId === stageId);
+      const nextStep = stageMeta?.steps[0]?.fullStepId ?? "";
+      setSelectedStepId(nextStep);
+    },
+    [recipeArtifacts.uiMeta.stages, stages]
+  );
+
+  const handleStepChange = useCallback((stepId: string) => setSelectedStepId(stepId), []);
+
+  const handleRiverLakeInspectorLayerSelect = useCallback(
+    (ref: RiverLakeInspectorLayerRef) => {
+      applyRiverLakeInspectorSelection(ref, {
+        stages: recipeArtifacts.uiMeta.stages,
+        setSelectedStageId,
+        setSelectedStepId,
+        setShowDebugLayers: viz.setShowDebugLayers,
+        setVizSelectedStepId: viz.setSelectedStepId,
+        setVizSelectedLayerKey: viz.setSelectedLayerKey,
+      });
+    },
+    [recipeArtifacts.uiMeta.stages, viz]
+  );
+
+  const handleDataTypeChange = useCallback(
+    (next: string) => {
+      if (!dataTypeModel) return;
+      const dt = dataTypeModel.dataTypes.find((x) => x.dataTypeId === next);
+      const space = dt?.spaces[0];
+      const rm = space?.renderModes[0];
+      if (!space || !rm) return;
+      if (eraMode === "fixed") {
+        selectLayerFor(next, space.spaceId, rm.renderModeId, { era: manualEra });
+        return;
+      }
+      selectLayerFor(next, space.spaceId, rm.renderModeId);
+    },
+    [dataTypeModel, eraMode, manualEra, selectLayerFor]
+  );
+
+  const handleSpaceChange = useCallback(
+    (next: string) => {
+      if (!selection) return;
+      const dataTypeId = selection.dataTypeId;
+      if (!dataTypeModel) return;
+      const dt = dataTypeModel.dataTypes.find((x) => x.dataTypeId === dataTypeId);
+      const space = dt?.spaces.find((s) => s.spaceId === next) ?? dt?.spaces[0];
+      const rm = space?.renderModes[0];
+      if (!space || !rm) return;
+      if (eraMode === "fixed") {
+        selectLayerFor(dataTypeId, space.spaceId, rm.renderModeId, { era: manualEra });
+        return;
+      }
+      selectLayerFor(dataTypeId, space.spaceId, rm.renderModeId);
+    },
+    [dataTypeModel, eraMode, manualEra, selectLayerFor, selection]
+  );
+
+  const handleRenderModeChange = useCallback(
+    (next: string) => {
+      if (!selection) return;
+      if (eraMode === "fixed") {
+        selectLayerFor(selection.dataTypeId, selection.spaceId, next, { era: manualEra });
+        return;
+      }
+      selectLayerFor(selection.dataTypeId, selection.spaceId, next);
+    },
+    [eraMode, manualEra, selectLayerFor, selection]
+  );
+
+  const handleVariantChange = useCallback(
+    (next: string) => {
+      if (!selection) return;
+      const variant = selectedVariants.find((v) => v.variantId === next) ?? null;
+      const parsedEra = parseEraVariantKey(variant?.layer.variantKey ?? null);
+      if (parsedEra != null) setManualEra(parsedEra);
+      if (parsedEra == null && eraMode === "fixed") setEraMode("auto");
+      selectLayerFor(selection.dataTypeId, selection.spaceId, selection.renderModeId, {
+        variantId: next,
+      });
+    },
+    [eraMode, selectLayerFor, selection, selectedVariants]
+  );
+
+  const handleEraModeChange = useCallback(
+    (nextMode: "auto" | "fixed") => {
+      if (nextMode === "auto") {
+        setEraMode("auto");
+        return;
+      }
+      if (!selection || !eraRange) {
+        setEraMode("fixed");
+        return;
+      }
+      const seedEra = autoEra ?? manualEra ?? eraRange.min;
+      const clampedEra = clampNumber(seedEra, eraRange.min, eraRange.max);
+      setManualEra(clampedEra);
+      setEraMode("fixed");
+      selectLayerFor(selection.dataTypeId, selection.spaceId, selection.renderModeId, {
+        era: clampedEra,
+      });
+    },
+    [autoEra, eraRange, manualEra, selectLayerFor, selection]
+  );
+
+  const handleEraValueChange = useCallback(
+    (nextEra: number) => {
+      if (!selection || !eraRange) return;
+      const clampedEra = clampNumber(nextEra, eraRange.min, eraRange.max);
+      setManualEra(clampedEra);
+      if (eraMode !== "fixed") setEraMode("fixed");
+      selectLayerFor(selection.dataTypeId, selection.spaceId, selection.renderModeId, {
+        era: clampedEra,
+      });
+    },
+    [eraMode, eraRange, selectLayerFor, selection]
+  );
+
+  return {
+    viz,
+    stages,
+    steps,
+    dataTypeOptions,
+    spaceOptions,
+    renderModeOptions,
+    variantOptions,
+    overlayOptions,
+    selection,
+    eraEnabled,
+    eraRange,
+    eraDisplayValue,
+    riverLakeInspectorSummary,
+    handleStageChange,
+    handleStepChange,
+    handleDataTypeChange,
+    handleSpaceChange,
+    handleRenderModeChange,
+    handleVariantChange,
+    handleEraModeChange,
+    handleEraValueChange,
+    handleRiverLakeInspectorLayerSelect,
+  };
+}

--- a/apps/mapgen-studio/test/controllers/useVizSelection.source.test.ts
+++ b/apps/mapgen-studio/test/controllers/useVizSelection.source.test.ts
@@ -1,0 +1,91 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+import hookSource from "../../src/app/hooks/useVizSelection.ts?raw";
+import hostSource from "../../src/app/StudioShell.tsx?raw";
+
+// Strip comments so doc-comments (which legitimately name effects/cascade members)
+// don't trip the ordering matchers. The eslint-disable assertion uses RAW source.
+const host = hostSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+const hook = hookSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+describe("useVizSelection source — render-phase + atomic ordering invariants", () => {
+  it("LS-6: overlayDataTypeKey is derived in render scope BEFORE the internal useVizState", () => {
+    const keyIdx = hook.indexOf(
+      "const overlayDataTypeKey = overlaySelection?.overlayDataTypeKey ?? null;"
+    );
+    const vizIdx = hook.indexOf("useVizState({");
+    expect(keyIdx).toBeGreaterThan(-1);
+    expect(vizIdx).toBeGreaterThan(-1);
+    // Forward edge of the overlay cycle: moving this into state/effect would feed
+    // useVizState a stale `null` for one render.
+    expect(keyIdx).toBeLessThan(vizIdx);
+  });
+
+  it("SS atomic group 1: stage-clamp → step-clamp → viz-sync in source order", () => {
+    const stageClamp = hook.indexOf("setSelectedStageId((prev) =>");
+    const stepClamp = hook.indexOf("setSelectedStepId((prev) =>");
+    const vizSync = hook.indexOf("viz.setSelectedStepId(selectedStepId)");
+    expect(stageClamp).toBeGreaterThan(-1);
+    expect(stepClamp).toBeGreaterThan(-1);
+    expect(vizSync).toBeGreaterThan(-1);
+    expect(stageClamp).toBeLessThan(stepClamp);
+    expect(stepClamp).toBeLessThan(vizSync);
+  });
+
+  it("SS-4: viz-sync keeps the exhaustive-deps suppression (deps [selectedStepId]) + dedupe guard", () => {
+    // The dedupe guard reads viz.selectedStepId but it is excluded from the deps.
+    expect(hook).toMatch(/if \(viz\.selectedStepId === selectedStepId\) return;/);
+    // The suppression is intentional and load-bearing (RAW source — it IS a comment).
+    expect(hookSource).toMatch(
+      /eslint-disable-next-line react-hooks\/exhaustive-deps\n\s*\}, \[selectedStepId\]\);/
+    );
+  });
+
+  it("EO-1: era/overlay atomic group keeps source order (manualEra-clamp → overlay-prune → overlay-variant-pref)", () => {
+    const clampIdx = hook.indexOf(
+      "setManualEra((prev) => clampNumber(prev, eraRange.min, eraRange.max))"
+    );
+    const pruneIdx = hook.indexOf('setOverlaySelectionId("")');
+    const prefIdx = hook.indexOf("findVariantKeyForEra(availableVariants, manualEra)");
+    expect(clampIdx).toBeGreaterThan(-1);
+    expect(pruneIdx).toBeGreaterThan(-1);
+    expect(prefIdx).toBeGreaterThan(-1);
+    // The overlay-variant-pref output PERSISTS, so reversal is a real bug.
+    expect(clampIdx).toBeLessThan(pruneIdx);
+    expect(pruneIdx).toBeLessThan(prefIdx);
+  });
+
+  it("hook: contains exactly the 6 cascade effects (Tier-A atomicity)", () => {
+    expect(hook.match(/useEffect\(/g)).toHaveLength(6);
+  });
+
+  it("hook: exposes the raw viz handle by value (no new memoization of viz)", () => {
+    expect(hook).toMatch(/return \{\s*viz,/);
+    expect(hook).not.toMatch(/const viz = useMemo/);
+  });
+});
+
+describe("StudioShell source — 2.7 seam + cascade no longer host-owned", () => {
+  it("calls useVizSelection threading recipe/recipeArtifacts/browserRunning and destructures viz", () => {
+    expect(host).toMatch(/} = useVizSelection\(\{/);
+    expect(host).toMatch(/recipe: recipeSettings\.recipe,/);
+    expect(host).toMatch(/recipeArtifacts,/);
+    expect(host).toMatch(/browserRunning,/);
+  });
+
+  it("keeps the vizIngestRef sink wiring in host render scope (the 2.6↔2.7 seam)", () => {
+    expect(host).toMatch(/\n {2}vizIngestRef\.current = viz\.ingest;/);
+  });
+
+  it("keeps deck-autofit refs + backgroundGridEnabled host-side reading viz BY VALUE (2.7b boundary)", () => {
+    expect(host).toMatch(/hasEverSeenVizManifestRef/);
+    expect(host).toMatch(/lastAutoFitSpaceRef/);
+    expect(host).toMatch(/const backgroundGridEnabled = useMemo/);
+  });
+
+  it("no longer owns the viz cascade (selectLayerFor / dataTypeModel / useVizState moved out)", () => {
+    expect(host).not.toMatch(/const selectLayerFor = useCallback/);
+    expect(host).not.toMatch(/const dataTypeModel = viz\.dataTypeModel/);
+    expect(host).not.toMatch(/useVizState\(/);
+  });
+});

--- a/apps/mapgen-studio/test/controllers/useVizSelection.test.tsx
+++ b/apps/mapgen-studio/test/controllers/useVizSelection.test.tsx
@@ -1,0 +1,325 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type UseVizSelectionArgs, useVizSelection } from "../../src/app/hooks/useVizSelection";
+import type { UseVizStateResult } from "../../src/features/viz/useVizState";
+import type { StudioRecipeId } from "../../src/recipes/catalog";
+import { useViewStore } from "../../src/stores/viewStore";
+import "./_setup";
+
+// `useVizState` is mocked to a controllable handle so the cascade can be driven
+// from a fixed `dataTypeModel`/`selectedLayerKey` and its viz writes observed.
+// `getOverlaySuggestions` is mocked so the overlay group (EO-3/EO-4) has a
+// deterministic, recipe-independent suggestion catalog.
+const vizMock = vi.hoisted(() => ({ handle: null as unknown as UseVizStateResult }));
+const overlayMock = vi.hoisted(() => ({
+  suggestions: [] as Array<{
+    id: string;
+    label: string;
+    primaryDataTypeKey: string;
+    overlayDataTypeKey: string;
+  }>,
+}));
+
+vi.mock("../../src/features/viz/useVizState", () => ({
+  useVizState: vi.fn(() => vizMock.handle),
+}));
+vi.mock("../../src/recipes/overlaySuggestions", () => ({
+  getOverlaySuggestions: vi.fn(() => overlayMock.suggestions),
+}));
+
+// ---- model fixture builders ----------------------------------------------
+function variant(variantId: string, layerKey: string, variantKey: string | null) {
+  return {
+    variantId,
+    label: variantId,
+    layerKey,
+    layer: { variantKey } as unknown as { variantKey: string | null },
+  };
+}
+function makeModel() {
+  return {
+    stepId: "stageA.a1",
+    dataTypes: [
+      {
+        dataTypeId: "terrain",
+        label: "Terrain",
+        visibility: "default",
+        spaces: [
+          {
+            spaceId: "tile.hexOddR",
+            label: "Tile",
+            renderModes: [
+              {
+                renderModeId: "grid",
+                label: "Grid",
+                variants: [
+                  variant("v3", "terrain.grid.e3", "era:3"),
+                  variant("v1", "terrain.grid.e1", "era:1"),
+                  variant("vp", "terrain.grid.plain", null),
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        dataTypeId: "rivers",
+        label: "Rivers",
+        visibility: "default",
+        // Distinct spaceId from `terrain` so EO-4 exercises the space FALLBACK
+        // (`selection.spaceId` is absent from the overlay data-type's spaces).
+        spaces: [
+          {
+            spaceId: "world.xy",
+            label: "World",
+            renderModes: [
+              {
+                renderModeId: "grid",
+                label: "Grid",
+                variants: [
+                  variant("rv1", "rivers.grid.e1", "era:1"),
+                  variant("rv2", "rivers.grid.e2", "era:2"),
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// `stageB` deliberately omits `stageLabel` so SS-5 also pins the
+// `formatStageName` label fallback.
+const recipeArtifacts = {
+  uiMeta: {
+    stages: [
+      {
+        stageId: "stageA",
+        stageLabel: "Stage A",
+        steps: [
+          { stepId: "a1", fullStepId: "stageA.a1", stepLabel: "A1" },
+          { stepId: "a2", fullStepId: "stageA.a2", stepLabel: "A2" },
+        ],
+      },
+      {
+        stageId: "stageB",
+        steps: [{ stepId: "b1", fullStepId: "stageB.b1", stepLabel: "B1" }],
+      },
+    ],
+  },
+} as unknown as UseVizSelectionArgs["recipeArtifacts"];
+
+function makeVizHandle(): UseVizStateResult {
+  return {
+    ingest: vi.fn(),
+    clearStream: vi.fn(),
+    selectedStepId: "stageA.a1",
+    setSelectedStepId: vi.fn(),
+    selectedLayerKey: null,
+    setSelectedLayerKey: vi.fn(),
+    showDebugLayers: false,
+    setShowDebugLayers: vi.fn(),
+    steps: [],
+    pipelineSteps: [],
+    pipelineStages: [],
+    dataTypeModel: makeModel(),
+    selectableLayers: [],
+    legend: null,
+    deck: { layers: [] },
+    effectiveLayer: null,
+    activeBounds: null,
+    manifest: null,
+  } as unknown as UseVizStateResult;
+}
+
+beforeEach(() => {
+  // Baseline view state: explore is on `stageA`/`stageA.a1`, era auto, no overlay.
+  useViewStore.setState({
+    selectedStageId: "stageA",
+    selectedStepId: "stageA.a1",
+    eraMode: "auto",
+    manualEra: 1,
+    overlaySelectionId: "",
+    overlayVariantKeyPreference: null,
+    overlayOpacity: 0.45,
+    showEdges: true,
+  });
+  vizMock.handle = makeVizHandle();
+  overlayMock.suggestions = [];
+});
+
+function render(overrides: Partial<UseVizSelectionArgs> = {}) {
+  const setLocalError = vi.fn();
+  let props: UseVizSelectionArgs = {
+    recipe: "test-recipe" as StudioRecipeId,
+    recipeArtifacts,
+    browserRunning: false,
+    setLocalError,
+    ...overrides,
+  };
+  const view = renderHook((p: UseVizSelectionArgs) => useVizSelection(p), { initialProps: props });
+  const rerender = (patch: Partial<UseVizSelectionArgs> = {}) => {
+    props = { ...props, ...patch };
+    act(() => view.rerender(props));
+  };
+  return { view, rerender, setLocalError };
+}
+
+const viz = () => vizMock.handle;
+const store = () => useViewStore.getState();
+
+describe("useVizSelection — Stage/Step cascade (SS)", () => {
+  it("SS-5: stages are 1-indexed StageOptions with formatStageName label fallback", () => {
+    const { view } = render();
+    const stages = view.result.current.stages;
+    expect(stages.map((s) => s.index)).toEqual([1, 2]);
+    expect(stages[0]!.label).toBe("Stage A"); // explicit stageLabel
+    expect(stages[1]!.label).not.toBe(""); // stageB had no label → formatStageName fallback
+    expect(stages[1]!.value).toBe("stageB");
+  });
+
+  it("SS-6: steps are derived ONLY from the selected stage", () => {
+    const { view, rerender } = render();
+    expect(view.result.current.steps.map((s) => s.value)).toEqual(["stageA.a1", "stageA.a2"]);
+
+    act(() => useViewStore.setState({ selectedStageId: "stageB" }));
+    rerender();
+    expect(view.result.current.steps.map((s) => s.value)).toEqual(["stageB.b1"]);
+
+    act(() => useViewStore.setState({ selectedStageId: "" }));
+    rerender();
+    expect(view.result.current.steps).toEqual([]);
+  });
+
+  it("SS-1: handleStageChange resets step to the new stage's first; viz syncs ONCE", () => {
+    const { view } = render();
+    viz().setSelectedStepId.mockClear();
+
+    act(() => view.result.current.handleStageChange("stageB"));
+
+    expect(store().selectedStageId).toBe("stageB");
+    expect(store().selectedStepId).toBe("stageB.b1");
+    // The viz-sync arm is the SOLE caller of viz.setSelectedStepId — exactly once,
+    // never doubled by handleStageChange itself.
+    expect(viz().setSelectedStepId).toHaveBeenCalledTimes(1);
+    expect(viz().setSelectedStepId).toHaveBeenCalledWith("stageB.b1");
+  });
+
+  it("SS-2: viz-sync clears the layer on a real step change, and is guarded when equal", () => {
+    const { view, rerender } = render();
+    viz().setSelectedLayerKey.mockClear();
+
+    // (a) real step change → one layer clear
+    act(() => useViewStore.setState({ selectedStepId: "stageA.a2" }));
+    rerender();
+    expect(viz().setSelectedLayerKey).toHaveBeenCalledTimes(1);
+    expect(viz().setSelectedLayerKey).toHaveBeenCalledWith(null);
+
+    // (b) the effect RE-RUNS (store step changes a2→a1) but viz is ALREADY at the
+    // new step → the dedupe guard must skip the clear (no layer clobber). This is
+    // the path the guard actually protects: a viz-led step move (e.g. the inspector)
+    // that the store then catches up to.
+    vizMock.handle.selectedStepId = "stageA.a1";
+    viz().setSelectedLayerKey.mockClear();
+    act(() => useViewStore.setState({ selectedStepId: "stageA.a1" }));
+    rerender();
+    expect(viz().setSelectedLayerKey).not.toHaveBeenCalled();
+  });
+
+  it("SS-4: viz-sync fires only on selectedStepId, not on unrelated viz rerenders", () => {
+    const { rerender } = render();
+    viz().setSelectedStepId.mockClear();
+
+    // A viz-internal change (new model) with selectedStepId unchanged must NOT
+    // re-run the sync arm (deps are [selectedStepId] only).
+    vizMock.handle.dataTypeModel = makeModel();
+    rerender({ browserRunning: true });
+    expect(viz().setSelectedStepId).not.toHaveBeenCalled();
+  });
+
+  it("SS-3: step-clamp RETAINS a step that is still valid in the (new) stage", () => {
+    // The clamp runs when `steps` changes (here, the mount transition []→[a1,a2]);
+    // a valid current step must be kept — the `some()` guard must not clobber it.
+    useViewStore.setState({ selectedStageId: "stageA", selectedStepId: "stageA.a2" });
+    render();
+    expect(store().selectedStepId).toBe("stageA.a2");
+  });
+
+  it("SS-3: step-clamp RESETS a foreign step to steps[0]", () => {
+    useViewStore.setState({ selectedStageId: "stageA", selectedStepId: "not-a-real-step" });
+    render();
+    expect(store().selectedStepId).toBe("stageA.a1");
+  });
+});
+
+describe("useVizSelection — Layer selection (LS)", () => {
+  it("LS-4: handleDataTypeChange applies era in fixed mode and bypasses it in auto", () => {
+    // auto → first variant of the target render mode (era ignored)
+    const auto = render();
+    viz().setSelectedLayerKey.mockClear();
+    act(() => auto.view.result.current.handleDataTypeChange("rivers"));
+    expect(viz().setSelectedLayerKey).toHaveBeenCalledWith("rivers.grid.e1");
+
+    // fixed, manualEra=2 → era-snapped variant (era:2)
+    useViewStore.setState({ eraMode: "fixed", manualEra: 2 });
+    const fixed = render();
+    viz().setSelectedLayerKey.mockClear();
+    act(() => fixed.view.result.current.handleDataTypeChange("rivers"));
+    expect(viz().setSelectedLayerKey).toHaveBeenCalledWith("rivers.grid.e2");
+  });
+
+  it("LS-5: handleVariantChange seeds manualEra for era variants; flips fixed→auto only for non-era", () => {
+    useViewStore.setState({ eraMode: "fixed", manualEra: 1 });
+    const { view } = render();
+
+    // era variant: set manualEra, KEEP fixed mode
+    act(() => view.result.current.handleVariantChange("v3"));
+    expect(store().manualEra).toBe(3);
+    expect(store().eraMode).toBe("fixed");
+    expect(viz().setSelectedLayerKey).toHaveBeenCalledWith("terrain.grid.e3");
+
+    // non-era variant in fixed mode: flip to auto
+    act(() => view.result.current.handleVariantChange("vp"));
+    expect(store().eraMode).toBe("auto");
+  });
+});
+
+describe("useVizSelection — Era / Overlay group (EO)", () => {
+  it("EO-5: handleEraModeChange('fixed') seeds manualEra from autoEra", () => {
+    // default selection variant is v3 (era:3) → autoEra=3
+    const { view } = render();
+    expect(store().manualEra).toBe(1);
+
+    act(() => view.result.current.handleEraModeChange("fixed"));
+    expect(store().eraMode).toBe("fixed");
+    expect(store().manualEra).toBe(3);
+  });
+
+  it("EO-6: handleEraValueChange clamps to range and activates fixed mode", () => {
+    const { view } = render();
+    // range is {min:1, max:3}; 7 clamps to 3
+    act(() => view.result.current.handleEraValueChange(7));
+    expect(store().manualEra).toBe(3);
+    expect(store().eraMode).toBe("fixed");
+  });
+
+  it("EO-3: overlay-prune clears a stale overlaySelectionId when no candidates exist", () => {
+    overlayMock.suggestions = []; // no candidates
+    useViewStore.setState({ overlaySelectionId: "stale" });
+    render();
+    expect(store().overlaySelectionId).toBe("");
+  });
+
+  it("EO-4: overlay-variant-pref era-snaps via the space fallback in fixed mode", () => {
+    overlayMock.suggestions = [
+      { id: "ov", label: "Ov", primaryDataTypeKey: "terrain", overlayDataTypeKey: "rivers" },
+    ];
+    useViewStore.setState({ overlaySelectionId: "ov", eraMode: "fixed", manualEra: 2 });
+    render();
+    // selection.spaceId ("tile.hexOddR") is absent from `rivers` → fallback to its
+    // first space ("world.xy"); manualEra=2 snaps to the era:2 variant key.
+    expect(store().overlayVariantKeyPreference).toBe("era:2");
+  });
+});


### PR DESCRIPTION
The visualization selection/exploration logic that previously lived inline in `StudioShell` has been extracted into a dedicated `useVizSelection` hook. This hook is now the sole owner of `useVizState` and the full stage → step → dataType → space → renderMode → variant → era → overlay cascade, including all associated `useMemo` derivations, `useEffect` clamp/sync/prune effects, and user-interaction handlers (`handleStageChange`, `handleStepChange`, `handleDataTypeChange`, `handleSpaceChange`, `handleRenderModeChange`, `handleVariantChange`, `handleEraModeChange`, `handleEraValueChange`, `handleRiverLakeInspectorLayerSelect`).

`StudioShell` now calls `useVizSelection` and destructures its outputs, retaining only the host-scope concerns: wiring `vizIngestRef.current = viz.ingest`, reading `eraMode` for the explore-panel JSX, and owning the deck-autofit refs and `backgroundGridEnabled` derivation. The write surface for `manualEra`, `setEraMode`, `overlayVariantKeyPreference`, and `setSelectedStageId` has moved entirely into the hook.

Three structural invariants are preserved and enforced by source-order tests: `overlayDataTypeKey` is resolved in render phase before the internal `useVizState` call to avoid a stale-`null` feed on the first render; the stage-clamp → step-clamp → viz-sync effect trio remains in source order; and the era/overlay group (manualEra-clamp → overlay-prune → overlay-variant-pref) retains its load-bearing write order.

A new test suite covers the hook's behavior across the stage/step cascade (clamp retention, reset, dedupe guard, viz-sync isolation), layer selection (era-aware data-type and variant changes), and the era/overlay group (mode transitions, value clamping, stale-ID pruning, space-fallback era snapping).