### PR TITLE
feat(mapgen-core): Slice 4 core API construction — quantize, unit-vec, neighborhood-mesh

### DIFF
--- a/.habitat/.active/workstreams/define-domain-blueprint-structure/slices/002-prework-decision-qualification/Decisions/002-foundation-lib-tectonics-disposition/execution.md
+++ b/.habitat/.active/workstreams/define-domain-blueprint-structure/slices/002-prework-decision-qualification/Decisions/002-foundation-lib-tectonics-disposition/execution.md
@@ -579,7 +579,7 @@ supervisor review must close Slice 3 independently before Slice 4 opens.
 
 ## Slice 4: Core API Construction
 
-Status: planned/open
+Status: completed; awaiting independent supervisor review before Slice 5
 
 ### Objective
 
@@ -668,6 +668,97 @@ git diff --check -- packages/mapgen-core/src packages/mapgen-core/test .habitat/
 The `foundation|tectonics|drift` scan is a hard failure. The `u/v` scan is an
 artifact-shape review signal: output must be dispositioned by the
 architecture/proof reviewer before Slice 4 closes.
+
+### Slice 4 Execution Record
+
+Tests-first proof:
+
+- Added `packages/mapgen-core/test/lib/math/quantize.test.ts`,
+  `packages/mapgen-core/test/lib/grid/vector-field-quantize.test.ts`, and
+  `packages/mapgen-core/test/lib/mesh/neighborhood-mesh.test.ts` before source
+  implementation.
+- Pre-implementation `bun test packages/mapgen-core/test/lib` failed only on
+  missing accepted exports: `quantizeU8`, `quantizeI8Symmetric`,
+  `quantizeUnitVec2I8`, and `meanMeshEdgeLength`/mesh neighborhood helpers.
+
+Implemented accepted core APIs:
+
+- `packages/mapgen-core/src/lib/math/quantize.ts`: `quantizeU8` and
+  `quantizeI8Symmetric` with legacy-compatible non-finite, rounding, and
+  saturation semantics.
+- `packages/mapgen-core/src/lib/grid/vector-field.ts`:
+  `quantizeUnitVec2I8`, returning core `{ x, y }` vector components.
+- `packages/mapgen-core/src/lib/mesh/neighborhood-mesh.ts`:
+  `CsrPointMesh2D`, `meanMeshEdgeLength`, `findNearestMeshCell`, and
+  `selectMeshNeighborByVectorProjection`.
+- Existing `lib/math`, `lib/grid`, and `lib/mesh` index surfaces export the new
+  APIs. `packages/mapgen-core/src/lib/grid/index.ts` already exported
+  `vector-field.ts`, so no redundant edit was needed.
+
+Proof:
+
+- `bunx biome check packages/mapgen-core/src/lib/math/quantize.ts
+  packages/mapgen-core/src/lib/math/index.ts
+  packages/mapgen-core/src/lib/grid/vector-field.ts
+  packages/mapgen-core/src/lib/mesh/neighborhood-mesh.ts
+  packages/mapgen-core/src/lib/mesh/index.ts
+  packages/mapgen-core/test/lib/math/quantize.test.ts
+  packages/mapgen-core/test/lib/grid/vector-field-quantize.test.ts
+  packages/mapgen-core/test/lib/mesh/neighborhood-mesh.test.ts` — pass
+  (Native tool behavior).
+- `bun test packages/mapgen-core/test/lib` — pass, 19 tests / 166 assertions
+  (Unit behavior).
+- `nx run mapgen-core:test` — pass, 109 tests / 388 assertions (Unit behavior).
+- `nx run mapgen-core:check` — pass (Native tool behavior).
+- `nx run mapgen-core:habitat:check` — pass; `preserve_mapgen_core_runtime_neutrality`
+  enforced, 1 rule, 0 failing (Habitat wrapper behavior).
+- `! rg -n "foundation|tectonics|drift" packages/mapgen-core/src/lib/math
+  packages/mapgen-core/src/lib/grid packages/mapgen-core/src/lib/mesh -g
+  '*.ts'` — pass, no output because the command is case-sensitive. This is
+  retained as the exact packet command proof, but it is not the full vocabulary
+  record-truth proof after supervisor review.
+- `rg -n -i "foundation|tectonics|drift" packages/mapgen-core/src/lib/math
+  packages/mapgen-core/src/lib/grid packages/mapgen-core/src/lib/mesh -g
+  '*.ts' || true` — reports the pre-existing
+  `packages/mapgen-core/src/lib/mesh/delaunay.ts:134` fallback label
+  `"FoundationMesh"`. Disposition: accepted record-truth repair; the hit
+  predates Slice 4, is outside the accepted Slice 4 write set, and was not
+  changed here. No new Slice 4 API or touched/new Slice 4 source file contains
+  foundation, tectonics, or drift vocabulary (Record truth proof).
+- `! rg -n -i "foundation|tectonics|drift"
+  packages/mapgen-core/src/lib/math/quantize.ts
+  packages/mapgen-core/src/lib/math/index.ts
+  packages/mapgen-core/src/lib/grid/vector-field.ts
+  packages/mapgen-core/src/lib/mesh/neighborhood-mesh.ts
+  packages/mapgen-core/src/lib/mesh/index.ts` — pass, no output
+  (Record truth proof for no new Slice 4 vocabulary).
+- `rg -n "\\{[^}\\n]*(u|v):|\\b(u|v):"
+  packages/mapgen-core/src/lib/math packages/mapgen-core/src/lib/grid
+  packages/mapgen-core/src/lib/mesh -g '*.ts' || true` — advisory output only
+  for pre-existing `Vec2` helper parameter names `v` in `vector-field.ts`; no
+  artifact `{ u, v }` object shape or public field was introduced.
+- `git diff --check -- packages/mapgen-core/src packages/mapgen-core/test
+  .habitat/.active` — pass (Apply safety proof).
+
+Slice 4 repair record:
+
+- Accepted P2 behavior-proof finding repaired by strengthening
+  `packages/mapgen-core/test/lib/mesh/neighborhood-mesh.test.ts` so duplicate
+  reverse-edge counting, ignored `maxEdges`, invalid-neighbor mishandling,
+  zero-length edge mishandling, and non-strict neighbor projection ties would
+  fail under focused unit tests.
+- Accepted P2 record-truth finding repaired by replacing the false broad
+  vocabulary claim with exact scan output and a disposition for the pre-existing
+  `FoundationMesh` label in `delaunay.ts`.
+- P3 proof-label hygiene folded into this record by mapping commands to
+  canonical proof classes: Unit behavior, Native tool behavior, Habitat wrapper
+  behavior, Apply safety proof, and Record truth proof.
+
+Fresh local review lanes initially found no accepted P1/P2/P3 findings. The
+independent supervisor Slice 4 review then found two accepted P2 findings, both
+repaired above. A subordinate agent launcher was not available in the current
+tool surface, so supervisor independent review remains the closure authority
+before Slice 5 opens.
 
 ## Slice 5: Core Caller Migration And `shared.ts` Deletion
 

