### PR TITLE
feat(studio-ui): templates group (StudioShellLayout) + nested DS explorations with cloud fixtures

### DIFF
--- a/apps/mapgen-studio/README.md
+++ b/apps/mapgen-studio/README.md
@@ -5,7 +5,7 @@ The MapGen Studio frontend (React 19 + Vite + Tailwind v4). See
 
 ## UI components, Storybook, and the design sync live in the package
 
-The studio's 46-component presentational surface is
+The studio's 47-component presentational surface is
 **`@swooper/mapgen-studio-ui`** (`packages/mapgen-studio-ui`) — a real workspace
 package with a compiled dist, generated `.d.ts`, and a compiled stylesheet. The
 app imports it like any dependency; its theme/fonts seams feed this app's

--- a/packages/mapgen-studio-ui/.design-sync/NOTES.md
+++ b/packages/mapgen-studio-ui/.design-sync/NOTES.md
@@ -243,3 +243,42 @@ historical.
   deleted (glob-fenced plan); token consumption in explorations MUST be
   `hsl(var(--token))` — bare `var(--token)` computes to transparent and only
   *looks* right because `color-scheme: dark` darkens the canvas.
+
+- **2026-07-02 — operating structure made concrete (47th component + nested
+  explorations + cloud fixtures).** The operating model is now enforced by
+  structure, not just prose:
+  - **`templates` picker group is real.** `StudioShellLayout`
+    (`src/components/templates/StudioShellLayout.tsx` + story
+    `templates/StudioShellLayout`) is the studio shell graduated INTO the
+    package as a slot-based component — the 47th synced component. Verify floor
+    raised to 101; `docsMap`/`overrides` + `groups/templates.md` added; every
+    "46" in living docs (package/app README, EXCLUSIONS, package.json,
+    index.ts, verify.mjs) bumped to 47 (historical NOTES/FRAME entries left).
+    Graded `match` on the storybook-vs-preview raw pair (gradeKey
+    7e1732f0093d9aae); design-sync:check verdict clean (added:[StudioShellLayout],
+    pendingGrade:[], canary churned:[]); upload partition bundle+styling+aux.
+  - **`explorations/` restructured to nested-by-subject + clean names.**
+    `proposals/<subject>/` (`legend/new-panel.html`,
+    `legend/merge-into-explore-panel.html`, `recipe-panel/flat-and-flush.html`),
+    `references/studio-shell.html` (rebuilt on `StudioShellLayout`),
+    `explorations/README.md` index, `explorations/fixtures/`. Kebab-case, no
+    spaces. Subject-folder rule: keyed by the primary thing designed; a
+    cross-cutting proposal files under its DRIVING subject (the merge is under
+    `legend/`), never duplicated. Replaces the 3 old flat files (`Legend
+    panel.html`, `Studio shell mock.html`, `RecipePanel flat and flush.html`) —
+    delete those remote paths on upload.
+  - **Cloud fixtures channel added.** `explorations/fixtures/map-layers.js`
+    assigns `window.__dsFixtures`; both `legend/` proposals `<script src>` it
+    (new-panel full depth, merge derives a coarse 3-tick view). Editable in the
+    project, NOT repo-compiled — the channel for reshaping exploration data /
+    depth variants without a resync. The sync driver ignores `explorations/**`
+    (recon-confirmed: no glob touches it, deletePaths only ever contains
+    `components/**`), so fixtures are safe from clobber.
+  - **Two verification gotchas.** (1) A relocated exploration that renders a
+    tooltip-bearing preview (`RecipePanel flat and flush`) paints BLANK without
+    an ambient provider — wrap the render in `window.MapGenStudio.TooltipProvider`
+    like every other exploration (fixed here; the original lacked it). (2)
+    Headless-chrome `--virtual-time-budget` hangs intermittently on
+    concurrent-React `createRoot` pages; run one Chrome per invocation with a
+    unique `--user-data-dir` and a hard background `kill -9` after ~12s, then
+    read the written PNG.

--- a/packages/mapgen-studio-ui/.design-sync/config.json
+++ b/packages/mapgen-studio-ui/.design-sync/config.json
@@ -42,7 +42,8 @@
     "BrowserConfigArrayFieldTemplate": { "cardMode": "column" },
     "PipelineStage": { "cardMode": "single", "viewport": "1080x620" },
     "SchemaConfigForm": { "cardMode": "column" },
-    "TagSelectWidget": { "cardMode": "column" }
+    "TagSelectWidget": { "cardMode": "column" },
+    "StudioShellLayout": { "cardMode": "single", "viewport": "1280x800" }
   },
   "docsMap": {
     "Button": ".design-sync/groups/primitives.md",
@@ -90,6 +91,7 @@
     "BrowserConfigObjectFieldTemplate": ".design-sync/groups/forms.md",
     "BrowserConfigArrayFieldTemplate": ".design-sync/groups/forms.md",
     "PipelineStage": ".design-sync/groups/panels.md",
-    "SchemaConfigForm": ".design-sync/groups/forms.md"
+    "SchemaConfigForm": ".design-sync/groups/forms.md",
+    "StudioShellLayout": ".design-sync/groups/templates.md"
   }
 }

