### PR TITLE
docs(habitat): update narrative liveness decision corpus to reflect Slice 1 deletions

### DIFF
--- a/.habitat/.active/workstreams/domain-closed-structure-dominoes/slices/002-prework-decision-qualification/Decisions/001-narrative-liveness-ownership/corpus/narrative-source-inventory.md
+++ b/.habitat/.active/workstreams/domain-closed-structure-dominoes/slices/002-prework-decision-qualification/Decisions/001-narrative-liveness-ownership/corpus/narrative-source-inventory.md
@@ -2,7 +2,7 @@
 
 Status: source corpus artifact
 
-Expanded source corpus: 36 files under
+Expanded source corpus after Slice 1 shell deletion: 32 files under
 `mods/mod-swooper-maps/src/domain/narrative/**`.
 
 ## Evidence Summary
@@ -16,6 +16,7 @@ Expanded source corpus: 36 files under
   narrative.
 - No production TypeScript caller outside `domain/narrative/**` was found for
   narrative behavior exports.
+- Slice 1 removed the empty `ops` shell and unused `orogeny/wind.ts` helper.
 - Current story tests import and call narrative surfaces under
   `mods/mod-swooper-maps/test/story/**`.
 
@@ -42,10 +43,10 @@ Expanded source corpus: 36 files under
 
 | Path | Current role | Exported symbols | External importers/callers found | Evidence tag |
 | --- | --- | --- | --- | --- |
-| `mods/mod-swooper-maps/src/domain/narrative/index.ts` | Root narrative facade | default `domain`; corridor/orogeny/overlay exports | `domain/index.ts`; story tests through package alias | public-collar-only; test-live |
-| `mods/mod-swooper-maps/src/domain/narrative/ops.ts` | Runtime domain binding | default `createDomain(...)` | No standard recipe import found | empty-domain-shell |
-| `mods/mod-swooper-maps/src/domain/narrative/ops/contracts.ts` | Empty op contracts | `contracts`; default | Internal only | empty-domain-shell |
-| `mods/mod-swooper-maps/src/domain/narrative/ops/index.ts` | Empty op implementations | default `implementations` | Internal only | empty-domain-shell |
+| `mods/mod-swooper-maps/src/domain/narrative/index.ts` | Root narrative facade after Slice 1 shell deletion | corridor/orogeny/overlay exports | `domain/index.ts`; story tests through package alias | public-collar-only; test-live |
+| `mods/mod-swooper-maps/src/domain/narrative/ops.ts` | Deleted in Slice 1 | none | No standard recipe import found | empty-domain-shell-deleted |
+| `mods/mod-swooper-maps/src/domain/narrative/ops/contracts.ts` | Deleted in Slice 1 | none | Internal only before deletion | empty-domain-shell-deleted |
+| `mods/mod-swooper-maps/src/domain/narrative/ops/index.ts` | Deleted in Slice 1 | none | Internal only before deletion | empty-domain-shell-deleted |
 | `mods/mod-swooper-maps/src/domain/narrative/config.ts` | Root story config aggregate | `NarrativeConfigSchema`; `StoryConfig`; subconfig exports | `domain/config.ts`; test imports direct corridor schema through this path | public-collar-only; test-live |
 | `mods/mod-swooper-maps/src/domain/narrative/models.ts` | Story motif/corridor model types | motif and corridor interfaces | Internal only | internal-composition-live |
 | `mods/mod-swooper-maps/src/domain/narrative/overlays/keys.ts` | Overlay key constants | `STORY_OVERLAY_KEYS`; `StoryOverlayKey` | Root story tests through facade | test-live |
@@ -75,9 +76,9 @@ Expanded source corpus: 36 files under
 | `mods/mod-swooper-maps/src/domain/narrative/corridors/index.ts` | Strategic corridor entry and overlay publisher | `storyTagStrategicCorridors`; result/input types | Root facade; story corridor test | test-live |
 | `mods/mod-swooper-maps/src/domain/narrative/orogeny/config.ts` | Orogeny tunables schema | `OrogenyTunablesSchema`; `OrogenyTunables` | Root config facade; internal orogeny | behavior-bearing-no-prod-caller |
 | `mods/mod-swooper-maps/src/domain/narrative/orogeny/cache.ts` | Orogeny cache keyed by context | `OrogenyCacheInstance`; `getOrogenyCache` | Internal through belts; broad public sub-barrel | module-cache-evidence |
-| `mods/mod-swooper-maps/src/domain/narrative/orogeny/wind.ts` | Zonal wind helper | `zonalWindStep` | Broad public sub-barrel; no caller found; KNIP unused export | possible-unused-helper |
+| `mods/mod-swooper-maps/src/domain/narrative/orogeny/wind.ts` | Deleted in Slice 1 | none | Broad public sub-barrel before deletion; no caller found; KNIP unused export | possible-unused-helper-deleted |
 | `mods/mod-swooper-maps/src/domain/narrative/orogeny/belts.ts` | Orogeny belt motif generator and overlay publisher | `OrogenySummary`; `storyTagOrogenyBelts` | Root facade; story orogeny test | test-live |