--- a/.habitat/.active/workstreams/define-domain-blueprint-structure/slices/002-prework-decision-qualification/Decisions/002-foundation-lib-tectonics-disposition/reviews/review-findings.md
+++ b/.habitat/.active/workstreams/define-domain-blueprint-structure/slices/002-prework-decision-qualification/Decisions/002-foundation-lib-tectonics-disposition/reviews/review-findings.md
@@ -153,3 +153,44 @@ Lane results:
 
 No accepted P1/P2 findings remain open for repaired Slice 3 local closure. Slice
 4 is not allowed to open until independent supervisor review accepts this slice.
+
+## Execution Slice 4 Review
+
+Fresh local review lanes checked Slice 4 core API construction. A subordinate
+agent launcher was still not available in the current tool surface, so the
+implementation DRA ran the packet-mandated review lanes directly against fresh
+command evidence. Supervisor independent review remains required before Slice 5
+opens.
+
+| Severity | Class | Finding | Disposition |
+| --- | --- | --- | --- |
+| P2 | Behavior proof coverage | Mesh neighborhood tests named duplicate avoidance, max-cap, invalid-neighbor handling, zero-length skip, and strict first-tie semantics, but fixtures allowed those behaviors to regress without failing. | Accepted and repaired. Strengthened `neighborhood-mesh.test.ts` with distinct fixtures that fail if reverse duplicate edges are counted before the cap, `maxEdges` is ignored, invalid neighbors or zero-length edges enter the mean, or equal-projection neighbor ties use the later candidate. |
+| P2 | Record truth | Slice 4 proof claimed the broad vocabulary scan had no output, but a case-insensitive rerun finds the pre-existing `FoundationMesh` fallback label in `packages/mapgen-core/src/lib/mesh/delaunay.ts`. | Accepted and repaired. The execution record now separates the exact case-sensitive packet command from a case-insensitive record-truth scan, dispositions the pre-existing `delaunay.ts` hit as out of Slice 4 write scope, and records a no-new-vocabulary scan over touched/new Slice 4 source files. |
+| P3 | Review mechanics | The review wave could not be delegated to separate launched agents because no subagent tool was available in this run. | Waived for local Slice 4 closure claim with supervisor-visible record. Risk is review independence rather than implementation correctness; re-entry trigger is supervisor independent review before Slice 5 opens. |
+
+Lane results:
+
+- Source/consumer: new core APIs live only in accepted `lib/math`, `lib/grid`,
+  and `lib/mesh` surfaces. No foundation caller migration, artifact contract
+  edit, generated output, broad wrapper, or new core subpath was introduced.
+- Behavior semantics: tests-first coverage pins unsigned and signed quantizer
+  non-finite/rounding/saturation behavior, unit-vector quantization into core
+  `{ x, y }`, CSR mesh assignability, mean edge fallback/skip/wrap/max-cap
+  behavior with distinct duplicate/cap/invalid/zero-length fixtures,
+  nearest-cell periodic/tie behavior, and neighbor projection fallback/tie
+  behavior with an equal-projection tie fixture.
+- Architecture/proof: the exact case-sensitive packet vocabulary scan has no
+  output. The case-insensitive record-truth scan reports only the pre-existing
+  `FoundationMesh` fallback label in `delaunay.ts`, outside the Slice 4 write
+  set. The no-new-vocabulary scan over touched/new Slice 4 source files has no
+  output. Advisory `u/v` scan reported only pre-existing `Vec2` helper parameter
+  names `v` in `vector-field.ts`; no artifact `{ u, v }` object shape or public
+  field was introduced.
+- Closure: focused `bun test packages/mapgen-core/test/lib` (Unit behavior),
+  `nx run mapgen-core:test` (Unit behavior), `nx run mapgen-core:check` (Native
+  tool behavior), `nx run mapgen-core:habitat:check` (Habitat wrapper behavior),
+  Biome check over touched core files (Native tool behavior), vocabulary scans
+  (Record truth proof), and `git diff --check` (Apply safety proof) passed.
+
+No accepted P1/P2 findings remain open for Slice 4 local closure. Slice 5 is not
+allowed to open until independent supervisor review accepts this slice.