--- a/packages/mapgen-studio-ui/.design-sync/conventions.md
+++ b/packages/mapgen-studio-ui/.design-sync/conventions.md
@@ -69,10 +69,24 @@ design-system project is a regenerated build artifact of it, except
 `explorations/` and `scraps/`.
 
 - **Work in the design-system project is about evolving the library itself.**
-  `explorations/` holds only system proposals: a candidate new component
-  (`Legend panel.html`), a before/after for changing an existing component, or
-  a canonical assembly reference (`Studio shell mock.html`). Every exploration
-  states its intent, status, and pull-down path in a header comment.
+  `explorations/` wears its taxonomy in the file tree (`explorations/README.md`
+  indexes every open item): `explorations/proposals/<subject>/` holds candidate
+  new components (`legend/new-panel.html`) and before/after changes
+  (`recipe-panel/flat-and-flush.html`), nested by design subject;
+  `explorations/references/` holds canonical assemblies (`studio-shell.html`);
+  `explorations/fixtures/` holds shared data the explorations load. Every
+  exploration states its intent, status, and pull-down path in a manifest
+  header. Filenames are kebab-case, no spaces.
+- **Assemblies that earn reuse graduate into the package.** They become real
+  slot-based components in the `templates` picker group — `StudioShellLayout`
+  is the studio shell. Start a whole-app composition from a template card and
+  fill its slots; don't hand-assemble the chrome.
+- **Exploration data can live in the cloud.** `explorations/fixtures/*.js`
+  assign onto `window.__dsFixtures` and are loaded via `<script src>`; edit
+  them here to reshape a legend/inspector across every proposal that reads
+  them, or keep simpler/denser variants for different depths. (The fixtures
+  that back graded component *cards* still come from the repo's typed story
+  args — those are the sync's oracle and can't move.)
 - **Product design happens in consuming projects.** Screens, flows, feature
   concepts, and design-space exploration belong in a Claude Design project
   that attaches this design system (e.g. "App Shell") — never here.

--- a/packages/mapgen-studio-ui/.design-sync/groups/templates.md
+++ b/packages/mapgen-studio-ui/.design-sync/groups/templates.md
@@ -1,0 +1,8 @@
+---
+category: Templates
+---
+
+Canonical assemblies — whole-app compositions promoted into the package once
+they earn reuse (the operating model's graduation path for reference
+explorations). Build product screens FROM these instead of hand-assembling the
+chrome: fill the slots with real components and keep the template's geometry.

--- a/packages/mapgen-studio-ui/.storybook/EXCLUSIONS.md
+++ b/packages/mapgen-studio-ui/.storybook/EXCLUSIONS.md
@@ -5,7 +5,7 @@
 > fidelity oracle) and the app has zero story files. The components below are
 > **app-side hosts** that stay unstoried; their paths are app paths.
 
