### PR TITLE
feat(mapgen-studio): extract `useSetupControls` hook (slice 2.12) from `StudioShell`

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -1,22 +1,7 @@
 import { stripSchemaMetadataRoot } from "@swooper/mapgen-core/authoring";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useBrowserRunner } from "../features/browserRunner/useBrowserRunner";
-import { requestCiv7Autoplay } from "../features/civ7Setup/api";
 import { LIVE_GAME_PRESET_ID, LIVE_GAME_PRESET_KEY } from "../features/civ7Setup/livePreset";
-import { formatCiv7StudioSeedError, parseCiv7StudioSeed } from "../features/civ7Setup/seedPolicy";
-import {
-  clearStudioSetupSavedConfig,
-  getLocalPlayerSetup,
-  optionRowsFromParameter,
-  studioSetupConfigFromSavedConfigFile,
-  studioSetupDriftsFromSavedConfig,
-} from "../features/civ7Setup/setupConfig";
-import {
-  ensureSelectOption,
-  findSetupParameterLike,
-  mergeSelectOptions,
-  setupCatalogOptions,
-} from "../features/civ7Setup/setupOptions";
 import { buildDefaultConfig } from "../features/configOverrides/configBuilders";
 import {
   PresetConfirmDialog,
@@ -27,7 +12,6 @@ import { type PresetKey, parsePresetKey } from "../features/presets/types";
 import { PipelineStage } from "../features/recipeDag/PipelineStage";
 import { liveSourceMatchesStudio } from "../features/runInGame/liveSource";
 import { runInGameRequiresProcessRestart } from "../features/runInGame/status";
-import { liveControlPort } from "../lib/control/liveControlPort";
 import { orpcClient } from "../lib/orpc";
 import { STUDIO_RECIPE_OPTIONS } from "../recipes/catalog";
 import type { VizEvent } from "../shared/vizEvents";
@@ -51,6 +35,7 @@ import { useLiveRuntime } from "./hooks/useLiveRuntime";
 import { usePresetLifecycle } from "./hooks/usePresetLifecycle";
 import { useRunInGame } from "./hooks/useRunInGame";
 import { useSaveDeploy } from "./hooks/useSaveDeploy";
+import { useSetupControls } from "./hooks/useSetupControls";
 import { useSetupDataQueries } from "./hooks/useSetupDataQueries";
 import { useStudioEvents } from "./hooks/useStudioEvents";
 import { useStudioOperations } from "./hooks/useStudioOperations";
@@ -288,8 +273,6 @@ export function StudioShell(props: StudioShellProps) {
   // defaults), replacing the prior hand-rolled load/retry/focus effect; the derived view
   // shapes are unchanged so `setupControlOptions` below consumes them as before.
   const { savedSetupConfigs, setupCatalog } = useSetupDataQueries();
-  const [autoplayActionRunning, setAutoplayActionRunning] = useState(false);
-  const [exploreActionRunning, setExploreActionRunning] = useState(false);
 
   // Viz selection/exploration fixpoint (slice 2.7): owns `useVizState` + the full
   // stage/step/dataType/space/mode/variant/era/overlay cascade and is the sole
@@ -532,115 +515,35 @@ export function StudioShell(props: StudioShellProps) {
       );
   }, [presetOptions, provedRunInGameSource?.materializationMode, studioMatchesProvedLiveSource]);
 
