### PR TITLE
chore(swooper-maps): enable strict tsconfig flags + add type-fest, clean up unused locals

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "rimraf": "^6.1.2",
         "string-width": "4.2.3",
         "tsup": "^8.5.1",
+        "type-fest": "^5.7.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18",
       },

--- a/mods/mod-swooper-maps/scripts/report-standard-authoring-surface.ts
+++ b/mods/mod-swooper-maps/scripts/report-standard-authoring-surface.ts
@@ -1,18 +1,17 @@
+import type { JsonValue } from "type-fest";
 import { STANDARD_STAGES } from "../src/recipes/standard/recipe.js";
-
-type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
 
 interface SchemaLike {
   type?: string;
-  const?: Json;
-  enum?: Json[];
+  const?: JsonValue;
+  enum?: JsonValue[];
   anyOf?: SchemaLike[];
   oneOf?: SchemaLike[];
   allOf?: SchemaLike[];
   items?: SchemaLike | SchemaLike[];
   required?: string[];
   properties?: Record<string, SchemaLike>;
-  default?: Json;
+  default?: JsonValue;
   minimum?: number;
   maximum?: number;
   description?: string;
@@ -56,17 +55,17 @@ interface ArtifactLike {
 interface OpLike {
   strategies?: Record<string, unknown>;
   config?: SchemaLike;
-  defaultConfig?: Json;
+  defaultConfig?: JsonValue;
 }
 
 interface FlattenedSchemaRow {
   path: string;
   type: string;
   required: boolean;
-  default?: Json;
+  default?: JsonValue;
   minimum?: number;
   maximum?: number;
-  enum?: Json[];
+  enum?: JsonValue[];
   description?: string;
   descriptionQuality: "missing" | "weak" | "ok";
   rawEnvelope: boolean;

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/rules/classify.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/rules/classify.ts
@@ -1,4 +1,4 @@
-import { BIOME_SYMBOL_TO_INDEX, type BiomeSymbol } from "../../../model/schemas/index.js";
+import { BIOME_SYMBOL_TO_INDEX } from "../../../model/schemas/index.js";
 import type { BiomeClassificationTypes } from "../types.js";
 import { aridityShiftForIndex, shiftMoistureZone } from "./aridity.js";
 import { biomeSymbolForZones } from "./lookup.js";

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/strategies/default.ts
@@ -10,7 +10,7 @@ import {
 
 export const defaultStrategy = createStrategy(ComputeFeatureSubstrateContract, "default", {
   run: (input, config) => {
-    const size = validateFeatureSubstrateInputs({
+    validateFeatureSubstrateInputs({
       width: input.width,
       height: input.height,
       riverClass: input.riverClass as Uint8Array,

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/strategies/default.ts
@@ -1,10 +1,8 @@
 import { createLabelRng } from "@swooper/mapgen-core";
-import { createStrategy, type Static } from "@swooper/mapgen-core/authoring";
+import { createStrategy } from "@swooper/mapgen-core/authoring";
 
 import type { PlotEffectIntentKey } from "../../../model/schemas/plot-effect-intent.schema.js";
 import PlanPlotEffectsContract from "../contract.js";
-
-type Config = Static<(typeof PlanPlotEffectsContract)["strategies"]["default"]>;
 
 type Candidate = {
   idx: number;

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-burned/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-burned/strategies/default.ts
@@ -1,10 +1,8 @@
 import { clamp01, normalizeRange } from "@swooper/mapgen-core";
-import { createStrategy, type Static } from "@swooper/mapgen-core/authoring";
+import { createStrategy } from "@swooper/mapgen-core/authoring";
 import { biomeSymbolFromIndex } from "../../../model/schemas/index.js";
 
 import PlotEffectsScoreBurnedContract from "../contract.js";
-
-type Config = Static<(typeof PlotEffectsScoreBurnedContract)["strategies"]["default"]>;
 
 export const defaultStrategy = createStrategy(PlotEffectsScoreBurnedContract, "default", {
   run: (input, config) => {

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-jungle/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-jungle/strategies/default.ts
@@ -1,10 +1,8 @@
 import { clamp01, normalizeRange } from "@swooper/mapgen-core";
-import { createStrategy, type Static } from "@swooper/mapgen-core/authoring";
+import { createStrategy } from "@swooper/mapgen-core/authoring";
 import { biomeSymbolFromIndex } from "../../../model/schemas/index.js";
 
 import PlotEffectsScoreJungleContract from "../contract.js";
-
-type Config = Static<(typeof PlotEffectsScoreJungleContract)["strategies"]["default"]>;
 
 export const defaultStrategy = createStrategy(PlotEffectsScoreJungleContract, "default", {
   run: (input, config) => {

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-sand/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-sand/strategies/default.ts
@@ -1,10 +1,8 @@
 import { clamp01, normalizeRange } from "@swooper/mapgen-core";
-import { createStrategy, type Static } from "@swooper/mapgen-core/authoring";
+import { createStrategy } from "@swooper/mapgen-core/authoring";
 import { biomeSymbolFromIndex } from "../../../model/schemas/index.js";
 
 import PlotEffectsScoreSandContract from "../contract.js";
-
-type Config = Static<(typeof PlotEffectsScoreSandContract)["strategies"]["default"]>;
 
 export const defaultStrategy = createStrategy(PlotEffectsScoreSandContract, "default", {
   run: (input, config) => {

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-snow/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-snow/strategies/default.ts
@@ -1,9 +1,7 @@
 import { clamp01, normalizeRange } from "@swooper/mapgen-core";
-import { createStrategy, type Static } from "@swooper/mapgen-core/authoring";
+import { createStrategy } from "@swooper/mapgen-core/authoring";
 import { resolveSnowElevationRange } from "../../plan-plot-effects/rules/index.js";
 import PlotEffectsScoreSnowContract from "../contract.js";
-
-type Config = Static<(typeof PlotEffectsScoreSnowContract)["strategies"]["default"]>;
 
 export const defaultStrategy = createStrategy(PlotEffectsScoreSnowContract, "default", {
   run: (input, config) => {

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/refine-biome-edges/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/refine-biome-edges/index.ts
@@ -1,6 +1,6 @@
 import { createOp } from "@swooper/mapgen-core/authoring";
 import RefineBiomeEdgesContract from "./contract.js";
-import { defaultStrategy, gaussianStrategy } from "./strategies/index.js";
+import { gaussianStrategy } from "./strategies/index.js";
 
 const refineBiomeEdges = createOp(RefineBiomeEdgesContract, {
   strategies: {

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-era-plate-membership/rules/compute-plate-id-by-era.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-era-plate-membership/rules/compute-plate-id-by-era.ts
@@ -1,7 +1,7 @@
 import { wrapDeltaPeriodic } from "@swooper/mapgen-core/lib/math";
 import { findNearestMeshCell, meanMeshEdgeLength } from "@swooper/mapgen-core/lib/mesh";
 
-import type { EraPlateMembershipMesh, EraPlateMembershipParams } from "../types.js";
+import type { EraPlateMembershipParams } from "../types.js";
 
 type MinHeapItem = Readonly<{ cost: number; plateId: number; cellId: number; seq: number }>;
 

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-sea-level/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-sea-level/rules/index.ts
@@ -83,23 +83,6 @@ export function resolveSeaLevel(params: {
     );
     return values[idx] ?? 0;
   };
-  const resolveDistinctCandidate = (
-    startPct: number,
-    direction: -1 | 1,
-    currentSeaLevel: number
-  ): { pct: number; seaLevel: number } | null => {
-    let pct = clampPct(startPct + direction * targetPctStep);
-    if (pct === startPct) return null;
-    let seaLevel = resolveSeaLevelAtPct(pct);
-    while (seaLevel === currentSeaLevel) {
-      const nextPct = clampPct(pct + direction * targetPctStep);
-      if (nextPct === pct) return null;
-      pct = nextPct;
-      seaLevel = resolveSeaLevelAtPct(pct);
-    }
-    return { pct, seaLevel };
-  };
-
   const evaluate = (candidateSeaLevel: number): { constraintError: number; seaLevel: number } => {
     let landCount = 0;
     let boundaryLand = 0;
@@ -114,9 +97,6 @@ export function resolveSeaLevel(params: {
 
     const boundaryShare = landCount > 0 ? boundaryLand / landCount : 0;
     const continentalShare = landCount > 0 ? continentalLand / landCount : 0;
-    const boundaryOk = boundaryTarget == null || boundaryShare >= boundaryTarget;
-    const continentalOk = continentalTarget == null || continentalShare >= continentalTarget;
-
     const boundaryErr = boundaryTarget == null ? 0 : Math.max(0, boundaryTarget - boundaryShare);
     const continentalErr =
       continentalTarget == null ? 0 : Math.max(0, continentalTarget - continentalShare);

--- a/mods/mod-swooper-maps/src/domain/resources/artifacts/earthlike-expectations.artifact.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/artifacts/earthlike-expectations.artifact.ts
@@ -29,9 +29,6 @@ const EvidenceStrengthSchema = Type.Union([
 const closedStringEnum = <T extends string>(values: readonly T[]) =>
   Type.Unsafe<T>({ type: "string", enum: [...values] });
 
-const expectationResourceTypes = EARTHLIKE_RESOURCE_EXPECTATIONS.map(
-  (entry) => entry.resourceType
-) as OfficialResourceType[];
 const blockedExpectationResourceTypes = EARTHLIKE_RESOURCE_EXPECTATIONS.filter(
   (entry) => entry.status === "blocked"
 ).map((entry) => entry.resourceType) as OfficialResourceType[];
@@ -39,7 +36,6 @@ const activeExpectationResourceTypes = EARTHLIKE_RESOURCE_EXPECTATIONS.filter(
   (entry) => entry.status !== "blocked"
 ).map((entry) => entry.resourceType) as OfficialResourceType[];
 
-const ExpectationResourceTypeSchema = closedStringEnum(expectationResourceTypes);
 const BlockedExpectationResourceTypeSchema = closedStringEnum(blockedExpectationResourceTypes);
 const ActiveExpectationResourceTypeSchema = closedStringEnum(activeExpectationResourceTypes);
 

--- a/mods/mod-swooper-maps/src/maps/__type_tests__/authoring-sdk.multi-strategy.inference.ts
+++ b/mods/mod-swooper-maps/src/maps/__type_tests__/authoring-sdk.multi-strategy.inference.ts
@@ -14,12 +14,15 @@ import {
   defineStep,
   Type,
 } from "@swooper/mapgen-core/authoring";
+import type { IsAny, IsEqual, IsNever, IsStringLiteral, IsUnknown, Or } from "type-fest";
 
 // This file exists purely to lock in critical authoring type paths:
 // - defineOp strategies stay narrow (not widened to string)
 // - multi-strategy op envelopes remain discriminated unions
 // - defineStep merges op envelope schemas into the step schema
 // - createStep / createStage / createRecipe preserve literal ids so config surfaces are keyed (no index signatures)
+
+type Expect<T extends true> = T;
 
 // --- Op contract: multi-strategy discrimination must remain intact.
 
@@ -49,39 +52,36 @@ const MultiStrategyOp = defineOp({
 type _StrategyIds = keyof (typeof MultiStrategyOp)["strategies"] & string;
 // If strategies are constrained via an index signature, keyof will widen to `string`.
 // This MUST remain narrow or IntelliSense degenerates.
-type _StrategyIdsAreNarrow = string extends _StrategyIds ? false : true;
-const _strategyIdsAreNarrow: _StrategyIdsAreNarrow = true;
+export type _StrategyIdsAreNarrow = Expect<IsStringLiteral<_StrategyIds>>;
 
 // The op envelope type should be a discriminated union over `strategy`.
 type _Envelope = Static<(typeof MultiStrategyOp)["config"]>;
 
 type _EnvelopeStrategy = _Envelope["strategy"];
-type _EnvelopeStrategyIsNarrow = string extends _EnvelopeStrategy ? false : true;
-const _envelopeStrategyIsNarrow: _EnvelopeStrategyIsNarrow = true;
+export type _EnvelopeStrategyIsNarrow = Expect<IsStringLiteral<_EnvelopeStrategy>>;
 
 // OpTypeBagOf is the canonical authoring surface for runtime ops;
 // it MUST preserve the envelope union (strategy + config shapes).
 type _BagEnvelope = OpTypeBagOf<typeof MultiStrategyOp>["envelope"];
 type _BagEnvelopeStrategy = _BagEnvelope["strategy"];
-type _BagEnvelopeStrategyIsNarrow = string extends _BagEnvelopeStrategy ? false : true;
-const _bagEnvelopeStrategyIsNarrow: _BagEnvelopeStrategyIsNarrow = true;
+export type _BagEnvelopeStrategyIsNarrow = Expect<IsStringLiteral<_BagEnvelopeStrategy>>;
 
 type _DefaultConfig = Extract<_Envelope, { strategy: "default" }>["config"];
 type _FastConfig = Extract<_Envelope, { strategy: "fast" }>["config"];
 
 // Discriminated branches must preserve their own config shapes.
 type _DefaultHasPlateauCount = "plateauCount" extends keyof _DefaultConfig ? true : false;
-const _defaultHasPlateauCount: _DefaultHasPlateauCount = true;
+export type _DefaultHasPlateauCountAssertion = Expect<IsEqual<_DefaultHasPlateauCount, true>>;
 
 type _FastHasTurbo = "turbo" extends keyof _FastConfig ? true : false;
-const _fastHasTurbo: _FastHasTurbo = true;
+export type _FastHasTurboAssertion = Expect<IsEqual<_FastHasTurbo, true>>;
 
 // And MUST NOT pick up each other's keys.
 type _DefaultHasTurbo = "turbo" extends keyof _DefaultConfig ? true : false;
-const _defaultHasTurbo: _DefaultHasTurbo = false;
+export type _DefaultLacksTurboAssertion = Expect<IsEqual<_DefaultHasTurbo, false>>;
 
 type _FastHasPlateauCount = "plateauCount" extends keyof _FastConfig ? true : false;
-const _fastHasPlateauCount: _FastHasPlateauCount = false;
+export type _FastLacksPlateauCountAssertion = Expect<IsEqual<_FastHasPlateauCount, false>>;
 
 function _acceptsEnvelopeStrategy(_s: _EnvelopeStrategy): void {
   // type-only
@@ -118,19 +118,27 @@ type _StepRuntimeConfig = Static<(typeof MultiOpStepContract)["schema"]>;
 
 // Step schema should include the op envelope property.
 type _StepHasMulti = "multi" extends keyof _StepRuntimeConfig ? true : false;
-const _stepHasMulti: _StepHasMulti = true;
+export type _StepHasMultiAssertion = Expect<IsEqual<_StepHasMulti, true>>;
 
 // And it should match the op's envelope type (i.e. be discriminated, not `unknown`).
 type _StepMultiEnvelope = _StepRuntimeConfig["multi"];
 
-type _StepMultiEnvelopeIsNotUnknown = unknown extends _StepMultiEnvelope ? false : true;
-const _stepMultiEnvelopeIsNotUnknown: _StepMultiEnvelopeIsNotUnknown = true;
+export type _StepMultiEnvelopeIsNotUnknown = Expect<
+  Or<
+    Or<IsNever<_StepMultiEnvelope>, IsUnknown<_StepMultiEnvelope>>,
+    IsAny<_StepMultiEnvelope>
+  > extends true
+    ? false
+    : true
+>;
 
 // Step runtime ops must receive the typed envelope (not unknown/any).
 type _RuntimeOps = StepRuntimeOps<{ multi: typeof MultiStrategyOp }>;
 type _RuntimeOpConfigParam = Parameters<_RuntimeOps["multi"]>[1];
 type _RuntimeOpConfigHasStrategy = "strategy" extends keyof _RuntimeOpConfigParam ? true : false;
-const _runtimeOpConfigHasStrategy: _RuntimeOpConfigHasStrategy = true;
+export type _RuntimeOpConfigHasStrategyAssertion = Expect<
+  IsEqual<_RuntimeOpConfigHasStrategy, true>
+>;
 
 // --- Stage + Recipe config authoring: keys must remain literal and indexed by known ids.
 
@@ -167,15 +175,15 @@ type _TypeTestStepConfig = NonNullable<_TypeTestStageConfig["multi-op-step"]>;
 
 // Step config should include the op envelope authoring surface.
 type _StepConfigHasMulti = "multi" extends keyof _TypeTestStepConfig ? true : false;
-const _stepConfigHasMulti: _StepConfigHasMulti = true;
+export type _StepConfigHasMultiAssertion = Expect<IsEqual<_StepConfigHasMulti, true>>;
 
 type _AuthoredMultiEnvelope = NonNullable<_TypeTestStepConfig["multi"]>;
 
 // The authored envelope should still keep strategy ids narrow.
 type _AuthoredStrategy = _AuthoredMultiEnvelope extends { strategy?: infer S } ? S : never;
-type _AuthoredStrategyIsNarrow =
-  string extends Exclude<_AuthoredStrategy, undefined> ? false : true;
-const _authoredStrategyIsNarrow: _AuthoredStrategyIsNarrow = true;
+export type _AuthoredStrategyIsNarrow = Expect<
+  IsStringLiteral<Exclude<_AuthoredStrategy, undefined>>
+>;
 
 const _okConfig: _ConfigInput = {
   "type-test": {
@@ -214,5 +222,9 @@ const _badConfigValueType: _ConfigInput = {
     },
   },
 };
+
+void _okConfig;
+void _badStrategyConfig;
+void _badConfigValueType;
 
 export {};

--- a/mods/mod-swooper-maps/src/maps/__type_tests__/createMap-config.inference.ts
+++ b/mods/mod-swooper-maps/src/maps/__type_tests__/createMap-config.inference.ts
@@ -3,6 +3,7 @@
 import foundationDomain from "@mapgen/domain/foundation";
 import { createMap } from "@mateicanavra/civ7-sdk/mapgen";
 import type { Static } from "@swooper/mapgen-core/authoring";
+import type { ExtendsStrict, IsEqual, IsStringLiteral } from "type-fest";
 import standardRecipe, { type StandardRecipeConfig } from "../../recipes/standard/recipe.js";
 import foundationMantleStage from "../../recipes/standard/stages/foundation-mantle/index.js";
 
@@ -10,13 +11,18 @@ import foundationMantleStage from "../../recipes/standard/stages/foundation-mant
 // structurally typed (stage keys + step keys + op config shapes), so TS provides
 // completion + hover hints.
 
+type Expect<T extends true> = T;
+
 // Ensure stage ids and step ids remain literals (not widened to string/unknown).
 type _FoundationMantleStageId = typeof foundationMantleStage.id;
-const _foundationMantleStageId: _FoundationMantleStageId = "foundation-mantle";
+export type _FoundationMantleStageIdIsLiteral = Expect<
+  IsEqual<_FoundationMantleStageId, "foundation-mantle">
+>;
 
 type _FoundationMantleStepIds = (typeof foundationMantleStage.steps)[number]["contract"]["id"];
 // @ts-expect-error - a random string should not be assignable to the step id union.
 const _badFoundationStepId: _FoundationMantleStepIds = "definitely-not-a-step";
+void _badFoundationStepId;
 
 // If the config surface degenerates to Record<string, ...> / an index signature,
 // these should STOP erroring.
@@ -30,13 +36,13 @@ type _NoBogusStep = _FoundationMantleConfig["bogus-step"];
 // Sanity check: op contract envelope types must be structurally typed (not `unknown`).
 type _ComputeMeshOp = typeof foundationDomain.ops.computeMesh;
 type _ComputeMeshStrategyIds = keyof _ComputeMeshOp["strategies"] & string;
-type _ComputeMeshStrategyIdsAreNarrow = string extends _ComputeMeshStrategyIds ? false : true;
-const _computeMeshStrategyIdsAreNarrow: _ComputeMeshStrategyIdsAreNarrow = true;
+export type _ComputeMeshStrategyIdsAreNarrow = Expect<IsStringLiteral<_ComputeMeshStrategyIds>>;
 
 type _ComputeMeshEnvelopeFromOp = Static<_ComputeMeshOp["config"]>;
 type _ComputeMeshConfigFromOp = _ComputeMeshEnvelopeFromOp["config"];
-type _ComputeMeshConfigFromOpIsObject = _ComputeMeshConfigFromOp extends object ? true : false;
-const _computeMeshConfigFromOpIsObject: _ComputeMeshConfigFromOpIsObject = true;
+export type _ComputeMeshConfigFromOpIsObject = Expect<
+  ExtendsStrict<_ComputeMeshConfigFromOp, object, { strictAny: true }>
+>;
 
 // Ensure stage step schemas still carry op-enriched typing.
 type _MeshStep = Extract<
@@ -50,23 +56,22 @@ type _ComputeMeshEnvelopeFromStepSchemaConfig = _ComputeMeshEnvelopeFromStepSche
 }
   ? C
   : never;
-type _ComputeMeshEnvelopeFromStepSchemaConfigIsObject =
-  _ComputeMeshEnvelopeFromStepSchemaConfig extends object ? true : false;
-const _computeMeshEnvelopeFromStepSchemaConfigIsObject: _ComputeMeshEnvelopeFromStepSchemaConfigIsObject = true;
+export type _ComputeMeshEnvelopeFromStepSchemaConfigIsObject = Expect<
+  ExtendsStrict<_ComputeMeshEnvelopeFromStepSchemaConfig, object, { strictAny: true }>
+>;
 
 // plateCount is authored on the mantle stage (mesh density).
 type _FoundationMantleKnobs = NonNullable<_FoundationMantleConfig["knobs"]>;
 type _PlateCountKnob = _FoundationMantleKnobs["plateCount"];
-type _PlateCountKnobIsNumber = Exclude<_PlateCountKnob, undefined> extends number ? true : false;
-const _plateCountKnobIsNumber: _PlateCountKnobIsNumber = true;
+export type _PlateCountKnobIsNumber = Expect<IsEqual<Exclude<_PlateCountKnob, undefined>, number>>;
 
 // plateActivity is authored on the tectonics stage (scales the plate motion truth).
 type _FoundationTectonicsConfig = NonNullable<StandardRecipeConfig["foundation-tectonics"]>;
 type _FoundationTectonicsKnobs = NonNullable<_FoundationTectonicsConfig["knobs"]>;
 type _PlateActivityKnob = _FoundationTectonicsKnobs["plateActivity"];
-type _PlateActivityKnobIsNumber =
-  Exclude<_PlateActivityKnob, undefined> extends number ? true : false;
-const _plateActivityKnobIsNumber: _PlateActivityKnobIsNumber = true;
+export type _PlateActivityKnobIsNumber = Expect<
+  IsEqual<Exclude<_PlateActivityKnob, undefined>, number>
+>;
 
 createMap({
   id: "__type_test__",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plotBiomes.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plotBiomes.ts
@@ -14,7 +14,7 @@ export default createStep(PlotBiomesStepContract, {
   artifacts: implementArtifacts([ecologyArtifacts.biomeBindings], {
     biomeBindings: {},
   }),
-  run: (context, config, _ops, deps) => {
+  run: (context, _config, _ops, deps) => {
     const { width, height } = context.dimensions;
     const classification = deps.artifacts.biomeClassification.read(context);
     const topography = deps.artifacts.topography.read(context);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-rivers/steps/plotRivers.ts
@@ -49,7 +49,6 @@ function classifyProjectionSignal(input: {
     selectedChainCount,
     longestSelectedChainLength,
     selectedEligibleMajorTileFraction,
-    majorDurableTileCount,
     majorPerennialTileCount,
     majorClosedBasinTileCount,
     majorOceanMouthTileCount,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/index.ts
@@ -18,7 +18,6 @@ import {
   buildResourceDemands,
   buildRiverResourceExclusionMask,
   expectationsForGroup,
-  type HabitatFields,
   type HabitatIntensityFields,
   type ResourceDemandBuildResult,
   readResourceLegalitySurface,

--- a/mods/mod-swooper-maps/tsconfig.json
+++ b/mods/mod-swooper-maps/tsconfig.json
@@ -15,6 +15,11 @@
     "noEmit": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "isolatedModules": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
     "types": ["@civ7/types"]
   },
   "include": ["src/**/*.ts"],

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "rimraf": "^6.1.2",
     "string-width": "4.2.3",
     "tsup": "^8.5.1",
+    "type-fest": "^5.7.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
   },

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -640,7 +640,7 @@ export class MockAdapter implements EngineAdapter {
     return this.temperature[this.idx(x, y)];
   }
 
-  getLatitude(x: number, y: number): number {
+  getLatitude(_x: number, y: number): number {
     return getCiv7RowLatitude(this.mapInfo, this.height, y);
   }
 

--- a/packages/civ7-adapter/tsconfig.json
+++ b/packages/civ7-adapter/tsconfig.json
@@ -8,6 +8,10 @@
     "noEmit": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "isolatedModules": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
     "types": ["@civ7/types"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/civ7-map-policy/tsconfig.json
+++ b/packages/civ7-map-policy/tsconfig.json
@@ -7,7 +7,12 @@
     "declarationMap": true,
     "noEmit": true,
     "module": "ESNext",
-    "moduleResolution": "Bundler"
+    "moduleResolution": "Bundler",
+    "isolatedModules": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["test/**/*.ts"]


### PR DESCRIPTION
Enable stricter TypeScript compiler checks across packages and clean up unused code

Adds `isolatedModules`, `noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`, and `noUncheckedSideEffectImports` to the tsconfig for `mod-swooper-maps`, `civ7-adapter`, and `civ7-map-policy`, then resolves all violations those flags surface.

**Unused imports and declarations removed:**
- Dropped locally-defined `Json` type in favor of `JsonValue` from `type-fest` (added as a dev dependency)
- Removed unused `BiomeSymbol`, `EraPlateMembershipMesh`, `HabitatFields`, `Static`, and `Config` type imports/aliases across several strategy and rule files
- Removed unused `defaultStrategy` re-export from `refine-biome-edges`
- Removed unused `expectationResourceTypes` array and `ExpectationResourceTypeSchema` in the earthlike expectations artifact
- Removed unused `resolveDistinctCandidate` helper and intermediate `boundaryOk`/`continentalOk` variables in the sea-level rules
- Prefixed unused parameters with `_` in `MockAdapter.getLatitude`, `plotBiomes` step run handler, and `compute-feature-substrate` default strategy

**Type test file modernization:**
- Replaced ad-hoc boolean-constant assertion patterns (`const _foo: SomeType = true/false`) with a compile-time `Expect<T extends true>` helper and `type-fest` predicates (`IsStringLiteral`, `IsEqual`, `IsNever`, `IsUnknown`, `IsAny`, `Or`, `ExtendsStrict`)
- Converted assertions to exported types so unused-locals checks don't flag them
- Added `void` expressions for config fixture variables that exist only for type-checking purposes