-The workbench stories the **46-component presentational surface** (every one a
+The workbench stories the **47-component presentational surface** (every one a
 pure, prop-driven leaf — now this package's public barrel; story titles are the
 sync's grouping authority). The components below are deliberately **not**
 storied, with reasons. These are orchestration hosts and deck.gl/WebGL surfaces
@@ -14,7 +14,7 @@ host given a story; StrictMode / live canvas in a story) or require live data.
 
 | Component | Reason excluded |
 |---|---|
-| `StudioShell` (`src/app/StudioShell.tsx`) | Top-level orchestration host — composes the whole app from hooks/stores, not a prop-driven leaf. Stop condition: an orchestration host is never given a story. |
+| `StudioShell` (`src/app/StudioShell.tsx`) | Top-level orchestration host — composes the whole app from hooks/stores, not a prop-driven leaf. Stop condition: an orchestration host is never given a story. (Its chrome *geometry* is packaged separately as the presentational `templates/StudioShellLayout`, which IS storied.) |
 | `StudioProviders` (`src/app/StudioProviders.tsx`) | Provider/orchestration host (theme effect + TooltipProvider + Toaster + shell). Its job is reproduced by the global decorator (`.storybook/preview.tsx`), not storied. |
 | `DeckCanvas` (`src/features/viz/DeckCanvas.tsx`) | deck.gl/luma WebGL surface. Cannot render as an isolated pure leaf; deck.gl double-mounts under StrictMode (which the app disables in dev) and needs a live viz manifest. Stop condition: no StrictMode/live-canvas story. |
 | `CanvasStage` (`src/app/CanvasStage.tsx`) | Wraps `DeckCanvas` (deck.gl). Its empty-state branch was a best-effort Tier-3 candidate (`design.md` §7) but is **deferred** in Stage 1: the deck.gl-free empty branch is low-value relative to the WebGL-host risk, and `CanvasStage` is not part of the 46-component design-sync surface this change covers. Revisit if the empty state earns a dedicated story. |

--- a/packages/mapgen-studio-ui/README.md
+++ b/packages/mapgen-studio-ui/README.md
@@ -1,6 +1,6 @@
 # @swooper/mapgen-studio-ui
 
-MapGen Studio's UI component library: the 46 design-synced components as a real
+MapGen Studio's UI component library: the 47 design-synced components as a real
 package — compiled `dist/index.js`, a strict generated `.d.ts` tree
 (`dist/types/`), a compiled stylesheet (`dist/styles.css`), and the theme/fonts
 seams the app and the Claude Design sync both consume. Single source of truth;
@@ -14,7 +14,7 @@ The frame everything below hangs off:
 - **This is a product design system.** It deliberately carries MapGen Studio's
   composites and panels alongside the generic primitives (the same shape as
   Shopify Polaris or GitHub Primer). The picker groups — `primitives / forms /
-  layout / composites / panels` — are the internal layering. Only a real
+  layout / composites / panels / templates` — are the internal layering. Only a real
   second consumer justifies splitting a primitives-only package with its own
   synced project (the B0 contract extraction is the mechanical precedent);
   don't pre-split for a consumer that doesn't exist.
@@ -35,22 +35,51 @@ Three surfaces, three owners:
 | DS project `explorations/` | humans + agents | **system proposals only** (lifecycle below) |
 | Consuming projects (e.g. "App Shell") | humans + agents | product design; attach the DS and explore freely |
 
-**Exploration lifecycle — the anti-dumping-ground rule.** A file in the DS
-project's `explorations/` must be one of exactly three things, each declaring
-its intent + pull-down path in a header comment:
+**Exploration lifecycle — the anti-dumping-ground rule.** The DS project's
+`explorations/` wears its taxonomy in the file tree — `explorations/README.md`
+is the living index (every open item, its type, its status, its target):
 
-1. **Proposal: new component** (e.g. `Legend panel.html`) — built on the live
-   bundle, names its intended package home and carries story-ready fixtures.
-   Lands as a package component → prune the exploration or flip it to a
-   reference.
-2. **Proposal: change to an existing component** — the before/after idiom. The
-   "Current" pane renders the live bundle *by reference* (so the before is
+```
+explorations/
+  proposals/<subject>/<proposal>.html   change or new-component proposals,
+                                         nested by design SUBJECT
+  references/<assembly>.html             canonical assemblies
+  fixtures/<data>.js                     shared cloud-side data (see below)
+```
+
+A proposal/reference must be one of exactly three things, each declaring its
+intent + pull-down path in a manifest header (filenames are kebab-case, no
+spaces):
+
+1. **Proposal: new component** (`proposals/<subject>/…`, e.g.
+   `proposals/legend/new-panel.html`) — built on the live bundle, names its
+   intended package home and carries story-ready fixtures. Lands as a package
+   component → prune the exploration or flip it to a reference.
+2. **Proposal: change to an existing component** (`proposals/<subject>/…`, e.g.
+   `proposals/recipe-panel/flat-and-flush.html`) — the before/after idiom.
+   The "Current" pane renders the live bundle *by reference* (so the before is
    automatically true forever); the "Proposed" pane carries consumer-side
-   overrides that annotate the exact repo edit. Landed = the panes render
-   identically → prune.
-3. **Reference: canonical assembly** (e.g. `Studio shell mock.html`) — bare
-   package components composed exactly as the app composes them; auto-tracks
-   every sync.
+   overrides or mocks that annotate the exact repo edit. Landed = the panes
+   render identically → prune.
+3. **Reference: canonical assembly** (`references/…`, e.g.
+   `references/studio-shell.html`) — bare package components composed exactly
+   as the app composes them; auto-tracks every sync.
+
+**Subject folders.** `proposals/<subject>/` is keyed by the primary thing being
+designed — a component name (`recipe-panel/`) or a net-new concept with no
+component yet (`legend/`). A cross-cutting proposal files under its *driving*
+subject, never both (`legend/merge-into-explore-panel.html` is legend-driven,
+so it is not duplicated under an `explore-panel/`). One concept, one folder.
+
+**Fixtures** (`explorations/fixtures/`) hold shared data the explorations load
+via `<script src>` global-assignment (`window.__dsFixtures`) — cloud-side and
+editable in the project, NOT compiled from the repo. This is the one exception
+to "exploration data is repo-sourced": it exists so a dataset reused across
+proposals (both `legend/` files read `map-layers.js`) is edited once, and so
+you can keep simpler/denser variants for different depths. The fixtures that
+back *graded component cards* still live in the repo as typed story args (the
+oracle grades cards against a Storybook render of those exact args); fixtures
+here never feed a graded card.
 
 Anything else — a screen idea, a flow, a feature sketch — belongs in a
 consuming project.
@@ -58,10 +87,15 @@ consuming project.
 Two deliberate non-features: there is **no standing `before/` snapshot
 structure** (the component cards ARE the always-current "before" for every
 component; maintained snapshots would only rot), and there is **no
-`templates/` directory of loose HTML** (an assembly that earns reuse graduates
-INTO the package as a real slot-based component with a story, surfaced in a
-`templates` picker group; loose HTML in the project is unindexed dead weight
-the design agent never reads).
+`templates/` directory of loose HTML** — an assembly that earns reuse
+graduates INTO the package as a real slot-based component with a story,
+surfaced in the `templates` picker group. `StudioShellLayout`
+(`src/components/templates/`) is the first graduation: the studio shell as a
+slot-based template, with `references/studio-shell.html` composing it in the
+project. Loose HTML would be unindexed dead weight the design agent never
+reads. (Free-form prototyping is *not* limited by this — you compose any new
+assembly you want as a cloud exploration on the live bundle; graduation only
+codifies the ones that earn reuse.)
 
 **Where new work starts.** Product-shaped ideas start in a consuming project —
 hacky is fine there. When a direction is worth locking, restate it as a DS
@@ -130,7 +164,7 @@ last `_ds-compiled.css` the retired pipeline shipped.
 This package IS the synced artifact: `.design-sync/` (config, notes,
 conventions) and `.ds-sync/` (the vendored converter) live here, and the
 config consumes the real build (`entry: dist/index.js`, `cssEntry:
-dist/styles.css`, `buildCmd: bunx nx run mapgen-studio-ui:build`). The 46
+dist/styles.css`, `buildCmd: bunx nx run mapgen-studio-ui:build`). The 47
 co-located stories are the fidelity oracle; story titles are the sync's
 grouping authority (byte-frozen).
 

