### PR TITLE
fix(mapgen): clear studio check and lint drift

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/extract-earth-metrics.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/extract-earth-metrics.ts
@@ -1,5 +1,5 @@
-import { biomeSymbolFromIndex } from "../../domain/ecology/model/schemas/index.js";
 import { isAnyRiverClass } from "@mapgen/domain/hydrology/model/policy/river-class.js";
+import { biomeSymbolFromIndex } from "../../domain/ecology/model/schemas/index.js";
 
 export type RiverNetworkBenchmarkSummary = Readonly<Record<string, number> & { version: 1 }>;
 

--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -3159,7 +3159,9 @@ function readLocalResourcePlacementEvidence(local: FinalSurfaceSnapshot): {
     if (!isPlainObject(intent)) continue;
     const plotIndex = numberValue(intent.plotIndex);
     const preferredResourceType =
-      typeof intent.resourceType === "string" ? resourceTypeIdForSymbol(intent.resourceType) : undefined;
+      typeof intent.resourceType === "string"
+        ? resourceTypeIdForSymbol(intent.resourceType)
+        : undefined;
     if (
       plotIndex === undefined ||
       preferredResourceType === undefined ||

--- a/mods/mod-swooper-maps/src/dev/diagnostics/placement-metrics.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/placement-metrics.ts
@@ -16,7 +16,7 @@
 
 import type { GameMapAdapter } from "@civ7/adapter";
 import { createMockAdapter } from "@civ7/adapter";
-import { requireResourceRuntimeId, type OfficialResourceType } from "@civ7/map-policy";
+import { type OfficialResourceType, requireResourceRuntimeId } from "@civ7/map-policy";
 import { createExtendedMapContext, createLabelRng, VOLCANO_FEATURE } from "@swooper/mapgen-core";
 import {
   getHexNeighborIndicesOddQ,

--- a/mods/mod-swooper-maps/src/domain/ecology/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/index.ts
@@ -10,7 +10,7 @@ export type { PlotEffectIntentKey } from "./model/schemas/index.js";
 export {
   BIOME_SYMBOL_ORDER,
   BIOME_SYMBOL_TO_INDEX,
-  PLOT_EFFECT_INTENT_KEYS,
-  biomeSymbolFromIndex,
   type BiomeSymbol,
+  biomeSymbolFromIndex,
+  PLOT_EFFECT_INTENT_KEYS,
 } from "./model/schemas/index.js";

--- a/mods/mod-swooper-maps/src/domain/ecology/model/schemas/feature-placement.schema.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/model/schemas/feature-placement.schema.ts
@@ -32,7 +32,8 @@ export type FeatureIntentKey = (typeof FEATURE_INTENT_KEYS)[number];
 
 export const FeatureIntentKeySchema = Type.Unsafe<FeatureIntentKey>(
   Type.String({
-    description: "Abstract ecology feature intent. Civ7 engine feature keys are chosen by projection.",
+    description:
+      "Abstract ecology feature intent. Civ7 engine feature keys are chosen by projection.",
     enum: [...FEATURE_INTENT_KEYS],
   })
 );

--- a/mods/mod-swooper-maps/src/domain/ecology/model/schemas/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/model/schemas/index.ts
@@ -1,18 +1,18 @@
 export {
   BIOME_SYMBOL_ORDER,
   BIOME_SYMBOL_TO_INDEX,
+  type BiomeSymbol,
   BiomeSymbolSchema,
   biomeSymbolFromIndex,
-  type BiomeSymbol,
 } from "./biome-symbol.schema.js";
 export {
   FEATURE_INTENT_KEYS,
+  type FeatureIntentKey,
   FeatureIntentKeySchema,
   FeaturePlacementSchema,
-  type FeatureIntentKey,
 } from "./feature-placement.schema.js";
 export {
   PLOT_EFFECT_INTENT_KEYS,
-  PlotEffectIntentKeySchema,
   type PlotEffectIntentKey,
+  PlotEffectIntentKeySchema,
 } from "./plot-effect-intent.schema.js";

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/rules/classify.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/rules/classify.ts
@@ -1,11 +1,11 @@
 import { BIOME_SYMBOL_TO_INDEX, type BiomeSymbol } from "../../../model/schemas/index.js";
+import type { BiomeClassificationTypes } from "../types.js";
 import { aridityShiftForIndex, shiftMoistureZone } from "./aridity.js";
 import { biomeSymbolForZones } from "./lookup.js";
 import { moistureZoneOf } from "./moisture.js";
 import { temperatureZoneOf } from "./temperature.js";
 import { clamp01 } from "./util.js";
 import { vegetationDensityForBiome } from "./vegetation.js";
-import type { BiomeClassificationTypes } from "../types.js";
 
 type DefaultConfig = BiomeClassificationTypes["config"]["default"];
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/rules/vegetation.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/rules/vegetation.ts
@@ -1,5 +1,5 @@
-import type { BiomeSymbol } from "../../../model/schemas/index.js";
 import { clamp01 } from "@swooper/mapgen-core";
+import type { BiomeSymbol } from "../../../model/schemas/index.js";
 
 /**
  * Computes vegetation density using climate signals and stress attenuation.

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-apply/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-apply/strategies/default.ts
@@ -1,5 +1,5 @@
-import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
+import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import FeaturesApplyContract from "../contract.js";
 
 type Placement = { x: number; y: number; feature: FeatureIntentKey; weight?: number };

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-floodplains/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-floodplains/strategies/default.ts
@@ -1,12 +1,11 @@
-import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
-
 import {
   choosePhysicalCandidate,
   confidenceFromScore01,
   stressFromConfidence01,
   validateGridSize,
 } from "../../../model/policy/feature-score-selection.js";
+import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import PlanFloodplainsContract from "../contract.js";
 
 type FloodplainCandidate = Readonly<{

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/strategies/continentality.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/strategies/continentality.ts
@@ -1,7 +1,9 @@
-import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
-
-import { confidenceFromScore01, validateGridSize } from "../../../model/policy/feature-score-selection.js";
+import {
+  confidenceFromScore01,
+  validateGridSize,
+} from "../../../model/policy/feature-score-selection.js";
+import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import PlanIceContract from "../contract.js";
 import { admitIceIntent } from "../policy/index.js";
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/strategies/default.ts
@@ -1,7 +1,9 @@
-import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
-
-import { confidenceFromScore01, validateGridSize } from "../../../model/policy/feature-score-selection.js";
+import {
+  confidenceFromScore01,
+  validateGridSize,
+} from "../../../model/policy/feature-score-selection.js";
+import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import PlanIceContract from "../contract.js";
 import { admitIceIntent } from "../policy/index.js";
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/strategies/default.ts
@@ -1,12 +1,11 @@
-import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
-
 import {
   choosePhysicalCandidate,
   confidenceFromScore01,
   stressFromConfidence01,
   validateGridSize,
 } from "../../../model/policy/feature-score-selection.js";
+import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import PlanReefsContract from "../contract.js";
 import { admitReefIntent, admitReefStride } from "../policy/index.js";
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/strategies/shipping-lanes.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/strategies/shipping-lanes.ts
@@ -1,12 +1,11 @@
-import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
-
 import {
   choosePhysicalCandidate,
   confidenceFromScore01,
   stressFromConfidence01,
   validateGridSize,
 } from "../../../model/policy/feature-score-selection.js";
+import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import PlanReefsContract from "../contract.js";
 import { admitReefIntent, admitReefStride } from "../policy/index.js";
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/contract.ts
@@ -31,7 +31,8 @@ const PlanVegetationContract = defineOp({
         "1 = land tile that will remain flat after terrain projection; 0 = water, hill, mountain, volcano, or lake.",
     }),
     biomeIndex: TypedArraySchemas.u8({
-      description: "Internal biome classification index used for broad vegetation habitat admission.",
+      description:
+        "Internal biome classification index used for broad vegetation habitat admission.",
     }),
     surfaceTemperature: TypedArraySchemas.f32({
       description: "Surface temperature per tile (C) used for broad feature habitat admission.",

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/strategies/default.ts
@@ -1,12 +1,12 @@
-import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
-import { BIOME_SYMBOL_TO_INDEX } from "../../../model/schemas/index.js";
 import {
   choosePhysicalCandidate,
   confidenceFromScore01,
   stressFromConfidence01,
   validateGridSize,
 } from "../../../model/policy/feature-score-selection.js";
+import type { FeatureIntentKey } from "../../../model/schemas/index.js";
+import { BIOME_SYMBOL_TO_INDEX } from "../../../model/schemas/index.js";
 import PlanVegetationContract from "../contract.js";
 import { admitVegetationIntent } from "../policy/index.js";
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-wetlands/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-wetlands/strategies/default.ts
@@ -1,4 +1,3 @@
-import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 import {
   choosePhysicalCandidate,
@@ -6,6 +5,7 @@ import {
   stressFromConfidence01,
   validateGridSize,
 } from "../../../model/policy/feature-score-selection.js";
+import type { FeatureIntentKey } from "../../../model/schemas/index.js";
 import PlanWetlandsContract from "../contract.js";
 import { admitWetlandIntent } from "../policy/index.js";
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/ice-score-ice/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/ice-score-ice/strategies/default.ts
@@ -1,7 +1,11 @@
 import { clamp01 } from "@swooper/mapgen-core";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 
-import { rampDown01, rampUp01, validateGridSize } from "../../../model/policy/feature-score-selection.js";
+import {
+  rampDown01,
+  rampUp01,
+  validateGridSize,
+} from "../../../model/policy/feature-score-selection.js";
 import ScoreIceContract from "../contract.js";
 
 export const defaultStrategy = createStrategy(ScoreIceContract, "default", {

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-burned/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-burned/strategies/default.ts
@@ -1,6 +1,6 @@
-import { biomeSymbolFromIndex } from "../../../model/schemas/index.js";
 import { clamp01, normalizeRange } from "@swooper/mapgen-core";
 import { createStrategy, type Static } from "@swooper/mapgen-core/authoring";
+import { biomeSymbolFromIndex } from "../../../model/schemas/index.js";
 
 import PlotEffectsScoreBurnedContract from "../contract.js";
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-jungle/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-jungle/strategies/default.ts
@@ -1,6 +1,6 @@
-import { biomeSymbolFromIndex } from "../../../model/schemas/index.js";
 import { clamp01, normalizeRange } from "@swooper/mapgen-core";
 import { createStrategy, type Static } from "@swooper/mapgen-core/authoring";
+import { biomeSymbolFromIndex } from "../../../model/schemas/index.js";
 
 import PlotEffectsScoreJungleContract from "../contract.js";
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-sand/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-sand/strategies/default.ts
@@ -1,6 +1,6 @@
-import { biomeSymbolFromIndex } from "../../../model/schemas/index.js";
 import { clamp01, normalizeRange } from "@swooper/mapgen-core";
 import { createStrategy, type Static } from "@swooper/mapgen-core/authoring";
+import { biomeSymbolFromIndex } from "../../../model/schemas/index.js";
 
 import PlotEffectsScoreSandContract from "../contract.js";
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-atoll/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-atoll/strategies/default.ts
@@ -1,7 +1,11 @@
 import { clamp01 } from "@swooper/mapgen-core";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 
-import { rampDown01, rampUp01, validateGridSize } from "../../../model/policy/feature-score-selection.js";
+import {
+  rampDown01,
+  rampUp01,
+  validateGridSize,
+} from "../../../model/policy/feature-score-selection.js";
 import ScoreAtollContract from "../contract.js";
 
 export const defaultStrategy = createStrategy(ScoreAtollContract, "default", {

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-cold-reef/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-cold-reef/strategies/default.ts
@@ -1,7 +1,11 @@
 import { clamp01 } from "@swooper/mapgen-core";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 
-import { rampDown01, validateGridSize, window01 } from "../../../model/policy/feature-score-selection.js";
+import {
+  rampDown01,
+  validateGridSize,
+  window01,
+} from "../../../model/policy/feature-score-selection.js";
 import ScoreColdReefContract from "../contract.js";
 
 export const defaultStrategy = createStrategy(ScoreColdReefContract, "default", {

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-lotus/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-lotus/strategies/default.ts
@@ -1,7 +1,11 @@
 import { clamp01 } from "@swooper/mapgen-core";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 
-import { rampDown01, rampUp01, validateGridSize } from "../../../model/policy/feature-score-selection.js";
+import {
+  rampDown01,
+  rampUp01,
+  validateGridSize,
+} from "../../../model/policy/feature-score-selection.js";
 import ScoreLotusContract from "../contract.js";
 
 export const defaultStrategy = createStrategy(ScoreLotusContract, "default", {

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-reef/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-reef/strategies/default.ts
@@ -1,7 +1,11 @@
 import { clamp01 } from "@swooper/mapgen-core";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 
-import { rampDown01, rampUp01, validateGridSize } from "../../../model/policy/feature-score-selection.js";
+import {
+  rampDown01,
+  rampUp01,
+  validateGridSize,
+} from "../../../model/policy/feature-score-selection.js";
 import ScoreReefContract from "../contract.js";
 
 export const defaultStrategy = createStrategy(ScoreReefContract, "default", {

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-mangrove/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-mangrove/strategies/default.ts
@@ -1,7 +1,11 @@
 import { clamp01 } from "@swooper/mapgen-core";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 
-import { rampDown01, rampUp01, validateGridSize } from "../../../model/policy/feature-score-selection.js";
+import {
+  rampDown01,
+  rampUp01,
+  validateGridSize,
+} from "../../../model/policy/feature-score-selection.js";
 import ScoreWetMangroveContract from "../contract.js";
 
 export const defaultStrategy = createStrategy(ScoreWetMangroveContract, "default", {

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-marsh/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-marsh/strategies/default.ts
@@ -1,7 +1,12 @@
 import { clamp01 } from "@swooper/mapgen-core";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 
-import { rampDown01, rampUp01, validateGridSize, window01 } from "../../../model/policy/feature-score-selection.js";
+import {
+  rampDown01,
+  rampUp01,
+  validateGridSize,
+  window01,
+} from "../../../model/policy/feature-score-selection.js";
 import ScoreWetMarshContract from "../contract.js";
 
 export const defaultStrategy = createStrategy(ScoreWetMarshContract, "default", {

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-tundra-bog/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-tundra-bog/strategies/default.ts
@@ -1,7 +1,11 @@
 import { clamp01 } from "@swooper/mapgen-core";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 
-import { rampDown01, rampUp01, validateGridSize } from "../../../model/policy/feature-score-selection.js";
+import {
+  rampDown01,
+  rampUp01,
+  validateGridSize,
+} from "../../../model/policy/feature-score-selection.js";
 import ScoreWetTundraBogContract from "../contract.js";
 
 export const defaultStrategy = createStrategy(ScoreWetTundraBogContract, "default", {

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/crust-init.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/crust-init.artifact.ts
@@ -1,7 +1,5 @@
 import { defineArtifact } from "@swooper/mapgen-core/authoring/contracts";
-
-import { Schema as CrustSchema } from "./crust.artifact.js";
-import { validate as validateCrust } from "./crust.artifact.js";
+import { Schema as CrustSchema, validate as validateCrust } from "./crust.artifact.js";
 
 export const Schema = CrustSchema;
 export type { Artifact } from "./crust.artifact.js";

--- a/mods/mod-swooper-maps/src/domain/foundation/artifacts/plate-topology.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/artifacts/plate-topology.artifact.ts
@@ -84,7 +84,9 @@ export function validate(value: unknown): readonly { message: string }[] {
         } else if (
           record.neighbors.some(
             (neighbor) =>
-              !Number.isInteger(neighbor) || (neighbor as number) < 0 || (neighbor as number) >= plateCount
+              !Number.isInteger(neighbor) ||
+              (neighbor as number) < 0 ||
+              (neighbor as number) >= plateCount
           )
         ) {
           issues.push(issue(`plates[${index}].neighbors contains an invalid plate id`));

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-era-plate-membership/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-era-plate-membership/contract.ts
@@ -1,8 +1,8 @@
 import type { Static } from "@swooper/mapgen-core/authoring/contracts";
 import { defineOp, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { Schema as PlateIdByEraSchema } from "../../artifacts/plate-id-by-era.artifact.js";
 import { Schema as FoundationMeshSchema } from "../../artifacts/mesh.artifact.js";
 import { Schema as FoundationPlateGraphSchema } from "../../artifacts/plate-graph.artifact.js";
+import { Schema as PlateIdByEraSchema } from "../../artifacts/plate-id-by-era.artifact.js";
 import { Schema as FoundationPlateMotionSchema } from "../../artifacts/plate-motion.artifact.js";
 
 const StrategySchema = Type.Object(

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-era-tectonic-fields/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-era-tectonic-fields/contract.ts
@@ -1,8 +1,8 @@
 import type { Static } from "@swooper/mapgen-core/authoring/contracts";
 import { defineOp, Type } from "@swooper/mapgen-core/authoring/contracts";
+import { Schema as FoundationMeshSchema } from "../../artifacts/mesh.artifact.js";
 import { Schema as FoundationTectonicEraFieldsInternalListSchema } from "../../artifacts/tectonic-era-fields.artifact.js";
 import { Schema as TectonicEventsSchema } from "../../artifacts/tectonic-events.artifact.js";
-import { Schema as FoundationMeshSchema } from "../../artifacts/mesh.artifact.js";
 
 const FoundationTectonicEraFieldsInternalSchema =
   FoundationTectonicEraFieldsInternalListSchema.items;

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-era-tectonic-fields/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-era-tectonic-fields/rules/index.ts
@@ -4,10 +4,9 @@ import {
   meanMeshEdgeLength,
   selectMeshNeighborByVectorProjection,
 } from "@swooper/mapgen-core/lib/mesh";
-
+import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import type { Artifact as FoundationTectonicEraFieldsInternalList } from "../../../artifacts/tectonic-era-fields.artifact.js";
 import type { Artifact as TectonicEvents } from "../../../artifacts/tectonic-events.artifact.js";
-import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import { EVENT_TYPE } from "../../../model/policy/tectonic-event-types.js";
 
 type FoundationTectonicEraFieldsInternal = FoundationTectonicEraFieldsInternalList[number];

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-hotspot-events/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-hotspot-events/contract.ts
@@ -1,7 +1,7 @@
 import { defineOp, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { Schema as TectonicEventsSchema } from "../../artifacts/tectonic-events.artifact.js";
 import { Schema as FoundationMantleForcingSchema } from "../../artifacts/mantle-forcing.artifact.js";
 import { Schema as FoundationMeshSchema } from "../../artifacts/mesh.artifact.js";
+import { Schema as TectonicEventsSchema } from "../../artifacts/tectonic-events.artifact.js";
 
 const ComputeHotspotEventsContract = defineOp({
   kind: "compute",

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-hotspot-events/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-hotspot-events/rules/index.ts
@@ -1,9 +1,9 @@
 import { quantizeUnitVec2I8 } from "@swooper/mapgen-core/lib/grid";
 import { clampFinite, quantizeU8 } from "@swooper/mapgen-core/lib/math";
-import type { Artifact as TectonicEvents } from "../../../artifacts/tectonic-events.artifact.js";
-import { EVENT_TYPE } from "../../../model/policy/tectonic-event-types.js";
 import type { Artifact as FoundationMantleForcing } from "../../../artifacts/mantle-forcing.artifact.js";
 import type { Artifact as FoundationMesh } from "../../../artifacts/mesh.artifact.js";
+import type { Artifact as TectonicEvents } from "../../../artifacts/tectonic-events.artifact.js";
+import { EVENT_TYPE } from "../../../model/policy/tectonic-event-types.js";
 
 type TectonicEventRecord = TectonicEvents[number];
 

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/contract.ts
@@ -1,15 +1,15 @@
 import type { Static, TSchema } from "@swooper/mapgen-core/authoring/contracts";
 import { defineOp, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
+import { Schema as FoundationCrustSchema } from "../../artifacts/crust.artifact.js";
 import { Schema as FoundationTectonicsSchema } from "../../artifacts/current-tectonics.artifact.js";
+import { Schema as FoundationMeshSchema } from "../../artifacts/mesh.artifact.js";
+import { Schema as FoundationPlateGraphSchema } from "../../artifacts/plate-graph.artifact.js";
+import { Schema as FoundationPlateMotionSchema } from "../../artifacts/plate-motion.artifact.js";
 import { Schema as FoundationTectonicHistorySchema } from "../../artifacts/tectonic-history.artifact.js";
 import {
   type Artifact as FoundationTectonicProvenanceArtifact,
   Schema as FoundationTectonicProvenanceSchema,
 } from "../../artifacts/tectonic-provenance.artifact.js";
-import { Schema as FoundationCrustSchema } from "../../artifacts/crust.artifact.js";
-import { Schema as FoundationMeshSchema } from "../../artifacts/mesh.artifact.js";
-import { Schema as FoundationPlateGraphSchema } from "../../artifacts/plate-graph.artifact.js";
-import { Schema as FoundationPlateMotionSchema } from "../../artifacts/plate-motion.artifact.js";
 
 function withDescription<T extends TSchema>(schema: T, description: string) {
   const { additionalProperties: _additionalProperties, default: _default, ...rest } = schema as any;

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/rules/project-plates.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/rules/project-plates.ts
@@ -4,14 +4,14 @@ import {
   quantizeU8,
   wrapAbsDeltaPeriodic,
 } from "@swooper/mapgen-core/lib/math";
-import type { Artifact as FoundationTectonics } from "../../../artifacts/current-tectonics.artifact.js";
-import type { Artifact as FoundationTectonicHistory } from "../../../artifacts/tectonic-history.artifact.js";
-import type { Artifact as FoundationTectonicProvenance } from "../../../artifacts/tectonic-provenance.artifact.js";
 import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import type { Artifact as FoundationCrust } from "../../../artifacts/crust.artifact.js";
+import type { Artifact as FoundationTectonics } from "../../../artifacts/current-tectonics.artifact.js";
 import type { Artifact as FoundationMesh } from "../../../artifacts/mesh.artifact.js";
 import type { Artifact as FoundationPlateGraph } from "../../../artifacts/plate-graph.artifact.js";
 import type { Artifact as FoundationPlateMotion } from "../../../artifacts/plate-motion.artifact.js";
+import type { Artifact as FoundationTectonicHistory } from "../../../artifacts/tectonic-history.artifact.js";
+import type { Artifact as FoundationTectonicProvenance } from "../../../artifacts/tectonic-provenance.artifact.js";
 
 function hexDistanceSq(ax: number, ay: number, bx: number, by: number, wrapWidth: number): number {
   const dx = wrapAbsDeltaPeriodic(ax - bx, wrapWidth);

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-segment-events/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-segment-events/contract.ts
@@ -1,7 +1,7 @@
 import { defineOp, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { Schema as TectonicEventsSchema } from "../../artifacts/tectonic-events.artifact.js";
 import { Schema as FoundationCrustSchema } from "../../artifacts/crust.artifact.js";
 import { Schema as FoundationMeshSchema } from "../../artifacts/mesh.artifact.js";
+import { Schema as TectonicEventsSchema } from "../../artifacts/tectonic-events.artifact.js";
 import { Schema as FoundationTectonicSegmentsSchema } from "../../artifacts/tectonic-segments.artifact.js";
 
 const ComputeSegmentEventsContract = defineOp({

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-segment-events/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-segment-events/rules/index.ts
@@ -1,9 +1,9 @@
-import type { Artifact as TectonicEvents } from "../../../artifacts/tectonic-events.artifact.js";
 import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
-import { EVENT_TYPE } from "../../../model/policy/tectonic-event-types.js";
 import type { Artifact as FoundationCrust } from "../../../artifacts/crust.artifact.js";
 import type { Artifact as FoundationMesh } from "../../../artifacts/mesh.artifact.js";
+import type { Artifact as TectonicEvents } from "../../../artifacts/tectonic-events.artifact.js";
 import type { Artifact as FoundationTectonicSegments } from "../../../artifacts/tectonic-segments.artifact.js";
+import { EVENT_TYPE } from "../../../model/policy/tectonic-event-types.js";
 
 type TectonicEventRecord = TectonicEvents[number];
 

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-segment-events/types.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-segment-events/types.ts
@@ -1,6 +1,6 @@
-import type { Artifact as TectonicEvents } from "../../artifacts/tectonic-events.artifact.js";
 import type { Artifact as FoundationCrust } from "../../artifacts/crust.artifact.js";
 import type { Artifact as FoundationMesh } from "../../artifacts/mesh.artifact.js";
+import type { Artifact as TectonicEvents } from "../../artifacts/tectonic-events.artifact.js";
 import type { Artifact as FoundationTectonicSegments } from "../../artifacts/tectonic-segments.artifact.js";
 
 type TectonicEventRecord = TectonicEvents[number];

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-provenance/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-provenance/contract.ts
@@ -1,9 +1,9 @@
 import { defineOp, Type } from "@swooper/mapgen-core/authoring/contracts";
+import { Schema as FoundationMeshSchema } from "../../artifacts/mesh.artifact.js";
+import { Schema as FoundationPlateGraphSchema } from "../../artifacts/plate-graph.artifact.js";
 import { Schema as FoundationTectonicEraFieldsInternalListSchema } from "../../artifacts/tectonic-era-fields.artifact.js";
 import { Schema as FoundationTectonicProvenanceSchema } from "../../artifacts/tectonic-provenance.artifact.js";
 import { Schema as TracerIndexByEraSchema } from "../../artifacts/tracer-index-by-era.artifact.js";
-import { Schema as FoundationMeshSchema } from "../../artifacts/mesh.artifact.js";
-import { Schema as FoundationPlateGraphSchema } from "../../artifacts/plate-graph.artifact.js";
 
 const ComputeTectonicProvenanceContract = defineOp({
   kind: "compute",

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-provenance/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-provenance/rules/index.ts
@@ -1,10 +1,10 @@
 import { quantizeU8 } from "@swooper/mapgen-core/lib/math";
-import type { Artifact as FoundationTectonicEraFieldsInternalList } from "../../../artifacts/tectonic-era-fields.artifact.js";
-import type { Artifact as FoundationTectonicProvenance } from "../../../artifacts/tectonic-provenance.artifact.js";
 import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
-import { EVENT_TYPE } from "../../../model/policy/tectonic-event-types.js";
 import type { Artifact as FoundationMesh } from "../../../artifacts/mesh.artifact.js";
 import type { Artifact as FoundationPlateGraph } from "../../../artifacts/plate-graph.artifact.js";
+import type { Artifact as FoundationTectonicEraFieldsInternalList } from "../../../artifacts/tectonic-era-fields.artifact.js";
+import type { Artifact as FoundationTectonicProvenance } from "../../../artifacts/tectonic-provenance.artifact.js";
+import { EVENT_TYPE } from "../../../model/policy/tectonic-event-types.js";
 import {
   ARC_RESET_THRESHOLD_FRAC_OF_MAX,
   ARC_RESET_THRESHOLD_MIN,

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tracer-advection/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tracer-advection/contract.ts
@@ -1,8 +1,8 @@
 import { defineOp, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { Schema as FoundationTectonicEraFieldsInternalListSchema } from "../../artifacts/tectonic-era-fields.artifact.js";
-import { Schema as TracerIndexByEraSchema } from "../../artifacts/tracer-index-by-era.artifact.js";
 import { Schema as FoundationMantleForcingSchema } from "../../artifacts/mantle-forcing.artifact.js";
 import { Schema as FoundationMeshSchema } from "../../artifacts/mesh.artifact.js";
+import { Schema as FoundationTectonicEraFieldsInternalListSchema } from "../../artifacts/tectonic-era-fields.artifact.js";
+import { Schema as TracerIndexByEraSchema } from "../../artifacts/tracer-index-by-era.artifact.js";
 
 const ComputeTracerAdvectionContract = defineOp({
   kind: "compute",

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tracer-advection/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tracer-advection/rules/index.ts
@@ -1,8 +1,8 @@
 import { quantizeUnitVec2I8 } from "@swooper/mapgen-core/lib/grid";
 import { selectMeshNeighborByVectorProjection } from "@swooper/mapgen-core/lib/mesh";
-import type { Artifact as FoundationTectonicEraFieldsInternalList } from "../../../artifacts/tectonic-era-fields.artifact.js";
 import type { Artifact as FoundationMantleForcing } from "../../../artifacts/mantle-forcing.artifact.js";
 import type { Artifact as FoundationMesh } from "../../../artifacts/mesh.artifact.js";
+import type { Artifact as FoundationTectonicEraFieldsInternalList } from "../../../artifacts/tectonic-era-fields.artifact.js";
 import { ADVECTION_STEPS_PER_ERA } from "./constants.js";
 
 type FoundationTectonicEraFieldsInternal = FoundationTectonicEraFieldsInternalList[number];

--- a/mods/mod-swooper-maps/src/domain/morphology/model/policy/orogeny-potential.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/model/policy/orogeny-potential.ts
@@ -1,7 +1,7 @@
-import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import { clamp01 } from "@swooper/mapgen-core/lib/math";
-import type { OrogenyPotentialPolicy } from "./mountain-scoring-policy.js";
+import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import { resolveBoundaryRegime } from "./boundary-regime.js";
+import type { OrogenyPotentialPolicy } from "./mountain-scoring-policy.js";
 
 export function computeOrogenyPotential(params: {
   boundaryStrength: number;

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-belt-drivers/rules/derive-belt-drivers-from-history.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-belt-drivers/rules/derive-belt-drivers-from-history.ts
@@ -1,9 +1,9 @@
+import { collectMaskComponentsOddQ, forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
 import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import type {
   TectonicHistorySourceTiles,
   TectonicProvenanceSourceTiles,
 } from "../../../model/schemas/tectonic-source-tiles.js";
-import { collectMaskComponentsOddQ, forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
 
 import type { BeltComponentSummary, BeltDriverOutputs } from "../types.js";
 
@@ -215,10 +215,16 @@ export function deriveBeltDriversFromHistory(input: {
 
   const eraCount = Math.max(1, historyTiles.eraCount | 0);
   if (!Array.isArray(historyTiles.perEra) || historyTiles.perEra.length < eraCount) {
-    throw new Error(`[compute-belt-drivers] historyTiles.perEra must contain ${eraCount} era rows.`);
+    throw new Error(
+      `[compute-belt-drivers] historyTiles.perEra must contain ${eraCount} era rows.`
+    );
   }
   const perEra = historyTiles.perEra.map((era, eraIndex) => ({
-    boundaryType: requireU8(`historyTiles.perEra[${eraIndex}].boundaryType`, era.boundaryType, size),
+    boundaryType: requireU8(
+      `historyTiles.perEra[${eraIndex}].boundaryType`,
+      era.boundaryType,
+      size
+    ),
     upliftPotential: requireU8(
       `historyTiles.perEra[${eraIndex}].upliftPotential`,
       era.upliftPotential,
@@ -274,7 +280,11 @@ export function deriveBeltDriversFromHistory(input: {
     rollups.subductionRecentFraction,
     size
   );
-  const lastActiveEra = requireU8("historyTiles.rollups.lastActiveEra", rollups.lastActiveEra, size);
+  const lastActiveEra = requireU8(
+    "historyTiles.rollups.lastActiveEra",
+    rollups.lastActiveEra,
+    size
+  );
   const originEra = requireU8("provenanceTiles.originEra", provenanceTiles.originEra, size);
   const originPlateId = requireI16(
     "provenanceTiles.originPlateId",

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/strategies/default.ts
@@ -1,7 +1,7 @@
-import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
 import { clamp01 } from "@swooper/mapgen-core/lib/math";
+import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 
 import ComputeLandmaskContract from "../contract.js";
 import { validateLandmaskInputs } from "../rules/index.js";

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-sculpt-continental-margin/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-sculpt-continental-margin/rules/index.ts
@@ -1,5 +1,5 @@
-import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import { clamp, clamp01 } from "@swooper/mapgen-core/lib/math";
+import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 
 import type { ComputeSculptContinentalMarginTypes } from "../types.js";
 

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/rules/hill-score.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/rules/hill-score.ts
@@ -1,6 +1,5 @@
-import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
-
 import { clamp } from "@swooper/mapgen-core/lib/math";
+import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import { resolveBoundaryRegime } from "../../../model/policy/boundary-regime.js";
 import type { HillScorePolicy } from "../../../model/policy/mountain-scoring-policy.js";
 import { computeOrogenyPotential } from "../../../model/policy/orogeny-potential.js";

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/strategies/default.ts
@@ -1,5 +1,5 @@
-import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
+import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import { resolveBoundaryStrength } from "../../../model/policy/boundary-strength.js";
 import { resolveDriverStrength } from "../../../model/policy/driver-strength.js";
 import { normalizeMountainFractal } from "../../../model/policy/mountain-fractal.js";
@@ -7,9 +7,9 @@ import type {
   HillScorePolicy,
   OrogenyPotentialPolicy,
 } from "../../../model/policy/mountain-scoring-policy.js";
+import PlanFoothillsContract from "../contract.js";
 import { computeHexDistanceToMask } from "../rules/distance-to-mask.js";
 import { computeHillScore } from "../rules/hill-score.js";
-import PlanFoothillsContract from "../contract.js";
 import type { PlanFoothillsTypes } from "../types.js";
 
 function validateFoothillsInputs(input: PlanFoothillsTypes["input"]): {

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/rules/mountain-score.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/rules/mountain-score.ts
@@ -1,6 +1,5 @@
-import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
-
 import { clamp } from "@swooper/mapgen-core/lib/math";
+import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import { resolveBoundaryRegime } from "../../../model/policy/boundary-regime.js";
 import type { MountainScorePolicy } from "../../../model/policy/mountain-scoring-policy.js";
 import { computeOrogenyPotential } from "../../../model/policy/orogeny-potential.js";

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/strategies/default.ts
@@ -15,10 +15,10 @@ import type {
 } from "../../../model/policy/mountain-scoring-policy.js";
 import { encodeNormalizedToU8 } from "../../../model/policy/normalized-byte.js";
 import { computeOrogenyPotential } from "../../../model/policy/orogeny-potential.js";
+import PlanRidgesContract from "../contract.js";
 import { computeFracturePotential } from "../rules/fracture-potential.js";
 import { isStrictLocalMaximumHexWithTies } from "../rules/local-maximum.js";
 import { computeMountainScore } from "../rules/mountain-score.js";
-import PlanRidgesContract from "../contract.js";
 import type { PlanRidgesTypes } from "../types.js";
 
 function validateRidgesInputs(input: PlanRidgesTypes["input"]): {

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-rough-lands/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-rough-lands/strategies/default.ts
@@ -1,7 +1,7 @@
-import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import { clampPct } from "@swooper/mapgen-core";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
+import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import { resolveDriverStrength } from "../../../model/policy/driver-strength.js";
 import { normalizeMountainFractal } from "../../../model/policy/mountain-fractal.js";
 import { encodeNormalizedToU8 } from "../../../model/policy/normalized-byte.js";

--- a/mods/mod-swooper-maps/src/domain/placement/ops/plan-natural-wonders/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/ops/plan-natural-wonders/strategies/default.ts
@@ -30,20 +30,20 @@
  *
  * @see openspec/changes/natural-wonders-full-set-parity-suitability/workstream/natural-wonders-system-reference.md
  */
-import { clamp01 } from "@swooper/mapgen-core";
-import { createStrategy } from "@swooper/mapgen-core/authoring";
-import { getHexNeighborIndicesOddQ, hexDistanceOddQPeriodicX } from "@swooper/mapgen-core/lib/grid";
 
 import {
   isAnyRiverClass,
   RIVER_CLASS_MAJOR,
   RIVER_CLASS_NONE,
 } from "@mapgen/domain/hydrology/model/policy/river-class.js";
+import { clamp01 } from "@swooper/mapgen-core";
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+import { getHexNeighborIndicesOddQ, hexDistanceOddQPeriodicX } from "@swooper/mapgen-core/lib/grid";
 import {
   type GroupSuitabilitySignals,
+  WONDER_GROUPS,
   type WonderGroup,
   wonderGroup,
-  WONDER_GROUPS,
 } from "../../../model/policy/natural-wonder-groups.js";
 import PlanNaturalWondersContract from "../contract.js";
 

--- a/mods/mod-swooper-maps/src/domain/resources/artifacts/earthlike-expectations.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/artifacts/earthlike-expectations.artifact.ts
@@ -1,8 +1,12 @@
-import { defineArtifact, type Static, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 import type { OfficialResourceType } from "@civ7/map-policy";
-import type { EarthlikeResourceExpectationsArtifact } from "../model/data/earthlike-expectations/types.js";
+import {
+  defineArtifact,
+  type Static,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 import { EARTHLIKE_RESOURCE_EXPECTATIONS } from "../model/data/earthlike-expectations/official-earthlike.js";
+import type { EarthlikeResourceExpectationsArtifact } from "../model/data/earthlike-expectations/types.js";
 
 /**
  * Artifact contract for the earthlike per-resource expectation corpus

--- a/mods/mod-swooper-maps/src/domain/resources/model/data/earthlike-expectations/official-earthlike.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/model/data/earthlike-expectations/official-earthlike.ts
@@ -1,9 +1,9 @@
-import { getInitialMapResourcePolicyForType } from "../../policy/initial-map-authoring.js";
 import {
   OFFICIAL_RESOURCE_BY_TYPE,
   OFFICIAL_RESOURCE_CORPUS,
   type OfficialResourceType,
 } from "@civ7/map-policy";
+import { getInitialMapResourcePolicyForType } from "../../policy/initial-map-authoring.js";
 import type {
   EarthlikeResourceExpectation,
   EarthlikeResourceExpectationsArtifact,

--- a/mods/mod-swooper-maps/src/domain/resources/model/data/earthlike-expectations/types.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/model/data/earthlike-expectations/types.ts
@@ -1,13 +1,13 @@
-import type { InitialMapResourceAuthoringStatus } from "../../policy/initial-map-authoring.js";
-import type {
-  ResourceExpectationRangeEvidence,
-  ResourceExpectedCountRange,
-} from "../../schemas/expected-count-range.schema.js";
 import type {
   OfficialAgeType,
   OfficialPlacementConstraintSummary,
   OfficialResourceType,
 } from "@civ7/map-policy";
+import type { InitialMapResourceAuthoringStatus } from "../../policy/initial-map-authoring.js";
+import type {
+  ResourceExpectationRangeEvidence,
+  ResourceExpectedCountRange,
+} from "../../schemas/expected-count-range.schema.js";
 
 export type ResourceExpectationGroupId =
   | "aquatic-coastal-navigable-river"

--- a/mods/mod-swooper-maps/src/domain/resources/model/policy/habitat-eligibility.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/model/policy/habitat-eligibility.ts
@@ -1,13 +1,13 @@
 import type { OfficialResourceType } from "@civ7/map-policy";
-import { AQUATIC_SIGNALS } from "./aquatic-resource-signals.js";
-import { CULTIVATED_SIGNALS } from "./cultivated-resource-signals.js";
-import { GEOLOGICAL_SIGNALS } from "./geological-resource-signals.js";
-import { TERRESTRIAL_SIGNALS } from "./terrestrial-resource-signals.js";
 import type {
   HabitatFieldsOutput,
   HabitatMaskFieldName,
   ResourceFamily,
 } from "../schemas/index.js";
+import { AQUATIC_SIGNALS } from "./aquatic-resource-signals.js";
+import { CULTIVATED_SIGNALS } from "./cultivated-resource-signals.js";
+import { GEOLOGICAL_SIGNALS } from "./geological-resource-signals.js";
+import { TERRESTRIAL_SIGNALS } from "./terrestrial-resource-signals.js";
 
 /**
  * Per-type habitat signal lookup shared between the family demand planners

--- a/mods/mod-swooper-maps/src/domain/resources/model/policy/initial-map-authoring.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/model/policy/initial-map-authoring.ts
@@ -1,9 +1,9 @@
-import { OFFICIAL_RESOURCE_CORPUS } from "@civ7/map-policy";
 import type {
   OfficialAgeType,
   OfficialResourceCorpusEntry,
   OfficialResourceType,
 } from "@civ7/map-policy";
+import { OFFICIAL_RESOURCE_CORPUS } from "@civ7/map-policy";
 
 export const INITIAL_MAP_RESOURCE_AUTHORING_AGE =
   "AGE_ANTIQUITY" as const satisfies OfficialAgeType;

--- a/mods/mod-swooper-maps/src/domain/resources/model/schemas/expected-count-range.schema.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/model/schemas/expected-count-range.schema.ts
@@ -1,4 +1,4 @@
-import { Type, type Static } from "@swooper/mapgen-core/authoring/contracts";
+import { type Static, Type } from "@swooper/mapgen-core/authoring/contracts";
 
 export const ResourceExpectationRangeEvidenceSchema = Type.Union([
   Type.Literal("source-backed"),

--- a/mods/mod-swooper-maps/src/domain/resources/model/schemas/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/model/schemas/index.ts
@@ -1,8 +1,8 @@
 export {
-  ResourceExpectedCountRangeSchema,
+  type ResourceExpectationRangeEvidence,
   ResourceExpectationRangeEvidenceSchema,
   type ResourceExpectedCountRange,
-  type ResourceExpectationRangeEvidence,
+  ResourceExpectedCountRangeSchema,
 } from "./expected-count-range.schema.js";
 
 export {
@@ -15,10 +15,10 @@ export {
 
 export {
   RESOURCE_FAMILIES,
-  ResourceFamilySchema,
-  ResourceSymbolSchema,
   type ResourceFamily,
+  ResourceFamilySchema,
   type ResourceSymbol,
+  ResourceSymbolSchema,
 } from "./resource-family.schema.js";
 
 export {

--- a/mods/mod-swooper-maps/src/domain/resources/ops/adjust-resource-support/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/adjust-resource-support/strategies/default.ts
@@ -1,7 +1,6 @@
+import type { OfficialResourceType } from "@civ7/map-policy";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 import { getHexRadiusIndicesOddQ, hexDistanceOddQPeriodicX } from "@swooper/mapgen-core/lib/grid";
-
-import type { OfficialResourceType } from "@civ7/map-policy";
 import AdjustResourceSupportContract from "../contract.js";
 
 /**

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-aquatic-resources/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-aquatic-resources/strategies/default.ts
@@ -1,6 +1,4 @@
 import { createStrategy } from "@swooper/mapgen-core/authoring";
-
-import PlanAquaticResourcesContract from "../contract.js";
 import {
   AQUATIC_RESOURCE_TYPES,
   AQUATIC_SIGNALS,
@@ -8,6 +6,7 @@ import {
   type AquaticResourceSignals,
   type AquaticResourceType,
 } from "../../../model/policy/aquatic-resource-signals.js";
+import PlanAquaticResourcesContract from "../contract.js";
 
 const DEFAULT_RANGE = {
   baseline: "standard-earthlike-map" as const,

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/contract.ts
@@ -83,7 +83,9 @@ const PlanCultivatedResourcesContract = defineOp({
         TypedArraySchemas.u8({ description: "Warm alluvial, irrigated, or fertile lowland mask." })
       ),
       floodplainOrRiverMask: Type.Optional(
-        TypedArraySchemas.u8({ description: "Floodplain, river, delta, or irrigation signal mask." })
+        TypedArraySchemas.u8({
+          description: "Floodplain, river, delta, or irrigation signal mask.",
+        })
       ),
       warmGrassPlainsMask: Type.Optional(
         TypedArraySchemas.u8({ description: "Warm grassland or plains crop suitability mask." })

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/strategies/default.ts
@@ -1,6 +1,4 @@
 import { createStrategy } from "@swooper/mapgen-core/authoring";
-
-import PlanCultivatedResourcesContract from "../contract.js";
 import {
   CULTIVATED_RESOURCE_TYPES,
   CULTIVATED_SIGNALS,
@@ -8,6 +6,7 @@ import {
   type CultivatedResourceSignals,
   type CultivatedResourceType,
 } from "../../../model/policy/cultivated-resource-signals.js";
+import PlanCultivatedResourcesContract from "../contract.js";
 
 const DEFAULT_RANGE = {
   baseline: "standard-earthlike-map" as const,

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-geological-resources/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-geological-resources/strategies/default.ts
@@ -1,6 +1,4 @@
 import { createStrategy } from "@swooper/mapgen-core/authoring";
-
-import PlanGeologicalResourcesContract from "../contract.js";
 import {
   GEOLOGICAL_RESOURCE_TYPES,
   GEOLOGICAL_SIGNALS,
@@ -8,6 +6,7 @@ import {
   type GeologicalResourceSignals,
   type GeologicalResourceType,
 } from "../../../model/policy/geological-resource-signals.js";
+import PlanGeologicalResourcesContract from "../contract.js";
 
 const DEFAULT_RANGE = {
   baseline: "standard-earthlike-map" as const,

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-terrestrial-resources/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-terrestrial-resources/strategies/default.ts
@@ -1,6 +1,4 @@
 import { createStrategy } from "@swooper/mapgen-core/authoring";
-
-import PlanTerrestrialResourcesContract from "../contract.js";
 import {
   TERRESTRIAL_RESOURCE_TYPES,
   TERRESTRIAL_SIGNALS,
@@ -8,6 +6,7 @@ import {
   type TerrestrialResourceSignals,
   type TerrestrialResourceType,
 } from "../../../model/policy/terrestrial-resource-signals.js";
+import PlanTerrestrialResourcesContract from "../contract.js";
 
 const DEFAULT_RANGE = {
   baseline: "standard-earthlike-map" as const,

--- a/mods/mod-swooper-maps/src/domain/resources/ops/select-resource-sites/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/select-resource-sites/strategies/default.ts
@@ -1,7 +1,6 @@
+import type { OfficialResourceType } from "@civ7/map-policy";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 import { hexDistanceOddQPeriodicX } from "@swooper/mapgen-core/lib/grid";
-
-import type { OfficialResourceType } from "@civ7/map-policy";
 import SelectResourceSitesContract from "../contract.js";
 import { spacingFloorFor } from "../policy/spacing-floors.js";
 

--- a/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/latest-juicy.config.json
@@ -114,20 +114,8 @@
         "computeEraPlateMembership": {
           "strategy": "default",
           "config": {
-            "eraWeights": [
-              0.3,
-              0.25,
-              0.2,
-              0.15,
-              0.1
-            ],
-            "driftStepsByEra": [
-              12,
-              9,
-              6,
-              3,
-              1
-            ]
+            "eraWeights": [0.3, 0.25, 0.2, 0.15, 0.1],
+            "driftStepsByEra": [12, 9, 6, 3, 1]
           }
         },
         "computeEraTectonicFields": {
@@ -629,12 +617,7 @@
               "tropicalThreshold": 30
             },
             "moisture": {
-              "thresholds": [
-                90,
-                188,
-                228,
-                252
-              ]
+              "thresholds": [90, 188, 228, 252]
             },
             "aridity": {
               "temperatureMin": 0,
@@ -645,10 +628,7 @@
               "rainfallWeight": 1.08,
               "bias": 2,
               "normalization": 118,
-              "moistureShiftThresholds": [
-                0.2,
-                0.66
-              ],
+              "moistureShiftThresholds": [0.2, 0.66],
               "vegetationPenalty": 0.78
             },
             "vegetation": {
@@ -899,10 +879,7 @@
             "maxFreeze": 0.5,
             "maxVegetation": 0.5,
             "maxMoisture": 200,
-            "allowedBiomes": [
-              "desert",
-              "temperateDry"
-            ]
+            "allowedBiomes": ["desert", "temperateDry"]
           }
         },
         "scoreBurned": {
@@ -913,10 +890,7 @@
             "maxFreeze": 0.22,
             "maxVegetation": 0.26,
             "maxMoisture": 98,
-            "allowedBiomes": [
-              "temperateDry",
-              "tropicalSeasonal"
-            ]
+            "allowedBiomes": ["temperateDry", "tropicalSeasonal"]
           }
         },
         "scoreJungle": {
@@ -925,9 +899,7 @@
             "minTemperature": 22,
             "minMoisture": 110,
             "minVegetation": 0.45,
-            "allowedBiomes": [
-              "tropicalRainforest"
-            ]
+            "allowedBiomes": ["tropicalRainforest"]
           }
         },
         "plotEffects": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountain-patch.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountain-patch.config.json
@@ -114,20 +114,8 @@
         "computeEraPlateMembership": {
           "strategy": "default",
           "config": {
-            "eraWeights": [
-              0.3,
-              0.25,
-              0.2,
-              0.15,
-              0.1
-            ],
-            "driftStepsByEra": [
-              12,
-              9,
-              6,
-              3,
-              1
-            ]
+            "eraWeights": [0.3, 0.25, 0.2, 0.15, 0.1],
+            "driftStepsByEra": [12, 9, 6, 3, 1]
           }
         },
         "computeEraTectonicFields": {
@@ -629,12 +617,7 @@
               "tropicalThreshold": 30
             },
             "moisture": {
-              "thresholds": [
-                90,
-                188,
-                228,
-                252
-              ]
+              "thresholds": [90, 188, 228, 252]
             },
             "aridity": {
               "temperatureMin": 0,
@@ -645,10 +628,7 @@
               "rainfallWeight": 1.08,
               "bias": 2,
               "normalization": 118,
-              "moistureShiftThresholds": [
-                0.2,
-                0.66
-              ],
+              "moistureShiftThresholds": [0.2, 0.66],
               "vegetationPenalty": 0.78
             },
             "vegetation": {
@@ -899,10 +879,7 @@
             "maxFreeze": 0.3,
             "maxVegetation": 0.23,
             "maxMoisture": 90,
-            "allowedBiomes": [
-              "desert",
-              "temperateDry"
-            ]
+            "allowedBiomes": ["desert", "temperateDry"]
           }
         },
         "scoreBurned": {
@@ -913,10 +890,7 @@
             "maxFreeze": 0.22,
             "maxVegetation": 0.26,
             "maxMoisture": 98,
-            "allowedBiomes": [
-              "temperateDry",
-              "tropicalSeasonal"
-            ]
+            "allowedBiomes": ["temperateDry", "tropicalSeasonal"]
           }
         },
         "scoreJungle": {
@@ -925,9 +899,7 @@
             "minTemperature": 22,
             "minMoisture": 110,
             "minVegetation": 0.45,
-            "allowedBiomes": [
-              "tropicalRainforest"
-            ]
+            "allowedBiomes": ["tropicalRainforest"]
           }
         },
         "plotEffects": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountain-rivers-patch.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountain-rivers-patch.config.json
@@ -114,20 +114,8 @@
         "computeEraPlateMembership": {
           "strategy": "default",
           "config": {
-            "eraWeights": [
-              0.3,
-              0.25,
-              0.2,
-              0.15,
-              0.1
-            ],
-            "driftStepsByEra": [
-              12,
-              9,
-              6,
-              3,
-              1
-            ]
+            "eraWeights": [0.3, 0.25, 0.2, 0.15, 0.1],
+            "driftStepsByEra": [12, 9, 6, 3, 1]
           }
         },
         "computeEraTectonicFields": {
@@ -629,12 +617,7 @@
               "tropicalThreshold": 30
             },
             "moisture": {
-              "thresholds": [
-                90,
-                188,
-                228,
-                252
-              ]
+              "thresholds": [90, 188, 228, 252]
             },
             "aridity": {
               "temperatureMin": 0,
@@ -645,10 +628,7 @@
               "rainfallWeight": 1.08,
               "bias": 2,
               "normalization": 118,
-              "moistureShiftThresholds": [
-                0.2,
-                0.66
-              ],
+              "moistureShiftThresholds": [0.2, 0.66],
               "vegetationPenalty": 0.78
             },
             "vegetation": {
@@ -899,10 +879,7 @@
             "maxFreeze": 0.3,
             "maxVegetation": 0.23,
             "maxMoisture": 90,
-            "allowedBiomes": [
-              "desert",
-              "temperateDry"
-            ]
+            "allowedBiomes": ["desert", "temperateDry"]
           }
         },
         "scoreBurned": {
@@ -913,10 +890,7 @@
             "maxFreeze": 0.22,
             "maxVegetation": 0.26,
             "maxMoisture": 98,
-            "allowedBiomes": [
-              "temperateDry",
-              "tropicalSeasonal"
-            ]
+            "allowedBiomes": ["temperateDry", "tropicalSeasonal"]
           }
         },
         "scoreJungle": {
@@ -925,9 +899,7 @@
             "minTemperature": 22,
             "minMoisture": 110,
             "minVegetation": 0.45,
-            "allowedBiomes": [
-              "tropicalRainforest"
-            ]
+            "allowedBiomes": ["tropicalRainforest"]
           }
         },
         "plotEffects": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-earthlike.config.json
@@ -114,20 +114,8 @@
         "computeEraPlateMembership": {
           "strategy": "default",
           "config": {
-            "eraWeights": [
-              0.3,
-              0.25,
-              0.2,
-              0.15,
-              0.1
-            ],
-            "driftStepsByEra": [
-              12,
-              9,
-              6,
-              3,
-              1
-            ]
+            "eraWeights": [0.3, 0.25, 0.2, 0.15, 0.1],
+            "driftStepsByEra": [12, 9, 6, 3, 1]
           }
         },
         "computeEraTectonicFields": {
@@ -629,12 +617,7 @@
               "tropicalThreshold": 30
             },
             "moisture": {
-              "thresholds": [
-                90,
-                188,
-                228,
-                252
-              ]
+              "thresholds": [90, 188, 228, 252]
             },
             "aridity": {
               "temperatureMin": 0,
@@ -645,10 +628,7 @@
               "rainfallWeight": 1.08,
               "bias": 2,
               "normalization": 118,
-              "moistureShiftThresholds": [
-                0.2,
-                0.66
-              ],
+              "moistureShiftThresholds": [0.2, 0.66],
               "vegetationPenalty": 0.78
             },
             "vegetation": {
@@ -899,10 +879,7 @@
             "maxFreeze": 0.3,
             "maxVegetation": 0.23,
             "maxMoisture": 90,
-            "allowedBiomes": [
-              "desert",
-              "temperateDry"
-            ]
+            "allowedBiomes": ["desert", "temperateDry"]
           }
         },
         "scoreBurned": {
@@ -913,10 +890,7 @@
             "maxFreeze": 0.22,
             "maxVegetation": 0.26,
             "maxMoisture": 98,
-            "allowedBiomes": [
-              "temperateDry",
-              "tropicalSeasonal"
-            ]
+            "allowedBiomes": ["temperateDry", "tropicalSeasonal"]
           }
         },
         "scoreJungle": {
@@ -925,9 +899,7 @@
             "minTemperature": 22,
             "minMoisture": 110,
             "minVegetation": 0.45,
-            "allowedBiomes": [
-              "tropicalRainforest"
-            ]
+            "allowedBiomes": ["tropicalRainforest"]
           }
         },
         "plotEffects": {

--- a/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-original.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/mountains-of-time-original.config.json
@@ -114,20 +114,8 @@
         "computeEraPlateMembership": {
           "strategy": "default",
           "config": {
-            "eraWeights": [
-              0.3,
-              0.25,
-              0.2,
-              0.15,
-              0.1
-            ],
-            "driftStepsByEra": [
-              12,
-              9,
-              6,
-              3,
-              1
-            ]
+            "eraWeights": [0.3, 0.25, 0.2, 0.15, 0.1],
+            "driftStepsByEra": [12, 9, 6, 3, 1]
           }
         },
         "computeEraTectonicFields": {
@@ -641,12 +629,7 @@
               "tropicalThreshold": 30
             },
             "moisture": {
-              "thresholds": [
-                90,
-                188,
-                228,
-                252
-              ]
+              "thresholds": [90, 188, 228, 252]
             },
             "aridity": {
               "temperatureMin": 0,
@@ -657,10 +640,7 @@
               "rainfallWeight": 1.08,
               "bias": 2,
               "normalization": 118,
-              "moistureShiftThresholds": [
-                0.2,
-                0.66
-              ],
+              "moistureShiftThresholds": [0.2, 0.66],
               "vegetationPenalty": 0.78
             },
             "vegetation": {
@@ -911,10 +891,7 @@
             "maxFreeze": 0.3,
             "maxVegetation": 0.23,
             "maxMoisture": 90,
-            "allowedBiomes": [
-              "desert",
-              "temperateDry"
-            ]
+            "allowedBiomes": ["desert", "temperateDry"]
           }
         },
         "scoreBurned": {
@@ -925,10 +902,7 @@
             "maxFreeze": 0.22,
             "maxVegetation": 0.26,
             "maxMoisture": 98,
-            "allowedBiomes": [
-              "temperateDry",
-              "tropicalSeasonal"
-            ]
+            "allowedBiomes": ["temperateDry", "tropicalSeasonal"]
           }
         },
         "scoreJungle": {
@@ -937,9 +911,7 @@
             "minTemperature": 22,
             "minMoisture": 110,
             "minVegetation": 0.45,
-            "allowedBiomes": [
-              "tropicalRainforest"
-            ]
+            "allowedBiomes": ["tropicalRainforest"]
           }
         },
         "plotEffects": {

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.json
@@ -111,20 +111,8 @@
         "computeEraPlateMembership": {
           "strategy": "default",
           "config": {
-            "eraWeights": [
-              0.3,
-              0.25,
-              0.2,
-              0.15,
-              0.1
-            ],
-            "driftStepsByEra": [
-              12,
-              9,
-              6,
-              3,
-              1
-            ]
+            "eraWeights": [0.3, 0.25, 0.2, 0.15, 0.1],
+            "driftStepsByEra": [12, 9, 6, 3, 1]
           }
         },
         "computeEraTectonicFields": {
@@ -583,12 +571,7 @@
               "tropicalThreshold": 22
             },
             "moisture": {
-              "thresholds": [
-                100,
-                140,
-                180,
-                225
-              ]
+              "thresholds": [100, 140, 180, 225]
             },
             "aridity": {
               "temperatureMin": 0,
@@ -599,10 +582,7 @@
               "rainfallWeight": 1.08,
               "bias": 7,
               "normalization": 104,
-              "moistureShiftThresholds": [
-                0.34,
-                0.58
-              ],
+              "moistureShiftThresholds": [0.34, 0.58],
               "vegetationPenalty": 0.2
             },
             "vegetation": {
@@ -831,10 +811,7 @@
             "maxFreeze": 0.25,
             "maxVegetation": 0.18,
             "maxMoisture": 90,
-            "allowedBiomes": [
-              "desert",
-              "temperateDry"
-            ]
+            "allowedBiomes": ["desert", "temperateDry"]
           }
         },
         "scoreBurned": {
@@ -845,11 +822,7 @@
             "maxFreeze": 0.25,
             "maxVegetation": 0.4,
             "maxMoisture": 128,
-            "allowedBiomes": [
-              "desert",
-              "temperateDry",
-              "tropicalSeasonal"
-            ]
+            "allowedBiomes": ["desert", "temperateDry", "tropicalSeasonal"]
           }
         },
         "scoreJungle": {
@@ -858,9 +831,7 @@
             "minTemperature": 22,
             "minMoisture": 110,
             "minVegetation": 0.45,
-            "allowedBiomes": [
-              "tropicalRainforest"
-            ]
+            "allowedBiomes": ["tropicalRainforest"]
           }
         },
         "plotEffects": {

--- a/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.json
@@ -111,20 +111,8 @@
         "computeEraPlateMembership": {
           "strategy": "default",
           "config": {
-            "eraWeights": [
-              0.3,
-              0.25,
-              0.2,
-              0.15,
-              0.1
-            ],
-            "driftStepsByEra": [
-              12,
-              9,
-              6,
-              3,
-              1
-            ]
+            "eraWeights": [0.3, 0.25, 0.2, 0.15, 0.1],
+            "driftStepsByEra": [12, 9, 6, 3, 1]
           }
         },
         "computeEraTectonicFields": {
@@ -583,12 +571,7 @@
               "tropicalThreshold": 24
             },
             "moisture": {
-              "thresholds": [
-                88,
-                120,
-                162,
-                210
-              ]
+              "thresholds": [88, 120, 162, 210]
             },
             "aridity": {
               "temperatureMin": 2,
@@ -599,10 +582,7 @@
               "rainfallWeight": 1.08,
               "bias": 2,
               "normalization": 132,
-              "moistureShiftThresholds": [
-                0.43,
-                0.66
-              ],
+              "moistureShiftThresholds": [0.43, 0.66],
               "vegetationPenalty": 0.14
             },
             "vegetation": {
@@ -831,10 +811,7 @@
             "maxFreeze": 0.2,
             "maxVegetation": 0.1,
             "maxMoisture": 70,
-            "allowedBiomes": [
-              "desert",
-              "temperateDry"
-            ]
+            "allowedBiomes": ["desert", "temperateDry"]
           }
         },
         "scoreBurned": {
@@ -845,10 +822,7 @@
             "maxFreeze": 0.15,
             "maxVegetation": 0.15,
             "maxMoisture": 90,
-            "allowedBiomes": [
-              "temperateDry",
-              "tropicalSeasonal"
-            ]
+            "allowedBiomes": ["temperateDry", "tropicalSeasonal"]
           }
         },
         "scoreJungle": {
@@ -857,9 +831,7 @@
             "minTemperature": 22,
             "minMoisture": 110,
             "minVegetation": 0.45,
-            "allowedBiomes": [
-              "tropicalRainforest"
-            ]
+            "allowedBiomes": ["tropicalRainforest"]
           }
         },
         "plotEffects": {

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.json
@@ -115,20 +115,8 @@
         "computeEraPlateMembership": {
           "strategy": "default",
           "config": {
-            "eraWeights": [
-              0.3,
-              0.25,
-              0.2,
-              0.15,
-              0.1
-            ],
-            "driftStepsByEra": [
-              12,
-              9,
-              6,
-              3,
-              1
-            ]
+            "eraWeights": [0.3, 0.25, 0.2, 0.15, 0.1],
+            "driftStepsByEra": [12, 9, 6, 3, 1]
           }
         },
         "computeEraTectonicFields": {
@@ -587,12 +575,7 @@
               "tropicalThreshold": 25
             },
             "moisture": {
-              "thresholds": [
-                48,
-                78,
-                112,
-                160
-              ]
+              "thresholds": [48, 78, 112, 160]
             },
             "aridity": {
               "temperatureMin": 2,
@@ -603,10 +586,7 @@
               "rainfallWeight": 0.95,
               "bias": 24,
               "normalization": 76,
-              "moistureShiftThresholds": [
-                0.38,
-                0.62
-              ],
+              "moistureShiftThresholds": [0.38, 0.62],
               "vegetationPenalty": 0.31
             },
             "vegetation": {
@@ -835,10 +815,7 @@
             "maxFreeze": 0.2,
             "maxVegetation": 0.15,
             "maxMoisture": 70,
-            "allowedBiomes": [
-              "desert",
-              "temperateDry"
-            ]
+            "allowedBiomes": ["desert", "temperateDry"]
           }
         },
         "scoreBurned": {
@@ -849,11 +826,7 @@
             "maxFreeze": 0.15,
             "maxVegetation": 0.22,
             "maxMoisture": 90,
-            "allowedBiomes": [
-              "desert",
-              "temperateDry",
-              "tropicalSeasonal"
-            ]
+            "allowedBiomes": ["desert", "temperateDry", "tropicalSeasonal"]
           }
         },
         "scoreJungle": {
@@ -862,9 +835,7 @@
             "minTemperature": 22,
             "minMoisture": 110,
             "minVegetation": 0.45,
-            "allowedBiomes": [
-              "tropicalRainforest"
-            ]
+            "allowedBiomes": ["tropicalRainforest"]
           }
         },
         "plotEffects": {

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -114,20 +114,8 @@
         "computeEraPlateMembership": {
           "strategy": "default",
           "config": {
-            "eraWeights": [
-              0.3,
-              0.25,
-              0.2,
-              0.15,
-              0.1
-            ],
-            "driftStepsByEra": [
-              12,
-              9,
-              6,
-              3,
-              1
-            ]
+            "eraWeights": [0.3, 0.25, 0.2, 0.15, 0.1],
+            "driftStepsByEra": [12, 9, 6, 3, 1]
           }
         },
         "computeEraTectonicFields": {
@@ -646,12 +634,7 @@
               "tropicalThreshold": 30
             },
             "moisture": {
-              "thresholds": [
-                90,
-                188,
-                228,
-                252
-              ]
+              "thresholds": [90, 188, 228, 252]
             },
             "aridity": {
               "temperatureMin": 0,
@@ -662,10 +645,7 @@
               "rainfallWeight": 1.08,
               "bias": 2,
               "normalization": 118,
-              "moistureShiftThresholds": [
-                0.2,
-                0.66
-              ],
+              "moistureShiftThresholds": [0.2, 0.66],
               "vegetationPenalty": 0.78
             },
             "vegetation": {
@@ -916,10 +896,7 @@
             "maxFreeze": 0.3,
             "maxVegetation": 0.23,
             "maxMoisture": 90,
-            "allowedBiomes": [
-              "desert",
-              "temperateDry"
-            ]
+            "allowedBiomes": ["desert", "temperateDry"]
           }
         },
         "scoreBurned": {
@@ -930,10 +907,7 @@
             "maxFreeze": 0.22,
             "maxVegetation": 0.26,
             "maxMoisture": 98,
-            "allowedBiomes": [
-              "temperateDry",
-              "tropicalSeasonal"
-            ]
+            "allowedBiomes": ["temperateDry", "tropicalSeasonal"]
           }
         },
         "scoreJungle": {
@@ -942,9 +916,7 @@
             "minTemperature": 22,
             "minMoisture": 110,
             "minVegetation": 0.45,
-            "allowedBiomes": [
-              "tropicalRainforest"
-            ]
+            "allowedBiomes": ["tropicalRainforest"]
           }
         },
         "plotEffects": {

--- a/mods/mod-swooper-maps/src/recipes/standard/artifacts/foundation-crust-tiles.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/artifacts/foundation-crust-tiles.artifact.ts
@@ -1,6 +1,10 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /** Foundation crust tiles artifact payload (tile-space crust driver tensors). */
 export const Schema = Type.Object(

--- a/mods/mod-swooper-maps/src/recipes/standard/artifacts/foundation-plates.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/artifacts/foundation-plates.artifact.ts
@@ -1,6 +1,10 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /** Foundation plates artifact payload (tile-space plate tensors). */
 export const Schema = Type.Object(

--- a/mods/mod-swooper-maps/src/recipes/standard/artifacts/foundation-tectonic-history-tiles.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/artifacts/foundation-tectonic-history-tiles.artifact.ts
@@ -1,6 +1,10 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /** Foundation tectonic history tiles era payload (tile-space era fields). */
 const FoundationTectonicHistoryTilesEraArtifactSchema = Type.Object(

--- a/mods/mod-swooper-maps/src/recipes/standard/artifacts/foundation-tectonic-provenance-tiles.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/artifacts/foundation-tectonic-provenance-tiles.artifact.ts
@@ -1,6 +1,10 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /** Foundation tectonic provenance tiles artifact payload (tile-space provenance scalars). */
 export const Schema = Type.Object(

--- a/mods/mod-swooper-maps/src/recipes/standard/artifacts/foundation-tile-to-cell-index.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/artifacts/foundation-tile-to-cell-index.artifact.ts
@@ -1,6 +1,9 @@
-import { defineArtifact, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /** Nearest mesh cellIndex per tileIndex (canonical mesh to tile projection mapping). */
 export const Schema = TypedArraySchemas.i32({

--- a/mods/mod-swooper-maps/src/recipes/standard/artifacts/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/artifacts/index.ts
@@ -8,7 +8,17 @@ import * as placementEngineTerrainSnapshot from "./placement-engine-terrain-snap
 import * as placementSurfaceValidationBoundary from "./placement-surface-validation-boundary.artifact.js";
 import * as projectionMeta from "./projection-meta.artifact.js";
 
-export { foundationCrustTiles, foundationPlates, foundationTectonicHistoryTiles, foundationTectonicProvenanceTiles, foundationTileToCellIndex, landmassRegionSlotByTile, placementEngineTerrainSnapshot, placementSurfaceValidationBoundary, projectionMeta };
+export {
+  foundationCrustTiles,
+  foundationPlates,
+  foundationTectonicHistoryTiles,
+  foundationTectonicProvenanceTiles,
+  foundationTileToCellIndex,
+  landmassRegionSlotByTile,
+  placementEngineTerrainSnapshot,
+  placementSurfaceValidationBoundary,
+  projectionMeta,
+};
 
 export const artifactContracts = {
   foundationCrustTiles,

--- a/mods/mod-swooper-maps/src/recipes/standard/artifacts/landmass-region-slot-by-tile.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/artifacts/landmass-region-slot-by-tile.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const LandmassRegionSlotByTileArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/artifacts/placement-engine-terrain-snapshot.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/artifacts/placement-engine-terrain-snapshot.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const EngineTerrainSnapshotArtifactSchema = Type.Object(
   {
@@ -41,10 +45,6 @@ function issue(message: string): ValidationIssue {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
-}
-
-function isCount(value: unknown): value is number {
-  return Number.isInteger(value) && (value as number) >= 0;
 }
 
 /**

--- a/mods/mod-swooper-maps/src/recipes/standard/artifacts/placement-surface-validation-boundary.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/artifacts/placement-surface-validation-boundary.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const EngineTerrainFactsSnapshotSchema = Type.Object(
   {
@@ -56,10 +60,6 @@ function issue(message: string): ValidationIssue {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
-}
-
-function isCount(value: unknown): value is number {
-  return Number.isInteger(value) && (value as number) >= 0;
 }
 
 /**

--- a/mods/mod-swooper-maps/src/recipes/standard/artifacts/projection-meta.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/artifacts/projection-meta.artifact.ts
@@ -1,5 +1,8 @@
-import { defineArtifact, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const ProjectionMetaArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-biomes/steps/biomes/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-biomes/steps/biomes/index.ts
@@ -1,13 +1,15 @@
 import { defineVizMeta, dumpScalarFieldVariants } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { clamp01 } from "@swooper/mapgen-core/lib/math";
-import { artifacts as ecologyArtifacts } from "../../../ecology/artifacts/index.js";
+import {
+  artifacts as ecologyArtifacts,
+  validators as ecologyArtifactValidators,
+} from "../../../ecology/artifacts/index.js";
 import {
   assertBiomeIndexVizCategoriesCoverSymbols,
   BIOME_INDEX_VIZ_CATEGORIES,
 } from "../../viz.js";
 import BiomesStepContract from "./contract.js";
-import { validators as ecologyArtifactValidators } from "../../../ecology/artifacts/index.js";
 
 const GROUP_BIOMES = "Ecology / Biomes";
 const TILE_SPACE_ID = "tile.hexOddQ" as const;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-floodplains/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-floodplains/index.ts
@@ -1,8 +1,10 @@
 import { ctxStepSeed, defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as ecologyArtifacts } from "../../../ecology/artifacts/index.js";
+import {
+  artifacts as ecologyArtifacts,
+  validators as ecologyArtifactValidators,
+} from "../../../ecology/artifacts/index.js";
 import PlanFloodplainsStepContract from "./contract.js";
-import { validators as ecologyArtifactValidators } from "../../../ecology/artifacts/index.js";
 
 const FLOODPLAIN_FEATURE_INTENTS = new Set([
   "desert-floodplain-minor",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-ice/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-ice/index.ts
@@ -1,8 +1,10 @@
 import { ctxStepSeed } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as ecologyArtifacts } from "../../../ecology/artifacts/index.js";
+import {
+  artifacts as ecologyArtifacts,
+  validators as ecologyArtifactValidators,
+} from "../../../ecology/artifacts/index.js";
 import PlanIceStepContract from "./contract.js";
-import { validators as ecologyArtifactValidators } from "../../../ecology/artifacts/index.js";
 
 export default createStep(PlanIceStepContract, {
   artifacts: implementArtifacts(

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-reefs/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-reefs/index.ts
@@ -1,8 +1,10 @@
 import { ctxStepSeed } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as ecologyArtifacts } from "../../../ecology/artifacts/index.js";
+import {
+  artifacts as ecologyArtifacts,
+  validators as ecologyArtifactValidators,
+} from "../../../ecology/artifacts/index.js";
 import PlanReefsStepContract from "./contract.js";
-import { validators as ecologyArtifactValidators } from "../../../ecology/artifacts/index.js";
 
 const REEF_FEATURE_INTENTS = new Set(["reef", "cold-reef", "atoll", "lotus"]);
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-vegetation/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-vegetation/index.ts
@@ -1,10 +1,11 @@
 import { isAnyRiverClass } from "@mapgen/domain/hydrology/model/policy/river-class.js";
 import { ctxStepSeed } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-
-import { artifacts as ecologyArtifacts } from "../../../ecology/artifacts/index.js";
+import {
+  artifacts as ecologyArtifacts,
+  validators as ecologyArtifactValidators,
+} from "../../../ecology/artifacts/index.js";
 import PlanVegetationStepContract from "./contract.js";
-import { validators as ecologyArtifactValidators } from "../../../ecology/artifacts/index.js";
 
 const VEGETATION_FEATURE_INTENTS = new Set([
   "forest",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-wetlands/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/plan-wetlands/index.ts
@@ -1,10 +1,11 @@
 import { isAnyRiverClass } from "@mapgen/domain/hydrology/model/policy/river-class.js";
 import { ctxStepSeed } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-
-import { artifacts as ecologyArtifacts } from "../../../ecology/artifacts/index.js";
+import {
+  artifacts as ecologyArtifacts,
+  validators as ecologyArtifactValidators,
+} from "../../../ecology/artifacts/index.js";
 import PlanWetlandsStepContract from "./contract.js";
-import { validators as ecologyArtifactValidators } from "../../../ecology/artifacts/index.js";
 
 const WETLANDS_FEATURE_INTENTS = new Set([
   "marsh",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/index.ts
@@ -4,9 +4,11 @@ import { clamp01, ctxStepSeed, defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { forEachHexNeighborOddQ, getHexNeighborIndicesOddQ } from "@swooper/mapgen-core/lib/grid";
 import { PerlinNoise } from "@swooper/mapgen-core/lib/noise";
-import { artifacts as ecologyArtifacts } from "../../../ecology/artifacts/index.js";
+import {
+  artifacts as ecologyArtifacts,
+  validators as ecologyArtifactValidators,
+} from "../../../ecology/artifacts/index.js";
 import ScoreLayersStepContract from "./contract.js";
-import { validators as ecologyArtifactValidators } from "../../../ecology/artifacts/index.js";
 
 const TILE_SPACE_ID = "tile.hexOddQ" as const;
 const MINOR_FLOODPLAIN_DISCHARGE_NORMALIZER = 1000;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-pedology/steps/pedology/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-pedology/steps/pedology/index.ts
@@ -1,9 +1,11 @@
 import { defineVizMeta, dumpScalarFieldVariants } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
-import { artifacts as ecologyArtifacts } from "../../../ecology/artifacts/index.js";
+import {
+  artifacts as ecologyArtifacts,
+  validators as ecologyArtifactValidators,
+} from "../../../ecology/artifacts/index.js";
 import PedologyStepContract from "./contract.js";
-import { validators as ecologyArtifactValidators } from "../../../ecology/artifacts/index.js";
 
 const GROUP_PEDOLOGY = "Ecology / Pedology";
 const TILE_SPACE_ID = "tile.hexOddQ" as const;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-pedology/steps/resource-basins/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-pedology/steps/resource-basins/index.ts
@@ -1,8 +1,10 @@
 import { defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as ecologyArtifacts } from "../../../ecology/artifacts/index.js";
+import {
+  artifacts as ecologyArtifacts,
+  validators as ecologyArtifactValidators,
+} from "../../../ecology/artifacts/index.js";
 import ResourceBasinsStepContract from "./contract.js";
-import { validators as ecologyArtifactValidators } from "../../../ecology/artifacts/index.js";
 
 const GROUP_RESOURCE_BASINS = "Ecology / Resource Basins";
 const TILE_SPACE_ID = "tile.hexOddQ" as const;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/biome-bindings.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/biome-bindings.artifact.ts
@@ -3,8 +3,8 @@ import {
   type Static,
   Type,
   TypedArraySchemas,
+  validateArtifactSchema,
 } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 export const BiomeBindingsArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/biome-classification.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/biome-classification.artifact.ts
@@ -4,8 +4,8 @@ import {
   type Static,
   Type,
   TypedArraySchemas,
+  validateArtifactSchema,
 } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 export const BiomeClassificationArtifactSchema = Type.Object({
   width: Type.Integer({ minimum: 1 }),
@@ -33,10 +33,6 @@ export const artifact = defineArtifact({
 });
 
 export type ArtifactValidationIssue = Readonly<{ message: string }>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 function expectedSize(dimensions: NonNullable<ArtifactValidationContext["dimensions"]>): number {
   return Math.max(0, (dimensions.width | 0) * (dimensions.height | 0));

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/feature-apply-diagnostics.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/feature-apply-diagnostics.artifact.ts
@@ -3,8 +3,8 @@ import {
   type Static,
   Type,
   TypedArraySchemas,
+  validateArtifactSchema,
 } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 export const FeatureApplyDiagnosticsArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/feature-intents-floodplains.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/feature-intents-floodplains.artifact.ts
@@ -1,6 +1,10 @@
 import { FeaturePlacementSchema } from "@mapgen/domain/ecology/model/schemas/index.js";
-import { defineArtifact, type Static, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  type Static,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 export const FeaturePlacementIntentSchema = FeaturePlacementSchema;
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/feature-intents-ice.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/feature-intents-ice.artifact.ts
@@ -1,6 +1,10 @@
 import { FeaturePlacementSchema } from "@mapgen/domain/ecology/model/schemas/index.js";
-import { defineArtifact, type Static, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  type Static,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 export const FeaturePlacementIntentSchema = FeaturePlacementSchema;
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/feature-intents-reefs.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/feature-intents-reefs.artifact.ts
@@ -1,6 +1,10 @@
 import { FeaturePlacementSchema } from "@mapgen/domain/ecology/model/schemas/index.js";
-import { defineArtifact, type Static, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  type Static,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 export const FeaturePlacementIntentSchema = FeaturePlacementSchema;
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/feature-intents-vegetation.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/feature-intents-vegetation.artifact.ts
@@ -1,6 +1,10 @@
 import { FeaturePlacementSchema } from "@mapgen/domain/ecology/model/schemas/index.js";
-import { defineArtifact, type Static, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  type Static,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 export const FeaturePlacementIntentSchema = FeaturePlacementSchema;
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/feature-intents-wetlands.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/feature-intents-wetlands.artifact.ts
@@ -1,6 +1,10 @@
 import { FeaturePlacementSchema } from "@mapgen/domain/ecology/model/schemas/index.js";
-import { defineArtifact, type Static, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  type Static,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 export const FeaturePlacementIntentSchema = FeaturePlacementSchema;
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/index.ts
@@ -17,7 +17,26 @@ import * as plotEffectPlan from "./plot-effect-plan.artifact.js";
 import * as resourceBasins from "./resource-basins.artifact.js";
 import * as scoreLayers from "./score-layers.artifact.js";
 
-export { biomeBindings, biomeClassification, featureApplyDiagnostics, featureIntentsFloodplains, featureIntentsIce, featureIntentsReefs, featureIntentsVegetation, featureIntentsWetlands, occupancyBase, occupancyFloodplains, occupancyIce, occupancyReefs, occupancyVegetation, occupancyWetlands, pedology, plotEffectPlan, resourceBasins, scoreLayers };
+export {
+  biomeBindings,
+  biomeClassification,
+  featureApplyDiagnostics,
+  featureIntentsFloodplains,
+  featureIntentsIce,
+  featureIntentsReefs,
+  featureIntentsVegetation,
+  featureIntentsWetlands,
+  occupancyBase,
+  occupancyFloodplains,
+  occupancyIce,
+  occupancyReefs,
+  occupancyVegetation,
+  occupancyWetlands,
+  pedology,
+  plotEffectPlan,
+  resourceBasins,
+  scoreLayers,
+};
 
 export const artifactContracts = {
   biomeBindings,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/occupancy-base.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/occupancy-base.artifact.ts
@@ -4,8 +4,8 @@ import {
   type Static,
   Type,
   TypedArraySchemas,
+  validateArtifactSchema,
 } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 export const OccupancyArtifactSchema = Type.Object({
   width: Type.Integer({ minimum: 1 }),
@@ -29,10 +29,6 @@ export const artifact = defineArtifact({
 });
 
 export type ArtifactValidationIssue = Readonly<{ message: string }>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 function expectedSize(dimensions: NonNullable<ArtifactValidationContext["dimensions"]>): number {
   return Math.max(0, (dimensions.width | 0) * (dimensions.height | 0));

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/occupancy-floodplains.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/occupancy-floodplains.artifact.ts
@@ -4,8 +4,8 @@ import {
   type Static,
   Type,
   TypedArraySchemas,
+  validateArtifactSchema,
 } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 export const OccupancyArtifactSchema = Type.Object({
   width: Type.Integer({ minimum: 1 }),
@@ -29,10 +29,6 @@ export const artifact = defineArtifact({
 });
 
 export type ArtifactValidationIssue = Readonly<{ message: string }>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 function expectedSize(dimensions: NonNullable<ArtifactValidationContext["dimensions"]>): number {
   return Math.max(0, (dimensions.width | 0) * (dimensions.height | 0));

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/occupancy-ice.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/occupancy-ice.artifact.ts
@@ -4,8 +4,8 @@ import {
   type Static,
   Type,
   TypedArraySchemas,
+  validateArtifactSchema,
 } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 export const OccupancyArtifactSchema = Type.Object({
   width: Type.Integer({ minimum: 1 }),
@@ -29,10 +29,6 @@ export const artifact = defineArtifact({
 });
 
 export type ArtifactValidationIssue = Readonly<{ message: string }>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 function expectedSize(dimensions: NonNullable<ArtifactValidationContext["dimensions"]>): number {
   return Math.max(0, (dimensions.width | 0) * (dimensions.height | 0));

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/occupancy-reefs.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/occupancy-reefs.artifact.ts
@@ -4,8 +4,8 @@ import {
   type Static,
   Type,
   TypedArraySchemas,
+  validateArtifactSchema,
 } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 export const OccupancyArtifactSchema = Type.Object({
   width: Type.Integer({ minimum: 1 }),
@@ -29,10 +29,6 @@ export const artifact = defineArtifact({
 });
 
 export type ArtifactValidationIssue = Readonly<{ message: string }>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 function expectedSize(dimensions: NonNullable<ArtifactValidationContext["dimensions"]>): number {
   return Math.max(0, (dimensions.width | 0) * (dimensions.height | 0));

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/occupancy-vegetation.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/occupancy-vegetation.artifact.ts
@@ -4,8 +4,8 @@ import {
   type Static,
   Type,
   TypedArraySchemas,
+  validateArtifactSchema,
 } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 export const OccupancyArtifactSchema = Type.Object({
   width: Type.Integer({ minimum: 1 }),
@@ -29,10 +29,6 @@ export const artifact = defineArtifact({
 });
 
 export type ArtifactValidationIssue = Readonly<{ message: string }>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 function expectedSize(dimensions: NonNullable<ArtifactValidationContext["dimensions"]>): number {
   return Math.max(0, (dimensions.width | 0) * (dimensions.height | 0));

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/occupancy-wetlands.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/occupancy-wetlands.artifact.ts
@@ -4,8 +4,8 @@ import {
   type Static,
   Type,
   TypedArraySchemas,
+  validateArtifactSchema,
 } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 export const OccupancyArtifactSchema = Type.Object({
   width: Type.Integer({ minimum: 1 }),
@@ -29,10 +29,6 @@ export const artifact = defineArtifact({
 });
 
 export type ArtifactValidationIssue = Readonly<{ message: string }>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 function expectedSize(dimensions: NonNullable<ArtifactValidationContext["dimensions"]>): number {
   return Math.max(0, (dimensions.width | 0) * (dimensions.height | 0));

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/pedology.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/pedology.artifact.ts
@@ -4,8 +4,8 @@ import {
   type Static,
   Type,
   TypedArraySchemas,
+  validateArtifactSchema,
 } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 export const PedologyArtifactSchema = Type.Object({
   width: Type.Integer({ minimum: 1 }),
@@ -25,10 +25,6 @@ export const artifact = defineArtifact({
 });
 
 export type ArtifactValidationIssue = Readonly<{ message: string }>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 function expectedSize(dimensions: NonNullable<ArtifactValidationContext["dimensions"]>): number {
   return Math.max(0, (dimensions.width | 0) * (dimensions.height | 0));

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/plot-effect-plan.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/plot-effect-plan.artifact.ts
@@ -1,15 +1,15 @@
+import type { PlotEffectIntentKey } from "@mapgen/domain/ecology";
 import {
   defineArtifact,
   type Static,
   Type,
-  TypedArraySchemas,
+  validateArtifactSchema,
 } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
-import type { PlotEffectIntentKey } from "@mapgen/domain/ecology";
 
 const PlotEffectIntentKeyArtifactSchema = Type.Unsafe<PlotEffectIntentKey>(
   Type.String({
-    description: "Abstract plot-effect intent planned by Ecology and later projected by map-ecology.",
+    description:
+      "Abstract plot-effect intent planned by Ecology and later projected by map-ecology.",
     enum: [
       "snow-light",
       "snow-medium",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/resource-basins.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/resource-basins.artifact.ts
@@ -3,9 +3,8 @@ import {
   defineArtifact,
   type Static,
   Type,
-  TypedArraySchemas,
+  validateArtifactSchema,
 } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 export const ResourceBasinsArtifactSchema = Type.Object({
   basins: Type.Array(
@@ -29,33 +28,6 @@ export const artifact = defineArtifact({
 });
 
 export type ArtifactValidationIssue = Readonly<{ message: string }>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function expectedSize(dimensions: NonNullable<ArtifactValidationContext["dimensions"]>): number {
-  return Math.max(0, (dimensions.width | 0) * (dimensions.height | 0));
-}
-
-function validateTypedArray(
-  errors: ArtifactValidationIssue[],
-  label: string,
-  value: unknown,
-  ctor: { new (...args: any[]): { length: number } },
-  expectedLength?: number
-): value is { length: number } {
-  if (!(value instanceof ctor)) {
-    errors.push({ message: `Expected ${label} to be ${ctor.name}.` });
-    return false;
-  }
-  if (expectedLength != null && value.length !== expectedLength) {
-    errors.push({
-      message: `Expected ${label} length ${expectedLength} (received ${value.length}).`,
-    });
-  }
-  return true;
-}
 
 function isResourceBasinsArtifact(value: unknown): value is ResourceBasinsArtifact {
   if (!value || typeof value !== "object") return false;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/score-layers.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts/score-layers.artifact.ts
@@ -5,8 +5,8 @@ import {
   type Static,
   Type,
   TypedArraySchemas,
+  validateArtifactSchema,
 } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 export const ScoreLayersArtifactSchema = Type.Object({
   width: Type.Integer({ minimum: 1 }),

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-lithosphere/steps/crust.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-lithosphere/steps/crust.contract.ts
@@ -1,7 +1,5 @@
-import foundation from "@mapgen/domain/foundation";
+import foundation, { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
-
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 
 const CrustStepContract = defineStep({
   id: "crust",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-lithosphere/steps/crust.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-lithosphere/steps/crust.ts
@@ -1,7 +1,9 @@
-import { validators as foundationArtifactValidators } from "@mapgen/domain/foundation";
+import {
+  artifacts as foundationArtifacts,
+  validators as foundationArtifactValidators,
+} from "@mapgen/domain/foundation";
 import { ctxRandom, ctxRandomLabel, defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { interleaveXY } from "../../foundation/viz.js";
 import CrustStepContract from "./crust.contract.js";
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-lithosphere/steps/plateGraph.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-lithosphere/steps/plateGraph.contract.ts
@@ -1,7 +1,5 @@
-import foundation from "@mapgen/domain/foundation";
+import foundation, { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
-
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 
 const PlateGraphStepContract = defineStep({
   id: "plate-graph",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-lithosphere/steps/plateGraph.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-lithosphere/steps/plateGraph.ts
@@ -1,7 +1,9 @@
-import { validators as foundationArtifactValidators } from "@mapgen/domain/foundation";
+import {
+  artifacts as foundationArtifacts,
+  validators as foundationArtifactValidators,
+} from "@mapgen/domain/foundation";
 import { clampInt, ctxRandom, ctxRandomLabel, defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { interleaveXY, pointsFromPlateSeeds } from "../../foundation/viz.js";
 import PlateGraphStepContract from "./plateGraph.contract.js";
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mantleForcing.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mantleForcing.contract.ts
@@ -1,7 +1,5 @@
-import foundation from "@mapgen/domain/foundation";
+import foundation, { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
-
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 
 const MantleForcingStepContract = defineStep({
   id: "mantle-forcing",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mantleForcing.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mantleForcing.ts
@@ -1,7 +1,9 @@
-import { validators as foundationArtifactValidators } from "@mapgen/domain/foundation";
+import {
+  artifacts as foundationArtifacts,
+  validators as foundationArtifactValidators,
+} from "@mapgen/domain/foundation";
 import { defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { interleaveXY } from "../../foundation/viz.js";
 import MantleForcingStepContract from "./mantleForcing.contract.js";
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mantlePotential.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mantlePotential.contract.ts
@@ -1,7 +1,5 @@
-import foundation from "@mapgen/domain/foundation";
+import foundation, { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
-
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 
 const MantlePotentialStepContract = defineStep({
   id: "mantle-potential",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mantlePotential.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mantlePotential.ts
@@ -1,7 +1,9 @@
-import { validators as foundationArtifactValidators } from "@mapgen/domain/foundation";
+import {
+  artifacts as foundationArtifacts,
+  validators as foundationArtifactValidators,
+} from "@mapgen/domain/foundation";
 import { ctxRandom, ctxRandomLabel, defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { interleaveXY } from "../../foundation/viz.js";
 import MantlePotentialStepContract from "./mantlePotential.contract.js";
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mesh.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mesh.contract.ts
@@ -1,7 +1,5 @@
-import foundation from "@mapgen/domain/foundation";
+import foundation, { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
-
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 
 const MeshStepContract = defineStep({
   id: "mesh",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mesh.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-mantle/steps/mesh.ts
@@ -1,7 +1,9 @@
-import { validators as foundationArtifactValidators } from "@mapgen/domain/foundation";
+import {
+  artifacts as foundationArtifacts,
+  validators as foundationArtifactValidators,
+} from "@mapgen/domain/foundation";
 import { clampInt, ctxRandom, ctxRandomLabel, defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { interleaveXY, segmentsFromMeshNeighbors } from "../../foundation/viz.js";
 import MeshStepContract from "./mesh.contract.js";
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-orogeny/steps/crustEvolution.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-orogeny/steps/crustEvolution.contract.ts
@@ -1,7 +1,5 @@
-import foundation from "@mapgen/domain/foundation";
+import foundation, { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
-
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 
 const CrustEvolutionStepContract = defineStep({
   id: "crust-evolution",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-orogeny/steps/crustEvolution.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-orogeny/steps/crustEvolution.ts
@@ -1,12 +1,13 @@
-import { validators as foundationArtifactValidators } from "@mapgen/domain/foundation";
+import {
+  artifacts as foundationArtifacts,
+  validators as foundationArtifactValidators,
+} from "@mapgen/domain/foundation";
 import {
   resolveContinentalAbundance,
   resolveContinentalRelief,
 } from "@mapgen/domain/foundation/model/policy/crust-character.js";
 import { defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { interleaveXY } from "../../foundation/viz.js";
 import CrustEvolutionStepContract from "./crustEvolution.contract.js";
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-projection/steps/plateTopology.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-projection/steps/plateTopology.contract.ts
@@ -1,7 +1,6 @@
-import foundation from "@mapgen/domain/foundation";
+import foundation, { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import { mapArtifacts } from "../../../map-artifacts.js";
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 
 const PlateTopologyStepContract = defineStep({
   id: "plate-topology",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-projection/steps/plateTopology.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-projection/steps/plateTopology.ts
@@ -1,8 +1,9 @@
-import { validators as foundationArtifactValidators } from "@mapgen/domain/foundation";
+import {
+  artifacts as foundationArtifacts,
+  validators as foundationArtifactValidators,
+} from "@mapgen/domain/foundation";
 import { defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import {
   pointsFromTileCentroids,
   segmentsFromTileTopologyNeighbors,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-projection/steps/projection.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-projection/steps/projection.contract.ts
@@ -1,7 +1,6 @@
-import foundation from "@mapgen/domain/foundation";
+import foundation, { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
 import { mapArtifacts } from "../../../map-artifacts.js";
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 
 const ProjectionStepContract = defineStep({
   id: "projection",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-projection/steps/projection.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-projection/steps/projection.ts
@@ -5,9 +5,9 @@ import {
   renderAsciiGrid,
 } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
+import { validators as standardArtifactValidators } from "../../../artifacts/index.js";
 import { mapArtifacts } from "../../../map-artifacts.js";
 import ProjectionStepContract from "./projection.contract.js";
-import { validators as standardArtifactValidators } from "../../../artifacts/index.js";
 
 const GROUP_PLATES = "Foundation / Plates";
 const GROUP_CRUST_TILES = "Foundation / Crust Tiles";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-tectonics/steps/plateMotion.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-tectonics/steps/plateMotion.contract.ts
@@ -1,7 +1,5 @@
-import foundation from "@mapgen/domain/foundation";
+import foundation, { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
-
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 
 const PlateMotionStepContract = defineStep({
   id: "plate-motion",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-tectonics/steps/plateMotion.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-tectonics/steps/plateMotion.ts
@@ -1,9 +1,10 @@
-import { validators as foundationArtifactValidators } from "@mapgen/domain/foundation";
+import {
+  artifacts as foundationArtifacts,
+  validators as foundationArtifactValidators,
+} from "@mapgen/domain/foundation";
 import { defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { wrapDeltaPeriodic } from "@swooper/mapgen-core/lib/math";
-
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import PlateMotionStepContract from "./plateMotion.contract.js";
 
 const GROUP_PLATE_MOTION = "Foundation / Plate Motion";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-tectonics/steps/tectonics.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-tectonics/steps/tectonics.contract.ts
@@ -1,7 +1,5 @@
-import foundation from "@mapgen/domain/foundation";
+import foundation, { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { defineStep, Type } from "@swooper/mapgen-core/authoring/contracts";
-
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 
 const TectonicsStepContract = defineStep({
   id: "tectonics",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-tectonics/steps/tectonics.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-tectonics/steps/tectonics.ts
@@ -1,9 +1,10 @@
-import { validators as foundationArtifactValidators } from "@mapgen/domain/foundation";
+import {
+  artifacts as foundationArtifacts,
+  validators as foundationArtifactValidators,
+} from "@mapgen/domain/foundation";
 import { resolvePlateActivityOrogenyMultiplier } from "@mapgen/domain/foundation/model/policy/plate-activity.js";
 import { defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { interleaveXY, segmentsFromCellPairs } from "../../foundation/viz.js";
 import TectonicsStepContract from "./tectonics.contract.js";
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/artifacts/wind-field.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/artifacts/wind-field.artifact.ts
@@ -1,10 +1,5 @@
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import {
-  defineArtifact,
-  Type,
-  TypedArraySchemas,
-  validateArtifactSchema,
-} from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 import { HydrologyWindFieldSchema } from "./wind-field.schema.js";
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.ts
@@ -21,8 +21,10 @@ import {
 } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { estimateCurlZOddQ, estimateDivergenceOddQ } from "@swooper/mapgen-core/lib/grid";
-import { validators as hydrologyClimateBaselineArtifactValidators } from "../artifacts/index.js";
-import { artifacts as hydrologyClimateBaselineArtifacts } from "../artifacts/index.js";
+import {
+  artifacts as hydrologyClimateBaselineArtifacts,
+  validators as hydrologyClimateBaselineArtifactValidators,
+} from "../artifacts/index.js";
 import ClimateBaselineStepContract from "./climateBaseline.contract.js";
 
 type HydrologyDrynessKnob = "wet" | "mix" | "dry";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/artifacts/climate-diagnostics.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/artifacts/climate-diagnostics.artifact.ts
@@ -1,6 +1,10 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 export const HydrologyClimateDiagnosticsSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/artifacts/climate-indices.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/artifacts/climate-indices.artifact.ts
@@ -1,6 +1,10 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /**
  * Indices derived from climate signals intended for downstream consumption (Ecology/Narrative/Placement).

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/artifacts/cryosphere.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/artifacts/cryosphere.artifact.ts
@@ -1,6 +1,10 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /**
  * Cryosphere state products (snow/sea-ice/albedo proxies).

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/steps/climateRefine.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/steps/climateRefine.ts
@@ -1,12 +1,13 @@
 import {
+  HYDROLOGY_DRYNESS_WETNESS_SCALE,
+  HYDROLOGY_TEMPERATURE_BASE_TEMPERATURE_C,
+} from "@mapgen/domain/hydrology/model/policy/climate-knob-policy.js";
+import { computeRiverAdjacencyMaskFromRiverClass } from "@mapgen/domain/hydrology/model/policy/river-adjacency.js";
+import {
   isMajorRiverClass,
   isMinorRiverClass,
   RIVER_CLASS_NONE,
 } from "@mapgen/domain/hydrology/model/policy/river-class.js";
-import {
-  HYDROLOGY_DRYNESS_WETNESS_SCALE,
-  HYDROLOGY_TEMPERATURE_BASE_TEMPERATURE_C,
-} from "@mapgen/domain/hydrology/model/policy/climate-knob-policy.js";
 import {
   ctxRandom,
   ctxRandomLabel,
@@ -15,9 +16,10 @@ import {
   writeClimateField,
 } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { computeRiverAdjacencyMaskFromRiverClass } from "@mapgen/domain/hydrology/model/policy/river-adjacency.js";
-import { validators as hydrologyClimateRefineArtifactValidators } from "../artifacts/index.js";
-import { artifacts as hydrologyClimateRefineArtifacts } from "../artifacts/index.js";
+import {
+  artifacts as hydrologyClimateRefineArtifacts,
+  validators as hydrologyClimateRefineArtifactValidators,
+} from "../artifacts/index.js";
 import ClimateRefineStepContract from "./climateRefine.contract.js";
 
 type HydrologyCryosphereKnob = "off" | "on";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/artifacts/hydrography.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/artifacts/hydrography.artifact.ts
@@ -1,7 +1,11 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 import { findInvalidRiverClassIndex } from "@mapgen/domain/hydrology/model/policy/river-class.js";
+import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /**
  * Snapshot of Hydrology hydrography derived from Morphology topography + Hydrology discharge projection.

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/artifacts/lake-plan.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/artifacts/lake-plan.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 export const HydrologyLakePlanArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/artifacts/river-network-metrics.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/artifacts/river-network-metrics.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const HydrologyRiverNetworkBenchmarkSummarySchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/rivers.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/rivers.ts
@@ -4,8 +4,10 @@ import {
 } from "@mapgen/domain/hydrology/model/policy/hydrography-knob-policy.js";
 import { defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { validators as hydrologyHydrographyArtifactValidators } from "../artifacts/index.js";
-import { artifacts as hydrologyHydrographyArtifacts } from "../artifacts/index.js";
+import {
+  artifacts as hydrologyHydrographyArtifacts,
+  validators as hydrologyHydrographyArtifactValidators,
+} from "../artifacts/index.js";
 import RiversStepContract from "./rivers.contract.js";
 
 type HydrologyRiverDensityKnob = "sparse" | "normal" | "dense";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plotBiomes.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plotBiomes.ts
@@ -3,8 +3,8 @@ import { defineVizMeta, logBiomeSummary } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { artifacts as ecologyArtifacts } from "../../ecology/artifacts/index.js";
 import { buildEngineBiomeIdVizCategories } from "../viz.js";
-import { clampToByte } from "./plot-biomes/helpers/apply.js";
 import { resolveEngineBiomeIds } from "./plot-biomes/engine-biome-bindings.js";
+import { clampToByte } from "./plot-biomes/helpers/apply.js";
 import PlotBiomesStepContract from "./plotBiomes.contract.js";
 
 const GROUP_MAP_ECOLOGY = "Map / Ecology (Engine)";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-elevation/artifacts/elevation-engine-terrain-snapshot.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-elevation/artifacts/elevation-engine-terrain-snapshot.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const MapElevationEngineTerrainSnapshotArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/artifacts/engine-projection-lakes.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/artifacts/engine-projection-lakes.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 export const MapHydrologyEngineProjectionArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/artifacts/hydrology-lakes-engine-terrain-snapshot.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/artifacts/hydrology-lakes-engine-terrain-snapshot.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 export const Schema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/artifacts/coast-classification.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/artifacts/coast-classification.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const MapMorphologyCoastClassificationArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/artifacts/coast-engine-terrain-snapshot.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/artifacts/coast-engine-terrain-snapshot.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const MapMorphologyEngineTerrainSnapshotArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/artifacts/continent-validation-terrain-snapshot.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/artifacts/continent-validation-terrain-snapshot.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const MapMorphologyEngineTerrainSnapshotArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/artifacts/engine-projection-rivers.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/artifacts/engine-projection-rivers.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const MapRiversEngineProjectionArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/artifacts/projected-navigable-rivers.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/artifacts/projected-navigable-rivers.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const NavigableRiverSignalStatusSchema = Type.Union(
   [

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/artifacts/rivers-engine-terrain-snapshot.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/artifacts/rivers-engine-terrain-snapshot.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 export const Schema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/index.ts
@@ -98,7 +98,6 @@ const MountainRangesPublicSchema = Type.Object(
   }
 );
 
-
 function resolveMountainRangesPublicConfig(value: unknown) {
   const config = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/landmasses.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/landmasses.ts
@@ -1,8 +1,7 @@
 import { defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-
-import LandmassesStepContract from "./landmasses.contract.js";
 import { validators as morphologyArtifactValidators } from "../../morphology/artifacts/index.js";
+import LandmassesStepContract from "./landmasses.contract.js";
 
 const GROUP_LANDMASSES = "Morphology / Landmasses";
 const TILE_SPACE_ID = "tile.hexOddQ" as const;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-routing/steps/routing.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-routing/steps/routing.ts
@@ -1,8 +1,7 @@
 import { defineVizMeta, dumpVectorFieldVariants } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-
-import RoutingStepContract from "./routing.contract.js";
 import { validators as morphologyArtifactValidators } from "../../morphology/artifacts/index.js";
+import RoutingStepContract from "./routing.contract.js";
 
 const GROUP_ROUTING = "Morphology / Routing";
 const TILE_SPACE_ID = "tile.hexOddQ" as const;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/belt-drivers.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/belt-drivers.artifact.ts
@@ -1,6 +1,10 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const MorphologyBeltComponentSummarySchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/coastline-metrics.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/coastline-metrics.artifact.ts
@@ -1,6 +1,10 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const MorphologyCoastlineMetricsArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/index.ts
@@ -8,7 +8,17 @@ import * as substrate from "./substrate.artifact.js";
 import * as topography from "./topography.artifact.js";
 import * as volcanoes from "./volcanoes.artifact.js";
 
-export { beltDrivers, coastlineMetrics, landmasses, mountains, routing, shelf, substrate, topography, volcanoes };
+export {
+  beltDrivers,
+  coastlineMetrics,
+  landmasses,
+  mountains,
+  routing,
+  shelf,
+  substrate,
+  topography,
+  volcanoes,
+};
 
 export const artifactContracts = {
   beltDrivers,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/landmasses.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/landmasses.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const MorphologyLandmassArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/mountains.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/mountains.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const MorphologyMountainsArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/routing.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/routing.artifact.ts
@@ -1,6 +1,10 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const MorphologyRoutingArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/shelf.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/shelf.artifact.ts
@@ -1,6 +1,10 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const MorphologyShelfArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/substrate.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/substrate.artifact.ts
@@ -1,6 +1,10 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const MorphologySubstrateArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/topography.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/topography.artifact.ts
@@ -1,6 +1,10 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
 import type { ArtifactValidationContext } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const MorphologyTopographyArtifactSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/volcanoes.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts/volcanoes.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 const VolcanoKindSchema = Type.Union([
   Type.Literal("subductionArc"),

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/advanced-start-assignment.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/advanced-start-assignment.artifact.ts
@@ -1,5 +1,8 @@
-import { defineArtifact, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /** Advanced-start evidence (`artifact:placement.advancedStartAssignment`). One artifact per file by repo convention. */
 const AdvancedStartAssignmentArtifactSchema = Type.Object(

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/discovery-placement-outcomes.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/discovery-placement-outcomes.artifact.ts
@@ -1,5 +1,8 @@
-import { defineArtifact, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /**
  * Discovery placement summary (`artifact:placement.discoveryPlacementOutcomes`).

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/engine-state.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/engine-state.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /** Terminal engine-state evidence (`artifact:placementEngineState`). One artifact per file by repo convention. */
 const PlacementEngineStateV1Schema = Type.Object(

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/index.ts
@@ -13,7 +13,22 @@ import * as resourcePlan from "./resource-plan.artifact.js";
 import * as resourcePlanAdjusted from "./resource-plan-adjusted.artifact.js";
 import * as startAssignment from "./start-assignment.artifact.js";
 
-export { advancedStartAssignment, discoveryPlacementOutcomes, engineState, naturalWonderPlacement, naturalWonderPlan, placementInputs, placementOutputs, placementSurfacePreparation, resourceDemandPlan, resourceEligibility, resourcePlacementOutcomes, resourcePlan, resourcePlanAdjusted, startAssignment };
+export {
+  advancedStartAssignment,
+  discoveryPlacementOutcomes,
+  engineState,
+  naturalWonderPlacement,
+  naturalWonderPlan,
+  placementInputs,
+  placementOutputs,
+  placementSurfacePreparation,
+  resourceDemandPlan,
+  resourceEligibility,
+  resourcePlacementOutcomes,
+  resourcePlan,
+  resourcePlanAdjusted,
+  startAssignment,
+};
 
 export const artifactContracts = {
   advancedStartAssignment,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/natural-wonder-placement.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/natural-wonder-placement.artifact.ts
@@ -1,5 +1,8 @@
-import { defineArtifact, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /** Natural-wonder stamping outcomes (`artifact:placement.naturalWonderPlacement`). One artifact per file by repo convention. */
 const NaturalWonderPlacementCoordinateDigestSchema = Type.Object(

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/natural-wonder-plan.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/natural-wonder-plan.artifact.ts
@@ -1,6 +1,5 @@
 import placement from "@mapgen/domain/placement";
-import { defineArtifact } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 /** Natural-wonder plan (`artifact:placement.naturalWonderPlan`). One artifact per file by repo convention. */
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/placement-surface-preparation.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/placement-surface-preparation.artifact.ts
@@ -1,5 +1,8 @@
-import { defineArtifact, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /** Surface preparation evidence (`artifact:placement.surfacePreparation`). One artifact per file by repo convention. */
 const PlacementSurfacePreparationSchema = Type.Object(

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/resource-demand-plan.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/resource-demand-plan.artifact.ts
@@ -1,6 +1,9 @@
 import resources from "@mapgen/domain/resources";
-import { defineArtifact, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /** Resource demand plan (`artifact:placement.resourceDemandPlan`). One artifact per file by repo convention. */
 const ResourceFamilySchema = Type.Union([

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/resource-eligibility.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/resource-eligibility.artifact.ts
@@ -1,5 +1,9 @@
-import { defineArtifact, Type, TypedArraySchemas } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  TypedArraySchemas,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /** Per-type eligibility fields (`artifact:placement.resourceEligibility`). One artifact per file by repo convention. */
 const ResourceEligibilityArtifactSchema = Type.Object(

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/resource-placement-outcomes.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/resource-placement-outcomes.artifact.ts
@@ -1,5 +1,8 @@
-import { defineArtifact, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /** Resource stamping outcomes (`artifact:placement.resourcePlacementOutcomes`). One artifact per file by repo convention. */
 const ResourcePlacementOutcomeSchema = Type.Object(

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/resource-plan-adjusted.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/resource-plan-adjusted.artifact.ts
@@ -1,6 +1,5 @@
 import resources from "@mapgen/domain/resources";
-import { defineArtifact } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 /** Support-adjusted resource plan (`artifact:placement.resourcePlanAdjusted`). One artifact per file by repo convention. */
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/resource-plan.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/resource-plan.artifact.ts
@@ -1,6 +1,5 @@
 import resources from "@mapgen/domain/resources";
-import { defineArtifact } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import { defineArtifact, validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
 
 /** Site-selection resource plan (`artifact:placement.resourcePlan`). One artifact per file by repo convention. */
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/start-assignment.artifact.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts/start-assignment.artifact.ts
@@ -1,6 +1,9 @@
 import placement from "@mapgen/domain/placement";
-import { defineArtifact, Type } from "@swooper/mapgen-core/authoring/contracts";
-import { validateArtifactSchema } from "@swooper/mapgen-core/authoring/contracts";
+import {
+  defineArtifact,
+  Type,
+  validateArtifactSchema,
+} from "@swooper/mapgen-core/authoring/contracts";
 
 /** Verified start assignment (`artifact:placement.startAssignment`). One artifact per file by repo convention. */
 const PlanStartsOutputSchema = placement.ops.planStarts.output;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/adjust-resources/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/adjust-resources/index.ts
@@ -1,8 +1,11 @@
+import { OFFICIAL_RESOURCE_BY_TYPE, type OfficialResourceType } from "@civ7/map-policy";
 import { defineVizMeta, deriveStepSeed, type ExtendedMapContext } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { hexDistanceOddQPeriodicX } from "@swooper/mapgen-core/lib/grid";
-import { OFFICIAL_RESOURCE_BY_TYPE, type OfficialResourceType } from "@civ7/map-policy";
-import { artifacts as placementArtifacts } from "../../artifacts/index.js";
+import {
+  artifacts as placementArtifacts,
+  validators as placementArtifactValidators,
+} from "../../artifacts/index.js";
 import { warnLog } from "../../log.js";
 import {
   buildPlacementPointBuffers,
@@ -11,7 +14,6 @@ import {
   transparentNoneCategory,
 } from "../../viz.js";
 import AdjustResourcesStepContract from "./contract.js";
-import { validators as placementArtifactValidators } from "../../artifacts/index.js";
 
 const SUPPORT_ADJUSTMENT_CATEGORIES = [
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-advanced-starts/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-advanced-starts/index.ts
@@ -1,8 +1,10 @@
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as placementArtifacts } from "../../artifacts/index.js";
+import {
+  artifacts as placementArtifacts,
+  validators as placementArtifactValidators,
+} from "../../artifacts/index.js";
 import { runPlacementProductStep } from "../product-runtime.js";
 import AssignAdvancedStartsStepContract from "./contract.js";
-import { validators as placementArtifactValidators } from "../../artifacts/index.js";
 
 export default createStep(AssignAdvancedStartsStepContract, {
   artifacts: implementArtifacts([placementArtifacts.advancedStartAssignment], {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/index.ts
@@ -1,8 +1,10 @@
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as placementArtifacts } from "../../artifacts/index.js";
+import {
+  artifacts as placementArtifacts,
+  validators as placementArtifactValidators,
+} from "../../artifacts/index.js";
 import { runPlacementProductStep } from "../product-runtime.js";
 import AssignStartsStepContract from "./contract.js";
-import { validators as placementArtifactValidators } from "../../artifacts/index.js";
 import {
   emitStartPositionsViz,
   emitStartViabilityViz,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/index.ts
@@ -1,6 +1,9 @@
 import { defineVizMeta, type ExtendedMapContext } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as placementArtifacts } from "../../artifacts/index.js";
+import {
+  artifacts as placementArtifacts,
+  validators as placementArtifactValidators,
+} from "../../artifacts/index.js";
 import { PLACEMENT_TILE_SPACE_ID, PLACEMENT_VIZ_GROUP, UNIT_SCORE_VALUE_SPEC } from "../../viz.js";
 import DerivePlacementInputsContract from "./contract.js";
 import { buildPlacementInputs } from "./inputs.js";
@@ -10,7 +13,6 @@ import {
   traceNaturalWonderPlanInputRuntimeTelemetry,
 } from "./natural-wonder-plan-input-telemetry.js";
 import { logNaturalWonderPlanRuntimeTelemetry } from "./natural-wonder-plan-telemetry.js";
-import { validators as placementArtifactValidators } from "../../artifacts/index.js";
 
 export default createStep(DerivePlacementInputsContract, {
   artifacts: implementArtifacts(

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-discoveries/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-discoveries/index.ts
@@ -1,10 +1,12 @@
 import { CIV7_BROWSER_TABLES_V0 } from "@civ7/map-policy";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as placementArtifacts } from "../../artifacts/index.js";
+import {
+  artifacts as placementArtifacts,
+  validators as placementArtifactValidators,
+} from "../../artifacts/index.js";
 import { runPlacementProductStep } from "../product-runtime.js";
 import PlaceDiscoveriesStepContract from "./contract.js";
 import { placeOfficialDiscoveries } from "./materialize.js";
-import { validators as placementArtifactValidators } from "../../artifacts/index.js";
 
 export default createStep(PlaceDiscoveriesStepContract, {
   artifacts: implementArtifacts([placementArtifacts.discoveryPlacementOutcomes], {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/index.ts
@@ -1,13 +1,15 @@
 import { defineVizMeta, type ExtendedMapContext } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as placementArtifacts } from "../../artifacts/index.js";
+import {
+  artifacts as placementArtifacts,
+  validators as placementArtifactValidators,
+} from "../../artifacts/index.js";
 import {
   buildPlacementPointBuffers,
   PLACEMENT_TILE_SPACE_ID,
   PLACEMENT_VIZ_GROUP,
 } from "../../viz.js";
 import PlaceNaturalWondersStepContract from "./contract.js";
-import { validators as placementArtifactValidators } from "../../artifacts/index.js";
 import {
   logNaturalWonderPlacementRuntimeTelemetry,
   type NaturalWonderStampingStats,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/index.ts
@@ -1,6 +1,9 @@
 import { defineVizMeta, type ExtendedMapContext } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as placementArtifacts } from "../../artifacts/index.js";
+import {
+  artifacts as placementArtifacts,
+  validators as placementArtifactValidators,
+} from "../../artifacts/index.js";
 import { warnLog } from "../../log.js";
 import {
   buildPlacementPointBuffers,
@@ -9,7 +12,6 @@ import {
 } from "../../viz.js";
 import { runPlacementProductStep } from "../product-runtime.js";
 import PlaceResourcesStepContract from "./contract.js";
-import { validators as placementArtifactValidators } from "../../artifacts/index.js";
 import {
   logResourcePlacementRuntimeTelemetry,
   placeResourcesWithTypedOutcomes,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
@@ -5,7 +5,7 @@ import type {
   ResourcePlacementOutcome,
   ResourcePlacementRejectionReason,
 } from "@civ7/adapter";
-import { requireResourceRuntimeId, type OfficialResourceType } from "@civ7/map-policy";
+import { type OfficialResourceType, requireResourceRuntimeId } from "@civ7/map-policy";
 import resources from "@mapgen/domain/resources";
 import type { ExtendedMapContext } from "@swooper/mapgen-core";
 import type { DeepReadonly, Static } from "@swooper/mapgen-core/authoring";
@@ -350,8 +350,9 @@ export function placeResourcesWithTypedOutcomes({
   const shortfallCounts = new Map<string, number>();
 
   for (const planned of plan.intents) {
-    const resourceTypeId = requireResourceRuntimeId(planned.resourceType as OfficialResourceType)
-      .resourceTypeId;
+    const resourceTypeId = requireResourceRuntimeId(
+      planned.resourceType as OfficialResourceType
+    ).resourceTypeId;
     const intent = {
       plotIndex: planned.plotIndex,
       resourceType: resourceTypeId,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/index.ts
@@ -1,10 +1,12 @@
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
+import { validators as standardArtifactValidators } from "../../../../artifacts/index.js";
 import { mapArtifacts } from "../../../../map-artifacts.js";
-import { artifacts as placementArtifacts } from "../../artifacts/index.js";
+import {
+  artifacts as placementArtifacts,
+  validators as placementArtifactValidators,
+} from "../../artifacts/index.js";
 import { applyPlacementPlan } from "./apply.js";
 import PlacementStepContract from "./contract.js";
-import { validators as standardArtifactValidators } from "../../../../artifacts/index.js";
-import { validators as placementArtifactValidators } from "../../artifacts/index.js";
 export default createStep(PlacementStepContract, {
   artifacts: implementArtifacts(
     [

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/index.ts
@@ -1,6 +1,9 @@
 import { defineVizMeta, deriveStepSeed, type ExtendedMapContext } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { artifacts as placementArtifacts } from "../../artifacts/index.js";
+import {
+  artifacts as placementArtifacts,
+  validators as placementArtifactValidators,
+} from "../../artifacts/index.js";
 import {
   buildPlacementPointBuffers,
   PLACEMENT_TILE_SPACE_ID,
@@ -10,7 +13,6 @@ import {
   UNIT_SCORE_VALUE_SPEC,
 } from "../../viz.js";
 import PlanResourcesStepContract from "./contract.js";
-import { validators as placementArtifactValidators } from "../../artifacts/index.js";
 import {
   assertHabitatFieldsOutput,
   buildResourceDemands,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/planning.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/planning.ts
@@ -7,6 +7,7 @@ import {
   type ResourceLegalitySurface,
   resolveResourceRuntimeIds,
 } from "@civ7/map-policy";
+import { default as resources } from "@mapgen/domain/resources";
 import {
   EARTHLIKE_RESOURCE_EXPECTATIONS,
   type EarthlikeResourceExpectation,
@@ -21,9 +22,6 @@ import {
   getInitialMapResourcePolicyForType,
   INITIAL_MAP_RESOURCE_AUTHORING_AGE,
 } from "@mapgen/domain/resources/model/policy/initial-map-authoring.js";
-import {
-  default as resources,
-} from "@mapgen/domain/resources";
 import {
   HABITAT_INTENSITY_FIELD_NAMES,
   HABITAT_MASK_FIELD_NAMES,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plot-landmass-regions/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plot-landmass-regions/index.ts
@@ -1,10 +1,10 @@
 import { balancedHemisphereMeridian, hemisphereSlotForColumn } from "@civ7/map-policy";
 import { defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
+import { validators as standardArtifactValidators } from "../../../../artifacts/index.js";
 import { mapArtifacts } from "../../../../map-artifacts.js";
 import { PLACEMENT_VIZ_GROUP, transparentNoneCategory } from "../../viz.js";
 import PlotLandmassRegionsStepContract from "./contract.js";
-import { validators as standardArtifactValidators } from "../../../../artifacts/index.js";
 
 type RegionSlot = 0 | 1 | 2;
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/index.ts
@@ -1,8 +1,12 @@
 import { defineVizMeta, type ExtendedMapContext } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
+import { validators as standardArtifactValidators } from "../../../../artifacts/index.js";
 import { mapArtifacts } from "../../../../map-artifacts.js";
 import { restoreProjectedCoastTerrain } from "../../../../projection-policies/coastProjectionParity.js";
-import { artifacts as placementArtifacts } from "../../artifacts/index.js";
+import {
+  artifacts as placementArtifacts,
+  validators as placementArtifactValidators,
+} from "../../artifacts/index.js";
 import {
   PLACEMENT_TILE_SPACE_ID,
   PLACEMENT_VIZ_GROUP,
@@ -13,8 +17,6 @@ import { logTerrainStats } from "../terrain-diagnostics.js";
 import PreparePlacementSurfaceStepContract from "./contract.js";
 import { readFinalLakeProjection } from "./lake-readback.js";
 import { applyLandmassRegionSlots } from "./landmass-regions.js";
-import { validators as standardArtifactValidators } from "../../../../artifacts/index.js";
-import { validators as placementArtifactValidators } from "../../artifacts/index.js";
 import {
   readTerrainValidationBoundarySnapshot,
   type TerrainValidationBoundarySnapshot,

--- a/mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts
+++ b/mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts
@@ -83,7 +83,8 @@ function retiredStagePublicKeyPaths(config: unknown): string[] {
     const stageConfig = (config as Record<string, unknown>)[stageId];
     if (!stageConfig || typeof stageConfig !== "object" || Array.isArray(stageConfig)) continue;
     for (const key of retiredKeys) {
-      if (Object.prototype.hasOwnProperty.call(stageConfig, key)) offenders.push(`${stageId}.${key}`);
+      if (Object.prototype.hasOwnProperty.call(stageConfig, key))
+        offenders.push(`${stageId}.${key}`);
     }
   }
   return offenders;
@@ -148,12 +149,12 @@ describe("Shipped map configs", () => {
     const config = swooperEarthlikeConfig.config as any;
 
     expect(config["foundation-mantle"].mesh.computeMesh.config.plateCount).toBe(28);
-    expect(config["foundation-lithosphere"]["plate-graph"].computePlateGraph.config.plateCount).toBe(
-      42
-    );
-    expect(config["foundation-tectonics"]["plate-motion"].computePlateMotion.config.omegaFactor).toBe(
-      1
-    );
+    expect(
+      config["foundation-lithosphere"]["plate-graph"].computePlateGraph.config.plateCount
+    ).toBe(42);
+    expect(
+      config["foundation-tectonics"]["plate-motion"].computePlateMotion.config.omegaFactor
+    ).toBe(1);
     expect(config["hydrology-climate-baseline"]["climate-baseline"].seasonality).toEqual({
       modeCount: 4,
       axialTiltDeg: 23,
@@ -182,24 +183,24 @@ describe("Shipped map configs", () => {
     ) as any;
 
     expect(compiled["foundation-mantle"].mesh.computeMesh.strategy).toBe("default");
-    expect(compiled["hydrology-climate-baseline"]["climate-baseline"].computePrecipitation.strategy).toBe(
-      "default"
-    );
-    expect(compiled["hydrology-climate-refine"]["climate-refine"].computePrecipitation.strategy).toBe(
-      "refine"
-    );
+    expect(
+      compiled["hydrology-climate-baseline"]["climate-baseline"].computePrecipitation.strategy
+    ).toBe("default");
+    expect(
+      compiled["hydrology-climate-refine"]["climate-refine"].computePrecipitation.strategy
+    ).toBe("refine");
     expect(compiled["ecology-pedology"].pedology.classify.strategy).toBe("orogeny-boosted");
     expect(compiled["ecology-pedology"]["resource-basins"].plan.strategy).toBe("mixed");
-    expect(compiled["ecology-features"]["plan-plot-effects"].plotEffects.config.snow).not.toHaveProperty(
-      "selectors"
-    );
-    expect(compiled["ecology-features"]["plan-plot-effects"].plotEffects.config.snow.coveragePct).toBe(
-      55
-    );
+    expect(
+      compiled["ecology-features"]["plan-plot-effects"].plotEffects.config.snow
+    ).not.toHaveProperty("selectors");
+    expect(
+      compiled["ecology-features"]["plan-plot-effects"].plotEffects.config.snow.coveragePct
+    ).toBe(55);
     expect(compiled["map-ecology"]["plot-biomes"]).toEqual({});
-    expect(compiled.placement["derive-placement-inputs"].naturalWonders.config.minSpacingTiles).toBe(
-      6
-    );
+    expect(
+      compiled.placement["derive-placement-inputs"].naturalWonders.config.minSpacingTiles
+    ).toBe(6);
     expect(compiled.placement["assign-starts"].starts.config.desiredSpacingTiles).toBe(9);
   });
 

--- a/mods/mod-swooper-maps/test/config/shipped-map-identity.test.ts
+++ b/mods/mod-swooper-maps/test/config/shipped-map-identity.test.ts
@@ -37,9 +37,9 @@ describe("shipped map config identity", () => {
     expect(swooperEarthlikeConfigRaw.sortIndex).toBe(501);
     expect(earthlike["foundation-tectonics"].knobs.plateActivity).toBe(0.5);
     expect(earthlike["foundation-mantle"].mesh.computeMesh.config.plateCount).toBe(28);
-    expect(earthlike["foundation-lithosphere"]["plate-graph"].computePlateGraph.config.plateCount).toBe(
-      42
-    );
+    expect(
+      earthlike["foundation-lithosphere"]["plate-graph"].computePlateGraph.config.plateCount
+    ).toBe(42);
     expect(earthlike["morphology-shelf"].knobs.shelfWidth).toBe("wide");
     // Re-blessed for the physical-margin shelf model (Path A): the compute-shelf-mask
     // classifier reads a seabed-gradient break (breakGradient/breakGradientScale) off the
@@ -58,8 +58,8 @@ describe("shipped map config identity", () => {
     expect(earthlike["ecology-pedology"].pedology.classify).toMatchObject({
       strategy: "orogeny-boosted",
       config: {
-      reliefWeight: 1.18,
-      bedrockWeight: 0.82,
+        reliefWeight: 1.18,
+        bedrockWeight: 0.82,
       },
     });
     expect(earthlike["ecology-biomes"].biomes.classify.config.moisture.thresholds).toEqual([

--- a/mods/mod-swooper-maps/test/ecology/classify-biomes.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/classify-biomes.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "bun:test";
-
-import ecology from "@mapgen/domain/ecology/ops";
 import { biomeSymbolFromIndex } from "@mapgen/domain/ecology/model/schemas/index.js";
+import ecology from "@mapgen/domain/ecology/ops";
 import { normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
 
 describe("classifyBiomes operation", () => {

--- a/mods/mod-swooper-maps/test/ecology/earthlike-balance-smoke.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/earthlike-balance-smoke.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { createMockAdapter } from "@civ7/adapter";
+import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/model/schemas/index.js";
 import { createExtendedMapContext } from "@swooper/mapgen-core";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 import { realismEarthlikeConfig } from "../../src/maps/presets/realism/earthlike.config.js";
-import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/model/schemas/index.js";
 import standardRecipe from "../../src/recipes/standard/recipe.js";
 import { initializeStandardRuntime } from "../../src/recipes/standard/runtime.js";
 import { artifacts as ecologyArtifacts } from "../../src/recipes/standard/stages/ecology/artifacts/index.js";

--- a/mods/mod-swooper-maps/test/ecology/extremes-regression.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/extremes-regression.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "bun:test";
-
-import ecology from "@mapgen/domain/ecology/ops";
 import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/model/schemas/index.js";
+import ecology from "@mapgen/domain/ecology/ops";
 import { runOpValidated } from "../support/compiler-helpers.js";
 
 describe("ecology defaults regression", () => {

--- a/mods/mod-swooper-maps/test/ecology/feature-planner-policies.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/feature-planner-policies.test.ts
@@ -2,9 +2,8 @@ import { describe, expect, it } from "bun:test";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import ecology from "@mapgen/domain/ecology/ops";
-
 import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/model/schemas/index.js";
+import ecology from "@mapgen/domain/ecology/ops";
 import { normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
 
 function f32(size: number, value: number): Float32Array {

--- a/mods/mod-swooper-maps/test/ecology/features-apply-strictness.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/features-apply-strictness.test.ts
@@ -94,9 +94,7 @@ describe("map-ecology features-apply strictness (M3-008)", () => {
       }
     );
 
-    stageArtifacts.featureIntentsVegetation.publish(ctx, [
-      { x: 0, y: 0, feature: "forest" },
-    ]);
+    stageArtifacts.featureIntentsVegetation.publish(ctx, [{ x: 0, y: 0, feature: "forest" }]);
     stageArtifacts.featureIntentsWetlands.publish(ctx, []);
     stageArtifacts.featureIntentsFloodplains.publish(ctx, []);
     stageArtifacts.featureIntentsReefs.publish(ctx, []);

--- a/mods/mod-swooper-maps/test/ecology/op-contracts.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/op-contracts.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/model/schemas/index.js";
 import ecology from "@mapgen/domain/ecology/ops";
 import { RIVER_CLASS_MINOR } from "@mapgen/domain/hydrology/model/policy/river-class.js";
-import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/model/schemas/index.js";
 import { normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
 
 function broadVegetationHabitatFields(size: number) {

--- a/mods/mod-swooper-maps/test/ecology/vegetation-atomic-op.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/vegetation-atomic-op.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import ecology from "@mapgen/domain/ecology/ops";
 import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/model/schemas/index.js";
+import ecology from "@mapgen/domain/ecology/ops";
 
 import { normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
 

--- a/mods/mod-swooper-maps/test/ecology/vegetation-plan-apply.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/vegetation-plan-apply.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { createMockAdapter } from "@civ7/adapter";
+import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/model/schemas/index.js";
 import ecology from "@mapgen/domain/ecology/ops";
 import { createExtendedMapContext } from "@swooper/mapgen-core";
 import { implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/model/schemas/index.js";
 import { artifacts as ecologyArtifacts } from "../../src/recipes/standard/stages/ecology/artifacts/index.js";
 import planVegetationStep from "../../src/recipes/standard/stages/ecology-features/steps/plan-vegetation/index.js";
 import { artifacts as hydrologyHydrographyArtifacts } from "../../src/recipes/standard/stages/hydrology-hydrography/artifacts/index.js";

--- a/mods/mod-swooper-maps/test/ecology/vegetation-step.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/vegetation-step.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { createMockAdapter } from "@civ7/adapter";
+import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/model/schemas/index.js";
 import ecology from "@mapgen/domain/ecology/ops";
 import { createExtendedMapContext } from "@swooper/mapgen-core";
 import { implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/model/schemas/index.js";
 import { artifacts as ecologyArtifacts } from "../../src/recipes/standard/stages/ecology/artifacts/index.js";
 import planVegetationStep from "../../src/recipes/standard/stages/ecology-features/steps/plan-vegetation/index.js";
 import { artifacts as hydrologyHydrographyArtifacts } from "../../src/recipes/standard/stages/hydrology-hydrography/artifacts/index.js";

--- a/mods/mod-swooper-maps/test/ecology/wetlands-atomic-op.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/wetlands-atomic-op.test.ts
@@ -56,11 +56,7 @@ describe("planWetlands (joint resolver)", () => {
       selection
     );
 
-    expect(result.placements.map((p) => p.feature)).toEqual([
-      "marsh",
-      "oasis",
-      "tundra-bog",
-    ]);
+    expect(result.placements.map((p) => p.feature)).toEqual(["marsh", "oasis", "tundra-bog"]);
   });
 
   it("is deterministic and seed-independent for exact ties", () => {

--- a/mods/mod-swooper-maps/test/ecology/wetlands-step.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/wetlands-step.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { createMockAdapter } from "@civ7/adapter";
+import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/model/schemas/index.js";
 import ecology from "@mapgen/domain/ecology/ops";
 import { createExtendedMapContext } from "@swooper/mapgen-core";
 import { implementArtifacts } from "@swooper/mapgen-core/authoring";
-import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/model/schemas/index.js";
 import { artifacts as ecologyArtifacts } from "../../src/recipes/standard/stages/ecology/artifacts/index.js";
 import planWetlandsStep from "../../src/recipes/standard/stages/ecology-features/steps/plan-wetlands/index.js";
 import { artifacts as hydrologyHydrographyArtifacts } from "../../src/recipes/standard/stages/hydrology-hydrography/artifacts/index.js";

--- a/mods/mod-swooper-maps/test/foundation/contract-guard.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/contract-guard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
+import foundation, { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import {
   FOUNDATION_MANTLE_FORCING_ARTIFACT_TAG,
   FOUNDATION_MANTLE_POTENTIAL_ARTIFACT_TAG,
@@ -11,9 +12,7 @@ import {
   FOUNDATION_TECTONIC_PROVENANCE_TILES_ARTIFACT_TAG,
 } from "@swooper/mapgen-core";
 import * as ts from "typescript";
-import foundation from "@mapgen/domain/foundation";
 import { mapArtifacts } from "../../src/recipes/standard/map-artifacts.js";
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import ProjectionStepContract from "../../src/recipes/standard/stages/foundation-projection/steps/projection.contract.js";
 import TectonicsStepContract from "../../src/recipes/standard/stages/foundation-tectonics/steps/tectonics.contract.js";
 

--- a/mods/mod-swooper-maps/test/foundation/foundation-artifacts.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/foundation-artifacts.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from "bun:test";
-import { crust, crustInit, currentTectonics, mantleForcing, mantlePotential, mesh, plateGraph, plateIdByEra, plateMotion, plateTopology, tectonicEraFields, tectonicEvents, tectonicHistory, tectonicProvenance, tectonicSegments, tracerIndexByEra } from "@mapgen/domain/foundation/artifacts";
+import {
+  crust,
+  crustInit,
+  currentTectonics,
+  mantleForcing,
+  mantlePotential,
+  mesh,
+  plateGraph,
+  plateIdByEra,
+  plateMotion,
+  plateTopology,
+  tectonicEraFields,
+  tectonicEvents,
+  tectonicHistory,
+  tectonicProvenance,
+  tectonicSegments,
+  tracerIndexByEra,
+} from "@mapgen/domain/foundation/artifacts";
 
 type ArtifactModule = Readonly<{
   Schema: unknown;

--- a/mods/mod-swooper-maps/test/foundation/m11-plate-motion.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/m11-plate-motion.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import foundationOpsPublic from "@mapgen/domain/foundation/ops";
 
-const { computeCrust, computeMantleForcing, computeMantlePotential, computeMesh, computePlateGraph, computePlateMotion } = foundationOpsPublic.ops;
+const {
+  computeCrust,
+  computeMantleForcing,
+  computeMantlePotential,
+  computeMesh,
+  computePlateGraph,
+  computePlateMotion,
+} = foundationOpsPublic.ops;
 function allFinite(values: Float32Array): boolean {
   for (let i = 0; i < values.length; i++) {
     const v = values[i] ?? 0;

--- a/mods/mod-swooper-maps/test/foundation/m11-polar-plates-policy.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/m11-polar-plates-policy.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import foundationOpsPublic from "@mapgen/domain/foundation/ops";
 
-const { computeCrust, computeMantleForcing, computeMantlePotential, computeMesh, computePlateGraph } = foundationOpsPublic.ops;
+const {
+  computeCrust,
+  computeMantleForcing,
+  computeMantlePotential,
+  computeMesh,
+  computePlateGraph,
+} = foundationOpsPublic.ops;
 function collectPlateCells(cellToPlate: Int16Array, plateId: number): number[] {
   const out: number[] = [];
   for (let i = 0; i < cellToPlate.length; i++) {

--- a/mods/mod-swooper-maps/test/foundation/m11-projection-boundary-band.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/m11-projection-boundary-band.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from "bun:test";
+import foundationOpsPublic from "@mapgen/domain/foundation/ops";
 import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
 import { runTectonicHistoryChain } from "../support/tectonics-history-runner.js";
-import foundationOpsPublic from "@mapgen/domain/foundation/ops";
 
-const { computeMantleForcing, computeMantlePotential, computeMesh, computePlateGraph, computePlateMotion, computePlatesTensors } = foundationOpsPublic.ops;
+const {
+  computeMantleForcing,
+  computeMantlePotential,
+  computeMesh,
+  computePlateGraph,
+  computePlateMotion,
+  computePlatesTensors,
+} = foundationOpsPublic.ops;
 function computeBoundaryTiles(width: number, height: number, plateId: Int16Array): Uint8Array {
   const size = width * height;
   const boundary = new Uint8Array(size);

--- a/mods/mod-swooper-maps/test/foundation/m11-tectonic-events.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/m11-tectonic-events.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, it } from "bun:test";
-
-import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import foundationOpsPublic from "@mapgen/domain/foundation/ops";
+import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 
-const { computeEraPlateMembership, computeEraTectonicFields, computeHotspotEvents, computePlateMotion, computeSegmentEvents, computeTectonicHistoryRollups, computeTectonicProvenance, computeTectonicSegments, computeTectonicsCurrent, computeTracerAdvection } = foundationOpsPublic.ops;
+const {
+  computeEraPlateMembership,
+  computeEraTectonicFields,
+  computeHotspotEvents,
+  computePlateMotion,
+  computeSegmentEvents,
+  computeTectonicHistoryRollups,
+  computeTectonicProvenance,
+  computeTectonicSegments,
+  computeTectonicsCurrent,
+  computeTracerAdvection,
+} = foundationOpsPublic.ops;
 const OROGENY_ERA_GAIN_MIN = 0.85;
 const OROGENY_ERA_GAIN_MAX = 1.15;
 

--- a/mods/mod-swooper-maps/test/foundation/m11-tectonic-segments-history.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/m11-tectonic-segments-history.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "bun:test";
 import foundationOpsPublic from "@mapgen/domain/foundation/ops";
 
-const { computeEraPlateMembership, computeEraTectonicFields, computeHotspotEvents, computePlateMotion, computeSegmentEvents, computeTectonicHistoryRollups, computeTectonicSegments } = foundationOpsPublic.ops;
+const {
+  computeEraPlateMembership,
+  computeEraTectonicFields,
+  computeHotspotEvents,
+  computePlateMotion,
+  computeSegmentEvents,
+  computeTectonicHistoryRollups,
+  computeTectonicSegments,
+} = foundationOpsPublic.ops;
 const OROGENY_ERA_GAIN_MIN = 0.85;
 const OROGENY_ERA_GAIN_MAX = 1.15;
 

--- a/mods/mod-swooper-maps/test/foundation/mesh-first-ops.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/mesh-first-ops.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from "bun:test";
+import foundationOpsPublic from "@mapgen/domain/foundation/ops";
 import { buildPlateTopology } from "@swooper/mapgen-core/lib/plates";
 import { runTectonicHistoryChain } from "../support/tectonics-history-runner.js";
-import foundationOpsPublic from "@mapgen/domain/foundation/ops";
 
-const { computeCrust, computeMantleForcing, computeMantlePotential, computeMesh, computePlateGraph, computePlateMotion, computePlatesTensors, computeTectonicSegments } = foundationOpsPublic.ops;
+const {
+  computeCrust,
+  computeMantleForcing,
+  computeMantlePotential,
+  computeMesh,
+  computePlateGraph,
+  computePlateMotion,
+  computePlatesTensors,
+  computeTectonicSegments,
+} = foundationOpsPublic.ops;
 function neighborsFor(
   mesh: {
     neighborsOffsets: Int32Array;

--- a/mods/mod-swooper-maps/test/foundation/tile-projection-materials.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/tile-projection-materials.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { HEX_WIDTH } from "@swooper/mapgen-core/lib/grid";
 import foundationOpsPublic from "@mapgen/domain/foundation/ops";
+import { HEX_WIDTH } from "@swooper/mapgen-core/lib/grid";
 
 const { computePlatesTensors } = foundationOpsPublic.ops;
 describe("foundation tile projection (materials)", () => {

--- a/mods/mod-swooper-maps/test/hydrology-ocean-currents-default.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology-ocean-currents-default.test.ts
@@ -56,18 +56,15 @@ describe("hydrology/compute-ocean-surface-currents (default)", () => {
       smoothIters: 0,
       projectionIters: 0,
     });
-    const projected = runOceanSurfaceCurrents(
-      input,
-      {
-        maxSpeed: 80,
-        windStrength: 0.55,
-        ekmanStrength: 0.35,
-        gyreStrength: 0,
-        coastStrength: 0,
-        smoothIters: 0,
-        projectionIters: 12,
-      }
-    );
+    const projected = runOceanSurfaceCurrents(input, {
+      maxSpeed: 80,
+      windStrength: 0.55,
+      ekmanStrength: 0.35,
+      gyreStrength: 0,
+      coastStrength: 0,
+      smoothIters: 0,
+      projectionIters: 12,
+    });
 
     // Land must be zero.
     for (let i = 0; i < size; i++) {

--- a/mods/mod-swooper-maps/test/hydrology-physical-benchmarks.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology-physical-benchmarks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import hydrologyOpsPublic from "@mapgen/domain/hydrology/ops";
 import { HYDROLOGY_LAKEINESS_TERMINAL_BASIN_POLICY } from "@mapgen/domain/hydrology/model/policy/hydrography-knob-policy.js";
+import hydrologyOpsPublic from "@mapgen/domain/hydrology/ops";
 
 const { accumulateDischarge, planLakes, projectRiverNetwork } = hydrologyOpsPublic.ops;
 const SIMPLE_DISCHARGE_CONFIG = {

--- a/mods/mod-swooper-maps/test/hydrology-plan-lakes.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology-plan-lakes.test.ts
@@ -27,10 +27,10 @@ describe("hydrology sink classification", () => {
       {
         strategy: "default",
         config: {
-        runoffScale: 1,
-        infiltrationFraction: 0.15,
-        humidityDampening: 0.25,
-        minRunoff: 0,
+          runoffScale: 1,
+          infiltrationFraction: 0.15,
+          humidityDampening: 0.25,
+          minRunoff: 0,
         },
       }
     );
@@ -59,10 +59,10 @@ describe("hydrology sink classification", () => {
       {
         strategy: "default",
         config: {
-        runoffScale: 1,
-        infiltrationFraction: 0.15,
-        humidityDampening: 0.25,
-        minRunoff: 0,
+          runoffScale: 1,
+          infiltrationFraction: 0.15,
+          humidityDampening: 0.25,
+          minRunoff: 0,
         },
       }
     );

--- a/mods/mod-swooper-maps/test/hydrology-precip-default.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology-precip-default.test.ts
@@ -51,13 +51,13 @@ describe("hydrology/compute-precipitation (default)", () => {
       {
         strategy: "default",
         config: {
-        rainfallScale: 180,
-        humidityExponent: 1,
-        noiseAmplitude: 0,
-        noiseScale: 0.12,
-        waterGradient: { radius: 5, perRingBonus: 4, lowlandBonus: 2, lowlandElevationMax: 150 },
-        upliftStrength: 40,
-        convergenceStrength: 0,
+          rainfallScale: 180,
+          humidityExponent: 1,
+          noiseAmplitude: 0,
+          noiseScale: 0.12,
+          waterGradient: { radius: 5, perRingBonus: 4, lowlandBonus: 2, lowlandElevationMax: 150 },
+          upliftStrength: 40,
+          convergenceStrength: 0,
         },
       }
     );

--- a/mods/mod-swooper-maps/test/hydrology-project-river-network.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology-project-river-network.test.ts
@@ -20,10 +20,10 @@ describe("hydrology/project-river-network (default strategy)", () => {
       {
         strategy: "default",
         config: {
-        minorPercentile: 0.85,
-        majorPercentile: 0.95,
-        minMinorDischarge: 0,
-        minMajorDischarge: 0,
+          minorPercentile: 0.85,
+          majorPercentile: 0.95,
+          minMinorDischarge: 0,
+          minMajorDischarge: 0,
         },
       }
     );
@@ -52,10 +52,10 @@ describe("hydrology/project-river-network (default strategy)", () => {
       {
         strategy: "default",
         config: {
-        minorPercentile: 0.85,
-        majorPercentile: 0.95,
-        minMinorDischarge: 0,
-        minMajorDischarge: 0,
+          minorPercentile: 0.85,
+          majorPercentile: 0.95,
+          minMinorDischarge: 0,
+          minMajorDischarge: 0,
         },
       }
     );
@@ -85,10 +85,10 @@ describe("hydrology/project-river-network (default strategy)", () => {
       {
         strategy: "default",
         config: {
-        minorPercentile: 0,
-        majorPercentile: 1,
-        minMinorDischarge: 30,
-        minMajorDischarge: 120,
+          minorPercentile: 0,
+          majorPercentile: 1,
+          minMinorDischarge: 30,
+          minMajorDischarge: 120,
         },
       }
     );

--- a/mods/mod-swooper-maps/test/hydrology-river-class-contract.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology-river-class-contract.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, it } from "bun:test";
-import { validators as hydrologyHydrographyArtifactValidators } from "../src/recipes/standard/stages/hydrology-hydrography/artifacts/index.js";
-
 import {
   findInvalidRiverClassIndex,
   isAnyRiverClass,
@@ -11,6 +9,7 @@ import {
   RIVER_CLASS_MINOR,
   RIVER_CLASS_NONE,
 } from "@mapgen/domain/hydrology/model/policy/river-class.js";
+import { validators as hydrologyHydrographyArtifactValidators } from "../src/recipes/standard/stages/hydrology-hydrography/artifacts/index.js";
 
 describe("hydrology river class contract", () => {
   it("keeps minor and major/projectable river intent distinct", () => {

--- a/mods/mod-swooper-maps/test/hydrology/river-network-metrics.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology/river-network-metrics.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
-
-import hydrologyOpsPublic from "@mapgen/domain/hydrology/ops";
+import {
+  RIVER_CLASS_MAJOR,
+  RIVER_CLASS_MINOR,
+} from "@mapgen/domain/hydrology/model/policy/river-class.js";
 import {
   HYDROLOGY_FLOW_DRY,
   HYDROLOGY_FLOW_EPHEMERAL,
@@ -12,10 +14,7 @@ import {
   HYDROLOGY_MOUTH_SPILL_PATH,
   HYDROLOGY_SLOPE_FLAT,
 } from "@mapgen/domain/hydrology/model/policy/river-network-metrics.js";
-import {
-  RIVER_CLASS_MAJOR,
-  RIVER_CLASS_MINOR,
-} from "@mapgen/domain/hydrology/model/policy/river-class.js";
+import hydrologyOpsPublic from "@mapgen/domain/hydrology/ops";
 import { runOpValidated } from "../support/compiler-helpers.js";
 
 const { computeRiverNetworkMetrics } = hydrologyOpsPublic.ops;

--- a/mods/mod-swooper-maps/test/map-hydrology/lakes-runtime-fill-drift.test.ts
+++ b/mods/mod-swooper-maps/test/map-hydrology/lakes-runtime-fill-drift.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "bun:test";
 
 import { MockAdapter } from "@civ7/adapter";
+import hydrologyOpsPublic from "@mapgen/domain/hydrology/ops";
 import { COAST_TERRAIN, createExtendedMapContext, FLAT_TERRAIN } from "@swooper/mapgen-core";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 import lakes from "../../src/recipes/standard/stages/map-hydrology/steps/lakes.js";
 import { artifacts as mapMorphologyArtifacts } from "../../src/recipes/standard/stages/map-morphology/artifacts/index.js";
 import plotRivers from "../../src/recipes/standard/stages/map-rivers/steps/plotRivers.js";
 import { buildTestDeps } from "../support/step-deps.js";
-import hydrologyOpsPublic from "@mapgen/domain/hydrology/ops";
 
 const { selectNavigableRiverTerrain } = hydrologyOpsPublic.ops;
 /**

--- a/mods/mod-swooper-maps/test/map-rivers/navigable-river-materialization.test.ts
+++ b/mods/mod-swooper-maps/test/map-rivers/navigable-river-materialization.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import hydrologyOpsPublic from "@mapgen/domain/hydrology/ops";
 import {
   RIVER_CLASS_MAJOR,
   RIVER_CLASS_MINOR,
 } from "@mapgen/domain/hydrology/model/policy/river-class.js";
 import { HYDROLOGY_MOUTH_OCEAN } from "@mapgen/domain/hydrology/model/policy/river-network-metrics.js";
+import hydrologyOpsPublic from "@mapgen/domain/hydrology/ops";
 import { runOpValidated } from "../support/compiler-helpers.js";
 
 const { selectNavigableRiverTerrain } = hydrologyOpsPublic.ops;

--- a/mods/mod-swooper-maps/test/map-rivers/plot-rivers-post-refresh.test.ts
+++ b/mods/mod-swooper-maps/test/map-rivers/plot-rivers-post-refresh.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "bun:test";
 
 import { MockAdapter } from "@civ7/adapter";
 import { RIVER_TYPE_NAVIGABLE } from "@civ7/map-policy";
+import {
+  RIVER_CLASS_MAJOR,
+  RIVER_CLASS_MINOR,
+} from "@mapgen/domain/hydrology/model/policy/river-class.js";
 import hydrologyOpsPublic from "@mapgen/domain/hydrology/ops";
 import {
   createExtendedMapContext,
@@ -9,11 +13,6 @@ import {
   NAVIGABLE_RIVER_TERRAIN,
 } from "@swooper/mapgen-core";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
-
-import {
-  RIVER_CLASS_MAJOR,
-  RIVER_CLASS_MINOR,
-} from "@mapgen/domain/hydrology/model/policy/river-class.js";
 import { artifacts as mapMorphologyArtifacts } from "../../src/recipes/standard/stages/map-morphology/artifacts/index.js";
 import { artifacts as mapRiversArtifacts } from "../../src/recipes/standard/stages/map-rivers/artifacts/index.js";
 import plotRivers from "../../src/recipes/standard/stages/map-rivers/steps/plotRivers.js";

--- a/mods/mod-swooper-maps/test/morphology/belt-drivers-boundary-closeness.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/belt-drivers-boundary-closeness.test.ts
@@ -7,13 +7,13 @@ const { computeBeltDrivers } = morphologyDomain.ops;
 function buildHistoryTiles(width: number, height: number, eraCount: number) {
   const size = width * height;
   const perEra = Array.from({ length: eraCount }, () => ({
-      boundaryType: new Uint8Array(size),
-      upliftPotential: new Uint8Array(size),
-      collisionPotential: new Uint8Array(size),
-      subductionPotential: new Uint8Array(size),
-      riftPotential: new Uint8Array(size),
-      shearStress: new Uint8Array(size),
-    }));
+    boundaryType: new Uint8Array(size),
+    upliftPotential: new Uint8Array(size),
+    collisionPotential: new Uint8Array(size),
+    subductionPotential: new Uint8Array(size),
+    riftPotential: new Uint8Array(size),
+    shearStress: new Uint8Array(size),
+  }));
   const rollups = {
     upliftTotal: new Uint8Array(size),
     collisionTotal: new Uint8Array(size),

--- a/mods/mod-swooper-maps/test/morphology/belt-synthesis-history-provenance.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/belt-synthesis-history-provenance.test.ts
@@ -7,13 +7,13 @@ const { computeBeltDrivers } = morphologyDomain.ops;
 function buildHistoryTiles(width: number, height: number, eraCount: number) {
   const size = width * height;
   const perEra = Array.from({ length: eraCount }, () => ({
-      boundaryType: new Uint8Array(size),
-      upliftPotential: new Uint8Array(size),
-      collisionPotential: new Uint8Array(size),
-      subductionPotential: new Uint8Array(size),
-      riftPotential: new Uint8Array(size),
-      shearStress: new Uint8Array(size),
-    }));
+    boundaryType: new Uint8Array(size),
+    upliftPotential: new Uint8Array(size),
+    collisionPotential: new Uint8Array(size),
+    subductionPotential: new Uint8Array(size),
+    riftPotential: new Uint8Array(size),
+    shearStress: new Uint8Array(size),
+  }));
   const rollups = {
     upliftTotal: new Uint8Array(size),
     collisionTotal: new Uint8Array(size),

--- a/mods/mod-swooper-maps/test/morphology/earthlike-coasts-smoke.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/earthlike-coasts-smoke.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { createMockAdapter } from "@civ7/adapter";
+import morphologyDomain from "@mapgen/domain/morphology/ops";
 import { COAST_TERRAIN, createExtendedMapContext, OCEAN_TERRAIN } from "@swooper/mapgen-core";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
-import morphologyDomain from "@mapgen/domain/morphology/ops";
 import { realismEarthlikeConfig } from "../../src/maps/presets/realism/earthlike.config.js";
 import standardRecipe from "../../src/recipes/standard/recipe.js";
 import { initializeStandardRuntime } from "../../src/recipes/standard/runtime.js";

--- a/mods/mod-swooper-maps/test/morphology/m11-crust-baseline-consumption.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m11-crust-baseline-consumption.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "bun:test";
-
-import { runTectonicHistoryChain } from "../support/tectonics-history-runner.js";
 import foundationOpsPublic from "@mapgen/domain/foundation/ops";
 import morphologyOpsPublic from "@mapgen/domain/morphology/ops";
+import { runTectonicHistoryChain } from "../support/tectonics-history-runner.js";
 
-const { computeCrust, computeMantleForcing, computeMantlePotential, computeMesh, computePlateGraph, computePlateMotion, computePlatesTensors } = foundationOpsPublic.ops;
+const {
+  computeCrust,
+  computeMantleForcing,
+  computeMantlePotential,
+  computeMesh,
+  computePlateGraph,
+  computePlateMotion,
+  computePlatesTensors,
+} = foundationOpsPublic.ops;
 const { computeBaseTopography } = morphologyOpsPublic.ops;
 function quantile(sorted: number[], q: number): number {
   if (sorted.length === 0) return 0;

--- a/mods/mod-swooper-maps/test/morphology/m11-hypsometry-continental-fraction.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m11-hypsometry-continental-fraction.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from "bun:test";
-import { runTectonicHistoryChain } from "../support/tectonics-history-runner.js";
 import foundationOpsPublic from "@mapgen/domain/foundation/ops";
 import morphologyOpsPublic from "@mapgen/domain/morphology/ops";
+import { runTectonicHistoryChain } from "../support/tectonics-history-runner.js";
 
-const { computeCrust, computeMantleForcing, computeMantlePotential, computeMesh, computePlateGraph, computePlateMotion, computePlatesTensors } = foundationOpsPublic.ops;
+const {
+  computeCrust,
+  computeMantleForcing,
+  computeMantlePotential,
+  computeMesh,
+  computePlateGraph,
+  computePlateMotion,
+  computePlatesTensors,
+} = foundationOpsPublic.ops;
 const { computeBaseTopography, computeLandmask, computeSeaLevel } = morphologyOpsPublic.ops;
 function share(numerator: number, denominator: number): number {
   if (denominator <= 0) return 0;

--- a/mods/mod-swooper-maps/test/morphology/m12-mountains-present.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m12-mountains-present.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from "bun:test";
+import foundationOpsPublic from "@mapgen/domain/foundation/ops";
 import morphology from "@mapgen/domain/morphology/ops";
 import { runTectonicHistoryChain } from "../support/tectonics-history-runner.js";
-import foundationOpsPublic from "@mapgen/domain/foundation/ops";
 
-const { computeCrust, computeMantleForcing, computeMantlePotential, computeMesh, computePlateGraph, computePlateMotion, computePlatesTensors } = foundationOpsPublic.ops;
+const {
+  computeCrust,
+  computeMantleForcing,
+  computeMantlePotential,
+  computeMesh,
+  computePlateGraph,
+  computePlateMotion,
+  computePlatesTensors,
+} = foundationOpsPublic.ops;
 const { computeBaseTopography, computeSeaLevel, planFoothills, planRidges } = morphology.ops;
 
 function derivePlateMotion(mesh: any, plateGraph: any, rngSeed: number) {

--- a/mods/mod-swooper-maps/test/morphology/mountain-family-controls.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/mountain-family-controls.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from "bun:test";
-
+import morphology from "@mapgen/domain/morphology/ops";
 import {
   collectMaskComponentsOddQ,
   forEachHexNeighborOddQ,
   resolveTileAreaSpacingTarget,
 } from "@swooper/mapgen-core/lib/grid";
-
 import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
-import morphology from "@mapgen/domain/morphology/ops";
 import { assertSameMountainFamilySelection } from "../../src/recipes/standard/stages/morphology-features/steps/mountains.js";
 
 const { planFoothills, planRidges } = morphology.ops;

--- a/mods/mod-swooper-maps/test/morphology/plan-rough-lands.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/plan-rough-lands.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "bun:test";
-
-import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 import morphology from "@mapgen/domain/morphology/ops";
+import { BOUNDARY_TYPE } from "@swooper/mapgen-core/lib/plates";
 
 const { planRoughLands } = morphology.ops;
 

--- a/mods/mod-swooper-maps/test/pipeline/artifacts.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/artifacts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { createMockAdapter } from "@civ7/adapter";
+import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { createExtendedMapContext } from "@swooper/mapgen-core";
 import { implementArtifacts } from "@swooper/mapgen-core/authoring";
 import {
@@ -9,7 +10,6 @@ import {
   StepRegistry,
 } from "@swooper/mapgen-core/engine";
 import { mapArtifacts } from "../../src/recipes/standard/map-artifacts.js";
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { artifacts as hydrologyClimateBaselineArtifacts } from "../../src/recipes/standard/stages/hydrology-climate-baseline/artifacts/index.js";
 import { artifacts as hydrologyHydrographyArtifacts } from "../../src/recipes/standard/stages/hydrology-hydrography/artifacts/index.js";
 import {

--- a/mods/mod-swooper-maps/test/pipeline/foundation-gates.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/foundation-gates.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "bun:test";
-
-import { mapArtifacts } from "../../src/recipes/standard/map-artifacts.js";
 import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
+import { mapArtifacts } from "../../src/recipes/standard/map-artifacts.js";
 import { M1_FOUNDATION_GATES } from "../support/foundation-invariants.js";
 
 function findGate(name: string) {

--- a/mods/mod-swooper-maps/test/pipeline/hydrology-river-network-metrics.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/hydrology-river-network-metrics.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "bun:test";
 import { createMockAdapter } from "@civ7/adapter";
-import { createExtendedMapContext } from "@swooper/mapgen-core";
-import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 import {
   HYDROLOGY_FLOW_DRY,
   HYDROLOGY_FLOW_EPHEMERAL,
@@ -9,6 +7,8 @@ import {
   HYDROLOGY_FLOW_PERENNIAL,
   HYDROLOGY_MOUTH_UNRESOLVED,
 } from "@mapgen/domain/hydrology/model/policy/river-network-metrics.js";
+import { createExtendedMapContext } from "@swooper/mapgen-core";
+import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 import {
   type CanonicalMapConfigWithRecipe,
   canonicalRecipeConfig,

--- a/mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts
@@ -23,8 +23,7 @@ function recipeConfig(config: CanonicalMapConfigWithRecipe): StandardRecipeConfi
 const ANTIQUITY_RESOURCE_CANDIDATE_TYPES = new Set(
   OFFICIAL_RESOURCE_CORPUS.filter(
     (entry) =>
-      entry.validAges.includes("AGE_ANTIQUITY") &&
-      entry.placeability.status === "placeable"
+      entry.validAges.includes("AGE_ANTIQUITY") && entry.placeability.status === "placeable"
   ).map((entry) => entry.staticResourceRowSlot)
 );
 const ANTIQUITY_RESOURCE_CANDIDATE_COUNT = ANTIQUITY_RESOURCE_CANDIDATE_TYPES.size;

--- a/mods/mod-swooper-maps/test/placement/placement-contracts.test.ts
+++ b/mods/mod-swooper-maps/test/placement/placement-contracts.test.ts
@@ -3,8 +3,10 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import standardRecipe from "../../src/recipes/standard/recipe.js";
-import { artifacts as placementArtifacts } from "../../src/recipes/standard/stages/placement/artifacts/index.js";
-import { startAssignment } from "../../src/recipes/standard/stages/placement/artifacts/index.js";
+import {
+  artifacts as placementArtifacts,
+  startAssignment,
+} from "../../src/recipes/standard/stages/placement/artifacts/index.js";
 import adjustResourcesStep from "../../src/recipes/standard/stages/placement/steps/adjust-resources/index.js";
 import assignAdvancedStartsStep from "../../src/recipes/standard/stages/placement/steps/assign-advanced-starts/index.js";
 import assignStartsStep from "../../src/recipes/standard/stages/placement/steps/assign-starts/index.js";

--- a/mods/mod-swooper-maps/test/placement/plan-ops.test.ts
+++ b/mods/mod-swooper-maps/test/placement/plan-ops.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import {
-  NATURAL_WONDER_CATALOG,
-} from "@civ7/map-policy";
+import { NATURAL_WONDER_CATALOG } from "@civ7/map-policy";
 import { WONDER_GROUPS } from "@mapgen/domain/placement/model/policy/natural-wonder-groups.js";
 import placementDomain from "@mapgen/domain/placement/ops";
 import { runOpValidated } from "../support/compiler-helpers.js";

--- a/mods/mod-swooper-maps/test/placement/resource-demand-planning.test.ts
+++ b/mods/mod-swooper-maps/test/placement/resource-demand-planning.test.ts
@@ -5,9 +5,7 @@ import {
   type ResourceLegalitySurface,
   resolveResourceRuntimeIds,
 } from "@civ7/map-policy";
-import {
-  EARTHLIKE_RESOURCE_EXPECTATIONS,
-} from "@mapgen/domain/resources/model/data/earthlike-expectations/index.js";
+import { EARTHLIKE_RESOURCE_EXPECTATIONS } from "@mapgen/domain/resources/model/data/earthlike-expectations/index.js";
 import { RESOURCE_HABITAT_SIGNALS } from "@mapgen/domain/resources/model/policy/habitat-eligibility.js";
 import {
   getInitialMapResourcePolicyForType,

--- a/mods/mod-swooper-maps/test/placement/start-viability.test.ts
+++ b/mods/mod-swooper-maps/test/placement/start-viability.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { createMockAdapter } from "@civ7/adapter";
+import placementDomain from "@mapgen/domain/placement/ops";
 import { createExtendedMapContext } from "@swooper/mapgen-core";
 import { hexDistanceOddQPeriodicX } from "@swooper/mapgen-core/lib/grid";
-
-import placementDomain from "@mapgen/domain/placement/ops";
+import { validators as placementArtifactValidators } from "../../src/recipes/standard/stages/placement/artifacts/index.js";
 import { materializeStartAssignment } from "../../src/recipes/standard/stages/placement/steps/assign-starts/materialize.js";
 import { runOpValidated } from "../support/compiler-helpers.js";
-import { validators as placementArtifactValidators } from "../../src/recipes/standard/stages/placement/artifacts/index.js";
 
 const { planStarts } = placementDomain.ops;
 

--- a/mods/mod-swooper-maps/test/resources/resource-aquatic-op-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-aquatic-op-contract.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import resources from "@mapgen/domain/resources/ops";
 import {
   EARTHLIKE_RESOURCE_EXPECTATIONS,
   type EarthlikeResourceExpectation,
 } from "@mapgen/domain/resources/model/data/earthlike-expectations/index.js";
+import resources from "@mapgen/domain/resources/ops";
 
 import { normalizeOpSelectionOrThrow, TestCompileError } from "../support/compiler-helpers.js";
 

--- a/mods/mod-swooper-maps/test/resources/resource-cultivated-op-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-cultivated-op-contract.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import resources from "@mapgen/domain/resources/ops";
 import {
   EARTHLIKE_RESOURCE_EXPECTATIONS,
   type EarthlikeResourceExpectation,
 } from "@mapgen/domain/resources/model/data/earthlike-expectations/index.js";
+import resources from "@mapgen/domain/resources/ops";
 
 import { normalizeOpSelectionOrThrow, TestCompileError } from "../support/compiler-helpers.js";
 

--- a/mods/mod-swooper-maps/test/resources/resource-earthlike-expectations-artifact.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-earthlike-expectations-artifact.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from "bun:test";
-import { Value } from "typebox/value";
+import { OFFICIAL_RESOURCE_BY_TYPE, OFFICIAL_RESOURCE_TYPE_ORDER } from "@civ7/map-policy";
 import { earthlikeExpectations } from "@mapgen/domain/resources/artifacts";
 import {
   EARTHLIKE_RESOURCE_EXPECTATIONS,
   EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT,
 } from "@mapgen/domain/resources/model/data/earthlike-expectations/index.js";
-import { OFFICIAL_RESOURCE_BY_TYPE, OFFICIAL_RESOURCE_TYPE_ORDER } from "@civ7/map-policy";
 import {
   DEFERRED_INITIAL_MAP_RESOURCE_TYPES,
   INITIAL_MAP_RESOURCE_TYPES,
 } from "@mapgen/domain/resources/model/policy/initial-map-authoring.js";
+import { Value } from "typebox/value";
 
 const resourceEarthlikeExpectationsArtifact = earthlikeExpectations.artifact;
 const ResourceEarthlikeExpectationsArtifactSchema = earthlikeExpectations.Schema;

--- a/mods/mod-swooper-maps/test/resources/resource-geological-op-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-geological-op-contract.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import resources from "@mapgen/domain/resources/ops";
 import {
   EARTHLIKE_RESOURCE_EXPECTATIONS,
   type EarthlikeResourceExpectation,
 } from "@mapgen/domain/resources/model/data/earthlike-expectations/index.js";
+import resources from "@mapgen/domain/resources/ops";
 
 import { normalizeOpSelectionOrThrow, TestCompileError } from "../support/compiler-helpers.js";
 

--- a/mods/mod-swooper-maps/test/resources/resource-group-rollup-op-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-group-rollup-op-contract.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import resources from "@mapgen/domain/resources/ops";
 import {
   EARTHLIKE_RESOURCE_EXPECTATIONS,
   type EarthlikeResourceExpectation,
 } from "@mapgen/domain/resources/model/data/earthlike-expectations/index.js";
+import resources from "@mapgen/domain/resources/ops";
 
 import { normalizeOpSelectionOrThrow, TestCompileError } from "../support/compiler-helpers.js";
 

--- a/mods/mod-swooper-maps/test/resources/resource-habitat-fields-op-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-habitat-fields-op-contract.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "bun:test";
-
-import resources from "@mapgen/domain/resources/ops";
-import { HABITAT_MASK_FIELD_NAMES } from "@mapgen/domain/resources/model/schemas/habitat-fields.schema.js";
 import { RESOURCE_HABITAT_SIGNALS } from "@mapgen/domain/resources/model/policy/habitat-eligibility.js";
+import { HABITAT_MASK_FIELD_NAMES } from "@mapgen/domain/resources/model/schemas/habitat-fields.schema.js";
+import resources from "@mapgen/domain/resources/ops";
 
 import { runOpValidated } from "../support/compiler-helpers.js";
 

--- a/mods/mod-swooper-maps/test/resources/resource-initial-map-authoring-policy.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-initial-map-authoring-policy.test.ts
@@ -11,9 +11,7 @@ import {
 
 function expectedTypesForAge(age: string): string[] {
   return OFFICIAL_RESOURCE_CORPUS.filter(
-    (entry) =>
-      entry.validAges.includes(age as never) &&
-      entry.placeability.status === "placeable"
+    (entry) => entry.validAges.includes(age as never) && entry.placeability.status === "placeable"
   ).map((entry) => entry.resourceType);
 }
 

--- a/mods/mod-swooper-maps/test/resources/resource-terrestrial-op-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-terrestrial-op-contract.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import resources from "@mapgen/domain/resources/ops";
 import {
   EARTHLIKE_RESOURCE_EXPECTATIONS,
   type EarthlikeResourceExpectation,
 } from "@mapgen/domain/resources/model/data/earthlike-expectations/index.js";
+import resources from "@mapgen/domain/resources/ops";
 
 import { normalizeOpSelectionOrThrow, TestCompileError } from "../support/compiler-helpers.js";
 

--- a/mods/mod-swooper-maps/test/standard-run.test.ts
+++ b/mods/mod-swooper-maps/test/standard-run.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import { createMockAdapter } from "@civ7/adapter";
 import { requireResourceRuntimeId } from "@civ7/map-policy";
+import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
+import { computeRiverAdjacencyMaskFromRiverClass } from "@mapgen/domain/hydrology/model/policy/river-adjacency.js";
+import { isAnyRiverClass } from "@mapgen/domain/hydrology/model/policy/river-class.js";
+import { DEFERRED_INITIAL_MAP_RESOURCE_TYPES } from "@mapgen/domain/resources/model/policy/initial-map-authoring.js";
 import {
   createExtendedMapContext,
   HILL_TERRAIN,
@@ -10,17 +14,13 @@ import {
   VOLCANO_FEATURE,
 } from "@swooper/mapgen-core";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
-import { isAnyRiverClass } from "@mapgen/domain/hydrology/model/policy/river-class.js";
-import { DEFERRED_INITIAL_MAP_RESOURCE_TYPES } from "@mapgen/domain/resources/model/policy/initial-map-authoring.js";
 import { mapArtifacts } from "../src/recipes/standard/map-artifacts.js";
 import type { StandardRecipeConfig } from "../src/recipes/standard/recipe.js";
 import standardRecipe from "../src/recipes/standard/recipe.js";
 import { initializeStandardRuntime } from "../src/recipes/standard/runtime.js";
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { artifacts as hydrologyClimateBaselineArtifacts } from "../src/recipes/standard/stages/hydrology-climate-baseline/artifacts/index.js";
 import { artifacts as hydrologyClimateRefineArtifacts } from "../src/recipes/standard/stages/hydrology-climate-refine/artifacts/index.js";
 import { artifacts as hydrologyHydrographyArtifacts } from "../src/recipes/standard/stages/hydrology-hydrography/artifacts/index.js";
-import { computeRiverAdjacencyMaskFromRiverClass } from "@mapgen/domain/hydrology/model/policy/river-adjacency.js";
 import { artifacts as placementArtifacts } from "../src/recipes/standard/stages/placement/artifacts/index.js";
 import { standardConfig } from "./support/standard-config.js";
 

--- a/mods/mod-swooper-maps/test/support/foundation-invariants.ts
+++ b/mods/mod-swooper-maps/test/support/foundation-invariants.ts
@@ -1,10 +1,10 @@
+import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
+import morphology from "@mapgen/domain/morphology/ops";
 import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
 import { PerlinNoise } from "@swooper/mapgen-core/lib/noise";
 import { deriveStepSeed } from "@swooper/mapgen-core/lib/rng";
-import morphology from "@mapgen/domain/morphology/ops";
 import { mapArtifacts } from "../../src/recipes/standard/map-artifacts.js";
 import standardRecipe from "../../src/recipes/standard/recipe.js";
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import { artifacts as morphologyArtifacts } from "../../src/recipes/standard/stages/morphology/artifacts/index.js";
 import { standardConfig } from "./standard-config.js";
 import type { ValidationInvariant, ValidationInvariantContext } from "./validation-harness.js";

--- a/mods/mod-swooper-maps/test/support/tectonics-history-runner.js
+++ b/mods/mod-swooper-maps/test/support/tectonics-history-runner.js
@@ -1,6 +1,17 @@
 import foundationOpsPublic from "@mapgen/domain/foundation/ops";
 
-const { computeEraPlateMembership, computeEraTectonicFields, computeHotspotEvents, computePlateMotion, computeSegmentEvents, computeTectonicHistoryRollups, computeTectonicProvenance, computeTectonicSegments, computeTectonicsCurrent, computeTracerAdvection } = foundationOpsPublic.ops;
+const {
+  computeEraPlateMembership,
+  computeEraTectonicFields,
+  computeHotspotEvents,
+  computePlateMotion,
+  computeSegmentEvents,
+  computeTectonicHistoryRollups,
+  computeTectonicProvenance,
+  computeTectonicSegments,
+  computeTectonicsCurrent,
+  computeTracerAdvection,
+} = foundationOpsPublic.ops;
 const OROGENY_ERA_GAIN_MIN = 0.85;
 const OROGENY_ERA_GAIN_MAX = 1.15;
 

--- a/mods/mod-swooper-maps/test/support/validation-harness.ts
+++ b/mods/mod-swooper-maps/test/support/validation-harness.ts
@@ -1,8 +1,7 @@
+import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 import type { ExtendedMapContext } from "@swooper/mapgen-core";
 import { sha256Hex, stableStringify } from "@swooper/mapgen-core";
-
 import { mapArtifacts } from "../../src/recipes/standard/map-artifacts.js";
-import { artifacts as foundationArtifacts } from "@mapgen/domain/foundation";
 
 export type ArtifactFingerprintEntry = {
   status: "present" | "missing";

--- a/mods/mod-swooper-maps/test/support/world-balance-stats.ts
+++ b/mods/mod-swooper-maps/test/support/world-balance-stats.ts
@@ -3,6 +3,12 @@ import {
   type ResourcePlacementMismatchReason,
   type ResourcePlacementRejectionReason,
 } from "@civ7/adapter";
+import {
+  getEngineFeatureLegality,
+  type OfficialResourceType,
+  requireResourceRuntimeId,
+} from "@civ7/map-policy";
+import { biomeSymbolFromIndex } from "@mapgen/domain/ecology/model/schemas/index.js";
 import { createExtendedMapContext } from "@swooper/mapgen-core";
 import {
   collectMaskComponentsOddQ,
@@ -10,12 +16,6 @@ import {
   hexDistanceOddQPeriodicX,
 } from "@swooper/mapgen-core/lib/grid";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
-import {
-  getEngineFeatureLegality,
-  requireResourceRuntimeId,
-  type OfficialResourceType,
-} from "@civ7/map-policy";
-import { biomeSymbolFromIndex } from "@mapgen/domain/ecology/model/schemas/index.js";
 import standardRecipe, { type StandardRecipeConfig } from "../../src/recipes/standard/recipe.js";
 import { initializeStandardRuntime } from "../../src/recipes/standard/runtime.js";
 import { artifacts as ecologyArtifacts } from "../../src/recipes/standard/stages/ecology/artifacts/index.js";
@@ -1050,8 +1050,9 @@ export function collectWorldBalanceStats(
   }
   const resourceIntentByPlot = new Map<number, { resourceTypeId: number; inHabitat: boolean }>();
   for (const intent of stampedResourceIntents) {
-    const resourceTypeId = requireResourceRuntimeId(intent.resourceType as OfficialResourceType)
-      .resourceTypeId;
+    const resourceTypeId = requireResourceRuntimeId(
+      intent.resourceType as OfficialResourceType
+    ).resourceTypeId;
     incrementCount(resourcePlanTypeCounts, resourceTypeId);
     const plotIndex = Number.isFinite(intent.plotIndex)
       ? Math.trunc(intent.plotIndex as number)


### PR DESCRIPTION
Remove stale optional artifact helpers/imports that failed MapGen Studio's stricter unused-symbol check, then apply the owning Swooper Maps Biome import/format hygiene pass.\n\nNo Habitat rules, TypeScript configs, generated outputs, or public artifact contracts are changed.\n\nVerified with:\n- nx run mapgen-studio:check --outputStyle=static --skipNxCache\n- nx run-many --targets=check --outputStyle=static --skipNxCache --nxBail=false\n- nx run mod-swooper-maps:lint --outputStyle=static --skipNxCache\n- bun run lint\n- bun habitat check --json --rule require_artifact_file_shape\n- bun habitat classify mods/mod-swooper-maps\n- bun run check\n- git diff --check