### PR TITLE
refactor(mapgen-studio): replace effect+setState with `useSyncExternalStore` for sonner theme + tests

### DIFF
--- a/apps/mapgen-studio/src/components/ui/sonner.tsx
+++ b/apps/mapgen-studio/src/components/ui/sonner.tsx
@@ -9,29 +9,48 @@ import { Toaster as Sonner, type ToasterProps } from "sonner";
  * Toasts are a floating layer, so they carry a shadow and ride the `popover`
  * tier; styling is token-driven via CSS variables.
  */
-const useThemeFromClass = (): "light" | "dark" => {
-  const getTheme = React.useCallback(
-    (): "light" | "dark" =>
-      typeof document !== "undefined" && document.documentElement.classList.contains("dark")
-        ? "dark"
-        : "light",
-    []
+
+/** Theme is an EXTERNAL store (the `<html>` class), not React state. */
+type ThemeMode = "light" | "dark";
+
+/**
+ * Subscribe to `<html>` class mutations. Module-scoped so its identity is stable
+ * across renders (a changing `subscribe` would make `useSyncExternalStore`
+ * re-subscribe every render). Returns the unsubscribe cleanup.
+ */
+function subscribeToThemeClass(onStoreChange: () => void): () => void {
+  if (typeof document === "undefined") return () => {};
+  const observer = new MutationObserver(onStoreChange);
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+  return () => observer.disconnect();
+}
+
+/** Read the current theme off the `<html>` class. Returns a primitive, so it is
+ * referentially stable when unchanged — no `useSyncExternalStore` tearing/loop. */
+function getThemeSnapshot(): ThemeMode {
+  return typeof document !== "undefined" && document.documentElement.classList.contains("dark")
+    ? "dark"
+    : "light";
+}
+
+/** SSR / non-DOM snapshot: the app's default surface is light. */
+function getThemeServerSnapshot(): ThemeMode {
+  return "light";
+}
+
+/**
+ * `useThemeFromClass` — the toast theme, sourced from the DOM class via
+ * `useSyncExternalStore`. This is the correct primitive for reading an external
+ * mutable source: no effect, no setState-in-render, no stale first paint. The
+ * store re-themes toasts the instant the chrome's `.dark` class flips.
+ */
+function useThemeFromClass(): ThemeMode {
+  return React.useSyncExternalStore(
+    subscribeToThemeClass,
+    getThemeSnapshot,
+    getThemeServerSnapshot
   );
-
-  const [theme, setTheme] = React.useState<"light" | "dark">(getTheme);
-
-  React.useEffect(() => {
-    if (typeof document === "undefined") return;
-    const root = document.documentElement;
-    const observer = new MutationObserver(() => setTheme(getTheme()));
-    observer.observe(root, { attributes: true, attributeFilter: ["class"] });
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- Vendor-ish theme primitive (shadcn sonner wrapper). This setState seeds the initial theme right after subscribing the MutationObserver — the read-initial-value half of an external-store subscription. Suppressed rather than rewritten per the vendor-component policy. Follow-up: replace effect+state with `useSyncExternalStore` (subscribe = observe the `.dark` class mutation; getSnapshot = read the class), which removes the effect and the setState entirely.
-    setTheme(getTheme());
-    return () => observer.disconnect();
-  }, [getTheme]);
-
-  return theme;
-};
+}
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const theme = useThemeFromClass();
@@ -61,4 +80,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
   );
 };
 
-export { Toaster };
+export { Toaster, useThemeFromClass };

--- a/apps/mapgen-studio/test/ui/sonnerTheme.test.tsx
+++ b/apps/mapgen-studio/test/ui/sonnerTheme.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useThemeFromClass } from "../../src/components/ui/sonner";
+
+// The toast theme is an EXTERNAL store: the `<html>` `.dark` class, read via
+// useSyncExternalStore (no effect, no setState-in-render). These pins guard the
+// store contract THROUGH the public hook — initial snapshot (both modes), live
+// re-theming, observer teardown on unmount, and the SSR default — so a regression
+// to a stale first paint, a missed update, or a leaked observer is caught.
+
+function ThemeProbe() {
+  return <span data-theme={useThemeFromClass()} />;
+}
+
+afterEach(() => {
+  cleanup();
+  document.documentElement.classList.remove("dark");
+});
+
+describe("sonner theme store (useSyncExternalStore via useThemeFromClass)", () => {
+  it("reads light when <html> has no .dark class", () => {
+    document.documentElement.classList.remove("dark");
+    const { result } = renderHook(() => useThemeFromClass());
+    expect(result.current).toBe("light");
+  });
+
+  it("reads dark when <html> already has .dark on mount", () => {
+    document.documentElement.classList.add("dark");
+    const { result } = renderHook(() => useThemeFromClass());
+    expect(result.current).toBe("dark");
+  });
+
+  it("tracks the live <html> class in both directions", async () => {
+    document.documentElement.classList.remove("dark");
+    const { result } = renderHook(() => useThemeFromClass());
+    expect(result.current).toBe("light");
+
+    document.documentElement.classList.add("dark");
+    await waitFor(() => expect(result.current).toBe("dark"));
+
+    document.documentElement.classList.remove("dark");
+    await waitFor(() => expect(result.current).toBe("light"));
+  });
+
+  it("disconnects the class observer on unmount (no leak)", () => {
+    const disconnectSpy = vi.spyOn(MutationObserver.prototype, "disconnect");
+    const { unmount } = renderHook(() => useThemeFromClass());
+    unmount();
+    expect(disconnectSpy).toHaveBeenCalled();
+    disconnectSpy.mockRestore();
+  });
+
+  it("uses the light server snapshot under SSR even when .dark is set", () => {
+    document.documentElement.classList.add("dark");
+    const html = renderToStaticMarkup(<ThemeProbe />);
+    expect(html).toContain('data-theme="light"');
+  });
+});


### PR DESCRIPTION
Replaces the `useEffect` + `setState` pattern in the Sonner toast wrapper with `useSyncExternalStore`, which is the correct React primitive for subscribing to an external mutable store (the `<html>` `.dark` class).

Previously, the hook used a `MutationObserver` inside a `useEffect` that called `setState` to sync the theme. This caused a stale first paint and triggered the `react-hooks/set-state-in-effect` lint rule. The new implementation lifts the observer subscription and snapshot functions to module scope, giving `useSyncExternalStore` stable references that avoid re-subscribing on every render. The SSR path now returns `"light"` via a dedicated server snapshot instead of relying on a `typeof document` guard inside state initialization.

`useThemeFromClass` is also exported so it can be tested directly. A new test suite pins the store contract through the public hook, covering:

- Initial snapshot in both light and dark modes
- Live re-theming in both directions via class mutation
- Observer teardown on unmount to prevent leaks
- SSR rendering defaulting to light regardless of the DOM state