--- a/packages/mapgen-studio-ui/package.json
+++ b/packages/mapgen-studio-ui/package.json
@@ -2,7 +2,7 @@
   "name": "@swooper/mapgen-studio-ui",
   "version": "0.1.0",
   "private": true,
-  "description": "MapGen Studio UI component library — the 46 design-synced components as a real package (dist + generated .d.ts + compiled stylesheet), single source for the app and the Claude Design sync.",
+  "description": "MapGen Studio UI component library — the 47 design-synced components as a real package (dist + generated .d.ts + compiled stylesheet), single source for the app and the Claude Design sync.",
   "type": "module",
   "sideEffects": [
     "**/*.css"

--- a/packages/mapgen-studio-ui/scripts/verify.mjs
+++ b/packages/mapgen-studio-ui/scripts/verify.mjs
@@ -3,7 +3,7 @@
 // Asserts the built package still honors its published contract:
 //   1. dist/index.js exists and carries at least EXPECTED_MIN_EXPORTS named
 //      exports (the floor RISES as each extraction branch lands components —
-//      final: 46 components + TooltipProvider + lib exports).
+//      currently: 47 components + TooltipProvider + lib exports).
 //   2. No `@civ7/studio-server` specifier anywhere in dist JS (unconditional),
 //      and no RUNTIME `@civ7/studio-contract` specifier either — contract
 //      usage is type-position only, so it must compile away entirely.
@@ -42,7 +42,9 @@ const dist = (p) => join(pkgRoot, "dist", p);
 // stay internal — package tests import them relatively.)
 // B6 (AppHeader, E4a redesign): AppHeader = 100. (AppHeaderProps /
 // AppHeaderSetupState are type-only — no runtime export.)
-const EXPECTED_MIN_EXPORTS = 100;
+// Operating-model wave (templates group): StudioShellLayout = 101.
+// (StudioShellGeometry / StudioShellLayoutProps are type-only.)
+const EXPECTED_MIN_EXPORTS = 101;
 
 const failures = [];
 const assert = (cond, msg) => {

--- a/packages/mapgen-studio-ui/src/components/templates/StudioShellLayout.stories.tsx
+++ b/packages/mapgen-studio-ui/src/components/templates/StudioShellLayout.stories.tsx
@@ -1,0 +1,326 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type {
+  AppHeaderSetupState,
+  ExplorePanelProps,
+  GameConsoleProps,
+  MapSize,
+  PipelineConfig,
+  RecipePanelProps,
+  RecipeSettings,
+  SelectOption,
+  StudioShellLayoutProps,
+  WorldSettings,
+} from "@swooper/mapgen-studio-ui";
+import {
+  AppFooter,
+  AppHeader,
+  ExplorePanel,
+  GameConsole,
+  RecipePanel,
+  StageViewTabs,
+  StudioShellLayout,
+} from "@swooper/mapgen-studio-ui";
+import type { ReactNode } from "react";
+
+/**
+ * StudioShellLayout is the whole studio chrome as one slot-based template —
+ * the canonical assembly the app host composes (StudioShell.tsx). This story
+ * fills every slot with the same fixtures the individual component stories
+ * use (AppHeader `Default` + GameConsole `LiveReady`, RecipePanel
+ * `RecipeAndConfig`, ExplorePanel `Inspector`, AppFooter `Ready`), so the
+ * template render IS the composed app at design time. The map canvas is
+ * app-side deck.gl runtime, so the `canvas` slot carries a placeholder.
+ * Tooltips ride the global decorator's `TooltipProvider`.
+ */
+const meta = {
+  title: "templates/StudioShellLayout",
+  component: StudioShellLayout,
+} satisfies Meta<typeof StudioShellLayout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+// ── AppHeader fixtures (composites/AppHeader `Default`) ─────────────────────
+const setup: AppHeaderSetupState = {
+  savedConfig: { id: "continents-std", displayName: "Continents — Standard" },
+  leaderId: "",
+  civilizationId: "",
+  difficultyId: "",
+  gameSpeedId: "",
+};
+const setupOptions = {
+  savedConfigOptions: [
+    { value: "continents-std", label: "Continents — Standard" },
+    { value: "archipelago", label: "Archipelago" },
+    { value: "pangaea", label: "Pangaea" },
+  ],
+  leaderOptions: [],
+  civilizationOptions: [],
+  difficultyOptions: [],
+  gameSpeedOptions: [],
+};
+
+// ── GameConsole fixtures (panels/GameConsole `LiveReady`) ────────────────────
+const gameConsoleProps = {
+  liveGameStudioRelation: "current",
+  onSyncFromLiveGame: noop,
+  onToggleAutoplay: noop,
+  onExplore: noop,
+  operationControlsDisabled: false,
+  isRunInGameRunning: false,
+  runInGameStatus: null,
+  runInGameCurrentRelation: "current",
+  onRunInGame: noop,
+  onCopyRunInGameDiagnostics: noop,
+  saveDeployStatus: null,
+  liveRuntime: {
+    status: "ok",
+    turn: 42,
+    seed: 1474829,
+    readiness: "Civ7 ready",
+    autoplayActive: false,
+  },
+} satisfies GameConsoleProps;
+
+// ── RecipePanel fixtures (panels/RecipePanel `RecipeAndConfig`) ──────────────
+const recipeOptions: SelectOption[] = [
+  { value: "mod-swooper-maps/standard", label: "Standard" },
+  { value: "mod-swooper-maps/continents", label: "Continents" },
+  { value: "mod-swooper-maps/archipelago", label: "Archipelago" },
+];
+const presetOptions: SelectOption[] = [
+  { value: "none", label: "None" },
+  { value: "continents", label: "Continents" },
+  { value: "archipelago", label: "Archipelago" },
+];
+const recipeSettings = {
+  recipe: "mod-swooper-maps/standard",
+  preset: "continents",
+  seed: "1474829",
+};
+const configSchema = {
+  type: "object",
+  properties: {
+    elevation: {
+      type: "object",
+      title: "Elevation",
+      properties: {
+        seaLevel: { type: "number", title: "Sea level", default: 0.6 },
+        mountainDensity: { type: "number", title: "Mountain density", default: 0.3 },
+      },
+    },
+    climate: {
+      type: "object",
+      title: "Climate",
+      properties: {
+        rainfall: {
+          type: "string",
+          title: "Rainfall",
+          enum: ["arid", "temperate", "wet"],
+          default: "temperate",
+        },
+      },
+    },
+  },
+};
+const config: PipelineConfig = {
+  elevation: { seaLevel: 0.6, mountainDensity: 0.3 },
+  climate: { rainfall: "temperate" },
+};
+const recipePanelProps = {
+  config,
+  configSchema,
+  onConfigChange: noop,
+  onConfigReset: noop,
+  recipeOptions,
+  presetOptions,
+  selectedStep: "",
+  settings: recipeSettings,
+  onSettingsChange: noop,
+  onSaveToCurrent: noop,
+  onSaveAsNew: noop,
+  onImportPreset: noop,
+  onExportPreset: noop,
+  onDeletePreset: noop,
+  canDeletePreset: true,
+  isSaveDeployRunning: false,
+  saveDeployStatus: null,
+  isSaveDisabled: false,
+  isDirty: false,
+  recipeCollapsed: false,
+  configCollapsed: false,
+} satisfies RecipePanelProps;
+
+// ── ExplorePanel fixtures (panels/ExplorePanel `Inspector`) ──────────────────
+const explorePanelProps = {
+  stages: [
+    { value: "foundation", label: "Foundation", index: 0 },
+    { value: "morphology", label: "Morphology", index: 1 },
+    { value: "climate", label: "Climate", index: 2 },
+    { value: "hydrology", label: "Hydrology", index: 3 },
+  ],
+  selectedStage: "morphology",
+  onSelectedStageChange: noop,
+  steps: [
+    { value: "plates", label: "Plates", category: "tectonics" },
+    { value: "uplift", label: "Uplift", category: "tectonics" },
+    { value: "coastlines", label: "Coastlines", category: "shaping" },
+  ],
+  selectedStep: "uplift",
+  onSelectedStepChange: noop,
+  dataTypeOptions: [
+    { value: "elevation", label: "Elevation" },
+    { value: "rainfall", label: "Rainfall" },
+    { value: "plates", label: "Plate ID" },
+  ],
+  selectedDataType: "elevation",
+  onSelectedDataTypeChange: noop,
+  spaceOptions: [{ value: "grid", label: "Grid" }],
+  selectedSpace: "grid",
+  onSelectedSpaceChange: noop,
+  renderModeOptions: [
+    { value: "heightmap", label: "Heightmap" },
+    { value: "hillshade", label: "Hillshade" },
+  ],
+  selectedRenderMode: "heightmap",
+  onSelectedRenderModeChange: noop,
+  variantOptions: [{ value: "default", label: "Default" }],
+  selectedVariant: "default",
+  onSelectedVariantChange: noop,
+  overlayOptions: [
+    { value: "none", label: "None" },
+    { value: "rivers", label: "Rivers" },
+  ],
+  selectedOverlay: "none",
+  onSelectedOverlayChange: noop,
+  overlayOpacity: 0.6,
+  onOverlayOpacityChange: noop,
+  eraEnabled: false,
+  eraMode: "auto" as const,
+  eraValue: 2,
+  eraMin: 0,
+  eraMax: 6,
+  onEraModeChange: noop,
+  onEraValueChange: noop,
+  showEdges: false,
+  onShowEdgesChange: noop,
+  showDebugLayers: false,
+  onShowDebugLayersChange: noop,
+  onFitView: noop,
+  riverLakeInspectorSummary: null,
+} satisfies ExplorePanelProps;
+
+// ── AppFooter fixtures (composites/AppFooter `Ready`) ────────────────────────
+const world: WorldSettings = {
+  mapSize: "MAPSIZE_STANDARD",
+  playerCount: 6,
+  resources: "balanced",
+};
+const footerRecipe: RecipeSettings = {
+  recipe: "mod-swooper-maps/standard",
+  preset: "continents",
+  seed: "1474829",
+};
+const mapSizeOptions: ReadonlyArray<SelectOption<MapSize>> = [
+  { value: "MAPSIZE_TINY", label: "Tiny" },
+  { value: "MAPSIZE_SMALL", label: "Small" },
+  { value: "MAPSIZE_STANDARD", label: "Standard" },
+  { value: "MAPSIZE_LARGE", label: "Large" },
+  { value: "MAPSIZE_HUGE", label: "Huge" },
+];
+const mapSizeShortLabels: Record<string, string> = {
+  MAPSIZE_TINY: "Tiny",
+  MAPSIZE_SMALL: "Small",
+  MAPSIZE_STANDARD: "Standard",
+  MAPSIZE_LARGE: "Large",
+  MAPSIZE_HUGE: "Huge",
+};
+
+// The map canvas is app-side deck.gl runtime, not a DS export — the stage
+// slot carries a token-tinted placeholder in its place.
+function CanvasPlaceholder() {
+  return (
+    <div
+      className="relative h-full w-full"
+      style={{
+        background:
+          "radial-gradient(ellipse 90% 70% at 50% 42%, hsl(var(--primary) / .07), transparent 65%)," +
+          "radial-gradient(ellipse 60% 45% at 38% 55%, hsl(var(--foreground) / .04), transparent 70%)," +
+          "hsl(var(--background))",
+      }}
+    >
+      <span className="absolute left-1/2 top-[58%] -translate-x-1/2 text-label uppercase tracking-widest text-muted-foreground opacity-55 text-center">
+        Map canvas
+        <br />
+        app-side deck.gl stage
+      </span>
+    </div>
+  );
+}
+
+// Preview-only fixed-size viewport so the h-full shell has a real box — not a
+// DS export.
+function Viewport({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ width: 1280, height: 800, borderRadius: 8, overflow: "hidden" }}>{children}</div>
+  );
+}
+
+export const FullShell: Story = {
+  // CSF3 requires args once when the component has required-ish shape; this
+  // story owns its full scene in render (slots are elements), so no per-story
+  // args are needed.
+  args: {} as unknown as StudioShellLayoutProps,
+  render: () => (
+    <Viewport>
+      <StudioShellLayout
+        canvas={<CanvasPlaceholder />}
+        leftPanel={<RecipePanel {...recipePanelProps} />}
+        rightPanel={<ExplorePanel {...explorePanelProps} />}
+        stageTabs={(g) => <StageViewTabs value="map" onValueChange={noop} top={g.panelTop} />}
+        header={
+          <AppHeader
+            themePreference="dark"
+            onThemeCycle={noop}
+            showGrid
+            onShowGridChange={noop}
+            setup={setup}
+            setupOptions={setupOptions}
+            savedConfigModified={false}
+            onSavedConfigChange={noop}
+            onLeaderChange={noop}
+            onCivilizationChange={noop}
+            onDifficultyChange={noop}
+            onGameSpeedChange={noop}
+            gameConsole={<GameConsole {...gameConsoleProps} />}
+          />
+        }
+        footer={
+          <AppFooter
+            status="ready"
+            lastRunSettings={footerRecipe}
+            lastGlobalSettings={world}
+            globalSettings={world}
+            currentSettings={footerRecipe}
+            onGlobalSettingsChange={noop}
+            onSettingsChange={noop}
+            onRun={noop}
+            onReroll={noop}
+            isRunning={false}
+            isRunInGameRunning={false}
+            isDirty={false}
+            autoRunEnabled={false}
+            onAutoRunEnabledChange={noop}
+            mapSizeOptions={mapSizeOptions}
+            mapSizeShortLabels={mapSizeShortLabels}
+            playerCountOptions={[2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]}
+            seedMin={0}
+            seedMax={2147483647}
+          />
+        }
+      />
+    </Viewport>
+  ),
+};