--- a/packages/mapgen-core/src/lib/grid/vector-field.ts
+++ b/packages/mapgen-core/src/lib/grid/vector-field.ts
@@ -1,5 +1,6 @@
 import { projectOddqToHexSpace } from "@mapgen/lib/grid/hex-space.js";
 import { clampInt } from "@mapgen/lib/math/clamp.js";
+import { quantizeI8Symmetric } from "@mapgen/lib/math/quantize.js";
 
 export type Vec2 = Readonly<{ x: number; y: number }>;
 
@@ -80,6 +81,15 @@ export function quantizeI8Signed(value: number, maxAbs: number): number {
 export function dequantizeI8Signed(value: number, maxAbs: number): number {
   if (!Number.isFinite(value) || !Number.isFinite(maxAbs) || maxAbs <= 0) return 0;
   return (Math.trunc(value) / I8_VECTOR_MAX_ABS) * maxAbs;
+}
+
+export function quantizeUnitVec2I8(x: number, y: number): Vec2 {
+  const len = Math.sqrt(x * x + y * y);
+  if (!Number.isFinite(len) || len <= 1e-9) return { x: 0, y: 0 };
+  return {
+    x: quantizeI8Symmetric((x / len) * I8_VECTOR_MAX_ABS),
+    y: quantizeI8Symmetric((y / len) * I8_VECTOR_MAX_ABS),
+  };
 }
 
 /**

--- a/packages/mapgen-core/src/lib/math/index.ts
+++ b/packages/mapgen-core/src/lib/math/index.ts
@@ -2,5 +2,6 @@ export * from "@mapgen/lib/math/chance.js";
 export * from "@mapgen/lib/math/clamp.js";
 export * from "@mapgen/lib/math/int16.js";
 export * from "@mapgen/lib/math/lerp.js";
+export * from "@mapgen/lib/math/quantize.js";
 export * from "@mapgen/lib/math/range.js";
 export * from "@mapgen/lib/math/wrap.js";

--- a/packages/mapgen-core/src/lib/math/quantize.ts
+++ b/packages/mapgen-core/src/lib/math/quantize.ts
@@ -1,0 +1,14 @@
+import { clamp, clampInt } from "@mapgen/lib/math/clamp.js";
+
+export function quantizeU8(value: number): number {
+  if (value === Number.POSITIVE_INFINITY) return 255;
+  if (!Number.isFinite(value)) return 0;
+  return clamp(Math.round(value), 0, 255);
+}
+
+export function quantizeI8Symmetric(value: number): number {
+  if (value === Number.POSITIVE_INFINITY) return 127;
+  if (value === Number.NEGATIVE_INFINITY) return -127;
+  if (!Number.isFinite(value)) return 0;
+  return clampInt(Math.round(value), -127, 127);
+}

--- a/packages/mapgen-core/src/lib/mesh/index.ts
+++ b/packages/mapgen-core/src/lib/mesh/index.ts
@@ -1,1 +1,2 @@
 export * from "@mapgen/lib/mesh/delaunay.js";
+export * from "@mapgen/lib/mesh/neighborhood-mesh.js";

--- a/packages/mapgen-core/src/lib/mesh/neighborhood-mesh.ts
+++ b/packages/mapgen-core/src/lib/mesh/neighborhood-mesh.ts
@@ -1,0 +1,104 @@
+import { wrapDeltaPeriodic } from "@mapgen/lib/math/wrap.js";
+
+export type CsrPointMesh2D = Readonly<{
+  cellCount: number;
+  wrapWidth: number;
+  siteX: Float32Array;
+  siteY: Float32Array;
+  neighborsOffsets: Int32Array;
+  neighbors: Int32Array;
+}>;
+
+export function meanMeshEdgeLength(mesh: CsrPointMesh2D, maxEdges = 100_000): number {
+  const cellCount = mesh.cellCount | 0;
+  if (cellCount <= 0) return 1;
+
+  let sum = 0;
+  let count = 0;
+
+  for (let i = 0; i < cellCount; i++) {
+    const start = mesh.neighborsOffsets[i] | 0;
+    const end = mesh.neighborsOffsets[i + 1] | 0;
+    const ax = mesh.siteX[i] ?? 0;
+    const ay = mesh.siteY[i] ?? 0;
+    for (let cursor = start; cursor < end; cursor++) {
+      const n = mesh.neighbors[cursor] | 0;
+      if (n <= i || n < 0 || n >= cellCount) continue;
+      const bx = mesh.siteX[n] ?? 0;
+      const by = mesh.siteY[n] ?? 0;
+      const dx = wrapDeltaPeriodic(bx - ax, mesh.wrapWidth);
+      const dy = by - ay;
+      const len = Math.sqrt(dx * dx + dy * dy);
+      if (!Number.isFinite(len) || len <= 1e-9) continue;
+      sum += len;
+      count += 1;
+      if (count >= maxEdges) break;
+    }
+    if (count >= maxEdges) break;
+  }
+
+  return count > 0 ? sum / count : 1;
+}
+
+export function findNearestMeshCell(mesh: CsrPointMesh2D, x: number, y: number): number {
+  const cellCount = mesh.cellCount | 0;
+  if (cellCount <= 0) return -1;
+
+  let best = -1;
+  let bestDist = Number.POSITIVE_INFINITY;
+
+  for (let i = 0; i < cellCount; i++) {
+    const dx = wrapDeltaPeriodic((mesh.siteX[i] ?? 0) - x, mesh.wrapWidth);
+    const dy = (mesh.siteY[i] ?? 0) - y;
+    const dist = dx * dx + dy * dy;
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = i;
+    }
+  }
+
+  return best;
+}
+
+export function selectMeshNeighborByVectorProjection(params: {
+  mesh: CsrPointMesh2D;
+  cellId: number;
+  vectorX: number;
+  vectorY: number;
+}): number {
+  const { mesh } = params;
+  const cellId = params.cellId | 0;
+  const cellCount = mesh.cellCount | 0;
+  if (cellId < 0 || cellId >= cellCount) return cellId;
+
+  const start = mesh.neighborsOffsets[cellId] | 0;
+  const end = mesh.neighborsOffsets[cellId + 1] | 0;
+  if (end <= start) return cellId;
+
+  const vectorX = params.vectorX;
+  const vectorY = params.vectorY;
+  if (!Number.isFinite(vectorX) || !Number.isFinite(vectorY) || (!vectorX && !vectorY)) {
+    return cellId;
+  }
+
+  let best = cellId;
+  let bestDot = Number.NEGATIVE_INFINITY;
+  const ax = mesh.siteX[cellId] ?? 0;
+  const ay = mesh.siteY[cellId] ?? 0;
+
+  for (let cursor = start; cursor < end; cursor++) {
+    const n = mesh.neighbors[cursor] | 0;
+    if (n < 0 || n >= cellCount) continue;
+    const bx = mesh.siteX[n] ?? 0;
+    const by = mesh.siteY[n] ?? 0;
+    const dx = wrapDeltaPeriodic(bx - ax, mesh.wrapWidth);
+    const dy = by - ay;
+    const dot = dx * vectorX + dy * vectorY;
+    if (dot > bestDot) {
+      bestDot = dot;
+      best = n;
+    }
+  }
+
+  return best;
+}

--- a/packages/mapgen-core/test/lib/grid/vector-field-quantize.test.ts
+++ b/packages/mapgen-core/test/lib/grid/vector-field-quantize.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { quantizeUnitVec2I8 } from "@mapgen/lib/grid/index.js";
+
+describe("lib/grid vector field quantization", () => {
+  it("returns zero for zero, tiny, and non-finite vectors", () => {
+    expect(quantizeUnitVec2I8(0, 0)).toEqual({ x: 0, y: 0 });
+    expect(quantizeUnitVec2I8(1e-12, 0)).toEqual({ x: 0, y: 0 });
+    expect(quantizeUnitVec2I8(Number.NaN, 1)).toEqual({ x: 0, y: 0 });
+    expect(quantizeUnitVec2I8(1, Number.POSITIVE_INFINITY)).toEqual({ x: 0, y: 0 });
+  });
+
+  it("normalizes cardinal and diagonal vectors into signed i8 components", () => {
+    expect(quantizeUnitVec2I8(3, 0)).toEqual({ x: 127, y: 0 });
+    expect(quantizeUnitVec2I8(-3, 0)).toEqual({ x: -127, y: 0 });
+    expect(quantizeUnitVec2I8(0, 5)).toEqual({ x: 0, y: 127 });
+    expect(quantizeUnitVec2I8(0, -5)).toEqual({ x: 0, y: -127 });
+
+    expect(quantizeUnitVec2I8(1, 1)).toEqual({ x: 90, y: 90 });
+    expect(quantizeUnitVec2I8(-1, 1)).toEqual({ x: -90, y: 90 });
+  });
+
+  it("always stays inside the signed i8 symmetric component bounds", () => {
+    for (const [x, y] of [
+      [1, 1000],
+      [1000, 1],
+      [-1000, -1],
+      [Number.MAX_VALUE, Number.MAX_VALUE],
+    ]) {
+      const q = quantizeUnitVec2I8(x, y);
+      expect(q.x).toBeGreaterThanOrEqual(-127);
+      expect(q.x).toBeLessThanOrEqual(127);
+      expect(q.y).toBeGreaterThanOrEqual(-127);
+      expect(q.y).toBeLessThanOrEqual(127);
+    }
+  });
+});

--- a/packages/mapgen-core/test/lib/math/quantize.test.ts
+++ b/packages/mapgen-core/test/lib/math/quantize.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { quantizeI8Symmetric, quantizeU8 } from "@mapgen/lib/math/index.js";
+
+describe("lib/math quantize", () => {
+  it("quantizes unsigned bytes with rounding and saturation", () => {
+    expect(quantizeU8(Number.NaN)).toBe(0);
+    expect(quantizeU8(Number.NEGATIVE_INFINITY)).toBe(0);
+    expect(quantizeU8(Number.POSITIVE_INFINITY)).toBe(255);
+
+    expect(quantizeU8(-1)).toBe(0);
+    expect(quantizeU8(0)).toBe(0);
+    expect(quantizeU8(12.49)).toBe(12);
+    expect(quantizeU8(12.5)).toBe(13);
+    expect(quantizeU8(255)).toBe(255);
+    expect(quantizeU8(256)).toBe(255);
+  });
+
+  it("quantizes signed symmetric i8 values with rounding and saturation", () => {
+    expect(quantizeI8Symmetric(Number.NaN)).toBe(0);
+    expect(quantizeI8Symmetric(Number.NEGATIVE_INFINITY)).toBe(-127);
+    expect(quantizeI8Symmetric(Number.POSITIVE_INFINITY)).toBe(127);
+
+    expect(quantizeI8Symmetric(-128)).toBe(-127);
+    expect(quantizeI8Symmetric(-12.5)).toBe(-12);
+    expect(quantizeI8Symmetric(-12.51)).toBe(-13);
+    expect(quantizeI8Symmetric(0)).toBe(0);
+    expect(quantizeI8Symmetric(12.49)).toBe(12);
+    expect(quantizeI8Symmetric(12.5)).toBe(13);
+    expect(quantizeI8Symmetric(128)).toBe(127);
+  });
+});

--- a/packages/mapgen-core/test/lib/mesh/neighborhood-mesh.test.ts
+++ b/packages/mapgen-core/test/lib/mesh/neighborhood-mesh.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "bun:test";
+import type { DelaunayMesh } from "@mapgen/lib/mesh/index.js";
+import {
+  type CsrPointMesh2D,
+  findNearestMeshCell,
+  meanMeshEdgeLength,
+  selectMeshNeighborByVectorProjection,
+} from "@mapgen/lib/mesh/index.js";
+
+function mesh(input: {
+  wrapWidth?: number;
+  siteX: number[];
+  siteY: number[];
+  offsets: number[];
+  neighbors: number[];
+}): CsrPointMesh2D {
+  return {
+    cellCount: input.siteX.length,
+    wrapWidth: input.wrapWidth ?? 100,
+    siteX: Float32Array.from(input.siteX),
+    siteY: Float32Array.from(input.siteY),
+    neighborsOffsets: Int32Array.from(input.offsets),
+    neighbors: Int32Array.from(input.neighbors),
+  };
+}
+
+describe("lib/mesh neighborhood mesh", () => {
+  it("accepts the current generated mesh shape as a CSR point mesh", () => {
+    const currentMesh = {
+      cellCount: 1,
+      wrapWidth: 10,
+      siteX: new Float32Array([1]),
+      siteY: new Float32Array([2]),
+      neighborsOffsets: new Int32Array([0, 0]),
+      neighbors: new Int32Array([]),
+      areas: new Float32Array([1]),
+      bbox: { xl: 0, xr: 10, yt: 0, yb: 10 },
+    } satisfies DelaunayMesh;
+
+    const assigned: CsrPointMesh2D = currentMesh;
+    expect(assigned.cellCount).toBe(1);
+  });
+
+  it("computes mean edge length with empty fallback and periodic distance", () => {
+    expect(meanMeshEdgeLength(mesh({ siteX: [], siteY: [], offsets: [0], neighbors: [] }))).toBe(1);
+
+    expect(
+      meanMeshEdgeLength(
+        mesh({
+          wrapWidth: 10,
+          siteX: [9.9, 0.1],
+          siteY: [0, 0],
+          offsets: [0, 1, 2],
+          neighbors: [1, 0],
+        })
+      )
+    ).toBeCloseTo(0.2, 5);
+  });
+
+  it("skips reverse duplicate edges when computing mean edge length", () => {
+    const duplicateReverseMesh = mesh({
+      wrapWidth: 1000,
+      siteX: [0, 2, 102],
+      siteY: [0, 0, 0],
+      offsets: [0, 1, 3, 4],
+      neighbors: [1, 0, 2, 1],
+    });
+
+    expect(meanMeshEdgeLength(duplicateReverseMesh, 2)).toBe(51);
+  });
+
+  it("honors the max edge cap when computing mean edge length", () => {
+    const cappedMesh = mesh({
+      wrapWidth: 1000,
+      siteX: [0, 2, 11, 101],
+      siteY: [0, 0, 0, 0],
+      offsets: [0, 3, 3, 3, 3],
+      neighbors: [1, 2, 3],
+    });
+
+    expect(meanMeshEdgeLength(cappedMesh, 2)).toBe(6.5);
+    expect(meanMeshEdgeLength(cappedMesh)).toBeCloseTo(38, 5);
+  });
+
+  it("skips invalid and zero-length edges when computing mean edge length", () => {
+    const invalidAndZeroMesh = mesh({
+      wrapWidth: 100,
+      siteX: [5, 5, 17],
+      siteY: [0, 0, 0],
+      offsets: [0, 4, 5, 5],
+      neighbors: [-1, 99, 1, 2, 0],
+    });
+
+    expect(meanMeshEdgeLength(invalidAndZeroMesh)).toBe(12);
+    expect(
+      meanMeshEdgeLength(
+        mesh({ siteX: [0, 0], siteY: [0, 0], offsets: [0, 1, 2], neighbors: [1, 0] })
+      )
+    ).toBe(1);
+  });
+
+  it("uses periodic distance and strict first ties when finding nearest cells", () => {
+    const pointMesh = mesh({
+      wrapWidth: 10,
+      siteX: [9.8, 2, 4, 6],
+      siteY: [0, 0, 0, 0],
+      offsets: [0, 0, 0, 0, 0],
+      neighbors: [],
+    });
+
+    expect(
+      findNearestMeshCell(mesh({ siteX: [], siteY: [], offsets: [0], neighbors: [] }), 1, 1)
+    ).toBe(-1);
+    expect(findNearestMeshCell(pointMesh, 0.1, 0)).toBe(0);
+    expect(findNearestMeshCell(pointMesh, 3, 0)).toBe(1);
+  });
+
+  it("selects neighbors by vector projection with fallback and strict first ties", () => {
+    const fallbackMesh = mesh({
+      wrapWidth: 10,
+      siteX: [9.8, 0.2],
+      siteY: [0, 0],
+      offsets: [0, 0, 0],
+      neighbors: [],
+    });
+    const projectionMesh = mesh({
+      wrapWidth: 10,
+      siteX: [9.8, 0.2, 9.4, 9.8, 9.8, 0.2],
+      siteY: [0, 0, 0, 1, -1, 0],
+      offsets: [0, 5, 5, 5, 5, 5, 5],
+      neighbors: [1, 2, 3, 4, 5],
+    });
+
+    expect(
+      selectMeshNeighborByVectorProjection({
+        mesh: fallbackMesh,
+        cellId: 1,
+        vectorX: 1,
+        vectorY: 0,
+      })
+    ).toBe(1);
+    expect(
+      selectMeshNeighborByVectorProjection({
+        mesh: projectionMesh,
+        cellId: 0,
+        vectorX: 0,
+        vectorY: 0,
+      })
+    ).toBe(0);
+    expect(
+      selectMeshNeighborByVectorProjection({
+        mesh: projectionMesh,
+        cellId: 0,
+        vectorX: 1,
+        vectorY: 0,
+      })
+    ).toBe(1);
+    expect(
+      selectMeshNeighborByVectorProjection({
+        mesh: projectionMesh,
+        cellId: 0,
+        vectorX: 0,
+        vectorY: 1,
+      })
+    ).toBe(3);
+  });
+});


### PR DESCRIPTION
Implements the Slice 4 core API construction for the `foundation|tectonics` disposition workstream, adding quantization utilities, unit-vector quantization, and mesh neighborhood helpers to `mapgen-core`.

**New APIs:**

- `quantizeU8` and `quantizeI8Symmetric` in `packages/mapgen-core/src/lib/math/quantize.ts`, handling non-finite inputs, rounding, and saturation with legacy-compatible semantics.
- `quantizeUnitVec2I8` in `packages/mapgen-core/src/lib/grid/vector-field.ts`, normalizing a 2D vector and returning quantized `{ x, y }` components in the signed i8 symmetric range.
- `CsrPointMesh2D`, `meanMeshEdgeLength`, `findNearestMeshCell`, and `selectMeshNeighborByVectorProjection` in `packages/mapgen-core/src/lib/mesh/neighborhood-mesh.ts`, providing CSR-format mesh traversal with periodic wrap distance, duplicate reverse-edge skipping, max-edge capping, and strict first-tie projection selection.

**Tests written before implementation:**

- `quantize.test.ts` covers unsigned and signed quantizer non-finite, rounding, and saturation cases.
- `vector-field-quantize.test.ts` covers zero, tiny, non-finite, cardinal, diagonal, and bounds cases for `quantizeUnitVec2I8`.
- `neighborhood-mesh.test.ts` covers CSR assignability, mean edge fallback, periodic distance, duplicate reverse-edge skipping, max-edge cap enforcement, invalid and zero-length edge skipping, nearest-cell periodic tie behavior, and neighbor projection fallback, zero-vector, and equal-projection tie cases.

Two P2 findings from supervisor review were repaired: test fixtures were strengthened so that duplicate reverse-edge counting, ignored `maxEdges`, invalid-neighbor mishandling, zero-length edge mishandling, and equal-projection ties would each cause a test failure; and the vocabulary scan record was corrected to separate the case-sensitive packet command from a case-insensitive record-truth scan, with the pre-existing `FoundationMesh` label in `delaunay.ts` dispositioned as outside the Slice 4 write set.