-| `mods/mod-swooper-maps/src/domain/narrative/orogeny/index.ts` | Orogeny wildcard barrel | `belts`, `cache`, `wind` wildcard exports | Root facade | broad sub-barrel |
+| `mods/mod-swooper-maps/src/domain/narrative/orogeny/index.ts` | Orogeny wildcard barrel after Slice 1 wind deletion | `belts`, `cache` wildcard exports | Root facade | broad sub-barrel |
 
 ## Evidence Tags
 
@@ -87,9 +88,9 @@ Expanded source corpus: 36 files under
 | public-collar-only | Publicly exported by a barrel, with no production caller found. |
 | behavior-bearing-no-prod-caller | Implements story behavior, usually overlay publication, with no production recipe/stage caller found. |
 | internal-composition-live | Supports test-live or public behavior through internal imports. |
-| empty-domain-shell | Domain contract/implementation binding has no ops and is absent from standard recipe. |
-| module-cache-evidence | Uses module-level or context-keyed cache material relevant to story-artifact ownership. |
-| possible-unused-helper | Exported helper with no current caller found. |
+| empty-domain-shell-deleted | Domain contract/implementation binding had no ops, was absent from the standard recipe, and was deleted in Slice 1. |
+| module-cache-evidence | Uses module-level or context-keyed cache material inside the retired story network. |
+| possible-unused-helper-deleted | Exported helper with no caller found and deleted in Slice 1. |
 | placement-name-collar | Current placement source mentions Civ7 narrative-system concepts while remaining owned by placement/adapter law. |
 | hydrology-name-collar | Current hydrology source mentions Narrative as a consumer/bias target while remaining owned by hydrology stage/artifact law. |
 | runtime-name-collar | Runtime/control code uses Civ7 narrative UI terminology while remaining outside the MapGen narrative-domain source network. |

--- a/.habitat/.active/workstreams/domain-closed-structure-dominoes/slices/002-prework-decision-qualification/Decisions/001-narrative-liveness-ownership/evidence/knip-dead-code.md
+++ b/.habitat/.active/workstreams/domain-closed-structure-dominoes/slices/002-prework-decision-qualification/Decisions/001-narrative-liveness-ownership/evidence/knip-dead-code.md
@@ -34,11 +34,11 @@ bunx knip --no-progress --no-exit-code --reporter compact --include files,export
 
 ## Raw Relevant Findings
 
-Scoped local report:
+Scoped local report after Slice 1 shell deletion:
 
 ```text
-Unused files (66)
-Unused exports (68)
+Unused files (64)
+Unused exports (65)
 Unused exported types (101)
 ```
 