-  const setupControlOptions = useMemo(() => {
-    const setup = liveSetup.setup;
-    const parameters = setup?.setup?.parameters ?? [];
-    const localPlayerId = Number(
-      setup?.setup?.localPlayerId?.ok === true
-        ? setup.setup.localPlayerId.value
-        : getLocalPlayerSetup(setupConfig).playerId
-    );
-    const playerParameters =
-      setup?.setup?.playerParameters?.find((player) => player.playerId === localPlayerId)
-        ?.parameters ??
-      setup?.setup?.playerParameters?.[0]?.parameters ??
-      [];
-    const localPlayer = getLocalPlayerSetup(setupConfig);
-    const gameOptions = setupConfig.gameOptions;
-    const playerOptions = localPlayer.options;
-    const savedConfigOptions = [
-      {
-        value: "",
-        label: savedSetupConfigs.status === "idle" ? "Loading configs" : "No saved config",
-      },
-      ...savedSetupConfigs.configurations.map((config) => ({
-        value: config.id,
-        label: config.displayName,
-      })),
-    ];
-    const leader = playerOptions.PlayerLeader;
-    const civilization = playerOptions.PlayerCivilization;
-    const difficulty = gameOptions.Difficulty ?? playerOptions.PlayerDifficulty;
-    const gameSpeed = gameOptions.GameSpeeds;
-    const catalog = setupCatalog.catalog;
-    return {
-      savedConfigOptions: ensureSelectOption(savedConfigOptions, setupConfig.savedConfig?.id),
-      leaderOptions: ensureSelectOption(
-        mergeSelectOptions(
-          [{ value: "", label: "Leader" }],
-          optionRowsFromParameter(findSetupParameterLike(playerParameters, "PlayerLeader")),
-          setupCatalogOptions(catalog?.leaders)
-        ),
-        leader
-      ),
-      civilizationOptions: ensureSelectOption(
-        mergeSelectOptions(
-          [{ value: "", label: "Civilization" }],
-          optionRowsFromParameter(findSetupParameterLike(playerParameters, "PlayerCivilization")),
-          setupCatalogOptions(catalog?.civilizations)
-        ),
-        civilization
-      ),
-      difficultyOptions: ensureSelectOption(
-        mergeSelectOptions(
-          [{ value: "", label: "Difficulty" }],
-          optionRowsFromParameter(findSetupParameterLike(parameters, "Difficulty")),
-          setupCatalogOptions(catalog?.difficulties)
-        ),
-        difficulty
-      ),
-      gameSpeedOptions: ensureSelectOption(
-        mergeSelectOptions(
-          [{ value: "", label: "Speed" }],
-          optionRowsFromParameter(findSetupParameterLike(parameters, "GameSpeeds")),
-          setupCatalogOptions(catalog?.gameSpeeds)
-        ),
-        gameSpeed
-      ),
-    };
-  }, [
-    liveSetup.setup,
-    savedSetupConfigs.configurations,
-    savedSetupConfigs.status,
-    setupCatalog.catalog,
+  // Setup-controls cluster (slice 2.12): the derived `setupControlOptions`
+  // projection, the value-equality saved-config drift detector, the saved-config
+  // selection handler, and the two live-game *actions* (autoplay toggle + explore)
+  // with their in-flight guard state. Initialized LAST in the hook sequence (§5):
+  // the autoplay toggle reads the LIVE `liveRuntime.autoplayActive` + `setLiveRuntime`
+  // (from `useLiveRuntime`) and both actions busy-gate on the flags threaded from
+  // `useStudioOperations`, so this must follow those hooks (and `useSetupDataQueries`).
+  const {
+    setupControlOptions,
+    savedSetupConfigModified,
+    handleSavedSetupConfigChange,
+    handleToggleAutoplay,
+    handleExplore,
+    autoplayActionRunning,
+    exploreActionRunning,
+  } = useSetupControls({
     setupConfig,
-  ]);
-
-  // Config precedence (Y2, hardened in P7): the selector claims the saved
-  // config ONLY while the authored setup state equals the file-derived state
-  // — any difference (dropdown edit, live sync, stray persisted key) means
-  // the launch would not be the file, so the header shows "Custom" instead.
-  // Re-selecting the config re-applies the file exactly and returns to clean.
-  const savedSetupConfigModified = useMemo(() => {
-    const selectedId = setupConfig.savedConfig?.id;
-    if (!selectedId) return false;
-    const savedConfig = savedSetupConfigs.configurations.find((config) => config.id === selectedId);
-    if (!savedConfig) return false;
-    return studioSetupDriftsFromSavedConfig(setupConfig, savedConfig);
-  }, [savedSetupConfigs.configurations, setupConfig]);
-
-  const handleSavedSetupConfigChange = useCallback(
-    (configId: string) => {
-      const savedConfig = savedSetupConfigs.configurations.find((config) => config.id === configId);
-      if (!savedConfig) {
-        setSetupConfig((current) => clearStudioSetupSavedConfig(current));
-        return;
-      }
-      setSetupConfig(studioSetupConfigFromSavedConfigFile(savedConfig));
-      const nextSeed = savedConfig.summary.mapSeed ?? savedConfig.summary.gameSeed;
-      if (nextSeed !== undefined) {
-        const seedPolicy = parseCiv7StudioSeed(nextSeed);
-        if (seedPolicy.ok) {
-          setRecipeSettings((current) => ({ ...current, seed: String(seedPolicy.value) }));
-        } else {
-          toast(`Saved config seed ignored: ${formatCiv7StudioSeedError(seedPolicy)}`, {
-            variant: "info",
-          });
-        }
-      }
-    },
-    [savedSetupConfigs.configurations, toast]
-  );
+    setSetupConfig,
+    setRecipeSettings,
+    savedSetupConfigs,
+    setupCatalog,
+    liveSetup,
+    liveRuntime,
+    setLiveRuntime,
+    browserRunning,
+    runInGameRunning,
+    saveDeployRunning,
+    toast,
+  });
 
   const markRunInGameToastHandled = useCallback((requestId: string) => {
     lastRunInGameToastRef.current = requestId;
@@ -675,94 +578,6 @@ export function StudioShell(props: StudioShellProps) {
     setLocalError,
     clearLocalError: clearLocalErrorIfCurrent,
   });
-
-  const handleToggleAutoplay = useCallback(async () => {
-    if (autoplayActionRunning) {
-      toast("Autoplay request is already in flight.", { variant: "info" });
-      return;
-    }
-    const busyMessage = studioBusyGateMessage({
-      subject: "Autoplay",
-      browserRunning,
-      runInGameRunning,
-      saveDeployRunning,
-    });
-    if (busyMessage) {
-      toast(busyMessage, { variant: "info" });
-      return;
-    }
-    const action = liveRuntime.autoplayActive ? "stop" : "start";
-    setAutoplayActionRunning(true);
-    try {
-      const result = await requestCiv7Autoplay(action);
-      if (!result.ok) {
-        toast(`Autoplay ${action} failed: ${result.error ?? "unknown error"}`, {
-          variant: "error",
-        });
-        return;
-      }
-      setLiveRuntime((current) => ({
-        ...current,
-        status: "ok",
-        autoplayActive: result.autoplay?.isActive ?? action === "start",
-        autoplayPaused: result.autoplay?.isPaused,
-        turn: result.game?.turn?.ok ? result.game.turn.value : current.turn,
-        updatedAt: new Date().toISOString(),
-        error: undefined,
-      }));
-      toast(action === "start" ? "Civ7 autoplay started" : "Civ7 autoplay stopped", {
-        variant: "success",
-      });
-    } finally {
-      setAutoplayActionRunning(false);
-    }
-  }, [
-    autoplayActionRunning,
-    browserRunning,
-    liveRuntime.autoplayActive,
-    runInGameRunning,
-    saveDeployRunning,
-    toast,
-  ]);
-
-  /**
-   * Explore (reveal the map) in the live game via the canonical
-   * `display.explore.request` control procedure — the studio's map-QA verb.
-   * The grant stays held (fog does not re-cover) for a disposable studio
-   * session; player 0 is the canonical local player, matching the CLI.
-   */
-  const handleExplore = useCallback(async () => {
-    if (exploreActionRunning) {
-      toast("Explore request is already in flight.", { variant: "info" });
-      return;
-    }
-    const busyMessage = studioBusyGateMessage({
-      subject: "Explore",
-      browserRunning,
-      runInGameRunning,
-      saveDeployRunning,
-    });
-    if (busyMessage) {
-      toast(busyMessage, { variant: "info" });
-      return;
-    }
-    setExploreActionRunning(true);
-    try {
-      const result = await liveControlPort.display.explore.request({ playerId: 0 });
-      toast(
-        result.classification === "already-explored"
-          ? "Live map already fully revealed"
-          : `Live map revealed — ${result.grantedPlots} plots granted`,
-        { variant: "success" }
-      );
-    } catch (err) {
-      toast(`Explore failed: ${err instanceof Error ? err.message : "live game unavailable"}`, {
-        variant: "error",
-      });
-    } finally {
-      setExploreActionRunning(false);
-    }
-  }, [browserRunning, exploreActionRunning, runInGameRunning, saveDeployRunning, toast]);
 
   const gameOperationBusyLabel = studioBusyGateMessage({
     subject: "Game controls",

--- a/apps/mapgen-studio/src/app/hooks/useSetupControls.ts
+++ b/apps/mapgen-studio/src/app/hooks/useSetupControls.ts
@@ -1,0 +1,344 @@
+import { useCallback, useMemo, useState } from "react";
+
+import { requestCiv7Autoplay } from "../../features/civ7Setup/api";
+import {
+  formatCiv7StudioSeedError,
+  parseCiv7StudioSeed,
+} from "../../features/civ7Setup/seedPolicy";
+import {
+  clearStudioSetupSavedConfig,
+  getLocalPlayerSetup,
+  optionRowsFromParameter,
+  studioSetupConfigFromSavedConfigFile,
+  studioSetupDriftsFromSavedConfig,
+} from "../../features/civ7Setup/setupConfig";
+import {
+  ensureSelectOption,
+  findSetupParameterLike,
+  mergeSelectOptions,
+  setupCatalogOptions,
+} from "../../features/civ7Setup/setupOptions";
+import { liveControlPort } from "../../lib/control/liveControlPort";
+import type { AuthoringState } from "../../stores/authoringStore";
+import { studioBusyGateMessage } from "../studioEventRecovery";
+import type { UseLiveRuntimeResult } from "./useLiveRuntime";
+import type { SavedSetupConfigsView, SetupCatalogView } from "./useSetupDataQueries";
+import type { StudioOperations } from "./useStudioOperations";
+import type { ToastFn } from "./useToast";
+
+export type UseSetupControlsArgs = {
+  /** Current authoring setup config (from `useAuthoringStore`). */
+  setupConfig: AuthoringState["setupConfig"];
+  /** Setter for the authoring setup config (from `useAuthoringStore`). */
+  setSetupConfig: AuthoringState["setSetupConfig"];
+  /** Setter for the authoring recipe settings — saved-config seed adoption. */
+  setRecipeSettings: AuthoringState["setRecipeSettings"];
+  /** Saved-config READ view (from `useSetupDataQueries`). */
+  savedSetupConfigs: SavedSetupConfigsView;
+  /** Setup-catalog READ view (from `useSetupDataQueries`). */
+  setupCatalog: SetupCatalogView;
+  /** Live setup snapshot (from `useLiveRuntime`) — feeds the setup-options projection. */
+  liveSetup: UseLiveRuntimeResult["liveSetup"];
+  /**
+   * Live runtime status (from `useLiveRuntime`). The autoplay toggle reads
+   * `liveRuntime.autoplayActive` LIVE off this value (not a stale prop) so a stop
+   * action is never issued against a stale active flag (MAN-3 / SC-5).
+   */
+  liveRuntime: UseLiveRuntimeResult["liveRuntime"];
+  /** Setter for `liveRuntime` (from `useLiveRuntime`) — autoplay-result reconciliation. */
+  setLiveRuntime: UseLiveRuntimeResult["setLiveRuntime"];
+  /** Synchronous busy flag for browser map generation (busy-gate). */
+  browserRunning: boolean;
+  /** Synchronous busy flag for run-in-game (busy-gate, from `useStudioOperations`). */
+  runInGameRunning: StudioOperations["runInGameRunning"];
+  /** Synchronous busy flag for save/deploy (busy-gate, from `useStudioOperations`). */
+  saveDeployRunning: StudioOperations["saveDeployRunning"];
+  toast: ToastFn;
+};
+
+/** A single Civ7 setup-control select option group (value/label rows). */
+type SetupControlSelectOptions = ReadonlyArray<{ value: string; label: string }>;
+
+/** Shape of the memoized setup-control options object (one group per control). */
+export type SetupControlOptions = {
+  savedConfigOptions: SetupControlSelectOptions;
+  leaderOptions: SetupControlSelectOptions;
+  civilizationOptions: SetupControlSelectOptions;
+  difficultyOptions: SetupControlSelectOptions;
+  gameSpeedOptions: SetupControlSelectOptions;
+};
+
+export type UseSetupControlsResult = {
+  /** Derived Civ7 setup-control select options (saved config + leader/civ/difficulty/speed). */
+  setupControlOptions: SetupControlOptions;
+  /** Drift flag — true when the authored setup diverges (by value) from the selected saved config. */
+  savedSetupConfigModified: boolean;
+  /** Applies (replaces) the authored setup from the chosen saved config + adopts its seed. */
+  handleSavedSetupConfigChange: (configId: string) => void;
+  /** Starts/stops Civ7 autoplay — busy-gated + re-entrant-guarded; reads LIVE autoplay state. */
+  handleToggleAutoplay: () => Promise<void>;
+  /** Reveals the live map (explore) — busy-gated + re-entrant-guarded. */
+  handleExplore: () => Promise<void>;
+  /** In-flight flag for the autoplay toggle (re-entrant guard, drives disabled state). */
+  autoplayActionRunning: boolean;
+  /** In-flight flag for the explore action (re-entrant guard, drives disabled state). */
+  exploreActionRunning: boolean;
+};
+
+/**
+ * `useSetupControls` — owns the Civ7 setup-controls cluster: the derived
+ * `setupControlOptions` select-option projection, the saved-config selection
+ * handler (`handleSavedSetupConfigChange`), the value-equality drift detector
+ * (`savedSetupConfigModified`), and the two live-game *actions* co-located here
+ * (`handleToggleAutoplay` / `handleExplore`) with their in-flight guard state.
+ *
+ * Load-bearing invariants preserved verbatim from the prior host body:
+ * - SC-4: drift detection is VALUE equality (`studioSetupDriftsFromSavedConfig`
+ *   → `studioSetupConfigsEqual`), never object identity — so it flips to "Custom"
+ *   only when the authored setup actually differs from the file (a post-sync
+ *   identity change alone never spuriously flips it).
+ * - SC-1/2/3: the saved-config replace + drift + normalized-equality PURE logic
+ *   stays in `features/civ7Setup/*` (`studioSetupConfigFromSavedConfigFile`,
+ *   `clearStudioSetupSavedConfig`, `studioSetupDriftsFromSavedConfig`) — called,
+ *   never inlined/re-derived.
+ * - SC-5: `handleToggleAutoplay` short-circuits + toasts when `autoplayAction
+ *   Running` (re-entrant guard) OR when a busy flag is set; the in-flight flag is
+ *   set BEFORE the await and cleared in a `finally`. The start/stop decision reads
+ *   the LIVE `liveRuntime.autoplayActive` threaded IN (not a stale capture).
+ * - SC-6: `handleExplore` short-circuits + toasts when `exploreActionRunning` OR
+ *   busy; the in-flight flag is set BEFORE the await and cleared in `finally`
+ *   (try/finally wraps the RPC).
+ *
+ * The setup config + setters, the saved-config/catalog READ views, the live setup/
+ * runtime + `setLiveRuntime`, and the busy booleans are threaded IN from their
+ * owners (`useAuthoringStore`, `useSetupDataQueries`, `useLiveRuntime`,
+ * `useStudioOperations`); the autoplay/explore RPC entry points
+ * (`requestCiv7Autoplay`, `liveControlPort`) are pure module imports.
+ */
+export function useSetupControls(args: UseSetupControlsArgs): UseSetupControlsResult {
+  const {
+    setupConfig,
+    setSetupConfig,
+    setRecipeSettings,
+    savedSetupConfigs,
+    setupCatalog,
+    liveSetup,
+    liveRuntime,
+    setLiveRuntime,
+    browserRunning,
+    runInGameRunning,
+    saveDeployRunning,
+    toast,
+  } = args;
+
+  const [autoplayActionRunning, setAutoplayActionRunning] = useState(false);
+  const [exploreActionRunning, setExploreActionRunning] = useState(false);
+
+  const setupControlOptions = useMemo(() => {
+    const setup = liveSetup.setup;
+    const parameters = setup?.setup?.parameters ?? [];
+    const localPlayerId = Number(
+      setup?.setup?.localPlayerId?.ok === true
+        ? setup.setup.localPlayerId.value
+        : getLocalPlayerSetup(setupConfig).playerId
+    );
+    const playerParameters =
+      setup?.setup?.playerParameters?.find((player) => player.playerId === localPlayerId)
+        ?.parameters ??
+      setup?.setup?.playerParameters?.[0]?.parameters ??
+      [];
+    const localPlayer = getLocalPlayerSetup(setupConfig);
+    const gameOptions = setupConfig.gameOptions;
+    const playerOptions = localPlayer.options;
+    const savedConfigOptions = [
+      {
+        value: "",
+        label: savedSetupConfigs.status === "idle" ? "Loading configs" : "No saved config",
+      },
+      ...savedSetupConfigs.configurations.map((config) => ({
+        value: config.id,
+        label: config.displayName,
+      })),
+    ];
+    const leader = playerOptions.PlayerLeader;
+    const civilization = playerOptions.PlayerCivilization;
+    const difficulty = gameOptions.Difficulty ?? playerOptions.PlayerDifficulty;
+    const gameSpeed = gameOptions.GameSpeeds;
+    const catalog = setupCatalog.catalog;
+    return {
+      savedConfigOptions: ensureSelectOption(savedConfigOptions, setupConfig.savedConfig?.id),
+      leaderOptions: ensureSelectOption(
+        mergeSelectOptions(
+          [{ value: "", label: "Leader" }],
+          optionRowsFromParameter(findSetupParameterLike(playerParameters, "PlayerLeader")),
+          setupCatalogOptions(catalog?.leaders)
+        ),
+        leader
+      ),
+      civilizationOptions: ensureSelectOption(
+        mergeSelectOptions(
+          [{ value: "", label: "Civilization" }],
+          optionRowsFromParameter(findSetupParameterLike(playerParameters, "PlayerCivilization")),
+          setupCatalogOptions(catalog?.civilizations)
+        ),
+        civilization
+      ),
+      difficultyOptions: ensureSelectOption(
+        mergeSelectOptions(
+          [{ value: "", label: "Difficulty" }],
+          optionRowsFromParameter(findSetupParameterLike(parameters, "Difficulty")),
+          setupCatalogOptions(catalog?.difficulties)
+        ),
+        difficulty
+      ),
+      gameSpeedOptions: ensureSelectOption(
+        mergeSelectOptions(
+          [{ value: "", label: "Speed" }],
+          optionRowsFromParameter(findSetupParameterLike(parameters, "GameSpeeds")),
+          setupCatalogOptions(catalog?.gameSpeeds)
+        ),
+        gameSpeed
+      ),
+    };
+  }, [
+    liveSetup.setup,
+    savedSetupConfigs.configurations,
+    savedSetupConfigs.status,
+    setupCatalog.catalog,
+    setupConfig,
+  ]);
+
+  // Config precedence (Y2, hardened in P7): the selector claims the saved
+  // config ONLY while the authored setup state equals the file-derived state
+  // — any difference (dropdown edit, live sync, stray persisted key) means
+  // the launch would not be the file, so the header shows "Custom" instead.
+  // Re-selecting the config re-applies the file exactly and returns to clean.
+  const savedSetupConfigModified = useMemo(() => {
+    const selectedId = setupConfig.savedConfig?.id;
+    if (!selectedId) return false;
+    const savedConfig = savedSetupConfigs.configurations.find((config) => config.id === selectedId);
+    if (!savedConfig) return false;
+    return studioSetupDriftsFromSavedConfig(setupConfig, savedConfig);
+  }, [savedSetupConfigs.configurations, setupConfig]);
+
+  const handleSavedSetupConfigChange = useCallback(
+    (configId: string) => {
+      const savedConfig = savedSetupConfigs.configurations.find((config) => config.id === configId);
+      if (!savedConfig) {
+        setSetupConfig((current) => clearStudioSetupSavedConfig(current));
+        return;
+      }
+      setSetupConfig(studioSetupConfigFromSavedConfigFile(savedConfig));
+      const nextSeed = savedConfig.summary.mapSeed ?? savedConfig.summary.gameSeed;
+      if (nextSeed !== undefined) {
+        const seedPolicy = parseCiv7StudioSeed(nextSeed);
+        if (seedPolicy.ok) {
+          setRecipeSettings((current) => ({ ...current, seed: String(seedPolicy.value) }));
+        } else {
+          toast(`Saved config seed ignored: ${formatCiv7StudioSeedError(seedPolicy)}`, {
+            variant: "info",
+          });
+        }
+      }
+    },
+    [savedSetupConfigs.configurations, toast]
+  );
+
+  const handleToggleAutoplay = useCallback(async () => {
+    if (autoplayActionRunning) {
+      toast("Autoplay request is already in flight.", { variant: "info" });
+      return;
+    }
+    const busyMessage = studioBusyGateMessage({
+      subject: "Autoplay",
+      browserRunning,
+      runInGameRunning,
+      saveDeployRunning,
+    });
+    if (busyMessage) {
+      toast(busyMessage, { variant: "info" });
+      return;
+    }
+    const action = liveRuntime.autoplayActive ? "stop" : "start";
+    setAutoplayActionRunning(true);
+    try {
+      const result = await requestCiv7Autoplay(action);
+      if (!result.ok) {
+        toast(`Autoplay ${action} failed: ${result.error ?? "unknown error"}`, {
+          variant: "error",
+        });
+        return;
+      }
+      setLiveRuntime((current) => ({
+        ...current,
+        status: "ok",
+        autoplayActive: result.autoplay?.isActive ?? action === "start",
+        autoplayPaused: result.autoplay?.isPaused,
+        turn: result.game?.turn?.ok ? result.game.turn.value : current.turn,
+        updatedAt: new Date().toISOString(),
+        error: undefined,
+      }));
+      toast(action === "start" ? "Civ7 autoplay started" : "Civ7 autoplay stopped", {
+        variant: "success",
+      });
+    } finally {
+      setAutoplayActionRunning(false);
+    }
+  }, [
+    autoplayActionRunning,
+    browserRunning,
+    liveRuntime.autoplayActive,
+    runInGameRunning,
+    saveDeployRunning,
+    toast,
+  ]);
+
+  /**
+   * Explore (reveal the map) in the live game via the canonical
+   * `display.explore.request` control procedure — the studio's map-QA verb.
+   * The grant stays held (fog does not re-cover) for a disposable studio
+   * session; player 0 is the canonical local player, matching the CLI.
+   */
+  const handleExplore = useCallback(async () => {
+    if (exploreActionRunning) {
+      toast("Explore request is already in flight.", { variant: "info" });
+      return;
+    }
+    const busyMessage = studioBusyGateMessage({
+      subject: "Explore",
+      browserRunning,
+      runInGameRunning,
+      saveDeployRunning,
+    });
+    if (busyMessage) {
+      toast(busyMessage, { variant: "info" });
+      return;
+    }
+    setExploreActionRunning(true);
+    try {
+      const result = await liveControlPort.display.explore.request({ playerId: 0 });
+      toast(
+        result.classification === "already-explored"
+          ? "Live map already fully revealed"
+          : `Live map revealed — ${result.grantedPlots} plots granted`,
+        { variant: "success" }
+      );
+    } catch (err) {
+      toast(`Explore failed: ${err instanceof Error ? err.message : "live game unavailable"}`, {
+        variant: "error",
+      });
+    } finally {
+      setExploreActionRunning(false);
+    }
+  }, [browserRunning, exploreActionRunning, runInGameRunning, saveDeployRunning, toast]);
+
+  return {
+    setupControlOptions,
+    savedSetupConfigModified,
+    handleSavedSetupConfigChange,
+    handleToggleAutoplay,
+    handleExplore,
+    autoplayActionRunning,
+    exploreActionRunning,
+  };
+}

--- a/apps/mapgen-studio/test/controllers/useSetupControls.source.test.ts
+++ b/apps/mapgen-studio/test/controllers/useSetupControls.source.test.ts
@@ -1,0 +1,121 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+import hookSource from "../../src/app/hooks/useSetupControls.ts?raw";
+import hostSource from "../../src/app/StudioShell.tsx?raw";
+
+// Strip comments so doc-comments (which legitimately name the pinned pure fns /
+// the invariants) don't trip the matchers.
+const host = hostSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+const hook = hookSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+describe("useSetupControls source — SC-1/2/3 pinned pure logic stays in features/* (called, not re-derived)", () => {
+  it("drift detection delegates to the pinned VALUE-equality fn (SC-4: studioSetupDriftsFromSavedConfig → studioSetupConfigsEqual)", () => {
+    // The hook must CALL the pure drift fn, never inline a JSON.stringify / `===`
+    // identity comparison. The pure fn (pinned in setupConfig.test.ts) routes
+    // through studioSetupConfigsEqual.
+    expect(hook).toMatch(/return studioSetupDriftsFromSavedConfig\(setupConfig, savedConfig\)/);
+    expect(hook).not.toMatch(/JSON\.stringify/);
+  });
+
+  it("saved-config selection delegates to the pinned replace + clear fns (SC-1/2)", () => {
+    expect(hook).toMatch(/setSetupConfig\(studioSetupConfigFromSavedConfigFile\(savedConfig\)\)/);
+    expect(hook).toMatch(/setSetupConfig\(\(current\) => clearStudioSetupSavedConfig\(current\)\)/);
+  });
+});
+
+describe("useSetupControls source — SC-5 (autoplay guard ordering)", () => {
+  it("the re-entrant guard short-circuits BEFORE the busy gate and BEFORE the RPC", () => {
+    const guardIdx = hook.indexOf("if (autoplayActionRunning) {");
+    const busyIdx = hook.indexOf('subject: "Autoplay",');
+    const rpcIdx = hook.indexOf("await requestCiv7Autoplay(action)");
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(busyIdx).toBeGreaterThan(-1);
+    expect(rpcIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(busyIdx);
+    expect(busyIdx).toBeLessThan(rpcIdx);
+  });
+
+  it("the in-flight flag is set BEFORE the await and cleared in a finally", () => {
+    const setIdx = hook.indexOf("setAutoplayActionRunning(true);");
+    const awaitIdx = hook.indexOf("await requestCiv7Autoplay(action)");
+    const clearIdx = hook.indexOf("setAutoplayActionRunning(false);");
+    expect(setIdx).toBeGreaterThan(-1);
+    expect(awaitIdx).toBeGreaterThan(-1);
+    expect(clearIdx).toBeGreaterThan(-1);
+    expect(setIdx).toBeLessThan(awaitIdx);
+    expect(awaitIdx).toBeLessThan(clearIdx);
+    // The clear sits inside a `finally` block.
+    expect(hook).toMatch(/\}\s*finally\s*\{\s*setAutoplayActionRunning\(false\);\s*\}/);
+  });
+
+  it("reads the LIVE liveRuntime.autoplayActive to pick start vs stop (not a stale capture)", () => {
+    expect(hook).toMatch(/const action = liveRuntime\.autoplayActive \? "stop" : "start";/);
+    // The handler dep array lists the live value so the closure is rebuilt on change.
+    expect(hook).toMatch(/liveRuntime\.autoplayActive,/);
+  });
+});
+
+describe("useSetupControls source — SC-6 (explore guard ordering, try/finally)", () => {
+  it("the re-entrant guard short-circuits BEFORE the busy gate and BEFORE the RPC", () => {
+    const guardIdx = hook.indexOf("if (exploreActionRunning) {");
+    const busyIdx = hook.indexOf('subject: "Explore",');
+    const rpcIdx = hook.indexOf("await liveControlPort.display.explore.request(");
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(busyIdx).toBeGreaterThan(-1);
+    expect(rpcIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(busyIdx);
+    expect(busyIdx).toBeLessThan(rpcIdx);
+  });
+
+  it("the in-flight flag is set BEFORE the await and cleared in a finally that wraps a try/catch", () => {
+    const setIdx = hook.indexOf("setExploreActionRunning(true);");
+    const awaitIdx = hook.indexOf("await liveControlPort.display.explore.request(");
+    const clearIdx = hook.indexOf("setExploreActionRunning(false);");
+    expect(setIdx).toBeGreaterThan(-1);
+    expect(awaitIdx).toBeLessThan(clearIdx);
+    expect(setIdx).toBeLessThan(awaitIdx);
+    expect(hook).toMatch(/\}\s*finally\s*\{\s*setExploreActionRunning\(false\);\s*\}/);
+    // try/catch wraps the RPC (error path toasts, does not rethrow).
+    expect(hook).toMatch(/\}\s*catch\s*\(err\)\s*\{/);
+  });
+});
+
+describe("StudioShell source — 2.12 seam (setup-controls no longer host-owned)", () => {
+  it("calls useSetupControls and destructures the setup-controls surface", () => {
+    expect(host).toMatch(/} = useSetupControls\(\{/);
+    expect(host).toMatch(/setupControlOptions,/);
+    expect(host).toMatch(/savedSetupConfigModified,/);
+    expect(host).toMatch(/handleSavedSetupConfigChange,/);
+    expect(host).toMatch(/handleToggleAutoplay,/);
+    expect(host).toMatch(/handleExplore,/);
+    expect(host).toMatch(/autoplayActionRunning,/);
+    expect(host).toMatch(/exploreActionRunning,/);
+  });
+
+  it("no longer owns the moved declarations (memos, handlers, in-flight state)", () => {
+    expect(host).not.toMatch(/const setupControlOptions = useMemo/);
+    expect(host).not.toMatch(/const savedSetupConfigModified = useMemo/);
+    expect(host).not.toMatch(/const handleSavedSetupConfigChange = useCallback/);
+    expect(host).not.toMatch(/const handleToggleAutoplay = useCallback/);
+    expect(host).not.toMatch(/const handleExplore = useCallback/);
+    expect(host).not.toMatch(/setAutoplayActionRunning/);
+    expect(host).not.toMatch(/setExploreActionRunning/);
+    // The autoplay/explore RPC entry points are no longer imported by the host.
+    expect(host).not.toMatch(/import \{ requestCiv7Autoplay \}/);
+    expect(host).not.toMatch(/import \{ liveControlPort \}/);
+  });
+
+  it("§5: useSetupControls is initialized AFTER useLiveRuntime + useStudioOperations + useSetupDataQueries", () => {
+    const liveRuntimeIdx = host.indexOf("useLiveRuntime({ orpcClient })");
+    const operationsIdx = host.indexOf("} = useStudioOperations();");
+    const dataQueriesIdx = host.indexOf("} = useSetupDataQueries();");
+    const setupControlsIdx = host.indexOf("} = useSetupControls({");
+    expect(liveRuntimeIdx).toBeGreaterThan(-1);
+    expect(operationsIdx).toBeGreaterThan(-1);
+    expect(dataQueriesIdx).toBeGreaterThan(-1);
+    expect(setupControlsIdx).toBeGreaterThan(-1);
+    expect(liveRuntimeIdx).toBeLessThan(setupControlsIdx);
+    expect(operationsIdx).toBeLessThan(setupControlsIdx);
+    expect(dataQueriesIdx).toBeLessThan(setupControlsIdx);
+  });
+});

--- a/apps/mapgen-studio/test/controllers/useSetupControls.test.tsx
+++ b/apps/mapgen-studio/test/controllers/useSetupControls.test.tsx
@@ -1,0 +1,281 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "./_setup";
+
+// The autoplay/explore RPC entry points are pure module imports inside the hook
+// (NOT hook params), so we mock the modules to controllable spies. Everything else
+// (the busy gate, the re-entrant guard, the in-flight flag + finally, the live
+// `liveRuntime.autoplayActive` read, the value-equality drift detector) runs for
+// real — the SC-* contracts must be exercised against the real machinery.
+vi.mock("../../src/features/civ7Setup/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/features/civ7Setup/api")>();
+  return {
+    ...actual,
+    requestCiv7Autoplay: vi.fn(),
+  };
+});
+vi.mock("../../src/lib/control/liveControlPort", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/lib/control/liveControlPort")>();
+  return {
+    ...actual,
+    liveControlPort: {
+      display: { explore: { request: vi.fn() } },
+    },
+  };
+});
+
+import { type UseSetupControlsArgs, useSetupControls } from "../../src/app/hooks/useSetupControls";
+import { requestCiv7Autoplay } from "../../src/features/civ7Setup/api";
+import {
+  type Civ7SavedSetupConfigFile,
+  type Civ7StudioSetupConfig,
+  studioSetupConfigFromSavedConfigFile,
+} from "../../src/features/civ7Setup/setupConfig";
+import type { LiveRuntimeStatusState } from "../../src/features/liveRuntime/model";
+import { liveControlPort } from "../../src/lib/control/liveControlPort";
+
+const autoplayRpc = vi.mocked(requestCiv7Autoplay);
+const exploreRpc = vi.mocked(liveControlPort.display.explore.request);
+
+// A minimal-but-valid saved config file. `studioSetupConfigFromSavedConfigFile`
+// (the same pure fn the real selection handler calls) derives the authored config
+// from it — so a config derived this way is, by construction, a value-equal copy
+// of the file-derived state (drift MUST be false).
+const SAVED_CONFIG: Civ7SavedSetupConfigFile = {
+  id: "saved-alpha",
+  displayName: "Saved Alpha",
+  fileName: "saved-alpha.config.json",
+  path: "/configs/saved-alpha.config.json",
+  sizeBytes: 10,
+  modifiedAt: "2026-06-29T00:00:00.000Z",
+  source: "local-disk",
+  summary: { difficulty: "DIFFICULTY_SOVEREIGN" },
+  setupOptions: { Difficulty: "DIFFICULTY_SOVEREIGN", GameSpeeds: "GAMESPEED_STANDARD" },
+  playerOptions: [
+    {
+      playerId: 0,
+      options: {
+        PlayerLeader: "LEADER_HARRIET_TUBMAN",
+        PlayerCivilization: "CIVILIZATION_AMERICA",
+      },
+    },
+  ],
+};
+
+const LIVE_RUNTIME_IDLE = {
+  status: "idle",
+  autoplayActive: false,
+} as unknown as LiveRuntimeStatusState;
+
+function makeArgs(over: Partial<UseSetupControlsArgs> = {}): UseSetupControlsArgs {
+  return {
+    setupConfig: studioSetupConfigFromSavedConfigFile(SAVED_CONFIG),
+    setSetupConfig: vi.fn(),
+    setRecipeSettings: vi.fn(),
+    savedSetupConfigs: { status: "ok", configurations: [SAVED_CONFIG] },
+    setupCatalog: { status: "idle" },
+    liveSetup: { status: "idle" },
+    liveRuntime: LIVE_RUNTIME_IDLE,
+    setLiveRuntime: vi.fn(),
+    browserRunning: false,
+    runInGameRunning: false,
+    saveDeployRunning: false,
+    toast: vi.fn(),
+    ...over,
+  };
+}
+
+function setup(over: Partial<UseSetupControlsArgs> = {}) {
+  const props = makeArgs(over);
+  const { result, rerender, unmount } = renderHook(
+    (p: UseSetupControlsArgs) => useSetupControls(p),
+    { initialProps: props }
+  );
+  return { result, rerender, props, unmount };
+}
+
+beforeEach(() => {
+  autoplayRpc.mockReset();
+  exploreRpc.mockReset();
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useSetupControls — SC-4 (drift via value equality, not identity)", () => {
+  it("savedSetupConfigModified is false when the authored setup equals the selected saved config (even though it is a fresh-reference object)", () => {
+    // The authored config is derived from the file via the SAME pure fn the real
+    // selection handler uses — a brand-new object reference each render. Value
+    // equality ⇒ no drift. An object-identity comparison would see distinct
+    // references and spuriously report drift here (the falsifier).
+    const { result } = setup({ setupConfig: studioSetupConfigFromSavedConfigFile(SAVED_CONFIG) });
+    expect(result.current.savedSetupConfigModified).toBe(false);
+  });
+
+  it("savedSetupConfigModified flips to true after a (simulated) sync writes a DIFFERENT setup value", () => {
+    // Simulate a live sync replacing one game-option value. The config still claims
+    // the saved id, but its VALUE now differs from the file ⇒ drift (header → Custom).
+    const derived = studioSetupConfigFromSavedConfigFile(SAVED_CONFIG);
+    const drifted: Civ7StudioSetupConfig = {
+      ...derived,
+      gameOptions: { ...derived.gameOptions, Difficulty: "DIFFICULTY_DEITY" },
+    };
+    const { result } = setup({ setupConfig: drifted });
+    expect(result.current.savedSetupConfigModified).toBe(true);
+  });
+
+  it("savedSetupConfigModified is false when no saved config is selected", () => {
+    const derived = studioSetupConfigFromSavedConfigFile(SAVED_CONFIG);
+    const noSelection: Civ7StudioSetupConfig = { ...derived, savedConfig: undefined };
+    const { result } = setup({ setupConfig: noSelection });
+    expect(result.current.savedSetupConfigModified).toBe(false);
+  });
+});
+
+describe("useSetupControls — SC-5 (handleToggleAutoplay busy-gate + re-entrant guard)", () => {
+  it("early-returns + toasts (no RPC) when a busy flag is set", async () => {
+    const toast = vi.fn();
+    const { result } = setup({ browserRunning: true, toast });
+    await act(async () => {
+      await result.current.handleToggleAutoplay();
+    });
+    expect(autoplayRpc).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith(expect.stringContaining("Autoplay"), { variant: "info" });
+  });
+
+  it("early-returns + toasts (no RPC) on a re-entrant call while one is already in flight", async () => {
+    const toast = vi.fn();
+    // First call: hold the RPC open so the in-flight flag stays set.
+    let resolveRpc: (v: Awaited<ReturnType<typeof requestCiv7Autoplay>>) => void = () => {};
+    autoplayRpc.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRpc = resolve;
+        })
+    );
+    const { result } = setup({ toast });
+
+    let firstCall!: Promise<void>;
+    act(() => {
+      firstCall = result.current.handleToggleAutoplay();
+    });
+    // Second (re-entrant) call WHILE the first is awaiting the RPC.
+    await act(async () => {
+      await result.current.handleToggleAutoplay();
+    });
+    // The guard short-circuited the second call: still exactly ONE RPC, and an
+    // in-flight info toast fired.
+    expect(autoplayRpc).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith("Autoplay request is already in flight.", {
+      variant: "info",
+    });
+    // Drain the first call.
+    await act(async () => {
+      resolveRpc({ ok: true, action: "start", autoplay: { isActive: true } });
+      await firstCall;
+    });
+  });
+
+  it("issues the RPC + reconciles liveRuntime when idle and not busy (flag set before await, cleared in finally)", async () => {
+    autoplayRpc.mockResolvedValue({ ok: true, action: "start", autoplay: { isActive: true } });
+    const setLiveRuntime = vi.fn();
+    const { result } = setup({ setLiveRuntime });
+    await act(async () => {
+      await result.current.handleToggleAutoplay();
+    });
+    expect(autoplayRpc).toHaveBeenCalledWith("start");
+    expect(setLiveRuntime).toHaveBeenCalledTimes(1);
+    // Cleared in finally ⇒ the in-flight flag is back to false.
+    expect(result.current.autoplayActionRunning).toBe(false);
+  });
+
+  it("clears the in-flight flag in finally even when the RPC throws", async () => {
+    autoplayRpc.mockRejectedValue(new Error("boom"));
+    const { result } = setup();
+    await act(async () => {
+      await expect(result.current.handleToggleAutoplay()).rejects.toThrow("boom");
+    });
+    // finally ran despite the throw ⇒ flag cleared (no permanent stuck state).
+    expect(result.current.autoplayActionRunning).toBe(false);
+  });
+
+  it("reads the LIVE liveRuntime.autoplayActive (issues 'stop' when active, not a stale 'start')", async () => {
+    autoplayRpc.mockResolvedValue({ ok: true, action: "stop", autoplay: { isActive: false } });
+    const activeRuntime = {
+      status: "ok",
+      autoplayActive: true,
+    } as unknown as LiveRuntimeStatusState;
+    const { result } = setup({ liveRuntime: activeRuntime });
+    await act(async () => {
+      await result.current.handleToggleAutoplay();
+    });
+    expect(autoplayRpc).toHaveBeenCalledWith("stop");
+  });
+});
+
+describe("useSetupControls — SC-6 (handleExplore busy-gate + re-entrant guard, try/finally)", () => {
+  it("early-returns + toasts (no RPC) when a busy flag is set", async () => {
+    const toast = vi.fn();
+    const { result } = setup({ saveDeployRunning: true, toast });
+    await act(async () => {
+      await result.current.handleExplore();
+    });
+    expect(exploreRpc).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith(expect.stringContaining("Explore"), { variant: "info" });
+  });
+
+  it("early-returns + toasts (no RPC) on a re-entrant call while one is already in flight", async () => {
+    const toast = vi.fn();
+    let resolveRpc: (v: { classification: string; grantedPlots: number }) => void = () => {};
+    exploreRpc.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRpc = resolve;
+        }) as ReturnType<typeof liveControlPort.display.explore.request>
+    );
+    const { result } = setup({ toast });
+
+    let firstCall!: Promise<void>;
+    act(() => {
+      firstCall = result.current.handleExplore();
+    });
+    await act(async () => {
+      await result.current.handleExplore();
+    });
+    expect(exploreRpc).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith("Explore request is already in flight.", {
+      variant: "info",
+    });
+    await act(async () => {
+      resolveRpc({ classification: "explored", grantedPlots: 12 });
+      await firstCall;
+    });
+  });
+
+  it("issues the explore RPC + clears the in-flight flag in finally on success", async () => {
+    exploreRpc.mockResolvedValue({
+      classification: "explored",
+      grantedPlots: 7,
+    } as Awaited<ReturnType<typeof liveControlPort.display.explore.request>>);
+    const { result } = setup();
+    await act(async () => {
+      await result.current.handleExplore();
+    });
+    expect(exploreRpc).toHaveBeenCalledWith({ playerId: 0 });
+    expect(result.current.exploreActionRunning).toBe(false);
+  });
+
+  it("catches a thrown RPC, toasts an error, and still clears the in-flight flag (try/finally)", async () => {
+    const toast = vi.fn();
+    exploreRpc.mockRejectedValue(new Error("live game unavailable"));
+    const { result } = setup({ toast });
+    await act(async () => {
+      await result.current.handleExplore();
+    });
+    expect(toast).toHaveBeenCalledWith(expect.stringContaining("Explore failed"), {
+      variant: "error",
+    });
+    expect(result.current.exploreActionRunning).toBe(false);
+  });
+});


