### PR TITLE
chore(mapgen-studio): run the studio daemon in watch mode (dev:server)

### DIFF
--- a/apps/mapgen-studio/package.json
+++ b/apps/mapgen-studio/package.json
@@ -96,7 +96,7 @@
   "scripts": {
     "dev": "vite",
     "dev:frontend": "vite",
-    "dev:server": "bun --watch src/server/daemon/daemon.ts",
+    "dev:server": "bun --conditions bun-source --watch src/server/daemon/daemon.ts",
     "serve": "bun src/server/daemon/daemon.ts --assets-root dist",
     "gen:civ7-tables": "bun ../../scripts/mapgen-studio/generate-civ7-browser-tables.ts",
     "check:worker-bundle": "node scripts/check-worker-bundle.mjs",

--- a/apps/mapgen-studio/package.json
+++ b/apps/mapgen-studio/package.json
@@ -96,7 +96,7 @@
   "scripts": {
     "dev": "vite",
     "dev:frontend": "vite",
-    "dev:server": "bun src/server/daemon/daemon.ts",
+    "dev:server": "bun --watch src/server/daemon/daemon.ts",
     "serve": "bun src/server/daemon/daemon.ts --assets-root dist",
     "gen:civ7-tables": "bun ../../scripts/mapgen-studio/generate-civ7-browser-tables.ts",
     "check:worker-bundle": "node scripts/check-worker-bundle.mjs",

--- a/apps/mapgen-studio/src/server/daemon/daemon.ts
+++ b/apps/mapgen-studio/src/server/daemon/daemon.ts
@@ -23,9 +23,15 @@ import { createStudioOperationRuntimePorts } from "../studio/engines";
 // (`/api/civ7/rpc`, `/api/recipe-dag/rpc`) and the 16 hand-rolled legacy
 // `/api/*` REST handlers are RETIRED — every non-`/rpc` API path is a 404.
 //
-// Executed with `bun src/server/daemon/daemon.ts` (never under node). The
-// fetch composition (`createStudioDaemonFetch`) is pure and unit-tested under
-// vitest; only `main()` touches `Bun.serve`.
+// Executed with `bun src/server/daemon/daemon.ts` (never under node). In DEV
+// (`dev:server`) it runs under `bun --conditions bun-source --watch`: the
+// custom opt-in `bun-source` export condition resolves `@civ7/studio-server`
+// to its TypeScript SOURCE (not built `dist`), so editing the server package
+// hot-reloads this daemon with no build step or manual bounce. The condition
+// is dev-only by construction — nothing else passes `--conditions bun-source`,
+// so prod `serve`, `vite` (browser bundle / frontend boundary), and `tsc` all
+// keep resolving `dist`. The fetch composition (`createStudioDaemonFetch`) is
+// pure and unit-tested under vitest; only `main()` touches `Bun.serve`.
 // ============================================================================
 
 declare const Bun: {

--- a/packages/civ7-control-orpc/package.json
+++ b/packages/civ7-control-orpc/package.json
@@ -79,21 +79,25 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "bun-source": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./runtime": {
       "types": "./dist/runtime.d.ts",
+      "bun-source": "./src/runtime.ts",
       "import": "./dist/runtime.js",
       "require": "./dist/runtime.cjs"
     },
     "./game-ui": {
       "types": "./dist/game-ui.d.ts",
+      "bun-source": "./src/game-ui.ts",
       "import": "./dist/game-ui.js",
       "require": "./dist/game-ui.cjs"
     },
     "./contract": {
       "types": "./dist/contract.d.ts",
+      "bun-source": "./src/contract.ts",
       "import": "./dist/contract.js",
       "require": "./dist/contract.cjs"
     }

--- a/packages/civ7-direct-control/package.json
+++ b/packages/civ7-direct-control/package.json
@@ -13,81 +13,97 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "bun-source": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./play/operations/production-choice-proof": {
       "types": "./dist/play/operations/production-choice-proof.d.ts",
+      "bun-source": "./src/play/operations/production-choice-proof.ts",
       "import": "./dist/play/operations/production-choice-proof.js",
       "require": "./dist/play/operations/production-choice-proof.cjs"
     },
     "./play/progression/choice-postconditions": {
       "types": "./dist/play/progression/choice-postconditions.d.ts",
+      "bun-source": "./src/play/progression/choice-postconditions.ts",
       "import": "./dist/play/progression/choice-postconditions.js",
       "require": "./dist/play/progression/choice-postconditions.cjs"
     },
     "./play/notifications/postconditions": {
       "types": "./dist/play/notifications/postconditions.d.ts",
+      "bun-source": "./src/play/notifications/postconditions.ts",
       "import": "./dist/play/notifications/postconditions.js",
       "require": "./dist/play/notifications/postconditions.cjs"
     },
     "./proof/diplomacy-response-proof-policy": {
       "types": "./dist/proof/diplomacy-response-proof-policy.d.ts",
+      "bun-source": "./src/proof/diplomacy-response-proof-policy.ts",
       "import": "./dist/proof/diplomacy-response-proof-policy.js",
       "require": "./dist/proof/diplomacy-response-proof-policy.cjs"
     },
     "./proof/first-meet-response-proof-policy": {
       "types": "./dist/proof/first-meet-response-proof-policy.d.ts",
+      "bun-source": "./src/proof/first-meet-response-proof-policy.ts",
       "import": "./dist/proof/first-meet-response-proof-policy.js",
       "require": "./dist/proof/first-meet-response-proof-policy.cjs"
     },
     "./proof/government-choice-proof-policy": {
       "types": "./dist/proof/government-choice-proof-policy.d.ts",
+      "bun-source": "./src/proof/government-choice-proof-policy.ts",
       "import": "./dist/proof/government-choice-proof-policy.js",
       "require": "./dist/proof/government-choice-proof-policy.cjs"
     },
     "./proof/narrative-choice-proof-policy": {
       "types": "./dist/proof/narrative-choice-proof-policy.d.ts",
+      "bun-source": "./src/proof/narrative-choice-proof-policy.ts",
       "import": "./dist/proof/narrative-choice-proof-policy.js",
       "require": "./dist/proof/narrative-choice-proof-policy.cjs"
     },
     "./proof/notification-dismissal-proof-policy": {
       "types": "./dist/proof/notification-dismissal-proof-policy.d.ts",
+      "bun-source": "./src/proof/notification-dismissal-proof-policy.ts",
       "import": "./dist/proof/notification-dismissal-proof-policy.js",
       "require": "./dist/proof/notification-dismissal-proof-policy.cjs"
     },
     "./proof/advisor-warning-proof-policy": {
       "types": "./dist/proof/advisor-warning-proof-policy.d.ts",
+      "bun-source": "./src/proof/advisor-warning-proof-policy.ts",
       "import": "./dist/proof/advisor-warning-proof-policy.js",
       "require": "./dist/proof/advisor-warning-proof-policy.cjs"
     },
     "./proof/population-placement-proof-policy": {
       "types": "./dist/proof/population-placement-proof-policy.d.ts",
+      "bun-source": "./src/proof/population-placement-proof-policy.ts",
       "import": "./dist/proof/population-placement-proof-policy.js",
       "require": "./dist/proof/population-placement-proof-policy.cjs"
     },
     "./proof/progression-player-choice-proof-policy": {
       "types": "./dist/proof/progression-player-choice-proof-policy.d.ts",
+      "bun-source": "./src/proof/progression-player-choice-proof-policy.ts",
       "import": "./dist/proof/progression-player-choice-proof-policy.js",
       "require": "./dist/proof/progression-player-choice-proof-policy.cjs"
     },
     "./proof/progression-target-proof-policy": {
       "types": "./dist/proof/progression-target-proof-policy.d.ts",
+      "bun-source": "./src/proof/progression-target-proof-policy.ts",
       "import": "./dist/proof/progression-target-proof-policy.js",
       "require": "./dist/proof/progression-target-proof-policy.cjs"
     },
     "./proof/turn-completion-proof-policy": {
       "types": "./dist/proof/turn-completion-proof-policy.d.ts",
+      "bun-source": "./src/proof/turn-completion-proof-policy.ts",
       "import": "./dist/proof/turn-completion-proof-policy.js",
       "require": "./dist/proof/turn-completion-proof-policy.cjs"
     },
     "./proof/town-focus-proof-policy": {
       "types": "./dist/proof/town-focus-proof-policy.d.ts",
+      "bun-source": "./src/proof/town-focus-proof-policy.ts",
       "import": "./dist/proof/town-focus-proof-policy.js",
       "require": "./dist/proof/town-focus-proof-policy.cjs"
     },
     "./proof/unit-target-proof-policy": {
       "types": "./dist/proof/unit-target-proof-policy.d.ts",
+      "bun-source": "./src/proof/unit-target-proof-policy.ts",
       "import": "./dist/proof/unit-target-proof-policy.js",
       "require": "./dist/proof/unit-target-proof-policy.cjs"
     }

--- a/packages/plugins/plugin-mods/package.json
+++ b/packages/plugins/plugin-mods/package.json
@@ -28,5 +28,14 @@
   },
   "engines": {
     "node": "22.22.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "bun-source": "./src/index.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
   }
 }

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -18,14 +18,17 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "bun-source": "./src/index.ts",
       "import": "./dist/index.js"
     },
     "./contract": {
       "types": "./dist/contract/index.d.ts",
+      "bun-source": "./src/contract/index.ts",
       "import": "./dist/contract/index.js"
     },
     "./live-game": {
       "types": "./dist/liveGame/model.d.ts",
+      "bun-source": "./src/liveGame/model.ts",
       "import": "./dist/liveGame/model.js"
     }
   },

