### PR TITLE
chore(biome): add React hooks + JSX key lint rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -46,7 +46,10 @@
         "noUnsafeFinally": "error",
         "noUnsafeOptionalChaining": "error",
         "useIsNan": "error",
-        "useValidTypeof": "error"
+        "useValidTypeof": "error",
+        "useExhaustiveDependencies": "warn",
+        "useHookAtTopLevel": "error",
+        "useJsxKeyInIterable": "error"
       },
       "suspicious": {
         "noDebugger": "error",


### PR DESCRIPTION
Enables three additional Biome linting rules to improve React code quality:

- **`useExhaustiveDependencies`** (warn) — Flags missing or unnecessary dependencies in React hooks like `useEffect` and `useCallback`
- **`useHookAtTopLevel`** (error) — Enforces that hooks are only called at the top level of a component, not inside loops, conditions, or nested functions
- **`useJsxKeyInIterable`** (error) — Requires a `key` prop when rendering lists of JSX elements