### PR DESCRIPTION
Extracts the Civ7 setup-controls cluster out of `StudioShell` into a dedicated `useSetupControls` hook (slice 2.12).

The following logic is moved verbatim into the new hook, with no behavioral changes:

- The `setupControlOptions` memoized projection (saved-config, leader, civilization, difficulty, game speed select options)
- The `savedSetupConfigModified` value-equality drift detector (`studioSetupDriftsFromSavedConfig`)
- `handleSavedSetupConfigChange` — replaces the authored setup from a saved config file and adopts its seed
- `handleToggleAutoplay` and `handleExplore` with their `autoplayActionRunning` / `exploreActionRunning` in-flight guard state

`StudioShell` now calls `useSetupControls(...)` and destructures the returned surface. The `requestCiv7Autoplay` and `liveControlPort` imports are removed from `StudioShell` entirely, as are the two `useState` declarations for the in-flight flags.

Adds two test files:

- `useSetupControls.test.tsx` — behavioral tests covering SC-4 (value-equality drift, not object identity), SC-5 (autoplay busy-gate, re-entrant guard, in-flight flag set before await and cleared in `finally`, live `autoplayActive` read), and SC-6 (explore busy-gate, re-entrant guard, `try/finally` error path)
- `useSetupControls.source.test.ts` — source-text tests asserting the pinned pure-function call sites, guard ordering, `finally` structure, and that `StudioShell` no longer owns any of the moved declarations