@@ -46,8 +46,6 @@ Narrative-specific scoped hits:
 
 ```text
 Unused files:
-mods/mod-swooper-maps/src/domain/narrative/ops.ts
-mods/mod-swooper-maps/src/domain/narrative/ops/index.ts
 mods/mod-swooper-maps/src/domain/narrative/tagging/hotspots.ts
 mods/mod-swooper-maps/src/domain/narrative/tagging/index.ts
 mods/mod-swooper-maps/src/domain/narrative/tagging/margins.ts
@@ -61,9 +59,6 @@ mods/mod-swooper-maps/src/domain/narrative/corridors/config.ts: SeaCorridorPolic
 mods/mod-swooper-maps/src/domain/narrative/corridors/runtime.ts: isCoastalLand, isWaterAt
 mods/mod-swooper-maps/src/domain/narrative/corridors/sea-lanes.ts: hasPerpWidth, longestWaterRunColumn, longestWaterRunRow, longestWaterRunDiagSum, longestWaterRunDiagDiff
 mods/mod-swooper-maps/src/domain/narrative/corridors/style-cache.ts: fetchCorridorStylePrimitive
-mods/mod-swooper-maps/src/domain/narrative/index.ts: default
-mods/mod-swooper-maps/src/domain/narrative/ops/contracts.ts: contracts
-mods/mod-swooper-maps/src/domain/narrative/orogeny/wind.ts: zonalWindStep
 mods/mod-swooper-maps/src/domain/narrative/overlays/index.ts: default
 
 Unused exported types:
@@ -82,7 +77,8 @@ binding and Habitat manifests provide entry surfaces KNIP did not model.
 
 KNIP supports these claims:
 
-- narrative ops are not reached by the current workspace entry model;
+- narrative ops were not reached by the current workspace entry model and were
+  deleted in Slice 1;
 - tagging helpers are especially stale because no current production or test
   caller reaches them;
 - root narrative/default and config exports are public-surface collars, not
@@ -90,13 +86,19 @@ KNIP supports these claims:
 - KNIP alone is insufficient deletion proof for Habitat rules, placement ops,
   or other repo-specific execution surfaces.
 
-The strongest deletion candidates are:
+The empty shell and unused wind helper were deleted in Slice 1:
 
 - `domain/narrative/ops.ts`;
 - `domain/narrative/ops/index.ts`;
 - `domain/narrative/ops/contracts.ts`;
+- `domain/narrative/orogeny/wind.ts`.
+
+The remaining strongest story-network deletion candidates are:
+
 - `domain/narrative/tagging/**`;
-- `domain/narrative/utils/latitude.ts` if tagging/rifts are deleted.
+- `domain/narrative/utils/latitude.ts` with tagging/rifts;
+- the test-live corridor, orogeny, overlay, config, and helper network assigned
+  to Slice 3 deletion by the disposition table.
 
 The broader narrative source network is test-live through story tests, but the
 tests exercise legacy/story behavior rather than current standard recipe wiring.

--- a/.habitat/.active/workstreams/domain-closed-structure-dominoes/slices/002-prework-decision-qualification/Decisions/001-narrative-liveness-ownership/evidence/narsil-graph.md
+++ b/.habitat/.active/workstreams/domain-closed-structure-dominoes/slices/002-prework-decision-qualification/Decisions/001-narrative-liveness-ownership/evidence/narsil-graph.md
@@ -22,9 +22,14 @@ mcp__narsil_code_intel_civ7.get_callers(repo="civ7-modding-tools", function="pub
 
 ## Raw Returned Evidence
 
+The `defineDomain` and `orogeny/wind.ts` evidence below was captured before
+Slice 1 removed the empty narrative shell and unused wind helper. It remains
+historical justification for the deletion, not a statement that those surfaces
+still exist after Slice 1.
+
 | Symbol | References returned | Callers returned |
 | --- | --- | --- |
-| `defineDomain` | `mods/mod-swooper-maps/src/domain/narrative/index.ts` defines `defineDomain({ id: "narrative", ops })`; indexed docs include prior architecture review rows describing narrative as dead code with zero recipe wiring and empty ops. | Not queried as a recipe liveness target. |
+| `defineDomain` | Pre-Slice 1, `mods/mod-swooper-maps/src/domain/narrative/index.ts` defined `defineDomain({ id: "narrative", ops })`; indexed docs include prior architecture review rows describing narrative as dead code with zero recipe wiring and empty ops. | Not queried as a recipe liveness target. |
 | `storyTagStrategicCorridors` | Archived JS, docs, `mods/mod-swooper-maps/test/story/corridors.test.ts`, `mods/mod-swooper-maps/src/domain/narrative/corridors/index.ts`, and root narrative facade. | Only transitive caller returned was archived original JS `generateMap`; current TypeScript callers are tests/re-exports, corroborated by `rg`. |
 | `storyTagOrogenyBelts` | Archived JS, docs, `mods/mod-swooper-maps/test/story/orogeny.test.ts`, `mods/mod-swooper-maps/src/domain/narrative/orogeny/belts.ts`, and root narrative facade. | Only transitive caller returned was archived original JS `generateMap`; current TypeScript caller is test/re-export. |
 | `publishStoryOverlay` | Current TypeScript references are narrative internals and story tests, plus docs/Habitat evidence. | Callers are narrative internals plus archived JS; no current standard recipe stage caller returned. |
@@ -34,7 +39,7 @@ mcp__narsil_code_intel_civ7.get_callers(repo="civ7-modding-tools", function="pub
 
 | Symbol | Decision implication |
 | --- | --- |
-| `defineDomain` | Narrative has a domain shell, while current source/docs indicate no recipe binding. |
+| `defineDomain` | Narrative had a domain shell before Slice 1, while source/docs indicated no recipe binding. |
 | `storyTagStrategicCorridors` | Current production recipe does not call this behavior. |
 | `storyTagOrogenyBelts` | Current production recipe does not call this behavior. |
 | `publishStoryOverlay` | Overlay publication is internal to the narrative source network and tests. |

--- a/.habitat/.active/workstreams/domain-closed-structure-dominoes/slices/002-prework-decision-qualification/Decisions/001-narrative-liveness-ownership/synthesis/disposition-table.md
+++ b/.habitat/.active/workstreams/domain-closed-structure-dominoes/slices/002-prework-decision-qualification/Decisions/001-narrative-liveness-ownership/synthesis/disposition-table.md
@@ -18,12 +18,12 @@ public barrels, not a production recipe owner.
 
 Disposition:
 
-- empty domain ops are deletion-ready in a later implementation slice after
-  import/type proof;
+- empty domain ops and the unused orogeny wind helper were deleted in Slice 1
+  after import/type proof;
 - behavior-bearing story code has no Domino 001 landing slot and is assigned to
-  a later Gameplay/story-artifact owner-law domino;
+  Slice 3 deletion with no replacement in this cleanup;
 - current tests under `mods/mod-swooper-maps/test/story/**` are compatibility
-  evidence for that later owner-law decision;
+  evidence for the removed implementation and are assigned to Slice 3 deletion;
 - placement, resource, adapter, and Civ7 runtime narrative UI surfaces remain
   outside this packet.
 
@@ -31,78 +31,78 @@ Disposition:
 
 | Path or symbol | Liveness | Owner | Disposition | Evidence strength | Governing authority |
 | --- | --- | --- | --- | --- | --- |
-| `mods/mod-swooper-maps/src/domain/narrative/index.ts` | Mixed barrel: empty domain shell plus story exports | split by symbol | Apply symbol-level split below; no file-level single owner | verified | recipe omits narrative; Narsil/rg tests only; Gameplay owner boundary |
-| `mods/mod-swooper-maps/src/domain/narrative/ops.ts` | No recipe caller | none | Delete | verified | recipe `collectCompileOps` omits narrative; KNIP unused file |
-| `mods/mod-swooper-maps/src/domain/narrative/ops/contracts.ts` | Empty contracts | none | Delete | verified | empty shell; KNIP unused export |
-| `mods/mod-swooper-maps/src/domain/narrative/ops/index.ts` | Empty implementations | none | Delete | verified | recipe omits narrative; KNIP unused file |
-| `mods/mod-swooper-maps/src/domain/narrative/config.ts` | Barrel/test-live config only | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino; no Domino 001 destination | corroborated | root config barrel; no stage caller; KNIP unused exports |
-| `mods/mod-swooper-maps/src/domain/narrative/models.ts` | Internal only | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | internal imports only; owner-boundaries |
-| `mods/mod-swooper-maps/src/domain/narrative/overlays/keys.ts` | Test-live | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | tests; target story-artifact law required |
-| `mods/mod-swooper-maps/src/domain/narrative/overlays/normalize.ts` | Internal overlay support | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | internal imports only |
-| `mods/mod-swooper-maps/src/domain/narrative/overlays/registry.ts` | Test-live; internal publishers | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | Narsil refs tests/internal only |
-| `mods/mod-swooper-maps/src/domain/narrative/overlays/index.ts` | Public sub-barrel/test-live | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | root facade; KNIP unused default |
-| `mods/mod-swooper-maps/src/domain/narrative/utils/dims.ts` | Internal only | Gameplay/story-artifact owner-law domino | Assign with parent story network | corroborated | internal-only imports |
-| `mods/mod-swooper-maps/src/domain/narrative/utils/adjacency.ts` | Internal only | Gameplay/story-artifact owner-law domino | Assign with parent story network | corroborated | internal-only imports |
-| `mods/mod-swooper-maps/src/domain/narrative/utils/latitude.ts` | Internal rift helper; KNIP unused file | Gameplay/story-artifact owner-law domino | Assign with rift/tagging network | verified | KNIP unused file; no external caller |
-| `mods/mod-swooper-maps/src/domain/narrative/utils/rng.ts` | Internal only | Gameplay/story-artifact owner-law domino | Assign with parent story network | corroborated | internal-only imports |
-| `mods/mod-swooper-maps/src/domain/narrative/utils/water.ts` | Internal adapter-backed context read | adapter/runtime integration | Assign to later Gameplay/story-artifact owner-law only as an adapter/runtime integration requirement; not a pure domain-model slot | corroborated | direct `ctx.adapter.isWater` call; internal-only imports |
-| `mods/mod-swooper-maps/src/domain/narrative/tagging/config.ts` | Public config re-export; no production caller | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | root config; KNIP unused exports |
-| `mods/mod-swooper-maps/src/domain/narrative/tagging/types.ts` | Internal only; KNIP unused file | Gameplay/story-artifact owner-law domino | Assign with tagging network | verified | KNIP unused file |
-| `mods/mod-swooper-maps/src/domain/narrative/tagging/index.ts` | No external caller; KNIP unused file | Gameplay/story-artifact owner-law domino | Assign with tagging network | verified | KNIP unused file; rg no callers |
-| `mods/mod-swooper-maps/src/domain/narrative/tagging/hotspots.ts` | No external caller; KNIP unused file | Gameplay/story-artifact owner-law domino | Assign with tagging network | verified | KNIP unused file; rg no callers |
-| `mods/mod-swooper-maps/src/domain/narrative/tagging/margins.ts` | No external caller; KNIP unused file | Gameplay/story-artifact owner-law domino | Assign with tagging network | verified | KNIP unused file; rg no callers |
-| `mods/mod-swooper-maps/src/domain/narrative/tagging/rifts.ts` | No external caller; KNIP unused file | Gameplay/story-artifact owner-law domino | Assign with tagging network | verified | KNIP unused file; rg no callers |
-| `mods/mod-swooper-maps/src/domain/narrative/corridors/config.ts` | Test-live via config import | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | story test import; no stage caller |
-| `mods/mod-swooper-maps/src/domain/narrative/corridors/types.ts` | Internal corridor support | Gameplay/story-artifact owner-law domino | Assign with corridors network | corroborated | internal-only imports |
-| `mods/mod-swooper-maps/src/domain/narrative/corridors/state.ts` | Internal corridor support | Gameplay/story-artifact owner-law domino | Assign with corridors network | corroborated | internal-only imports |
-| `mods/mod-swooper-maps/src/domain/narrative/corridors/runtime.ts` | Internal corridor support | Gameplay/story-artifact owner-law domino | Assign with corridors network | corroborated | internal-only imports; KNIP unused exports |
-| `mods/mod-swooper-maps/src/domain/narrative/corridors/style-cache.ts` | Internal module-cache helper | Gameplay/story-artifact owner-law domino | Assign with corridors network; later owner law must name cache/scoping law | corroborated | module cache evidence; no external caller |
-| `mods/mod-swooper-maps/src/domain/narrative/corridors/backfill.ts` | Internal corridor support | Gameplay/story-artifact owner-law domino | Assign with corridors network | corroborated | internal-only imports |
-| `mods/mod-swooper-maps/src/domain/narrative/corridors/sea-lanes.ts` | Internal corridor implementation; test-live indirectly | Gameplay/story-artifact owner-law domino | Assign with corridors network | corroborated | story corridor test through entry |
-| `mods/mod-swooper-maps/src/domain/narrative/corridors/island-hop.ts` | Internal corridor implementation; test-live indirectly | Gameplay/story-artifact owner-law domino | Assign with corridors network | corroborated | story corridor test through entry |
-| `mods/mod-swooper-maps/src/domain/narrative/corridors/land-corridors.ts` | Internal corridor implementation; test-live indirectly | Gameplay/story-artifact owner-law domino | Assign with corridors network | corroborated | story corridor test through entry |
-| `mods/mod-swooper-maps/src/domain/narrative/corridors/index.ts` | Test-live; no production caller | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | Narsil refs test/root facade only |
-| `mods/mod-swooper-maps/src/domain/narrative/orogeny/config.ts` | Config re-export; internal orogeny use | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | root config; no stage caller |
-| `mods/mod-swooper-maps/src/domain/narrative/orogeny/cache.ts` | Internal context-keyed cache | Gameplay/story-artifact owner-law domino | Assign with orogeny network; later owner law must name cache/scoping law | corroborated | module cache evidence |
-| `mods/mod-swooper-maps/src/domain/narrative/orogeny/wind.ts` | No caller found; KNIP unused export | none | Delete | verified | KNIP unused export; rg no caller |
-| `mods/mod-swooper-maps/src/domain/narrative/orogeny/belts.ts` | Test-live; no production caller | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | Narsil refs test/root facade only |
-| `mods/mod-swooper-maps/src/domain/narrative/orogeny/index.ts` | Mixed wildcard barrel: story exports plus unused wind export | split by symbol | Apply symbol-level split below; no file-level single owner | corroborated | root facade only |
+| `mods/mod-swooper-maps/src/domain/narrative/index.ts` | Story exports only after Slice 1 shell deletion | retired MapGen story network | Delete current implementation, no replacement in this cleanup | verified | recipe omits narrative; rg tests only; public collar/test liveness |
+| `mods/mod-swooper-maps/src/domain/narrative/ops.ts` | No recipe caller | none | Deleted in Slice 1 | verified | recipe `collectCompileOps` omits narrative; KNIP unused file |
+| `mods/mod-swooper-maps/src/domain/narrative/ops/contracts.ts` | Empty contracts | none | Deleted in Slice 1 | verified | empty shell; KNIP unused export |
+| `mods/mod-swooper-maps/src/domain/narrative/ops/index.ts` | Empty implementations | none | Deleted in Slice 1 | verified | recipe omits narrative; KNIP unused file |
+| `mods/mod-swooper-maps/src/domain/narrative/config.ts` | Barrel/test-live config only | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | root config barrel; no stage caller; KNIP unused exports |
+| `mods/mod-swooper-maps/src/domain/narrative/models.ts` | Internal only | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | internal imports only; owner-boundaries |
+| `mods/mod-swooper-maps/src/domain/narrative/overlays/keys.ts` | Test-live | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | tests; compatibility evidence only |
+| `mods/mod-swooper-maps/src/domain/narrative/overlays/normalize.ts` | Internal overlay support | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | internal imports only |
+| `mods/mod-swooper-maps/src/domain/narrative/overlays/registry.ts` | Test-live; internal publishers | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | Narsil refs tests/internal only |
+| `mods/mod-swooper-maps/src/domain/narrative/overlays/index.ts` | Public sub-barrel/test-live | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | root facade; KNIP unused default |
+| `mods/mod-swooper-maps/src/domain/narrative/utils/dims.ts` | Internal only | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | internal-only imports |
+| `mods/mod-swooper-maps/src/domain/narrative/utils/adjacency.ts` | Internal only | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | internal-only imports |
+| `mods/mod-swooper-maps/src/domain/narrative/utils/latitude.ts` | Internal rift helper; KNIP unused file | retired MapGen story network | Delete current implementation, no replacement in this cleanup | verified | KNIP unused file; no external caller |
+| `mods/mod-swooper-maps/src/domain/narrative/utils/rng.ts` | Internal only | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | internal-only imports |
+| `mods/mod-swooper-maps/src/domain/narrative/utils/water.ts` | Internal adapter-backed context read | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | direct `ctx.adapter.isWater` call is internal to the deleted story network |
+| `mods/mod-swooper-maps/src/domain/narrative/tagging/config.ts` | Public config re-export; no production caller | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | root config; KNIP unused exports |
+| `mods/mod-swooper-maps/src/domain/narrative/tagging/types.ts` | Internal only; KNIP unused file | retired MapGen story network | Delete current implementation, no replacement in this cleanup | verified | KNIP unused file |
+| `mods/mod-swooper-maps/src/domain/narrative/tagging/index.ts` | No external caller; KNIP unused file | retired MapGen story network | Delete current implementation, no replacement in this cleanup | verified | KNIP unused file; rg no callers |
+| `mods/mod-swooper-maps/src/domain/narrative/tagging/hotspots.ts` | No external caller; KNIP unused file | retired MapGen story network | Delete current implementation, no replacement in this cleanup | verified | KNIP unused file; rg no callers |
+| `mods/mod-swooper-maps/src/domain/narrative/tagging/margins.ts` | No external caller; KNIP unused file | retired MapGen story network | Delete current implementation, no replacement in this cleanup | verified | KNIP unused file; rg no callers |
+| `mods/mod-swooper-maps/src/domain/narrative/tagging/rifts.ts` | No external caller; KNIP unused file | retired MapGen story network | Delete current implementation, no replacement in this cleanup | verified | KNIP unused file; rg no callers |
+| `mods/mod-swooper-maps/src/domain/narrative/corridors/config.ts` | Test-live via config import | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | story test import; no stage caller |
+| `mods/mod-swooper-maps/src/domain/narrative/corridors/types.ts` | Internal corridor support | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | internal-only imports |
+| `mods/mod-swooper-maps/src/domain/narrative/corridors/state.ts` | Internal corridor support | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | internal-only imports |
+| `mods/mod-swooper-maps/src/domain/narrative/corridors/runtime.ts` | Internal corridor support | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | internal-only imports; KNIP unused exports |
+| `mods/mod-swooper-maps/src/domain/narrative/corridors/style-cache.ts` | Internal module-cache helper | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | module cache evidence; no external caller |
+| `mods/mod-swooper-maps/src/domain/narrative/corridors/backfill.ts` | Internal corridor support | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | internal-only imports |
+| `mods/mod-swooper-maps/src/domain/narrative/corridors/sea-lanes.ts` | Internal corridor implementation; test-live indirectly | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | story corridor test through entry |
+| `mods/mod-swooper-maps/src/domain/narrative/corridors/island-hop.ts` | Internal corridor implementation; test-live indirectly | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | story corridor test through entry |
+| `mods/mod-swooper-maps/src/domain/narrative/corridors/land-corridors.ts` | Internal corridor implementation; test-live indirectly | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | story corridor test through entry |
+| `mods/mod-swooper-maps/src/domain/narrative/corridors/index.ts` | Test-live; no production caller | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | Narsil refs test/root facade only |
+| `mods/mod-swooper-maps/src/domain/narrative/orogeny/config.ts` | Config re-export; internal orogeny use | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | root config; no stage caller |
+| `mods/mod-swooper-maps/src/domain/narrative/orogeny/cache.ts` | Internal context-keyed cache | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | module cache evidence |
+| `mods/mod-swooper-maps/src/domain/narrative/orogeny/wind.ts` | No caller found; KNIP unused export | none | Deleted in Slice 1 | verified | KNIP unused export; rg no caller |
+| `mods/mod-swooper-maps/src/domain/narrative/orogeny/belts.ts` | Test-live; no production caller | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | Narsil refs test/root facade only |
+| `mods/mod-swooper-maps/src/domain/narrative/orogeny/index.ts` | Story exports only after Slice 1 wind deletion | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | root facade only |
 
 ## Symbol-Level Barrel Splits
 
 | Path or symbol | Liveness | Owner | Disposition | Evidence strength | Governing authority |
 | --- | --- | --- | --- | --- | --- |
-| `mods/mod-swooper-maps/src/domain/narrative/index.ts` default `domain` / `defineDomain({ id: "narrative", ops })` | Empty domain shell; no recipe caller | none | Delete with empty ops shell after import/type proof | verified | recipe omits narrative ops; empty contracts |
-| `mods/mod-swooper-maps/src/domain/narrative/index.ts` import from `./ops/contracts.js` | Empty domain shell dependency | none | Delete with empty ops shell after import/type proof | verified | empty contracts |
-| `mods/mod-swooper-maps/src/domain/narrative/index.ts` `storyTagStrategicCorridors` export | Test-live story behavior | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | story test import; no production recipe caller |
-| `mods/mod-swooper-maps/src/domain/narrative/index.ts` `storyTagOrogenyBelts` export | Test-live story behavior | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | story test import; no production recipe caller |
-| `mods/mod-swooper-maps/src/domain/narrative/index.ts` overlay exports | Test-live story overlay helpers | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | story test import; overlay refs |
-| `mods/mod-swooper-maps/src/domain/narrative/orogeny/index.ts` wildcard export from `belts.ts` | Test-live story behavior | Gameplay/story-artifact owner-law domino | Assign to Gameplay/story-artifact owner-law domino | corroborated | story test import |
-| `mods/mod-swooper-maps/src/domain/narrative/orogeny/index.ts` wildcard export from `cache.ts` | Internal orogeny cache surface | Gameplay/story-artifact owner-law domino | Assign with orogeny network; later owner law must name cache/scoping law | corroborated | module cache evidence |
-| `mods/mod-swooper-maps/src/domain/narrative/orogeny/index.ts` wildcard export from `wind.ts` | No caller found | none | Delete with `orogeny/wind.ts` after import/type proof | verified | KNIP unused export; rg no caller |
+| `mods/mod-swooper-maps/src/domain/narrative/index.ts` default `domain` / `defineDomain({ id: "narrative", ops })` | Empty domain shell; no recipe caller | none | Deleted in Slice 1 | verified | recipe omits narrative ops; empty contracts |
+| `mods/mod-swooper-maps/src/domain/narrative/index.ts` import from `./ops/contracts.js` | Empty domain shell dependency | none | Deleted in Slice 1 | verified | empty contracts |
+| `mods/mod-swooper-maps/src/domain/narrative/index.ts` `storyTagStrategicCorridors` export | Test-live story behavior | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | story test import; no production recipe caller |
+| `mods/mod-swooper-maps/src/domain/narrative/index.ts` `storyTagOrogenyBelts` export | Test-live story behavior | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | story test import; no production recipe caller |
+| `mods/mod-swooper-maps/src/domain/narrative/index.ts` overlay exports | Test-live story overlay helpers | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | story test import; overlay refs |
+| `mods/mod-swooper-maps/src/domain/narrative/orogeny/index.ts` wildcard export from `belts.ts` | Test-live story behavior | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | story test import |
+| `mods/mod-swooper-maps/src/domain/narrative/orogeny/index.ts` wildcard export from `cache.ts` | Internal orogeny cache surface | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | module cache evidence |
+| `mods/mod-swooper-maps/src/domain/narrative/orogeny/index.ts` wildcard export from `wind.ts` | No caller found | none | Deleted in Slice 1 | verified | KNIP unused export; rg no caller |
 
 ## Collar Dispositions
 
 | Path or symbol | Liveness | Owner | Disposition | Evidence strength | Governing authority |
 | --- | --- | --- | --- | --- | --- |
-| `mods/mod-swooper-maps/src/domain/index.ts` narrative export | Public collar only | Gameplay/story-artifact owner-law domino | Assign with narrative root facade; remove only in the slice that decommissions the story network | verified | rg no production caller; domain scope public law |
-| `mods/mod-swooper-maps/src/domain/config.ts` narrative export | Public config collar only | Gameplay/story-artifact owner-law domino | Assign with narrative config facade; remove only in the slice that decommissions the story network | verified | rg no production stage caller |
+| `mods/mod-swooper-maps/src/domain/index.ts` narrative export | Public collar only | retired MapGen story network | Remove root narrative collar in Slice 3 | verified | rg no production caller; domain scope public law |
+| `mods/mod-swooper-maps/src/domain/config.ts` narrative export | Public config collar only | retired MapGen story network | Remove root narrative config collar in Slice 3 | verified | rg no production stage caller |
 | `mods/mod-swooper-maps/src/recipes/standard/recipe.ts` | No narrative binding | recipe authority | No write needed for this decision; keep as proof that narrative is absent from standard recipe | verified | current recipe source |
 | `mods/mod-swooper-maps/src/recipes/standard/runtime.ts` `storyEnabled` | Runtime flag only | standard recipe runtime | Out of this packet; no action | verified | runtime source; no import/call into `domain/narrative/**` |
 | `mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-discoveries/materialize.ts` narrative-system comment | Placement discovery materialization | placement/adapter stage | Out of this packet; no action | verified | placement stage source; official generator owner |
 | `mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/contract/discovery-placement-outcomes.contract.ts` narrative-system comment | Placement discovery artifact contract | placement artifact contract | Out of this packet; no action | verified | placement artifact source; discovery placement owner |
 | `mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/artifacts.ts` Narrative downstream-consumer description | Hydrology artifact description | hydrology stage/artifact contract | Out of this packet; no action | verified | hydrology artifact source; no import/call into `domain/narrative/**` |
 | `mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/artifacts.ts` Narrative downstream-consumer/bias descriptions | Hydrology advisory artifact descriptions | hydrology stage/artifact contract | Out of this packet; no action | verified | hydrology artifact source; no import/call into `domain/narrative/**` |
-| `mods/mod-swooper-maps/test/story/overlays.test.ts` | Test-live only | Gameplay/story-artifact owner-law domino | Assign with overlay story surface | corroborated | test import evidence; owner-boundaries |
-| `mods/mod-swooper-maps/test/story/orogeny.test.ts` | Test-live only | Gameplay/story-artifact owner-law domino | Assign with orogeny story surface | corroborated | test import evidence |
-| `mods/mod-swooper-maps/test/story/corridors.test.ts` | Test-live only | Gameplay/story-artifact owner-law domino | Assign with corridor story surface | corroborated | test import evidence |
+| `mods/mod-swooper-maps/test/story/overlays.test.ts` | Test-live only | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | test import evidence; owner-boundaries |
+| `mods/mod-swooper-maps/test/story/orogeny.test.ts` | Test-live only | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | test import evidence |
+| `mods/mod-swooper-maps/test/story/corridors.test.ts` | Test-live only | retired MapGen story network | Delete current implementation, no replacement in this cleanup | corroborated | test import evidence |
 | `packages/civ7-direct-control/src/play/operations/narrative-request.ts` | Live runtime/control operation | direct-control runtime | Out of this packet; no action | verified | direct-control source references; unrelated owner |
 | `packages/civ7-direct-control/src/proof/narrative-choice-proof-policy.ts` | Live runtime/control proof policy | direct-control runtime proof | Out of this packet; no action | verified | direct-control source references; unrelated owner |
 | `packages/cli/src/commands/game/play/choose-narrative.ts` | Live CLI command | CLI/direct-control command surface | Out of this packet; no action | verified | CLI source references; unrelated owner |
 
 ## Implementation-Ready Rows
 
-These rows can enter a later deletion slice after import/type proof:
+These empty-shell rows were removed in Slice 1 after import/type proof:
 
 - `mods/mod-swooper-maps/src/domain/narrative/ops.ts`
 - `mods/mod-swooper-maps/src/domain/narrative/ops/contracts.ts`
@@ -111,8 +111,7 @@ These rows can enter a later deletion slice after import/type proof:
 - `mods/mod-swooper-maps/src/domain/narrative/orogeny/wind.ts`
 - `mods/mod-swooper-maps/src/domain/narrative/orogeny/index.ts` wildcard export from `wind.ts`
 
-These rows are assigned to the Gameplay/story-artifact owner-law decision before
-any retention, movement, or deletion:
+These rows are assigned to Slice 3 deletion with no replacement in this cleanup:
 
 - behavior-bearing story/corridor/orogeny/overlay code;
 - story config schemas;


### PR DESCRIPTION
The disposition table, source inventory, KNIP evidence, and Narsil graph artifacts have been updated to reflect the completed Slice 1 deletions. Specifically:

- `domain/narrative/ops.ts`, `ops/contracts.ts`, and `ops/index.ts` are marked as deleted rather than pending deletion, with evidence tags updated from `empty-domain-shell` to `empty-domain-shell-deleted`.
- `orogeny/wind.ts` and its wildcard re-export from `orogeny/index.ts` are marked as deleted, with the evidence tag updated from `possible-unused-helper` to `possible-unused-helper-deleted`.
- The KNIP unused file and export counts are updated from 66/68 to 64/65 to reflect the four removed files.
- All remaining narrative source files previously assigned to a "Gameplay/story-artifact owner-law domino" are re-classified as belonging to the "retired MapGen story network" and assigned to Slice 3 deletion with no replacement.
- The `domain/narrative/index.ts` and `orogeny/index.ts` barrel descriptions are updated to reflect their post-Slice-1 state after the shell and wind exports were removed.
- The Narsil graph evidence is annotated to clarify that the `defineDomain` and `orogeny/wind.ts` entries are historical justification for the deletion rather than descriptions of currently existing surfaces.
- The root narrative and config collars in `domain/index.ts` and `domain/config.ts` are assigned to Slice 3 removal rather than a future owner-law domino.
- Story tests (`overlays.test.ts`, `orogeny.test.ts`, `corridors.test.ts`) are re-classified as Slice 3 deletion targets with no replacement.