--- a/packages/mapgen-studio-ui/src/components/templates/StudioShellLayout.tsx
+++ b/packages/mapgen-studio-ui/src/components/templates/StudioShellLayout.tsx
@@ -1,0 +1,118 @@
+import type { ReactNode } from "react";
+import { LAYOUT } from "../../lib/layout.js";
+import { cn } from "../../lib/utils.js";
+import { LeftDock } from "../layout/LeftDock.js";
+import { RightDock } from "../layout/RightDock.js";
+
+// ============================================================================
+// STUDIO SHELL LAYOUT — the canonical shell assembly (templates group)
+// ============================================================================
+// The whole studio chrome as one slot-based template: a relative root over a
+// full-bleed canvas layer, the two docks wired to shared top/bottom offsets,
+// and self-positioning chrome (header / footer / stage tabs / banner) painted
+// in the app's order. It mirrors the composition of the app host
+// (apps/mapgen-studio/src/app/StudioShell.tsx) — same layering, same geometry
+// formula — so a design built on this template maps 1:1 onto the app.
+//
+// This is the graduation target of the operating model's "reference:
+// canonical assembly" explorations (see README.md → Operating model): an
+// assembly that earns reuse becomes a real component here, with a story and
+// verified renders, instead of living as loose HTML in the design project.
+//
+// Deliberately NOT here (app-side runtime, not chrome geometry): the skip
+// link + sr-only live region, preset dialogs, the hidden import input, the
+// measured header height (the app's ResizeObserver refines `panelTop`; the
+// defaults below use the LAYOUT seed values), and the map/pipeline stage swap
+// (pass the active stage as `canvas` and swap `rightPanel` out in pipeline
+// view, as the app does).
+// ============================================================================
+
+/** The resolved dock offsets, handed to function-form chrome slots. */
+export interface StudioShellGeometry {
+  /** px from the viewport top to the docks' top edge. */
+  panelTop: number;
+  /** px from the viewport bottom to the docks' bottom edge. */
+  panelBottom: number;
+}
+
+/**
+ * A chrome slot: a plain node, or a function of the resolved geometry for
+ * chrome that needs the offsets (`StageViewTabs`/`ErrorBanner` take `top`) —
+ * the function form keeps one geometry authority when overriding the
+ * defaults.
+ */
+type ChromeSlot = ReactNode | ((geometry: StudioShellGeometry) => ReactNode);
+
+export interface StudioShellLayoutProps {
+  /** The stage layer (map canvas, pipeline view, or a placeholder); filled to the root via `absolute inset-0`. */
+  canvas?: ReactNode;
+  /** Left-dock content (the Recipe panel in the app); wrapped in `LeftDock` at the shared offsets. */
+  leftPanel?: ReactNode;
+  /** Right-dock content (the Explore panel in the app, map view only); wrapped in `RightDock` at the shared offsets. */
+  rightPanel?: ReactNode;
+  /** Top-center stage furniture (`StageViewTabs`); self-positions — use the function form for its `top`. */
+  stageTabs?: ChromeSlot;
+  /** Top chrome (`AppHeader`); self-positions `absolute top-4`. */
+  header?: ChromeSlot;
+  /** Bottom chrome (`AppFooter`); self-positions `absolute bottom-4`. */
+  footer?: ChromeSlot;
+  /** Interruptive overlay (`ErrorBanner`); painted last — use the function form for its `top`. */
+  banner?: ChromeSlot;
+  /**
+   * Dock top offset (px). Defaults to the LAYOUT formula the app uses,
+   * seeded with the estimated header height (the app substitutes the
+   * measured one): `SPACING + HEADER_HEIGHT + SPACING`.
+   */
+  panelTop?: number;
+  /** Dock bottom offset (px). Defaults to the app's `FOOTER_HEIGHT + 2 * SPACING`. */
+  panelBottom?: number;
+  /** Merged onto the root (e.g. `min-h-screen` when the host owns page height). */
+  className?: string;
+}
+
+const DEFAULT_PANEL_TOP = LAYOUT.SPACING + LAYOUT.HEADER_HEIGHT + LAYOUT.SPACING;
+const DEFAULT_PANEL_BOTTOM = LAYOUT.FOOTER_HEIGHT + 2 * LAYOUT.SPACING;
+
+function renderSlot(slot: ChromeSlot, geometry: StudioShellGeometry): ReactNode {
+  return typeof slot === "function" ? slot(geometry) : slot;
+}
+
+/**
+ * `StudioShellLayout` — the studio's application shell as a template. Hosts
+ * supply the parts; the template owns the geometry: root box, canvas fill,
+ * dock offsets, and paint order (canvas → docks → tabs → header → footer →
+ * banner). Requires the ambient `TooltipProvider` like every composed panel.
+ */
+export function StudioShellLayout({
+  canvas,
+  leftPanel,
+  rightPanel,
+  stageTabs,
+  header,
+  footer,
+  banner,
+  panelTop = DEFAULT_PANEL_TOP,
+  panelBottom = DEFAULT_PANEL_BOTTOM,
+  className,
+}: StudioShellLayoutProps) {
+  const geometry: StudioShellGeometry = { panelTop, panelBottom };
+  return (
+    <div className={cn("relative h-full w-full overflow-hidden bg-background", className)}>
+      <div className="absolute inset-0">{canvas}</div>
+      {leftPanel ? (
+        <LeftDock top={panelTop} bottom={panelBottom}>
+          {leftPanel}
+        </LeftDock>
+      ) : null}
+      {rightPanel ? (
+        <RightDock top={panelTop} bottom={panelBottom}>
+          {rightPanel}
+        </RightDock>
+      ) : null}
+      {renderSlot(stageTabs, geometry)}
+      {renderSlot(header, geometry)}
+      {renderSlot(footer, geometry)}
+      {renderSlot(banner, geometry)}
+    </div>
+  );
+}

