### PR TITLE
docs(mapgen-studio): add inline architecture comments for StudioShell decomposition + hook seams

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -72,6 +72,43 @@ export type StudioShellProps = {
  * behavior (browserRunner gating, run-in-game fingerprint/relation/materialization,
  * live-runtime request-key staleness + adaptive backoff, localStorage schema) is
  * touched — see architecture/10 §7.
+ *
+ * ROLE AFTER DECOMPOSITION. Domain orchestration lives in the controller hooks
+ * (`usePresetLifecycle`, `useBrowserRun`, `useSaveDeploy`, `useLiveRuntime`,
+ * `useRunInGame`, `useSetupControls`, `useVizSelection`, …). The host owns only
+ * what cannot move: the store reads, the hook-wiring, the single error-recovery
+ * adoption effect, the cross-hook seam callbacks, the cycle-break derivations that
+ * must stay at render scope, and the JSX layout (header/footer/docks/canvas/
+ * dialogs + the a11y skip-link / live-region chrome). It holds essentially no logic
+ * of its own.
+ *
+ * HOOK INIT ORDER IS LOAD-BEARING. The hooks are called in a fixed sequence because
+ * LATER hooks consume EARLIER hooks' setters/outputs by value (never republished):
+ *   1. `useStudioOperations` FIRST — owns the op state + error channel and derives
+ *      the busy booleans synchronously, so they are stable from render 1 and can be
+ *      threaded down without an ordering cycle.
+ *   2. `useViewportLayout` before viz — viz + deck-autofit consume the deck handle /
+ *      viewport by reference.
+ *   3. `usePresetLifecycle` — the preset contracts (`markPresetApplied`,
+ *      `applyAuthoringSnapshot`, `resolvePreset`) the save + run-in-game owners drive.
+ *   4. `useBrowserRunner` → `browserRunning` → `useVizSelection` — viz reads
+ *      `browserRunning`, and its `viz` handle threads onward to deck-autofit and JSX.
+ *   5. `useSaveDeploy`, then `useLiveRuntime`, then `useRunInGame` — the operation-
+ *      adoption effect (§5) needs BOTH op setters, so save/live init before it, and
+ *      run-in-game's sync-back reads the live-runtime outputs.
+ *   6. `useSetupControls` LAST — its autoplay toggle reads live `liveRuntime` +
+ *      `setLiveRuntime`, and both live-game actions busy-gate on the threaded flags.
+ * Reordering any of these would force a hook to read a value before its owner exists.
+ *
+ * CYCLE-BREAK DERIVATIONS STAY HERE. A handful of memos are computed in host render
+ * scope rather than inside a hook because they straddle two hooks that would
+ * otherwise form an init cycle, or because deriving them via effect would be unsafe:
+ * `provedRunInGameSource`, `livePresets`, `displayedPresetOptions`,
+ * `studioMatchesProvedLiveSource`, `liveGameStudioRelation`, `backgroundGridEnabled`,
+ * `recipeOptions`, and `runInGameMaterializationMode`. The last is security-adjacent
+ * (it gates whether a config is materialized DURABLY vs disposably) and is therefore
+ * derived synchronously from current state, NEVER from an effect that could lag a
+ * render and let a stale "durable" decision through. Each is documented at its site.
  */
 export function StudioShell(props: StudioShellProps) {
   const toast = useToast();
@@ -176,6 +213,11 @@ export function StudioShell(props: StudioShellProps) {
   const lastRunInGameSource = useRunStore((s) => s.lastRunInGameSource);
   const setLastRunInGameSource = useRunStore((s) => s.setLastRunInGameSource);
 
+  // Cycle break (§7.6): the run-in-game source that was actually PROVED through to a
+  // completed operation — `lastRunInGameSource` is what the user last requested, but
+  // it only counts as proved once an operation with the SAME requestId reports
+  // `complete`. Computed here (not in `useRunInGame`) because both `usePresetLifecycle`
+  // (via `livePresets`) and `useRunInGame` consume it, and it must exist before either.
   const provedRunInGameSource = useMemo(
     () =>
       lastRunInGameSource &&
@@ -185,6 +227,11 @@ export function StudioShell(props: StudioShellProps) {
         : null,
     [lastRunInGameSource, runInGameOperation]
   );
+  // Cycle break (§7.6): the synthetic "Live Game" preset entry, surfaced only when the
+  // last run-in-game source matches the CURRENT recipe. Threaded INTO `usePresetLifecycle`
+  // so `resolvePreset(LIVE_GAME_PRESET_KEY).config` stays referentially the proved
+  // `lastRunInGameSource.pipelineConfig` (live-sync identity invariant, ADD-1b) — keeping
+  // it host-side avoids the preset hook reaching back into run-state.
   const livePresets = useMemo(
     () =>
       lastRunInGameSource && lastRunInGameSource.recipeSettings.recipe === recipeSettings.recipe
@@ -249,6 +296,11 @@ export function StudioShell(props: StudioShellProps) {
   // Authoring persistence is now driven by `authoringStore`'s `persist` middleware
   // (same serializer, same key, same schema) — the prior manual save effect is removed.
 
+  // Seam #1: the browser-runner → viz event sink. `useBrowserRunner` needs a STABLE
+  // `onVizEvent` at construction, but the real `viz.ingest` is produced by
+  // `useVizSelection` which runs LATER (it reads `browserRunning`, which depends on the
+  // runner). The ref breaks that cycle: the runner is handed this stable forwarder now,
+  // and `vizIngestRef.current` is pointed at `viz.ingest` in render scope once it exists.
   const vizIngestRef = useRef<(event: VizEvent) => void>(() => {});
   const handleVizEvent = useCallback((event: VizEvent) => {
     vizIngestRef.current?.(event);
@@ -331,6 +383,9 @@ export function StudioShell(props: StudioShellProps) {
   // `useVizSelection` (their sole writer).
   const setSelectedStepId = useViewStore((s) => s.setSelectedStepId);
 
+  // Static recipe dropdown options (`[]` deps — the catalog is build-time constant).
+  // A trivial host-render projection: too small to warrant a hook, and the recipe panel
+  // needs it synchronously.
   const recipeOptions = useMemo(
     () => STUDIO_RECIPE_OPTIONS.map((opt) => ({ value: opt.id, label: opt.label })),
     []
@@ -400,6 +455,13 @@ export function StudioShell(props: StudioShellProps) {
 
   const status: GenerationStatus = browserRunning ? "running" : error ? "error" : "ready";
 
+  // Cycle break + SECURITY-ADJACENT (§7.6). Decides whether Run in Game writes the
+  // config to a DURABLE on-disk map script or a DISPOSABLE one. "durable" requires a
+  // built-in preset WITH a source path AND the current config still matching either the
+  // resolved preset config or the last save/deploy config — i.e. the bytes about to run
+  // are exactly the bytes already on disk. Derived synchronously here, never from an
+  // effect: an effect could lag a render and let an edited config inherit a stale
+  // "durable" verdict, deploying unintended bytes. Threaded INTO `useRunInGame`.
   const runInGameMaterializationMode = useMemo<"durable" | "disposable">(() => {
     const parsed = parsePresetKey(recipeSettings.preset);
     const resolved = resolvePreset(recipeSettings.preset as PresetKey);
@@ -462,6 +524,11 @@ export function StudioShell(props: StudioShellProps) {
     toast,
   });
 
+  // Cycle break (§7.6): how the LIVE Civ7 game relates to the current Studio authoring
+  // state — drives the GameConsole "current / stale / sync" affordance. Spans
+  // `useLiveRuntime` (status/seed) AND `provedRunInGameSource`, so it must sit after
+  // run-in-game inits but stay host-side to bridge both. Seed mismatch short-circuits to
+  // "stale"/"unknown" before the fuller field-by-field `liveSourceMatchesStudio` compare.
   const liveGameStudioRelation = useMemo<"current" | "stale" | "unknown">(() => {
     if (liveRuntime.status !== "ok") return "unknown";
     if (liveRuntime.seed !== undefined && String(liveRuntime.seed) !== recipeSettings.seed)
@@ -492,6 +559,10 @@ export function StudioShell(props: StudioShellProps) {
     worldSettings,
   ]);
 
+  // Cycle break (§7.6): does the current authoring state still match the proved live
+  // source, field for field? Feeds `displayedPresetOptions` (whether "None" is relabeled
+  // "Live / Live Game"). Distinct from `liveGameStudioRelation`: this ignores the live
+  // runtime's seed/status and asks only about the proved-source identity.
   const studioMatchesProvedLiveSource = useMemo(() => {
     if (!provedRunInGameSource) return false;
     return liveSourceMatchesStudio({
@@ -503,6 +574,11 @@ export function StudioShell(props: StudioShellProps) {
     });
   }, [pipelineConfig, provedRunInGameSource, recipeSettings, setupConfig, worldSettings]);
 
+  // Cycle break (§7.6): the preset dropdown options actually rendered. When the current
+  // authoring state IS the proved disposable live source, the standalone "Live Game" row
+  // is dropped and "None" is relabeled "Live / Live Game" — so the user sees one
+  // truthful entry instead of a duplicate. Derived host-side because it composes the
+  // preset hook's `presetOptions` with the host-only `studioMatchesProvedLiveSource`.
   const displayedPresetOptions = useMemo(() => {
     const relabelNoneAsLive =
       studioMatchesProvedLiveSource && provedRunInGameSource?.materializationMode === "disposable";
@@ -545,10 +621,23 @@ export function StudioShell(props: StudioShellProps) {
     toast,
   });
 
+  // Seam #2: the shared run-in-game toast-dedupe stamp. Both the adoption effect below
+  // and `useStudioEvents` call this to mark a requestId as already-toasted, so whichever
+  // observes a terminal run-in-game status first suppresses the other's toast (see
+  // `useRunInGameTerminalToast`). Stable identity (`[]`) so it can be threaded into the
+  // adoption effect's deps without re-triggering it.
   const markRunInGameToastHandled = useCallback((requestId: string) => {
     lastRunInGameToastRef.current = requestId;
   }, []);
 
+  // The SINGLE mount-time operation-adoption effect (§5). On load, reconcile the shell
+  // against `studio.operations.current` so a run-in-game / save-deploy that completed
+  // (or is still running) on the daemon while the tab was closed is re-attached: it
+  // restores both op states and stamps the toast guard so an already-finished operation
+  // is not re-toasted. Reads the live op state via the `*Ref` mirrors (not deps) so it
+  // runs ONCE; `markRunInGameToastHandled` is its only reactive dep (and is `[]`-stable).
+  // This is the live-stream's static counterpart — `useStudioEvents` keeps it current
+  // afterward. Initialized after save/live/run hooks so their setters exist here.
   useEffect(() => {
     let cancelled = false;
     void readAndAdoptStudioOperationsCurrent({
@@ -624,6 +713,9 @@ export function StudioShell(props: StudioShellProps) {
     },
   });
 
+  // Host-render derivation (§7.6): composes the view-store `showGrid` toggle with the
+  // by-value `viz` read-projection, so it lives where both are in scope rather than in a
+  // hook owning only one. Fed straight to `CanvasStage`.
   const backgroundGridEnabled = useMemo(() => {
     if (!showGrid) return false;
     // The graticule is CANVAS substrate, not layer furniture: once a manifest

--- a/apps/mapgen-studio/src/app/hooks/useRunInGameTerminalToast.ts
+++ b/apps/mapgen-studio/src/app/hooks/useRunInGameTerminalToast.ts
@@ -3,6 +3,21 @@ import { type MutableRefObject, useEffect } from "react";
 import { isRunInGameTerminalPhase } from "../../features/runInGame/status";
 import type { ToastFn } from "./useToast";
 
+/**
+ * `useRunInGameTerminalToast` — fires the single success/failure toast when a
+ * run-in-game operation reaches a terminal phase.
+ *
+ * The same operation can be observed terminal from MULTIPLE sources — the
+ * studio-events push, the mount-time `operations.current` adoption, and the
+ * run-in-game handler's own completion — so the toast must be idempotent. The
+ * `lastRunInGameToastRef` (keyed by `requestId`) is the shared dedupe guard: it is
+ * stamped here AND by the adoption/event paths via `markRunInGameToastHandled`, so
+ * whichever observes the terminal status first wins and the others no-op. Without it,
+ * adopting an already-finished operation on reload would re-toast a stale result.
+ *
+ * This hook only emits the notification; the operation state itself is owned by
+ * `useStudioOperations` / `useRunInGame`.
+ */
 export function useRunInGameTerminalToast(args: {
   runInGameOperation: RunInGameOperationStatus | null;
   lastRunInGameToastRef: MutableRefObject<string | null>;

--- a/apps/mapgen-studio/src/app/hooks/useSetupDataQueries.ts
+++ b/apps/mapgen-studio/src/app/hooks/useSetupDataQueries.ts
@@ -29,6 +29,13 @@ import { orpc } from "../../lib/orpc";
  * oRPC extraction wrapper.
  */
 
+/**
+ * Reduced view of the saved-configs query consumed by `setupControlOptions` /
+ * `useSetupControls`. Mirrors the legacy `useState`-backed shape exactly so the
+ * shell's drift-detection and option building are unchanged: `status` is `"idle"`
+ * until the first settle, `error` carries only the message, and `updatedAt` falls
+ * back to "now" so a settled-but-bodyless response still timestamps.
+ */
 export type SavedSetupConfigsView = {
   status: "idle" | "ok" | "error";
   directory?: string;
@@ -37,6 +44,12 @@ export type SavedSetupConfigsView = {
   error?: string;
 };
 
+/**
+ * Reduced view of the setup-catalog query (civilizations/leaders/etc. the setup
+ * controls offer). Same `idle`/`ok`/`error` + message-only contract as
+ * {@link SavedSetupConfigsView}; consumed by `useSetupControls` to populate the
+ * setup dropdowns.
+ */
 export type SetupCatalogView = {
   status: "idle" | "ok" | "error";
   catalog?: Civ7SetupCatalog;

--- a/apps/mapgen-studio/src/app/hooks/useStudioEvents.ts
+++ b/apps/mapgen-studio/src/app/hooks/useStudioEvents.ts
@@ -21,8 +21,21 @@ import {
   studioEventClearsStreamError,
 } from "../studioEventRecovery";
 
+/**
+ * The daemon event stream is a long-lived live query that must never give up:
+ * losing it silently means the shell stops adopting daemon-side operation/live-game
+ * changes. Infinite retry keeps it reconnecting across daemon restarts; the visible
+ * failure is surfaced as a recoverable banner (see `formatStudioEventStreamError`),
+ * not by tearing the subscription down. Exported so the retry contract is asserted
+ * directly in tests.
+ */
 export const STUDIO_EVENT_STREAM_RETRY_ATTEMPTS = Number.POSITIVE_INFINITY;
 
+/**
+ * The oRPC client context carrying the infinite-retry policy for the watch call.
+ * Split out from `studioEventsWatchLiveOptions` so the policy is independently
+ * inspectable in tests without standing up a live-query subscription.
+ */
 export function studioEventsWatchClientContext() {
   return {
     retry: STUDIO_EVENT_STREAM_RETRY_ATTEMPTS,
@@ -31,10 +44,23 @@ export function studioEventsWatchClientContext() {
 
 type StudioEventsWatchProcedure = Pick<typeof orpc.studio.events.watch, "experimental_liveOptions">;
 
+/**
+ * The live-query options consumed by the `useQuery` below — the real production
+ * call, bound to the shared `orpc.studio.events.watch` procedure.
+ */
 export function studioEventsWatchLiveOptions() {
   return studioEventsWatchLiveOptionsFor(orpc.studio.events.watch);
 }
 
+/**
+ * Builds the watch live-query options against an INJECTED watch procedure. The
+ * `watch`-as-parameter indirection exists purely so tests can pass a fake procedure
+ * and assert the exact options shape. The options pin the stream to be persistent:
+ * `retry: false` here defers reconnection to the client-context infinite retry (above),
+ * `refetchOnWindowFocus: false` + `staleTime: ∞` stop the cache machinery from
+ * re-subscribing on focus/staleness, and `gcTime: 0` drops the snapshot the instant
+ * the stream unmounts so a stale event can't replay on remount.
+ */
 export function studioEventsWatchLiveOptionsFor(watch: StudioEventsWatchProcedure) {
   return watch.experimental_liveOptions({
     input: {},
@@ -46,6 +72,28 @@ export function studioEventsWatchLiveOptionsFor(watch: StudioEventsWatchProcedur
   });
 }
 
+/**
+ * `useStudioEvents` — subscribes the shell to the daemon's single event stream and
+ * fans each event into the host's operation/live-game/error state. This is the live
+ * counterpart to the one-shot adoption effect in `StudioShell` (which reconciles
+ * `studio.operations.current` on mount): here the daemon PUSHES changes and the host
+ * stays in lockstep without polling.
+ *
+ * Event kinds are dispatched by a stable per-event key (`helloKey`/`operationKey`/
+ * `liveGameKey`) so each effect re-runs only when its own event actually changes:
+ * - `hello`: a daemon (re)start. Re-adopt `operations.current`, but ONLY if the
+ *   running daemon's identity matches the hello — a mismatch means the snapshot
+ *   belongs to a different daemon instance, surfaced as a recoverable banner.
+ * - `operation`: a run-in-game / save-deploy status push, applied to the op setters.
+ * - `live-game`: a live Civ7 runtime snapshot, applied via `applyLiveGameState`.
+ *
+ * The stream's own transport failure is mirrored into the shell error channel
+ * (`setLocalError`) and cleared the moment any well-formed event arrives, so a
+ * dropped daemon connection shows a banner that self-heals on reconnect rather than
+ * a dead stream. The `current*OperationRef` mirrors let the adoption path read the
+ * latest op state without making the hello effect depend on (and re-run for) every
+ * status change.
+ */
 export function useStudioEvents(
   args: StudioOperationAdoptionTargets & {
     applyLiveGameState(state: LiveRuntimeStatusState): void;
@@ -85,6 +133,9 @@ export function useStudioEvents(
       ? `${event.state.snapshotId ?? event.state.snapshotHash ?? event.state.status}:${event.observedAt}`
       : null;
 
+  // Stream-recovery error tracking. The ref remembers the message this hook
+  // raised so it can clear EXACTLY that message later (via `clearLocalError`) and
+  // not stomp an unrelated error some other writer put on the shared channel.
   const setEventRecoveryError = useCallback(
     (message: string) => {
       eventRecoveryErrorRef.current = message;

--- a/apps/mapgen-studio/src/app/hooks/useToast.ts
+++ b/apps/mapgen-studio/src/app/hooks/useToast.ts
@@ -2,8 +2,14 @@ import { useCallback } from "react";
 
 import { toast as sonnerToast } from "../../components/ui";
 
+/** The variant set the adapter maps to sonner methods (`success`/`error`/`info`). */
 export type ToastVariant = "default" | "success" | "error" | "info";
 
+/**
+ * The single toast contract every container/hook depends on. Threaded IN to the
+ * domain hooks (rather than re-importing sonner) so notification behavior has one
+ * owner and the call sites stay decoupled from the toast backend.
+ */
 export type ToastFn = (
   message: string,
   options?: { variant?: ToastVariant; duration?: number }


### PR DESCRIPTION
Adds inline documentation throughout `StudioShell` and several supporting hooks to explain the architectural decisions that are otherwise invisible from the code alone.

The `StudioShell` JSX doc block gains a "Role After Decomposition" section describing what the host retains after domain logic moved into controller hooks, a "Hook Init Order Is Load-Bearing" section enumerating the fixed call sequence and the reason each hook must precede the next, and a "Cycle-Break Derivations Stay Here" section listing the memos that must live at host render scope rather than inside a hook.

Each of those memos (`provedRunInGameSource`, `livePresets`, `runInGameMaterializationMode`, `liveGameStudioRelation`, `studioMatchesProvedLiveSource`, `displayedPresetOptions`, `backgroundGridEnabled`, `recipeOptions`) receives a co-located comment explaining why it cannot move into a hook without creating an init cycle or an unsafe effect lag — with the security rationale for `runInGameMaterializationMode` called out explicitly.

The two cross-hook seams (`vizIngestRef` forwarding `viz.ingest` before `useVizSelection` exists, and `markRunInGameToastHandled` shared between the adoption effect and `useStudioEvents`) are documented at their declaration sites.

`useRunInGameTerminalToast`, `useStudioEvents`, `studioEventsWatchClientContext`, `studioEventsWatchLiveOptionsFor`, and the two `SavedSetupConfigsView`/`SetupCatalogView` types in `useSetupDataQueries` each receive a JSX doc block covering their contract, the deduplication/idempotency invariants, and the retry/cache policy that keeps the daemon event stream alive across restarts. `ToastFn` and `ToastVariant` in `useToast` get brief doc comments explaining the single-owner threading pattern.