### PR TITLE
docs(habitat): blueprint authority stewardship frame + transition anchor hardening

### DIFF
--- a/.habitat/.active/workstreams/define-domain-blueprint-structure/active-transition-anchor.md
+++ b/.habitat/.active/workstreams/define-domain-blueprint-structure/active-transition-anchor.md
@@ -12,6 +12,12 @@ system.
 This document is intentionally temporary. It should go away after its three
 containers are either opened as their own frames/slices or explicitly closed.
 
+Durable handoff:
+`blueprint-authority-stewardship-frame.md` carries the live DRA stewardship
+frame for this transition. Use this anchor for the three immediate containers;
+use the stewardship frame for the role, proof, source-precedence, and agent-team
+operating contract that must survive takeover.
+
 ## Current Frame
 
 We just completed one full descent:
@@ -58,9 +64,11 @@ which are transitional sentries, and which should be retired, split, or replaced
 with positive assertions.
 
 Why now:
-all blueprint rules are currently enforced and green, but green is not the same
-as permanent. This is the exact moment where scaffolding can become accidental
-architecture if we do not classify it.
+Slice 001 records report enforced closure, but recorded pass state is not the
+same as permanent law. Rule Ecology Cleanup must first re-prove current rule
+state with a named Habitat command before using that state as authority. This
+is the exact moment where scaffolding can become accidental architecture if we
+do not classify it.
 
 Initial classes:
 
@@ -85,7 +93,7 @@ Known inputs:
 - `.habitat/.active/workstreams/define-domain-blueprint-structure/review-protocol.md`;
 - `.habitat/.active/workstreams/define-domain-blueprint-structure/scopes-and-slices-reference.md`.
 
-Standing positive-law candidates requiring reusable-class proof:
+Hypotheses to seed the ecology ledger as standing positive-law candidates:
 
 - `require_domain_source_topology`;
 - `require_domain_ops_binding_surface`;
@@ -96,7 +104,7 @@ Standing positive-law candidates requiring reusable-class proof:
 - `require_artifact_index_aggregate_shape`;
 - `require_recipe_stage_authoring_file_shape`.
 
-Initial boundary-rail candidates to classify:
+Hypotheses to seed the ecology ledger as boundary-rail candidates:
 
 - adapter/runtime import blocks;
 - cross-operation runtime call blocks;
@@ -113,7 +121,7 @@ Other rule families that must be included in the ecology ledger:
 - shipped catalog leakage rules;
 - any rule outside the just-closed domain-root lane.
 
-Initial cleanup candidates:
+Hypotheses to seed the ecology ledger as cleanup candidates:
 
 - retired domain root/catalog guards;
 - old config facade prohibitions;
@@ -123,12 +131,18 @@ Initial cleanup candidates:
 - any rule whose scan root is now entirely covered by a positive topology or
   file-shape rule.
 
+No keep, retire, replace, or split decision is authorized here. Every candidate
+requires row-level evidence and proof in the Rule Ecology Cleanup container.
+
 Required output when opened:
 
 - a rule ecology frame;
-- a rule-by-rule ledger with class, owner, keep/retire/replace/split decision,
-  parity proof requirement, and Habitat verification command;
-- a review loop focused on positive-law quality and no one-off fossil rules;
+- a rule-by-rule ledger with rule id/path, source authority, current evidence,
+  evidence/proof class, owner layer, keep/retire/replace/split disposition,
+  first falsifier, required proof commands, non-claims, and review disposition;
+- a fresh read-only review loop, separate from implementation agents, covering
+  product outcome, owner-boundary, proof, stale-record, and stack lanes, with
+  accepted P1/P2 findings blocking closure;
 - a Graphite-submitted cleanup if rules or records change.
 
 ## Container 2: Reusable Initiative Frame Capture
@@ -241,11 +255,26 @@ Required output when opened:
 
 This anchor can close when:
 
-- Rule Ecology Cleanup has a proper frame or execution packet;
-- Reusable Initiative Frame Capture has a proper frame or document home;
+- Rule Ecology Cleanup has a frame or execution packet with proof gates,
+  row-level ledger contract, and review disposition contract;
+- Reusable Initiative Frame Capture has a frame or document home with explicit
+  scope, source provenance, non-claims, and retirement/promotion path;
 - Move Across, Not Down has selected the next blueprint-level slice or recorded
   why cleanup must continue first;
 - this file no longer contains the only copy of any active decision;
