### PR TITLE
feat(swooper-maps): foundation artifact contract construction (Slice 2)

### DIFF
--- a/.habitat/.active/workstreams/define-domain-blueprint-structure/slices/002-prework-decision-qualification/Decisions/002-foundation-lib-tectonics-disposition/execution.md
+++ b/.habitat/.active/workstreams/define-domain-blueprint-structure/slices/002-prework-decision-qualification/Decisions/002-foundation-lib-tectonics-disposition/execution.md
@@ -193,7 +193,7 @@ and core-extraction slices.
 
 ## Slice 2: Artifact Contract Construction
 
-Status: planned/open
+Status: closed
 
 ### Objective
 
@@ -227,6 +227,24 @@ record or an adjacent packet note with one row per artifact file:
 ```text
 artifact file -> current source schemas/guards -> artifact id evidence -> validate coverage -> assert candidate -> tests
 ```
+
+Slice 2 artifact corpus:
+
+| Artifact file | Current source schemas/guards | Artifact id evidence | Validate coverage | Assert candidate | Tests |
+| --- | --- | --- | --- | --- | --- |
+| `mesh.artifact.ts` | `FoundationMeshSchema`; `requireMesh` checks presence, positive `cellCount`, finite positive `wrapWidth`, `siteX/siteY/areas` length `cellCount`, `neighborsOffsets` length `cellCount + 1`, and `neighbors` constructor. | Current stage artifact `foundationArtifacts.mesh` uses `artifact:foundation.mesh`; mapgen-core also exports `FOUNDATION_MESH_ARTIFACT_TAG`. | Constructor/schema shape; positive `cellCount`; finite positive `wrapWidth`; typed arrays; per-cell lengths; CSR offset length; no mutation or repair. | No. Publish-time validation can know all intrinsic mesh requirements; no external compatibility context is required. | `foundation-artifacts.test.ts`: shape/export row, valid mesh, invalid constructor/length/wrap checks. |
+| `crust.artifact.ts` | `FoundationCrustSchema`; `requireCrust` checks presence and `type/maturity/thickness/thermalAge/damage/age/buoyancy/baseElevation/strength` arrays against caller-provided `cellCount`. | Current stage artifacts use `artifact:foundation.crust` and `artifact:foundation.crustInit` with the same `FoundationCrustArtifactSchema`; closed row keeps destination `crust.artifact.ts`, so `crustInit` is alias/current recipe evidence for this contract, not a distinct Slice 2 owner. | Constructor/schema shape; all required crust arrays; intrinsic same-length compatibility across crust arrays; no mutation or repair. | Candidate for Slice 3 only if a direct operation boundary still needs external mesh `cellCount` compatibility after publish validation. | `foundation-artifacts.test.ts`: crust and crust-init id reconciliation, valid crust, invalid constructor/length checks. |
+| `mantle-potential.artifact.ts` | `FoundationMantlePotentialSchema`; `requireMantlePotential` checks presence, `cellCount`, `potential` length, nonnegative `sourceCount`, and source arrays against `sourceCount`. | Current stage artifact `foundationArtifacts.mantlePotential` uses `artifact:foundation.mantlePotential`; mapgen-core also exports `FOUNDATION_MANTLE_POTENTIAL_ARTIFACT_TAG`. | Constructor/schema shape; `cellCount`; `potential` length; nonnegative `sourceCount`; source array constructors and lengths; no mutation or repair. | No. The artifact carries both `cellCount` and `sourceCount`, so publish-time validation can cover intrinsic lengths. | `foundation-artifacts.test.ts`: valid payload, source-count and cell-count invalid cases. |
+| `mantle-forcing.artifact.ts` | `FoundationMantleForcingSchema`; `requireMantleForcing` checks presence, `cellCount`, and stress/vector/magnitude/class/divergence arrays against `cellCount`. | Current stage artifact `foundationArtifacts.mantleForcing` uses `artifact:foundation.mantleForcing`; mapgen-core also exports `FOUNDATION_MANTLE_FORCING_ARTIFACT_TAG`. | Constructor/schema shape; `cellCount`; `stress`, `forcingU`, `forcingV`, `forcingMag`, `upwellingClass`, and `divergence` constructors/lengths; no mutation or repair. | No. The artifact carries `cellCount`, so publish-time validation can cover intrinsic lengths. | `foundation-artifacts.test.ts`: valid payload, invalid forcing array constructor/length cases. |
+| `plate-graph.artifact.ts` | `FoundationPlateGraphSchema`; `requirePlateGraph` checks presence, `cellToPlate` constructor/length against caller `cellCount`, and nonempty `plates`; stage artifact includes plate metadata schema. | Current stage artifact `foundationArtifacts.plateGraph` uses `artifact:foundation.plateGraph`; mapgen-core also exports `FOUNDATION_PLATE_GRAPH_ARTIFACT_TAG`. | Constructor/schema shape; `cellToPlate` typed array; nonempty `plates`; plate metadata fields; no mutation or repair. | Candidate for Slice 3 only if direct callers still need external mesh `cellCount` compatibility. | `foundation-artifacts.test.ts`: valid graph, invalid `cellToPlate`, empty plates, and malformed plate metadata cases. |
+| `plate-motion.artifact.ts` | `FoundationPlateMotionSchema`; `requirePlateMotion` checks presence, `cellCount`, `plateCount`, plate arrays against `plateCount`, and `cellFitError` against caller `cellCount`. | Current stage artifact `foundationArtifacts.plateMotion` uses `artifact:foundation.plateMotion`; mapgen-core also exports `FOUNDATION_PLATE_MOTION_ARTIFACT_TAG`. | Constructor/schema shape; `cellCount`; `plateCount`; plate-center/velocity/omega/fit arrays; `plateQuality`; `cellFitError`; no mutation or repair. | Candidate for Slice 3 only if direct callers still need compatibility with external mesh `cellCount` or accepted plate graph `plateCount`. | `foundation-artifacts.test.ts`: valid motion, invalid plate-count and cell-count array cases. |
+| `current-tectonics.artifact.ts` | `FoundationTectonicsSchema`; `requireTectonics` checks presence and seven `Uint8Array` fields against caller `cellCount`. | Current recipe artifact is named `foundationArtifacts.tectonics` with `artifact:foundation.tectonics`; closed destination is `current-tectonics.artifact.ts` to avoid preserving the old `FoundationTectonics` owner name. | Constructor/schema shape; required current tectonics arrays; intrinsic same-length compatibility across arrays; no mutation or repair. | Candidate for Slice 3 only if direct operation boundaries still need external mesh `cellCount` compatibility. | `foundation-artifacts.test.ts`: id reconciliation, valid current tectonics, invalid constructor/length cases. |
+| `tectonic-history.artifact.ts` | `FoundationTectonicHistorySchema`; `requireTectonicHistory` checks `eraCount`, `eras` length, rollup arrays, and per-era field arrays; source schema also includes `plateIdByEra`. | Current stage artifact `foundationArtifacts.tectonicHistory` uses `artifact:foundation.tectonicHistory`; closed row requires `plateIdByEra` coverage in this contract. | Constructor/schema shape; `eraCount` 5..8; `eras` length; per-era arrays; `plateIdByEra` length/constructors; rollup arrays; intrinsic cell-length consistency; no mutation or repair. | Candidate for Slice 3 only if direct operation boundaries still need external mesh `cellCount` compatibility. | `foundation-artifacts.test.ts`: valid history, invalid era count, era-field, plate-id-by-era, and rollup cases. |
+| `tectonic-provenance.artifact.ts` | `FoundationTectonicProvenanceSchema`; `requireTectonicProvenance` checks `version`, `eraCount`, `cellCount`, `tracerIndex` arrays, and provenance scalar arrays. | Current stage artifact `foundationArtifacts.tectonicProvenance` uses `artifact:foundation.tectonicProvenance`; mapgen-core also exports `FOUNDATION_TECTONIC_PROVENANCE_ARTIFACT_TAG`. | Constructor/schema shape; `eraCount`; `cellCount`; tracer-index list length and array constructors; provenance scalar constructors/lengths; no mutation or repair. | Candidate for Slice 3 only for optional direct-input truthy-branch compatibility with external mesh `cellCount`. | `foundation-artifacts.test.ts`: valid provenance, invalid era count, tracer index, scalar arrays, and optional-input assertion candidate coverage label. |
+| `tectonic-events.artifact.ts` | `TectonicEventSchema` and `TectonicEventsSchema` from `internal-contract.ts`. | No current recipe artifact id exists; id is derived from the closed destination plus the existing `artifact:foundation.<camelCase>` convention as `artifact:foundation.tectonicEvents`. | Event record schema; event list schema; integer ranges; seed cell list; no mutation or repair. | No. Event list validity is intrinsic to the event payload. | `foundation-artifacts.test.ts`: valid event list, invalid event field and list constructor cases. |
+| `tectonic-era-fields.artifact.ts` | `FoundationTectonicEraFieldsInternalSchema` and list schema from `internal-contract.ts`. | No current recipe artifact id exists; id is derived from the closed destination plus the existing `artifact:foundation.<camelCase>` convention as `artifact:foundation.tectonicEraFields`. | Era-field object schema; era-field list schema; required field constructors; intrinsic same-length compatibility across fields; no mutation or repair. | Candidate for Slice 3 only if direct operation boundaries still need external mesh `cellCount` compatibility. | `foundation-artifacts.test.ts`: valid era-field list, invalid missing/constructor/length cases. |
+| `plate-id-by-era.artifact.ts` | `PlateIdByEraSchema` from `internal-contract.ts`; `tectonic-history` source schema embeds the same per-era `Int16Array` list. | No current recipe artifact id exists; id is derived from the closed destination plus the existing `artifact:foundation.<camelCase>` convention as `artifact:foundation.plateIdByEra`. | Per-era `Int16Array` list; nonempty list; intrinsic same-length compatibility across eras; no mutation or repair. | Candidate for Slice 3 only if direct operation boundaries still need era count or external mesh `cellCount` compatibility. | `foundation-artifacts.test.ts`: valid list, invalid constructor and inconsistent length cases. |
+| `tracer-index-by-era.artifact.ts` | `TracerIndexByEraSchema` from `internal-contract.ts`; provenance schema embeds the same per-era `Uint32Array` list. | No current recipe artifact id exists; id is derived from the closed destination plus the existing `artifact:foundation.<camelCase>` convention as `artifact:foundation.tracerIndexByEra`. | Per-era `Uint32Array` list; nonempty list; intrinsic same-length compatibility across eras; no mutation or repair. | Candidate for Slice 3 only if direct operation boundaries still need era count or external mesh `cellCount` compatibility. | `foundation-artifacts.test.ts`: valid list, invalid constructor and inconsistent length cases. |
 
 Pass:
 
