### PR TITLE
chore(mapgen-studio): migrate exhaustive-deps suppression from eslint to biome-ignore + update source guard test

### DIFF
--- a/apps/mapgen-studio/src/app/hooks/useVizSelection.ts
+++ b/apps/mapgen-studio/src/app/hooks/useVizSelection.ts
@@ -182,12 +182,12 @@ export function useVizSelection({
     setSelectedStepId((prev) => (steps.some((s) => s.value === prev) ? prev : steps[0]!.value));
   }, [steps]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional one-directional resync (external selectedStepId -> viz). Depending on viz.selectedStepId would re-run the effect on viz changes and defeat the equality guard below.
   useEffect(() => {
     if (!selectedStepId) return;
     if (viz.selectedStepId === selectedStepId) return;
     viz.setSelectedStepId(selectedStepId);
     viz.setSelectedLayerKey(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedStepId]);
 
   const dataTypeOptions: DataTypeOption[] = useMemo(() => {
@@ -204,6 +204,7 @@ export function useVizSelection({
     [viz.manifest]
   );
 
+  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- The React Compiler is not wired into this app's build (no babel-plugin-react-compiler), so this is advisory only. The manual memo is intentional and correct; this documents the bail until/unless the compiler is adopted (checkback: biomejs/biome#10710).
   const selection = useMemo(() => {
     if (!dataTypeModel) return null;
     for (const dt of dataTypeModel.dataTypes) {

--- a/apps/mapgen-studio/test/controllers/useVizSelection.source.test.ts
+++ b/apps/mapgen-studio/test/controllers/useVizSelection.source.test.ts
@@ -36,9 +36,14 @@ describe("useVizSelection source — render-phase + atomic ordering invariants",
     // The dedupe guard reads viz.selectedStepId but it is excluded from the deps.
     expect(hook).toMatch(/if \(viz\.selectedStepId === selectedStepId\) return;/);
     // The suppression is intentional and load-bearing (RAW source — it IS a comment).
+    // Biome now owns exhaustive-deps (correctness.useExhaustiveDependencies), so the
+    // suppression is a biome-ignore directly above the effect rather than a (Biome-inert)
+    // eslint-disable before the deps array.
     expect(hookSource).toMatch(
-      /eslint-disable-next-line react-hooks\/exhaustive-deps\n\s*\}, \[selectedStepId\]\);/
+      /biome-ignore lint\/correctness\/useExhaustiveDependencies:[^\n]*\n\s*useEffect\(\(\) => \{/
     );
+    // …and the deps array stays pinned to [selectedStepId] (adding viz would loop).
+    expect(hookSource).toMatch(/viz\.setSelectedLayerKey\(null\);\n\s*\}, \[selectedStepId\]\);/);
   });
 
   it("EO-1: era/overlay atomic group keeps source order (manualEra-clamp → overlay-prune → overlay-variant-pref)", () => {


### PR DESCRIPTION
Migrates the intentional exhaustive-deps suppression on the `useEffect` in `useVizSelection` from an ESLint disable comment to a `biome-ignore` comment, since Biome now owns the `correctness/useExhaustiveDependencies` rule for this codebase. The suppression is load-bearing: the effect intentionally omits `viz.selectedStepId` from its dependency array to avoid a feedback loop where viz changes would re-trigger the effect and defeat the equality guard.

Also adds a `eslint-disable react-hooks/preserve-manual-memoization` comment on the `selection` memo to document that the React Compiler is not wired into this app's build, making the manual memoization intentional and correct until the compiler is adopted.

Updates the source-level test assertions to reflect the new comment format, verifying that the `biome-ignore` appears directly above the `useEffect` call and that the deps array remains pinned to `[selectedStepId]`.