### PR TITLE
feat(mapgen-studio): Stage 1 Storybook component workbench (46 stories)

### DIFF
--- a/apps/mapgen-studio/.gitignore
+++ b/apps/mapgen-studio/.gitignore
@@ -2,6 +2,9 @@ node_modules
 dist
 *.local
 
+# Storybook static build output
+storybook-static
+
 # design-sync (claude.ai/design) — scaffolding + build artifacts
 .ds-sync/
 ds-bundle/

--- a/apps/mapgen-studio/.storybook/main.ts
+++ b/apps/mapgen-studio/.storybook/main.ts
@@ -1,0 +1,62 @@
+import { fileURLToPath } from "node:url";
+import type { StorybookConfig } from "@storybook/react-vite";
+import tailwindcss from "@tailwindcss/vite";
+
+/**
+ * MapGen Studio component workbench (Stage 1).
+ *
+ * The builder inherits the app's `vite.config.ts` essentials through `viteFinal`
+ * — the `@` and `child_process` resolve aliases plus the Tailwind v4 plugin — so
+ * stories render the real components in their real styling context. It does NOT
+ * carry the app's dev `server` block: there is no `/rpc` proxy and no daemon
+ * watch here, because the workbench runs with no daemon (Stage-1 invariant: no
+ * story fires a live `/rpc` call). `@vitejs/plugin-react` is intentionally not
+ * re-added — `@storybook/react-vite` already provides it.
+ *
+ * Storybook 9 dissolved `addon-essentials` (viewport/controls/interactions/
+ * actions moved into core); `@storybook/addon-docs` is the one addon that must
+ * be installed + registered explicitly for autodocs.
+ */
+const config: StorybookConfig = {
+  framework: { name: "@storybook/react-vite", options: {} },
+  stories: ["../src/**/*.stories.@(tsx|jsx)"],
+  addons: ["@storybook/addon-docs"],
+  core: { disableTelemetry: true },
+  viteFinal: (viteConfig, { configType }) => {
+    viteConfig.resolve ??= {};
+
+    // Mirror vite.config.ts aliases. Paths resolve relative to `.storybook/`,
+    // one level deeper than the app's `vite.config.ts`, so `./src` becomes
+    // `../src`. The `@swooper/mapgen-viz` source alias is dev/serve-only, exactly
+    // as the app gates it on `command === "serve"`.
+    const extraAlias: Record<string, string> = {
+      "@": fileURLToPath(new URL("../src", import.meta.url)),
+      child_process: fileURLToPath(new URL("../src/shims/child_process.ts", import.meta.url)),
+      ...(configType === "DEVELOPMENT"
+        ? {
+            "@swooper/mapgen-viz": fileURLToPath(
+              new URL("../../../packages/mapgen-viz/src/index.ts", import.meta.url)
+            ),
+          }
+        : {}),
+    };
+
+    const existingAlias = viteConfig.resolve.alias;
+    viteConfig.resolve.alias = Array.isArray(existingAlias)
+      ? [
+          ...existingAlias,
+          ...Object.entries(extraAlias).map(([find, replacement]) => ({ find, replacement })),
+        ]
+      : { ...(existingAlias as Record<string, string> | undefined), ...extraAlias };
+
+    // Tailwind v4 is wired through Vite (not PostCSS); without this plugin the
+    // `@import "tailwindcss"` + `@custom-variant`/token directives in
+    // `src/index.css` never compile and every story renders unstyled. React stays
+    // framework-owned.
+    viteConfig.plugins = [...(viteConfig.plugins ?? []), tailwindcss()];
+
+    return viteConfig;
+  },
+};
+
+export default config;

--- a/apps/mapgen-studio/.storybook/preview.tsx
+++ b/apps/mapgen-studio/.storybook/preview.tsx
@@ -1,0 +1,95 @@
+// Self-hosted fonts + the token system — mirror `src/main.tsx` exactly, at module
+// load, before any story renders. Without `src/index.css` every story is unstyled
+// and untokened; without the fonts the type renders in a fallback face.
+import "@fontsource/inter/400.css";
+import "@fontsource/inter/500.css";
+import "@fontsource/inter/600.css";
+import "@fontsource/inter/700.css";
+import "@fontsource/jetbrains-mono/400.css";
+import "@fontsource/jetbrains-mono/500.css";
+import "../src/index.css";
+
+import type { Decorator, Preview } from "@storybook/react-vite";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+import { Toaster, TooltipProvider } from "../src/components/ui";
+import { createStoryQueryClient } from "../src/storybook/queryStub";
+import { resetStudioStores } from "../src/storybook/storeReset";
+
+/**
+ * The runtime provider shell MINUS the network seam, mirroring the nesting the
+ * app assembles in `main.tsx` (root `QueryClientProvider`) + `StudioProviders.tsx`
+ * (`TooltipProvider` wrapping the shell + a sibling `Toaster`):
+ *
+ *   QueryClientProvider(stub) > TooltipProvider(delay 300) > [Story, Toaster]
+ *
+ * A fresh stub QueryClient per mount keeps the `/rpc` seam cold and prevents
+ * cross-story cache bleed. `TooltipProvider` is mandatory — tooltip-using
+ * components render silently blank with no console error if it is absent.
+ */
+function StudioStoryProviders({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(createStoryQueryClient);
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider delayDuration={300}>
+        {children}
+        <Toaster />
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+}
+
+/**
+ * Theme is a single `.dark` class on `document.documentElement` (the app's
+ * single-class strategy, no next-themes). Own it directly from the toolbar global
+ * rather than mounting `StudioProviders`/`useThemePreference` (which read+write
+ * `localStorage["theme-preference"]` and subscribe to matchMedia — story-hostile
+ * side effects). `<Toaster/>` re-themes off this class automatically via the app's
+ * `useThemeFromClass`. Set per render so flipping the toolbar re-themes live.
+ */
+const withStudioContext: Decorator = (Story, context) => {
+  const theme = context.globals.theme ?? "dark";
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.toggle("dark", theme !== "light");
+  }
+  return (
+    <StudioStoryProviders>
+      <Story />
+    </StudioStoryProviders>
+  );
+};
+
+const preview: Preview = {
+  // Every story is autodoc-eligible — the story tree doubles as living docs.
+  tags: ["autodocs"],
+  parameters: {
+    controls: { matchers: { color: /(background|color)$/i, date: /Date$/i } },
+  },
+  // Dark-first by workbench convention: the studio is a dark instrument (its
+  // pre-paint guard's catch path defaults to dark). The toolbar global — not
+  // `localStorage["theme-preference"]` or OS preference — is the source of truth
+  // for theme in stories.
+  initialGlobals: { theme: "dark" },
+  globalTypes: {
+    theme: {
+      description: "Studio theme (.dark class on <html>)",
+      toolbar: {
+        title: "Theme",
+        icon: "circlehollow",
+        items: [
+          { value: "dark", title: "Dark", icon: "circle" },
+          { value: "light", title: "Light", icon: "circlehollow" },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  decorators: [withStudioContext],
+  // Reset the module-singleton stores before each story so view/run/authoring
+  // state never bleeds across stories in one preview iframe.
+  beforeEach: () => {
+    resetStudioStores();
+  },
+};
+
+export default preview;

--- a/apps/mapgen-studio/README.md
+++ b/apps/mapgen-studio/README.md
@@ -1,0 +1,29 @@
+# mapgen-studio
+
+The MapGen Studio frontend (React 19 + Vite + Tailwind v4). See
+[`system.md`](./system.md) for the as-built design language.
+
+## Component workbench (Storybook)
+
+The studio's presentational components have an isolated Storybook workbench —
+view, exercise, and review every component in light/dark theme without booting
+the daemon, the live game runtime, or the full app shell. Stories are co-located
+beside their components (`src/**/*.stories.tsx`) and double as living docs via
+autodocs.
+
+```sh
+# from apps/mapgen-studio
+bun run storybook          # dev workbench on http://localhost:6006
+bun run build-storybook    # static build -> storybook-static/
+
+# or via Nx from the repo root
+nx storybook mapgen-studio
+nx build-storybook mapgen-studio
+```
+
+The workbench runs with **no daemon and no `/rpc`**: components are pure
+prop-driven leaves, and each story supplies fixture props of the same shape the
+app produces. Global decorators (`.storybook/preview.tsx`) reproduce the app's
+rendering context — the `.dark` theme + token CSS + fonts, a `TooltipProvider`, a
+per-story stub `QueryClientProvider` (the cold-`/rpc` backstop), a `Toaster`, and
+a per-story Zustand store reset. Shared fixtures live in `src/storybook/`.

--- a/apps/mapgen-studio/package.json
+++ b/apps/mapgen-studio/package.json
@@ -90,6 +90,23 @@
         ],
         "cache": true,
         "outputs": []
+      },
+      "storybook": {
+        "executor": "nx:run-script",
+        "options": {
+          "script": "storybook"
+        },
+        "cache": false,
+        "continuous": true
+      },
+      "build-storybook": {
+        "executor": "nx:run-script",
+        "options": {
+          "script": "build-storybook"
+        },
+        "outputs": [
+          "{projectRoot}/storybook-static/**"
+        ]
       }
     }
   },
@@ -105,7 +122,9 @@
     "test": "vitest run --config ../../vitest.config.ts --project mapgen-studio",
     "build": "vite build",
     "preview": "vite preview",