@@ -302,6 +320,54 @@ bun test mods/mod-swooper-maps/test/foundation
 nx run mod-swooper-maps:check
 git diff --check -- mods/mod-swooper-maps/src mods/mod-swooper-maps/test .habitat/.active
 ```
+
+### Executed Rows
+
+| Row class | Execution |
+| --- | --- |
+| Direct artifact owners | Created all 13 closed artifact destinations under `mods/mod-swooper-maps/src/domain/foundation/artifacts/*.artifact.ts`: mesh, crust, mantle potential, mantle forcing, plate graph, plate motion, current tectonics, tectonic history, tectonic provenance, tectonic events, tectonic era fields, plate id by era, and tracer index by era. |
+| Stable artifact shape | Each artifact file exports `Schema`, `Artifact`, `artifact`, and `validate`; no Slice 2 file exports `assert` or semantic validation/assertion function names. |
+| Validation ownership | Moved artifact-internal constructor, range, count, and intrinsic length checks into `validate` without operation normalization, repair, registry logic, examples, generated output edits, or caller migration. |
+| `crustInit` reconciliation | Recorded `artifact:foundation.crustInit` as current recipe alias evidence for the same crust payload contract. No distinct `crust-init.artifact.ts` owner was created. |
+| Recipe/stage artifact reconciliation | Current stage artifact definitions remain current evidence for Slice 3 import/re-export migration. Slice 2 did not change recipe ids or stage artifact registries. |
+| Legacy owners | `foundation/lib/require.ts`, `foundation/lib/tectonics/internal-contract.ts`, `foundation/lib/tectonics/schemas.ts`, and `foundation/lib/tectonics/shared.ts` remain present for the caller-migration/deletion slices. |
+
+### Proof
+
+Proof labels:
+
+- Tests-first proof: `bun test mods/mod-swooper-maps/test/foundation/foundation-artifacts.test.ts` first failed on the pre-implementation tree because `crust.artifact.js` was missing, then passed after the direct artifact owners were constructed.
+- Supervisor repair proof: after independent behavior review accepted the
+  missing direct count/range and invalid no-repair coverage gap,
+  `foundation-artifacts.test.ts` was extended with focused invalid
+  `sourceCount`, `plateCount`, low/high `eraCount`, and invalid-payload
+  no-mutation/no-repair assertions; `bun test
+  mods/mod-swooper-maps/test/foundation/foundation-artifacts.test.ts` passed
+  with 6 tests and 209 assertions.
+- Unit behavior proof: `bun test mods/mod-swooper-maps/test/foundation` passed.
+- Shape/export proof: negative semantic-export scan passed; every `*.artifact.ts` file has exactly one `defineArtifact(...)`; `bunx biome check mods/mod-swooper-maps/src/domain/foundation/artifacts mods/mod-swooper-maps/test/foundation/foundation-artifacts.test.ts .habitat/.active/workstreams/define-domain-blueprint-structure/slices/002-prework-decision-qualification/Decisions/002-foundation-lib-tectonics-disposition/execution.md` passed.
+- Type/import proof: `nx run mod-swooper-maps:check` passed.
+- Diff hygiene proof: `git diff --check -- mods/mod-swooper-maps/src mods/mod-swooper-maps/test .habitat/.active` passed.
+- Source/consumer scan proof: focused scan over the new artifact owners/tests found no imports or references to old `foundation/lib` owners or old `require*` guards.
+
+Verification limitation:
+
+- No subordinate-agent launcher was available in the tool surface for this run. The required review lanes were executed directly by the implementation DRA against fresh command evidence and recorded in `reviews/review-findings.md`.
+
+### Review
+
+Fresh Slice 2 review lanes initially found no accepted P1/P2 findings. The
+independent supervisor review then found one accepted behavior coverage gap,
+which was repaired before Slice 2 closure:
+
+- Source/import lane: no findings.
+- Behavior lane: accepted finding that `foundation-artifacts.test.ts` did not
+  directly pin invalid `sourceCount`, invalid `plateCount`, out-of-range
+  `eraCount` scalar failures, or broad enough invalid no-mutation/no-repair
+  behavior. Repaired in the same test file with focused count/range and snapshot
+  assertions; focused test passed.
+- Architecture/proof lane: files live directly under `foundation/artifacts/*.artifact.ts`, each owns one artifact, and no `contract/`, helper bucket, registry, semantic validation export, operation body edit, or `packages/mapgen-core/**` edit was introduced.
+- Closure lane: proof commands above passed; review disposition has no open accepted P1/P2 findings; Slice 3 may open only after this repair is committed cleanly through Graphite and supervisor explicitly approves Slice 3 implementation.
 
 ## Slice 3: Artifact Caller Migration And Legacy Deletion
 

--- a/.habitat/.active/workstreams/define-domain-blueprint-structure/slices/002-prework-decision-qualification/Decisions/002-foundation-lib-tectonics-disposition/reviews/review-findings.md
+++ b/.habitat/.active/workstreams/define-domain-blueprint-structure/slices/002-prework-decision-qualification/Decisions/002-foundation-lib-tectonics-disposition/reviews/review-findings.md
@@ -77,3 +77,39 @@ was composed:
 | P3 | Vocabulary scan noise | Slice 4's vocabulary scan was overbroad and non-deterministic, especially for `u`/`v`. | Accepted and repaired. Forbidden `foundation|tectonics|drift` vocabulary is a hard negative scan; `u/v` object-shape output is advisory and must be reviewer-dispositioned. |
 
 No accepted P1/P2 findings remain open after these repairs.
+
+## Execution Slice 2 Review
+
+Fresh review lanes checked Slice 2 artifact-contract construction after
+implementation. A subordinate-agent launcher was not available in the current
+tool surface, so the implementation DRA ran the packet-mandated review lanes
+directly against fresh command evidence. The supervisor then ran an independent
+Slice 2 review before Slice 3 source implementation.
+
+| Severity | Class | Finding | Disposition |
+| --- | --- | --- | --- |
+| P2 | Behavior coverage | `foundation-artifacts.test.ts` covered constructor/length failures but did not directly pin invalid `sourceCount`, invalid `plateCount`, out-of-range `eraCount` scalar failures, or broad enough invalid no-mutation/no-repair behavior for the Slice 2 Tests First gate. | Accepted and repaired. Added focused artifact-contract tests for invalid `sourceCount`, invalid `plateCount`, low/high out-of-range `eraCount`, and invalid-payload snapshot checks proving `validate` reports issues without mutating or repairing payloads. `bun test mods/mod-swooper-maps/test/foundation/foundation-artifacts.test.ts` passed after repair. |
+| P3 | Review mechanics | The review wave could not be delegated to separate launched agents because no subagent tool was available in this run. | Waived for Slice 2 with supervisor-visible record. Risk is review independence rather than implementation correctness; re-entry trigger is availability of a subordinate-agent launcher before Slice 3 closure. |
+
+Lane results:
+
+- Source/consumer: no new artifact owner or artifact test imports old
+  `foundation/lib/**`, `internal-contract`, `schemas`, `shared`, or `require*`
+  guard surfaces. Independent supervisor source/import review found no findings.
+- Behavior semantics: focused artifact tests pass positive and negative
+  validation cases for every constructed artifact destination, including
+  typed-array constructors, intrinsic length consistency, era/source/plate
+  counts, invalid scalar count/range failures, and no mutation/no throw/no
+  repair for invalid payloads. Independent supervisor behavior finding was
+  accepted and repaired with the added test evidence above.
+- Architecture/proof: every artifact file is a direct
+  `foundation/artifacts/*.artifact.ts` owner with exactly one
+  `defineArtifact(...)`, stable `Schema`/`artifact`/`validate` exports, no
+  `assert`, no semantic validation exports, and no new bucket under
+  `artifacts/`. Independent supervisor architecture review found no findings.
+- Closure: `bun test mods/mod-swooper-maps/test/foundation`,
+  `nx run mod-swooper-maps:check`, Biome check over touched files, semantic
+  export scan, one-artifact scan, old-owner scan, and `git diff --check`
+  passed.
+
+No accepted P1/P2 findings remain open for Slice 2.

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/crust.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/crust.artifact.ts
@@ -1,0 +1,86 @@
+import type { Static } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+import { Value } from "typebox/value";
+
+export const Schema = Type.Object(
+  {
+    maturity: TypedArraySchemas.f32({ shape: null }),
+    thickness: TypedArraySchemas.f32({ shape: null }),
+    thermalAge: TypedArraySchemas.u8({ shape: null }),
+    damage: TypedArraySchemas.u8({ shape: null }),
+    type: TypedArraySchemas.u8({ shape: null }),
+    age: TypedArraySchemas.u8({ shape: null }),
+    buoyancy: TypedArraySchemas.f32({ shape: null }),
+    baseElevation: TypedArraySchemas.f32({ shape: null }),
+    strength: TypedArraySchemas.f32({ shape: null }),
+  },
+  { additionalProperties: false }
+);
+
+export type Artifact = Static<typeof Schema>;
+
+export const artifact = defineArtifact({
+  name: "foundationCrust",
+  id: "artifact:foundation.crust",
+  schema: Schema,
+});
+
+type Ctor = Float32ArrayConstructor | Uint8ArrayConstructor;
+
+function issue(message: string): { message: string } {
+  return { message };
+}
+
+function typedArrayIssue(
+  value: unknown,
+  ctor: Ctor,
+  key: string,
+  length: number
+): { message: string } | null {
+  if (!(value instanceof ctor)) return issue(`${key} must be ${ctor.name}`);
+  if (value.length !== length) return issue(`${key} length must match crust arrays`);
+  return null;
+}
+
+export function validate(value: unknown): readonly { message: string }[] {
+  const issues = Array.from(Value.Errors(Schema, value), (error) =>
+    issue(
+      `${(error as { path?: string; instancePath?: string }).path ?? (error as { instancePath?: string }).instancePath ?? "/"} ${error.message}`
+    )
+  );
+
+  if (value && typeof value === "object") {
+    const crust = value as Record<string, unknown>;
+    const lengths = [
+      crust.maturity,
+      crust.thickness,
+      crust.thermalAge,
+      crust.damage,
+      crust.type,
+      crust.age,
+      crust.buoyancy,
+      crust.baseElevation,
+      crust.strength,
+    ].filter(
+      (candidate): candidate is { length: number } =>
+        candidate instanceof Float32Array || candidate instanceof Uint8Array
+    );
+    const length = lengths[0]?.length ?? 0;
+    if (length <= 0) issues.push(issue("crust arrays must be nonempty"));
+    for (const candidate of [
+      typedArrayIssue(crust.maturity, Float32Array, "maturity", length),
+      typedArrayIssue(crust.thickness, Float32Array, "thickness", length),
+      typedArrayIssue(crust.thermalAge, Uint8Array, "thermalAge", length),
+      typedArrayIssue(crust.damage, Uint8Array, "damage", length),
+      typedArrayIssue(crust.type, Uint8Array, "type", length),
+      typedArrayIssue(crust.age, Uint8Array, "age", length),
+      typedArrayIssue(crust.buoyancy, Float32Array, "buoyancy", length),
+      typedArrayIssue(crust.baseElevation, Float32Array, "baseElevation", length),
+      typedArrayIssue(crust.strength, Float32Array, "strength", length),
+    ]) {
+      if (candidate) issues.push(candidate);
+    }
+  }
+
+  return Object.freeze(issues);
+}

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/current-tectonics.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/current-tectonics.artifact.ts
@@ -1,0 +1,68 @@
+import type { Static } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+import { Value } from "typebox/value";
+
+export const Schema = Type.Object(
+  {
+    boundaryType: TypedArraySchemas.u8({ shape: null }),
+    upliftPotential: TypedArraySchemas.u8({ shape: null }),
+    riftPotential: TypedArraySchemas.u8({ shape: null }),
+    shearStress: TypedArraySchemas.u8({ shape: null }),
+    volcanism: TypedArraySchemas.u8({ shape: null }),
+    fracture: TypedArraySchemas.u8({ shape: null }),
+    cumulativeUplift: TypedArraySchemas.u8({ shape: null }),
+  },
+  { additionalProperties: false }
+);
+
+export type Artifact = Static<typeof Schema>;
+
+export const artifact = defineArtifact({
+  name: "foundationTectonics",
+  id: "artifact:foundation.tectonics",
+  schema: Schema,
+});
+
+function issue(message: string): { message: string } {
+  return { message };
+}
+
+function typedArrayIssue(value: unknown, key: string, length: number): { message: string } | null {
+  if (!(value instanceof Uint8Array)) return issue(`${key} must be Uint8Array`);
+  if (value.length !== length) return issue(`${key} length must match current tectonics arrays`);
+  return null;
+}
+
+export function validate(value: unknown): readonly { message: string }[] {
+  const issues = Array.from(Value.Errors(Schema, value), (error) =>
+    issue(
+      `${(error as { path?: string; instancePath?: string }).path ?? (error as { instancePath?: string }).instancePath ?? "/"} ${error.message}`
+    )
+  );
+  if (value && typeof value === "object") {
+    const tectonics = value as Record<string, unknown>;
+    const arrays = [
+      tectonics.boundaryType,
+      tectonics.upliftPotential,
+      tectonics.riftPotential,
+      tectonics.shearStress,
+      tectonics.volcanism,
+      tectonics.fracture,
+      tectonics.cumulativeUplift,
+    ].filter((candidate): candidate is Uint8Array => candidate instanceof Uint8Array);
+    const length = arrays[0]?.length ?? 0;
+    if (length <= 0) issues.push(issue("current tectonics arrays must be nonempty"));
+    for (const candidate of [
+      typedArrayIssue(tectonics.boundaryType, "boundaryType", length),
+      typedArrayIssue(tectonics.upliftPotential, "upliftPotential", length),
+      typedArrayIssue(tectonics.riftPotential, "riftPotential", length),
+      typedArrayIssue(tectonics.shearStress, "shearStress", length),
+      typedArrayIssue(tectonics.volcanism, "volcanism", length),
+      typedArrayIssue(tectonics.fracture, "fracture", length),
+      typedArrayIssue(tectonics.cumulativeUplift, "cumulativeUplift", length),
+    ]) {
+      if (candidate) issues.push(candidate);
+    }
+  }
+  return Object.freeze(issues);
+}

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/mantle-forcing.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/mantle-forcing.artifact.ts
@@ -1,0 +1,65 @@
+import type { Static } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+import { Value } from "typebox/value";
+
+export const Schema = Type.Object(
+  {
+    version: Type.Integer({ minimum: 1 }),
+    cellCount: Type.Integer({ minimum: 1 }),
+    stress: TypedArraySchemas.f32({ shape: null }),
+    forcingU: TypedArraySchemas.f32({ shape: null }),
+    forcingV: TypedArraySchemas.f32({ shape: null }),
+    forcingMag: TypedArraySchemas.f32({ shape: null }),
+    upwellingClass: TypedArraySchemas.i8({ shape: null }),
+    divergence: TypedArraySchemas.f32({ shape: null }),
+  },
+  { additionalProperties: false }
+);
+
+export type Artifact = Static<typeof Schema>;
+
+export const artifact = defineArtifact({
+  name: "foundationMantleForcing",
+  id: "artifact:foundation.mantleForcing",
+  schema: Schema,
+});
+
+type Ctor = Float32ArrayConstructor | Int8ArrayConstructor;
+
+function issue(message: string): { message: string } {
+  return { message };
+}
+
+function typedArrayIssue(
+  value: unknown,
+  ctor: Ctor,
+  key: string,
+  length: number
+): { message: string } | null {
+  if (!(value instanceof ctor)) return issue(`${key} must be ${ctor.name}`);
+  if (value.length !== length) return issue(`${key} length must be ${length}`);
+  return null;
+}
+
+export function validate(value: unknown): readonly { message: string }[] {
+  const issues = Array.from(Value.Errors(Schema, value), (error) =>
+    issue(
+      `${(error as { path?: string; instancePath?: string }).path ?? (error as { instancePath?: string }).instancePath ?? "/"} ${error.message}`
+    )
+  );
+  if (value && typeof value === "object") {
+    const forcing = value as Record<string, unknown>;
+    const cellCount = Number.isInteger(forcing.cellCount) ? (forcing.cellCount as number) : 0;
+    for (const candidate of [
+      typedArrayIssue(forcing.stress, Float32Array, "stress", cellCount),
+      typedArrayIssue(forcing.forcingU, Float32Array, "forcingU", cellCount),
+      typedArrayIssue(forcing.forcingV, Float32Array, "forcingV", cellCount),
+      typedArrayIssue(forcing.forcingMag, Float32Array, "forcingMag", cellCount),
+      typedArrayIssue(forcing.upwellingClass, Int8Array, "upwellingClass", cellCount),
+      typedArrayIssue(forcing.divergence, Float32Array, "divergence", cellCount),
+    ]) {
+      if (candidate) issues.push(candidate);
+    }
+  }
+  return Object.freeze(issues);
+}

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/mantle-potential.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/mantle-potential.artifact.ts
@@ -1,0 +1,65 @@
+import type { Static } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+import { Value } from "typebox/value";
+
+export const Schema = Type.Object(
+  {
+    version: Type.Integer({ minimum: 1 }),
+    cellCount: Type.Integer({ minimum: 1 }),
+    potential: TypedArraySchemas.f32({ shape: null }),
+    sourceCount: Type.Integer({ minimum: 0 }),
+    sourceType: TypedArraySchemas.i8({ shape: null }),
+    sourceCell: TypedArraySchemas.u32({ shape: null }),
+    sourceAmplitude: TypedArraySchemas.f32({ shape: null }),
+    sourceRadius: TypedArraySchemas.f32({ shape: null }),
+  },
+  { additionalProperties: false }
+);
+
+export type Artifact = Static<typeof Schema>;
+
+export const artifact = defineArtifact({
+  name: "foundationMantlePotential",
+  id: "artifact:foundation.mantlePotential",
+  schema: Schema,
+});
+
+type Ctor = Float32ArrayConstructor | Int8ArrayConstructor | Uint32ArrayConstructor;
+
+function issue(message: string): { message: string } {
+  return { message };
+}
+
+function typedArrayIssue(
+  value: unknown,
+  ctor: Ctor,
+  key: string,
+  length: number
+): { message: string } | null {
+  if (!(value instanceof ctor)) return issue(`${key} must be ${ctor.name}`);
+  if (value.length !== length) return issue(`${key} length must be ${length}`);
+  return null;
+}
+
+export function validate(value: unknown): readonly { message: string }[] {
+  const issues = Array.from(Value.Errors(Schema, value), (error) =>
+    issue(
+      `${(error as { path?: string; instancePath?: string }).path ?? (error as { instancePath?: string }).instancePath ?? "/"} ${error.message}`
+    )
+  );
+  if (value && typeof value === "object") {
+    const mantle = value as Record<string, unknown>;
+    const cellCount = Number.isInteger(mantle.cellCount) ? (mantle.cellCount as number) : 0;
+    const sourceCount = Number.isInteger(mantle.sourceCount) ? (mantle.sourceCount as number) : -1;
+    for (const candidate of [
+      typedArrayIssue(mantle.potential, Float32Array, "potential", cellCount),
+      typedArrayIssue(mantle.sourceType, Int8Array, "sourceType", sourceCount),
+      typedArrayIssue(mantle.sourceCell, Uint32Array, "sourceCell", sourceCount),
+      typedArrayIssue(mantle.sourceAmplitude, Float32Array, "sourceAmplitude", sourceCount),
+      typedArrayIssue(mantle.sourceRadius, Float32Array, "sourceRadius", sourceCount),
+    ]) {
+      if (candidate) issues.push(candidate);
+    }
+  }
+  return Object.freeze(issues);
+}

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/mesh.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/mesh.artifact.ts
@@ -1,0 +1,83 @@
+import type { Static } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+import { Value } from "typebox/value";
+
+const BoundingBoxSchema = Type.Object(
+  {
+    xl: Type.Number(),
+    xr: Type.Number(),
+    yt: Type.Number(),
+    yb: Type.Number(),
+  },
+  { additionalProperties: false }
+);
+
+export const Schema = Type.Object(
+  {
+    cellCount: Type.Integer({ minimum: 1 }),
+    wrapWidth: Type.Number(),
+    siteX: TypedArraySchemas.f32({ shape: null }),
+    siteY: TypedArraySchemas.f32({ shape: null }),
+    neighborsOffsets: TypedArraySchemas.i32({ shape: null }),
+    neighbors: TypedArraySchemas.i32({ shape: null }),
+    areas: TypedArraySchemas.f32({ shape: null }),
+    bbox: BoundingBoxSchema,
+  },
+  { additionalProperties: false }
+);
+
+export type Artifact = Static<typeof Schema>;
+
+export const artifact = defineArtifact({
+  name: "foundationMesh",
+  id: "artifact:foundation.mesh",
+  schema: Schema,
+});
+
+function issue(message: string): { message: string } {
+  return { message };
+}
+
+function typedArrayIssue(
+  value: unknown,
+  ctor: Float32ArrayConstructor | Int32ArrayConstructor,
+  key: string,
+  length?: number
+): { message: string } | null {
+  if (!(value instanceof ctor)) return issue(`${key} must be ${ctor.name}`);
+  if (length !== undefined && value.length !== length) {
+    return issue(`${key} length must be ${length}`);
+  }
+  return null;
+}
+
+export function validate(value: unknown): readonly { message: string }[] {
+  const issues = Array.from(Value.Errors(Schema, value), (error) =>
+    issue(
+      `${(error as { path?: string; instancePath?: string }).path ?? (error as { instancePath?: string }).instancePath ?? "/"} ${error.message}`
+    )
+  );
+
+  if (value && typeof value === "object") {
+    const mesh = value as Record<string, unknown>;
+    const cellCount = Number.isInteger(mesh.cellCount) ? (mesh.cellCount as number) : 0;
+    if (
+      typeof mesh.wrapWidth !== "number" ||
+      !Number.isFinite(mesh.wrapWidth) ||
+      mesh.wrapWidth <= 0
+    ) {
+      issues.push(issue("wrapWidth must be finite and positive"));
+    }
+    for (const candidate of [
+      typedArrayIssue(mesh.siteX, Float32Array, "siteX", cellCount),
+      typedArrayIssue(mesh.siteY, Float32Array, "siteY", cellCount),
+      typedArrayIssue(mesh.neighborsOffsets, Int32Array, "neighborsOffsets", cellCount + 1),
+      typedArrayIssue(mesh.neighbors, Int32Array, "neighbors"),
+      typedArrayIssue(mesh.areas, Float32Array, "areas", cellCount),
+    ]) {
+      if (candidate) issues.push(candidate);
+    }
+  }
+
+  return Object.freeze(issues);
+}

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/plate-graph.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/plate-graph.artifact.ts
@@ -1,0 +1,79 @@
+import type { Static } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+import { Value } from "typebox/value";
+
+const PlateSchema = Type.Object(
+  {
+    id: Type.Integer({ minimum: 0 }),
+    role: Type.Union([
+      Type.Literal("polarCap"),
+      Type.Literal("polarMicroplate"),
+      Type.Literal("tectonic"),
+    ]),
+    kind: Type.Union([Type.Literal("major"), Type.Literal("minor")]),
+    seedX: Type.Number(),
+    seedY: Type.Number(),
+  },
+  { additionalProperties: false }
+);
+
+export const Schema = Type.Object(
+  {
+    cellToPlate: TypedArraySchemas.i16({ shape: null }),
+    plates: Type.Immutable(Type.Array(PlateSchema)),
+  },
+  { additionalProperties: false }
+);
+
+export type Artifact = Static<typeof Schema>;
+
+export const artifact = defineArtifact({
+  name: "foundationPlateGraph",
+  id: "artifact:foundation.plateGraph",
+  schema: Schema,
+});
+
+function issue(message: string): { message: string } {
+  return { message };
+}
+
+export function validate(value: unknown): readonly { message: string }[] {
+  const issues = Array.from(Value.Errors(Schema, value), (error) =>
+    issue(
+      `${(error as { path?: string; instancePath?: string }).path ?? (error as { instancePath?: string }).instancePath ?? "/"} ${error.message}`
+    )
+  );
+  if (value && typeof value === "object") {
+    const graph = value as Record<string, unknown>;
+    if (!(graph.cellToPlate instanceof Int16Array)) {
+      issues.push(issue("cellToPlate must be Int16Array"));
+    }
+    if (!Array.isArray(graph.plates) || graph.plates.length <= 0) {
+      issues.push(issue("plates must be a nonempty array"));
+    } else {
+      graph.plates.forEach((plate, index) => {
+        if (!plate || typeof plate !== "object") {
+          issues.push(issue(`plates[${index}] must be an object`));
+          return;
+        }
+        const record = plate as Record<string, unknown>;
+        if (!Number.isInteger(record.id) || (record.id as number) < 0) {
+          issues.push(issue(`plates[${index}].id must be a nonnegative integer`));
+        }
+        if (!["polarCap", "polarMicroplate", "tectonic"].includes(String(record.role))) {
+          issues.push(issue(`plates[${index}].role is invalid`));
+        }
+        if (!["major", "minor"].includes(String(record.kind))) {
+          issues.push(issue(`plates[${index}].kind is invalid`));
+        }
+        if (typeof record.seedX !== "number" || !Number.isFinite(record.seedX)) {
+          issues.push(issue(`plates[${index}].seedX must be finite`));
+        }
+        if (typeof record.seedY !== "number" || !Number.isFinite(record.seedY)) {
+          issues.push(issue(`plates[${index}].seedY must be finite`));
+        }
+      });
+    }
+  }
+  return Object.freeze(issues);
+}

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/plate-id-by-era.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/plate-id-by-era.artifact.ts
@@ -1,0 +1,37 @@
+import type { Static } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+import { Value } from "typebox/value";
+
+export const Schema = Type.Array(TypedArraySchemas.i16({ shape: null }));
+
+export type Artifact = Static<typeof Schema>;
+
+export const artifact = defineArtifact({
+  name: "foundationPlateIdByEra",
+  id: "artifact:foundation.plateIdByEra",
+  schema: Schema,
+});
+
+function issue(message: string): { message: string } {
+  return { message };
+}
+
+export function validate(value: unknown): readonly { message: string }[] {
+  const issues = Array.from(Value.Errors(Schema, value), (error) =>
+    issue(
+      `${(error as { path?: string; instancePath?: string }).path ?? (error as { instancePath?: string }).instancePath ?? "/"} ${error.message}`
+    )
+  );
+  if (!Array.isArray(value) || value.length <= 0) {
+    issues.push(issue("plateIdByEra must be a nonempty era list"));
+  } else {
+    const length = value.find((arr): arr is Int16Array => arr instanceof Int16Array)?.length ?? 0;
+    value.forEach((arr, index) => {
+      if (!(arr instanceof Int16Array))
+        issues.push(issue(`plateIdByEra[${index}] must be Int16Array`));
+      else if (arr.length !== length)
+        issues.push(issue(`plateIdByEra[${index}] length must match prior eras`));
+    });
+  }
+  return Object.freeze(issues);
+}

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/plate-motion.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/plate-motion.artifact.ts
@@ -1,0 +1,73 @@
+import type { Static } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+import { Value } from "typebox/value";
+
+export const Schema = Type.Object(
+  {
+    version: Type.Integer({ minimum: 1 }),
+    cellCount: Type.Integer({ minimum: 1 }),
+    plateCount: Type.Integer({ minimum: 1 }),
+    plateCenterX: TypedArraySchemas.f32({ shape: null }),
+    plateCenterY: TypedArraySchemas.f32({ shape: null }),
+    plateVelocityX: TypedArraySchemas.f32({ shape: null }),
+    plateVelocityY: TypedArraySchemas.f32({ shape: null }),
+    plateOmega: TypedArraySchemas.f32({ shape: null }),
+    plateFitRms: TypedArraySchemas.f32({ shape: null }),
+    plateFitP90: TypedArraySchemas.f32({ shape: null }),
+    plateQuality: TypedArraySchemas.u8({ shape: null }),
+    cellFitError: TypedArraySchemas.u8({ shape: null }),
+  },
+  { additionalProperties: false }
+);
+
+export type Artifact = Static<typeof Schema>;
+
+export const artifact = defineArtifact({
+  name: "foundationPlateMotion",
+  id: "artifact:foundation.plateMotion",
+  schema: Schema,
+});
+
+type Ctor = Float32ArrayConstructor | Uint8ArrayConstructor;
+
+function issue(message: string): { message: string } {
+  return { message };
+}
+
+function typedArrayIssue(
+  value: unknown,
+  ctor: Ctor,
+  key: string,
+  length: number
+): { message: string } | null {
+  if (!(value instanceof ctor)) return issue(`${key} must be ${ctor.name}`);
+  if (value.length !== length) return issue(`${key} length must be ${length}`);
+  return null;
+}
+
+export function validate(value: unknown): readonly { message: string }[] {
+  const issues = Array.from(Value.Errors(Schema, value), (error) =>
+    issue(
+      `${(error as { path?: string; instancePath?: string }).path ?? (error as { instancePath?: string }).instancePath ?? "/"} ${error.message}`
+    )
+  );
+  if (value && typeof value === "object") {
+    const motion = value as Record<string, unknown>;
+    const cellCount = Number.isInteger(motion.cellCount) ? (motion.cellCount as number) : 0;
+    const plateCount = Number.isInteger(motion.plateCount) ? (motion.plateCount as number) : 0;
+    for (const candidate of [
+      typedArrayIssue(motion.plateCenterX, Float32Array, "plateCenterX", plateCount),
+      typedArrayIssue(motion.plateCenterY, Float32Array, "plateCenterY", plateCount),
+      typedArrayIssue(motion.plateVelocityX, Float32Array, "plateVelocityX", plateCount),
+      typedArrayIssue(motion.plateVelocityY, Float32Array, "plateVelocityY", plateCount),
+      typedArrayIssue(motion.plateOmega, Float32Array, "plateOmega", plateCount),
+      typedArrayIssue(motion.plateFitRms, Float32Array, "plateFitRms", plateCount),
+      typedArrayIssue(motion.plateFitP90, Float32Array, "plateFitP90", plateCount),
+      typedArrayIssue(motion.plateQuality, Uint8Array, "plateQuality", plateCount),
+      typedArrayIssue(motion.cellFitError, Uint8Array, "cellFitError", cellCount),
+    ]) {
+      if (candidate) issues.push(candidate);
+    }
+  }
+  return Object.freeze(issues);
+}

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/tectonic-era-fields.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/tectonic-era-fields.artifact.ts
@@ -1,0 +1,93 @@
+import type { Static } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+import { Value } from "typebox/value";
+
+const EraFieldsSchema = Type.Object(
+  {
+    boundaryType: TypedArraySchemas.u8({ shape: null }),
+    boundaryPolarity: TypedArraySchemas.i8({ shape: null }),
+    boundaryIntensity: TypedArraySchemas.u8({ shape: null }),
+    upliftPotential: TypedArraySchemas.u8({ shape: null }),
+    collisionPotential: TypedArraySchemas.u8({ shape: null }),
+    subductionPotential: TypedArraySchemas.u8({ shape: null }),
+    riftPotential: TypedArraySchemas.u8({ shape: null }),
+    shearStress: TypedArraySchemas.u8({ shape: null }),
+    volcanism: TypedArraySchemas.u8({ shape: null }),
+    fracture: TypedArraySchemas.u8({ shape: null }),
+    riftOriginPlate: TypedArraySchemas.i16({ shape: null }),
+    volcanismOriginPlate: TypedArraySchemas.i16({ shape: null }),
+    volcanismEventType: TypedArraySchemas.u8({ shape: null }),
+    boundaryDriftU: TypedArraySchemas.i8({ shape: null }),
+    boundaryDriftV: TypedArraySchemas.i8({ shape: null }),
+  },
+  { additionalProperties: false }
+);
+
+export const Schema = Type.Array(EraFieldsSchema);
+
+export type Artifact = Static<typeof Schema>;
+
+export const artifact = defineArtifact({
+  name: "foundationTectonicEraFields",
+  id: "artifact:foundation.tectonicEraFields",
+  schema: Schema,
+});
+
+type Ctor = Uint8ArrayConstructor | Int8ArrayConstructor | Int16ArrayConstructor;
+
+function issue(message: string): { message: string } {
+  return { message };
+}
+
+function typedArrayIssue(
+  value: unknown,
+  ctor: Ctor,
+  key: string,
+  length: number
+): { message: string } | null {
+  if (!(value instanceof ctor)) return issue(`${key} must be ${ctor.name}`);
+  if (value.length !== length) return issue(`${key} length must be ${length}`);
+  return null;
+}
+
+export function validate(value: unknown): readonly { message: string }[] {
+  const issues = Array.from(Value.Errors(Schema, value), (error) =>
+    issue(
+      `${(error as { path?: string; instancePath?: string }).path ?? (error as { instancePath?: string }).instancePath ?? "/"} ${error.message}`
+    )
+  );
+  if (Array.isArray(value)) {
+    value.forEach((rawEra, eraIndex) => {
+      const era = rawEra as Record<string, unknown>;
+      const arrays = Object.values(era ?? {}).filter(
+        (candidate): candidate is { length: number } =>
+          candidate instanceof Uint8Array ||
+          candidate instanceof Int8Array ||
+          candidate instanceof Int16Array
+      );
+      const length = arrays[0]?.length ?? 0;
+      if (length <= 0) issues.push(issue(`eraFields[${eraIndex}] arrays must be nonempty`));
+      for (const [field, ctor] of [
+        ["boundaryType", Uint8Array],
+        ["boundaryPolarity", Int8Array],
+        ["boundaryIntensity", Uint8Array],
+        ["upliftPotential", Uint8Array],
+        ["collisionPotential", Uint8Array],
+        ["subductionPotential", Uint8Array],
+        ["riftPotential", Uint8Array],
+        ["shearStress", Uint8Array],
+        ["volcanism", Uint8Array],
+        ["fracture", Uint8Array],
+        ["riftOriginPlate", Int16Array],
+        ["volcanismOriginPlate", Int16Array],
+        ["volcanismEventType", Uint8Array],
+        ["boundaryDriftU", Int8Array],
+        ["boundaryDriftV", Int8Array],
+      ] as const) {
+        const candidate = typedArrayIssue(era?.[field], ctor, `${field}`, length);
+        if (candidate) issues.push(candidate);
+      }
+    });
+  }
+  return Object.freeze(issues);
+}

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/tectonic-events.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/tectonic-events.artifact.ts
@@ -1,0 +1,76 @@
+import type { Static } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, Type } from "@swooper/mapgen-core/authoring/contracts";
+import { Value } from "typebox/value";
+
+const EventSchema = Type.Object(
+  {
+    eventType: Type.Integer({ minimum: 0, maximum: 255 }),
+    plateA: Type.Integer({ minimum: -1, maximum: 32767 }),
+    plateB: Type.Integer({ minimum: -1, maximum: 32767 }),
+    polarity: Type.Integer({ minimum: -127, maximum: 127 }),
+    intensityUplift: Type.Integer({ minimum: 0, maximum: 255 }),
+    intensityRift: Type.Integer({ minimum: 0, maximum: 255 }),
+    intensityShear: Type.Integer({ minimum: 0, maximum: 255 }),
+    intensityVolcanism: Type.Integer({ minimum: 0, maximum: 255 }),
+    intensityFracture: Type.Integer({ minimum: 0, maximum: 255 }),
+    driftU: Type.Integer({ minimum: -127, maximum: 127 }),
+    driftV: Type.Integer({ minimum: -127, maximum: 127 }),
+    seedCells: Type.Array(Type.Integer({ minimum: 0 })),
+    originPlateId: Type.Integer({ minimum: -1, maximum: 32767 }),
+  },
+  { additionalProperties: false }
+);
+
+export const Schema = Type.Array(EventSchema);
+
+export type Artifact = Static<typeof Schema>;
+
+export const artifact = defineArtifact({
+  name: "foundationTectonicEvents",
+  id: "artifact:foundation.tectonicEvents",
+  schema: Schema,
+});
+
+function issue(message: string): { message: string } {
+  return { message };
+}
+
+export function validate(value: unknown): readonly { message: string }[] {
+  const issues = Array.from(Value.Errors(Schema, value), (error) =>
+    issue(
+      `${(error as { path?: string; instancePath?: string }).path ?? (error as { instancePath?: string }).instancePath ?? "/"} ${error.message}`
+    )
+  );
+  if (Array.isArray(value)) {
+    value.forEach((event, index) => {
+      if (!event || typeof event !== "object") return;
+      const record = event as Record<string, unknown>;
+      for (const [field, min, max] of [
+        ["eventType", 0, 255],
+        ["plateA", -1, 32767],
+        ["plateB", -1, 32767],
+        ["polarity", -127, 127],
+        ["intensityUplift", 0, 255],
+        ["intensityRift", 0, 255],
+        ["intensityShear", 0, 255],
+        ["intensityVolcanism", 0, 255],
+        ["intensityFracture", 0, 255],
+        ["driftU", -127, 127],
+        ["driftV", -127, 127],
+        ["originPlateId", -1, 32767],
+      ] as const) {
+        const value = record[field];
+        if (!Number.isInteger(value) || (value as number) < min || (value as number) > max) {
+          issues.push(issue(`events[${index}].${field} must be an integer in ${min}..${max}`));
+        }
+      }
+      if (
+        !Array.isArray(record.seedCells) ||
+        record.seedCells.some((cell) => !Number.isInteger(cell) || cell < 0)
+      ) {
+        issues.push(issue(`events[${index}].seedCells must be nonnegative integers`));
+      }
+    });
+  }
+  return Object.freeze(issues);
+}

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/tectonic-history.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/tectonic-history.artifact.ts
@@ -1,0 +1,135 @@
+import type { Static } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+import { Value } from "typebox/value";
+
+const EraFieldsSchema = Type.Object(
+  {
+    boundaryType: TypedArraySchemas.u8({ shape: null }),
+    upliftPotential: TypedArraySchemas.u8({ shape: null }),
+    collisionPotential: TypedArraySchemas.u8({ shape: null }),
+    subductionPotential: TypedArraySchemas.u8({ shape: null }),
+    riftPotential: TypedArraySchemas.u8({ shape: null }),
+    shearStress: TypedArraySchemas.u8({ shape: null }),
+    volcanism: TypedArraySchemas.u8({ shape: null }),
+    fracture: TypedArraySchemas.u8({ shape: null }),
+  },
+  { additionalProperties: false }
+);
+
+export const Schema = Type.Object(
+  {
+    eraCount: Type.Integer({ minimum: 5, maximum: 8 }),
+    eras: Type.Immutable(Type.Array(EraFieldsSchema)),
+    plateIdByEra: Type.Immutable(Type.Array(TypedArraySchemas.i16({ shape: null }))),
+    upliftTotal: TypedArraySchemas.u8({ shape: null }),
+    collisionTotal: TypedArraySchemas.u8({ shape: null }),
+    subductionTotal: TypedArraySchemas.u8({ shape: null }),
+    fractureTotal: TypedArraySchemas.u8({ shape: null }),
+    volcanismTotal: TypedArraySchemas.u8({ shape: null }),
+    upliftRecentFraction: TypedArraySchemas.u8({ shape: null }),
+    collisionRecentFraction: TypedArraySchemas.u8({ shape: null }),
+    subductionRecentFraction: TypedArraySchemas.u8({ shape: null }),
+    lastActiveEra: TypedArraySchemas.u8({ shape: null }),
+    lastCollisionEra: TypedArraySchemas.u8({ shape: null }),
+    lastSubductionEra: TypedArraySchemas.u8({ shape: null }),
+  },
+  { additionalProperties: false }
+);
+
+export type Artifact = Static<typeof Schema>;
+
+export const artifact = defineArtifact({
+  name: "foundationTectonicHistory",
+  id: "artifact:foundation.tectonicHistory",
+  schema: Schema,
+});
+
+function issue(message: string): { message: string } {
+  return { message };
+}
+
+function u8Issue(value: unknown, key: string, length: number): { message: string } | null {
+  if (!(value instanceof Uint8Array)) return issue(`${key} must be Uint8Array`);
+  if (value.length !== length) return issue(`${key} length must be ${length}`);
+  return null;
+}
+
+function i16Issue(value: unknown, key: string, length: number): { message: string } | null {
+  if (!(value instanceof Int16Array)) return issue(`${key} must be Int16Array`);
+  if (value.length !== length) return issue(`${key} length must be ${length}`);
+  return null;
+}
+
+export function validate(value: unknown): readonly { message: string }[] {
+  const issues = Array.from(Value.Errors(Schema, value), (error) =>
+    issue(
+      `${(error as { path?: string; instancePath?: string }).path ?? (error as { instancePath?: string }).instancePath ?? "/"} ${error.message}`
+    )
+  );
+  if (value && typeof value === "object") {
+    const history = value as Record<string, unknown>;
+    const eraCount = Number.isInteger(history.eraCount) ? (history.eraCount as number) : 0;
+    if (!Array.isArray(history.eras) || history.eras.length !== eraCount) {
+      issues.push(issue("eras length must match eraCount"));
+    }
+    if (!Array.isArray(history.plateIdByEra) || history.plateIdByEra.length !== eraCount) {
+      issues.push(issue("plateIdByEra length must match eraCount"));
+    }
+    const totals = [
+      history.upliftTotal,
+      history.collisionTotal,
+      history.subductionTotal,
+      history.fractureTotal,
+      history.volcanismTotal,
+      history.upliftRecentFraction,
+      history.collisionRecentFraction,
+      history.subductionRecentFraction,
+      history.lastActiveEra,
+      history.lastCollisionEra,
+      history.lastSubductionEra,
+    ].filter((candidate): candidate is Uint8Array => candidate instanceof Uint8Array);
+    const cellCount = totals[0]?.length ?? 0;
+    if (cellCount <= 0) issues.push(issue("tectonicHistory arrays must be nonempty"));
+    for (const [key, arr] of [
+      ["upliftTotal", history.upliftTotal],
+      ["collisionTotal", history.collisionTotal],
+      ["subductionTotal", history.subductionTotal],
+      ["fractureTotal", history.fractureTotal],
+      ["volcanismTotal", history.volcanismTotal],
+      ["upliftRecentFraction", history.upliftRecentFraction],
+      ["collisionRecentFraction", history.collisionRecentFraction],
+      ["subductionRecentFraction", history.subductionRecentFraction],
+      ["lastActiveEra", history.lastActiveEra],
+      ["lastCollisionEra", history.lastCollisionEra],
+      ["lastSubductionEra", history.lastSubductionEra],
+    ] as const) {
+      const candidate = u8Issue(arr, key, cellCount);
+      if (candidate) issues.push(candidate);
+    }
+    if (Array.isArray(history.eras)) {
+      history.eras.forEach((rawEra, eraIndex) => {
+        const era = rawEra as Record<string, unknown>;
+        for (const field of [
+          "boundaryType",
+          "upliftPotential",
+          "collisionPotential",
+          "subductionPotential",
+          "riftPotential",
+          "shearStress",
+          "volcanism",
+          "fracture",
+        ] as const) {
+          const candidate = u8Issue(era?.[field], `eras[${eraIndex}].${field}`, cellCount);
+          if (candidate) issues.push(candidate);
+        }
+      });
+    }
+    if (Array.isArray(history.plateIdByEra)) {
+      history.plateIdByEra.forEach((arr, eraIndex) => {
+        const candidate = i16Issue(arr, `plateIdByEra[${eraIndex}]`, cellCount);
+        if (candidate) issues.push(candidate);
+      });
+    }
+  }
+  return Object.freeze(issues);
+}

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/tectonic-provenance.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/tectonic-provenance.artifact.ts
@@ -1,0 +1,99 @@
+import type { Static } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+import { Value } from "typebox/value";
+
+const ScalarsSchema = Type.Object(
+  {
+    originEra: TypedArraySchemas.u8({ shape: null }),
+    originPlateId: TypedArraySchemas.i16({ shape: null }),
+    lastBoundaryEra: TypedArraySchemas.u8({ shape: null }),
+    lastBoundaryType: TypedArraySchemas.u8({ shape: null }),
+    lastBoundaryPolarity: TypedArraySchemas.i8({ shape: null }),
+    lastBoundaryIntensity: TypedArraySchemas.u8({ shape: null }),
+    crustAge: TypedArraySchemas.u8({ shape: null }),
+  },
+  { additionalProperties: false }
+);
+
+export const Schema = Type.Object(
+  {
+    version: Type.Integer({ minimum: 1 }),
+    eraCount: Type.Integer({ minimum: 5, maximum: 8 }),
+    cellCount: Type.Integer({ minimum: 1 }),
+    tracerIndex: Type.Immutable(Type.Array(TypedArraySchemas.u32({ shape: null }))),
+    provenance: ScalarsSchema,
+  },
+  { additionalProperties: false }
+);
+
+export type Artifact = Static<typeof Schema>;
+
+export const artifact = defineArtifact({
+  name: "foundationTectonicProvenance",
+  id: "artifact:foundation.tectonicProvenance",
+  schema: Schema,
+});
+
+type Ctor =
+  | Uint8ArrayConstructor
+  | Int8ArrayConstructor
+  | Int16ArrayConstructor
+  | Uint32ArrayConstructor;
+
+function issue(message: string): { message: string } {
+  return { message };
+}
+
+function typedArrayIssue(
+  value: unknown,
+  ctor: Ctor,
+  key: string,
+  length: number
+): { message: string } | null {
+  if (!(value instanceof ctor)) return issue(`${key} must be ${ctor.name}`);
+  if (value.length !== length) return issue(`${key} length must be ${length}`);
+  return null;
+}
+
+export function validate(value: unknown): readonly { message: string }[] {
+  const issues = Array.from(Value.Errors(Schema, value), (error) =>
+    issue(
+      `${(error as { path?: string; instancePath?: string }).path ?? (error as { instancePath?: string }).instancePath ?? "/"} ${error.message}`
+    )
+  );
+  if (value && typeof value === "object") {
+    const provenance = value as Record<string, unknown>;
+    const eraCount = Number.isInteger(provenance.eraCount) ? (provenance.eraCount as number) : 0;
+    const cellCount = Number.isInteger(provenance.cellCount) ? (provenance.cellCount as number) : 0;
+    if (!Array.isArray(provenance.tracerIndex) || provenance.tracerIndex.length !== eraCount) {
+      issues.push(issue("tracerIndex length must match eraCount"));
+    } else {
+      provenance.tracerIndex.forEach((arr, eraIndex) => {
+        const candidate = typedArrayIssue(arr, Uint32Array, `tracerIndex[${eraIndex}]`, cellCount);
+        if (candidate) issues.push(candidate);
+      });
+    }
+    const scalars = provenance.provenance as Record<string, unknown> | undefined;
+    if (!scalars || typeof scalars !== "object") {
+      issues.push(issue("provenance scalars must be an object"));
+    } else {
+      for (const candidate of [
+        typedArrayIssue(scalars.originEra, Uint8Array, "originEra", cellCount),
+        typedArrayIssue(scalars.originPlateId, Int16Array, "originPlateId", cellCount),
+        typedArrayIssue(scalars.lastBoundaryEra, Uint8Array, "lastBoundaryEra", cellCount),
+        typedArrayIssue(scalars.lastBoundaryType, Uint8Array, "lastBoundaryType", cellCount),
+        typedArrayIssue(scalars.lastBoundaryPolarity, Int8Array, "lastBoundaryPolarity", cellCount),
+        typedArrayIssue(
+          scalars.lastBoundaryIntensity,
+          Uint8Array,
+          "lastBoundaryIntensity",
+          cellCount
+        ),
+        typedArrayIssue(scalars.crustAge, Uint8Array, "crustAge", cellCount),
+      ]) {
+        if (candidate) issues.push(candidate);
+      }
+    }
+  }
+  return Object.freeze(issues);
+}

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/tracer-index-by-era.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/tracer-index-by-era.artifact.ts
@@ -1,0 +1,38 @@
+import type { Static } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+import { Value } from "typebox/value";
+
+export const Schema = Type.Array(TypedArraySchemas.u32({ shape: null }));
+
+export type Artifact = Static<typeof Schema>;
+
+export const artifact = defineArtifact({
+  name: "foundationTracerIndexByEra",
+  id: "artifact:foundation.tracerIndexByEra",
+  schema: Schema,
+});
+
+function issue(message: string): { message: string } {
+  return { message };
+}
+
+export function validate(value: unknown): readonly { message: string }[] {
+  const issues = Array.from(Value.Errors(Schema, value), (error) =>
+    issue(
+      `${(error as { path?: string; instancePath?: string }).path ?? (error as { instancePath?: string }).instancePath ?? "/"} ${error.message}`
+    )
+  );
+  if (!Array.isArray(value) || value.length <= 0) {
+    issues.push(issue("tracerIndexByEra must be a nonempty era list"));
+  } else {
+    const length = value.find((arr): arr is Uint32Array => arr instanceof Uint32Array)?.length ?? 0;
+    value.forEach((arr, index) => {
+      if (!(arr instanceof Uint32Array)) {
+        issues.push(issue(`tracerIndexByEra[${index}] must be Uint32Array`));
+      } else if (arr.length !== length) {
+        issues.push(issue(`tracerIndexByEra[${index}] length must match prior eras`));
+      }
+    });
+  }
+  return Object.freeze(issues);
+}

--- a/mods/mod-swooper-maps/test/foundation/foundation-artifacts.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/foundation-artifacts.test.ts
@@ -1,0 +1,451 @@
+import { describe, expect, it } from "bun:test";
+
+import * as crust from "../../src/domain/foundation/artifacts/crust.artifact.js";
+import * as currentTectonics from "../../src/domain/foundation/artifacts/current-tectonics.artifact.js";
+import * as mantleForcing from "../../src/domain/foundation/artifacts/mantle-forcing.artifact.js";
+import * as mantlePotential from "../../src/domain/foundation/artifacts/mantle-potential.artifact.js";
+import * as mesh from "../../src/domain/foundation/artifacts/mesh.artifact.js";
+import * as plateGraph from "../../src/domain/foundation/artifacts/plate-graph.artifact.js";
+import * as plateIdByEra from "../../src/domain/foundation/artifacts/plate-id-by-era.artifact.js";
+import * as plateMotion from "../../src/domain/foundation/artifacts/plate-motion.artifact.js";
+import * as tectonicEraFields from "../../src/domain/foundation/artifacts/tectonic-era-fields.artifact.js";
+import * as tectonicEvents from "../../src/domain/foundation/artifacts/tectonic-events.artifact.js";
+import * as tectonicHistory from "../../src/domain/foundation/artifacts/tectonic-history.artifact.js";
+import * as tectonicProvenance from "../../src/domain/foundation/artifacts/tectonic-provenance.artifact.js";
+import * as tracerIndexByEra from "../../src/domain/foundation/artifacts/tracer-index-by-era.artifact.js";
+
+type ArtifactModule = Readonly<{
+  Schema: unknown;
+  artifact: Readonly<{ id: string; name: string; schema: unknown }>;
+  validate: (value: unknown) => readonly { message: string }[];
+  assert?: unknown;
+}>;
+
+const modules = [
+  ["mesh", mesh, "artifact:foundation.mesh"],
+  ["crust", crust, "artifact:foundation.crust"],
+  ["mantle-potential", mantlePotential, "artifact:foundation.mantlePotential"],
+  ["mantle-forcing", mantleForcing, "artifact:foundation.mantleForcing"],
+  ["plate-graph", plateGraph, "artifact:foundation.plateGraph"],
+  ["plate-motion", plateMotion, "artifact:foundation.plateMotion"],
+  ["current-tectonics", currentTectonics, "artifact:foundation.tectonics"],
+  ["tectonic-history", tectonicHistory, "artifact:foundation.tectonicHistory"],
+  ["tectonic-provenance", tectonicProvenance, "artifact:foundation.tectonicProvenance"],
+  ["tectonic-events", tectonicEvents, "artifact:foundation.tectonicEvents"],
+  ["tectonic-era-fields", tectonicEraFields, "artifact:foundation.tectonicEraFields"],
+  ["plate-id-by-era", plateIdByEra, "artifact:foundation.plateIdByEra"],
+  ["tracer-index-by-era", tracerIndexByEra, "artifact:foundation.tracerIndexByEra"],
+] as const satisfies readonly (readonly [string, ArtifactModule, string])[];
+
+function messages(issues: readonly { message: string }[]): string {
+  return issues.map((issue) => issue.message).join("\n");
+}
+
+function expectValid(module: ArtifactModule, value: unknown): void {
+  expect(module.validate(value)).toEqual([]);
+}
+
+function expectInvalid(module: ArtifactModule, value: unknown, pattern: RegExp): void {
+  expect(() => module.validate(value)).not.toThrow();
+  const issues = module.validate(value);
+  expect(issues.length).toBeGreaterThan(0);
+  expect(Object.isFrozen(issues)).toBe(true);
+  expect(messages(issues)).toMatch(pattern);
+}
+
+function expectInvalidWithoutMutation(
+  module: ArtifactModule,
+  value: unknown,
+  pattern: RegExp
+): void {
+  const before = snapshotPayload(value);
+  expectInvalid(module, value, pattern);
+  expect(snapshotPayload(value)).toBe(before);
+}
+
+function snapshotPayload(value: unknown): string {
+  return JSON.stringify(value, (_key, candidate) => {
+    if (ArrayBuffer.isView(candidate)) {
+      return {
+        ctor: candidate.constructor.name,
+        values: Array.from(candidate as ArrayLike<number>),
+      };
+    }
+    return candidate;
+  });
+}
+
+const cellCount = 3;
+const eraCount = 5;
+const plateCount = 2;
+
+function f32(length = cellCount): Float32Array {
+  return new Float32Array(length).fill(1);
+}
+
+function u8(length = cellCount): Uint8Array {
+  return new Uint8Array(length).fill(1);
+}
+
+function i8(length = cellCount): Int8Array {
+  return new Int8Array(length).fill(1);
+}
+
+function u32(length = cellCount): Uint32Array {
+  return new Uint32Array(length).fill(1);
+}
+
+function i16(length = cellCount): Int16Array {
+  return new Int16Array(length).fill(1);
+}
+
+function i32(length = cellCount): Int32Array {
+  return new Int32Array(length).fill(1);
+}
+
+function validMesh() {
+  return {
+    cellCount,
+    wrapWidth: 128,
+    siteX: f32(),
+    siteY: f32(),
+    neighborsOffsets: new Int32Array([0, 1, 2, 3]),
+    neighbors: i32(),
+    areas: f32(),
+    bbox: { xl: 0, xr: 128, yt: 0, yb: 64 },
+  };
+}
+
+function validCrust() {
+  return {
+    maturity: f32(),
+    thickness: f32(),
+    thermalAge: u8(),
+    damage: u8(),
+    type: u8(),
+    age: u8(),
+    buoyancy: f32(),
+    baseElevation: f32(),
+    strength: f32(),
+  };
+}
+
+function validMantlePotential() {
+  return {
+    version: 1,
+    cellCount,
+    potential: f32(),
+    sourceCount: 2,
+    sourceType: i8(2),
+    sourceCell: u32(2),
+    sourceAmplitude: f32(2),
+    sourceRadius: f32(2),
+  };
+}
+
+function validMantleForcing() {
+  return {
+    version: 1,
+    cellCount,
+    stress: f32(),
+    forcingU: f32(),
+    forcingV: f32(),
+    forcingMag: f32(),
+    upwellingClass: i8(),
+    divergence: f32(),
+  };
+}
+
+function validPlateGraph() {
+  return {
+    cellToPlate: i16(),
+    plates: [
+      { id: 0, role: "tectonic", kind: "major", seedX: 1, seedY: 2 },
+      { id: 1, role: "polarCap", kind: "minor", seedX: 3, seedY: 4 },
+    ],
+  };
+}
+
+function validPlateMotion() {
+  return {
+    version: 1,
+    cellCount,
+    plateCount,
+    plateCenterX: f32(plateCount),
+    plateCenterY: f32(plateCount),
+    plateVelocityX: f32(plateCount),
+    plateVelocityY: f32(plateCount),
+    plateOmega: f32(plateCount),
+    plateFitRms: f32(plateCount),
+    plateFitP90: f32(plateCount),
+    plateQuality: u8(plateCount),
+    cellFitError: u8(),
+  };
+}
+
+function validCurrentTectonics() {
+  return {
+    boundaryType: u8(),
+    upliftPotential: u8(),
+    riftPotential: u8(),
+    shearStress: u8(),
+    volcanism: u8(),
+    fracture: u8(),
+    cumulativeUplift: u8(),
+  };
+}
+
+function validEraFields() {
+  return {
+    boundaryType: u8(),
+    boundaryPolarity: i8(),
+    boundaryIntensity: u8(),
+    upliftPotential: u8(),
+    collisionPotential: u8(),
+    subductionPotential: u8(),
+    riftPotential: u8(),
+    shearStress: u8(),
+    volcanism: u8(),
+    fracture: u8(),
+    riftOriginPlate: i16(),
+    volcanismOriginPlate: i16(),
+    volcanismEventType: u8(),
+    boundaryDriftU: i8(),
+    boundaryDriftV: i8(),
+  };
+}
+
+function validHistoryEra() {
+  const {
+    boundaryPolarity: _boundaryPolarity,
+    boundaryIntensity: _boundaryIntensity,
+    riftOriginPlate: _riftOriginPlate,
+    volcanismOriginPlate: _volcanismOriginPlate,
+    volcanismEventType: _volcanismEventType,
+    boundaryDriftU: _boundaryDriftU,
+    boundaryDriftV: _boundaryDriftV,
+    ...historyFields
+  } = validEraFields();
+  return historyFields;
+}
+
+function validTectonicHistory() {
+  return {
+    eraCount,
+    eras: Array.from({ length: eraCount }, validHistoryEra),
+    plateIdByEra: Array.from({ length: eraCount }, () => i16()),
+    upliftTotal: u8(),
+    collisionTotal: u8(),
+    subductionTotal: u8(),
+    fractureTotal: u8(),
+    volcanismTotal: u8(),
+    upliftRecentFraction: u8(),
+    collisionRecentFraction: u8(),
+    subductionRecentFraction: u8(),
+    lastActiveEra: u8(),
+    lastCollisionEra: u8(),
+    lastSubductionEra: u8(),
+  };
+}
+
+function validTectonicProvenance() {
+  return {
+    version: 1,
+    eraCount,
+    cellCount,
+    tracerIndex: Array.from({ length: eraCount }, () => u32()),
+    provenance: {
+      originEra: u8(),
+      originPlateId: i16(),
+      lastBoundaryEra: u8(),
+      lastBoundaryType: u8(),
+      lastBoundaryPolarity: i8(),
+      lastBoundaryIntensity: u8(),
+      crustAge: u8(),
+    },
+  };
+}
+
+function validEvent() {
+  return {
+    eventType: 1,
+    plateA: 0,
+    plateB: 1,
+    polarity: -1,
+    intensityUplift: 10,
+    intensityRift: 20,
+    intensityShear: 30,
+    intensityVolcanism: 40,
+    intensityFracture: 50,
+    driftU: -3,
+    driftV: 4,
+    seedCells: [0, 1],
+    originPlateId: 0,
+  };
+}
+
+describe("foundation artifact contract files", () => {
+  it("exports exactly one stable artifact contract surface per file", () => {
+    for (const [name, module, id] of modules) {
+      expect(module.Schema, name).toBeDefined();
+      expect(module.artifact.id, name).toBe(id);
+      expect(module.artifact.schema, name).toBe(module.Schema);
+      expect(typeof module.validate, name).toBe("function");
+      expect(module.assert, name).toBeUndefined();
+
+      const semanticFunctionExports = Object.keys(module).filter((key) =>
+        /^(validate|assert)[A-Z]|validateFoundation|assertFoundation/.test(key)
+      );
+      expect(semanticFunctionExports, name).toEqual([]);
+    }
+  });
+
+  it("validates direct foundation artifact payloads without mutating or throwing", () => {
+    const validPayloads: readonly (readonly [ArtifactModule, unknown])[] = [
+      [mesh, validMesh()],
+      [crust, validCrust()],
+      [mantlePotential, validMantlePotential()],
+      [mantleForcing, validMantleForcing()],
+      [plateGraph, validPlateGraph()],
+      [plateMotion, validPlateMotion()],
+      [currentTectonics, validCurrentTectonics()],
+      [tectonicHistory, validTectonicHistory()],
+      [tectonicProvenance, validTectonicProvenance()],
+      [tectonicEvents, [validEvent()]],
+      [tectonicEraFields, [validEraFields()]],
+      [plateIdByEra, Array.from({ length: eraCount }, () => i16())],
+      [tracerIndexByEra, Array.from({ length: eraCount }, () => u32())],
+    ];
+
+    for (const [module, payload] of validPayloads) {
+      expectValid(module, payload);
+    }
+
+    const crustPayload = validCrust();
+    const before = crustPayload.type;
+    expectValid(crust, crustPayload);
+    expect(crustPayload.type).toBe(before);
+  });
+
+  it("reports invalid count and range scalars without repairing payloads", () => {
+    expectInvalidWithoutMutation(
+      mantlePotential,
+      { ...validMantlePotential(), sourceCount: -1 },
+      /sourceCount|sourceType/
+    );
+    expectInvalidWithoutMutation(
+      mantlePotential,
+      { ...validMantlePotential(), sourceCount: 3 },
+      /sourceType|sourceCell|sourceAmplitude|sourceRadius/
+    );
+    expectInvalidWithoutMutation(
+      plateMotion,
+      { ...validPlateMotion(), plateCount: 0 },
+      /plateCount|plateCenterX/
+    );
+
+    const lowEraHistory = {
+      ...validTectonicHistory(),
+      eraCount: 4,
+      eras: Array.from({ length: 4 }, validHistoryEra),
+      plateIdByEra: Array.from({ length: 4 }, () => i16()),
+    };
+    expectInvalidWithoutMutation(tectonicHistory, lowEraHistory, /eraCount/);
+
+    const highEraProvenance = {
+      ...validTectonicProvenance(),
+      eraCount: 9,
+      tracerIndex: Array.from({ length: 9 }, () => u32()),
+    };
+    expectInvalidWithoutMutation(tectonicProvenance, highEraProvenance, /eraCount/);
+  });
+
+  it("does not mutate or repair invalid constructor and length failures", () => {
+    expectInvalidWithoutMutation(
+      crust,
+      { ...validCrust(), strength: f32(cellCount - 1) },
+      /strength/
+    );
+    expectInvalidWithoutMutation(
+      currentTectonics,
+      { ...validCurrentTectonics(), shearStress: f32() },
+      /shearStress/
+    );
+    expectInvalidWithoutMutation(
+      tectonicEvents,
+      [{ ...validEvent(), seedCells: [-1], driftU: -128 }],
+      /seedCells|driftU/
+    );
+  });
+
+  it("reports invalid mesh, crust, mantle, plate, and current tectonics payloads", () => {
+    expectInvalid(mesh, { ...validMesh(), wrapWidth: Number.NaN }, /wrapWidth/);
+    expectInvalid(mesh, { ...validMesh(), neighborsOffsets: new Int32Array([0, 1]) }, /offset/i);
+    expectInvalid(crust, { ...validCrust(), type: new Float32Array(cellCount) }, /type/);
+    expectInvalid(crust, { ...validCrust(), strength: f32(cellCount - 1) }, /strength/);
+    expectInvalid(
+      mantlePotential,
+      { ...validMantlePotential(), sourceAmplitude: f32(1) },
+      /sourceAmplitude/
+    );
+    expectInvalid(
+      mantleForcing,
+      { ...validMantleForcing(), upwellingClass: u8() },
+      /upwellingClass/
+    );
+    expectInvalid(plateGraph, { ...validPlateGraph(), plates: [] }, /plates/);
+    expectInvalid(
+      plateGraph,
+      { ...validPlateGraph(), plates: [{ id: 0, role: "other" }] },
+      /plates/
+    );
+    expectInvalid(plateMotion, { ...validPlateMotion(), plateVelocityX: f32(1) }, /plateVelocityX/);
+    expectInvalid(
+      currentTectonics,
+      { ...validCurrentTectonics(), shearStress: f32() },
+      /shearStress/
+    );
+  });
+
+  it("reports invalid tectonic history, provenance, event, and per-era payloads", () => {
+    expectInvalid(
+      tectonicHistory,
+      { ...validTectonicHistory(), eras: [validHistoryEra()] },
+      /eraCount|eras/
+    );
+    expectInvalid(
+      tectonicHistory,
+      { ...validTectonicHistory(), plateIdByEra: [i16()] },
+      /plateIdByEra/
+    );
+    expectInvalid(
+      tectonicHistory,
+      {
+        ...validTectonicHistory(),
+        eras: [{ ...validHistoryEra(), upliftPotential: u8(cellCount - 1) }],
+      },
+      /upliftPotential/
+    );
+    expectInvalid(
+      tectonicProvenance,
+      { ...validTectonicProvenance(), tracerIndex: [u32()] },
+      /tracerIndex/
+    );
+    expectInvalid(
+      tectonicProvenance,
+      {
+        ...validTectonicProvenance(),
+        provenance: { ...validTectonicProvenance().provenance, originPlateId: u8() },
+      },
+      /originPlateId/
+    );
+    expectInvalid(tectonicEvents, [{ ...validEvent(), driftU: -128 }], /driftU/);
+    expectInvalid(
+      tectonicEraFields,
+      [{ ...validEraFields(), boundaryDriftV: f32() }],
+      /boundaryDriftV/
+    );
+    expectInvalid(plateIdByEra, [i16(), i16(cellCount - 1)], /plateIdByEra|era/i);
+    expectInvalid(tracerIndexByEra, [u32(), i32()], /tracerIndexByEra|era/i);
+  });
+});


### PR DESCRIPTION
Closes Slice 2 of the `foundation-lib-tectonics` disposition decision by constructing the artifact contract layer for all 13 foundation artifact destinations.

Each artifact file under `foundation/artifacts/` owns exactly one `defineArtifact(...)` call and exports a stable `Schema`, `Artifact` type, `artifact` descriptor, and `validate` function. Validation covers typed-array constructor checks, intrinsic length consistency across arrays, scalar count and range constraints (e.g. `sourceCount`, `plateCount`, `eraCount` bounds of 5–8), and a no-mutation/no-repair guarantee for invalid payloads. No `assert` exports, semantic validation helpers, operation bodies, or registry changes were introduced.

Artifacts constructed:
- `mesh.artifact.ts` — cell count, wrap width, CSR offset length, typed-array constructors
- `crust.artifact.ts` — nine crust arrays with intrinsic same-length consistency; `crustInit` recorded as alias evidence, not a separate owner
- `mantle-potential.artifact.ts` — `cellCount`/`potential` and `sourceCount`/source-array length pairs
- `mantle-forcing.artifact.ts` — `cellCount` against six stress/vector/class/divergence arrays
- `plate-graph.artifact.ts` — `Int16Array` cell-to-plate mapping, nonempty plates list, plate metadata field validation
- `plate-motion.artifact.ts` — `plateCount` against eight plate arrays, `cellCount` against `cellFitError`
- `current-tectonics.artifact.ts` — seven `Uint8Array` fields with intrinsic same-length consistency
- `tectonic-history.artifact.ts` — `eraCount` 5–8, per-era field arrays, `plateIdByEra` list, eleven rollup arrays
- `tectonic-provenance.artifact.ts` — `eraCount`/`tracerIndex` list and `cellCount`/provenance scalar arrays
- `tectonic-events.artifact.ts` — event record integer ranges and `seedCells` nonnegative constraint
- `tectonic-era-fields.artifact.ts` — fifteen per-era typed-array fields with intrinsic same-length consistency
- `plate-id-by-era.artifact.ts` — nonempty `Int16Array` era list with consistent lengths
- `tracer-index-by-era.artifact.ts` — nonempty `Uint32Array` era list with consistent lengths

`foundation-artifacts.test.ts` covers positive validation for all 13 artifacts, invalid constructor and length failures, invalid scalar count/range failures (including `sourceCount`, `plateCount`, low/high `eraCount`), and snapshot assertions proving `validate` neither mutates nor repairs invalid payloads. Legacy owners (`foundation/lib/require.ts`, `internal-contract.ts`, `schemas.ts`, `shared.ts`) remain untouched for the caller-migration and deletion slices.