### PR TITLE
refactor(mapgen-studio): extract live-runtime staleness machine into `useLiveRuntime` hook (slice 2.10)

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -2,17 +2,15 @@ import { stripSchemaMetadataRoot } from "@swooper/mapgen-core/authoring";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getCiv7MapSizePreset } from "../features/browserRunner/mapSizes";
 import { useBrowserRunner } from "../features/browserRunner/useBrowserRunner";
-import { fetchCiv7SetupConfig, requestCiv7Autoplay } from "../features/civ7Setup/api";
+import { requestCiv7Autoplay } from "../features/civ7Setup/api";
 import { LIVE_GAME_PRESET_ID, LIVE_GAME_PRESET_KEY } from "../features/civ7Setup/livePreset";
 import { formatCiv7StudioSeedError, parseCiv7StudioSeed } from "../features/civ7Setup/seedPolicy";
 import {
-  type Civ7SetupSnapshotLike,
   type Civ7StudioSetupConfig,
   clearStudioSetupSavedConfig,
   getLocalPlayerSetup,
   normalizeStudioSetupConfig,
   optionRowsFromParameter,
-  studioSetupConfigFromLiveSnapshot,
   studioSetupConfigFromSavedConfigFile,
   studioSetupDriftsFromSavedConfig,
 } from "../features/civ7Setup/setupConfig";
@@ -23,18 +21,7 @@ import {
   setupCatalogOptions,
 } from "../features/civ7Setup/setupOptions";
 import { buildDefaultConfig, isPlainObject } from "../features/configOverrides/configBuilders";
