### PR TITLE
`refactor(swooper-maps): remove storyEnabled flag and StoryOverlayRegistry from runtime`

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -680,7 +680,7 @@ export function runLocalFinalSurfaceSnapshot(
   const context = createExtendedMapContext({ width, height }, adapter, env);
   const traceEvents: TraceEvent[] = [];
 
-  initializeStandardRuntime(context, { mapInfo, logPrefix: "[parity]", storyEnabled: true });
+  initializeStandardRuntime(context, { mapInfo, logPrefix: "[parity]" });
   standardRecipe.run(context, env, config, {
     traceSink: createMemoryTraceSink(traceEvents),
     log: () => {},

--- a/mods/mod-swooper-maps/src/dev/diagnostics/placement-metrics.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/placement-metrics.ts
@@ -376,7 +376,6 @@ export function runPlacementMetrics(options: PlacementMetricsRunOptions): Placem
   initializeStandardRuntime(context, {
     mapInfo,
     logPrefix: "[placement-metrics]",
-    storyEnabled: true,
   });
   standardRecipe.run(context, env, config, { log: () => {} });
 

--- a/mods/mod-swooper-maps/src/dev/diagnostics/run-standard-dump.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/run-standard-dump.ts
@@ -140,7 +140,7 @@ async function main(): Promise<void> {
   const context = createExtendedMapContext({ width, height }, adapter, env);
   context.viz = viz;
 
-  initializeStandardRuntime(context, { mapInfo, logPrefix: "[diag]", storyEnabled: true });
+  initializeStandardRuntime(context, { mapInfo, logPrefix: "[diag]" });
   standardRecipe.run(context, env, merged, { traceSink, log: () => {} });
 
   const runId = deriveRunId(plan);

--- a/mods/mod-swooper-maps/src/dev/viz/standard-run.ts
+++ b/mods/mod-swooper-maps/src/dev/viz/standard-run.ts
@@ -68,7 +68,7 @@ const adapter = createMockAdapter({
 const context = createExtendedMapContext({ width, height }, adapter, env);
 context.viz = viz;
 
-initializeStandardRuntime(context, { mapInfo, logPrefix: "[viz]", storyEnabled: true });
+initializeStandardRuntime(context, { mapInfo, logPrefix: "[viz]" });
 standardRecipe.run(context, env, config, { traceSink, log: () => {} });
 
 const runId = deriveRunId(plan);

--- a/mods/mod-swooper-maps/src/recipes/standard/runtime.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/runtime.ts
@@ -6,13 +6,11 @@ export type StandardRuntime = {
   mapInfo: MapInfo;
   playersLandmass1: number;
   playersLandmass2: number;
-  storyEnabled: boolean;
 };
 
 export type StandardRuntimeInit = {
   logPrefix?: string;
   mapInfo?: MapInfo;
-  storyEnabled?: boolean;
 };
 
 const runtimeByContext = new WeakMap<ExtendedMapContext, StandardRuntime>();
@@ -36,7 +34,6 @@ function createRuntime(context: ExtendedMapContext): StandardRuntime {
     mapInfo,
     playersLandmass1,
     playersLandmass2,
-    storyEnabled: true,
   };
 }
 
@@ -54,7 +51,6 @@ export function initializeStandardRuntime(
 ): StandardRuntime {
   const runtime = getStandardRuntime(context);
   if (init.logPrefix) runtime.logPrefix = init.logPrefix;
-  if (init.storyEnabled !== undefined) runtime.storyEnabled = init.storyEnabled;
   if (init.mapInfo) {
     runtime.mapInfo = init.mapInfo;
     runtime.playersLandmass1 = init.mapInfo.PlayersLandmass1 ?? runtime.playersLandmass1;

--- a/mods/mod-swooper-maps/test/ecology/biomes-latcutoff-regression.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/biomes-latcutoff-regression.test.ts
@@ -44,7 +44,7 @@ describe("biomes latitude-cutoff regression (M3-013)", () => {
     });
 
     const ctx = createExtendedMapContext({ width, height }, adapter, env);
-    initializeStandardRuntime(ctx, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+    initializeStandardRuntime(ctx, { mapInfo, logPrefix: "[test]" });
 
     const config = canonicalRecipeConfig(swooperEarthlikeConfigRaw);
     standardRecipe.run(ctx, env, config, { log: () => {} });

--- a/mods/mod-swooper-maps/test/ecology/biomes-stripes-regression.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/biomes-stripes-regression.test.ts
@@ -52,7 +52,7 @@ describe("biomes stripes regression (M3-012)", () => {
     });
 
     const ctx = createExtendedMapContext({ width, height }, adapter, env);
-    initializeStandardRuntime(ctx, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+    initializeStandardRuntime(ctx, { mapInfo, logPrefix: "[test]" });
 
     const config = canonicalRecipeConfig(swooperEarthlikeConfigRaw);
     standardRecipe.run(ctx, env, config, { log: () => {} });

--- a/mods/mod-swooper-maps/test/ecology/earthlike-balance-smoke.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/earthlike-balance-smoke.test.ts
@@ -45,7 +45,7 @@ describe("Earthlike ecology balance (smoke)", () => {
     });
 
     const context = createExtendedMapContext({ width, height }, adapter, env);
-    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
 
     standardRecipe.run(context, env, realismEarthlikeConfig, { log: () => {} });
 

--- a/mods/mod-swooper-maps/test/hydrology-dryness-effects.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology-dryness-effects.test.ts
@@ -46,7 +46,7 @@ describe("hydrology dryness knob effects (integration)", () => {
         rng: createLabelRng(seed),
       });
       const context = createExtendedMapContext({ width, height }, adapter, env);
-      initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+      initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
 
       standardRecipe.run(context, env, config, { log: () => {} });
 

--- a/mods/mod-swooper-maps/test/hydrology-knobs.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology-knobs.test.ts
@@ -44,7 +44,6 @@ function runHydrologyTruth(config: Record<string, unknown>) {
   initializeStandardRuntime(context, {
     mapInfo,
     logPrefix: "[hydrology-knobs]",
-    storyEnabled: false,
   });
   standardRecipe.run(context, env, withFoundation(config), { log: () => {} });
 

--- a/mods/mod-swooper-maps/test/hydrology-seasonality-modes.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology-seasonality-modes.test.ts
@@ -47,7 +47,7 @@ function runWithTilt(axialTiltDeg: number): {
   });
   const context = createExtendedMapContext({ width, height }, adapter, env);
 
-  initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+  initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
   standardRecipe.run(
     context,
     env,

--- a/mods/mod-swooper-maps/test/map-hydrology/lakes-area-recalc-resources.test.ts
+++ b/mods/mod-swooper-maps/test/map-hydrology/lakes-area-recalc-resources.test.ts
@@ -130,7 +130,6 @@ describe("map-hydrology lakes area/water ordering", () => {
     initializeStandardRuntime(context, {
       mapInfo,
       logPrefix: "[test]",
-      storyEnabled: true,
     });
     standardRecipe.run(context, env, standardConfig, { log: () => {} });
 

--- a/mods/mod-swooper-maps/test/morphology/earthlike-coasts-smoke.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/earthlike-coasts-smoke.test.ts
@@ -43,7 +43,7 @@ describe("Earthlike coasts (smoke)", () => {
       rng: createLabelRng(seed),
     });
     const context = createExtendedMapContext({ width, height }, adapter, env);
-    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
     standardRecipe.run(context, env, realismEarthlikeConfig, { log: () => {} });
 
     const topography = context.artifacts.get(morphologyArtifacts.topography.id) as

--- a/mods/mod-swooper-maps/test/morphology/m11-volcanoes-truth-contract.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m11-volcanoes-truth-contract.test.ts
@@ -51,7 +51,7 @@ describe("m11 volcanoes truth contract", () => {
       rng: createLabelRng(seed),
     });
     const context = createExtendedMapContext({ width, height }, adapter, env);
-    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
 
     standardRecipe.run(context, env, realismEarthlikeConfig, { log: () => {} });
 

--- a/mods/mod-swooper-maps/test/morphology/tracing-observability-smoke.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/tracing-observability-smoke.test.ts
@@ -64,7 +64,7 @@ describe("Morphology tracing (observability hardening smoke)", () => {
       rng: createLabelRng(seed),
     });
     const context = createExtendedMapContext({ width, height }, adapter, env);
-    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
 
     const events: TraceEvent[] = [];
     standardRecipe.run(context, env, realismEarthlikeConfig, {

--- a/mods/mod-swooper-maps/test/pipeline/circulation-v2.integration.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/circulation-v2.integration.test.ts
@@ -74,7 +74,7 @@ function runAndCaptureSst(options: {
   };
   context.viz = viz;
 
-  initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+  initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
   standardRecipe.run(context, env, config, { log: () => {} });
 
   if (!capturedSst)

--- a/mods/mod-swooper-maps/test/pipeline/determinism-suite.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/determinism-suite.test.ts
@@ -44,7 +44,6 @@ function runStandardContext(caseData: DeterminismCase) {
   initializeStandardRuntime(context, {
     mapInfo,
     logPrefix: "[determinism-suite]",
-    storyEnabled: true,
   });
   standardRecipe.run(context, env, config, { log: () => {} });
   return context;

--- a/mods/mod-swooper-maps/test/pipeline/earth-metrics.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/earth-metrics.test.ts
@@ -58,7 +58,6 @@ describe("pipeline earth metrics", () => {
     initializeStandardRuntime(context, {
       mapInfo,
       logPrefix: "[earth-metrics]",
-      storyEnabled: true,
     });
     standardRecipe.run(context, env, standardConfig, { log: () => {} });
 

--- a/mods/mod-swooper-maps/test/pipeline/hydrology-river-network-metrics.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/hydrology-river-network-metrics.test.ts
@@ -62,7 +62,6 @@ function runHydrologyMetrics(
   initializeStandardRuntime(context, {
     mapInfo,
     logPrefix: "[hydrology-metrics]",
-    storyEnabled: true,
   });
   standardRecipe.run(context, env, args.config, { log: () => {} });
 

--- a/mods/mod-swooper-maps/test/pipeline/mountains-nonzero-probe.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/mountains-nonzero-probe.test.ts
@@ -63,7 +63,6 @@ function runStandardContext(args: {
   initializeStandardRuntime(context, {
     mapInfo,
     logPrefix: "[mountains-probe]",
-    storyEnabled: true,
   });
   standardRecipe.run(context, env, config, { log: () => {} });
   return { context, env } as const;

--- a/mods/mod-swooper-maps/test/pipeline/seed-matrix-stats.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/seed-matrix-stats.test.ts
@@ -37,7 +37,7 @@ function runMetrics(seed: number, width: number, height: number) {
     rng: createLabelRng(seed),
   });
   const context = createExtendedMapContext({ width, height }, adapter, env);
-  initializeStandardRuntime(context, { mapInfo, logPrefix: "[seed-matrix]", storyEnabled: true });
+  initializeStandardRuntime(context, { mapInfo, logPrefix: "[seed-matrix]" });
   standardRecipe.run(context, env, standardConfig, { log: () => {} });
 
   const topography = context.artifacts.get(morphologyArtifacts.topography.id) as

--- a/mods/mod-swooper-maps/test/pipeline/standard-rng-authority.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/standard-rng-authority.test.ts
@@ -44,7 +44,6 @@ describe("standard recipe RNG authority", () => {
     initializeStandardRuntime(context, {
       mapInfo,
       logPrefix: "[rng-authority]",
-      storyEnabled: true,
     });
     standardRecipe.run(context, env, standardConfig, { log: () => {} });
 

--- a/mods/mod-swooper-maps/test/pipeline/validation-harness.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/validation-harness.test.ts
@@ -42,7 +42,7 @@ function runStandardContext(seed: number) {
     rng: createLabelRng(seed),
   });
   const context = createExtendedMapContext({ width, height }, adapter, env);
-  initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+  initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
   standardRecipe.run(context, env, standardConfig, { log: () => {} });
   return context;
 }

--- a/mods/mod-swooper-maps/test/pipeline/viz-emissions.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/viz-emissions.test.ts
@@ -59,7 +59,7 @@ describe("standard pipeline viz emissions", () => {
     };
 
     context.viz = viz;
-    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
     standardRecipe.run(context, env, standardConfig, { log: () => {} });
 
     // Regression guard: never encode temporal slices into `dataTypeKey`.
@@ -158,7 +158,7 @@ describe("standard pipeline viz emissions", () => {
     };
 
     context.viz = viz;
-    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
     standardRecipe.run(context, env, standardConfig, { log: () => {} });
 
     const historyBoundaryVariants =
@@ -237,7 +237,7 @@ describe("standard pipeline viz emissions", () => {
     };
 
     context.viz = viz;
-    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
     standardRecipe.run(context, env, standardConfig, { log: () => {} });
 
     const plateIdMetas = metasByKey.get("foundation.plates.tilePlateId") as any[] | undefined;

--- a/mods/mod-swooper-maps/test/placement/landmass-region-id-projection.test.ts
+++ b/mods/mod-swooper-maps/test/placement/landmass-region-id-projection.test.ts
@@ -60,7 +60,7 @@ describe("placement landmass region projection", () => {
     };
 
     const context = createExtendedMapContext({ width, height }, adapter, env);
-    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
     standardRecipe.run(context, env, realismEarthlikeConfig, { log: () => {} });
 
     const firstProjection = callOrder.indexOf("setLandmassRegionId");

--- a/mods/mod-swooper-maps/test/placement/placement-does-not-call-generate-snow.test.ts
+++ b/mods/mod-swooper-maps/test/placement/placement-does-not-call-generate-snow.test.ts
@@ -72,7 +72,6 @@ function runStandardPlacementRecipe({
   initializeStandardRuntime(context, {
     mapInfo: resolvedMapInfo,
     logPrefix: "[test]",
-    storyEnabled: true,
   });
   standardRecipe.run(context, env, config, { log: () => {} });
 

--- a/mods/mod-swooper-maps/test/placement/resources-landmass-region-restamp.test.ts
+++ b/mods/mod-swooper-maps/test/placement/resources-landmass-region-restamp.test.ts
@@ -71,7 +71,6 @@ function runRecipeWithAdapter(adapter: MockAdapter, width: number, height: numbe
   initializeStandardRuntime(context, {
     mapInfo,
     logPrefix: "[test]",
-    storyEnabled: true,
   });
   standardRecipe.run(context, env, realismEarthlikeConfig, { log: () => {} });
 

--- a/mods/mod-swooper-maps/test/placement/viz-coverage.test.ts
+++ b/mods/mod-swooper-maps/test/placement/viz-coverage.test.ts
@@ -121,7 +121,7 @@ describe("placement per-step viz coverage (E4.2/E4.3)", () => {
     dumpGridFields: (_trace, layer) => record(layer),
   };
   context.viz = viz;
-  initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+  initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
   standardRecipe.run(context, env, standardConfig, { log: () => {} });
 
   it("every placement step emits its expected decision-substance layers", () => {

--- a/mods/mod-swooper-maps/test/standard-run.test.ts
+++ b/mods/mod-swooper-maps/test/standard-run.test.ts
@@ -59,7 +59,7 @@ describe("standard recipe execution", () => {
     });
     const context = createExtendedMapContext({ width, height }, adapter, env);
 
-    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
     standardRecipe.run(context, env, standardConfig, { log: () => {} });
 
     const hydrography = context.artifacts.get(hydrologyHydrographyArtifacts.hydrography.id) as
@@ -243,7 +243,7 @@ describe("standard recipe execution", () => {
     const adapter = createMockAdapter({ width, height, mapInfo, mapSizeId: 1 });
     const context = createExtendedMapContext({ width, height }, adapter, env);
 
-    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+    initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
 
     const config = standardConfig;
     const plan = standardRecipe.compile(env, config);
@@ -396,7 +396,7 @@ describe("standard recipe execution", () => {
         rng: createLabelRng(seed),
       });
       const context = createExtendedMapContext({ width, height }, adapter, env);
-      initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+      initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
       standardRecipe.run(context, env, cfg, { log: () => {} });
       const indices = context.artifacts.get(hydrologyClimateRefineArtifacts.climateIndices.id) as
         | { surfaceTemperatureC?: Float32Array }
@@ -462,7 +462,7 @@ describe("standard recipe execution", () => {
         rng: createLabelRng(seed),
       });
       const context = createExtendedMapContext({ width, height }, adapter, env);
-      initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+      initializeStandardRuntime(context, { mapInfo, logPrefix: "[test]" });
       standardRecipe.run(context, env, cfg, { log: () => {} });
       const hydrography = context.artifacts.get(hydrologyHydrographyArtifacts.hydrography.id) as
         | { riverClass?: Uint8Array }

--- a/mods/mod-swooper-maps/test/support/ecology-fixtures.ts
+++ b/mods/mod-swooper-maps/test/support/ecology-fixtures.ts
@@ -125,7 +125,6 @@ export function computeEcologyBaselineV1(input?: {
   initializeStandardRuntime(context, {
     mapInfo,
     logPrefix: "[ecology-baseline]",
-    storyEnabled: true,
   });
 
   standardRecipe.run(context, env, config, { traceSink: NOOP_TRACE_SINK, log: () => {} });

--- a/mods/mod-swooper-maps/test/support/world-balance-stats.ts
+++ b/mods/mod-swooper-maps/test/support/world-balance-stats.ts
@@ -667,7 +667,6 @@ export function collectWorldBalanceStats(
   initializeStandardRuntime(context, {
     mapInfo,
     logPrefix: "[world-balance]",
-    storyEnabled: false,
   });
   standardRecipe.run(context, env, args.config, { log: () => {} });
 

--- a/packages/mapgen-core/src/core/types.ts
+++ b/packages/mapgen-core/src/core/types.ts
@@ -105,40 +105,6 @@ export interface MapBuffers {
   scratchMasks: Map<string, Uint8Array>;
 }
 
-// ============================================================================
-// Story Overlay Types
-// ============================================================================
-
-/**
- * Derived snapshot describing a sparse narrative overlay (debug/inspection surface).
- *
- * This is not a canonical pipeline product: narrative story entries are the published primitives,
- * and overlay snapshots are derived on demand from those story entries.
- */
-export interface StoryOverlaySnapshot {
-  key: string;
-  kind: string;
-  version: number;
-  width: number;
-  height: number;
-  active?: readonly string[];
-  passive?: readonly string[];
-  summary: Readonly<Record<string, unknown>>;
-}
-
-/**
- * Non-canonical overlay collections (debug/compat only).
- *
- * Overlays are append-preferred and may be mutated by multiple steps. They are
- * currently threaded through artifacts for wiring, but will be redesigned as a
- * distinct dependency kind in a future architecture pass.
- */
-export interface StoryOverlayRegistry {
-  corridors: StoryOverlaySnapshot[];
-  swatches: StoryOverlaySnapshot[];
-  motifs: StoryOverlaySnapshot[];
-}
-
 /**
  * Plate-centric tensors emitted by the foundation stage.
  */
@@ -312,14 +278,6 @@ export interface ExtendedMapContext {
    * mutable after the initial publish. Do not republish buffer artifacts.
    */
   buffers: MapBuffers;
-  /**
-   * Derived narrative overlays (debug/compat view).
-   *
-   * Overlays are append-preferred and may be mutated across steps. They are
-   * currently carried via artifacts for wiring only.
-   * TODO(architecture): redesign overlays as a distinct dependency kind.
-   */
-  overlays: StoryOverlayRegistry;
 }
 
 // ============================================================================
@@ -380,11 +338,6 @@ export function createExtendedMapContext(
       heightfield,
       climate,
       scratchMasks: new Map(),
-    },
-    overlays: {
-      corridors: [],
-      swatches: [],
-      motifs: [],
     },
   };
 }


### PR DESCRIPTION
The `storyEnabled` flag and its associated `StoryOverlayRegistry`/`StoryOverlaySnapshot` types have been removed from the standard runtime and map context. The `overlays` field (corridors, swatches, motifs) has been dropped from `ExtendedMapContext`, along with the initialization logic that populated it. All call sites that previously passed `storyEnabled: true` or `storyEnabled: false` to `initializeStandardRuntime` have been updated to omit the option entirely, since the flag no longer has any effect.