### PR TITLE
chore(mapgen-studio): add eslint-disable comments for sanctioned render-phase ref writes + route ops through `useLatestRef`

### DIFF
--- a/apps/mapgen-studio/src/app/StudioShell.tsx
+++ b/apps/mapgen-studio/src/app/StudioShell.tsx
@@ -362,6 +362,7 @@ export function StudioShell(props: StudioShellProps) {
     browserRunning,
     setLocalError,
   });
+  // eslint-disable-next-line react-hooks/refs -- Host-owned event sink: `vizIngestRef` is declared with a no-op default (line ~304) and consumed by the `onVizEvent` callback created in render scope ABOVE this point, so it cannot route through `useLatestRef` (the consumer precedes `viz`). Wiring it to `viz.ingest` here is the deliberate "create sink early, point it at viz once viz exists" pattern; the write is idempotent and does not affect this render's output.
   vizIngestRef.current = viz.ingest;
   // Deck-camera auto-fit (slice 2.7b): the ordered per-space + first-paint refit
   // pair and their guard refs, consuming the viz read-projection BY VALUE and the

--- a/apps/mapgen-studio/src/app/hooks/useLatestRef.ts
+++ b/apps/mapgen-studio/src/app/hooks/useLatestRef.ts
@@ -20,6 +20,7 @@ import { type RefObject, useRef } from "react";
  */
 export function useLatestRef<T>(value: T): RefObject<T> {
   const ref = useRef(value);
+  // eslint-disable-next-line react-hooks/refs -- This render-phase ref write IS the hook's purpose: the write is idempotent, derives only from the current value, and affects nothing this render returns. React's own docs sanction caching the latest value this way (see the doc comment above). This is the single sanctioned site; all other "latest ref" mirrors route through here.
   ref.current = value;
   return ref;
 }

--- a/apps/mapgen-studio/src/app/hooks/useStudioEvents.ts
+++ b/apps/mapgen-studio/src/app/hooks/useStudioEvents.ts
@@ -20,6 +20,7 @@ import {
   identityFromStudioOperationsCurrent,
   studioEventClearsStreamError,
 } from "../studioEventRecovery";
+import { useLatestRef } from "./useLatestRef";
 
 /**
  * The daemon event stream is a long-lived live query that must never give up:
@@ -114,10 +115,13 @@ export function useStudioEvents(
     clearLocalError,
   } = args;
   const eventRecoveryErrorRef = useRef<string | null>(null);
-  const currentRunInGameOperationRef = useRef<RunInGameOperationStatus | null>(null);
-  const currentSaveDeployOperationRef = useRef<MapConfigSaveDeployStatus | null>(null);
-  currentRunInGameOperationRef.current = currentRunInGameOperation ?? null;
-  currentSaveDeployOperationRef.current = currentSaveDeployOperation ?? null;
+  // Mirror the latest operation status into refs so the long-lived getter
+  // closures below (`getCurrentRunInGameOperation` / `getCurrentSaveDeployOperation`)
+  // read fresh values without being recreated each change. `useLatestRef` owns the
+  // sanctioned render-phase ref write, so these sites no longer write `.current`
+  // during render directly (react-hooks/refs).
+  const currentRunInGameOperationRef = useLatestRef(currentRunInGameOperation ?? null);
+  const currentSaveDeployOperationRef = useLatestRef(currentSaveDeployOperation ?? null);
   const eventQuery = useQuery(studioEventsWatchLiveOptions());
   const event = eventQuery.data as StudioEvent | undefined;
   const helloKey =


### PR DESCRIPTION
Introduces a `react-hooks/refs` ESLint rule and brings existing render-phase ref writes into compliance with it.

`useLatestRef` is the single sanctioned location for writing a ref during render — its inline `eslint-disable` comment explains why that specific write is intentional and safe (idempotent, derives only from the current value, does not affect render output). All other "mirror the latest value into a ref" patterns in `useStudioEvents` are migrated to route through `useLatestRef` instead of writing `.current` directly during render.

The `vizIngestRef` assignment in `StudioShell` is a deliberate exception: because the `onVizEvent` callback that consumes the ref is created earlier in the same render scope than `viz` itself exists, it cannot be routed through `useLatestRef`. The disable comment documents the "create sink early, point it at viz once viz exists" pattern and why it is safe (idempotent, no effect on render output).