### PR TITLE
feat(studio-server): name & surface the "map mod disabled" Run-in-Game failure

### DIFF
--- a/apps/mapgen-studio/src/ui/components/GameConsole.tsx
+++ b/apps/mapgen-studio/src/ui/components/GameConsole.tsx
@@ -509,14 +509,31 @@ export const GameConsole: React.FC<GameConsoleProps> = ({
                   >
                     {runInGameStatus.requestId}
                   </span>
-                  {runInGameStatus.error ? (
-                    <p className="text-label text-destructive">{runInGameStatus.error}</p>
-                  ) : null}
-                  {runInGameStatus.details?.recoveryHint ? (
-                    <p className={`text-label ${textMuted}`}>
-                      {runInGameStatus.details.recoveryHint}
-                    </p>
-                  ) : null}
+                  {runInGameStatus.details?.code === "map-mod-not-loaded" ? (
+                    // Known error: the map deployed fine but Civ isn't loading the
+                    // mod (a game update commonly auto-disables it). Surface it as a
+                    // named, actionable condition rather than a raw failure string.
+                    <div className="flex flex-col gap-1 rounded border border-warning/40 bg-warning/10 px-2 py-1.5">
+                      <span className="text-label font-medium text-warning">
+                        Map mod disabled in Civilization
+                      </span>
+                      <p className="text-label text-muted-foreground">
+                        {runInGameStatus.details.recoveryHint ??
+                          "Enable the Swooper Physics Maps mod in Civ’s Add-Ons menu, then retry Run in Game."}
+                      </p>
+                    </div>
+                  ) : (
+                    <>
+                      {runInGameStatus.error ? (
+                        <p className="text-label text-destructive">{runInGameStatus.error}</p>
+                      ) : null}
+                      {runInGameStatus.details?.recoveryHint ? (
+                        <p className={`text-label ${textMuted}`}>
+                          {runInGameStatus.details.recoveryHint}
+                        </p>
+                      ) : null}
+                    </>
+                  )}
                 </>
               ) : (
                 <span className={`text-data ${textMuted}`}>No run yet</span>

--- a/packages/studio-server/src/ports/Civ7WorkflowControl.ts
+++ b/packages/studio-server/src/ports/Civ7WorkflowControl.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_CIV7_TUNER_TIMEOUT_MS,
   ensureCiv7SetupMapRowVisible,
   getCiv7PlayableStatus,
+  getCiv7SetupMapRows,
   runCiv7SinglePlayerFromSetup,
   startCiv7Autoplay,
   stopCiv7Autoplay,
@@ -25,6 +26,7 @@ import {
   type StudioRuntimeFailure,
 } from "../errors/index.js";
 import { Civ7TunerSession } from "../services/Civ7TunerSession.js";
+import { classifyMapRowVisibilityFailure } from "./mapModVisibility.js";
 import type {
   RunInGameDeployment,
   RunInGamePreparedRequest,
@@ -153,21 +155,64 @@ export const Civ7WorkflowControlLive: Layer.Layer<Civ7WorkflowControl, never, Ci
             Effect.flatMap((rowVisibility) => {
               const rowProof = rowVisibility.final;
               if (rowProof.rows.length === 0) {
-                return Effect.fail(
-                  proofFailed({
-                    message: `Civ7 setup cannot see ${launchMapScript}`,
+                const reloadBoundary =
+                  args.prepared.request.materializationMode === "disposable"
+                    ? "process-restart-required"
+                    : "setup-row-missing";
+                // The map is materialized + deployed + registered (verified above)
+                // yet Civ7 setup cannot see it. Read the FULL setup map list to tell
+                // the two real causes apart: a disabled/unloaded map mod (NO sibling
+                // maps from the mod visible) vs. a freshly-deployed disposable row
+                // that has not been enumerated yet (siblings visible). This turns the
+                // opaque `setup-map-row-not-visible` into the actionable, named
+                // `map-mod-not-loaded` known error when the mod is disabled.
+                const failFromVisibleRows = (
+                  visibleMapRows: ReadonlyArray<{ readonly file: string }>
+                ) => {
+                  const classification = classifyMapRowVisibilityFailure({
+                    launchMapScript,
+                    visibleMapRows,
+                    materializationMode: args.prepared.request.materializationMode,
+                  });
+                  return proofFailed({
+                    message: classification.message,
                     reason: "setup-row-unavailable",
                     diagnostics: boundedDiagnostics({
-                      code: "setup-map-row-not-visible",
+                      code: classification.code,
+                      ...(classification.modNamespace
+                        ? { modNamespace: classification.modNamespace }
+                        : {}),
+                      siblingMapRowCount: classification.siblingMapRowCount,
+                      visibleMapRowCount: classification.visibleMapRowCount,
+                      recoveryHint: classification.recoveryHint,
                       reloadRequired: true,
-                      reloadBoundary:
-                        args.prepared.request.materializationMode === "disposable"
-                          ? "process-restart-required"
-                          : "setup-row-missing",
+                      reloadBoundary,
                       reloadAttempted: rowVisibility.refreshed,
                       mapScript: launchMapScript,
                       materialization,
                     }),
+                  });
+                };
+                return runTuner(
+                  (options) =>
+                    getCiv7SetupMapRows(
+                      {},
+                      { timeoutMs: DEFAULT_CIV7_TUNER_TIMEOUT_MS, ...options }
+                    ),
+                  (err) =>
+                    directControlUnavailable(
+                      "Civ7 setup map list is unavailable",
+                      "direct-control-setup-rows-unavailable",
+                      err,
+                      { materialization }
+                    )
+                ).pipe(
+                  Effect.matchEffect({
+                    // If the full-list read fails we do NOT guess "mod disabled":
+                    // classify from the (empty) rows we already have, which the
+                    // false-positive guard reports as `setup-map-row-not-visible`.
+                    onFailure: () => Effect.fail(failFromVisibleRows(rowProof.rows)),
+                    onSuccess: (allRows) => Effect.fail(failFromVisibleRows(allRows.rows)),
                   })
                 );
               }

--- a/packages/studio-server/src/ports/mapModVisibility.ts
+++ b/packages/studio-server/src/ports/mapModVisibility.ts
@@ -1,0 +1,106 @@
+/**
+ * Run-in-Game "map row not visible in Civ7 setup" classifier.
+ *
+ * Forensic basis (proven live 2026-06-29): a Run-in-Game request can materialize,
+ * build, deploy (verified sha) AND register (inject the `<Maps>` row) the map
+ * script — `studio.operations.current` shows every artifact present — and STILL
+ * fail because Civ7's setup map list does not contain the map row. There are two
+ * distinct real causes, and they need different messages (and, for the operator,
+ * different actions):
+ *
+ *   1. THE MAP MOD ITSELF IS NOT LOADED — most commonly a Civ update auto-disabled
+ *      it. Signature: Civ7 setup shows maps (base-game maps are present) but NONE
+ *      of the target mod's maps are visible. For a disposable run the daemon has
+ *      already exit-to-shell restarted Civ and the mod's maps still did not appear,
+ *      so the mod is disabled / failed to load — a further restart will not help.
+ *      => `map-mod-not-loaded`. Action: re-enable the mod in Civ, then retry.
+ *
+ *   2. THE MOD IS LOADED but this one freshly-deployed (disposable) map row has not
+ *      been enumerated yet. Signature: sibling maps from the SAME mod ARE visible;
+ *      only the target is missing.
+ *      => `setup-map-row-not-visible`. Action: restart Civ / retry to re-scan.
+ *
+ * This is pure and deterministic so the identification path is unit-tested directly
+ * against both forensic scenarios — no live engine required.
+ */
+
+export type MapRowVisibilityFailureCode = "map-mod-not-loaded" | "setup-map-row-not-visible";
+
+export type MapRowVisibilityClassification = Readonly<{
+  code: MapRowVisibilityFailureCode;
+  message: string;
+  recoveryHint: string;
+  /** The mod namespace token parsed from the map script, e.g. `{swooper-maps}`. */
+  modNamespace: string | null;
+  /** How many OTHER maps from the same mod are currently visible in Civ7 setup. */
+  siblingMapRowCount: number;
+  /** Total map rows Civ7 setup is currently showing (base game + any mods). */
+  visibleMapRowCount: number;
+}>;
+
+/** Civ7 map-script references are mod-namespaced as `{mod-id}/path/to/map.js`. */
+const MOD_NAMESPACE_PATTERN = /^(\{[^}]+\})\//;
+
+/** Parse the `{mod-id}` namespace token from a Civ7 map-script reference. */
+export function modNamespaceFromMapScript(mapScript: string): string | null {
+  const match = MOD_NAMESPACE_PATTERN.exec(mapScript.trim());
+  return match ? match[1] : null;
+}
+
+function isSameModRow(file: string, modNamespace: string): boolean {
+  return file === modNamespace || file.startsWith(`${modNamespace}/`);
+}
+
+/**
+ * Classify a "target map row absent from Civ7 setup" failure into a specific,
+ * actionable cause using the sibling-visibility discriminator described above.
+ *
+ * `visibleMapRows` is the FULL Civ7 setup map list (call `getCiv7SetupMapRows({})`
+ * with no `file` filter). We only assert `map-mod-not-loaded` when Civ is
+ * demonstrably showing OTHER maps yet none from the target mod — that guards
+ * against a transient/empty setup read being mislabelled as a disabled mod.
+ */
+export function classifyMapRowVisibilityFailure(args: {
+  readonly launchMapScript: string;
+  readonly visibleMapRows: ReadonlyArray<{ readonly file: string }>;
+  readonly materializationMode?: string;
+}): MapRowVisibilityClassification {
+  const launchMapScript = args.launchMapScript;
+  const modNamespace = modNamespaceFromMapScript(launchMapScript);
+  const visibleMapRowCount = args.visibleMapRows.length;
+  const siblingMapRowCount = modNamespace
+    ? args.visibleMapRows.filter(
+        (row) => row.file !== launchMapScript && isSameModRow(row.file, modNamespace)
+      ).length
+    : 0;
+
+  // Disabled/not-loaded mod: Civ IS showing maps, but none belong to this mod.
+  if (modNamespace && siblingMapRowCount === 0 && visibleMapRowCount > 0) {
+    return {
+      code: "map-mod-not-loaded",
+      message: `Civilization is not loading the ${modNamespace} map mod, so its setup map list cannot show ${launchMapScript}.`,
+      recoveryHint:
+        `Civilization isn't loading the ${modNamespace} map mod (Swooper Physics Maps) — a game update may have ` +
+        "auto-disabled it. In Civilization, open Add-Ons / Mods, enable the mod, then retry Run in Game. " +
+        "The map was generated and deployed correctly; Civ simply isn't loading the mod that provides it.",
+      modNamespace,
+      siblingMapRowCount,
+      visibleMapRowCount,
+    };
+  }
+
+  // Mod is loaded (or we cannot tell): the specific freshly-deployed row just is
+  // not enumerated yet. Keep the established code; nudge toward a re-scan.
+  return {
+    code: "setup-map-row-not-visible",
+    message: `Civ7 setup cannot see ${launchMapScript}.`,
+    recoveryHint:
+      modNamespace && siblingMapRowCount > 0
+        ? `Other ${modNamespace} maps are loaded, but ${launchMapScript} has not appeared in Civ7 setup yet. ` +
+          "Restart Civilization (or retry Run in Game) so it re-scans the newly deployed map."
+        : `${launchMapScript} has not appeared in Civ7 setup yet. Restart Civilization (or retry Run in Game) to re-scan it.`,
+    modNamespace,
+    siblingMapRowCount,
+    visibleMapRowCount,
+  };
+}

--- a/packages/studio-server/test/mapModVisibility.test.ts
+++ b/packages/studio-server/test/mapModVisibility.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyMapRowVisibilityFailure,
+  modNamespaceFromMapScript,
+} from "../src/ports/mapModVisibility.js";
+
+const TARGET = "{swooper-maps}/maps/studio-current.js";
+
+// The base-game map rows Civ7 setup shows regardless of mods (so "Civ shows maps"
+// is true even when our mod is disabled).
+const BASE_GAME_ROWS = [
+  { file: "{base-standard}/maps/continents.js" },
+  { file: "{base-standard}/maps/pangaea.js" },
+];
+
+// Sibling maps from the SAME mod — present only when the mod is actually loaded.
+const SWOOPER_SIBLINGS = [
+  { file: "{swooper-maps}/maps/latest-juicy.js" },
+  { file: "{swooper-maps}/maps/swooper-earthlike.js" },
+];
+
+describe("modNamespaceFromMapScript", () => {
+  it("parses the mod namespace token", () => {
+    expect(modNamespaceFromMapScript(TARGET)).toBe("{swooper-maps}");
+    expect(modNamespaceFromMapScript("  {swooper-maps}/maps/x.js  ")).toBe("{swooper-maps}");
+  });
+
+  it("returns null when there is no namespace token", () => {
+    expect(modNamespaceFromMapScript("maps/studio-current.js")).toBeNull();
+    expect(modNamespaceFromMapScript("studio-current.js")).toBeNull();
+  });
+});
+
+describe("classifyMapRowVisibilityFailure", () => {
+  it('"seemed to work but CIV could not read it": mod disabled => map-mod-not-loaded', () => {
+    // Civ shows base-game maps, but NONE from {swooper-maps} (the mod is disabled).
+    const result = classifyMapRowVisibilityFailure({
+      launchMapScript: TARGET,
+      visibleMapRows: BASE_GAME_ROWS,
+      materializationMode: "disposable",
+    });
+    expect(result.code).toBe("map-mod-not-loaded");
+    expect(result.modNamespace).toBe("{swooper-maps}");
+    expect(result.siblingMapRowCount).toBe(0);
+    expect(result.recoveryHint).toMatch(/enable the mod/i);
+    expect(result.recoveryHint).toMatch(/deployed correctly/i);
+  });
+
+  it('"works when mods enabled": siblings visible, target not yet enumerated => setup-map-row-not-visible', () => {
+    const result = classifyMapRowVisibilityFailure({
+      launchMapScript: TARGET,
+      visibleMapRows: [...BASE_GAME_ROWS, ...SWOOPER_SIBLINGS],
+      materializationMode: "disposable",
+    });
+    expect(result.code).toBe("setup-map-row-not-visible");
+    expect(result.siblingMapRowCount).toBe(2);
+    expect(result.recoveryHint).toMatch(/re-?scan|restart/i);
+  });
+
+  it("does NOT claim mod-not-loaded from an empty/transient setup read (false-positive guard)", () => {
+    const result = classifyMapRowVisibilityFailure({
+      launchMapScript: TARGET,
+      visibleMapRows: [],
+      materializationMode: "disposable",
+    });
+    expect(result.code).toBe("setup-map-row-not-visible");
+    expect(result.visibleMapRowCount).toBe(0);
+  });
+
+  it("does NOT count the target itself as a sibling", () => {
+    // Only the target row is present (and base maps): still no real siblings.
+    const result = classifyMapRowVisibilityFailure({
+      launchMapScript: TARGET,
+      visibleMapRows: [...BASE_GAME_ROWS, { file: TARGET }],
+    });
+    expect(result.code).toBe("map-mod-not-loaded");
+    expect(result.siblingMapRowCount).toBe(0);
+  });
+
+  it("durable preset map with the mod disabled also classifies as map-mod-not-loaded", () => {
+    const result = classifyMapRowVisibilityFailure({
+      launchMapScript: "{swooper-maps}/maps/latest-juicy.js",
+      visibleMapRows: BASE_GAME_ROWS,
+      materializationMode: "durable",
+    });
+    expect(result.code).toBe("map-mod-not-loaded");
+  });
+
+  it("falls back to setup-map-row-not-visible when the script has no mod namespace", () => {
+    const result = classifyMapRowVisibilityFailure({
+      launchMapScript: "maps/studio-current.js",
+      visibleMapRows: BASE_GAME_ROWS,
+    });
+    expect(result.code).toBe("setup-map-row-not-visible");
+    expect(result.modNamespace).toBeNull();
+  });
+});


### PR DESCRIPTION
Run in Game could materialize, build, deploy (verified sha) AND register a map
script, yet still fail with the opaque `setup-map-row-not-visible` — because Civ7
had the swooper-maps mod disabled (a Civ update auto-disables it). It only
surfaced after grinding through the ~4.5 min reload -> restart-Civ fallback (a
restart cannot re-enable a disabled mod).

Forensically reproduced 2026-06-30 against the live daemon: the disposable run
failed setup-row-visible with the mod off; re-enabling it completed the same run
in 51s with in-engine `[mapgen-complete]` proof (requestId-matched). The whole
failure path (materialize/deploy/register/ensureCiv7SetupMapRowVisible) is
byte-identical to main, so this is not a decomposition regression — it is a latent
"deploy proves copy, not load" gap.

Identification path (the simplest discriminator from the two forensic paths):
when the target map row is absent from Civ7 setup, read the FULL setup map list
and check for OTHER maps from the same mod namespace (`{swooper-maps}`).
- No siblings visible while Civ shows other maps => the mod is not loaded
  => `map-mod-not-loaded` + actionable "enable the mod, then retry" recovery hint.
- Siblings visible, only the fresh disposable row missing => keep
  `setup-map-row-not-visible` (not yet enumerated; restart/re-scan).
Falsification-guarded: only claims mod-not-loaded when Civ demonstrably shows
other maps (an empty/transient read cannot false-positive), and only after the
disposable reload already failed.

- packages/studio-server: pure `classifyMapRowVisibilityFailure` (ports/mapModVisibility.ts)
  wired into `Civ7WorkflowControl.prepareSetup` (one extra `getCiv7SetupMapRows`
  read; falls back to the established failure if that read itself errors).
- mapgen-studio GameConsole: distinct "Map mod disabled in Civilization" callout
  for `details.code === "map-mod-not-loaded"` (recoveryHint surfaces as before).

Verify: studio-server tsc 0; studio-server vitest 42/42 (8 new classifier + 34
operationRuntime, no regression on setup-map-row-not-visible); mapgen-studio tsc 0;
biome clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>