### PR TITLE
chore(mapgen-studio): sort React imports (types-first, alphabetical)

### DIFF
--- a/apps/mapgen-studio/src/app/hooks/useBrowserRun.ts
+++ b/apps/mapgen-studio/src/app/hooks/useBrowserRun.ts
@@ -1,11 +1,11 @@
 import {
+  type Dispatch,
+  type SetStateAction,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
-  type Dispatch,
-  type SetStateAction,
 } from "react";
 
 import { getCiv7MapSizePreset } from "../../features/browserRunner/mapSizes";
@@ -31,7 +31,11 @@ import type { ToastFn } from "./useToast";
  */
 export type BrowserRunVizHandle = Pick<
   UseVizStateResult,
-  "selectedStepId" | "selectedLayerKey" | "clearStream" | "setSelectedStepId" | "setSelectedLayerKey"
+  | "selectedStepId"
+  | "selectedLayerKey"
+  | "clearStream"
+  | "setSelectedStepId"
+  | "setSelectedLayerKey"
 >;
 
 export type UseBrowserRunArgs = {

--- a/apps/mapgen-studio/src/app/hooks/useLatestRef.ts
+++ b/apps/mapgen-studio/src/app/hooks/useLatestRef.ts
@@ -1,4 +1,4 @@
-import { useRef, type RefObject } from "react";
+import { type RefObject, useRef } from "react";
 
 /**
  * `useLatestRef` — keep a ref pointing at the most recent render's `value`.

--- a/apps/mapgen-studio/src/app/hooks/useStudioOperations.ts
+++ b/apps/mapgen-studio/src/app/hooks/useStudioOperations.ts
@@ -1,6 +1,5 @@
-import { useCallback, useState, type Dispatch, type RefObject, type SetStateAction } from "react";
-
 import type { MapConfigSaveDeployStatus, RunInGameOperationStatus } from "@civ7/studio-server";
+import { type Dispatch, type RefObject, type SetStateAction, useCallback, useState } from "react";
 
 import { useLatestRef } from "./useLatestRef";
 

--- a/apps/mapgen-studio/src/app/hooks/useViewportLayout.ts
+++ b/apps/mapgen-studio/src/app/hooks/useViewportLayout.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
 
 import { prunePipelineExpandedStageIds } from "../../features/recipeDag/prunePipelineExpansion";
 import {
@@ -38,10 +38,7 @@ export type ViewportLayout = Readonly<{
  * deck-autofit effects deliberately stay OUT of this hook — they depend on viz
  * VALUES produced downstream and are lifted in their own slice.
  */
-export function useViewportLayout(args: {
-  recipe: string;
-  stageView: StageView;
-}): ViewportLayout {
+export function useViewportLayout(args: { recipe: string; stageView: StageView }): ViewportLayout {
   const { recipe, stageView } = args;
 
   // Deck canvas handle + measured viewport ---------------------------------


### PR DESCRIPTION
Reorders React type imports to appear before value imports, consistent with the convention of placing `type` imports first. Also reformats multi-line union type picks and inline object parameter types for improved readability.