+- accepted P1/P2 review findings for transition claims are resolved, rejected
+  with source evidence, invalidated by later evidence, or explicitly moved out
+  of scope by sealed authority;
+- current claims introduced by the transition containers have proof-class
+  labels and exact commands or source evidence;
+- downstream records capture any active decision that should outlive this
+  temporary anchor;
+- the relevant Graphite layer has been submitted or deliberately held with a
+  recorded reason;
+- the worktree and stack state are clean, or an explicit handoff records the
+  remaining dirty state;
+- `blueprint-authority-stewardship-frame.md` is promoted, superseded, archived,
+  or deleted once its decisions land in owning artifacts;
 - this file is deleted, or moved to archive only if it contains historical
   evidence that was not captured elsewhere.
 

--- a/.habitat/.active/workstreams/define-domain-blueprint-structure/blueprint-authority-stewardship-frame.md
+++ b/.habitat/.active/workstreams/define-domain-blueprint-structure/blueprint-authority-stewardship-frame.md
@@ -1,0 +1,186 @@
+# Blueprint Authority Stewardship Frame
+
+## Frame identity
+
+Frame name: Blueprint Authority Stewardship
+
+Built by: Codex DRA steward
+
+For situation: transition after the completed domain-root topology descent, before the next repeatable blueprint-authority descent is selected and executed.
+
+Built when: 2026-07-05
+
+Mode: frame-discovery with audience-export for peer agents and future DRA takeover
+
+Object-path: objective
+
+Durability: standalone active-workstream frame; intended to survive compaction, takeover, and peer review while this authority cascade continues.
+
+## Scope and provenance
+
+In scope:
+
+- The DRA role for the blueprint-authority transition above completed Slice 001.
+- The completed descent as method evidence: domain blueprint frame -> Slice 001 domain-root topology -> decision prework -> row disposition -> execution -> repair -> Habitat ratchet -> closure and ascent.
+- The active pressure set: rule ecology cleanup, reusable cascade capture, and next blueprint-level slice selection.
+- Agent-team operating discipline, including fresh evidence lanes, separate review lanes, and DRA-owned synthesis.
+- Proof-before-closure discipline for future authority containers.
+
+Out of scope:
+
+- Starting rule ecology cleanup in this frame.
+- Reopening Slice 001 unless fresh repo or Habitat evidence falsifies its closure.
+- Moving source files, changing rules, editing `structure.toml`, changing runtime behavior, or changing public APIs.
+- Promoting transcript language into durable law without confirmation from current user instruction, active repo authority, sealed records, current source, or fresh command evidence.
+- Treating this frame as evergreen product or architecture authority after its active workstream role ends.
+
+Source pointers:
+
+- Direct current user instruction for this takeover, frame implementation, and
+  operational guardrail recovery.
+- `AGENTS.md`
+- `.agents/skills/civ7-habitat-dra-workstream/SKILL.md`
+- `.agents/skills/civ7-habitat-dra-workstream/references/authority-map.md`
+- `docs/process/GRAPHITE.md`
+- `docs/projects/habitat-harness/FRAME.md`
+- `docs/projects/habitat-harness/dra-takeover-frame.md`, as historical
+  project-origin/provenance for the Habitat DRA recovery work only; the actual
+  DRA operating skill lives under `.agents/skills/` and controls skill use.
+- `docs/projects/habitat-harness/recovery-claim-ledger.md`
+- `.habitat/.active/workstreams/define-domain-blueprint-structure/active-transition-anchor.md`
+- `.habitat/.active/workstreams/define-domain-blueprint-structure/review-protocol.md`
+- `.habitat/.active/workstreams/define-domain-blueprint-structure/scopes-and-slices-reference.md`
+- Completed Slice 001 records under `.habitat/.active/workstreams/define-domain-blueprint-structure/slices/001-domain-root-immediate-ops-topology/`
+- Slice 002 prework records only where they explain decisions that became current Habitat law.
+- Prior session transcript extraction for session `019f2a58-c2dc-75d3-a9fc-b875c02f7639`,
+  discovery only; never standalone authority.
+
+## WHAT
+
+This frame treats the current work as stewardship of a repeatable blueprint-authority cascade, not as the first available cleanup task. The unit of analysis is the container transition after one successful structural descent: what has closed, what pressure remains live, what evidence can become law, what remains historical, and what proof would make the next descent safe. It makes the DRA responsible for holding that container geometry while future work descends, burns down, repairs, ratchets, closes, and moves back up.
+
+## WHY
+
+The completed domain-root topology descent proved the machine works, but it also created the exact risk Habitat exists to prevent: temporary scaffolding, negative guards, transition anchors, and narrative records can harden into accidental architecture if they are not classified while the descent is fresh. `active-transition-anchor.md` selects Rule Ecology Cleanup as the next container to open. A structurally different alternative would make that cleanup the whole frame. That alternative is too narrow: it would make one pressure salient and hide the larger job of turning a successful descent into a reusable authority practice.
+
+## Construction history
+
+Structural alternative considered:
+
+Frame the work as "Rule Ecology Cleanup" with the current rule set as the unit of analysis.
+
+Why rejected or demoted:
+
+Rule Ecology Cleanup is the selected next container to open, but it is not the whole transition. Making it the top-level frame would collapse DRA stewardship into task execution and would leave reusable method capture and next-slice selection as secondary afterthoughts.
+
+Perspective / discovery passes used:
+
+- Current repo and Graphite state check in the target worktree.
+- Active workstream document pass over the transition anchor, review protocol, and scopes/slices reference.
+- Repo-local Habitat DRA skill pass through
+  `.agents/skills/civ7-habitat-dra-workstream/SKILL.md` and its authority-map
+  reference for operating loop, proof classes, row discipline, and closure
+  hygiene.
+- Habitat harness project-frame pass for product outcome. The older DRA
+  takeover project document is provenance for the origin of the recovery work,
+  not an official skill and not the controlling operating guide for this frame.
+- Bounded transcript mining for operational guardrails, treated as discovery only.
+
+## Selection commitments
+
+In:
+
+- Active repo authority, current worktree and Graphite state, fresh Habitat output, current source, sealed records, and direct current user instruction.
+- The repo-local Habitat DRA agent skill as the active DRA operating guide for
+  Habitat recovery/stewardship loops.
+- The completed Slice 001 descent as evidence that the cascade can close.
+- The active transition containers named by `active-transition-anchor.md`.
+- The DRA operating model: synthesis, authority calls, proof claims, Graphite state, and closure remain owned by the main steward.
+- Fresh peer-agent evidence and review lanes, with implementation and review kept separate.
+
+Foreground:
+
+- Positive assertions over durable shape; negative guards are temporary containment unless promoted by proof.
+- Question-resolution only where destination is not deterministic; deterministic rows burn down into known destinations.
+- Habitat patterns as file-shape law, `structure.toml` as topology law, and behavior tests as behavior proof.
+- Admitted `.habitat/**/rule.json` packets as the rule authority surface; runners, baselines, and fixtures as proof surfaces only when routed by the owning manifest.
+- Row-level obligations; grouping reduces execution cost but never hides rows.
+- Live law vs historical evidence vs ignored or discovery-only material.
+
+Exterior:
+
+- Operation-internal cleanup, source movement, or new domain row disposition unless an opened container explicitly selects them.
+- Transcript phrasing as standalone authority.
+- Treating older `docs/projects/**` DRA recovery documents as skills or as
+  substitutes for the repo-local `.agents/skills/` guidance.
+- Generic process prose that cannot guide a future red/green descent.
+- Closure claims based on green output alone when owner, proof class, and ratchet status are not named.
+- Agent delegation that transfers synthesis, authority, or closure responsibility away from the DRA.
+
+## Hard core and protective belt
+
+Hard core:
+
+1. The DRA owns synthesis, authority calls, proof claims, Graphite state, and clean closure; agents provide bounded evidence or review.
+2. Blueprint authority moves through the descent/ascent loop defined by the active transition anchor and scopes/slices reference.
+3. Live law beats historical narrative; transcript language is discovery unless confirmed by current authority, sealed records, source, commands, or the user.
+4. Positive allowed-shape law is the target state; negative guards must be classified as transitional, durable, superseded, or needing positive replacement.
+5. Row-level obligations remain visible through every grouping, slice, review, and closure claim.
+
+Protective belt:
+
+- Exact file names and homes for future rule ecology, initiative-frame, and next-slice artifacts.
+- Exact number and names of peer-agent lanes, as long as evidence and review remain fresh and separated.
+- Exact sequencing after the Rule Ecology Cleanup container, unless fresh source or Habitat evidence forces a reframe of the transition anchor.
+- Whether Narsil, `rg`, Git, Habitat classify, Habitat checks, or Graphite history supplies the first evidence pass for a given question.
+- Whether this frame later promotes into a more durable method document or retires after its decisions land in owning artifacts.
+
+## Reframe conditions
+
+What would force a reframe:
+
+If fresh repo state, Habitat output, or sealed authority shows that Slice 001 did not actually close, or if a rule/workstream artifact cannot be classified without reopening source semantics, the stewardship frame must stop and open a dedicated reframe or slice instead of absorbing that anomaly into transition prose.
+
+Degeneration trigger:
+
+If three successive future containers or handoffs use this frame without naming the current container, what has genuinely closed, what pressure remains active, and which proof would make the next move safe, run a reframe diagnostic before continuing.
+
+## DRA operating contract
+
+- Begin each substantive container by naming the container, selection, exterior, falsifier, and proof gate.
+- Use fresh read-only agents for bounded evidence when parallel discovery materially helps; keep prompts concrete and output-shaped.
+- Use a fresh review team after a draft or implementation exists; reviewers must not be the same agents that implemented or drafted the reviewed surface.
+- Keep implementation agents separate from review agents in later workstreams.
+- Do not delegate final synthesis, authority precedence, Graphite state, closure claims, or user-facing decisions.
+- Treat accepted P1/P2 review findings as blockers until repaired, rejected with source evidence, invalidated by later evidence, or explicitly moved out of scope by sealed authority or the user.
+- Leave the worktree, branch, and stack clean at closure, or record an explicit handoff if closure is not claimed.
+
+## Composition and assumptions
+
+Perspectives composed:
+
+- Habitat product outcome perspective: agent-operable structural operating system.
+- Repo-local Habitat DRA skill perspective: operating loop, proof class
+  separation, row authority, supervision/review lanes, and clean Graphite
+  closure.
+- Architecture authority perspective: current paths are evidence, not target architecture.
+- Systematic workstream perspective: authority/oracle -> corpus -> expectation model -> owner map -> slices -> proof -> closure.
+- Framing perspective: selection, exterior, hard core, protective belt, falsifier, and no hidden HOW.
+- User operational perspective from current instruction, supported by the review protocol and DRA docs: use agents, but keep DRA judgment and review separation intact.
+
+Assumptions committed:
+
+- The target worktree remains `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-dra-narrative-burndown` unless the user redirects or current repo state proves a newer handoff branch.
+- This frame belongs in a new Graphite layer above `codex/foundation-lib-tectonics-s6-closure`; closure is not claimable until the frame is committed through Graphite and the worktree/stack state is clean.
+- `active-transition-anchor.md`, `review-protocol.md`, and `scopes-and-slices-reference.md` are the controlling active workstream docs for this frame.
+- `.agents/skills/civ7-habitat-dra-workstream/SKILL.md` is the actual repo
+  agent skill for Habitat DRA operation; project/workstream documents inform
+  provenance, product intent, or sealed records according to the skill's
+  authority map, but they are not skills.
+- Rule Ecology Cleanup is the selected next container to open, not an implementation task opened by this frame.
+- This frame is active-workstream authority for takeover and stewardship; it is not evergreen law until promoted or superseded by a more durable owner.
+- The active rule set may be green without being permanently classified; reusable-class proof belongs to the rule ecology container, not this frame.
+
+## NOT HOW
+
+This frame does not prescribe the exact rule ecology edits, the next-slice selection, the rule-by-rule ledger, or any source movement. Those belong in the next opened container's frame, slice packet, ledger, implementation plan, review records, and Graphite layer.