--- a/packages/mapgen-studio-ui/src/index.ts
+++ b/packages/mapgen-studio-ui/src/index.ts
@@ -24,8 +24,11 @@
  * B6 surface: AppHeader (E4a redesign — props-driven view over the
  * `AppHeaderSetupState` view-model + intent callbacks; the app container owns
  * the setup-config updates and the difficulty double-write).
+ * Templates surface (operating-model wave): StudioShellLayout — the studio
+ * shell as a slot-based canonical assembly (the graduation path for
+ * reference explorations; README.md → Operating model).
  * Each branch adds its exports here and raises the `verify` export floor.
- * Final surface: the 46 design-synced components (+ TooltipProvider and the
+ * Final surface: the 47 design-synced components (+ TooltipProvider and the
  * lib exports — `cn`, `useResolvedTheme`, `LAYOUT`, statusLabels formatters,
  * `useConfigCollapse`).
  *
@@ -128,6 +131,13 @@ export {
 } from "./components/panels/statusLabels.js";
 // primitives — the shadcn sub-barrel (15 components + families)
 export * from "./components/ui/index.js";
+// templates — canonical assemblies (the graduation target for reference
+// explorations that earn reuse; operating model in README.md)
+export {
+  type StudioShellGeometry,
+  StudioShellLayout,
+  type StudioShellLayoutProps,
+} from "./components/templates/StudioShellLayout.js";
 
 // lib foundation
 export { LAYOUT, type LayoutConfig } from "./lib/layout.js";


### PR DESCRIPTION
Makes the design-system operating model (recorded in #2005) **concrete in structure**, not just prose.

## Package — the 47th synced component
- **`templates/StudioShellLayout`**: the studio shell as a slot-based component mirroring `StudioShell.tsx` composition (canvas fill, dock offsets from `LAYOUT`, self-positioning header/footer/stage-tabs/banner). Slots accept a node or a function of the resolved geometry. First member of a new **`templates`** picker group — the graduation target for reference explorations that earn reuse.
- Story `templates/StudioShellLayout` (FullShell) composed from the existing panel/chrome story fixtures; graded `match`; `design-sync:check` verdict clean (`added:[StudioShellLayout]`, `pendingGrade:[]`).
- Barrel export; verify floor to 101; `docsMap` + `overrides` + `groups/templates.md`; every "46" in living docs bumped to 47 (historical records left).

## DS project (531d158d) — explorations restructured & uploaded
Nested by **design subject**, kebab-case, no whitespace:

```
explorations/
  proposals/legend/new-panel.html                  (new component)
  proposals/legend/merge-into-explore-panel.html   (change: Legend x ExplorePanel)
  proposals/recipe-panel/flat-and-flush.html       (change)
  references/studio-shell.html                     (rebuilt on StudioShellLayout)
  fixtures/map-layers.js                           (shared cloud data)
  README.md                                         (index + subject rule)
```

- **Cloud fixtures channel**: `fixtures/map-layers.js` assigns `window.__dsFixtures`; both legend proposals load it via `<script src>` (new-panel at full depth, merge derives a coarser view). Editable in the project — reshape once, both update, no repo resync. Repo story-args remain the source for graded *cards*.
- Replaces the 3 old flat exploration files (deleted remotely). All four pages render-verified via headless Chrome.

## Docs
README operating-model section + `conventions.md` updated for the nested taxonomy, the subject-folder rule, the templates graduation path, and the cloud-fixtures channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
