### PR TITLE
chore(mapgen-studio): add eslint-disable comments for legitimate `set-state-in-effect` suppressions

### DIFF
--- a/apps/mapgen-studio/src/app/hooks/usePresetLifecycle.ts
+++ b/apps/mapgen-studio/src/app/hooks/usePresetLifecycle.ts
@@ -194,6 +194,7 @@ export function usePresetLifecycle(args: UsePresetLifecycleArgs): UsePresetLifec
     const resolved = resolvePreset(nextKey);
     if (!resolved) {
       toast("Preset not found", { variant: "error" });
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- This effect applies the selected preset: it resolves the preset, validates it, surfaces toasts, and on failure records the error. The interleaved side effects (toast, resolvePreset, applyPresetConfig) make it genuinely effect-shaped, not render-derivable.
       setPresetError({
         title: "Preset not found",
         message: "The selected preset could not be resolved for this recipe.",

--- a/apps/mapgen-studio/src/components/ui/sonner.tsx
+++ b/apps/mapgen-studio/src/components/ui/sonner.tsx
@@ -25,6 +25,7 @@ const useThemeFromClass = (): "light" | "dark" => {
     const root = document.documentElement;
     const observer = new MutationObserver(() => setTheme(getTheme()));
     observer.observe(root, { attributes: true, attributeFilter: ["class"] });
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Vendor-ish theme primitive (shadcn sonner wrapper). This setState seeds the initial theme right after subscribing the MutationObserver — the read-initial-value half of an external-store subscription. Suppressed rather than rewritten per the vendor-component policy. Follow-up: replace effect+state with `useSyncExternalStore` (subscribe = observe the `.dark` class mutation; getSnapshot = read the class), which removes the effect and the setState entirely.
     setTheme(getTheme());
     return () => observer.disconnect();
   }, [getTheme]);

--- a/apps/mapgen-studio/src/features/browserRunner/useBrowserRunner.ts
+++ b/apps/mapgen-studio/src/features/browserRunner/useBrowserRunner.ts
@@ -188,6 +188,7 @@ export function useBrowserRunner(args: UseBrowserRunnerArgs): UseBrowserRunnerRe
   );
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- This effect synchronizes an external resource: when the runner is disabled it aborts any in-flight worker generation via `cancel()`. The setState inside `cancel` is incidental to that teardown and has no render-derivable equivalent, so this is a legitimate effect.
     if (!enabled) cancel();
   }, [enabled, cancel]);
 

--- a/apps/mapgen-studio/src/features/viz/useVizState.ts
+++ b/apps/mapgen-studio/src/features/viz/useVizState.ts
@@ -284,6 +284,7 @@ export function useVizState(args: UseVizStateArgs): UseVizStateResult {
     renderAbortRef.current = controller;
 
     if (!manifest || !effectiveLayer) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- This effect orchestrates async render work (AbortController + renderDeckLayers). The synchronous setState here clears stale layers when there is no manifest/layer to render; clearing as part of an external-render-sync effect is legitimate and cannot be derived during render (the work is async).
       setResolvedLayers((prev) => (prev.length ? [] : prev));
       setLayerStats((prev) => (prev ? null : prev));
       return;


### PR DESCRIPTION
This PR adds targeted `eslint-disable-next-line react-hooks/set-state-in-effect` suppressions for four `setState` calls inside `useEffect` hooks that are genuinely effect-shaped and cannot be refactored into render-derivable logic.

Each suppression includes an inline explanation of why the pattern is legitimate in that specific context:

- **`usePresetLifecycle`** – The effect applies a selected preset, interleaving side effects (toast, `resolvePreset`, `applyPresetConfig`). The `setPresetError` on failure is part of that orchestration, not a derived value.
- **`sonner.tsx`** – The `setTheme` call seeds the initial theme value immediately after subscribing a `MutationObserver`, following the read-initial-value half of an external-store subscription pattern. A follow-up is noted to replace this with `useSyncExternalStore`.
- **`useBrowserRunner`** – The effect cancels an in-flight worker when the runner is disabled. The `setState` inside `cancel` is incidental to that external-resource teardown.
- **`useVizState`** – The effect orchestrates async render work via `AbortController`. The synchronous `setState` clears stale layers when no manifest or layer is present, which cannot be derived at render time due to the async nature of the work.