-    "build:vite": "vite build"
+    "build:vite": "vite build",
+    "storybook": "storybook dev -p 6006 --no-open",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@civ7/adapter": "workspace:*",
@@ -156,6 +175,8 @@
     "zustand": "5.0.14"
   },
   "devDependencies": {
+    "@storybook/addon-docs": "9.1.20",
+    "@storybook/react-vite": "9.1.20",
     "@tailwindcss/vite": "^4.1.13",
     "@testing-library/dom": "10.4.1",
     "@testing-library/react": "16.3.2",
@@ -163,6 +184,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
     "jsdom": "29.1.1",
+    "storybook": "9.1.20",
     "tailwindcss": "^4.1.13",
     "tw-animate-css": "^1.4.0",
     "vite": "^7.3.1"

--- a/apps/mapgen-studio/src/app/ErrorBanner.stories.tsx
+++ b/apps/mapgen-studio/src/app/ErrorBanner.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { ErrorBanner } from "@/app/ErrorBanner";
+
+/**
+ * ErrorBanner is the centered destructive alert (role=alert) that renders only
+ * when a message is present. Adapted from `.design-sync/previews/ErrorBanner.tsx`;
+ * title maps to the design-sync export name for the Stage-2 flip.
+ */
+const meta = {
+  title: "composites/ErrorBanner",
+  component: ErrorBanner,
+} satisfies Meta<typeof ErrorBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ErrorBanner is absolutely positioned, so the preview frames it in a `relative`
+// map-substrate stage — preview-only scaffolding, not a DS export.
+function Stage({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background"
+      style={{ position: "relative", width: 480, height: 120, borderRadius: 8, overflow: "hidden" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const GenerationFailed: Story = {
+  args: {
+    message:
+      "Map generation failed: recipe ‘mod-swooper-maps/standard’ produced no land tiles at seed 1474829.",
+    top: 16,
+  },
+  render: (args) => (
+    <Stage>
+      <ErrorBanner {...args} />
+    </Stage>
+  ),
+};

--- a/apps/mapgen-studio/src/app/LeftDock.stories.tsx
+++ b/apps/mapgen-studio/src/app/LeftDock.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { LeftDock, type LeftDockProps } from "@/app/LeftDock";
+
+/**
+ * LeftDock is the left-anchored floating rail that hosts the recipe authoring
+ * panel. Adapted from `.design-sync/previews/LeftDock.tsx`; title maps to the
+ * design-sync export name for the Stage-2 flip.
+ */
+const meta = {
+  title: "layout/LeftDock",
+  component: LeftDock,
+  // CSF3 requires args once when the component has required props; these stories
+  // own their full scene in render, so no per-story args are needed.
+  args: {} as unknown as LeftDockProps,
+} satisfies Meta<typeof LeftDock>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// LeftDock is `position: absolute` + `pointer-events-none`, so the preview frames
+// it in a `relative` map-substrate stage — preview-only scaffolding.
+function Stage({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background"
+      style={{ position: "relative", width: 360, height: 300, borderRadius: 8, overflow: "hidden" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// Sample panel (pointer-events-auto) standing in for the composed-in content.
+function SamplePanel() {
+  return (
+    <div
+      className="bg-card border border-border pointer-events-auto"
+      style={{ width: 200, borderRadius: 8, padding: 12 }}
+    >
+      <div className="text-label uppercase text-muted-foreground" style={{ marginBottom: 6 }}>
+        Recipe
+      </div>
+      <div className="text-data text-foreground font-mono">mod-swooper-maps/standard</div>
+    </div>
+  );
+}
+
+export const WithPanel: Story = {
+  render: () => (
+    <Stage>
+      <LeftDock top={12} bottom={12}>
+        <SamplePanel />
+      </LeftDock>
+    </Stage>
+  ),
+};

--- a/apps/mapgen-studio/src/app/RightDock.stories.tsx
+++ b/apps/mapgen-studio/src/app/RightDock.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { RightDock, type RightDockProps } from "@/app/RightDock";
+
+/**
+ * RightDock is the right-anchored floating rail that hosts the explore panel.
+ * Adapted from `.design-sync/previews/RightDock.tsx`; title maps to the
+ * design-sync export name for the Stage-2 flip.
+ */
+const meta = {
+  title: "layout/RightDock",
+  component: RightDock,
+  // CSF3 requires args once when the component has required props; these stories
+  // own their full scene in render, so no per-story args are needed.
+  args: {} as unknown as RightDockProps,
+} satisfies Meta<typeof RightDock>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// RightDock is `position: absolute` + `pointer-events-none`, so the preview frames
+// it in a `relative` map-substrate stage — preview-only scaffolding.
+function Stage({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background"
+      style={{ position: "relative", width: 360, height: 300, borderRadius: 8, overflow: "hidden" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// Sample panel (pointer-events-auto) standing in for the composed-in content.
+function SamplePanel() {
+  return (
+    <div
+      className="bg-card border border-border pointer-events-auto"
+      style={{ width: 200, borderRadius: 8, padding: 12 }}
+    >
+      <div className="text-label uppercase text-muted-foreground" style={{ marginBottom: 6 }}>
+        Explore
+      </div>
+      <div className="text-data text-foreground">Stage · Step · Layers</div>
+    </div>
+  );
+}
+
+export const WithPanel: Story = {
+  render: () => (
+    <Stage>
+      <RightDock top={12} bottom={12}>
+        <SamplePanel />
+      </RightDock>
+    </Stage>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/button.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/button.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Dices, Play } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui";
+
+/**
+ * Smoke story for the Stage-1 workbench foundation: proves theme + tokens + fonts
+ * load and a borders-only primitive renders on its real graphite substrate.
+ * Adapted from `.design-sync/previews/Button.tsx` (title maps to the design-sync
+ * export name so Stage 2's package→storybook flip is a no-re-author cutover).
+ */
+const meta = {
+  title: "primitives/Button",
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop so contours and the one filled primary read
+// correctly — not a DS export.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{
+        padding: 20,
+        borderRadius: 6,
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 10,
+        alignItems: "center",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const Variants: Story = {
+  render: () => (
+    <Demo>
+      <Button>
+        <Play /> Generate map
+      </Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="outline">Outline</Button>
+      <Button variant="ghost">Ghost</Button>
+      <Button variant="destructive">Delete preset</Button>
+      <Button variant="link">View docs</Button>
+    </Demo>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <Demo>
+      <Button size="lg">Large</Button>
+      <Button size="default">Default</Button>
+      <Button size="sm">Small</Button>
+      <Button size="icon" variant="outline" aria-label="Re-roll seed">
+        <Dices />
+      </Button>
+    </Demo>
+  ),
+};
+
+export const States: Story = {
+  render: () => (
+    <Demo>
+      <Button>Run</Button>
+      <Button disabled>Disabled</Button>
+      <Button variant="outline" disabled>
+        Disabled outline
+      </Button>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/checkbox.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/checkbox.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { Checkbox, Label } from "@/components/ui";
+
+/**
+ * Adapted from `.design-sync/previews/Checkbox.tsx`: a dense 14px box on the
+ * studio's inset control substrate; checked fills with the one primary slate.
+ */
+const meta = {
+  title: "primitives/Checkbox",
+  component: Checkbox,
+} satisfies Meta<typeof Checkbox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop so the contour border and filled state read on the
+// real graphite surface — not a DS export.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 20, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => (
+    <Demo>
+      <Checkbox />
+    </Demo>
+  ),
+};
+
+export const Checked: Story = {
+  render: () => (
+    <Demo>
+      <Checkbox defaultChecked />
+    </Demo>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <Demo>
+      <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+        <Checkbox disabled />
+        <Checkbox defaultChecked disabled />
+      </div>
+    </Demo>
+  ),
+};
+
+export const WithLabel: Story = {
+  render: () => (
+    <Demo>
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <Checkbox id="auto-run" defaultChecked />
+        <Label htmlFor="auto-run">Auto-run on config change</Label>
+      </div>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/dialog.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/dialog.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui";
+
+/**
+ * Adapted from `.design-sync/previews/Dialog.tsx`: a modal on the floating tier
+ * (Radix portal → dimmed scrim + blurred panel). Rendered `defaultOpen` so the
+ * real modal state shows; the global decorator provides the surrounding shell.
+ */
+const meta = {
+  title: "primitives/Dialog",
+  component: Dialog,
+} satisfies Meta<typeof Dialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SavePreset: Story = {
+  render: () => (
+    <Dialog defaultOpen>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Save preset</DialogTitle>
+          <DialogDescription>
+            Capture the current recipe and config overrides as a reusable preset. A preset with the
+            same name will be overwritten.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button>Save preset</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/dropdown-menu.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/dropdown-menu.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ChevronDown } from "lucide-react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui";
+
+/**
+ * Adapted from `.design-sync/previews/DropdownMenu.tsx`: a Radix menu on the
+ * popover floating tier. Rendered `open` so the menu items (preset actions) are
+ * captured on first paint.
+ */
+const meta = {
+  title: "primitives/DropdownMenu",
+  component: DropdownMenu,
+} satisfies Meta<typeof DropdownMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PresetActions: Story = {
+  render: () => (
+    <DropdownMenu open>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">
+          Preset <ChevronDown />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuLabel>Preset</DropdownMenuLabel>
+        <DropdownMenuItem>Save to current</DropdownMenuItem>
+        <DropdownMenuItem>Save as new</DropdownMenuItem>
+        <DropdownMenuItem>Import preset</DropdownMenuItem>
+        <DropdownMenuItem>Export preset</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="text-destructive">Delete preset</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/input.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/input.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { Input, Label } from "@/components/ui";
+
+/**
+ * Adapted from `.design-sync/previews/Input.tsx`: the dense inset field (h-7,
+ * 11px data type) on the `input-background` substrate with the control border.
+ */
+const meta = {
+  title: "primitives/Input",
+  component: Input,
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop so the inset field and placeholder/value type read
+// on the real graphite surface — not a DS export.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 20, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => (
+    <Demo>
+      <div style={{ width: 240 }}>
+        <Input placeholder="Search layers…" />
+      </div>
+    </Demo>
+  ),
+};
+
+export const WithValue: Story = {
+  render: () => (
+    <Demo>
+      <div style={{ width: 240 }}>
+        <Input className="font-mono" defaultValue="1474829" aria-label="Seed" />
+      </div>
+    </Demo>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <Demo>
+      <div style={{ width: 240 }}>
+        <Input disabled defaultValue="mod-swooper-maps/standard" />
+      </div>
+    </Demo>
+  ),
+};
+
+export const Field: Story = {
+  render: () => (
+    <Demo>
+      <div style={{ width: 240, display: "flex", flexDirection: "column", gap: 4 }}>
+        <Label htmlFor="seed">Seed</Label>
+        <Input id="seed" className="font-mono" defaultValue="1474829" />
+      </div>
+      <div style={{ width: 240, display: "flex", flexDirection: "column", gap: 4 }}>
+        <Label htmlFor="map-name">Map name</Label>
+        <Input id="map-name" placeholder="Untitled continents" />
+      </div>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/label.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/label.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { Checkbox, Input, Label, Switch } from "@/components/ui";
+
+/**
+ * Adapted from `.design-sync/previews/Label.tsx`: the field eyebrow — meaningless
+ * alone, so every story pairs it with the control it names. `text-label` is the
+ * 10px uppercase eyebrow variant.
+ */
+const meta = {
+  title: "primitives/Label",
+  component: Label,
+} satisfies Meta<typeof Label>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop matching the studio — not a DS export.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 20, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const WithInput: Story = {
+  render: () => (
+    <Demo>
+      <div style={{ width: 220, display: "flex", flexDirection: "column", gap: 4 }}>
+        <Label htmlFor="seed">Seed</Label>
+        <Input id="seed" className="font-mono" defaultValue="1474829" />
+      </div>
+    </Demo>
+  ),
+};
+
+export const WithSwitch: Story = {
+  render: () => (
+    <Demo>
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          alignItems: "center",
+          justifyContent: "space-between",
+          width: 220,
+        }}
+      >
+        <Label htmlFor="show-grid">Show grid</Label>
+        <Switch id="show-grid" defaultChecked />
+      </div>
+    </Demo>
+  ),
+};
+
+export const WithCheckbox: Story = {
+  render: () => (
+    <Demo>
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <Checkbox id="place-resources" defaultChecked />
+        <Label htmlFor="place-resources">Resources</Label>
+      </div>
+    </Demo>
+  ),
+};
+
+export const Eyebrow: Story = {
+  render: () => (
+    <Demo>
+      <div style={{ width: 220, display: "flex", flexDirection: "column", gap: 4 }}>
+        <Label htmlFor="players" className="text-label text-muted-foreground">
+          Players
+        </Label>
+        <Input id="players" className="font-mono" defaultValue="6" />
+      </div>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/popover.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/popover.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SlidersHorizontal } from "lucide-react";
+import { Button, Label, Popover, PopoverContent, PopoverTrigger } from "@/components/ui";
+
+/**
+ * Adapted from `.design-sync/previews/Popover.tsx`: a Radix floating surface on
+ * the popover tier — a generic container for inspector pickers and overflow
+ * content. Rendered `defaultOpen` so the open content is captured on first paint.
+ */
+const meta = {
+  title: "primitives/Popover",
+  component: Popover,
+} satisfies Meta<typeof Popover>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OverlayOpacity: Story = {
+  render: () => (
+    <Popover defaultOpen>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="icon" aria-label="Overlay settings">
+          <SlidersHorizontal />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start">
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <Label>Overlay opacity</Label>
+          <p className="text-muted-foreground" style={{ fontSize: 12, lineHeight: 1.5 }}>
+            Blend the elevation overlay against the base terrain. Set to 0% to hide the overlay;
+            100% paints it fully opaque over the surface map.
+          </p>
+          <div
+            className="border border-border bg-input-background text-foreground"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              borderRadius: 4,
+              padding: "4px 8px",
+            }}
+          >
+            <span className="text-muted-foreground" style={{ fontSize: 11 }}>
+              Opacity
+            </span>
+            <span style={{ fontSize: 12, fontFamily: "var(--font-mono, monospace)" }}>65%</span>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/scroll-area.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/scroll-area.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { ScrollArea } from "@/components/ui";
+
+/**
+ * Adapted from `.design-sync/previews/ScrollArea.tsx`: Radix's custom scroller
+ * with a quiet hairline thumb. A fixed 160px viewport + a tall preset list forces
+ * overflow so the thumb shows.
+ */
+const meta = {
+  title: "primitives/ScrollArea",
+  component: ScrollArea,
+} satisfies Meta<typeof ScrollArea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop — not a DS export.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 20, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// Module-scope fixture (hoisted so the render stays referentially stable).
+const presets = [
+  "continents",
+  "pangaea",
+  "archipelago",
+  "fractal-highlands",
+  "inland-sea",
+  "shattered-plates",
+  "tropical-belt",
+  "polar-frontier",
+  "rift-valley",
+  "sundered-archipelago",
+  "drowned-platform",
+  "craton-cradle",
+  "volcanic-arc",
+  "monsoon-coast",
+  "great-steppe",
+];
+
+export const PresetList: Story = {
+  render: () => (
+    <Demo>
+      <div
+        className="bg-card border border-border"
+        style={{ width: 300, borderRadius: 6, overflow: "hidden" }}
+      >
+        <div
+          className="text-muted-foreground border-b border-border"
+          style={{
+            padding: "8px 12px",
+            fontSize: 11,
+            letterSpacing: "0.04em",
+            textTransform: "uppercase",
+          }}
+        >
+          Presets · 15
+        </div>
+        <ScrollArea style={{ height: 160 }}>
+          <div style={{ padding: 4, display: "flex", flexDirection: "column" }}>
+            {presets.map((name, i) => (
+              <div
+                key={name}
+                className="text-foreground"
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: "7px 10px",
+                  borderRadius: 4,
+                  fontSize: 12,
+                  fontFamily: "var(--font-mono, monospace)",
+                  backgroundColor: i === 0 ? "var(--muted, transparent)" : "transparent",
+                }}
+              >
+                <span>{name}</span>
+                <span className="text-muted-foreground" style={{ fontSize: 11 }}>
+                  96 × 60
+                </span>
+              </div>
+            ))}
+          </div>
+        </ScrollArea>
+      </div>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/select.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/select.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui";
+
+/**
+ * Adapted from `.design-sync/previews/Select.tsx`. Select is a Radix listbox
+ * floating on the popover tier; rendered `defaultOpen` so the open map-size list
+ * is captured. Controlled `value="standard"` mirrors how the app supplies the
+ * current choice.
+ */
+const meta = {
+  title: "primitives/Select",
+  component: Select,
+} satisfies Meta<typeof Select>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MapSize: Story = {
+  render: () => (
+    <Select defaultOpen value="standard">
+      <SelectTrigger style={{ width: 200 }}>
+        <SelectValue placeholder="Map size" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="tiny">Tiny</SelectItem>
+        <SelectItem value="small">Small</SelectItem>
+        <SelectItem value="standard">Standard</SelectItem>
+        <SelectItem value="large">Large</SelectItem>
+        <SelectItem value="huge">Huge</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/separator.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/separator.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { Separator } from "@/components/ui";
+
+/**
+ * Adapted from `.design-sync/previews/Separator.tsx`. Separator is the studio's
+ * intra-surface hairline (border-subtle tier) — quieter than a panel edge. Both
+ * stories give the rule visible content on either side so the hairline reads.
+ */
+const meta = {
+  title: "primitives/Separator",
+  component: Separator,
+} satisfies Meta<typeof Separator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop so the hairline reads on the real graphite surface
+// — not a DS export.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{
+        padding: 20,
+        borderRadius: 6,
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// Horizontal: a labeled settings group split into two stacked sections.
+export const Horizontal: Story = {
+  render: () => (
+    <Demo>
+      <div
+        className="bg-card border border-border"
+        style={{
+          width: 320,
+          borderRadius: 6,
+          padding: 14,
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <span className="text-foreground" style={{ fontSize: 13, fontWeight: 600 }}>
+            World
+          </span>
+          <span className="text-muted-foreground" style={{ fontSize: 12 }}>
+            Standard · 6 players · balanced resources
+          </span>
+        </div>
+        <Separator />
+        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <span className="text-foreground" style={{ fontSize: 13, fontWeight: 600 }}>
+            Recipe
+          </span>
+          <span className="text-muted-foreground" style={{ fontSize: 12 }}>
+            mod-swooper-maps/standard · seed 1474829
+          </span>
+        </div>
+      </div>
+    </Demo>
+  ),
+};
+
+// Vertical: hairlines dividing inline items in a toolbar row.
+export const Vertical: Story = {
+  render: () => (
+    <Demo>
+      <div
+        className="bg-card border border-border text-muted-foreground"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          height: 32,
+          padding: "0 12px",
+          borderRadius: 6,
+          fontSize: 12,
+        }}
+      >
+        <span className="text-foreground" style={{ fontFamily: "var(--font-mono, monospace)" }}>
+          96 × 60
+        </span>
+        <Separator orientation="vertical" />
+        <span>Continents</span>
+        <Separator orientation="vertical" />
+        <span style={{ fontFamily: "var(--font-mono, monospace)" }}>seed 1474829</span>
+      </div>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/sonner.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/sonner.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect } from "react";
+import { Toaster, toast } from "@/components/ui";
+
+/**
+ * Adapted from `.design-sync/previews/Toaster.tsx`. Toaster is sonner bound to the
+ * studio tokens (popover tier, shadowed). The global decorator already mounts a
+ * `<Toaster/>` and owns the `.dark` class, so this story does NOT mount a second
+ * Toaster — a top-level render component fires realistic studio notifications in a
+ * `useEffect` and the decorator's Toaster displays them.
+ */
+const meta = {
+  title: "primitives/Toaster",
+  component: Toaster,
+} satisfies Meta<typeof Toaster>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Top-level render component (hooks must not live in a bare render arrow): fires
+// the toasts on mount; the decorator's Toaster renders the stack.
+function ToastDemo() {
+  useEffect(() => {
+    toast.success("Seed copied to clipboard");
+    toast.info("Generation complete", {
+      description: "Standard · 6 players · seed 1474829",
+    });
+    toast.error("Run failed", {
+      description: "Pipeline stage “climate” threw — see console",
+    });
+  }, []);
+  return (
+    <div
+      className="bg-background"
+      style={{ position: "relative", width: "100%", minHeight: 300 }}
+    />
+  );
+}
+
+export const Notifications: Story = {
+  render: () => <ToastDemo />,
+};

--- a/apps/mapgen-studio/src/components/ui/switch.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/switch.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { Label, Switch } from "@/components/ui";
+
+/**
+ * Adapted from `.design-sync/previews/Switch.tsx`. Switch is the 36x20 toggle —
+ * checked fills with the one primary slate, unchecked rests on the muted surface.
+ */
+const meta = {
+  title: "primitives/Switch",
+  component: Switch,
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop so the track fill and thumb read on the real
+// graphite surface — not a DS export.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{
+        padding: 20,
+        borderRadius: 6,
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const Off: Story = {
+  render: () => (
+    <Demo>
+      <Switch />
+    </Demo>
+  ),
+};
+
+export const On: Story = {
+  render: () => (
+    <Demo>
+      <Switch defaultChecked />
+    </Demo>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <Demo>
+      <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+        <Switch disabled />
+        <Switch defaultChecked disabled />
+      </div>
+    </Demo>
+  ),
+};
+
+export const WithLabel: Story = {
+  render: () => (
+    <Demo>
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          alignItems: "center",
+          justifyContent: "space-between",
+          width: 200,
+        }}
+      >
+        <Label htmlFor="show-grid">Show grid</Label>
+        <Switch id="show-grid" defaultChecked />
+      </div>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/tabs.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/tabs.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui";
+
+/**
+ * Adapted from `.design-sync/previews/Tabs.tsx`. Tabs marks the active trigger
+ * with a thin steel underline (border-primary), not a filled slab — the list
+ * rides the muted surface, the active label lifts to foreground.
+ */
+const meta = {
+  title: "primitives/Tabs",
+  component: Tabs,
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop — not a DS export.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{
+        padding: 20,
+        borderRadius: 6,
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// Three-tab studio panel; the default-selected "Recipe" tab shows its blurb.
+export const RecipePanel: Story = {
+  render: () => (
+    <Demo>
+      <Tabs defaultValue="recipe" style={{ width: 340 }}>
+        <TabsList>
+          <TabsTrigger value="recipe">Recipe</TabsTrigger>
+          <TabsTrigger value="config">Config</TabsTrigger>
+          <TabsTrigger value="presets">Presets</TabsTrigger>
+        </TabsList>
+        <TabsContent value="recipe">
+          <p className="text-muted-foreground" style={{ fontSize: 12, lineHeight: 1.5, margin: 0 }}>
+            <span className="text-foreground" style={{ fontWeight: 600 }}>
+              mod-swooper-maps/standard
+            </span>{" "}
+            — the full foundation → morphology → ecology pipeline. Edit the active recipe steps,
+            then re-run to regenerate the map.
+          </p>
+        </TabsContent>
+        <TabsContent value="config">
+          <p className="text-muted-foreground" style={{ fontSize: 12, lineHeight: 1.5, margin: 0 }}>
+            Per-domain overrides (plate count, water %, climate bands) layered onto the recipe
+            defaults.
+          </p>
+        </TabsContent>
+        <TabsContent value="presets">
+          <p className="text-muted-foreground" style={{ fontSize: 12, lineHeight: 1.5, margin: 0 }}>
+            Saved recipe + override bundles. Load a preset to seed a new map.
+          </p>
+        </TabsContent>
+      </Tabs>
+    </Demo>
+  ),
+};
+
+// Two-tab variant with a different default selection (Pipeline active).
+export const MapPipeline: Story = {
+  render: () => (
+    <Demo>
+      <Tabs defaultValue="pipeline" style={{ width: 340 }}>
+        <TabsList>
+          <TabsTrigger value="map">Map</TabsTrigger>
+          <TabsTrigger value="pipeline">Pipeline</TabsTrigger>
+        </TabsList>
+        <TabsContent value="map">
+          <p className="text-muted-foreground" style={{ fontSize: 12, lineHeight: 1.5, margin: 0 }}>
+            The rendered 96 × 60 grid — elevation, biomes, and placement overlays.
+          </p>
+        </TabsContent>
+        <TabsContent value="pipeline">
+          <p className="text-muted-foreground" style={{ fontSize: 12, lineHeight: 1.5, margin: 0 }}>
+            Stage-by-stage view of the last run: foundation, morphology, hydrology, ecology,
+            placement. Inspect intermediate layers per stage.
+          </p>
+        </TabsContent>
+      </Tabs>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/textarea.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/textarea.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { Label, Textarea } from "@/components/ui";
+
+/**
+ * Adapted from `.design-sync/previews/Textarea.tsx`. Textarea is the multi-line
+ * sibling of Input — same inset substrate, control border, and 11px data type.
+ */
+const meta = {
+  title: "primitives/Textarea",
+  component: Textarea,
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop so the inset field and placeholder/value type read
+// on the real graphite surface — not a DS export.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{
+        padding: 20,
+        borderRadius: 6,
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// Hoisted constant fixture (module scope) — stable across renders.
+const overrides = `{
+  "landmass": { "waterPercent": 0.62 },
+  "climate": { "rainfall": "wet" }
+}`;
+
+export const Default: Story = {
+  render: () => (
+    <Demo>
+      <div style={{ width: 320 }}>
+        <Textarea placeholder="Notes for this preset…" />
+      </div>
+    </Demo>
+  ),
+};
+
+export const WithValue: Story = {
+  render: () => (
+    <Demo>
+      <div style={{ width: 320, display: "flex", flexDirection: "column", gap: 4 }}>
+        <Label htmlFor="overrides">Config overrides</Label>
+        <Textarea id="overrides" className="font-mono" defaultValue={overrides} rows={4} />
+      </div>
+    </Demo>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <Demo>
+      <div style={{ width: 320 }}>
+        <Textarea disabled defaultValue={overrides} className="font-mono" rows={4} />
+      </div>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/components/ui/tooltip.stories.tsx
+++ b/apps/mapgen-studio/src/components/ui/tooltip.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Dices } from "lucide-react";
+import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui";
+
+/**
+ * Foundation proof that a Radix tooltip renders visible (not silently blank).
+ * Mirrors `.design-sync/previews/Tooltip.tsx`, which self-provides its own
+ * `TooltipProvider` and renders `open` so the portalled hint is captured — the
+ * global decorator's `TooltipProvider` is exercised separately by the six
+ * tooltip-consuming composites in Tier 1.
+ */
+const meta = {
+  title: "primitives/Tooltip",
+  component: Tooltip,
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ReRoll: Story = {
+  render: () => (
+    <TooltipProvider>
+      <Tooltip open>
+        <TooltipTrigger asChild>
+          <Button variant="outline" size="icon" aria-label="Re-roll seed">
+            <Dices />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Re-roll: new seed and run</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ),
+};

--- a/apps/mapgen-studio/src/features/configOverrides/BrowserConfigArrayFieldTemplate.stories.tsx
+++ b/apps/mapgen-studio/src/features/configOverrides/BrowserConfigArrayFieldTemplate.stories.tsx
@@ -1,0 +1,82 @@
+import type { ArrayFieldTemplateProps, RJSFSchema } from "@rjsf/utils";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import {
+  BrowserConfigArrayFieldTemplate,
+  type BrowserConfigFormContext,
+} from "@/features/configOverrides/rjsfTemplates";
+import { alwaysExpandedCollapse, mockFieldContent, noop } from "@/storybook/mockWidgetProps";
+
+/**
+ * BrowserConfigArrayFieldTemplate is the config explorer's array section: the same
+ * flat disclosure-row anatomy as object groups, with the "Add" button riding the
+ * header's trailing action zone and hairline-divided item rows. Adapted from
+ * `.design-sync/previews/BrowserConfigArrayFieldTemplate.tsx`. Each item's
+ * `children` is the pre-rendered item element; the registry set-like forces
+ * "always expanded".
+ */
+// `args` is cast to the full ArrayFieldTemplateProps so Storybook's CSF3 type
+// inference treats every (otherwise-required) rjsf prop as optional — letting
+// these render-only stories omit an `args` block. The value is never read: each
+// story drives the component entirely through its own `render` body.
+const meta = {
+  title: "forms/BrowserConfigArrayFieldTemplate",
+  component: BrowserConfigArrayFieldTemplate,
+  args: {} as unknown as ArrayFieldTemplateProps<unknown, RJSFSchema, BrowserConfigFormContext>,
+} satisfies Meta<typeof BrowserConfigArrayFieldTemplate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Shared array fixture (hoisted to module scope so the constant props are stable).
+const base = {
+  title: "Hotspot seeds",
+  canAdd: true,
+  onAddClick: noop,
+  disabled: false,
+  readonly: false,
+  schema: {},
+  fieldPathId: { path: ["hotspots"] },
+  registry: { formContext: { collapse: alwaysExpandedCollapse } },
+};
+
+// Preview-only `bg-card` frame so the array section reads on the right tier.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-card border border-border text-foreground"
+      style={{ width: 360, borderRadius: 8, overflow: "hidden" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const WithItems: Story = {
+  render: () => (
+    <Demo>
+      <BrowserConfigArrayFieldTemplate
+        {...({
+          ...base,
+          items: [
+            { key: "0", children: mockFieldContent("seed 0", "0.42, 0.18") },
+            { key: "1", children: mockFieldContent("seed 1", "0.71, 0.66") },
+          ],
+        } as unknown as ArrayFieldTemplateProps<unknown, RJSFSchema, BrowserConfigFormContext>)}
+      />
+    </Demo>
+  ),
+};
+
+export const Empty: Story = {
+  render: () => (
+    <Demo>
+      <BrowserConfigArrayFieldTemplate
+        {...({
+          ...base,
+          items: [],
+        } as unknown as ArrayFieldTemplateProps<unknown, RJSFSchema, BrowserConfigFormContext>)}
+      />
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/features/configOverrides/BrowserConfigFieldTemplate.stories.tsx
+++ b/apps/mapgen-studio/src/features/configOverrides/BrowserConfigFieldTemplate.stories.tsx
@@ -1,0 +1,88 @@
+import type { FieldTemplateProps, RJSFSchema } from "@rjsf/utils";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { Input } from "@/components/ui";
+import {
+  BrowserConfigFieldTemplate,
+  type BrowserConfigFormContext,
+} from "@/features/configOverrides/rjsfTemplates";
+
+/**
+ * BrowserConfigFieldTemplate is the per-field row of the config form: a humanized
+ * label (min-w 96) + control split (via FieldRow), with description / live error
+ * region / help stacked below. Adapted from
+ * `.design-sync/previews/BrowserConfigFieldTemplate.tsx`. RJSF FieldTemplateProps
+ * are read for a small subset at render, so each story builds a narrow object and
+ * casts once to the full rjsf prop type; `children` is the already-rendered control.
+ */
+// `args` is cast to the full FieldTemplateProps so Storybook's CSF3 type
+// inference treats every (otherwise-required) rjsf prop as optional — letting
+// these render-only stories omit an `args` block. The value is never read: each
+// story drives the component entirely through its own `render` body.
+const meta = {
+  title: "forms/BrowserConfigFieldTemplate",
+  component: BrowserConfigFieldTemplate,
+  args: {} as unknown as FieldTemplateProps<unknown, RJSFSchema, BrowserConfigFormContext>,
+} satisfies Meta<typeof BrowserConfigFieldTemplate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only `bg-card` panel so the field row reads on its real surface tier.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-card border border-border text-foreground"
+      style={{ width: 340, padding: 14, borderRadius: 8 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const ScalarField: Story = {
+  render: () => (
+    <Demo>
+      <BrowserConfigFieldTemplate
+        {...({
+          id: "cfg_seaLevel",
+          label: "seaLevel",
+          displayLabel: true,
+          required: false,
+          description: "Fraction of the map surface below sea level.",
+          schema: { type: "number" },
+          rawErrors: [],
+          classNames: "",
+          children: <Input className="w-28 font-mono" defaultValue="0.6" aria-label="seaLevel" />,
+        } as unknown as FieldTemplateProps<unknown, RJSFSchema, BrowserConfigFormContext>)}
+      />
+    </Demo>
+  ),
+};
+
+export const Invalid: Story = {
+  render: () => (
+    <Demo>
+      <BrowserConfigFieldTemplate
+        {...({
+          id: "cfg_mountainDensity",
+          label: "mountainDensity",
+          displayLabel: true,
+          required: true,
+          schema: { type: "number" },
+          rawErrors: ["must be ≤ 1"],
+          errors: <span>must be ≤ 1</span>,
+          classNames: "",
+          children: (
+            <Input
+              className="w-28 font-mono"
+              defaultValue="1.4"
+              aria-invalid
+              aria-label="mountainDensity"
+            />
+          ),
+        } as unknown as FieldTemplateProps<unknown, RJSFSchema, BrowserConfigFormContext>)}
+      />
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/features/configOverrides/BrowserConfigObjectFieldTemplate.stories.tsx
+++ b/apps/mapgen-studio/src/features/configOverrides/BrowserConfigObjectFieldTemplate.stories.tsx
@@ -1,0 +1,102 @@
+import type { ObjectFieldTemplateProps, RJSFSchema } from "@rjsf/utils";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import {
+  type BrowserConfigFormContext,
+  BrowserConfigObjectFieldTemplate,
+} from "@/features/configOverrides/rjsfTemplates";
+import {
+  alwaysExpandedCollapse,
+  mockFieldContent,
+  mockSectionContent,
+  noTransparentPaths,
+} from "@/storybook/mockWidgetProps";
+
+/**
+ * BrowserConfigObjectFieldTemplate is the config explorer's stage section: a
+ * full-bleed disclosure header (chevron when collapse plumbing is present) that
+ * opens a recessed slab. Scalar children render as one padded field run; object/
+ * array children render flush as their own rows (hairline-divided). Adapted from
+ * `.design-sync/previews/BrowserConfigObjectFieldTemplate.tsx`. Each property's
+ * `content` is pre-rendered; the registry set-likes force "always expanded /
+ * nothing transparent".
+ */
+// `args` is cast to the full ObjectFieldTemplateProps so Storybook's CSF3 type
+// inference treats every (otherwise-required) rjsf prop as optional — letting
+// these render-only stories omit an `args` block. The value is never read: each
+// story drives the component entirely through its own `render` body.
+const meta = {
+  title: "forms/BrowserConfigObjectFieldTemplate",
+  component: BrowserConfigObjectFieldTemplate,
+  args: {} as unknown as ObjectFieldTemplateProps<unknown, RJSFSchema, BrowserConfigFormContext>,
+} satisfies Meta<typeof BrowserConfigObjectFieldTemplate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Shared stage fixture (hoisted to module scope so the constant content is stable).
+const stageProps = {
+  title: "Elevation",
+  description: "Sea level, mountain density, and range placement.",
+  fieldPathId: { path: ["elevation"] },
+  schema: {
+    type: "object",
+    properties: {
+      seaLevel: { type: "number" },
+      mountainDensity: { type: "number" },
+      ranges: { type: "array" },
+    },
+  },
+  properties: [
+    { name: "seaLevel", hidden: false, content: mockFieldContent("Sea Level", "0.6") },
+    {
+      name: "mountainDensity",
+      hidden: false,
+      content: mockFieldContent("Mountain Density", "0.3"),
+    },
+    { name: "ranges", hidden: false, content: mockSectionContent("Ranges") },
+  ],
+};
+
+// Preview-only `bg-card` frame so the recessed slab reads on the right tier.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-card border border-border text-foreground"
+      style={{ width: 360, borderRadius: 8, overflow: "hidden" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const ExpandedStage: Story = {
+  render: () => (
+    <Demo>
+      <BrowserConfigObjectFieldTemplate
+        {...({
+          ...stageProps,
+          registry: {
+            formContext: {
+              transparentPaths: noTransparentPaths,
+              collapse: alwaysExpandedCollapse,
+            },
+          },
+        } as unknown as ObjectFieldTemplateProps<unknown, RJSFSchema, BrowserConfigFormContext>)}
+      />
+    </Demo>
+  ),
+};
+
+export const WithoutCollapse: Story = {
+  render: () => (
+    <Demo>
+      <BrowserConfigObjectFieldTemplate
+        {...({
+          ...stageProps,
+          registry: { formContext: { transparentPaths: noTransparentPaths } },
+        } as unknown as ObjectFieldTemplateProps<unknown, RJSFSchema, BrowserConfigFormContext>)}
+      />
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/features/configOverrides/CheckboxWidget.stories.tsx
+++ b/apps/mapgen-studio/src/features/configOverrides/CheckboxWidget.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { CheckboxWidget } from "@/features/configOverrides/rjsfWidgets";
+import { widgetProps } from "@/storybook/mockWidgetProps";
+
+/**
+ * CheckboxWidget is the RJSF boolean control on the DS `Checkbox`. Adapted from
+ * `.design-sync/previews/CheckboxWidget.tsx`; the typed `widgetProps` factory feeds
+ * the story `args` (CSF3 requires args for required-prop widgets), and `render`
+ * spreads them into the real widget on its preview substrate.
+ */
+const meta = {
+  title: "forms/CheckboxWidget",
+  component: CheckboxWidget,
+} satisfies Meta<typeof CheckboxWidget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop so the control reads on its real substrate.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 20, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// Preview-only label row — the widget is just the box; the label is chrome.
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+      {children}
+      <span className="text-data text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+export const Checked: Story = {
+  args: widgetProps({
+    id: "cfg_wrapX",
+    name: "flag",
+    value: true,
+    options: { emptyValue: false },
+  }),
+  render: (args) => (
+    <Demo>
+      <Row label="Wrap east–west">
+        <CheckboxWidget {...args} />
+      </Row>
+    </Demo>
+  ),
+};
+
+export const Unchecked: Story = {
+  args: widgetProps({
+    id: "cfg_iceCaps",
+    name: "flag",
+    value: false,
+    options: { emptyValue: false },
+  }),
+  render: (args) => (
+    <Demo>
+      <Row label="Polar ice caps">
+        <CheckboxWidget {...args} />
+      </Row>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/features/configOverrides/NumberWidget.stories.tsx
+++ b/apps/mapgen-studio/src/features/configOverrides/NumberWidget.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { NumberWidget } from "@/features/configOverrides/rjsfWidgets";
+import { widgetProps } from "@/storybook/mockWidgetProps";
+
+/**
+ * NumberWidget is the RJSF numeric control (type=number, inputMode=decimal) on the
+ * DS `Input` — empties normalize to `emptyValue`, NaN is rejected. Adapted from
+ * `.design-sync/previews/NumberWidget.tsx`; the typed `widgetProps` factory feeds the
+ * story `args` (CSF3 requires args for required-prop widgets), and `render` spreads
+ * them into the real widget on its preview substrate.
+ */
+const meta = {
+  title: "forms/NumberWidget",
+  component: NumberWidget,
+} satisfies Meta<typeof NumberWidget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop so the control reads on its real substrate.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 20, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const Filled: Story = {
+  args: widgetProps({
+    id: "cfg_seaLevel",
+    name: "seaLevel",
+    value: 0.6,
+    options: { emptyValue: undefined },
+  }),
+  render: (args) => (
+    <Demo>
+      <div style={{ width: 160 }}>
+        <NumberWidget {...args} />
+      </div>
+    </Demo>
+  ),
+};
+
+export const Disabled: Story = {
+  args: widgetProps({
+    id: "cfg_seaLevel",
+    name: "seaLevel",
+    value: 0.3,
+    options: { emptyValue: undefined },
+    disabled: true,
+  }),
+  render: (args) => (
+    <Demo>
+      <div style={{ width: 160 }}>
+        <NumberWidget {...args} />
+      </div>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/features/configOverrides/SchemaConfigForm.stories.tsx
+++ b/apps/mapgen-studio/src/features/configOverrides/SchemaConfigForm.stories.tsx
@@ -1,0 +1,151 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import {
+  SchemaConfigForm,
+  type SchemaConfigFormProps,
+} from "@/features/configOverrides/SchemaConfigForm";
+import { alwaysExpandedCollapse, noop } from "@/storybook/mockWidgetProps";
+
+/**
+ * SchemaConfigForm is the config-authoring ENGINE: it takes a JSON-schema-ish
+ * `schema` + matching `value`, derives an rjsf uiSchema (boolean→switch,
+ * string-enum→select, enum-array→tagSelect, long-string→textarea, …) and renders
+ * the BrowserConfig* templates + widgets through @rjsf/core. Adapted from
+ * `.design-sync/previews/SchemaConfigForm.tsx`. The fixture is a representative
+ * civ7 mapgen config block so every widget/template node is exercised — schema +
+ * value are plain props (exactly how RecipePanel feeds it), no server or oRPC.
+ */
+// `args` is cast to the full props so Storybook's CSF3 type inference treats
+// every (otherwise-required) prop as optional — letting these render-only
+// stories omit an `args` block. The value is never read: each story drives the
+// component entirely through its own `render` body.
+const meta = {
+  title: "forms/SchemaConfigForm",
+  component: SchemaConfigForm,
+  args: {} as unknown as SchemaConfigFormProps<unknown>,
+} satisfies Meta<typeof SchemaConfigForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// A representative published-config-style schema; each branch targets one
+// widget/template path. `climate.biomes.uniqueItems` marks the tag-set so rjsf
+// surfaces `items.enum` as enumOptions for the tagSelect widget.
+const schema = {
+  type: "object",
+  properties: {
+    climate: {
+      type: "object",
+      title: "Climate",
+      properties: {
+        model: {
+          type: "string",
+          title: "Model",
+          enum: ["earthlike", "arid", "tropical", "frozen"],
+        },
+        rainfall: { type: "number", title: "Rainfall" },
+        enableRivers: { type: "boolean", title: "Enable Rivers" },
+        biomes: {
+          type: "array",
+          title: "Biomes",
+          uniqueItems: true,
+          items: {
+            type: "string",
+            enum: ["tundra", "grassland", "desert", "rainforest", "marsh"],
+          },
+        },
+        notes: {
+          type: "string",
+          title: "Notes",
+          maxLength: 200,
+        },
+      },
+    },
+    landmass: {
+      type: "object",
+      title: "Landmass",
+      properties: {
+        waterPercent: { type: "number", title: "Water Percent" },
+        continents: { type: "number", title: "Continents" },
+        islands: {
+          type: "array",
+          title: "Islands",
+          items: {
+            type: "object",
+            properties: {
+              name: { type: "string", title: "Name" },
+              size: {
+                type: "string",
+                title: "Size",
+                enum: ["small", "medium", "large"],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const value = {
+  climate: {
+    model: "earthlike",
+    rainfall: 0.6,
+    enableRivers: true,
+    biomes: ["grassland", "rainforest"],
+    notes: "Temperate baseline with elevated coastal moisture.",
+  },
+  landmass: {
+    waterPercent: 0.62,
+    continents: 3,
+    islands: [
+      { name: "Aurelia", size: "medium" },
+      { name: "Borealis", size: "small" },
+    ],
+  },
+};
+
+// Preview-only popover-surface column matching RecipePanel's config section, so
+// the recessed slabs read on the right tier.
+function Panel({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-popover text-foreground border border-border"
+      style={{ width: 384, borderRadius: 8, overflow: "hidden" }}
+    >
+      <div className="px-3 py-3">{children}</div>
+    </div>
+  );
+}
+
+// The whole engine: a multi-group config form driven by schema + value.
+export const ConfigForm: Story = {
+  render: () => (
+    <Panel>
+      <SchemaConfigForm
+        schema={schema}
+        value={value}
+        disabled={false}
+        collapse={alwaysExpandedCollapse}
+        onChange={noop}
+      />
+    </Panel>
+  ),
+};
+
+// focusPath narrows the engine to a single stage (RecipePanel's per-step "focus
+// mode") — here it isolates the Climate group.
+export const FocusedStage: Story = {
+  render: () => (
+    <Panel>
+      <SchemaConfigForm
+        schema={schema}
+        value={value}
+        focusPath={["climate"]}
+        disabled={false}
+        collapse={alwaysExpandedCollapse}
+        onChange={noop}
+      />
+    </Panel>
+  ),
+};

--- a/apps/mapgen-studio/src/features/configOverrides/SelectWidget.stories.tsx
+++ b/apps/mapgen-studio/src/features/configOverrides/SelectWidget.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { SelectWidget } from "@/features/configOverrides/rjsfWidgets";
+import { widgetProps } from "@/storybook/mockWidgetProps";
+
+/**
+ * SelectWidget maps an RJSF enum onto the DS `Select` — the schema's "no selection"
+ * placeholder round-trips through a reserved sentinel. Shown at rest. Adapted from
+ * `.design-sync/previews/SelectWidget.tsx`; the typed `widgetProps` factory feeds the
+ * story `args` (CSF3 requires args for required-prop widgets), and `render` spreads
+ * them into the real widget on its preview substrate.
+ */
+const meta = {
+  title: "forms/SelectWidget",
+  component: SelectWidget,
+} satisfies Meta<typeof SelectWidget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop so the control reads on its real substrate.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 20, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// Enum option set hoisted to module scope (constant fixture).
+const rainfallOptions = [
+  { value: "arid", label: "Arid" },
+  { value: "temperate", label: "Temperate" },
+  { value: "wet", label: "Wet" },
+];
+
+export const Selected: Story = {
+  args: widgetProps({
+    id: "cfg_rainfall",
+    name: "rainfall",
+    value: "temperate",
+    options: { emptyValue: "", enumOptions: rainfallOptions },
+    placeholder: "Choose rainfall",
+  }),
+  render: (args) => (
+    <Demo>
+      <div style={{ width: 220 }}>
+        <SelectWidget {...args} />
+      </div>
+    </Demo>
+  ),
+};
+
+export const Disabled: Story = {
+  args: widgetProps({
+    id: "cfg_rainfall",
+    name: "rainfall",
+    value: "wet",
+    options: { emptyValue: "", enumOptions: rainfallOptions },
+    disabled: true,
+  }),
+  render: (args) => (
+    <Demo>
+      <div style={{ width: 220 }}>
+        <SelectWidget {...args} />
+      </div>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/features/configOverrides/SwitchWidget.stories.tsx
+++ b/apps/mapgen-studio/src/features/configOverrides/SwitchWidget.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { SwitchWidget } from "@/features/configOverrides/rjsfWidgets";
+import { widgetProps } from "@/storybook/mockWidgetProps";
+
+/**
+ * SwitchWidget is the RJSF boolean control rendered as the DS `Switch` (the toggle
+ * idiom, vs CheckboxWidget's box). Adapted from `.design-sync/previews/SwitchWidget.tsx`;
+ * the typed `widgetProps` factory feeds the story `args` (CSF3 requires args for
+ * required-prop widgets), and `render` spreads them into the real widget on its
+ * preview substrate.
+ */
+const meta = {
+  title: "forms/SwitchWidget",
+  component: SwitchWidget,
+} satisfies Meta<typeof SwitchWidget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop so the control reads on its real substrate.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 20, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// Preview-only label row — the widget is just the toggle; the label is chrome.
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 8,
+        alignItems: "center",
+        justifyContent: "space-between",
+        width: 220,
+      }}
+    >
+      <span className="text-data text-muted-foreground">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+export const On: Story = {
+  args: widgetProps({
+    id: "cfg_drift",
+    name: "flag",
+    value: true,
+    options: { emptyValue: false },
+  }),
+  render: (args) => (
+    <Demo>
+      <Row label="Continental drift">
+        <SwitchWidget {...args} />
+      </Row>
+    </Demo>
+  ),
+};
+
+export const Off: Story = {
+  args: widgetProps({
+    id: "cfg_mirror",
+    name: "flag",
+    value: false,
+    options: { emptyValue: false },
+  }),
+  render: (args) => (
+    <Demo>
+      <Row label="Mirror hemispheres">
+        <SwitchWidget {...args} />
+      </Row>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/features/configOverrides/TagSelectWidget.stories.tsx
+++ b/apps/mapgen-studio/src/features/configOverrides/TagSelectWidget.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { TagSelectWidget } from "@/features/configOverrides/rjsfWidgets";
+import { widgetProps } from "@/storybook/mockWidgetProps";
+
+/**
+ * TagSelectWidget is the multi-select pill row — the RJSF registry's Checkboxes/
+ * tagSelect target. Each enum option is a toggle pill. The novel reusable control of
+ * this cluster (no raw DS primitive equivalent). Adapted from
+ * `.design-sync/previews/TagSelectWidget.tsx`; the typed `widgetProps` factory feeds
+ * the story `args` (CSF3 requires args for required-prop widgets), and `render`
+ * spreads them into the real widget on its preview substrate.
+ */
+const meta = {
+  title: "forms/TagSelectWidget",
+  component: TagSelectWidget,
+} satisfies Meta<typeof TagSelectWidget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop so the control reads on its real substrate.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 20, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// Enum option set hoisted to module scope (constant fixture).
+const biomeOptions = [
+  { value: "temperate", label: "Temperate" },
+  { value: "arid", label: "Arid" },
+  { value: "wet", label: "Wet" },
+  { value: "tropical", label: "Tropical" },
+  { value: "tundra", label: "Tundra" },
+  { value: "alpine", label: "Alpine" },
+];
+
+export const Selection: Story = {
+  args: widgetProps({
+    id: "cfg_biomes",
+    name: "biomes",
+    value: ["temperate", "wet", "alpine"],
+    options: { emptyValue: [], enumOptions: biomeOptions },
+  }),
+  render: (args) => (
+    <Demo>
+      <div style={{ width: 320 }}>
+        <TagSelectWidget {...args} />
+      </div>
+    </Demo>
+  ),
+};
+
+export const Disabled: Story = {
+  args: widgetProps({
+    id: "cfg_biomes",
+    name: "biomes",
+    value: ["arid", "tundra"],
+    options: { emptyValue: [], enumOptions: biomeOptions },
+    disabled: true,
+  }),
+  render: (args) => (
+    <Demo>
+      <div style={{ width: 320 }}>
+        <TagSelectWidget {...args} />
+      </div>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/features/configOverrides/TextWidget.stories.tsx
+++ b/apps/mapgen-studio/src/features/configOverrides/TextWidget.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { TextWidget } from "@/features/configOverrides/rjsfWidgets";
+import { widgetProps } from "@/storybook/mockWidgetProps";
+
+/**
+ * TextWidget is the RJSF text control re-skinned onto the DS `Input` — the form's
+ * string field, wired with empty-value normalization + error a11y. Adapted from
+ * `.design-sync/previews/TextWidget.tsx`; props come from the typed `widgetProps`
+ * factory.
+ */
+const meta = {
+  title: "forms/TextWidget",
+  component: TextWidget,
+} satisfies Meta<typeof TextWidget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop so the control reads on its real substrate.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 20, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const Filled: Story = {
+  args: widgetProps({
+    id: "cfg_recipe",
+    name: "recipe",
+    value: "mod-swooper-maps/standard",
+    placeholder: "recipe id",
+  }),
+  render: (args) => (
+    <Demo>
+      <div style={{ width: 260 }}>
+        <TextWidget {...args} />
+      </div>
+    </Demo>
+  ),
+};
+
+export const Disabled: Story = {
+  args: widgetProps({
+    id: "cfg_recipe",
+    name: "recipe",
+    value: "mod-swooper-maps/standard",
+    disabled: true,
+  }),
+  render: (args) => (
+    <Demo>
+      <div style={{ width: 260 }}>
+        <TextWidget {...args} />
+      </div>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/features/configOverrides/TextareaWidget.stories.tsx
+++ b/apps/mapgen-studio/src/features/configOverrides/TextareaWidget.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { TextareaWidget } from "@/features/configOverrides/rjsfWidgets";
+import { widgetProps } from "@/storybook/mockWidgetProps";
+
+/**
+ * TextareaWidget is the RJSF multiline control re-skinned onto the DS `Textarea`.
+ * Adapted from `.design-sync/previews/TextareaWidget.tsx`; the typed `widgetProps`
+ * factory feeds the story `args` (CSF3 requires args for required-prop widgets), and
+ * `render` spreads them into the real widget on its preview substrate.
+ */
+const meta = {
+  title: "forms/TextareaWidget",
+  component: TextareaWidget,
+} satisfies Meta<typeof TextareaWidget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark backdrop so the control reads on its real substrate.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 20, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const Filled: Story = {
+  args: widgetProps({
+    id: "cfg_notes",
+    name: "notes",
+    value: "Cool, wet archipelago.\nHigh sea level, frequent island chains.",
+  }),
+  render: (args) => (
+    <Demo>
+      <div style={{ width: 300 }}>
+        <TextareaWidget {...args} />
+      </div>
+    </Demo>
+  ),
+};
+
+export const Empty: Story = {
+  args: widgetProps({
+    id: "cfg_notes",
+    name: "notes",
+    value: "",
+    placeholder: "Describe this preset…",
+  }),
+  render: (args) => (
+    <Demo>
+      <div style={{ width: 300 }}>
+        <TextareaWidget {...args} />
+      </div>
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/features/presets/PresetConfirmDialog.stories.tsx
+++ b/apps/mapgen-studio/src/features/presets/PresetConfirmDialog.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PresetConfirmDialog } from "@/features/presets/PresetDialogs";
+
+/**
+ * PresetConfirmDialog is the destructive-confirm flow (outline Cancel + filled
+ * confirm). Adapted from `.design-sync/previews/PresetConfirmDialog.tsx`;
+ * rendered open (it portals its own popover surface).
+ */
+const meta = {
+  title: "composites/PresetConfirmDialog",
+  component: PresetConfirmDialog,
+} satisfies Meta<typeof PresetConfirmDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+export const DeletePreset: Story = {
+  args: {
+    open: true,
+    title: "Delete preset?",
+    message: "‘Tropical Archipelago’ will be permanently removed. This can’t be undone.",
+    confirmLabel: "Delete",
+    onCancel: noop,
+    onConfirm: noop,
+  },
+  render: (args) => <PresetConfirmDialog {...args} />,
+};

--- a/apps/mapgen-studio/src/features/presets/PresetErrorDialog.stories.tsx
+++ b/apps/mapgen-studio/src/features/presets/PresetErrorDialog.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PresetErrorDialog } from "@/features/presets/PresetDialogs";
+
+/**
+ * PresetErrorDialog surfaces a failed preset import/save on the token-driven
+ * shadcn Dialog. Adapted from `.design-sync/previews/PresetErrorDialog.tsx`;
+ * rendered open (it portals its own popover surface).
+ */
+const meta = {
+  title: "composites/PresetErrorDialog",
+  component: PresetErrorDialog,
+} satisfies Meta<typeof PresetErrorDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+export const ImportFailed: Story = {
+  args: {
+    open: true,
+    title: "Couldn’t import preset",
+    message: "The preset file is missing required recipe fields and can’t be loaded.",
+    details: [
+      "config.layers.climate: required",
+      "config.recipe: unknown key ‘placement.discoveries’",
+    ],
+    onOpenChange: noop,
+  },
+  render: (args) => <PresetErrorDialog {...args} />,
+};

--- a/apps/mapgen-studio/src/features/presets/PresetSaveDialog.stories.tsx
+++ b/apps/mapgen-studio/src/features/presets/PresetSaveDialog.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PresetSaveDialog } from "@/features/presets/PresetDialogs";
+
+/**
+ * PresetSaveDialog captures the current config as a named preset (Save disabled
+ * until a label is entered). Adapted from `.design-sync/previews/PresetSaveDialog.tsx`;
+ * rendered open (it portals its own popover surface).
+ */
+const meta = {
+  title: "composites/PresetSaveDialog",
+  component: PresetSaveDialog,
+} satisfies Meta<typeof PresetSaveDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+export const SaveConfig: Story = {
+  args: {
+    open: true,
+    initialLabel: "Tropical Archipelago",
+    initialDescription: "High sea level, hotspot island chains",
+    onCancel: noop,
+    onConfirm: noop,
+  },
+  render: (args) => <PresetSaveDialog {...args} />,
+};

--- a/apps/mapgen-studio/src/features/recipeDag/PipelineStage.stories.tsx
+++ b/apps/mapgen-studio/src/features/recipeDag/PipelineStage.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { PipelineStage, type PipelineStageProps } from "@/features/recipeDag/PipelineStage";
+import { recipeDagFixture } from "@/storybook/recipeDagFixture";
+
+/**
+ * Adapted from `.design-sync/previews/PipelineStage.tsx`. The recipe dependency
+ * graph as a first-class stage view: a headless-laid-out SVG canvas — dependency
+ * rank crossed with phase lanes, bundled artifact edges, and selectable stage
+ * nodes that expand to their steps. Driven by the shared `recipeDagFixture`
+ * (a valid `RecipeDagResult`) so `buildRecipeDagLayout` lays it out
+ * deterministically with no server.
+ */
+const meta = {
+  title: "panels/PipelineStage",
+  component: PipelineStage,
+} satisfies Meta<typeof PipelineStage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+// The full prop bag — used both as `args` (to satisfy the typed `StoryObj`'s
+// required props) and spread into the rendered component.
+const props = {
+  recipeId: "mod-swooper-maps/standard",
+  dag: recipeDagFixture,
+  status: "ready",
+  error: null,
+  isLightMode: false,
+  expandedStageIds: new Set(["relief"]),
+  selectedStageId: null,
+  onToggleStage: noop,
+  onSelectStage: noop,
+  topInset: 16,
+  bottomInset: 16,
+} satisfies PipelineStageProps;
+
+// Preview-only relative dark Stage surface — the component is `absolute inset-0`,
+// so it needs a bounded positioned host; a wide viewport reveals the lanes/nodes/
+// edges. Not a DS export.
+function Stage({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="relative bg-background"
+      style={{ width: 1080, height: 600, borderRadius: 8, overflow: "hidden" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// The ready graph: phase lanes crossed with dependency ranks, the `relief` stage
+// expanded to its steps (the fixture invariant), the console strip top-right.
+export const PipelineGraph: Story = {
+  args: props,
+  render: (args) => (
+    <Stage>
+      <PipelineStage {...args} />
+    </Stage>
+  ),
+};

--- a/apps/mapgen-studio/src/storybook/EXCLUSIONS.md
+++ b/apps/mapgen-studio/src/storybook/EXCLUSIONS.md
@@ -1,0 +1,20 @@
+# Storybook workbench — excluded components (Stage 1)
+
+The workbench stories the **46-component presentational surface** enumerated by
+the design-sync `componentSrcMap` (every one is a pure, prop-driven leaf). The
+components below are deliberately **not** storied in Stage 1, with reasons. These
+are orchestration hosts and deck.gl/WebGL surfaces — storying them would violate
+the change's stop conditions (an orchestration host given a story; StrictMode /
+live canvas in a story) or require live data.
+
+| Component | Reason excluded |
+|---|---|
+| `StudioShell` (`src/app/StudioShell.tsx`) | Top-level orchestration host — composes the whole app from hooks/stores, not a prop-driven leaf. Stop condition: an orchestration host is never given a story. |
+| `StudioProviders` (`src/app/StudioProviders.tsx`) | Provider/orchestration host (theme effect + TooltipProvider + Toaster + shell). Its job is reproduced by the global decorator (`.storybook/preview.tsx`), not storied. |
+| `DeckCanvas` (`src/features/viz/DeckCanvas.tsx`) | deck.gl/luma WebGL surface. Cannot render as an isolated pure leaf; deck.gl double-mounts under StrictMode (which the app disables in dev) and needs a live viz manifest. Stop condition: no StrictMode/live-canvas story. |
+| `CanvasStage` (`src/app/CanvasStage.tsx`) | Wraps `DeckCanvas` (deck.gl). Its empty-state branch was a best-effort Tier-3 candidate (`design.md` §7) but is **deferred** in Stage 1: the deck.gl-free empty branch is low-value relative to the WebGL-host risk, and `CanvasStage` is not part of the 46-component design-sync surface this change covers. Revisit if the empty state earns a dedicated story. |
+
+**Data-coupling exclusions:** none. The census confirmed all 46 in-scope
+components are prop-driven and reach no `/rpc`/daemon data; none had to be
+excluded for live-data coupling. The per-story stub `QueryClient` is the cold-
+`/rpc` backstop, not a mock for any storied component's own queries.

--- a/apps/mapgen-studio/src/storybook/mockWidgetProps.tsx
+++ b/apps/mapgen-studio/src/storybook/mockWidgetProps.tsx
@@ -1,0 +1,78 @@
+import type { RJSFSchema, WidgetProps } from "@rjsf/utils";
+import type { ReactNode } from "react";
+import { Input } from "@/components/ui";
+import type {
+  BrowserConfigFormContext,
+  ConfigCollapseContext,
+} from "@/features/configOverrides/rjsfTemplates";
+import { FieldRow } from "@/ui/components/fields";
+
+/**
+ * Shared rjsf mock support for the Stage-1 config-override stories.
+ *
+ * The widgets + templates accept large `@rjsf/utils` prop types but read only a
+ * small subset at render; the design-sync previews exploited that with loose
+ * esbuild-only mocks. Co-located stories ARE typechecked, so this module
+ * constructs exactly the fields each component reads and casts to the full rjsf
+ * type — honest about the mock surface, type-safe at the call site.
+ */
+
+export const noop = () => {};
+
+type ConfigWidgetProps = WidgetProps<unknown, RJSFSchema, BrowserConfigFormContext>;
+
+/**
+ * A `WidgetProps` for the seven config widgets. Pass `value` plus whichever of
+ * `options.{emptyValue,enumOptions}` / `disabled` / `placeholder` the story
+ * exercises; the rest defaults to an inert, error-free control.
+ */
+export function widgetProps(overrides: Partial<ConfigWidgetProps> = {}): ConfigWidgetProps {
+  return {
+    id: "cfg_field",
+    name: "field",
+    onChange: noop,
+    options: { emptyValue: "" },
+    rawErrors: [],
+    ...overrides,
+  } as ConfigWidgetProps;
+}
+
+/**
+ * Collapse context reporting every pointer as expanded (`has() => true`) — the
+ * form's "all open" state — without enumerating pointer strings. The templates
+ * only call `.has()` on the set, so the cast is to exactly what they read.
+ */
+export const alwaysExpandedCollapse: ConfigCollapseContext = {
+  expandedPointers: { has: () => true } as unknown as ReadonlySet<string>,
+  toggle: noop,
+};
+
+/** Nothing transparent — object sections render their disclosure chrome. */
+export const noTransparentPaths: ReadonlySet<string> = new Set<string>();
+
+/**
+ * A rendered scalar field row mirroring the real field-template output, used as
+ * a template story's pre-rendered `content` / item `children` (the object and
+ * array templates receive already-rendered controls, never schema).
+ */
+export function mockFieldContent(label: string, value: string): ReactNode {
+  return (
+    <FieldRow>
+      <label className="text-data min-w-[96px] text-muted-foreground">
+        <span className="font-medium">{label}</span>
+      </label>
+      <div className="flex-1 min-w-[120px]">
+        <Input className="w-28 font-mono" defaultValue={value} aria-label={label} />
+      </div>
+    </FieldRow>
+  );
+}
+
+/** A nested object/array child rendered flush as its own group-eyebrow row. */
+export function mockSectionContent(title: string): ReactNode {
+  return (
+    <div className="px-2.5 py-2 text-label font-semibold uppercase tracking-wider text-muted-foreground">
+      {title}
+    </div>
+  );
+}

--- a/apps/mapgen-studio/src/storybook/queryStub.ts
+++ b/apps/mapgen-studio/src/storybook/queryStub.ts
@@ -1,0 +1,31 @@
+import { QueryClient } from "@tanstack/react-query";
+
+/**
+ * The stub TanStack Query client every story renders under.
+ *
+ * It is the cold-`/rpc` backstop for the workbench. Stage-1 stories pass fixtures
+ * to pure presentational leaves and should mount no `orpc.*` query at all; this
+ * client guarantees the network seam stays cold even if a leaf is accidentally
+ * wrapped in a query. It deliberately OVERRIDES the prod defaults from
+ * `src/lib/query.ts` (`staleTime: 5_000`, `retry: 1`, `refetchOnWindowFocus: true`)
+ * — those would let a stray query thrash `/rpc` on focus.
+ *
+ * Build a FRESH client per story (the preview decorator does, via `useState`) so
+ * seeded cache state never leaks across stories.
+ */
+export function createStoryQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        refetchOnWindowFocus: false,
+        refetchOnMount: false,
+        refetchOnReconnect: false,
+        staleTime: Number.POSITIVE_INFINITY,
+        gcTime: Number.POSITIVE_INFINITY,
+        networkMode: "always",
+      },
+      mutations: { retry: false },
+    },
+  });
+}

--- a/apps/mapgen-studio/src/storybook/recipeDagFixture.ts
+++ b/apps/mapgen-studio/src/storybook/recipeDagFixture.ts
@@ -1,0 +1,163 @@
+import type { RecipeDagResult } from "@civ7/studio-server/contract";
+
+/**
+ * A small but complete, valid `RecipeDagResult` for the `PipelineStage` story —
+ * a four-phase map-generation recipe (foundation → morphology → hydrology →
+ * ecology), wired by the artifacts each stage provides/consumes. Ported from the
+ * synced `.design-sync/previews/PipelineStage.tsx` fixture and typed against the
+ * real `@civ7/studio-server/contract` schema, so `buildRecipeDagLayout` lays it
+ * out deterministically with no server.
+ *
+ * INVARIANT (mirrored by the story): every id in the story's `expandedStageIds`
+ * must equal one of the `stages[].stageId` defined here. The story expands
+ * "relief", which exists below.
+ */
+type ArtifactRef = RecipeDagResult["stages"][number]["artifactRequires"][number];
+type Step = RecipeDagResult["stages"][number]["steps"][number];
+type Edge = RecipeDagResult["edges"][number];
+
+const ref = (id: string): ArtifactRef => ({ id, name: id });
+
+const step = (
+  stageId: string,
+  stepId: string,
+  order: number,
+  orderInStage: number,
+  phase: string,
+  requires: string[],
+  provides: string[]
+): Step => ({
+  id: `${stageId}.${stepId}`,
+  stageId,
+  stepId,
+  fullStepId: `${stageId}.${stepId}`,
+  order,
+  orderInStage,
+  phase,
+  artifactRequires: requires.map(ref),
+  artifactProvides: provides.map(ref),
+  tagRequires: [],
+  tagProvides: [],
+});
+
+const edge = (
+  artifact: string,
+  fromStage: string,
+  fromStep: string,
+  toStage: string,
+  toStep: string
+): Edge => ({
+  id: `${fromStage}.${fromStep}->${toStage}.${toStep}:${artifact}`,
+  artifact: ref(artifact),
+  from: { stageId: fromStage, stepId: fromStep, fullStepId: `${fromStage}.${fromStep}` },
+  to: { stageId: toStage, stepId: toStep, fullStepId: `${toStage}.${toStep}` },
+  internal: false,
+});
+
+export const recipeDagFixture: RecipeDagResult = {
+  recipeId: "mod-swooper-maps/standard",
+  recipeKey: "standard",
+  namespace: "mod-swooper-maps",
+  title: "Standard",
+  phases: [
+    { id: "foundation", order: 0, stageIds: ["plates"], stepCount: 2 },
+    { id: "morphology", order: 1, stageIds: ["relief", "coastlines"], stepCount: 3 },
+    { id: "hydrology", order: 2, stageIds: ["rivers"], stepCount: 3 },
+    { id: "ecology", order: 3, stageIds: ["biomes"], stepCount: 2 },
+  ],
+  stages: [
+    {
+      id: "plates",
+      stageId: "plates",
+      order: 0,
+      phases: ["foundation"],
+      steps: [
+        step("plates", "seedPlates", 0, 0, "foundation", [], ["crust"]),
+        step("plates", "driftPlates", 1, 1, "foundation", ["crust"], ["plates"]),
+      ],
+      artifactRequires: [],
+      artifactProvides: [ref("crust"), ref("plates")],
+      inboundArtifactEdgeCount: 0,
+      outboundArtifactEdgeCount: 2,
+      internalArtifactEdgeCount: 1,
+      diagnosticCount: 0,
+    },
+    {
+      id: "relief",
+      stageId: "relief",
+      order: 1,
+      phases: ["morphology"],
+      steps: [
+        step("relief", "upliftRanges", 2, 0, "morphology", ["crust"], ["elevation"]),
+        step("relief", "carveBasins", 3, 1, "morphology", ["elevation"], ["landmask"]),
+      ],
+      artifactRequires: [ref("crust")],
+      artifactProvides: [ref("elevation"), ref("landmask")],
+      inboundArtifactEdgeCount: 1,
+      outboundArtifactEdgeCount: 3,
+      internalArtifactEdgeCount: 1,
+      diagnosticCount: 0,
+    },
+    {
+      id: "coastlines",
+      stageId: "coastlines",
+      order: 2,
+      phases: ["morphology"],
+      steps: [step("coastlines", "traceCoast", 4, 0, "morphology", ["landmask"], ["coast"])],
+      artifactRequires: [ref("landmask")],
+      artifactProvides: [ref("coast")],
+      inboundArtifactEdgeCount: 1,
+      outboundArtifactEdgeCount: 1,
+      internalArtifactEdgeCount: 0,
+      diagnosticCount: 0,
+    },
+    {
+      id: "rivers",
+      stageId: "rivers",
+      order: 3,
+      phases: ["hydrology"],
+      steps: [
+        step("rivers", "accumulateFlow", 5, 0, "hydrology", ["elevation"], ["flow"]),
+        step("rivers", "routeRivers", 6, 1, "hydrology", ["flow", "coast"], ["rivers"]),
+        step("rivers", "carveValleys", 7, 2, "hydrology", ["rivers"], ["valleys"]),
+      ],
+      artifactRequires: [ref("elevation"), ref("coast")],
+      artifactProvides: [ref("rivers"), ref("flow"), ref("valleys")],
+      inboundArtifactEdgeCount: 2,
+      outboundArtifactEdgeCount: 1,
+      internalArtifactEdgeCount: 2,
+      diagnosticCount: 1,
+    },
+    {
+      id: "biomes",
+      stageId: "biomes",
+      order: 4,
+      phases: ["ecology"],
+      steps: [
+        step("biomes", "classifyBiomes", 8, 0, "ecology", ["rivers", "elevation"], ["biomes"]),
+        step("biomes", "scatterVegetation", 9, 1, "ecology", ["biomes"], ["vegetation"]),
+      ],
+      artifactRequires: [ref("rivers"), ref("elevation")],
+      artifactProvides: [ref("biomes"), ref("vegetation")],
+      inboundArtifactEdgeCount: 2,
+      outboundArtifactEdgeCount: 0,
+      internalArtifactEdgeCount: 1,
+      diagnosticCount: 0,
+    },
+  ],
+  edges: [
+    edge("crust", "plates", "seedPlates", "relief", "upliftRanges"),
+    edge("landmask", "relief", "carveBasins", "coastlines", "traceCoast"),
+    edge("elevation", "relief", "upliftRanges", "rivers", "accumulateFlow"),
+    edge("coast", "coastlines", "traceCoast", "rivers", "routeRivers"),
+    edge("elevation", "relief", "upliftRanges", "biomes", "classifyBiomes"),
+    edge("rivers", "rivers", "routeRivers", "biomes", "classifyBiomes"),
+  ],
+  diagnostics: [
+    {
+      kind: "artifact-consumer-missing",
+      artifact: ref("valleys"),
+      provider: { stageId: "rivers", stepId: "carveValleys", fullStepId: "rivers.carveValleys" },
+    },
+  ],
+};

--- a/apps/mapgen-studio/src/storybook/storeReset.ts
+++ b/apps/mapgen-studio/src/storybook/storeReset.ts
@@ -1,0 +1,35 @@
+import { STUDIO_AUTHORING_STATE_KEY } from "@/features/studioState/persistence";
+import { useAuthoringStore } from "@/stores/authoringStore";
+import { useRunStore } from "@/stores/runStore";
+import { useViewStore } from "@/stores/viewStore";
+
+/**
+ * Per-story reset of the three studio Zustand stores.
+ *
+ * The stores are module singletons (no provider), so mutations leak across
+ * stories inside one preview iframe. Pure leaves with fixture props shouldn't
+ * touch store state at all — these resets are the safety net so a leaf that DOES
+ * read a store sees deterministic defaults.
+ *
+ * INIT snapshots are captured ONCE at module load, immediately after importing
+ * the stores and before any story mutates them. `authoringStore`'s
+ * `buildInitialAuthoringData()` runs at its own module load reading whatever is
+ * in `localStorage` at that moment (empty in a fresh iframe → app defaults). The
+ * stores use immutable value/updater setters, so each setter produces a NEW state
+ * object and never mutates the captured INIT reference — a shallow capture is
+ * safe to restore via `setState(INIT, true)`.
+ */
+const VIEW_INIT = useViewStore.getState();
+const RUN_INIT = useRunStore.getState();
+const AUTH_INIT = useAuthoringStore.getState();
+
+export function resetStudioStores(): void {
+  useViewStore.setState(VIEW_INIT, true);
+  useRunStore.setState(RUN_INIT, true);
+  useAuthoringStore.setState(AUTH_INIT, true);
+  try {
+    localStorage.removeItem(STUDIO_AUTHORING_STATE_KEY);
+  } catch {
+    // localStorage hygiene is best-effort; never fail a story over it.
+  }
+}

--- a/apps/mapgen-studio/src/ui/components/AppBrand.stories.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppBrand.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { AppBrand } from "@/ui/components/AppBrand";
+
+/**
+ * AppBrand is the identity pill in the header ("MapGen Studio v0.1"), riding the
+ * popover tier over the deck.gl map. The hover info-card only mounts on
+ * mouseenter, so a static capture shows the resting pill only.
+ * Adapted from `.design-sync/previews/AppBrand.tsx`.
+ */
+const meta = {
+  title: "composites/AppBrand",
+  component: AppBrand,
+} satisfies Meta<typeof AppBrand>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark surface so the bordered popover chrome reads against the
+// studio substrate — not a DS export.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 24, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => (
+    <Demo>
+      <AppBrand />
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/ui/components/AppFooter.stories.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppFooter.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { AppFooter } from "@/ui/components/AppFooter";
+import type { RecipeSettings, WorldSettings } from "@/ui/types";
+
+/**
+ * AppFooter is the World/Map console — a centered floating bar (size · players ·
+ * seed · status · run). It positions `absolute bottom-4`, so it's framed in a
+ * relative dark surface sized like its dock over the map. The footer
+ * self-provides its own TooltipProvider internally, so its diagnostic hints work
+ * standalone here.
+ * Adapted from `.design-sync/previews/AppFooter.tsx`.
+ */
+const meta = {
+  title: "composites/AppFooter",
+  component: AppFooter,
+} satisfies Meta<typeof AppFooter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+const world: WorldSettings = {
+  mapSize: "MAPSIZE_STANDARD",
+  playerCount: 6,
+  resources: "balanced",
+};
+const recipe: RecipeSettings = {
+  recipe: "mod-swooper-maps/standard",
+  preset: "continents",
+  seed: "1474829",
+};
+
+// Preview-only relative dark surface sized like the footer's dock over the
+// map — not a DS export.
+function Dock({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="relative bg-background"
+      style={{ width: 760, height: 80, borderRadius: 8, overflow: "hidden" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const Ready: Story = {
+  args: {
+    status: "ready",
+    lastRunSettings: recipe,
+    lastGlobalSettings: world,
+    globalSettings: world,
+    currentSettings: recipe,
+    onGlobalSettingsChange: noop,
+    onSettingsChange: noop,
+    onRun: noop,
+    onReroll: noop,
+    isRunning: false,
+    isRunInGameRunning: false,
+    isDirty: false,
+    autoRunEnabled: false,
+    onAutoRunEnabledChange: noop,
+  },
+  render: (args) => (
+    <Dock>
+      <AppFooter {...args} />
+    </Dock>
+  ),
+};
+
+export const RunningDirty: Story = {
+  args: {
+    status: "running",
+    lastRunSettings: recipe,
+    lastGlobalSettings: world,
+    globalSettings: world,
+    currentSettings: { ...recipe, seed: "1474830" },
+    onGlobalSettingsChange: noop,
+    onSettingsChange: noop,
+    onRun: noop,
+    onReroll: noop,
+    isRunning: true,
+    isRunInGameRunning: false,
+    isDirty: true,
+    autoRunEnabled: true,
+    onAutoRunEnabledChange: noop,
+  },
+  render: (args) => (
+    <Dock>
+      <AppFooter {...args} />
+    </Dock>
+  ),
+};

--- a/apps/mapgen-studio/src/ui/components/AppHeader.stories.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppHeader.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import type { Civ7StudioSetupConfig } from "@/features/civ7Setup/setupConfig";
+import { AppHeader } from "@/ui/components/AppHeader";
+
+/**
+ * AppHeader is the top chrome bar: AppBrand (left), the Game bar (config
+ * selector + setup gear), and the view controls (theme/grid) on the right. It
+ * positions `absolute top-4`, so it's framed in a relative dark surface.
+ * Tooltips are covered by the global Storybook decorator's TooltipProvider.
+ * Adapted from `.design-sync/previews/AppHeader.tsx` — the preview's loose
+ * `setupConfig` mock is completed here against the real `Civ7StudioSetupConfig`
+ * (full `savedConfig` ref + required `gameOptions`).
+ */
+const meta = {
+  title: "composites/AppHeader",
+  component: AppHeader,
+} satisfies Meta<typeof AppHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+const savedConfigOptions = [
+  { value: "continents-std", label: "Continents — Standard" },
+  { value: "archipelago", label: "Archipelago" },
+  { value: "pangaea", label: "Pangaea" },
+];
+
+const setupConfig: Civ7StudioSetupConfig = {
+  savedConfig: {
+    id: "continents-std",
+    displayName: "Continents — Standard",
+    fileName: "continents-std.json",
+    path: "/configs/continents-std.json",
+  },
+  gameOptions: {},
+  playerOptions: [{ playerId: 0, options: {} }],
+};
+
+const setupOptions = {
+  savedConfigOptions,
+  leaderOptions: [],
+  civilizationOptions: [],
+  difficultyOptions: [],
+  gameSpeedOptions: [],
+};
+
+// Preview-only relative dark surface; full width so the `absolute top-4` header
+// reads on its real substrate — not a DS export.
+function Bar({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="relative bg-background"
+      style={{ width: 920, height: 72, borderRadius: 8, overflow: "hidden" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const Default: Story = {
+  args: {
+    themePreference: "dark",
+    onThemeCycle: noop,
+    showGrid: true,
+    onShowGridChange: noop,
+    setupConfig,
+    setupOptions,
+    onSetupConfigChange: noop,
+    onSavedConfigChange: noop,
+    savedConfigModified: false,
+  },
+  render: (args) => (
+    <Bar>
+      <AppHeader {...args} />
+    </Bar>
+  ),
+};
+
+export const ModifiedConfig: Story = {
+  args: {
+    themePreference: "dark",
+    onThemeCycle: noop,
+    showGrid: false,
+    onShowGridChange: noop,
+    setupConfig,
+    setupOptions,
+    onSetupConfigChange: noop,
+    onSavedConfigChange: noop,
+    savedConfigModified: true,
+  },
+  render: (args) => (
+    <Bar>
+      <AppHeader {...args} />
+    </Bar>
+  ),
+};

--- a/apps/mapgen-studio/src/ui/components/DisclosureHeader.stories.tsx
+++ b/apps/mapgen-studio/src/ui/components/DisclosureHeader.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Compass, Layers, Settings } from "lucide-react";
+import type { ReactNode } from "react";
+import { DisclosureHeader, type DisclosureHeaderProps } from "@/ui/components/DisclosureHeader";
+
+/**
+ * DisclosureHeader is the controlled section-header row used across the studio
+ * panels. Adapted from `.design-sync/previews/DisclosureHeader.tsx`; title maps
+ * to the design-sync export name for the Stage-2 package→storybook flip.
+ */
+const meta = {
+  title: "composites/DisclosureHeader",
+  component: DisclosureHeader,
+  // CSF3 requires args once when the component has required props; these stories
+  // own their full scene in render, so no per-story args are needed.
+  args: {} as unknown as DisclosureHeaderProps,
+} satisfies Meta<typeof DisclosureHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark panel column standing in for the ExplorePanel/RecipePanel
+// dock — not a DS export.
+function Dock({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-popover/95 text-foreground border border-border divide-y divide-border-subtle"
+      style={{ width: 300, borderRadius: 8, overflow: "hidden" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const PanelHeaders: Story = {
+  render: () => (
+    <Dock>
+      <DisclosureHeader
+        className="px-3 py-2.5"
+        expanded={true}
+        controls="disclosure-stage"
+        icon={<Compass className="w-4 h-4 shrink-0 text-muted-foreground" />}
+        title={<span className="text-[13px] font-semibold text-foreground">Stage</span>}
+        trailing={<span className="text-label text-muted-foreground/70">7</span>}
+      />
+      <DisclosureHeader
+        className="px-3 py-2"
+        expanded={false}
+        controls="disclosure-step"
+        icon={<Layers className="w-3.5 h-3.5 shrink-0 text-muted-foreground" />}
+        title={
+          <span className="text-data font-semibold text-muted-foreground uppercase tracking-wider">
+            Step
+          </span>
+        }
+        summary={
+          <span className="text-data font-mono text-foreground truncate">apply-rainfall</span>
+        }
+        trailing={<span className="text-label text-muted-foreground/70">12</span>}
+      />
+    </Dock>
+  ),
+};
+
+export const ChevronlessWithTag: Story = {
+  render: () => (
+    <Dock>
+      <DisclosureHeader
+        className="px-3 py-2.5"
+        chevron={false}
+        expanded={true}
+        controls="disclosure-config"
+        icon={<Settings className="w-4 h-4 shrink-0 text-muted-foreground" />}
+        title={<span className="text-[13px] font-semibold text-foreground">Config</span>}
+        trailing={
+          <span className="text-[9px] font-medium uppercase tracking-wider text-primary">
+            Modified
+          </span>
+        }
+      />
+    </Dock>
+  ),
+};

--- a/apps/mapgen-studio/src/ui/components/EmptyState.stories.tsx
+++ b/apps/mapgen-studio/src/ui/components/EmptyState.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import type { ReactNode } from "react";
+import { EmptyState, type EmptyStateProps } from "@/ui/components/EmptyState";
+
+/**
+ * EmptyState is the centered status card — the shared awaiting/loading/error/
+ * empty surface. Adapted from `.design-sync/previews/EmptyState.tsx`; title maps
+ * to the design-sync export name for the Stage-2 package→storybook flip.
+ */
+const meta = {
+  title: "composites/EmptyState",
+  component: EmptyState,
+  // CSF3 requires args once when the component has required props; these stories
+  // own their full scene in render, so no per-story args are needed.
+  args: {} as unknown as EmptyStateProps,
+} satisfies Meta<typeof EmptyState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only backdrop standing in for the deck.gl canvas / DAG area; EmptyState
+// does not own the centering layer, so the caller wraps it in its own fill layer.
+function Stage({ children }: { children: ReactNode }) {
+  return (
+    <div className="relative bg-background" style={{ width: 460, height: 220 }}>
+      <div className="absolute inset-0 flex items-center justify-center px-4">{children}</div>
+    </div>
+  );
+}
+
+export const Loading: Story = {
+  render: () => (
+    <Stage>
+      <EmptyState
+        className="max-w-[420px]"
+        icon={<Loader2 className="h-5 w-5 animate-spin" />}
+        title={
+          <span className="text-data font-medium text-foreground">Loading recipe pipeline</span>
+        }
+        message={
+          <span className="text-label text-muted-foreground">
+            Reading authored artifact contracts for the selected recipe.
+          </span>
+        }
+      />
+    </Stage>
+  ),
+};
+
+export const ErrorState: Story = {
+  render: () => (
+    <Stage>
+      <EmptyState
+        className="max-w-[420px]"
+        icon={<AlertTriangle className="h-5 w-5" />}
+        title={
+          <span className="text-data font-medium text-foreground">Recipe pipeline unavailable</span>
+        }
+        message={
+          <span className="text-label text-muted-foreground">
+            Studio could not load the dependency graph for this recipe.
+          </span>
+        }
+      />
+    </Stage>
+  ),
+};
+
+export const Awaiting: Story = {
+  render: () => (
+    <Stage>
+      <EmptyState
+        title={
+          <span className="text-label uppercase tracking-[0.2em] text-muted-foreground/70">
+            Awaiting matter
+          </span>
+        }
+        message={
+          <span className="text-data font-medium text-muted-foreground">
+            Click Run to generate a map
+          </span>
+        }
+      />
+    </Stage>
+  ),
+};

--- a/apps/mapgen-studio/src/ui/components/ExplorePanel.stories.tsx
+++ b/apps/mapgen-studio/src/ui/components/ExplorePanel.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { ExplorePanel, type ExplorePanelProps } from "@/ui/components/ExplorePanel";
+
+/**
+ * Adapted from `.design-sync/previews/ExplorePanel.tsx`. The Explore dock:
+ * stage/step navigation + the layer inspector (data type · space · render mode ·
+ * variant · overlay) + era and water-proof sections. The water-proof summary is
+ * null here (no active run). Tooltips come from the global decorator's
+ * `TooltipProvider`.
+ */
+const meta = {
+  title: "panels/ExplorePanel",
+  component: ExplorePanel,
+} satisfies Meta<typeof ExplorePanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+// Hoisted fixture props (constant scene; keeps the render body literal and avoids
+// re-creating the bag per render).
+const props = {
+  stages: [
+    { value: "foundation", label: "Foundation", index: 0 },
+    { value: "morphology", label: "Morphology", index: 1 },
+    { value: "climate", label: "Climate", index: 2 },
+    { value: "hydrology", label: "Hydrology", index: 3 },
+  ],
+  selectedStage: "morphology",
+  onSelectedStageChange: noop,
+  steps: [
+    { value: "plates", label: "Plates", category: "tectonics" },
+    { value: "uplift", label: "Uplift", category: "tectonics" },
+    { value: "coastlines", label: "Coastlines", category: "shaping" },
+  ],
+  selectedStep: "uplift",
+  onSelectedStepChange: noop,
+  dataTypeOptions: [
+    { value: "elevation", label: "Elevation" },
+    { value: "rainfall", label: "Rainfall" },
+    { value: "plates", label: "Plate ID" },
+  ],
+  selectedDataType: "elevation",
+  onSelectedDataTypeChange: noop,
+  spaceOptions: [{ value: "grid", label: "Grid" }],
+  selectedSpace: "grid",
+  onSelectedSpaceChange: noop,
+  renderModeOptions: [
+    { value: "heightmap", label: "Heightmap" },
+    { value: "hillshade", label: "Hillshade" },
+  ],
+  selectedRenderMode: "heightmap",
+  onSelectedRenderModeChange: noop,
+  variantOptions: [{ value: "default", label: "Default" }],
+  selectedVariant: "default",
+  onSelectedVariantChange: noop,
+  overlayOptions: [
+    { value: "none", label: "None" },
+    { value: "rivers", label: "Rivers" },
+  ],
+  selectedOverlay: "none",
+  onSelectedOverlayChange: noop,
+  overlayOpacity: 0.6,
+  onOverlayOpacityChange: noop,
+  eraEnabled: false,
+  eraMode: "auto" as const,
+  eraValue: 2,
+  eraMin: 0,
+  eraMax: 6,
+  onEraModeChange: noop,
+  onEraValueChange: noop,
+  showEdges: false,
+  onShowEdgesChange: noop,
+  showDebugLayers: false,
+  onShowDebugLayersChange: noop,
+  onFitView: noop,
+  riverLakeInspectorSummary: null,
+} satisfies ExplorePanelProps;
+
+// Preview-only bounded dark dock so the floating panel reads on its real
+// substrate — not a DS export.
+function Dock({ children }: { children: ReactNode }) {
+  return (
+    <div className="bg-background" style={{ padding: 16, height: 600, display: "flex" }}>
+      {children}
+    </div>
+  );
+}
+
+export const Inspector: Story = {
+  args: props,
+  render: (args) => (
+    <Dock>
+      <ExplorePanel {...args} />
+    </Dock>
+  ),
+};

--- a/apps/mapgen-studio/src/ui/components/GameConsole.stories.tsx
+++ b/apps/mapgen-studio/src/ui/components/GameConsole.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { GameConsole, type GameConsoleProps } from "@/ui/components/GameConsole";
+
+/**
+ * Adapted from `.design-sync/previews/GameConsole.tsx`. The live-Civ7 command
+ * cluster (live status chip + autoplay / explore / Run-in-Game controls) as
+ * composed into the header's Game bar. Tooltips come from the global decorator's
+ * `TooltipProvider`.
+ */
+const meta = {
+  title: "panels/GameConsole",
+  component: GameConsole,
+} satisfies Meta<typeof GameConsole>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+// Shared GameConsole props common to both stories; each story differs only by
+// `liveRuntime` (present vs absent) supplied in its own `args`.
+const base = {
+  liveGameStudioRelation: "current",
+  onSyncFromLiveGame: noop,
+  onToggleAutoplay: noop,
+  onExplore: noop,
+  operationControlsDisabled: false,
+  isRunInGameRunning: false,
+  runInGameStatus: null,
+  runInGameCurrentRelation: "current",
+  onRunInGame: noop,
+  onCopyRunInGameDiagnostics: noop,
+  saveDeployStatus: null,
+} satisfies Omit<GameConsoleProps, "liveRuntime">;
+
+// Preview-only centered dark bar so the floating cluster reads on its real
+// substrate — not a DS export.
+function Bar({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="relative bg-background"
+      style={{ padding: 16, borderRadius: 8, display: "flex", justifyContent: "center" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const LiveReady: Story = {
+  args: {
+    ...base,
+    // `seed` is numeric on GameConsoleLiveRuntime (the preview's string was a
+    // loose mock); corrected to the real type here.
+    liveRuntime: {
+      status: "ok",
+      turn: 42,
+      seed: 1474829,
+      readiness: "Civ7 ready",
+      autoplayActive: false,
+    },
+  },
+  render: (args) => (
+    <Bar>
+      <GameConsole {...args} />
+    </Bar>
+  ),
+};
+
+export const NoLiveGame: Story = {
+  args: { ...base, liveRuntime: undefined },
+  render: (args) => (
+    <Bar>
+      <GameConsole {...args} />
+    </Bar>
+  ),
+};

--- a/apps/mapgen-studio/src/ui/components/OptionSelect.stories.tsx
+++ b/apps/mapgen-studio/src/ui/components/OptionSelect.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { OptionSelect } from "@/ui/components/OptionSelect";
+
+/**
+ * OptionSelect is a thin, token-driven adapter over the Radix Select that keeps
+ * the studio chrome's simple value/onValueChange/options shape. Rendered CLOSED
+ * here so each card shows the trigger with its selected label.
+ * Adapted from `.design-sync/previews/OptionSelect.tsx`.
+ */
+const meta = {
+  title: "composites/OptionSelect",
+  component: OptionSelect,
+} satisfies Meta<typeof OptionSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+const MAP_SIZES = [
+  { value: "MAPSIZE_TINY", label: "Tiny" },
+  { value: "MAPSIZE_SMALL", label: "Small" },
+  { value: "MAPSIZE_STANDARD", label: "Standard" },
+  { value: "MAPSIZE_LARGE", label: "Large" },
+  { value: "MAPSIZE_HUGE", label: "Huge" },
+];
+
+const RESOURCE_MODES = [
+  { value: "balanced", label: "Balanced" },
+  { value: "strategic", label: "Strategic" },
+  { value: "abundant", label: "Abundant" },
+];
+
+// Preview-only dark surface — not a DS export.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 20, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const MapSize: Story = {
+  args: {
+    value: "MAPSIZE_STANDARD",
+    onValueChange: noop,
+    options: MAP_SIZES,
+    ariaLabel: "Map size",
+    className: "w-44",
+  },
+  render: (args) => (
+    <Demo>
+      <OptionSelect {...args} />
+    </Demo>
+  ),
+};
+
+export const ResourceMode: Story = {
+  args: {
+    value: "strategic",
+    onValueChange: noop,
+    options: RESOURCE_MODES,
+    ariaLabel: "Resource distribution",
+    className: "w-44",
+  },
+  render: (args) => (
+    <Demo>
+      <OptionSelect {...args} />
+    </Demo>
+  ),
+};
+
+export const Disabled: Story = {
+  args: {
+    value: "MAPSIZE_STANDARD",
+    onValueChange: noop,
+    options: MAP_SIZES,
+    ariaLabel: "Map size",
+    className: "w-44",
+    disabled: true,
+  },
+  render: (args) => (
+    <Demo>
+      <OptionSelect {...args} />
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/ui/components/RecipePanel.stories.tsx
+++ b/apps/mapgen-studio/src/ui/components/RecipePanel.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { RecipePanel, type RecipePanelProps } from "@/ui/components/RecipePanel";
+import type { PipelineConfig, SelectOption } from "@/ui/types";
+
+/**
+ * Adapted from `.design-sync/previews/RecipePanel.tsx`. The 340px Recipe dock:
+ * recipe/preset selection + a schema-driven config-override form. A small but
+ * real RJSF schema + matching config drive the override form. Tooltips come from
+ * the global decorator's `TooltipProvider`.
+ */
+const meta = {
+  title: "panels/RecipePanel",
+  component: RecipePanel,
+} satisfies Meta<typeof RecipePanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+const recipeOptions: SelectOption[] = [
+  { value: "mod-swooper-maps/standard", label: "Standard" },
+  { value: "mod-swooper-maps/continents", label: "Continents" },
+  { value: "mod-swooper-maps/archipelago", label: "Archipelago" },
+];
+const presetOptions: SelectOption[] = [
+  { value: "none", label: "None" },
+  { value: "continents", label: "Continents" },
+  { value: "archipelago", label: "Archipelago" },
+];
+const settings = { recipe: "mod-swooper-maps/standard", preset: "continents", seed: "1474829" };
+
+// A small but real RJSF schema + matching config so the override form renders.
+const configSchema = {
+  type: "object",
+  properties: {
+    elevation: {
+      type: "object",
+      title: "Elevation",
+      properties: {
+        seaLevel: { type: "number", title: "Sea level", default: 0.6 },
+        mountainDensity: { type: "number", title: "Mountain density", default: 0.3 },
+      },
+    },
+    climate: {
+      type: "object",
+      title: "Climate",
+      properties: {
+        rainfall: {
+          type: "string",
+          title: "Rainfall",
+          enum: ["arid", "temperate", "wet"],
+          default: "temperate",
+        },
+      },
+    },
+  },
+};
+const config: PipelineConfig = {
+  elevation: { seaLevel: 0.6, mountainDensity: 0.3 },
+  climate: { rainfall: "temperate" },
+};
+
+const base = {
+  config,
+  configSchema,
+  onConfigChange: noop,
+  onConfigReset: noop,
+  recipeOptions,
+  presetOptions,
+  selectedStep: "",
+  settings,
+  onSettingsChange: noop,
+  onSaveToCurrent: noop,
+  onSaveAsNew: noop,
+  onImportPreset: noop,
+  onExportPreset: noop,
+  onDeletePreset: noop,
+  canDeletePreset: true,
+  isSaveDeployRunning: false,
+  saveDeployStatus: null,
+  isSaveDisabled: false,
+  isDirty: false,
+} satisfies Omit<RecipePanelProps, "recipeCollapsed" | "configCollapsed">;
+
+// Preview-only bounded dark dock so the floating panel reads on its real
+// substrate — not a DS export.
+function Dock({ children }: { children: ReactNode }) {
+  return (
+    <div className="bg-background" style={{ padding: 16, height: 540, display: "flex" }}>
+      {children}
+    </div>
+  );
+}
+
+export const RecipeAndConfig: Story = {
+  args: { ...base, recipeCollapsed: false, configCollapsed: false },
+  render: (args) => (
+    <Dock>
+      <RecipePanel {...args} />
+    </Dock>
+  ),
+};
+
+export const RecipeSelection: Story = {
+  args: { ...base, recipeCollapsed: false, configCollapsed: true },
+  render: (args) => (
+    <Dock>
+      <RecipePanel {...args} />
+    </Dock>
+  ),
+};

--- a/apps/mapgen-studio/src/ui/components/StageViewTabs.stories.tsx
+++ b/apps/mapgen-studio/src/ui/components/StageViewTabs.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { StageViewTabs } from "@/ui/components/StageViewTabs";
+
+/**
+ * StageViewTabs is the stage's own Map/Pipeline view switcher — a segmented pill
+ * that floats `absolute`, centered, at the stage's top edge.
+ * Adapted from `.design-sync/previews/StageViewTabs.tsx`.
+ */
+const meta = {
+  title: "composites/StageViewTabs",
+  component: StageViewTabs,
+} satisfies Meta<typeof StageViewTabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+// Preview-only relative dark stage surface sized to reveal the floating pill,
+// with top: 12 to clear the edge — not a DS export.
+function Stage({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="relative bg-background"
+      style={{ width: 360, height: 64, borderRadius: 8, overflow: "hidden" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const MapActive: Story = {
+  args: { value: "map", onValueChange: noop, top: 12 },
+  render: (args) => (
+    <Stage>
+      <StageViewTabs {...args} />
+    </Stage>
+  ),
+};
+
+export const PipelineActive: Story = {
+  args: { value: "pipeline", onValueChange: noop, top: 12 },
+  render: (args) => (
+    <Stage>
+      <StageViewTabs {...args} />
+    </Stage>
+  ),
+};

--- a/apps/mapgen-studio/src/ui/components/ViewControls.stories.tsx
+++ b/apps/mapgen-studio/src/ui/components/ViewControls.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { ViewControls } from "@/ui/components/ViewControls";
+
+/**
+ * ViewControls is the floating map toolbar: a theme-cycle button (auto/light/
+ * dark icon) + a grid-visibility toggle, separated by a hairline divider, on the
+ * popover tier over the map. The buttons carry shadcn Tooltips whose
+ * TooltipProvider is supplied by the global Storybook decorator.
+ * Adapted from `.design-sync/previews/ViewControls.tsx`.
+ */
+const meta = {
+  title: "composites/ViewControls",
+  component: ViewControls,
+} satisfies Meta<typeof ViewControls>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+// Preview-only dark surface — not a DS export.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-background text-foreground"
+      style={{ padding: 20, borderRadius: 6, display: "flex", flexDirection: "column", gap: 12 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const GridOn: Story = {
+  args: { themePreference: "dark", onThemeCycle: noop, showGrid: true, onShowGridChange: noop },
+  render: (args) => (
+    <Demo>
+      <ViewControls {...args} />
+    </Demo>
+  ),
+};
+
+export const GridOff: Story = {
+  args: { themePreference: "system", onThemeCycle: noop, showGrid: false, onShowGridChange: noop },
+  render: (args) => (
+    <Demo>
+      <ViewControls {...args} />
+    </Demo>
+  ),
+};

--- a/apps/mapgen-studio/src/ui/components/WaterStatsSection.stories.tsx
+++ b/apps/mapgen-studio/src/ui/components/WaterStatsSection.stories.tsx
@@ -1,0 +1,208 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import type {
+  RiverLakeFloodplainInspectorSummary,
+  RiverLakeInspectorLayerRef,
+  RiverLakeInspectorMaskCategory,
+  RiverLakeInspectorRow,
+} from "@/features/viz/riverLakeInspector";
+import { WaterStatsSection } from "@/ui/components/WaterStatsSection";
+
+/**
+ * WaterStatsSection is the hydrology/lake/floodplain stats surface inside the
+ * ExplorePanel dock: a disclosure header ("WATER STATS" · row count) over one
+ * compact line per data family — semantic count chips plus jump-to-layer chips
+ * (module-owned data colors). Divergence counts (mismatch/rejected) are
+ * emphasized in warning when nonzero. The expanded row's chips carry shadcn
+ * Tooltips whose TooltipProvider is supplied by the global Storybook decorator.
+ * Adapted from `.design-sync/previews/WaterStatsSection.tsx` — the preview's
+ * loose `ref()`/`summary` mock is completed here against the real
+ * `RiverLakeFloodplainInspectorSummary` (every required ref/row field present).
+ */
+const meta = {
+  title: "composites/WaterStatsSection",
+  component: WaterStatsSection,
+} satisfies Meta<typeof WaterStatsSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+// Fully-typed layer ref. The component reads only layerKey/dataTypeKey/label and
+// presentation.categoryLabel + palette.activeColor; the remaining fields are
+// completed with valid Viz values so the fixture satisfies the real type.
+const makeRef = (
+  layerKey: string,
+  dataTypeKey: string,
+  label: string,
+  category: RiverLakeInspectorMaskCategory,
+  categoryLabel: string,
+  activeColor: string
+): RiverLakeInspectorLayerRef => ({
+  dataTypeKey,
+  layerKey,
+  stepId: "rivers",
+  stepIndex: 0,
+  spaceId: "tile.hexOddR",
+  kind: "grid",
+  role: null,
+  variantKey: null,
+  visibility: "default",
+  label,
+  renderModeId: "mask",
+  nonZeroCount: null,
+  sampleCount: null,
+  presentation: {
+    category,
+    categoryLabel,
+    palette: {
+      paletteId: `${category}-palette`,
+      label: categoryLabel,
+      activeColor,
+      inactiveColor: "#1f2937",
+      debugColor: "#dc2626",
+    },
+  },
+});
+
+// Fully-typed row. The component reads rowKey/label/counts/layerRefs; the lane/
+// proof/claim/display/evidence fields are completed to satisfy the real type.
+const makeRow = (
+  rowKey: string,
+  label: string,
+  counts: Record<string, number>,
+  layerRefs: RiverLakeInspectorLayerRef[]
+): RiverLakeInspectorRow => ({
+  rowKey,
+  lane: "hydrology",
+  laneLabel: "Hydrology",
+  label,
+  proofClass: "hydrology-truth",
+  claimStatus: "available",
+  displayStatus: "hydrology-truth-present",
+  counts,
+  layerRefs,
+  evidence: [],
+});
+
+const summary: RiverLakeFloodplainInspectorSummary = {
+  version: 1,
+  rows: [
+    makeRow(
+      "projection-plan",
+      "Navigable river plan",
+      { layers: 3, projected: 184, minor: 142, major: 42 },
+      [
+        makeRef(
+          "map.rivers.projectedRiverMask@9",
+          "map.rivers.projectedRiverMask",
+          "Projected navigable rivers",
+          "navigable-projection",
+          "Projection plan",
+          "#0f766e"
+        ),
+        makeRef(
+          "map.rivers.plannedMajorRiverMask@9",
+          "map.rivers.plannedMajorRiverMask",
+          "Planned major rivers",
+          "navigable-projection",
+          "Projection plan",
+          "#0f766e"
+        ),
+      ]
+    ),
+    makeRow(
+      "terrain-readback",
+      "Engine terrain readback",
+      { layers: 2, terrain: 171, mismatch: 13 },
+      [
+        makeRef(
+          "map.rivers.engineRiverMask@14",
+          "map.rivers.engineRiverMask",
+          "Engine river terrain",
+          "engine-terrain-readback",
+          "Terrain readback",
+          "#0891b2"
+        ),
+        makeRef(
+          "map.rivers.riverMismatchMask@14",
+          "map.rivers.riverMismatchMask",
+          "River terrain mismatch",
+          "mismatch-debug",
+          "Mismatch/debug",
+          "#dc2626"
+        ),
+      ]
+    ),
+    makeRow(
+      "lake-plan-readback",
+      "Lake plan/readback",
+      { layers: 3, "planned lakes": 28, "engine lakes": 26, "rejected lakes": 2 },
+      [
+        makeRef(
+          "map.hydrology.lakes.plannedLakeMask@11",
+          "map.hydrology.lakes.plannedLakeMask",
+          "Planned lakes",
+          "lake-plan-readback",
+          "Lake plan/readback",
+          "#4f46e5"
+        ),
+        makeRef(
+          "map.hydrology.lakes.rejectedLakeMask@11",
+          "map.hydrology.lakes.rejectedLakeMask",
+          "Rejected lakes",
+          "mismatch-debug",
+          "Mismatch/debug",
+          "#dc2626"
+        ),
+      ]
+    ),
+    makeRow(
+      "floodplain-apply",
+      "Floodplain apply",
+      { layers: 2, "fp applied": 96, "fp rejected": 7 },
+      [
+        makeRef(
+          "map.ecology.features.floodplainAppliedMask@22",
+          "map.ecology.features.floodplainAppliedMask",
+          "Applied floodplains",
+          "floodplain-apply",
+          "Floodplain apply",
+          "#16a34a"
+        ),
+      ]
+    ),
+  ],
+};
+
+// Preview-only dark dock surface sized to the ExplorePanel column width — not a
+// DS export.
+function Dock({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-card text-foreground border border-border"
+      style={{ width: 320, borderRadius: 8, overflow: "hidden" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const Expanded: Story = {
+  args: { summary, onLayerSelect: noop, expanded: true, onExpandedChange: noop },
+  render: (args) => (
+    <Dock>
+      <WaterStatsSection {...args} />
+    </Dock>
+  ),
+};
+
+export const Collapsed: Story = {
+  args: { summary, onLayerSelect: noop, expanded: false, onExpandedChange: noop },
+  render: (args) => (
+    <Dock>
+      <WaterStatsSection {...args} />
+    </Dock>
+  ),
+};

--- a/apps/mapgen-studio/src/ui/components/fields/FieldRow.stories.tsx
+++ b/apps/mapgen-studio/src/ui/components/fields/FieldRow.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ComponentProps, ReactNode } from "react";
+import { Input, Switch } from "@/components/ui";
+import { FieldRow } from "@/ui/components/fields";
+
+/**
+ * Adapted from `.design-sync/previews/FieldRow.tsx`. FieldRow is the form-row
+ * layout atom: one flex row that pushes a label to the left and its control to
+ * the right (items-center justify-between gap-3 py-1).
+ */
+const meta = {
+  title: "primitives/FieldRow",
+  component: FieldRow,
+  // CSF3 requires args once when the component has required props; these stories
+  // own their full scene in render, so no per-story args are needed.
+  args: {} as unknown as ComponentProps<typeof FieldRow>,
+} satisfies Meta<typeof FieldRow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Preview-only dark panel substrate so the label/control split reads — not a DS
+// export.
+function Demo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="bg-card border border-border text-foreground"
+      style={{ width: 300, padding: 12, borderRadius: 8 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// A small config panel: label/control pairs stacked as FieldRows.
+export const ConfigRows: Story = {
+  render: () => (
+    <Demo>
+      <FieldRow>
+        <span className="text-data text-muted-foreground">Map size</span>
+        <Input className="w-28 font-mono" defaultValue="96 × 60" />
+      </FieldRow>
+      <FieldRow>
+        <span className="text-data text-muted-foreground">Seed</span>
+        <Input className="w-28 font-mono" defaultValue="1474829" />
+      </FieldRow>
+      <FieldRow>
+        <span className="text-data text-muted-foreground">Wrap east–west</span>
+        <Switch defaultChecked />
+      </FieldRow>
+    </Demo>
+  ),
+};
+
+// A single row in isolation — the label/control split at its simplest.
+export const SingleRow: Story = {
+  render: () => (
+    <Demo>
+      <FieldRow>
+        <span className="text-data text-muted-foreground">Rainfall</span>
+        <Input className="w-20 font-mono" defaultValue="1.0" />
+      </FieldRow>
+    </Demo>
+  ),
+};

--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,8 @@
         "zustand": "5.0.14",
       },
       "devDependencies": {
+        "@storybook/addon-docs": "9.1.20",
+        "@storybook/react-vite": "9.1.20",
         "@tailwindcss/vite": "^4.1.13",
         "@testing-library/dom": "10.4.1",
         "@testing-library/react": "16.3.2",
@@ -95,6 +97,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.2",
         "jsdom": "29.1.1",
+        "storybook": "9.1.20",
         "tailwindcss": "^4.1.13",
         "tw-animate-css": "^1.4.0",
         "vite": "^7.3.1",
@@ -314,6 +317,8 @@
     "typescript": "^5.9.3",
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
+
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.3", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-jsElTJ0sQ4wHRz+C45tfect76BwbTbgkgKByOzpCN9xG61N5V6u/glvg1CsNJhq2xJIFpKHSwG3D2wPPuEYOrQ=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -856,9 +861,13 @@
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
 
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@jest/diff-sequences": ["@jest/diff-sequences@30.0.1", "", {}, "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw=="],
+
+    "@joshwooding/vite-plugin-react-docgen-typescript": ["@joshwooding/vite-plugin-react-docgen-typescript@0.6.1", "", { "dependencies": { "glob": "^10.0.0", "magic-string": "^0.30.0", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "typescript": ">= 4.3.x", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["typescript"] }, "sha512-J4BaTocTOYFkMHIra1JDWrMWpNmBl4EkplIwHEsV8aeUOtdWjwSnln9U7twjMFTAEB7mptNtSKyVi1Y2W9sDJw=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -1054,6 +1063,8 @@
 
     "@phenomnomnominal/tsquery": ["@phenomnomnominal/tsquery@6.2.0", "", { "dependencies": { "@types/esquery": "^1.5.4", "esquery": "^1.7.0" }, "peerDependencies": { "typescript": ">3.0.0" } }, "sha512-Vo9nkhfZxDB/sBiqIY3pjDC4mOSyure+AFlEW5hcy/tRE82MqCXjRN4InnVNMldinRt0dLYqg4HAU2XPq5e1LA=="],
 
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
     "@pnpm/network.ca-file": ["@pnpm/network.ca-file@1.0.2", "", { "dependencies": { "graceful-fs": "4.2.10" } }, "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA=="],
@@ -1159,6 +1170,8 @@
     "@rjsf/validator-ajv8": ["@rjsf/validator-ajv8@6.2.5", "", { "dependencies": { "ajv": "^8.17.1", "ajv-formats": "^2.1.1", "lodash": "^4.17.21", "lodash-es": "^4.17.21" }, "peerDependencies": { "@rjsf/utils": "^6.2.x" } }, "sha512-+yLhFRuT2aY91KiUujhUKg8SyTBrUuQP3QAFINeGi+RljA3S+NQN56oeCaNdz9X+35+Sdy6jqmxy/0Q2K+K9vQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.53", "", {}, "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ=="],
+
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.4.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.56.0", "", { "os": "android", "cpu": "arm" }, "sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw=="],
 
@@ -1286,6 +1299,22 @@
 
     "@stoplight/yaml-ast-parser": ["@stoplight/yaml-ast-parser@0.0.50", "", {}, "sha512-Pb6M8TDO9DtSVla9yXSTAxmo9GVEouq5P40DWXdOie69bXogZTkgvopCq+yEvTMA0F6PEvdJmbtTV3ccIp11VQ=="],
 
+    "@storybook/addon-docs": ["@storybook/addon-docs@9.1.20", "", { "dependencies": { "@mdx-js/react": "^3.0.0", "@storybook/csf-plugin": "9.1.20", "@storybook/icons": "^1.4.0", "@storybook/react-dom-shim": "9.1.20", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^9.1.20" } }, "sha512-eUIOd4u/p9994Nkv8Avn6r/xmS7D+RNmhmu6KGROefN3myLe3JfhSdimal2wDFe/h/OUNZ/LVVKMZrya9oEfKQ=="],
+
+    "@storybook/builder-vite": ["@storybook/builder-vite@9.1.20", "", { "dependencies": { "@storybook/csf-plugin": "9.1.20", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^9.1.20", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-cdU3Q2/wEaT8h+mApFToRiF/0hYKH1eAkD0scQn67aODgp7xnkr0YHcdA+8w0Uxd2V7U8crV/cmT/HD0ELVOGw=="],
+
+    "@storybook/csf-plugin": ["@storybook/csf-plugin@9.1.20", "", { "dependencies": { "unplugin": "^1.3.1" }, "peerDependencies": { "storybook": "^9.1.20" } }, "sha512-HHgk50YQhML7mT01Mzf9N7lNMFHWN4HwwRP90kPT9Ct+Jhx7h3LBDbdmWjI96HwujcpY7eoYdTfpB1Sw8Z7nBQ=="],
+
+    "@storybook/global": ["@storybook/global@5.0.0", "", {}, "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ=="],
+
+    "@storybook/icons": ["@storybook/icons@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta" } }, "sha512-hcFZIjW8yQz8O8//2WTIXylm5Xsgc+lW9ISLgUk1xGmptIJQRdlhVIXCpSyLrQaaRiyhQRaVg7l3BD9S216BHw=="],
+
+    "@storybook/react": ["@storybook/react@9.1.20", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/react-dom-shim": "9.1.20" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "storybook": "^9.1.20", "typescript": ">= 4.9.x" }, "optionalPeers": ["typescript"] }, "sha512-TJhqzggs7HCvLhTXKfx8HodnVq9YizsB2J31s9v6olU0UCxbCY+FYaCF+XdE8qUCyefGRZgHKzGBIczJ/q9e2g=="],
+
+    "@storybook/react-dom-shim": ["@storybook/react-dom-shim@9.1.20", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "storybook": "^9.1.20" } }, "sha512-UYdZavfPwHEqCKMqPssUOlyFVZiJExLxnSHwkICSZBmw3gxXJcp1aXWs7PvoZdWz2K4ztl3IcKErXXHeiY6w+A=="],
+
+    "@storybook/react-vite": ["@storybook/react-vite@9.1.20", "", { "dependencies": { "@joshwooding/vite-plugin-react-docgen-typescript": "0.6.1", "@rollup/pluginutils": "^5.0.2", "@storybook/builder-vite": "9.1.20", "@storybook/react": "9.1.20", "find-up": "^7.0.0", "magic-string": "^0.30.0", "react-docgen": "^8.0.0", "resolve": "^1.22.8", "tsconfig-paths": "^4.2.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "storybook": "^9.1.20", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-buXeNvEJ9kp4FKbGYV7zW4sh/KS01EAjeq8Z6AVxaXOh4W2CIRTKM9maWGz+Rr+YyqQIq/Gl+RqNwxctpxeuHA=="],
+
     "@swooper/mapgen-core": ["@swooper/mapgen-core@workspace:packages/mapgen-core"],
 
     "@swooper/mapgen-viz": ["@swooper/mapgen-viz@workspace:packages/mapgen-viz"],
@@ -1328,7 +1357,11 @@
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
@@ -1355,6 +1388,8 @@
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/doctrine": ["@types/doctrine@0.0.9", "", {}, "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA=="],
 
     "@types/es-aggregate-error": ["@types/es-aggregate-error@1.0.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-qJ7LIFp06h1QE1aVxbVd+zJP2wdaugYXYfd6JxsyRMrYHaxb6itXPogW2tz+ylUJ1n1b+JF1PHyYCfYHm0dvUg=="],
 
@@ -1397,6 +1432,8 @@
     "@types/react": ["@types/react@19.2.10", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/resolve": ["@types/resolve@1.20.6", "", {}, "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1520,7 +1557,7 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
-    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+    "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
@@ -1654,6 +1691,8 @@
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
@@ -1756,6 +1795,8 @@
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "cssfilter": ["cssfilter@0.0.10", "", {}, "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="],
@@ -1787,6 +1828,8 @@
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
@@ -1840,6 +1883,8 @@
 
     "docsify-server-renderer": ["docsify-server-renderer@4.13.1", "", { "dependencies": { "debug": "^4.3.3", "docsify": "^4.12.4", "node-fetch": "^2.6.6", "resolve-pathname": "^3.0.0" } }, "sha512-XNJeCK3zp+mVO7JZFn0bH4hNBAMMC1MbuCU7CBsjLHYn4NHrjIgCBGmylzEan3/4Qm6kbSzQx8XzUK5T7GQxHw=="],
 
+    "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "dot-case": ["dot-case@3.0.4", "", { "dependencies": { "no-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w=="],
@@ -1855,6 +1900,8 @@
     "duplexer3": ["duplexer3@0.1.5", "", {}, "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA=="],
 
     "earcut": ["earcut@2.2.4", "", {}, "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
     "easy-table": ["easy-table@1.1.0", "", { "optionalDependencies": { "wcwidth": ">=1.0.1" } }, "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA=="],
 
@@ -1913,6 +1960,8 @@
     "esast-util-from-js": ["esast-util-from-js@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "acorn": "^8.0.0", "esast-util-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw=="],
 
     "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
+
+    "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -2039,6 +2088,8 @@
     "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
@@ -2344,6 +2395,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
 
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
@@ -2455,6 +2508,8 @@
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
     "lower-case": ["lower-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg=="],
 
@@ -2806,6 +2861,8 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -2896,6 +2953,10 @@
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
+    "react-docgen": ["react-docgen@8.0.3", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/traverse": "^7.28.0", "@babel/types": "^7.28.2", "@types/babel__core": "^7.20.5", "@types/babel__traverse": "^7.20.7", "@types/doctrine": "^0.0.9", "@types/resolve": "^1.20.2", "doctrine": "^3.0.0", "resolve": "^1.22.1", "strip-indent": "^4.0.0" } }, "sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w=="],
+
+    "react-docgen-typescript": ["react-docgen-typescript@2.4.0", "", { "peerDependencies": { "typescript": ">= 4.3.x" } }, "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg=="],
+
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
@@ -2916,6 +2977,8 @@
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
+    "recast": ["recast@0.23.12", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA=="],
+
     "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
 
     "recma-jsx": ["recma-jsx@1.0.1", "", { "dependencies": { "acorn-jsx": "^5.0.0", "estree-util-to-js": "^2.0.0", "recma-parse": "^1.0.0", "recma-stringify": "^1.0.0", "unified": "^11.0.0" }, "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w=="],
@@ -2923,6 +2986,8 @@
     "recma-parse": ["recma-parse@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "esast-util-from-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ=="],
 
     "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -3146,9 +3211,13 @@
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
+    "storybook": ["storybook@9.1.20", "", { "dependencies": { "@storybook/global": "^5.0.0", "@testing-library/jest-dom": "^6.6.3", "@testing-library/user-event": "^14.6.1", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/spy": "3.2.4", "better-opn": "^3.0.2", "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0", "esbuild-register": "^3.5.0", "recast": "^0.23.5", "semver": "^7.6.2", "ws": "^8.18.0" }, "peerDependencies": { "prettier": "^2 || ^3" }, "optionalPeers": ["prettier"], "bin": "./bin/index.cjs" }, "sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA=="],
+
     "streamx": ["streamx@2.23.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string.prototype.trim": ["string.prototype.trim@1.2.10", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-data-property": "^1.1.4", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-object-atoms": "^1.0.0", "has-property-descriptors": "^1.0.2" } }, "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA=="],
 
@@ -3161,6 +3230,8 @@
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
@@ -3206,6 +3277,8 @@
 
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tiny-jsonc": ["tiny-jsonc@1.0.2", "", {}, "sha512-f5QDAfLq6zIVSyCZQZhhyl0QS6MvAyTxgz4X4x3+EoCktNWEYJ6PeoEA97fyb98njpBNNi88ybpD7m+BDFXaCw=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
@@ -3217,6 +3290,8 @@
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
     "tldts": ["tldts@7.4.4", "", { "dependencies": { "tldts-core": "^7.4.4" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-kFXFK7O4WPextIUAOk8qtnw9dxR9UIXP9CjuH1cTBVBZMDeQcUPgr/IazGiw1B0Yiw5L75gHLWeW4iD793r90g=="],
 
@@ -3247,6 +3322,8 @@
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
+
+    "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
@@ -3308,6 +3385,8 @@
 
     "unicode-property-aliases-ecmascript": ["unicode-property-aliases-ecmascript@2.2.0", "", {}, "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ=="],
 
+    "unicorn-magic": ["unicorn-magic@0.1.0", "", {}, "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="],
+
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
     "unique-string": ["unique-string@2.0.0", "", { "dependencies": { "crypto-random-string": "^2.0.0" } }, "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg=="],
@@ -3341,6 +3420,8 @@
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "unplugin": ["unplugin@1.16.1", "", { "dependencies": { "acorn": "^8.14.0", "webpack-virtual-modules": "^0.6.2" } }, "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
@@ -3396,6 +3477,8 @@
 
     "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
+    "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
+
     "wgsl_reflect": ["wgsl_reflect@1.2.3", "", {}, "sha512-BQWBIsOn411M+ffBxmA6QRLvAOVbuz3Uk4NusxnqC1H7aeQcVLhdA3k2k/EFFFtqVjhz3z7JOOZF1a9hj2tv4Q=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
@@ -3423,6 +3506,8 @@
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -3776,6 +3861,14 @@
 
     "@inquirer/select/@inquirer/type": ["@inquirer/type@1.5.5", "", { "dependencies": { "mute-stream": "^1.0.0" } }, "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA=="],
 
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@joshwooding/vite-plugin-react-docgen-typescript/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
     "@mintlify/cli/@inquirer/prompts": ["@inquirer/prompts@7.9.0", "", { "dependencies": { "@inquirer/checkbox": "^4.3.0", "@inquirer/confirm": "^5.1.19", "@inquirer/editor": "^4.2.21", "@inquirer/expand": "^4.0.21", "@inquirer/input": "^4.2.5", "@inquirer/number": "^3.0.21", "@inquirer/password": "^4.0.21", "@inquirer/rawlist": "^4.1.9", "@inquirer/search": "^3.2.0", "@inquirer/select": "^4.4.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A=="],
 
     "@mintlify/cli/chalk": ["chalk@5.2.0", "", {}, "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="],
@@ -3908,6 +4001,10 @@
 
     "@rjsf/validator-ajv8/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
+    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@rollup/pluginutils/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
     "@shikijs/core/hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "@sindresorhus/slugify/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
@@ -3932,6 +4029,8 @@
 
     "@stoplight/yaml/@stoplight/types": ["@stoplight/types@14.1.1", "", { "dependencies": { "@types/json-schema": "^7.0.4", "utility-types": "^3.10.0" } }, "sha512-/kjtr+0t0tjKr+heVfviO9FrU/uGLc+QNX3fHJc19xsCNYqU7lVhaXxDmEID9BZTjG+/r9pK9xP/xU02XGg65g=="],
 
+    "@storybook/react-vite/find-up": ["find-up@7.0.0", "", { "dependencies": { "locate-path": "^7.2.0", "path-exists": "^5.0.0", "unicorn-magic": "^0.1.0" } }, "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g=="],
+
     "@tailwindcss/node/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
@@ -3945,6 +4044,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "@types/babel__core/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
 
@@ -4010,6 +4111,8 @@
 
     "decompress-response/mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
+    "degenerator/ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
     "docsify-cli/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "docsify-cli/enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
@@ -4047,6 +4150,8 @@
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "finalhandler/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
+
+    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "front-matter/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
@@ -4206,7 +4311,15 @@
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
+    "react-docgen/@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
+
+    "react-docgen/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "react-docgen/strip-indent": ["strip-indent@4.1.1", "", {}, "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA=="],
+
     "react-reconciler/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
+
+    "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "rehype-katex/unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
@@ -4239,6 +4352,18 @@
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "storybook/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "storybook/@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "storybook/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "storybook/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "storybook/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
+
+    "storybook/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
@@ -4460,6 +4585,16 @@
 
     "@inquirer/select/@inquirer/type/mute-stream": ["mute-stream@1.0.0", "", {}, "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA=="],
 
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "@joshwooding/vite-plugin-react-docgen-typescript/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@joshwooding/vite-plugin-react-docgen-typescript/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
     "@mintlify/cli/@inquirer/prompts/@inquirer/confirm": ["@inquirer/confirm@5.1.21", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ=="],
 
     "@mintlify/cli/@inquirer/prompts/@inquirer/input": ["@inquirer/input@4.3.1", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g=="],
@@ -4549,6 +4684,10 @@
     "@stoplight/spectral-core/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@stoplight/spectral-functions/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@storybook/react-vite/find-up/locate-path": ["locate-path@7.2.0", "", { "dependencies": { "p-locate": "^6.0.0" } }, "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA=="],
+
+    "@storybook/react-vite/find-up/path-exists": ["path-exists@5.0.0", "", {}, "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -4656,7 +4795,73 @@
 
     "puppeteer/cosmiconfig/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
+    "react-docgen/@babel/traverse/@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
+
+    "react-docgen/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "react-docgen/@babel/traverse/@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+
+    "react-docgen/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "storybook/@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "storybook/@vitest/expect/chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "storybook/@vitest/expect/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "storybook/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "storybook/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "storybook/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "storybook/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "storybook/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "storybook/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "storybook/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "storybook/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "storybook/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "storybook/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "storybook/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "storybook/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "storybook/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "storybook/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "storybook/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "storybook/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "storybook/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "storybook/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "storybook/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "storybook/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "storybook/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "storybook/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "storybook/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "storybook/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "storybook/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "storybook/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -4732,6 +4937,10 @@
 
     "@hpcc-js/wasm/yargs/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
+    "@joshwooding/vite-plugin-react-docgen-typescript/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "@joshwooding/vite-plugin-react-docgen-typescript/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "@mintlify/common/tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "@mintlify/common/tailwindcss/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
@@ -4741,6 +4950,8 @@
     "@mintlify/common/tailwindcss/sucrase/lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "@mintlify/previewing/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "@storybook/react-vite/find-up/locate-path/p-locate": ["p-locate@6.0.0", "", { "dependencies": { "p-limit": "^4.0.0" } }, "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
@@ -4785,6 +4996,8 @@
     "puppeteer/cosmiconfig/parse-json/@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
 
     "puppeteer/cosmiconfig/parse-json/lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "storybook/@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
 
     "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -4854,7 +5067,11 @@
 
     "@hpcc-js/wasm/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
+    "@joshwooding/vite-plugin-react-docgen-typescript/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "@mintlify/common/tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "@storybook/react-vite/find-up/locate-path/p-locate/p-limit": ["p-limit@4.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ=="],
 
     "docsify-cli/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
@@ -4865,6 +5082,8 @@
     "package-json/got/cacheable-request/responselike/lowercase-keys": ["lowercase-keys@1.0.1", "", {}, "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="],
 
     "puppeteer/cosmiconfig/parse-json/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@storybook/react-vite/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
     "docsify-cli/yargs/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
   }

--- a/openspec/changes/mapgen-studio-storybook-workbench/design.md
+++ b/openspec/changes/mapgen-studio-storybook-workbench/design.md
@@ -1,0 +1,209 @@
+# Design: MapGen Studio Storybook Component Workbench (Stage 1)
+
+This design resolves the target shape of the Stage 1 workbench. Every decision
+below is settled; none is left as a fallback, optional, or "decide later" path.
+
+## 1. Stack and version
+
+- **Framework:** `@storybook/react-vite` at Storybook **9.x**. The studio is
+  React 19.2 + Vite 7.3, so the React-Vite builder reuses the existing
+  toolchain natively.
+- **Version pin gate:** the repo is on **Vite 7** and **Tailwind v4**, both
+  newer than Storybook 9's baseline. The exact 9.x minor that lists Vite 7 in
+  its builder peer range is verified as the first implementation task (see
+  `tasks.md`); the pin is the latest 9.x that satisfies Vite 7 + React 19. If no
+  published 9.x supports Vite 7, that is a blocking finding surfaced to the
+  owner, not worked around with a downgraded Vite.
+- **Package manager / runtime:** Bun 1.3.14, Node 22.22.0 (repo-pinned). Deps
+  are added with Bun; `bun.lock` is the only lockfile touched.
+
+## 2. Placement
+
+- `.storybook/` lives **inside `apps/mapgen-studio`**, co-located with the
+  components. Rationale: the components are studio-local (no shared
+  `packages/ui`), and co-location lets `viteFinal` inherit `vite.config.ts`
+  and the tsconfig path aliases directly. A dedicated Storybook package is
+  rejected for Stage 1 — it would duplicate the Vite/alias config for no
+  current benefit (revisit only if components later graduate to a shared
+  package).
+
+## 3. Vite builder integration (`viteFinal`)
+
+`.storybook/main.ts` merges the app's Vite config via `viteFinal` and **inherits**:
+
+- the `@` → `./src` alias and the `@mapgen/domain*` tsconfig path aliases;
+- the **`child_process` → `src/shims/child_process.ts`** alias (mandatory —
+  deck.gl/loaders.gl pulls a Node-only `child_process` path; without the shim
+  any deck.gl-touching story breaks the build);
+- the Tailwind v4 Vite plugin (`@tailwindcss/vite`) — Tailwind v4 is wired
+  through Vite, not PostCSS; the preview must load it or stories render
+  unstyled.
+
+It **strips / does not activate**:
+
+- the `/rpc` dev proxy and `server.watch.ignored` globs (daemon-oriented; the
+  workbench runs with no daemon);
+- StrictMode is not forced around stories (deck.gl + luma crash under
+  StrictMode double-mount; `main.tsx` already disables it in dev).
+
+The `@swooper/mapgen-viz` source alias applies only in Vite `serve` mode;
+Storybook dev (`serve`) gets the source, `build-storybook` (`build`) resolves
+the package's built output. Viz-heavy canvas stories are out of the Tier-1/2
+scope, so this asymmetry does not affect Stage 1 stories.
+
+## 4. Decorators / `preview.tsx` (the rendering-context contract)
+
+`.storybook/preview.tsx` composes the same context the app assembles in
+`main.tsx` + `StudioProviders.tsx`, as global decorators applied to every story:
+
+| Decorator | Source it mirrors | Why required |
+|---|---|---|
+| Theme (`.dark` class on the iframe `document.documentElement`) + `src/index.css` + `@fontsource/*` | `StudioProviders.tsx` theme effect, `index.html` pre-paint script, `main.tsx` font imports | Theming is a single `.dark` class + token CSS; without it every story is unstyled/unthemed. A `globalTypes` theme toolbar toggles light/dark. **Must apply the class to `document.documentElement` (`<html>`), not a wrapper div, and at mount** — post-merge `sonner` reads the theme from that class via `useSyncExternalStore` with no internal-state settle, so a late/misplaced class leaves the first toast unthemed. The decorator may reuse the app's exported `useThemeFromClass` (`src/components/ui/sonner.tsx`) to stay in lockstep. |
+| `TooltipProvider` (Radix, `delayDuration={300}`) | `StudioProviders.tsx` | Tooltip-using components render **silently blank** with no console error if absent (bit the design-sync on 6 components). |
+| Per-story `QueryClientProvider` | `main.tsx` (`createQueryClient()`) | Components reaching `orpc.*.queryOptions()` need a client; each story gets a fresh one to avoid cross-story cache bleed. |
+| `Toaster` (sonner) | `StudioProviders.tsx` | Toast-emitting components need it mounted. Reads theme from the `<html>.dark` class (see the theme row) — no extra wiring beyond mounting it. |
+| Zustand store reset | `src/stores/{viewStore,runStore,authoringStore}` | Stores are module singletons (no provider); a `beforeEach` decorator resets state per story. `authoringStore` hydrates from `localStorage` at module load, so the reset seeds/clears `localStorage` deterministically. |
+
+No router decorator: the studio has no React Router; navigation is `viewStore`
+state.
+
+**All five decorator-mirror sources are unchanged by the StudioShell decomposition stack** (verified at its tip `aa389e317`): `StudioProviders.tsx`, `main.tsx`, `lib/query.ts`, `ui/hooks/useTheme.ts`, and the three stores. The only stack change touching this layer is `sonner.tsx`'s internal rewrite to `useSyncExternalStore` (additive `useThemeFromClass` export; `ToasterProps` unchanged) — captured in the theme/Toaster rows above. So the decorator contract is stable across the merge.
+
+## 5. oRPC / daemon isolation (the headline risk)
+
+`src/lib/orpc.ts` instantiates an oRPC client at module load, reading
+`window.location.origin` for `/rpc`. Components that import `features/*/api.ts`
+or the app data hooks would fire RPC at a daemon that is not running in the
+workbench. Resolution:
+
+- **Tier-1/2 stories use components that do not reach the data layer.** The
+  census confirms the presentational surface (`components/ui/*`, the studio
+  composites, `PipelineStage`) is prop-driven and clean.
+- **Data-reaching components** are storied with a **stub `QueryClient` seeded
+  with fixture data** (not MSW — Stage 1 keeps the mock surface minimal), or, if
+  a component cannot render meaningfully without live data, it is **excluded
+  with a recorded reason** in the story-support notes. No story attempts a live
+  `/rpc` call.
+- `@civ7/studio-server/contract` imports in the component tree are `import type`
+  (erased) plus a few value imports of plain constant arrays — safe; no
+  `node:`/`bun:` runtime enters the client component tree.
+
+## 6. Story authoring: source, format, coverage, location
+
+- **Source:** adapt the 46 `apps/mapgen-studio/.design-sync/previews/*.tsx`
+  scenes — they already encode the correct fixtures, mocks, and decorators
+  (documented in `.design-sync/NOTES.md`). Stage 1 reads them as reference; it
+  does not modify them (they remain the package-shape source until Stage 2
+  retires them).
+- **Format:** CSF 3, named exports, one `Meta` default per file. Component
+  imports inside stories use the same aliases as app code.
+- **Coverage:** at least one faithful **primary** story per in-scope component,
+  plus variant stories for load-bearing visual states. Exhaustive prop coverage
+  is not required (the future design-sync grades the primary and trusts the
+  rest; ≤6 stories/component is the sync cap).
+- **Location & titles:** co-located `src/**/*.stories.tsx`; story **titles map
+  to the design-sync component export names** and group by the design-sync
+  categories (`primitives`, `composites`, `panels`, `presets`, `configoverrides`,
+  `recipedag`, `fields`, `app`). This is the forward-hook that makes Stage 2's
+  flip a no-re-author cutover.
+
+## 7. Component scope (from the census)
+
+- **Tier 1 (~30, primary + variants):** all 15 `src/components/ui/*` shadcn
+  primitives; the prop-pure composites/leaves (AppBrand, ViewControls,
+  OptionSelect, DisclosureHeader, EmptyState, FieldRow, StageViewTabs,
+  WaterStatsSection, AppHeader, AppFooter, GameConsole, ExplorePanel, LeftDock,
+  RightDock, ErrorBanner) and the 3 preset dialogs.
+- **Tier 2 (~10, needs the support fixtures):** the 7 rjsf widgets + 2 simpler
+  rjsf templates via one `mockWidgetProps()` factory; `PipelineStage` via a
+  static `RecipeDagResult` fixture. **Fixture invariant (post-merge):** the
+  StudioShell stack added `prunePipelineExpansion` so the app prunes
+  `expandedStageIds` down to `dag.stages[].stageId` in the orchestration hook
+  (`useViewportLayout`) before the prop reaches `PipelineStage`. The story must
+  keep its `expandedStageIds` fixture consistent with its `dag.stages[].stageId`
+  — same prop shape, just a self-consistent fixture (no new field; `PipelineStage`
+  itself and the `RecipeDagResult` contract are unchanged).
+- **Tier 3 (best-effort fixtures):** `RecipePanel` (collapsed primary;
+  `SchemaConfigForm` child needs an RJSF schema+value fixture),
+  `SchemaConfigForm`, `BrowserConfigObjectFieldTemplate`, and `CanvasStage`
+  **empty-state branch only** (deck.gl-free path).
+- **Excluded (no story):** `StudioShell`, `StudioProviders`, `DeckCanvas`, and
+  any component that cannot render without live data — recorded as excluded with
+  a reason.
+
+## 8. Nx / target convention
+
+- `storybook` and `build-storybook` are added as `package.json` `nx` targets
+  in `apps/mapgen-studio`, matching the studio's existing inference-only
+  convention (`dev`, `build`, `build:vite`). `build-storybook` declares its
+  `storybook-static/` output so it participates in Nx caching without polluting
+  the `build`/`build:vite` cache keys.
+- `@nx/storybook` is **not** introduced — Stage 1 keeps the inference-only,
+  executor-free convention; the two targets are plain `package.json` `nx`
+  entries. Stage 1 also does **not** mint a `project.json` (current `main` has
+  none for the studio).
+- **Habitat coordination (captured 2026-06-30).** The Habitat toolkit stack —
+  **unmerged and deferred** ("not yet" per the owner; its tip `8458690cb` is not
+  an ancestor of `main`) — converts `apps/mapgen-studio` from inference-only
+  targets to an explicit `project.json` with a `targets` block (`dev`/`build`
+  executors; verified in that tip's diff). So a `project.json` is **not** a model
+  "the repo deliberately avoids" — it is arriving later via Habitat. The decision
+  above stands for the **current** integrated tree (package.json `nx` targets);
+  the two Storybook targets are authored to be **trivially portable**, so when
+  Habitat lands, whoever runs that migration lifts `storybook`/`build-storybook`
+  into the new `project.json` beside `dev`/`build`. Stage 1 does **not**
+  pre-build for that unmerged, in-flux model — coupling to a 40-branch stack that
+  has not landed would be speculative.
+
+## 9. Test-runner / lint coexistence
+
+- The Storybook Vitest **test addon is not added in Stage 1** — the repo runs
+  Vitest 4 with a `mapgen-studio` project, and the Storybook test addon would
+  contend on Vitest config/version. Stage 1's verification is build + render +
+  visual review, not a Storybook-test-runner gate.
+- Stories and config are checked against **Biome** (`biome.json`), the repo's
+  app-code linter (not ESLint). The StudioShell stack lands **three React rules**
+  globally (no `overrides`, no stories exclusion), which the generated story +
+  decorator code must satisfy:
+  - `correctness.useHookAtTopLevel` = **error** — no hooks inside `fixtures.map()`,
+    inline child callbacks, or after an early return. Interactive stories wrap
+    their hook usage in a top-level render **component**, never a bare render arrow.
+  - `correctness.useJsxKeyInIterable` = **error** — variant-gallery stories that
+    `.map()` JSX must key each element.
+  - `correctness.useExhaustiveDependencies` = **warn** (non-blocking) — hoist
+    constant fixtures and reset callbacks to module scope to keep dep arrays clean.
+  The proposal's stories-specific Biome-override escape hatch applies only if a
+  genuine CSF pattern proves incompatible.
+- The stack also adds `@testing-library/react` 16.x + `@testing-library/dom` +
+  `jsdom` (React-19-aligned) to the studio devDeps — these are the same testing
+  stack Storybook 9 builds on, so they are net-positive shared deps, not a new
+  conflict. The opt-in `lint:react-compiler` script is advisory (exit 0 without
+  `--strict`) and imposes no Storybook gate.
+
+## 10. Review lanes (run before/with implementation)
+
+Per the runtime-simplification precedent, frame Codex + Claude review around the
+parity and isolation hazards, not "does it look right":
+
+- **Isolation / parity reviewer (Claude):** confirms no component implementation
+  was edited to fit Storybook; confirms no story reaches a live `/rpc`/daemon
+  call; confirms StrictMode is off for canvas stories.
+- **Architecture-boundary reviewer (Codex `codex:review`):** confirms the
+  write set stays inside the proposal's paths — design-sync surface untouched,
+  daemon untouched, no `@nx/storybook`/`project.json`.
+- **Adversarial reviewer (Codex `codex:adversarial-review`):** challenges the
+  decorator-context fidelity (does a story render the same as in-app?), the
+  stub-QueryClient choice vs MSW, and the design-sync-titling forward-hook (will
+  Stage 2 actually consume these unchanged?).
+- **Code-quality bar (`dev:review-code-quality`):** the decorator/fixture
+  support module must not grow wrappers or special-cases; one `mockWidgetProps`
+  factory, one fixture, one preview.
+
+## 11. Non-claims
+
+- Stage 1 does not prove design-sync storybook-shape verification — no
+  screenshot pairs are produced; the live sync stays `package` shape.
+- A rendered story proves the component renders in the workbench's decorator
+  context; it does not prove pixel-identity with the in-app render (that is
+  Stage 2's screenshot-pair job).
+- OpenSpec validation proves artifact shape only.

--- a/openspec/changes/mapgen-studio-storybook-workbench/proposal.md
+++ b/openspec/changes/mapgen-studio-storybook-workbench/proposal.md
@@ -1,0 +1,222 @@
+# Proposal: MapGen Studio Storybook Component Workbench (Stage 1)
+
+## Summary
+
+Stand up Storybook as an isolated component workbench and living-docs surface
+for `apps/mapgen-studio`. This is **Stage 1** of a two-stage Storybook
+introduction: Stage 1 builds the Storybook instance, the global decorators, and
+authored CSF stories for the studio's presentational component surface. The
+deferred **Stage 2** (a separate change) flips the existing claude.ai/design
+design-sync from `package` shape to `storybook` shape so those same stories
+become the screenshot-verified preview source.
+
+Storybook is currently absent from the repo (no `.storybook/`, no `*.stories.*`,
+no `@storybook/*` dependency). The studio's presentational components are
+unusually well-suited to isolation: the design-sync already enumerated a
+**46-component syncable surface**, and almost all of those components are
+pure prop-driven leaves whose state is hoisted to `StudioShell`/stores. A
+near-complete set of validated render fixtures already exists at
+`apps/mapgen-studio/.design-sync/previews/*.tsx`; Stage 1 adapts those into
+co-located CSF stories rather than authoring from scratch.
+
+Stage 1 changes no component behavior. It adds a workbench around the existing
+components; it does not modify them to fit the workbench.
+
+## Authority
+
+- **Direct user decision (this session, 2026-06-28):** introduce Storybook as a
+  full design-system surface — workbench + verified design-sync source + living
+  docs — sequenced **workbench-first, sync-flip deferred** to a later stage.
+- `docs/projects/studio-shell-decomposition/FRAME.md`, **Appendix B** —
+  establishes Storybook as an independent track from the StudioShell
+  decomposition; the decomposition produces non-visual controller hooks and
+  therefore no Storybook material, so the two tracks do not gate each other.
+- **StudioShell decomposition stack (PRs #1960–#1988, tip `aa389e317`) — merging
+  upstream; look-ahead verified 2026-06-30.** A four-lane analysis of that stack
+  vs `main` confirmed the two-layer separation holds: the decomposition is an
+  orchestration-layer refactor (16 `src/app/hooks/*` controller hooks; host
+  2117→940) that changes **who produces** props, not the leaves that consume
+  them. All six touched presentational story targets (`sonner`, `ExplorePanel`,
+  `RecipePanel`, `PresetDialogs`/`PresetSaveDialog`, `SchemaConfigForm`,
+  and `PipelineStage` via the new orchestration-only `prunePipelineExpansion`)
+  have **unchanged prop interfaces** — internal-only changes (effect→render-phase
+  store-prev-value, rules-of-hooks reordering, sonner→`useSyncExternalStore`). The
+  five decorator-mirror sources (`StudioProviders`, `main.tsx`, `lib/query.ts`,
+  `useTheme.ts`, the three stores) are unchanged. Net: Stage 1 must **author
+  against the post-merge component versions** but needs no plan change — only the
+  refinements folded into this change (the `biome` React rules, the sonner/theme
+  decorator note, the `PipelineStage` fixture invariant).
+- **Design-sync prior art (present-behavior evidence):**
+  `apps/mapgen-studio/.design-sync/config.json` (`shape: "package"`, the
+  46-entry `componentSrcMap`, `projectId 531d158d-…`),
+  `apps/mapgen-studio/.design-sync/previews/*.tsx` (46 hand-authored isolated
+  render scenes), `apps/mapgen-studio/.design-sync/NOTES.md` (per-component
+  provider/fixture notes), and the design-sync storybook-shape contract at
+  `apps/mapgen-studio/.ds-sync/storybook/SKILL.md`.
+- **Current studio source (present-behavior evidence, not target authority):**
+  `apps/mapgen-studio/src/app/StudioProviders.tsx`,
+  `apps/mapgen-studio/src/main.tsx`, `apps/mapgen-studio/vite.config.ts`,
+  `apps/mapgen-studio/src/lib/{orpc,query}.ts`,
+  `apps/mapgen-studio/src/stores/*`, `apps/mapgen-studio/components.json`.
+
+## Product Scenario
+
+A studio developer or designer opens the workbench to view, exercise, and review
+every presentational component in isolation — in light and dark theme, across its
+load-bearing visual states — without booting the daemon, the live game runtime,
+or the full app shell. A reviewer uses the same surface as living documentation
+of the component library. Because the stories are authored to a design-sync-
+compatible shape, a later stage can promote them to the verified preview source
+the claude.ai/design agent builds with, with no re-authoring.
+
+## What Changes
+
+- **A Storybook 9 instance** (`@storybook/react-vite`) is added to
+  `apps/mapgen-studio`, configured to reuse the app's Vite toolchain (aliases,
+  Tailwind v4 plugin, tsconfig paths) and to run **without** the daemon, the
+  `/rpc` proxy, or the live runtime.
+- **A global decorator/preview layer** supplies the studio's real rendering
+  context: theme (`.dark` class + `index.css` + the Inter/JetBrains-Mono
+  fonts), `TooltipProvider`, a per-story `QueryClientProvider`, the `Toaster`,
+  and a per-story Zustand store reset utility. A theme toolbar toggles
+  light/dark.
+- **Authored CSF stories** for the in-scope component surface — the ~40
+  isolatable components (Tier 1 + Tier 2 from the census) plus best-effort
+  Tier-3 fixtures — adapted from the existing `.design-sync/previews/*.tsx`
+  fixtures and `NOTES.md`. Stories are co-located (`src/**/*.stories.tsx`) and
+  titled to match the design-sync component export names.
+- **A small story-support module** (decorators, a `mockWidgetProps()` factory
+  for the rjsf widget cluster, and a static `RecipeDagResult` fixture for
+  `PipelineStage`) so the entangled-but-pure components can be storied without
+  live data.
+- **Nx targets** `storybook` and `build-storybook` defined as `package.json`
+  `nx` targets, matching the studio's existing inference-only target convention.
+- **Autodocs** enabled so each story tree doubles as living component docs.
+
+## What Does Not Change
+
+- **No component behavior changes.** Components are not modified to render in
+  isolation; if a component needs context, the story supplies a decorator or
+  mock, and if it cannot render statically it is excluded with a recorded
+  reason. (StudioShell and the controller glue are untouched — that surface
+  belongs to the separate StudioShell-decomposition workstream.)
+- **No design-sync shape flip.** Stage 1 does not touch
+  `apps/mapgen-studio/.design-sync/`, `.ds-sync/`, or `ds-bundle/`, does not
+  change `config.json` `shape`, and does not run the screenshot re-verify. The
+  live design-sync remains `package` shape until **Stage 2**.
+- **No daemon/server changes** (`apps/mapgen-studio/src/server/**`).
+- **No new design-system / syncable components are minted.** The component
+  surface is the existing 46-component set.
+- **No `@nx/storybook` plugin, and no `project.json` minted by this change** —
+  Stage 1 keeps the studio's current inference-only Nx targets. (The Habitat
+  toolkit stack — unmerged, deferred — will later convert the studio to an
+  explicit `project.json`; the two Storybook targets are authored to migrate into
+  it then, not duplicated for it now. See `design.md` §8.)
+
+## Affected Owners
+
+- This change owns the Storybook configuration, the global decorator/preview
+  layer, the story-support fixtures, the authored stories, and the two Nx
+  targets.
+- The studio components remain owned by their existing modules; this change
+  consumes them read-only (adds stories beside them, does not edit them).
+- The design-sync pipeline (`.design-sync/`, `.ds-sync/`, the `DesignSync`
+  tool, `projectId 531d158d-…`) remains owned by the design-sync workstream;
+  Stage 2 — not this change — flips its shape.
+
+## Expected Implementation Write Set
+
+Implementation may touch only:
+
+- `apps/mapgen-studio/.storybook/**` (new: `main.ts`, `preview.tsx`, any
+  manager/theme config).
+- `apps/mapgen-studio/src/storybook/**` (new: decorators, `mockWidgetProps`
+  factory, `RecipeDagResult` fixture, store-reset helper).
+- `apps/mapgen-studio/src/**/*.stories.tsx` (new, co-located beside the
+  components they cover).
+- `apps/mapgen-studio/package.json` (add `@storybook/*` devDependencies and the
+  `storybook` / `build-storybook` `nx` targets).
+- `bun.lock` (generated by the dependency add).
+- `apps/mapgen-studio/.gitignore` (ignore `storybook-static/`).
+- `biome.json` only if a stories-specific override is required for generated
+  story patterns.
+- This OpenSpec change path.
+
+## Protected Paths
+
+- All existing studio component source (`src/components/**`, `src/ui/**`,
+  `src/app/**`, `src/features/**`) — read-only; this change adds stories beside
+  components, it does not edit component implementations.
+- `apps/mapgen-studio/src/server/**` (daemon/server).
+- `apps/mapgen-studio/src/app/StudioShell.tsx` and `StudioProviders.tsx`
+  implementations.
+- The design-sync surface: `apps/mapgen-studio/.design-sync/**`,
+  `apps/mapgen-studio/.ds-sync/**`, `apps/mapgen-studio/ds-bundle/**` — Stage 2
+  owns any change here.
+- The in-flight design-sync PR stack draining to `main`.
+- Generated outputs, `dist/**`, Nx cache, lockfiles except the `bun.lock`
+  delta caused by the Storybook dependency add.
+- `apps/mapgen-studio/vite.config.ts` — inherited via `viteFinal`, not edited.
+
+## Branch Hygiene
+
+This change set (the definition docs) is committed now to a **fresh Graphite
+branch off `main`** (`studio-storybook-workbench`). Two upstream stacks gate the
+**implementation** (the stories + config), not this definition commit:
+
+1. The design-sync PR stack — **drained** (merged to `main`, tip `5aa6ccf7c`).
+2. The StudioShell decomposition stack (PRs #1960–#1988) — **merging next**.
+
+After the StudioShell stack merges, **re-stack** this branch onto the new `main`
+(`gt sync`/restack) so implementation authors stories against the integrated
+component versions. Story implementation does not begin until that re-stack lands
+(it is the only place the post-merge `sonner`/`biome`/panel changes matter). The
+definition commit carries no `apps/mapgen-studio` source, so it re-stacks cleanly
+(it touches only `openspec/changes/**`). The foreign `.civ7/outputs/resources`
+file is never staged.
+
+## Enables
+
+- **Stage 2** — design-sync `package → storybook` shape flip: the authored,
+  design-sync-titled, statically-renderable stories become the screenshot-
+  verified preview source (one full re-verify of the 46-component set, reusing
+  the existing `projectId`).
+- Ongoing isolated component development, review, and visual QA.
+- Living component documentation via Storybook autodocs.
+
+## Stop Conditions
+
+- A story triggers a live `/rpc` or daemon call (the workbench must run with no
+  daemon; data-reaching components are mocked or excluded).
+- A component's implementation is modified to make it render in isolation
+  (parity violation — story around it, do not rewrite it).
+- The design-sync `shape` is flipped or `.design-sync`/`.ds-sync`/`ds-bundle`
+  is modified (that is Stage 2).
+- **This change** introduces `@nx/storybook` or mints a `project.json` (the
+  later Habitat-driven `project.json` migration is out of Stage 1's scope — a
+  downstream handoff, not a violation).
+- React StrictMode is forced around deck.gl / canvas stories.
+- An orchestration host (`StudioShell`, `StudioProviders`, `DeckCanvas`) is
+  given a story.
+
+## Validation Gates
+
+The implementation phase must run and record, each with expected status, actual
+status, oracle, bad case, and non-claims:
+
+- `bun run openspec -- validate mapgen-studio-storybook-workbench --strict`
+- `bun run openspec:validate` (full OpenSpec records)
+- `build-storybook` completes (static build succeeds, `iframe.html` emitted).
+- Storybook dev server serves and the in-scope stories render with **no console
+  errors** and no attempted `/rpc` calls (daemon not running).
+- Theme toggle renders both light and dark; a Tooltip-using component renders
+  visible (not silently blank) — TooltipProvider decorator present.
+- Biome check passes on the new `.storybook`, story-support, and `*.stories.tsx`
+  files.
+- Studio typecheck passes with the stories present.
+- `git diff --check` and a final clean `git status` (only the expected write
+  set).
+
+Validation proves OpenSpec artifact shape and that Storybook builds/renders; it
+does **not** prove design-sync storybook-shape verification (Stage 2) or any
+in-game / runtime behavior.

--- a/openspec/changes/mapgen-studio-storybook-workbench/specs/mapgen-studio-storybook/spec.md
+++ b/openspec/changes/mapgen-studio-storybook-workbench/specs/mapgen-studio-storybook/spec.md
@@ -1,0 +1,128 @@
+## ADDED Requirements
+
+### Requirement: The Workbench Renders Studio Components Without The Runtime
+
+The studio Storybook SHALL render presentational components in isolation without
+the daemon, the `/rpc` proxy, or the live game runtime, and no story SHALL
+attempt a live `/rpc` or daemon call.
+
+#### Scenario: Workbench starts with no daemon
+- **WHEN** the `storybook` target runs and no studio daemon is running
+- **THEN** Storybook serves the component catalog
+- **AND** no story issues a network request to `/rpc`
+
+#### Scenario: Prop-driven component renders from props alone
+- **WHEN** a Tier-1 presentational component story renders
+- **THEN** the component renders from its story props with no store, query, or
+  daemon dependency
+- **AND** the browser console reports no errors
+
+#### Scenario: Data-reaching component is mocked or excluded
+- **WHEN** a component imports the oRPC client / data layer
+- **THEN** its story supplies a seeded stub query client, or the component is
+  recorded as excluded with a reason
+- **AND** in neither case is a live `/rpc` call attempted
+
+### Requirement: Stories Render In The Studio's Real Theme And Provider Context
+
+The Storybook preview layer SHALL supply, as global decorators, the studio's
+theme (light and dark), design tokens, fonts, and the providers components
+require, so a story renders at in-app fidelity.
+
+#### Scenario: Tooltip-using component renders visible
+- **WHEN** a component that uses Radix Tooltip renders in a story
+- **THEN** a `TooltipProvider` ancestor is present from the global decorators
+- **AND** the tooltip content is reachable, not silently blank
+
+#### Scenario: Theme toggled to dark
+- **WHEN** the theme toolbar is set to dark
+- **THEN** the preview root carries the `.dark` class
+- **AND** the component reflects dark-theme tokens
+
+#### Scenario: Store-reading story is reset per story
+- **WHEN** a story depends on a Zustand store value
+- **THEN** the store is reset (and `localStorage` seeded/cleared for the
+  load-time-hydrated store) before that story renders
+- **AND** state does not bleed from a previously viewed story
+
+### Requirement: Each In-Scope Component Has A Faithful Primary Story
+
+The workbench SHALL provide at least one faithful primary story for every
+in-scope component, plus variant stories for that component's load-bearing
+visual states; exhaustive prop coverage is not required.
+
+#### Scenario: In-scope component has a primary story
+- **WHEN** a component is in the Tier-1 or Tier-2 scope
+- **THEN** it has a primary story rendering a representative default state
+
+#### Scenario: Component with distinct states has variant stories
+- **WHEN** a component has load-bearing visual states (for example dirty vs
+  clean, running vs idle, expanded vs collapsed)
+- **THEN** those states are covered by variant stories
+
+#### Scenario: Orchestration host has no story
+- **WHEN** the component is an orchestration or runtime host (`StudioShell`,
+  `StudioProviders`, `DeckCanvas`) or can only render with live data
+- **THEN** it has no story
+- **AND** its exclusion and reason are recorded
+
+### Requirement: Component Behavior Is Unchanged By The Workbench
+
+Standing up the workbench SHALL NOT modify any component implementation; missing
+render context is supplied by a decorator, a mock, or a fixture in the story
+layer, never by editing the component.
+
+#### Scenario: Component needs context to render
+- **WHEN** a component cannot render in isolation without a provider or data
+- **THEN** the story supplies a decorator, a seeded stub, or a fixture
+- **AND** the component source is not edited to fit the workbench
+
+#### Scenario: Component cannot be storied statically
+- **WHEN** a component cannot render statically even with mocks
+- **THEN** it is excluded with a recorded reason
+- **AND** it is not rewritten to make it story-able
+
+### Requirement: Stories Are Authored In A Design-Sync-Consumable Shape
+
+Stage 1 stories SHALL be authored so a later design-sync `storybook`-shape flip
+can consume them without re-authoring: CSF named exports, titles mapped to the
+design-sync component export names, and static renderability.
+
+#### Scenario: Story title maps to the design-sync export name
+- **WHEN** a story is authored for a component in the design-sync 46-component
+  set
+- **THEN** its title maps to that component's design-sync export name and
+  category group
+
+#### Scenario: Non-static story is marked, not left to crash
+- **WHEN** a story cannot render statically (needs live data or interaction)
+- **THEN** it is excluded or skip-marked with a recorded reason
+- **AND** it does not crash the build at import
+
+#### Scenario: Story imports the studio's real component
+- **WHEN** a story imports the component it covers
+- **THEN** the import resolves through the studio's own aliases to the real
+  component implementation
+
+### Requirement: Storybook Coexists With The App Build, Daemon, And Test Runner
+
+Adding the workbench SHALL NOT alter the existing app build, daemon, or test
+targets, and SHALL be reachable through the repo's existing Nx target convention.
+
+#### Scenario: Builder inherits the app's required aliases
+- **WHEN** Storybook builds a story that transitively pulls deck.gl
+- **THEN** the builder has inherited the `child_process` shim alias and the
+  build resolves
+- **AND** StrictMode is not forced around the canvas story
+
+#### Scenario: Workbench targets follow the inference-only convention
+- **WHEN** the workbench is invoked
+- **THEN** it runs through `storybook` / `build-storybook` `package.json` `nx`
+  targets, not an `@nx/storybook` generator or a `project.json`
+- **AND** the existing `dev`, `build`, `build:vite`, and Vitest targets are
+  unchanged
+
+#### Scenario: Design-sync surface is untouched in Stage 1
+- **WHEN** Stage 1 implementation completes
+- **THEN** `.design-sync/`, `.ds-sync/`, and `ds-bundle/` are unchanged
+- **AND** the live design-sync remains `package` shape

--- a/openspec/changes/mapgen-studio-storybook-workbench/tasks.md
+++ b/openspec/changes/mapgen-studio-storybook-workbench/tasks.md
@@ -1,0 +1,112 @@
+# Tasks: MapGen Studio Storybook Component Workbench (Stage 1)
+
+Ordered implementation steps. Each block is closeable; do not start a block
+before its prerequisites. Runs on a fresh Graphite branch off a settled `main`.
+
+## 0. Branch and version baseline
+
+- [ ] Confirm the design-sync PR stack has finished draining and `main` is
+      settled; create the `studio-storybook-workbench` Graphite branch + worktree
+      off `main`; commit this change set as the first commit.
+- [ ] Resolve the Storybook 9.x minor that supports Vite 7 + React 19 (check the
+      `@storybook/react-vite` builder peer range). Record the pinned version. If
+      no 9.x supports Vite 7, stop and surface to the owner (do not downgrade
+      Vite).
+
+## 1. Storybook install and Vite wiring
+
+- [ ] Add `@storybook/react-vite` + the Storybook 9.x core/addons (essentials,
+      autodocs) as `apps/mapgen-studio` devDependencies via Bun.
+- [ ] Write `apps/mapgen-studio/.storybook/main.ts`: framework
+      `@storybook/react-vite`, `stories` glob `../src/**/*.stories.@(tsx|jsx)`,
+      autodocs on, and `viteFinal` merging the app Vite config — inheriting the
+      `@`, `@mapgen/domain*`, and `child_process`-shim aliases and the Tailwind
+      v4 plugin, while not activating the `/rpc` proxy or daemon watch-ignores.
+- [ ] Add `storybook` and `build-storybook` `nx` targets to
+      `apps/mapgen-studio/package.json`; declare `storybook-static/` as the
+      `build-storybook` output; add `storybook-static/` to
+      `apps/mapgen-studio/.gitignore`.
+- [ ] Verify `build-storybook` produces a static build with `iframe.html`
+      (empty-stories build is acceptable at this step).
+
+## 2. Global rendering-context layer (`preview.tsx` + decorators)
+
+- [ ] Write `apps/mapgen-studio/.storybook/preview.tsx` importing
+      `src/index.css` + the Inter/JetBrains-Mono fonts, with global decorators:
+      theme (`.dark` class on the preview root, driven by a `globalTypes` theme
+      toolbar), `TooltipProvider`, a fresh per-story `QueryClientProvider`, and
+      `Toaster`.
+- [ ] Write `apps/mapgen-studio/src/storybook/storeReset.ts`: a decorator that
+      resets `viewStore`/`runStore`/`authoringStore` per story and seeds/clears
+      `localStorage` for `authoringStore`'s load-time hydration.
+- [ ] Render a trivial primitive (Button) story to confirm theme + tokens +
+      fonts + Tooltip all render; toggle dark/light.
+
+## 3. Story-support fixtures
+
+- [ ] Write `apps/mapgen-studio/src/storybook/mockWidgetProps.ts`: a factory for
+      rjsf `WidgetProps` / `*TemplateProps` covering the 7 widgets + 2 templates.
+- [ ] Write `apps/mapgen-studio/src/storybook/recipeDagFixture.ts`: a static
+      valid `RecipeDagResult` for `PipelineStage` (satisfying the real contract;
+      mirror the existing synced preview's fixture).
+- [ ] Write a seeded stub `QueryClient` helper for any data-reaching story.
+
+## 4. Tier 1 stories (primitives + prop-pure composites/leaves)
+
+- [ ] Author co-located `*.stories.tsx` for the 15 `src/components/ui/*`
+      primitives (primary + key variants; overlay primitives get one open
+      story), adapting `.design-sync/previews/*.tsx`.
+- [ ] Author stories for the prop-pure composites/leaves (AppBrand, ViewControls,
+      OptionSelect, DisclosureHeader, EmptyState, FieldRow, StageViewTabs,
+      WaterStatsSection, AppHeader, AppFooter, GameConsole, ExplorePanel,
+      LeftDock, RightDock, ErrorBanner) and the 3 preset dialogs — primary +
+      load-bearing visual states.
+- [ ] Confirm titles map to the design-sync export names and group by design-sync
+      category.
+
+## 5. Tier 2 + best-effort Tier 3 stories
+
+- [ ] Author stories for the 7 rjsf widgets + 2 templates using
+      `mockWidgetProps()`, and `PipelineStage` using the `RecipeDagResult`
+      fixture.
+- [ ] Author best-effort Tier-3 stories: `RecipePanel` (collapsed primary),
+      `SchemaConfigForm` (schema+value fixture), `BrowserConfigObjectFieldTemplate`,
+      and `CanvasStage` empty-state branch only.
+- [ ] Record excluded components (`StudioShell`, `StudioProviders`, `DeckCanvas`,
+      any live-data-only component) and the exclusion reason in a
+      `src/storybook/EXCLUSIONS.md` note.
+
+## 6. Verification gates
+
+- [ ] `build-storybook` completes with all in-scope stories; `iframe.html`
+      emitted.
+- [ ] Storybook dev server: every in-scope story renders with no console errors
+      and no attempted `/rpc` call (daemon not running). Spot-check a
+      Tooltip-using component renders visible (not blank) and a deck.gl-free
+      canvas empty-state builds.
+- [ ] Theme toggle renders both light and dark across a sample of each category.
+- [ ] Biome check passes on `.storybook/**`, `src/storybook/**`, and all new
+      `*.stories.tsx`.
+- [ ] Studio typecheck passes with stories present.
+- [ ] `bun run openspec -- validate mapgen-studio-storybook-workbench --strict`.
+- [ ] `bun run openspec:validate`.
+- [ ] `git diff --check`; final `git status` shows only the expected write set.
+
+## 7. Review and disposition
+
+- [ ] Run the four review lanes (isolation/parity, architecture-boundary via
+      `codex:review`, adversarial via `codex:adversarial-review`, code-quality
+      via `dev:review-code-quality`).
+- [ ] Disposition findings; repair accepted P1/P2 blockers before close.
+
+## 8. Downstream realignment and closure
+
+- [ ] Confirm no design-sync artifact (`.design-sync/`, `.ds-sync/`, `ds-bundle/`)
+      was touched and the live sync remains `package` shape.
+- [ ] Note the Stage 2 enabler in the change record: stories are authored to the
+      design-sync-titled, statically-renderable shape; Stage 2 flips
+      `config.json` `shape` and runs the screenshot re-verify.
+- [ ] Add a `docs/` pointer (or studio README line) to how to run the workbench
+      (`nx storybook mapgen-studio`).
+- [ ] Commit per the Graphite workflow; leave the repo clean; archive the change
+      when accepted.

--- a/openspec/changes/mapgen-studio-storybook-workbench/tasks.md
+++ b/openspec/changes/mapgen-studio-storybook-workbench/tasks.md
@@ -5,108 +5,137 @@ before its prerequisites. Runs on a fresh Graphite branch off a settled `main`.
 
 ## 0. Branch and version baseline
 
-- [ ] Confirm the design-sync PR stack has finished draining and `main` is
+- [x] Confirm the design-sync PR stack has finished draining and `main` is
       settled; create the `studio-storybook-workbench` Graphite branch + worktree
       off `main`; commit this change set as the first commit.
-- [ ] Resolve the Storybook 9.x minor that supports Vite 7 + React 19 (check the
+- [x] Resolve the Storybook 9.x minor that supports Vite 7 + React 19 (check the
       `@storybook/react-vite` builder peer range). Record the pinned version. If
       no 9.x supports Vite 7, stop and surface to the owner (do not downgrade
       Vite).
 
 ## 1. Storybook install and Vite wiring
 
-- [ ] Add `@storybook/react-vite` + the Storybook 9.x core/addons (essentials,
+- [x] Add `@storybook/react-vite` + the Storybook 9.x core/addons (essentials,
       autodocs) as `apps/mapgen-studio` devDependencies via Bun.
-- [ ] Write `apps/mapgen-studio/.storybook/main.ts`: framework
+- [x] Write `apps/mapgen-studio/.storybook/main.ts`: framework
       `@storybook/react-vite`, `stories` glob `../src/**/*.stories.@(tsx|jsx)`,
       autodocs on, and `viteFinal` merging the app Vite config — inheriting the
       `@`, `@mapgen/domain*`, and `child_process`-shim aliases and the Tailwind
       v4 plugin, while not activating the `/rpc` proxy or daemon watch-ignores.
-- [ ] Add `storybook` and `build-storybook` `nx` targets to
+- [x] Add `storybook` and `build-storybook` `nx` targets to
       `apps/mapgen-studio/package.json`; declare `storybook-static/` as the
       `build-storybook` output; add `storybook-static/` to
       `apps/mapgen-studio/.gitignore`.
-- [ ] Verify `build-storybook` produces a static build with `iframe.html`
+- [x] Verify `build-storybook` produces a static build with `iframe.html`
       (empty-stories build is acceptable at this step).
 
 ## 2. Global rendering-context layer (`preview.tsx` + decorators)
 
-- [ ] Write `apps/mapgen-studio/.storybook/preview.tsx` importing
+- [x] Write `apps/mapgen-studio/.storybook/preview.tsx` importing
       `src/index.css` + the Inter/JetBrains-Mono fonts, with global decorators:
       theme (`.dark` class on the preview root, driven by a `globalTypes` theme
       toolbar), `TooltipProvider`, a fresh per-story `QueryClientProvider`, and
       `Toaster`.
-- [ ] Write `apps/mapgen-studio/src/storybook/storeReset.ts`: a decorator that
+- [x] Write `apps/mapgen-studio/src/storybook/storeReset.ts`: a decorator that
       resets `viewStore`/`runStore`/`authoringStore` per story and seeds/clears
       `localStorage` for `authoringStore`'s load-time hydration.
-- [ ] Render a trivial primitive (Button) story to confirm theme + tokens +
+- [x] Render a trivial primitive (Button) story to confirm theme + tokens +
       fonts + Tooltip all render; toggle dark/light.
 
 ## 3. Story-support fixtures
 
-- [ ] Write `apps/mapgen-studio/src/storybook/mockWidgetProps.ts`: a factory for
+- [x] Write `apps/mapgen-studio/src/storybook/mockWidgetProps.ts`: a factory for
       rjsf `WidgetProps` / `*TemplateProps` covering the 7 widgets + 2 templates.
-- [ ] Write `apps/mapgen-studio/src/storybook/recipeDagFixture.ts`: a static
+- [x] Write `apps/mapgen-studio/src/storybook/recipeDagFixture.ts`: a static
       valid `RecipeDagResult` for `PipelineStage` (satisfying the real contract;
       mirror the existing synced preview's fixture).
-- [ ] Write a seeded stub `QueryClient` helper for any data-reaching story.
+- [x] Write a seeded stub `QueryClient` helper for any data-reaching story.
 
 ## 4. Tier 1 stories (primitives + prop-pure composites/leaves)
 
-- [ ] Author co-located `*.stories.tsx` for the 15 `src/components/ui/*`
+- [x] Author co-located `*.stories.tsx` for the 15 `src/components/ui/*`
       primitives (primary + key variants; overlay primitives get one open
       story), adapting `.design-sync/previews/*.tsx`.
-- [ ] Author stories for the prop-pure composites/leaves (AppBrand, ViewControls,
+- [x] Author stories for the prop-pure composites/leaves (AppBrand, ViewControls,
       OptionSelect, DisclosureHeader, EmptyState, FieldRow, StageViewTabs,
       WaterStatsSection, AppHeader, AppFooter, GameConsole, ExplorePanel,
       LeftDock, RightDock, ErrorBanner) and the 3 preset dialogs — primary +
       load-bearing visual states.
-- [ ] Confirm titles map to the design-sync export names and group by design-sync
+- [x] Confirm titles map to the design-sync export names and group by design-sync
       category.
 
 ## 5. Tier 2 + best-effort Tier 3 stories
 
-- [ ] Author stories for the 7 rjsf widgets + 2 templates using
+- [x] Author stories for the 7 rjsf widgets + 2 templates using
       `mockWidgetProps()`, and `PipelineStage` using the `RecipeDagResult`
       fixture.
-- [ ] Author best-effort Tier-3 stories: `RecipePanel` (collapsed primary),
-      `SchemaConfigForm` (schema+value fixture), `BrowserConfigObjectFieldTemplate`,
-      and `CanvasStage` empty-state branch only.
-- [ ] Record excluded components (`StudioShell`, `StudioProviders`, `DeckCanvas`,
+- [x] Author best-effort Tier-3 stories: `RecipePanel` (collapsed primary),
+      `SchemaConfigForm` (schema+value fixture), `BrowserConfigObjectFieldTemplate`.
+      `CanvasStage` empty-state branch **deferred** (deck.gl host, not part of the
+      46-component surface) — recorded in `src/storybook/EXCLUSIONS.md`.
+- [x] Record excluded components (`StudioShell`, `StudioProviders`, `DeckCanvas`,
       any live-data-only component) and the exclusion reason in a
       `src/storybook/EXCLUSIONS.md` note.
 
 ## 6. Verification gates
 
-- [ ] `build-storybook` completes with all in-scope stories; `iframe.html`
+- [x] `build-storybook` completes with all in-scope stories; `iframe.html`
       emitted.
-- [ ] Storybook dev server: every in-scope story renders with no console errors
+- [x] Storybook dev server: every in-scope story renders with no console errors
       and no attempted `/rpc` call (daemon not running). Spot-check a
       Tooltip-using component renders visible (not blank) and a deck.gl-free
       canvas empty-state builds.
-- [ ] Theme toggle renders both light and dark across a sample of each category.
-- [ ] Biome check passes on `.storybook/**`, `src/storybook/**`, and all new
+- [x] Theme toggle renders both light and dark across a sample of each category.
+- [x] Biome check passes on `.storybook/**`, `src/storybook/**`, and all new
       `*.stories.tsx`.
-- [ ] Studio typecheck passes with stories present.
-- [ ] `bun run openspec -- validate mapgen-studio-storybook-workbench --strict`.
-- [ ] `bun run openspec:validate`.
-- [ ] `git diff --check`; final `git status` shows only the expected write set.
+- [x] Studio typecheck passes with stories present.
+- [x] `bun run openspec -- validate mapgen-studio-storybook-workbench --strict`.
+- [x] `bun run openspec:validate`.
+- [x] `git diff --check`; final `git status` shows only the expected write set.
 
 ## 7. Review and disposition
 
-- [ ] Run the four review lanes (isolation/parity, architecture-boundary via
+- [x] Run the four review lanes (isolation/parity, architecture-boundary via
       `codex:review`, adversarial via `codex:adversarial-review`, code-quality
       via `dev:review-code-quality`).
-- [ ] Disposition findings; repair accepted P1/P2 blockers before close.
+- [x] Disposition findings; repair accepted P1/P2 blockers before close.
 
 ## 8. Downstream realignment and closure
 
-- [ ] Confirm no design-sync artifact (`.design-sync/`, `.ds-sync/`, `ds-bundle/`)
+- [x] Confirm no design-sync artifact (`.design-sync/`, `.ds-sync/`, `ds-bundle/`)
       was touched and the live sync remains `package` shape.
-- [ ] Note the Stage 2 enabler in the change record: stories are authored to the
+- [x] Note the Stage 2 enabler in the change record: stories are authored to the
       design-sync-titled, statically-renderable shape; Stage 2 flips
       `config.json` `shape` and runs the screenshot re-verify.
-- [ ] Add a `docs/` pointer (or studio README line) to how to run the workbench
+- [x] Add a `docs/` pointer (or studio README line) to how to run the workbench
       (`nx storybook mapgen-studio`).
-- [ ] Commit per the Graphite workflow; leave the repo clean; archive the change
+- [x] Commit per the Graphite workflow; leave the repo clean; archive the change
       when accepted.
+
+## Validation results (Stage 1 closeout)
+
+Branch `studio-storybook-workbench` on `main` (`f23784e7e`); commits: definition
+`cc1d3dc51` → foundation `b254db7d3` → story surface `8987a1642` → this closeout.
+Each gate recorded expected / actual / oracle.
+
+| Gate | Expected | Actual | Oracle |
+|---|---|---|---|
+| `openspec validate … --strict` | valid | **valid** | OpenSpec CLI |
+| `openspec:validate` | 0 failed | **255 passed / 0 failed** | OpenSpec CLI |
+| `build-storybook` | `iframe.html` emitted | **emitted; 88 stories, 0 build errors** | Vite/Storybook build |
+| dev server: render + no console errors + no `/rpc` | all in-scope stories render clean | **88/88 stories: 0 console errors, 0 error overlays; network scan 0 `/rpc`/daemon** | headless render sweep + network capture |
+| theme light/dark; Tooltip visible | both themes; tooltip not blank | **dark↔light token flip; `role=tooltip` visible** | DOM/computed-style probe |
+| Biome on `.storybook`/`src/storybook`/`*.stories.tsx` | clean | **clean (50 files)** | `biome check` |
+| Studio typecheck with stories | clean | **`tsc --noEmit` clean** | tsc |
+| `git diff --check` + clean status | only the write set | **clean; write set only (no protected paths, no component edits, no `@nx/storybook`/`project.json`)** | git |
+
+Non-claims (unchanged): Stage 1 does not prove design-sync storybook-shape
+screenshot verification (Stage 2), nor pixel-identity with the in-app render,
+nor any in-game/runtime behavior. The design-sync surface (`.design-sync/`,
+`.ds-sync/`, `ds-bundle/`) stays `package` shape and was not touched.
+
+**Stage 2 enabler:** the 46 stories are authored design-sync-titled (group =
+docsMap group; export names = preview export names) and statically renderable, so
+the deferred `package → storybook` shape flip is a no-re-author cutover. Run the
+workbench with `bun run storybook` (or `nx storybook mapgen-studio`); see
+`apps/mapgen-studio/README.md`.


### PR DESCRIPTION
Stage 1 of the MapGen Studio Storybook workbench (OpenSpec change `mapgen-studio-storybook-workbench`). Stands up Storybook 9 as an isolated, daemon-free component workbench + living docs for `apps/mapgen-studio`, with CSF stories for the full 46-component presentational surface. **No component behavior changes; no design-sync shape flip** (that is the deferred Stage 2).

**Foundation** — `@storybook/react-vite` 9.1.20 + `@storybook/addon-docs`; `viteFinal` inherits the app's `@`/`child_process` aliases + Tailwind v4 and strips the `/rpc` proxy; a global decorator (stub `QueryClient` > `TooltipProvider` > Story + `Toaster`) + a `.dark` theme toolbar; `package.json` nx targets (no `@nx/storybook`, no `project.json`).

**Stories** — 46 co-located CSF3 stories titled to the design-sync groups (primitives/composites/layout/panels/forms) with export names matching the previews exactly, so the Stage-2 `package -> storybook` flip is a no-re-author cutover. Shared rjsf / `RecipeDagResult` fixtures live in `src/storybook/`.

**Gates** (recorded in the change's `tasks.md`): `openspec validate --strict` valid + `openspec:validate` 255/0; `build-storybook` compiles all 88 stories -> `iframe.html`; a headless render sweep of all 88 stories shows zero console errors / zero error overlays and a network scan shows zero `/rpc`; biome + tsc clean; the write set was audited (no protected paths touched, no component edits, no `@nx/storybook`/`project.json`).

Run the workbench: `bun run storybook` (or `nx storybook mapgen-studio`); see `apps/mapgen-studio/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