-import {
-  buildLiveRuntimeSetupRequestKey,
-  buildLiveRuntimeSnapshotRequest,
-  buildLiveRuntimeSnapshotState,
-  buildLiveRuntimeSuggestionRecords,
-  type LiveRuntimeSnapshotRequest,
-  type LiveRuntimeSnapshotState,
-  type LiveRuntimeStatusState,
-  type LiveRuntimeSuggestionRecord,
-  shouldCommitLiveRuntimeSetup,
-  shouldCommitLiveRuntimeSnapshot,
-} from "../features/liveRuntime/model";
+import { buildLiveRuntimeSuggestionRecords } from "../features/liveRuntime/model";
 import {
   PresetConfirmDialog,
   PresetErrorDialog,
@@ -58,7 +45,6 @@ import {
 import { liveControlPort } from "../lib/control/liveControlPort";
 import { orpcClient } from "../lib/orpc";
 import { STUDIO_RECIPE_OPTIONS } from "../recipes/catalog";
-import { isAbortLikeError } from "../shared/async";
 import type { VizEvent } from "../shared/vizEvents";
 import { useAuthoringStore } from "../stores/authoringStore";
 import { useRunStore } from "../stores/runStore";
@@ -76,6 +62,7 @@ import { ErrorBanner } from "./ErrorBanner";
 import { useBrowserRun } from "./hooks/useBrowserRun";
 import { useDeckAutofit } from "./hooks/useDeckAutofit";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
+import { useLiveRuntime } from "./hooks/useLiveRuntime";
 import { usePresetLifecycle } from "./hooks/usePresetLifecycle";
 import { useRunInGameTerminalToast } from "./hooks/useRunInGameTerminalToast";
 import { useSaveDeploy } from "./hooks/useSaveDeploy";
@@ -310,37 +297,6 @@ export function StudioShell(props: StudioShellProps) {
   const lastSaveDeployConfig = useRunStore((s) => s.lastSaveDeployConfig);
   const setLastSaveDeployConfig = useRunStore((s) => s.setLastSaveDeployConfig);
   const lastRunInGameToastRef = useRef<string | null>(null);
-  const liveSnapshotFailureCountRef = useRef(0);
-  const activeLiveSnapshotRequestKeyRef = useRef<string | null>(null);
-  const activeLiveSetupRequestKeyRef = useRef<string | null>(null);
-  const liveSnapshotAbortRef = useRef<AbortController | null>(null);
-  const liveSetupAbortRef = useRef<AbortController | null>(null);
-  const liveRuntimeMountedRef = useRef(true);
-  const [liveRuntime, setLiveRuntime] = useState<LiveRuntimeStatusState>({
-    status: "idle",
-    snapshotStatus: "idle",
-    bindingStatus: "unbound-runtime",
-    failureCount: 0,
-  });
-  const [, setLiveRuntimeSnapshot] = useState<LiveRuntimeSnapshotState | null>(null);
-  const [liveRuntimeSuggestions, setLiveRuntimeSuggestions] = useState<
-    ReadonlyArray<LiveRuntimeSuggestionRecord>
-  >([]);
-  const [liveSetup, setLiveSetup] = useState<{
-    status: "idle" | "ok" | "error";
-    setup?: Civ7SetupSnapshotLike;
-    updatedAt?: string;
-    error?: string;
-  }>({ status: "idle" });
-
-  useEffect(() => {
-    liveRuntimeMountedRef.current = true;
-    return () => {
-      liveRuntimeMountedRef.current = false;
-      liveSnapshotAbortRef.current?.abort();
-      liveSetupAbortRef.current?.abort();
-    };
-  }, []);
 
   // Saved configs + setup catalog are READ through oRPC-native TanStack Query
   // (architecture/10 §2). The query layer owns retry + refetch-on-focus (query client
@@ -393,171 +349,6 @@ export function StudioShell(props: StudioShellProps) {
   const { handleFitView } = useDeckAutofit({ deckApiRef, viewportSize, deckApiReadyTick, viz });
 
   const error = localError ?? browserRunner.state.error;
-
-  const readLiveRuntimeSnapshot = useCallback(async (request: LiveRuntimeSnapshotRequest) => {
-    liveSnapshotAbortRef.current?.abort();
-    const snapshotAbortController = new AbortController();
-    liveSnapshotAbortRef.current = snapshotAbortController;
-    activeLiveSnapshotRequestKeyRef.current = request.key;
-
-    try {
-      // Snapshot remains request/response. The event stream tells us when live
-      // status changed; the existing request-key guard still owns stale result
-      // rejection.
-      let body: unknown;
-      try {
-        body = await orpcClient.civ7.live.snapshot(
-          {
-            x: request.bounds.x,
-            y: request.bounds.y,
-            width: request.bounds.width,
-            height: request.bounds.height,
-            fields: request.fields.join(","),
-            maxPlots: request.maxPlots,
-            ...(request.playerId === undefined ? {} : { playerId: request.playerId }),
-          },
-          { signal: snapshotAbortController.signal }
-        );
-      } catch (snapshotErr) {
-        if (!liveRuntimeMountedRef.current || isAbortLikeError(snapshotErr)) throw snapshotErr;
-        body = {
-          ok: false,
-          error: snapshotErr instanceof Error ? snapshotErr.message : "Live snapshot unavailable",
-        };
-      }
-      if (!liveRuntimeMountedRef.current) return;
-      if (
-        !shouldCommitLiveRuntimeSnapshot({
-          activeRequestKey: activeLiveSnapshotRequestKeyRef.current,
-          resultRequestKey: request.key,
-          aborted: snapshotAbortController.signal.aborted,
-        })
-      ) {
-        return;
-      }
-      const snapshotState = buildLiveRuntimeSnapshotState({
-        request,
-        body,
-        observedAtFallback: new Date().toISOString(),
-      });
-      liveSnapshotFailureCountRef.current =
-        snapshotState.status === "ok" ? 0 : liveSnapshotFailureCountRef.current + 1;
-      setLiveRuntimeSnapshot(snapshotState);
-      setLiveRuntime((current) => ({
-        ...current,
-        snapshotStatus: snapshotState.status,
-        snapshotHash: snapshotState.snapshotHash ?? current.snapshotHash,
-        bindingStatus: snapshotState.status === "ok" ? current.bindingStatus : "partial",
-        failureCount: Math.max(current.failureCount ?? 0, liveSnapshotFailureCountRef.current),
-        error: snapshotState.status === "ok" ? current.error : snapshotState.error,
-      }));
-    } catch (err) {
-      if (!liveRuntimeMountedRef.current || isAbortLikeError(err)) return;
-      if (
-        !shouldCommitLiveRuntimeSnapshot({
-          activeRequestKey: activeLiveSnapshotRequestKeyRef.current,
-          resultRequestKey: request.key,
-        })
-      ) {
-        return;
-      }
-      liveSnapshotFailureCountRef.current += 1;
-      const snapshotState: LiveRuntimeSnapshotState = {
-        status: "error",
-        requestKey: request.key,
-        error: err instanceof Error ? err.message : "Live snapshot unavailable",
-      };
-      setLiveRuntimeSnapshot(snapshotState);
-      setLiveRuntime((current) => ({
-        ...current,
-        snapshotStatus: "error",
-        bindingStatus: "partial",
-        failureCount: Math.max(current.failureCount ?? 0, liveSnapshotFailureCountRef.current),
-        error: snapshotState.error,
-      }));
-    }
-  }, []);
-
-  const refreshLiveSetupFromEvent = useCallback(async (statusState: LiveRuntimeStatusState) => {
-    liveSetupAbortRef.current?.abort();
-    const setupAbortController = new AbortController();
-    liveSetupAbortRef.current = setupAbortController;
-    const setupRequestKey = buildLiveRuntimeSetupRequestKey(statusState);
-    activeLiveSetupRequestKeyRef.current = setupRequestKey;
-    const shouldCommitSetup = () =>
-      liveRuntimeMountedRef.current &&
-      shouldCommitLiveRuntimeSetup({
-        activeRequestKey: activeLiveSetupRequestKeyRef.current,
-        resultRequestKey: setupRequestKey,
-        aborted: setupAbortController.signal.aborted,
-      });
-
-    try {
-      const setup = await fetchCiv7SetupConfig({ signal: setupAbortController.signal });
-      if (!shouldCommitSetup()) return;
-      const suggestedSetupConfig = setup.ok
-        ? normalizeStudioSetupConfig(studioSetupConfigFromLiveSnapshot(setup.setup))
-        : undefined;
-      if (setup.ok) {
-        setLiveSetup({ status: "ok", setup: setup.setup, updatedAt: setup.observedAt });
-      } else {
-        setLiveSetup({
-          status: "error",
-          error: setup.error,
-          updatedAt: setup.observedAt ?? new Date().toISOString(),
-        });
-      }
-      setLiveRuntimeSuggestions(
-        buildLiveRuntimeSuggestionRecords({
-          sourceSnapshotId: statusState.snapshotId,
-          seed: statusState.seed,
-          setupConfig: suggestedSetupConfig,
-          provedStudioRun: false,
-        })
-      );
-    } catch (err) {
-      if (!liveRuntimeMountedRef.current || isAbortLikeError(err)) return;
-      if (!shouldCommitSetup()) return;
-      const observedAt = new Date().toISOString();
-      setLiveSetup({
-        status: "error",
-        error: err instanceof Error ? err.message : "Live setup unavailable",
-        updatedAt: observedAt,
-      });
-      setLiveRuntimeSuggestions(
-        buildLiveRuntimeSuggestionRecords({
-          sourceSnapshotId: statusState.snapshotId,
-          seed: statusState.seed,
-          provedStudioRun: false,
-          now: () => new Date(observedAt),
-        })
-      );
-    }
-  }, []);
-
-  const applyLiveGameState = useCallback(
-    (statusState: LiveRuntimeStatusState) => {
-      const snapshotRequest = buildLiveRuntimeSnapshotRequest({ status: statusState });
-      if (!snapshotRequest) {
-        activeLiveSnapshotRequestKeyRef.current = null;
-        liveSnapshotAbortRef.current?.abort();
-      }
-
-      setLiveRuntime((current) => ({
-        ...statusState,
-        snapshotStatus:
-          snapshotRequest === null
-            ? statusState.snapshotStatus
-            : current.snapshotId === statusState.snapshotId && current.snapshotStatus === "ok"
-              ? current.snapshotStatus
-              : "loading",
-        failureCount: Math.max(statusState.failureCount ?? 0, liveSnapshotFailureCountRef.current),
-      }));
-      void refreshLiveSetupFromEvent(statusState);
-      if (snapshotRequest) void readLiveRuntimeSnapshot(snapshotRequest);
-    },
-    [readLiveRuntimeSnapshot, refreshLiveSetupFromEvent]
-  );
 
   // Saved configs + setup catalog now load via `useSetupDataQueries` (TanStack Query);
   // the prior hand-rolled load/retry/focus-refetch effect is replaced by the query
@@ -625,6 +416,19 @@ export function StudioShell(props: StudioShellProps) {
     setLastSaveDeployConfig,
     toast,
   });
+
+  // Live-runtime snapshot/setup staleness machine (slice 2.10): the abort/mounted
+  // lifecycle refs travel WITH the mount lifecycle and the three event-driven read
+  // functions into one hook (atomic mount-lifecycle group). `applyLiveGameState` is
+  // wired into `useStudioEvents`; `setLiveRuntime` feeds the autoplay toggle (2.12)
+  // and run-in-game sync-back (2.11). The host still reads `liveRuntime.status/seed`,
+  // `liveSetup.setup`, and `liveRuntimeSuggestions` from the returned outputs. The
+  // `orpcClient` is threaded IN so the abort/staleness contracts are renderHook-testable.
+  // Initialized BEFORE `useRunInGame`'s territory / the operation-adoption effect (§5)
+  // because adoption needs the run-in-game + save-deploy setters and run-in-game inits
+  // after this hook.
+  const { liveRuntime, setLiveRuntime, liveRuntimeSuggestions, liveSetup, applyLiveGameState } =
+    useLiveRuntime({ orpcClient });
 
   const status: GenerationStatus = browserRunning ? "running" : error ? "error" : "ready";
 

--- a/apps/mapgen-studio/src/app/hooks/useLiveRuntime.ts
+++ b/apps/mapgen-studio/src/app/hooks/useLiveRuntime.ts
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { fetchCiv7SetupConfig } from "../../features/civ7Setup/api";
+import {
+  type Civ7SetupSnapshotLike,
+  normalizeStudioSetupConfig,
+  studioSetupConfigFromLiveSnapshot,
+} from "../../features/civ7Setup/setupConfig";
+import {
+  buildLiveRuntimeSetupRequestKey,
+  buildLiveRuntimeSnapshotRequest,
+  buildLiveRuntimeSnapshotState,
+  buildLiveRuntimeSuggestionRecords,
+  type LiveRuntimeSnapshotRequest,
+  type LiveRuntimeSnapshotState,
+  type LiveRuntimeStatusState,
+  type LiveRuntimeSuggestionRecord,
+  shouldCommitLiveRuntimeSetup,
+  shouldCommitLiveRuntimeSnapshot,
+} from "../../features/liveRuntime/model";
+import type { orpcClient as OrpcClient } from "../../lib/orpc";
+import { isAbortLikeError } from "../../shared/async";
+
+export type UseLiveRuntimeArgs = {
+  /**
+   * oRPC client used by the snapshot read (`civ7.live.snapshot`). Threaded IN as a
+   * param (not the module import) so the abort/staleness contracts (LR-2/LR-3) are
+   * exercisable with a mock `orpcClient` in `renderHook` tests.
+   */
+  orpcClient: typeof OrpcClient;
+};
+
+export type UseLiveRuntimeResult = {
+  /** Live runtime status state (snapshot/binding/failure machine). */
+  liveRuntime: LiveRuntimeStatusState;
+  /** Setter for `liveRuntime` — used by autoplay toggle (slice 2.12) + run-in-game (2.11). */
+  setLiveRuntime: React.Dispatch<React.SetStateAction<LiveRuntimeStatusState>>;
+  /** Live runtime sync-back suggestion records (visible-studio-control only). */
+  liveRuntimeSuggestions: ReadonlyArray<LiveRuntimeSuggestionRecord>;
+  /** Live setup snapshot (idle/ok/error) consumed by the host setup-options derivation. */
+  liveSetup: {
+    status: "idle" | "ok" | "error";
+    setup?: Civ7SetupSnapshotLike;
+    updatedAt?: string;
+    error?: string;
+  };
+  /**
+   * Entry point wired into `useStudioEvents`: ingests a live status event, advances
+   * `liveRuntime`, and fans out the bounded setup/snapshot reads. Null-request events
+   * abort + skip the snapshot read (LR-6).
+   */
+  applyLiveGameState: (statusState: LiveRuntimeStatusState) => void;
+};
+
+/**
+ * `useLiveRuntime` — owns the live-runtime snapshot/setup staleness machine: the
+ * abort/mounted-lifecycle refs, the live status/suggestions/setup state, the
+ * mount-lifecycle effect (which aborts both in-flight requests on unmount), and
+ * the three event-driven read functions (`readLiveRuntimeSnapshot`,
+ * `refreshLiveSetupFromEvent`, `applyLiveGameState`).
+ *
+ * This is the atomic mount-lifecycle group (invariant b): the abort/mounted refs
+ * (`liveSnapshotAbortRef`, `liveSetupAbortRef`, `activeLive*RequestKeyRef`,
+ * `liveRuntimeMountedRef`, `liveSnapshotFailureCountRef`) travel WITH the mount
+ * lifecycle and the three read functions into one hook — they cannot be split.
+ *
+ * Load-bearing invariants preserved verbatim from the prior host body:
+ * - LR-2: `readLiveRuntimeSnapshot` aborts the prior in-flight snapshot controller
+ *   (`liveSnapshotAbortRef.current?.abort()`) BEFORE starting a new one, then stores
+ *   the new controller + request key, so an older response never overwrites a newer.
+ * - LR-3: every post-await setState is guarded by `liveRuntimeMountedRef.current`
+ *   (and `isAbortLikeError`) so no setState fires after unmount.
+ * - LR-6: `applyLiveGameState`'s null-request path aborts + nulls the request key and
+ *   does NOT fetch; a valid request fires the read.
+ * - LR-7: the snapshotStatus 'loading' transition only fires on a snapshotId change /
+ *   non-ok prior status.
+ * - LR-4/LR-8: `liveSnapshotFailureCountRef` is display-only — no timer/retry/cadence
+ *   is introduced; the bodies stay event-driven (bounded reads).
+ *
+ * The `orpcClient` is threaded IN as a param (LR-2/LR-3 testability); all other
+ * dependencies (`fetchCiv7SetupConfig`, the model builders/staleness guards) are
+ * pure module imports.
+ */
+export function useLiveRuntime(args: UseLiveRuntimeArgs): UseLiveRuntimeResult {
+  const { orpcClient } = args;
+
+  const liveSnapshotFailureCountRef = useRef(0);
+  const activeLiveSnapshotRequestKeyRef = useRef<string | null>(null);
+  const activeLiveSetupRequestKeyRef = useRef<string | null>(null);
+  const liveSnapshotAbortRef = useRef<AbortController | null>(null);
+  const liveSetupAbortRef = useRef<AbortController | null>(null);
+  const liveRuntimeMountedRef = useRef(true);
+  const [liveRuntime, setLiveRuntime] = useState<LiveRuntimeStatusState>({
+    status: "idle",
+    snapshotStatus: "idle",
+    bindingStatus: "unbound-runtime",
+    failureCount: 0,
+  });
+  const [, setLiveRuntimeSnapshot] = useState<LiveRuntimeSnapshotState | null>(null);
+  const [liveRuntimeSuggestions, setLiveRuntimeSuggestions] = useState<
+    ReadonlyArray<LiveRuntimeSuggestionRecord>
+  >([]);
+  const [liveSetup, setLiveSetup] = useState<{
+    status: "idle" | "ok" | "error";
+    setup?: Civ7SetupSnapshotLike;
+    updatedAt?: string;
+    error?: string;
+  }>({ status: "idle" });
+
+  useEffect(() => {
+    liveRuntimeMountedRef.current = true;
+    return () => {
+      liveRuntimeMountedRef.current = false;
+      liveSnapshotAbortRef.current?.abort();
+      liveSetupAbortRef.current?.abort();
+    };
+  }, []);
+
+  const readLiveRuntimeSnapshot = useCallback(
+    async (request: LiveRuntimeSnapshotRequest) => {
+      liveSnapshotAbortRef.current?.abort();
+      const snapshotAbortController = new AbortController();
+      liveSnapshotAbortRef.current = snapshotAbortController;
+      activeLiveSnapshotRequestKeyRef.current = request.key;
+
+      try {
+        // Snapshot remains request/response. The event stream tells us when live
+        // status changed; the existing request-key guard still owns stale result
+        // rejection.
+        let body: unknown;
+        try {
+          body = await orpcClient.civ7.live.snapshot(
+            {
+              x: request.bounds.x,
+              y: request.bounds.y,
+              width: request.bounds.width,
+              height: request.bounds.height,
+              fields: request.fields.join(","),
+              maxPlots: request.maxPlots,
+              ...(request.playerId === undefined ? {} : { playerId: request.playerId }),
+            },
+            { signal: snapshotAbortController.signal }
+          );
+        } catch (snapshotErr) {
+          if (!liveRuntimeMountedRef.current || isAbortLikeError(snapshotErr)) throw snapshotErr;
+          body = {
+            ok: false,
+            error: snapshotErr instanceof Error ? snapshotErr.message : "Live snapshot unavailable",
+          };
+        }
+        if (!liveRuntimeMountedRef.current) return;
+        if (
+          !shouldCommitLiveRuntimeSnapshot({
+            activeRequestKey: activeLiveSnapshotRequestKeyRef.current,
+            resultRequestKey: request.key,
+            aborted: snapshotAbortController.signal.aborted,
+          })
+        ) {
+          return;
+        }
+        const snapshotState = buildLiveRuntimeSnapshotState({
+          request,
+          body,
+          observedAtFallback: new Date().toISOString(),
+        });
+        liveSnapshotFailureCountRef.current =
+          snapshotState.status === "ok" ? 0 : liveSnapshotFailureCountRef.current + 1;
+        setLiveRuntimeSnapshot(snapshotState);
+        setLiveRuntime((current) => ({
+          ...current,
+          snapshotStatus: snapshotState.status,
+          snapshotHash: snapshotState.snapshotHash ?? current.snapshotHash,
+          bindingStatus: snapshotState.status === "ok" ? current.bindingStatus : "partial",
+          failureCount: Math.max(current.failureCount ?? 0, liveSnapshotFailureCountRef.current),
+          error: snapshotState.status === "ok" ? current.error : snapshotState.error,
+        }));
+      } catch (err) {
+        if (!liveRuntimeMountedRef.current || isAbortLikeError(err)) return;
+        if (
+          !shouldCommitLiveRuntimeSnapshot({
+            activeRequestKey: activeLiveSnapshotRequestKeyRef.current,
+            resultRequestKey: request.key,
+          })
+        ) {
+          return;
+        }
+        liveSnapshotFailureCountRef.current += 1;
+        const snapshotState: LiveRuntimeSnapshotState = {
+          status: "error",
+          requestKey: request.key,
+          error: err instanceof Error ? err.message : "Live snapshot unavailable",
+        };
+        setLiveRuntimeSnapshot(snapshotState);
+        setLiveRuntime((current) => ({
+          ...current,
+          snapshotStatus: "error",
+          bindingStatus: "partial",
+          failureCount: Math.max(current.failureCount ?? 0, liveSnapshotFailureCountRef.current),
+          error: snapshotState.error,
+        }));
+      }
+    },
+    [orpcClient]
+  );
+
+  const refreshLiveSetupFromEvent = useCallback(async (statusState: LiveRuntimeStatusState) => {
+    liveSetupAbortRef.current?.abort();
+    const setupAbortController = new AbortController();
+    liveSetupAbortRef.current = setupAbortController;
+    const setupRequestKey = buildLiveRuntimeSetupRequestKey(statusState);
+    activeLiveSetupRequestKeyRef.current = setupRequestKey;
+    const shouldCommitSetup = () =>
+      liveRuntimeMountedRef.current &&
+      shouldCommitLiveRuntimeSetup({
+        activeRequestKey: activeLiveSetupRequestKeyRef.current,
+        resultRequestKey: setupRequestKey,
+        aborted: setupAbortController.signal.aborted,
+      });
+
+    try {
+      const setup = await fetchCiv7SetupConfig({ signal: setupAbortController.signal });
+      if (!shouldCommitSetup()) return;
+      const suggestedSetupConfig = setup.ok
+        ? normalizeStudioSetupConfig(studioSetupConfigFromLiveSnapshot(setup.setup))
+        : undefined;
+      if (setup.ok) {
+        setLiveSetup({ status: "ok", setup: setup.setup, updatedAt: setup.observedAt });
+      } else {
+        setLiveSetup({
+          status: "error",
+          error: setup.error,
+          updatedAt: setup.observedAt ?? new Date().toISOString(),
+        });
+      }
+      setLiveRuntimeSuggestions(
+        buildLiveRuntimeSuggestionRecords({
+          sourceSnapshotId: statusState.snapshotId,
+          seed: statusState.seed,
+          setupConfig: suggestedSetupConfig,
+          provedStudioRun: false,
+        })
+      );
+    } catch (err) {
+      if (!liveRuntimeMountedRef.current || isAbortLikeError(err)) return;
+      if (!shouldCommitSetup()) return;
+      const observedAt = new Date().toISOString();
+      setLiveSetup({
+        status: "error",
+        error: err instanceof Error ? err.message : "Live setup unavailable",
+        updatedAt: observedAt,
+      });
+      setLiveRuntimeSuggestions(
+        buildLiveRuntimeSuggestionRecords({
+          sourceSnapshotId: statusState.snapshotId,
+          seed: statusState.seed,
+          provedStudioRun: false,
+          now: () => new Date(observedAt),
+        })
+      );
+    }
+  }, []);
+
+  const applyLiveGameState = useCallback(
+    (statusState: LiveRuntimeStatusState) => {
+      const snapshotRequest = buildLiveRuntimeSnapshotRequest({ status: statusState });
+      if (!snapshotRequest) {
+        activeLiveSnapshotRequestKeyRef.current = null;
+        liveSnapshotAbortRef.current?.abort();
+      }
+
+      setLiveRuntime((current) => ({
+        ...statusState,
+        snapshotStatus:
+          snapshotRequest === null
+            ? statusState.snapshotStatus
+            : current.snapshotId === statusState.snapshotId && current.snapshotStatus === "ok"
+              ? current.snapshotStatus
+              : "loading",
+        failureCount: Math.max(statusState.failureCount ?? 0, liveSnapshotFailureCountRef.current),
+      }));
+      void refreshLiveSetupFromEvent(statusState);
+      if (snapshotRequest) void readLiveRuntimeSnapshot(snapshotRequest);
+    },
+    [readLiveRuntimeSnapshot, refreshLiveSetupFromEvent]
+  );
+
+  return {
+    liveRuntime,
+    setLiveRuntime,
+    liveRuntimeSuggestions,
+    liveSetup,
+    applyLiveGameState,
+  };
+}

--- a/apps/mapgen-studio/test/controllers/useLiveRuntime.source.test.ts
+++ b/apps/mapgen-studio/test/controllers/useLiveRuntime.source.test.ts
@@ -1,0 +1,110 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+import hookSource from "../../src/app/hooks/useLiveRuntime.ts?raw";
+import hostSource from "../../src/app/StudioShell.tsx?raw";
+
+// Strip comments so doc-comments (which legitimately name the refs/invariants/timers
+// in prose) don't trip the source matchers.
+const host = hostSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+const hook = hookSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+describe("useLiveRuntime source — failureCount is display-only, no cadence (LR-4 / LR-8)", () => {
+  it("LR-4/LR-8: the hook introduces NO setTimeout/setInterval/retry cadence", () => {
+    // The failure counter feeds DISPLAY (Math.max into liveRuntime.failureCount) only.
+    // If an extraction wires it to a timer (e.g. setTimeout(read, count*1000)) it would
+    // turn an event-driven bounded read into a retry fan-out / polling DoS.
+    expect(hook).not.toMatch(/setTimeout/);
+    expect(hook).not.toMatch(/setInterval/);
+    expect(hook).not.toMatch(/requestAnimationFrame/);
+  });
+
+  it("LR-4: liveSnapshotFailureCountRef only increments + feeds Math.max into failureCount (no scheduling)", () => {
+    // The ref is read in exactly the display sites (the two Math.max calls) and written
+    // in exactly the increment/reset sites — never passed to a scheduler.
+    expect(hook).toMatch(/liveSnapshotFailureCountRef\.current \+ 1/);
+    expect(hook).toMatch(
+      /Math\.max\(current\.failureCount \?\? 0, liveSnapshotFailureCountRef\.current\)/
+    );
+    // No timer/scheduler ever receives the counter or a read fn.
+    expect(hook).not.toMatch(/setTimeout\([^)]*liveSnapshotFailureCountRef/);
+    expect(hook).not.toMatch(/setTimeout\([^)]*readLiveRuntimeSnapshot/);
+  });
+});
+
+describe("useLiveRuntime source — atomic mount-lifecycle group (invariant b)", () => {
+  it("the abort/mounted refs + mount-lifecycle effect + the 3 read fns are co-resident in the hook", () => {
+    // The mount-lifecycle effect aborts BOTH controllers on unmount; the refs and the
+    // three read fns must live in the SAME hook (they cannot be split — invariant b).
+    expect(hook).toMatch(/liveRuntimeMountedRef\.current = true;/);
+    expect(hook).toMatch(/liveRuntimeMountedRef\.current = false;/);
+    expect(hook).toMatch(/liveSnapshotAbortRef\.current\?\.abort\(\);/);
+    expect(hook).toMatch(/liveSetupAbortRef\.current\?\.abort\(\);/);
+    expect(hook).toMatch(/const readLiveRuntimeSnapshot = useCallback\(/);
+    expect(hook).toMatch(/const refreshLiveSetupFromEvent = useCallback\(/);
+    expect(hook).toMatch(/const applyLiveGameState = useCallback\(/);
+  });
+
+  it("LR-2: readLiveRuntimeSnapshot aborts the prior controller BEFORE storing the new one", () => {
+    // The abort must precede the new-controller assign; otherwise the prior in-flight
+    // read is never cancelled and a stale response can clobber the newer commit.
+    const abortIdx = hook.indexOf("liveSnapshotAbortRef.current?.abort();");
+    const assignIdx = hook.indexOf("liveSnapshotAbortRef.current = snapshotAbortController;");
+    expect(abortIdx).toBeGreaterThan(-1);
+    expect(assignIdx).toBeGreaterThan(-1);
+    expect(abortIdx).toBeLessThan(assignIdx);
+  });
+
+  it("orpcClient is threaded IN as a param (not the module import) for renderHook testability", () => {
+    // The snapshot read must go through the injected client; a bare module import would
+    // make the LR-2/LR-3 mock-driven contracts unobservable.
+    expect(hook).toMatch(/const \{ orpcClient \} = args;/);
+    expect(hook).toMatch(/await orpcClient\.civ7\.live\.snapshot\(/);
+    // The bodies must NOT close over a VALUE import of the orpc client (only the
+    // `import type` alias is allowed — it carries no runtime binding).
+    expect(hook).not.toMatch(/^import \{ orpcClient \} from "\.\.\/\.\.\/lib\/orpc";/m);
+  });
+});
+
+describe("StudioShell source — 2.10 seam (live-runtime no longer host-owned)", () => {
+  it("calls useLiveRuntime and destructures the live-runtime surface", () => {
+    expect(host).toMatch(/useLiveRuntime\(\{ orpcClient \}\)/);
+    expect(host).toMatch(/\bliveRuntime,/);
+    expect(host).toMatch(/setLiveRuntime,/);
+    expect(host).toMatch(/liveRuntimeSuggestions,/);
+    expect(host).toMatch(/liveSetup,/);
+    expect(host).toMatch(/applyLiveGameState,/);
+  });
+
+  it("no longer owns the abort/mounted refs, the read fns, or the live-runtime state declarations", () => {
+    expect(host).not.toMatch(/liveSnapshotFailureCountRef/);
+    expect(host).not.toMatch(/activeLiveSnapshotRequestKeyRef/);
+    expect(host).not.toMatch(/activeLiveSetupRequestKeyRef/);
+    expect(host).not.toMatch(/liveSnapshotAbortRef/);
+    expect(host).not.toMatch(/liveSetupAbortRef/);
+    expect(host).not.toMatch(/liveRuntimeMountedRef/);
+    expect(host).not.toMatch(/const readLiveRuntimeSnapshot = useCallback/);
+    expect(host).not.toMatch(/const refreshLiveSetupFromEvent = useCallback/);
+    expect(host).not.toMatch(/const applyLiveGameState = useCallback/);
+    expect(host).not.toMatch(/setLiveRuntimeSnapshot/);
+    expect(host).not.toMatch(/setLiveRuntimeSuggestions/);
+    expect(host).not.toMatch(/setLiveSetup\b/);
+  });
+
+  it("§5: useLiveRuntime is initialized AFTER useSaveDeploy and BEFORE the operation-adoption effect", () => {
+    const saveDeployIdx = host.indexOf("} = useSaveDeploy({");
+    const liveRuntimeIdx = host.indexOf("useLiveRuntime({ orpcClient })");
+    const adoptionIdx = host.indexOf("readAndAdoptStudioOperationsCurrent({");
+    expect(saveDeployIdx).toBeGreaterThan(-1);
+    expect(liveRuntimeIdx).toBeGreaterThan(-1);
+    expect(adoptionIdx).toBeGreaterThan(-1);
+    expect(saveDeployIdx).toBeLessThan(liveRuntimeIdx);
+    expect(liveRuntimeIdx).toBeLessThan(adoptionIdx);
+  });
+
+  it("applyLiveGameState (from the hook) is wired into useStudioEvents", () => {
+    const liveRuntimeIdx = host.indexOf("useLiveRuntime({ orpcClient })");
+    const studioEventsIdx = host.indexOf("useStudioEvents({");
+    expect(liveRuntimeIdx).toBeLessThan(studioEventsIdx);
+    expect(host).toMatch(/useStudioEvents\(\{\s*applyLiveGameState,/);
+  });
+});

--- a/apps/mapgen-studio/test/controllers/useLiveRuntime.test.tsx
+++ b/apps/mapgen-studio/test/controllers/useLiveRuntime.test.tsx
@@ -1,0 +1,273 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "./_setup";
+
+// The setup fetch (`fetchCiv7SetupConfig`) runs unconditionally inside
+// `applyLiveGameState`. It is a module import (NOT a hook param), so we mock the
+// module to a controllable resolution; the SNAPSHOT read is what the LR-2/LR-3/LR-6
+// contracts hinge on and that goes through the INJECTED `orpcClient` mock — the whole
+// reason `orpcClient` is a hook PARAM. Everything else (the abort/mounted refs, the
+// staleness guards, the state machine) runs for real.
+vi.mock("../../src/features/civ7Setup/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/features/civ7Setup/api")>();
+  return {
+    ...actual,
+    fetchCiv7SetupConfig: vi.fn(async () => ({
+      ok: false as const,
+      error: "setup unavailable (test stub)",
+      observedAt: "2026-06-29T00:00:00.000Z",
+    })),
+  };
+});
+
+import { type UseLiveRuntimeArgs, useLiveRuntime } from "../../src/app/hooks/useLiveRuntime";
+import { fetchCiv7SetupConfig } from "../../src/features/civ7Setup/api";
+import type { LiveRuntimeStatusState } from "../../src/features/liveRuntime/model";
+
+const setupFetch = vi.mocked(fetchCiv7SetupConfig);
+
+/**
+ * A controllable `orpcClient.civ7.live.snapshot` mock. `resolveNext(body)` settles the
+ * MOST RECENT in-flight snapshot call; this lets us drive two overlapping reads and
+ * resolve them out-of-order (LR-2) or resolve AFTER unmount (LR-3).
+ */
+function makeSnapshotMock() {
+  const deferreds: Array<{
+    resolve: (body: unknown) => void;
+    reject: (err: unknown) => void;
+    signal?: AbortSignal;
+  }> = [];
+  const snapshot = vi.fn(
+    (_params: Record<string, unknown>, opts?: { signal?: AbortSignal }) =>
+      new Promise<unknown>((resolve, reject) => {
+        deferreds.push({ resolve, reject, signal: opts?.signal });
+      })
+  );
+  return {
+    snapshot,
+    /** Settle the i-th snapshot call (default: latest) with an ok body. */
+    resolveOk(i = deferreds.length - 1, grid: unknown = { tiles: [] }) {
+      deferreds[i]?.resolve({ ok: true, observedAt: "2026-06-29T00:00:00.000Z", grid });
+    },
+    /**
+     * Settle the i-th call with an ok body whose `ok`/`grid` are GETTERS that flip
+     * `onConsume`. The post-await commit path passes the body to
+     * `buildLiveRuntimeSnapshotState` (which reads `.ok`/`.grid`) — so reading those
+     * getters proves the body reached the commit path. If the mounted-ref guard fires
+     * first (unmount case), the body is never consumed → the getters never run.
+     */
+    resolveOkTrap(i: number, onConsume: () => void, grid: unknown = { tiles: [] }) {
+      deferreds[i]?.resolve({
+        observedAt: "2026-06-29T00:00:00.000Z",
+        get ok() {
+          onConsume();
+          return true;
+        },
+        get grid() {
+          return grid;
+        },
+      });
+    },
+    deferreds,
+  };
+}
+
+function makeArgs(snapshot: ReturnType<typeof makeSnapshotMock>["snapshot"]): UseLiveRuntimeArgs {
+  return {
+    orpcClient: {
+      civ7: { live: { snapshot } },
+    } as unknown as UseLiveRuntimeArgs["orpcClient"],
+  };
+}
+
+const okStatus = (over: Partial<LiveRuntimeStatusState> = {}): LiveRuntimeStatusState =>
+  ({ status: "ok", snapshotId: "snap-1", ...over }) as LiveRuntimeStatusState;
+
+beforeEach(() => {
+  setupFetch.mockClear();
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useLiveRuntime — snapshot abort + staleness (LR-2)", () => {
+  it("LR-2: a new snapshot request aborts the prior in-flight controller; the stale (older) response is dropped", async () => {
+    // Oracle: applyLiveGameState fires twice (two distinct snapshotIds) → the SECOND
+    // read aborts the FIRST's AbortController, and the request-key guard rejects the
+    // first response if it arrives later. After resolving BOTH (older last), liveRuntime
+    // reflects ONLY the second snapshot (snapshotStatus 'ok'), not a clobber from the
+    // stale first. Falsifier: drop `liveSnapshotAbortRef.current?.abort()` in
+    // readLiveRuntimeSnapshot → the first controller never aborts and its late ok-body
+    // commits over the second (snapshotHash/snapshotId from snap-1, not snap-2).
+    const mock = makeSnapshotMock();
+    const { result } = renderHook((p: UseLiveRuntimeArgs) => useLiveRuntime(p), {
+      initialProps: makeArgs(mock.snapshot),
+    });
+
+    await act(async () => {
+      result.current.applyLiveGameState(okStatus({ snapshotId: "snap-1", turn: 1 }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      result.current.applyLiveGameState(okStatus({ snapshotId: "snap-2", turn: 2 }));
+      await Promise.resolve();
+    });
+
+    // Two reads were issued; the FIRST controller must have been aborted by the second.
+    expect(mock.snapshot).toHaveBeenCalledTimes(2);
+    expect(mock.deferreds[0]?.signal?.aborted).toBe(true);
+    expect(mock.deferreds[1]?.signal?.aborted).toBe(false);
+
+    // Resolve the NEWER read first (committed), then the STALE one (must be dropped).
+    await act(async () => {
+      mock.resolveOk(1);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const afterNewer = result.current.liveRuntime;
+    expect(afterNewer.snapshotStatus).toBe("ok");
+    const hashAfterNewer = afterNewer.snapshotHash;
+
+    await act(async () => {
+      mock.resolveOk(0); // older response arrives late — request-key guard drops it
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    // The stale response did NOT overwrite the newer commit.
+    expect(result.current.liveRuntime.snapshotHash).toBe(hashAfterNewer);
+    expect(result.current.liveRuntime.snapshotStatus).toBe("ok");
+  });
+});
+
+describe("useLiveRuntime — mounted-ref guard (LR-3)", () => {
+  it("LR-3: a snapshot resolving AFTER unmount short-circuits at the mounted-ref guard (body never reaches the commit path)", async () => {
+    // Oracle: unmount mid-fetch, THEN resolve the snapshot. The `if (!liveRuntime
+    // MountedRef.current) return;` guard sits BEFORE the body is handed to
+    // buildLiveRuntimeSnapshotState, so on the unmount path the body's `ok`/`grid`
+    // getters are NEVER read. We instrument the resolved body with a consume-trap and
+    // assert it stays untouched after unmount+resolve.
+    //
+    // Falsifier (atomic-constraint / invariant b): if the mounted-ref machinery does
+    // NOT travel with the read fns into this hook (the refs get split off, or the
+    // mounted guard is dropped), the post-await commit reads the body (trap fires) and
+    // setLiveRuntime/setLiveRuntimeSnapshot run on an unmounted component. NOTE: the
+    // mounted guard and the abort guard are intentional defense-in-depth — on the
+    // unmount path the cleanup also aborts the controller; this test kills the failure
+    // where the mounted-ref carry is lost so the commit is no longer guarded.
+    const mock = makeSnapshotMock();
+    const { result, unmount } = renderHook((p: UseLiveRuntimeArgs) => useLiveRuntime(p), {
+      initialProps: makeArgs(mock.snapshot),
+    });
+
+    await act(async () => {
+      result.current.applyLiveGameState(okStatus({ snapshotId: "snap-1", turn: 1 }));
+      await Promise.resolve();
+    });
+    expect(mock.snapshot).toHaveBeenCalledTimes(1);
+
+    // Control: while still MOUNTED, the body IS consumed (trap fires) — proves the trap
+    // is a real signal, not a false negative.
+    let consumedWhileMounted = false;
+    await act(async () => {
+      mock.resolveOkTrap(0, () => {
+        consumedWhileMounted = true;
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(consumedWhileMounted).toBe(true);
+
+    // Now drive a SECOND read, unmount mid-flight, then resolve: the mounted-ref guard
+    // must short-circuit before the body is consumed.
+    await act(async () => {
+      result.current.applyLiveGameState(okStatus({ snapshotId: "snap-2", turn: 2 }));
+      await Promise.resolve();
+    });
+    expect(mock.snapshot).toHaveBeenCalledTimes(2);
+
+    let consumedAfterUnmount = false;
+    unmount();
+    await act(async () => {
+      mock.resolveOkTrap(1, () => {
+        consumedAfterUnmount = true;
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(consumedAfterUnmount).toBe(false);
+  });
+});
+
+describe("useLiveRuntime — applyLiveGameState request gating (LR-6)", () => {
+  it("LR-6: a non-ok / null-snapshotId status aborts + does NOT call orpcClient.civ7.live.snapshot", async () => {
+    // Oracle: status !== 'ok' (or missing snapshotId) → buildLiveRuntimeSnapshotRequest
+    // returns null → applyLiveGameState nulls the request key + aborts and SKIPS the
+    // read. Falsifier: removing the null-request guard so it always fetches → error
+    // events trigger a snapshot fetch storm.
+    const mock = makeSnapshotMock();
+    const { result } = renderHook((p: UseLiveRuntimeArgs) => useLiveRuntime(p), {
+      initialProps: makeArgs(mock.snapshot),
+    });
+
+    await act(async () => {
+      result.current.applyLiveGameState({ status: "error" } as LiveRuntimeStatusState);
+      await Promise.resolve();
+    });
+    expect(mock.snapshot).not.toHaveBeenCalled();
+
+    // An ok status WITHOUT a snapshotId is also a null request → still no fetch.
+    await act(async () => {
+      result.current.applyLiveGameState({ status: "ok" } as LiveRuntimeStatusState);
+      await Promise.resolve();
+    });
+    expect(mock.snapshot).not.toHaveBeenCalled();
+
+    // A valid ok+snapshotId status DOES fire the read.
+    await act(async () => {
+      result.current.applyLiveGameState(okStatus({ snapshotId: "snap-1", turn: 1 }));
+      await Promise.resolve();
+    });
+    expect(mock.snapshot).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useLiveRuntime — snapshotStatus 'loading' transition (LR-7)", () => {
+  it("LR-7: applyLiveGameState sets snapshotStatus 'loading' only on a snapshotId change / non-ok prior", async () => {
+    // Oracle: first ok+snapshotId → 'loading'; once the snapshot resolves ok → 'ok';
+    // re-applying the SAME snapshotId while prior is 'ok' → stays 'ok' (no loading
+    // flicker); a NEW snapshotId → 'loading' again. Falsifier: always 'loading' → a
+    // flicker on every autoplay tick even when the snapshot is unchanged.
+    const mock = makeSnapshotMock();
+    const { result } = renderHook((p: UseLiveRuntimeArgs) => useLiveRuntime(p), {
+      initialProps: makeArgs(mock.snapshot),
+    });
+
+    await act(async () => {
+      result.current.applyLiveGameState(okStatus({ snapshotId: "snap-1", turn: 1 }));
+      await Promise.resolve();
+    });
+    expect(result.current.liveRuntime.snapshotStatus).toBe("loading");
+
+    await act(async () => {
+      mock.resolveOk(0);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.liveRuntime.snapshotStatus).toBe("ok");
+
+    // Re-apply the SAME snapshotId while prior is 'ok' → must NOT flip back to loading.
+    await act(async () => {
+      result.current.applyLiveGameState(okStatus({ snapshotId: "snap-1", turn: 1 }));
+      await Promise.resolve();
+    });
+    expect(result.current.liveRuntime.snapshotStatus).toBe("ok");
+
+    // A NEW snapshotId → loading again.
+    await act(async () => {
+      result.current.applyLiveGameState(okStatus({ snapshotId: "snap-2", turn: 2 }));
+      await Promise.resolve();
+    });
+    expect(result.current.liveRuntime.snapshotStatus).toBe("loading");
+  });
+});

--- a/apps/mapgen-studio/test/studioEvents/operationAdoption.test.ts
+++ b/apps/mapgen-studio/test/studioEvents/operationAdoption.test.ts
@@ -526,8 +526,10 @@ describe("Studio event operation adoption", () => {
   });
 
   test("StudioShell live-game events trigger bounded follow-up reads without a cadence", () => {
+    // The live-runtime read functions moved into `useLiveRuntime` (slice 2.10); the
+    // bounded-read / no-cadence (LR-8) contract is now pinned against the hook source.
     const shellSource = readFileSync(
-      join(repoRoot, "apps/mapgen-studio/src/app/StudioShell.tsx"),
+      join(repoRoot, "apps/mapgen-studio/src/app/hooks/useLiveRuntime.ts"),
       "utf8"
     );
 


### PR DESCRIPTION
Extracts the live-runtime snapshot/setup staleness machine out of `StudioShell` and into a dedicated `useLiveRuntime` hook.

The abort/mounted-lifecycle refs (`liveSnapshotAbortRef`, `liveSetupAbortRef`, `activeLive*RequestKeyRef`, `liveRuntimeMountedRef`, `liveSnapshotFailureCountRef`), the three event-driven read functions (`readLiveRuntimeSnapshot`, `refreshLiveSetupFromEvent`, `applyLiveGameState`), and the associated state (`liveRuntime`, `liveRuntimeSuggestions`, `liveSetup`) are moved as an atomic group into `src/app/hooks/useLiveRuntime.ts`. `StudioShell` now calls `useLiveRuntime({ orpcClient })` and destructures the returned surface.

The `orpcClient` is threaded in as a hook parameter rather than consumed as a module import, making the abort/staleness contracts (LR-2/LR-3) exercisable with a mock client in `renderHook` tests. The existing bounded-read / no-cadence source assertion in `operationAdoption.test.ts` is redirected from `StudioShell.tsx` to `useLiveRuntime.ts`.

Two new test files are added:
- `useLiveRuntime.test.tsx` — `renderHook`-based behavioural tests covering the snapshot abort + staleness guard (LR-2), the mounted-ref short-circuit on unmount (LR-3), the null-request gating that prevents snapshot fetches on non-ok status events (LR-6), and the `snapshotStatus` loading-transition logic (LR-7).
- `useLiveRuntime.source.test.ts` — source-text assertions pinning that no `setTimeout`/`setInterval` cadence is introduced (LR-4/LR-8), that the abort/mounted refs and read functions are co-resident in the hook, that the prior-abort precedes the new-controller assignment (LR-2), and that `StudioShell` no longer owns any of the extracted machinery.