### PR TITLE
refactor(mapgen-studio): replace `useEffect` state-syncs with render-time store-prev-value pattern

### DIFF
--- a/apps/mapgen-studio/src/features/presets/PresetDialogs.tsx
+++ b/apps/mapgen-studio/src/features/presets/PresetDialogs.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   Button,
   Dialog,
@@ -65,12 +65,24 @@ export function PresetSaveDialog(props: PresetSaveDialogProps) {
   const [label, setLabel] = useState(initialLabel ?? "");
   const [description, setDescription] = useState(initialDescription ?? "");
 
-  useEffect(() => {
+  // Re-sync the inputs to the incoming initials whenever the dialog opens or its
+  // initials change while open — done during render via the store-prev-value
+  // pattern instead of in an effect (react-hooks/set-state-in-effect). Parity:
+  // fires on the same dep transitions as the prior effect; mount is a no-op
+  // because the useState initializers above already seed label/description from
+  // the initials.
+  const [prevInitials, setPrevInitials] = useState({ open, initialLabel, initialDescription });
+  if (
+    prevInitials.open !== open ||
+    prevInitials.initialLabel !== initialLabel ||
+    prevInitials.initialDescription !== initialDescription
+  ) {
+    setPrevInitials({ open, initialLabel, initialDescription });
     if (open) {
       setLabel(initialLabel ?? "");
       setDescription(initialDescription ?? "");
     }
-  }, [open, initialLabel, initialDescription]);
+  }
 
   const canSave = label.trim().length > 0;
 

--- a/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
+++ b/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
@@ -219,14 +219,22 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
     }
   }, [dataTypeOptions, selectedDataType, onSelectedDataTypeChange]);
 
-  useEffect(() => {
-    if (!currentLayerGroup) return;
-    setGroupOpen((prev) => {
-      const current = prev[currentLayerGroup] ?? true;
-      if (current) return prev;
-      return { ...prev, [currentLayerGroup]: true };
-    });
-  }, [currentLayerGroup]);
+  // Auto-open the current layer's group when it changes — done during render via
+  // the store-prev-value pattern instead of in an effect
+  // (react-hooks/set-state-in-effect). Parity: fires on the same currentLayerGroup
+  // transition as the prior effect; mount is a no-op (groupOpen starts empty, so
+  // `?? true` treats every group as already open).
+  const [prevLayerGroup, setPrevLayerGroup] = useState(currentLayerGroup);
+  if (currentLayerGroup !== prevLayerGroup) {
+    setPrevLayerGroup(currentLayerGroup);
+    if (currentLayerGroup) {
+      setGroupOpen((prev) => {
+        const current = prev[currentLayerGroup] ?? true;
+        if (current) return prev;
+        return { ...prev, [currentLayerGroup]: true };
+      });
+    }
+  }
   // ==========================================================================
   // Handlers
   // ==========================================================================

--- a/apps/mapgen-studio/src/ui/components/RecipePanel.tsx
+++ b/apps/mapgen-studio/src/ui/components/RecipePanel.tsx
@@ -8,7 +8,7 @@
 
 import type { MapConfigSaveDeployStatus } from "@civ7/studio-server";
 import { BookOpen, Braces, Eraser, Focus, ListCollapse, Save, Settings } from "lucide-react";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import {
   Button,
   Dialog,
@@ -156,9 +156,16 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
       ? "Save unavailable while another operation is running"
       : "Save & Deploy Config";
 
-  useEffect(() => {
+  // Close the save menu the instant the action transitions to disabled. Done
+  // during render via the store-prev-value pattern rather than in an effect
+  // (react-hooks/set-state-in-effect). Parity with the prior effect: it fires
+  // only on the disabled transition; mount is a no-op (the menu starts closed)
+  // and the menu stays closed across a later re-enable, exactly as before.
+  const [prevSaveActionDisabled, setPrevSaveActionDisabled] = useState(saveActionDisabled);
+  if (saveActionDisabled !== prevSaveActionDisabled) {
+    setPrevSaveActionDisabled(saveActionDisabled);
     if (saveActionDisabled) setShowSaveMenu(false);
-  }, [saveActionDisabled]);
+  }
   // ==========================================================================
   // Derived State
   // ==========================================================================


### PR DESCRIPTION
Replaces `useEffect`-based state synchronization with the React-recommended "store previous value" render-time pattern in three components (`PresetSaveDialog`, `ExplorePanel`, and `RecipePanel`).

Each affected `useEffect` was only used to derive or reset local state in response to prop/value changes — a pattern that React discourages in favor of comparing against a stored previous value during render. The refactored code:

- Stores the previous value of the relevant dependency alongside a `setPrev*` setter
- Performs the state update inline during render when a change is detected, avoiding the extra render cycle introduced by effects
- Preserves identical behavior: mount is a no-op in all three cases since initial state is already seeded correctly, and transitions fire on the same conditions as before