--- a/scripts/restart-mapgen-studio.sh
+++ b/scripts/restart-mapgen-studio.sh
@@ -133,8 +133,11 @@ kill_port_listeners "$FRONTEND_PORT"
 kill_port_listeners "$DAEMON_PORT"
 
 echo "Starting MapGen Studio tmux session '$SESSION'..."
+# Daemon runs via `dev:server` (bun --conditions bun-source --watch): it resolves
+# @civ7/studio-server to SOURCE and hot-reloads on server-package edits — no dist
+# build/skew, no manual bounce. One source of truth for the dev daemon invocation.
 tmux new-session -d -s "$SESSION" -n daemon -c "$APP_DIR" \
-  "STUDIO_DAEMON_PORT='$DAEMON_PORT' bun src/server/daemon/daemon.ts"
+  "STUDIO_DAEMON_PORT='$DAEMON_PORT' bun run dev:server"
 tmux new-window -t "$SESSION" -n vite -c "$APP_DIR" \
   "STUDIO_DEV_PORT='$FRONTEND_PORT' STUDIO_DEV_RPC_TARGET='$RPC_TARGET' bun run dev:frontend"
 


### PR DESCRIPTION
dev:server (the bun daemon that nx serve-daemon runs) was launched without
--watch, so server-side changes (apps/mapgen-studio/src/server/** and the
@civ7/studio-server dist it imports) required a manual daemon bounce. Add
--watch so the daemon auto-restarts on changes — vite already watches the
frontend, so the studio now runs fully in watch.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>