### PR DESCRIPTION
Introduces a durable stewardship frame for the blueprint-authority transition following the completed Slice 001 domain-root topology descent, and tightens the active transition anchor to match.

**Blueprint Authority Stewardship Frame (`blueprint-authority-stewardship-frame.md`)**

Adds a new standalone active-workstream frame that holds the DRA role, operating contract, and proof discipline across the full transition — covering rule ecology cleanup, reusable cascade capture, and next-slice selection — rather than collapsing stewardship into any single task. The frame defines:

- Hard core and protective belt separating live law from historical narrative and transcript discovery
- DRA operating contract requiring fresh, separated evidence and review lanes, with implementation agents kept distinct from review agents
- Reframe and degeneration triggers to prevent transition prose from absorbing anomalies that belong in dedicated containers
- Explicit scope boundaries preventing source movement, rule changes, or closure claims based on green output alone

**Transition anchor updates (`active-transition-anchor.md`)**

- Adds a durable handoff note pointing to the stewardship frame as the carrier for role, proof, source-precedence, and agent-team operating contract across takeover
- Replaces "green is permanent" language with an explicit requirement that Rule Ecology Cleanup re-prove current rule state with a named Habitat command before treating it as authority
- Reframes candidate lists as hypotheses seeding the ecology ledger rather than standing decisions, and adds an explicit prohibition on keep/retire/replace/split decisions without row-level evidence and proof in the cleanup container
- Expands the required ledger output to include rule id/path, source authority, current evidence, evidence/proof class, owner layer, first falsifier, required proof commands, non-claims, and review disposition
- Expands the review loop requirement to a fresh read-only team separate from implementation agents, with accepted P1/P2 findings blocking closure
- Expands anchor closure conditions to require proof-class labels on transition claims, clean worktree or explicit dirty-state handoff, downstream capture of active decisions, and explicit disposition of the stewardship frame itself