### PR TITLE
`refactor(habitat): rename rule-remediation ledger to rule-authority-cleanup-ledger`

### DIFF
--- a/.habitat/.active/dominoes/items/042-establish-and-sweep-the-artifact-blueprint-kind.md
+++ b/.habitat/.active/dominoes/items/042-establish-and-sweep-the-artifact-blueprint-kind.md
@@ -53,7 +53,7 @@ Stage 2: bounded artifact-vocabulary sweep.
     artifact authority;
   - do not introduce `_triage`; the existing `_remainder` lane is the visual
     marker for reviewed-but-not-admitted debt.
-- Update `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json` for every inspected
+- Update `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json` for every inspected
   row, including explicit non-moves and pending actions.
 - Record the disposition receipt in this file so future agents can tell which
   artifact-vocabulary rows have been processed.

--- a/.habitat/.active/dominoes/items/051-retire-clean-garbage-collection-rule-residue.md
+++ b/.habitat/.active/dominoes/items/051-retire-clean-garbage-collection-rule-residue.md
@@ -19,7 +19,7 @@ survivor-authority work.
 
 Controlling records:
 
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 - `.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-retirement-slice.md`
 
 Decision matrix:

--- a/.habitat/.active/dominoes/items/052-admit-domain-operation-strategy-blueprint-authority.md
+++ b/.habitat/.active/dominoes/items/052-admit-domain-operation-strategy-blueprint-authority.md
@@ -57,7 +57,7 @@ Review disposition:
 | --- | --- | --- | --- | --- |
 | `domain-operation-strategy` is constructible and product-backed. | P2 | accepted | Authority lane and tree-shape docs created. | Generic strategy-locality or strategy-contract rules still need decision packets before movement. |
 | No current live rule moves whole into the new authority. | P2 | accepted | Explicit non-move dispositions recorded in slice, ledger, and blueprint README. | Avoid using `strategies/**/*.ts` scan roots as an owner test. |
-| The old authority-tree rule ledger still looked like a second current-state matrix. | P2 | accepted | Absorbed its unique process data into `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json` and removed the Markdown ledger. | None; JSON is the active source of truth. |
+| The old authority-tree rule ledger still looked like a second current-state matrix. | P2 | accepted | Absorbed its unique process data into `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json` and removed the Markdown ledger. | None; JSON is the active source of truth. |
 
 Closure note:
 

--- a/.habitat/.active/dominoes/items/053-unite-layer-2-packet-state-into-canonical-rule-matrix.md
+++ b/.habitat/.active/dominoes/items/053-unite-layer-2-packet-state-into-canonical-rule-matrix.md
@@ -15,7 +15,7 @@ Disposition:
 
 | Record | Decision | Reason | Follow-up |
 | --- | --- | --- | --- |
-| `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json` | canonical operational ledger | The same JSON record now owns live rule rows, retired/stale references, queued/completed slices, blockers, findings, and counts. | Future agents should query `rules`, `slices`, `blockers`, `findings`, and `counts`; do not create a separate matrix or packet-index table. |
+| `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json` | canonical operational ledger | The same JSON record now owns live rule rows, retired/stale references, queued/completed slices, blockers, findings, and counts. | Future agents should query `rules`, `slices`, `blockers`, `findings`, and `counts`; do not create a separate matrix or packet-index table. |
 | `.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-retirement-slice.md` | source reference repair | The receipt still named the archived Markdown matrix as its source. | Slice receipts may reference the canonical JSON, but they are not operational sources of truth. |
 
 Moves it forward:

--- a/.habitat/.active/dominoes/items/054-packet-config-key-native-schema-replacement.md
+++ b/.habitat/.active/dominoes/items/054-packet-config-key-native-schema-replacement.md
@@ -24,7 +24,7 @@ Disposition:
 Moves it forward:
 
 - Records the packet outcome in
-  `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`.
+  `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`.
 - Initially moved the config-key slice into the implementation-ready queue;
   Domino 55 corrected this and returned the slice to Layer 2.
 

--- a/.habitat/.active/dominoes/items/055-correct-config-key-proof-owner.md
+++ b/.habitat/.active/dominoes/items/055-correct-config-key-proof-owner.md
@@ -24,7 +24,7 @@ Disposition:
 
 Moves it forward:
 
-- Corrects `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+- Corrects `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
   so `config-key native-schema replacement` is no longer marked
   implementation-ready.
 - Initially added `config-key source schema authority replacement` back to the

--- a/.habitat/.active/dominoes/items/088-re-read-residual-cascade-stop-gates.md
+++ b/.habitat/.active/dominoes/items/088-re-read-residual-cascade-stop-gates.md
@@ -22,7 +22,7 @@ Disposition receipt:
 
 Moves it forward:
 
-- Keeps `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json` as
+- Keeps `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json` as
   the single operational matrix.
 - Removes resolved names from the sealed blocker list so later resumes do not
   reprocess closed Grit/native-rail slices.

--- a/.habitat/.active/dominoes/items/092-reopen-local-proxy-authority-rows.md
+++ b/.habitat/.active/dominoes/items/092-reopen-local-proxy-authority-rows.md
@@ -19,11 +19,11 @@ Disposition receipt:
 
 | Corpus | Action | Receipt |
 | --- | --- | --- |
-| Previously settled local/context rows that looked like repeated-kind special cases | Reopened 26 rows as packet-needed and repopulated the canonical Layer 2 queue. No rule packets were moved or deleted. | Recorded directly in `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`; this domino is the narrative receipt. |
+| Previously settled local/context rows that looked like repeated-kind special cases | Reopened 26 rows as packet-needed and repopulated the canonical Layer 2 queue. No rule packets were moved or deleted. | Recorded directly in `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`; this domino is the narrative receipt. |
 
 Canonical queue repair:
 
-- The queue is operational only in `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`.
+- The queue is operational only in `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`.
 - Query queued Layer 2 work from `slices[] | select(.status == "queued")`.
 - Do not copy the queue, counts, or packet-needed rows into domino receipts.
 

--- a/.habitat/.active/frames/BLUEPRINT-KIND-GATHERING-FRAME.md
+++ b/.habitat/.active/frames/BLUEPRINT-KIND-GATHERING-FRAME.md
@@ -247,7 +247,7 @@ Use `<smallest-honest-niche>/_remainder/<rule-id>/` when:
 - it points to a missing positive kind rule but is too narrow or negative as
   written;
 - it belongs to a future projection, import-law, package graph, build, or
-  generated-artifact surface not designed in this slice;
+  generated-output surface not designed in this slice;
 - it needs split, consolidation, or retirement before final ownership; or
 - it mixes owners and no source-obvious behavior-preserving split belongs in
   the current branch.
@@ -388,7 +388,7 @@ Expected caution:
 - `generated-map-entrypoint` and `shipped-map-catalog` may be parts of a map
   mod output bundle rather than standalone top-level blueprints.
 - `map-projection`, `placement-outcome`, and recipe artifact parity may be
-  adjacent projection, recipe-step, or generated-artifact pressure rather than
+  adjacent projection, recipe-step, or generated-output pressure rather than
   mod-map authority.
 - Do not create `map-projection` or any sibling blueprint in the mod-map slice
   unless failing to do so would force a false move.

--- a/.habitat/.active/frames/FRAME.md
+++ b/.habitat/.active/frames/FRAME.md
@@ -166,7 +166,7 @@ In:
   metadata, Nx targets, docs, and bridge surfaces.
 - Existing package-local validators that must be explicitly kept out of
   Habitat when their oracle is behavior, runtime state, or product correctness.
-- Nx dependency and target metadata where build ordering or generated-artifact
+- Nx dependency and target metadata where build ordering or generated-output
   freshness is the real owner.
 
 Foreground:

--- a/.habitat/.active/frames/UNDERSCORE-BLUEPRINT-BURNDOWN-FRAME.md
+++ b/.habitat/.active/frames/UNDERSCORE-BLUEPRINT-BURNDOWN-FRAME.md
@@ -46,7 +46,7 @@ Authority sources, in order:
 4. Existing method frames:
    - `.habitat/.active/frames/BLUEPRINT-KIND-GATHERING-FRAME.md`
    - `.habitat/.active/frames/DESTINATION-SIMPLIFICATION-FRAME.md`
-   - `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+   - `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 5. Current `.habitat/**/rule.json` manifests as corpus and placement evidence.
 6. Current source code, package docs, and canonical architecture docs as
    constructibility and ownership evidence.
@@ -339,7 +339,7 @@ Required updates for each loop:
 
 - Add or update the relevant disposition receipt under
   `.habitat/.active/dominoes/items/`.
-- Update `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json` for every scoped row.
+- Update `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json` for every scoped row.
 - Update `.habitat/AUTHORITY.md` if a current niche is added, removed, or
   renamed.
 - Update `.habitat/AUTHORITY-TREE-SHAPE.md` if the loop establishes a new
@@ -591,7 +591,7 @@ After the active Civ7 dominoes:
 - Every former Civ7 `_blueprints` row has an explicit domino receipt.
 - Any non-Civ7 row pulled in by the hidden-Civ exception has an explicit
   receipt and no longer hides Civ7 authority under its old directory.
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json` has current paths,
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json` has current paths,
   placements, dispositions, and pending actions for all scoped rows.
 - Any new blueprint directories are source-backed constructible kinds.
 - Any new child niches are governed operating areas, not renamed output or
@@ -639,7 +639,7 @@ authority, and record why the old directory hid the real owner.
 For each loop: re-count the scoped corpus, inspect source-backed ownership,
 build the decision matrix, make physical packet moves, update manifests,
 update the relevant `.habitat/.active/dominoes/items/` record, update
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`, update authority docs if
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`, update authority docs if
 niches or blueprints change, regenerate execution-surface docs if paths move,
 run selected-rule checks, verify support/runner refs and ledger coverage, and
 commit through Graphite. Do not create renamed catch-all buckets. Admit a

--- a/.habitat/.active/workstreams/current-scope-scan.md
+++ b/.habitat/.active/workstreams/current-scope-scan.md
@@ -83,7 +83,7 @@ prework slice needs to name the domino it advances or falsifies.
 
 Path: `.habitat/.active/workstreams/remediate-rule-authority/`
 
-- `ledgers/rule-remediation-layer1-action-matrix.json`: canonical
+- `ledgers/rule-authority-cleanup-ledger.json`: canonical
   machine-readable operational ledger for live rule-remediation state.
 - `receipts/**`: closed slice receipts and review evidence. These are
   historical proof and precedent, not active per-slice plans unless a current

--- a/.habitat/.active/workstreams/define-domain-blueprint-structure/active-transition-anchor.md
+++ b/.habitat/.active/workstreams/define-domain-blueprint-structure/active-transition-anchor.md
@@ -42,7 +42,7 @@ this frame selects the transition between a completed descent and the next
 blueprint-level descent.
 
 Foreground:
-rule ecology cleanup, reusable initiative-frame capture, and next slice
+rule authority cleanup, reusable initiative-frame capture, and next slice
 selection.
 
 Exterior:
@@ -50,11 +50,11 @@ new source movement, new domain row disposition, and operation-internal cleanup
 unless one of the three containers opens them explicitly.
 
 Falsifier:
-if a rule or workstream artifact cannot be classified without reopening source
+if a rule or workstream record cannot be classified without reopening source
 semantics, stop and open a dedicated slice instead of burying that decision in
 this transition anchor.
 
-## Container 1: Rule Ecology Cleanup Pass
+## Container 1: Rule Authority Cleanup Pass
 
 Status: next active container to open.
 
@@ -65,7 +65,7 @@ with positive assertions.
 
 Why now:
 Slice 001 records report enforced closure, but recorded pass state is not the
-same as permanent law. Rule Ecology Cleanup must first re-prove current rule
+same as permanent law. Rule Authority Cleanup must first re-prove current rule
 state with a named Habitat command before using that state as authority. This
 is the exact moment where scaffolding can become accidental architecture if we
 do not classify it.
@@ -83,6 +83,10 @@ Initial classes:
 
 Known inputs:
 
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`,
+  the refreshed machine-readable live rule corpus and action ledger;
+- `.habitat/.active/workstreams/remediate-rule-authority/rule-authority-corpus-grounding.md`,
+  the current corpus-location and analytics receipt;
 - `.habitat/blueprints/**/rule.json`;
 - `.habitat/.active/workstreams/define-domain-blueprint-structure/slices/001-domain-root-immediate-ops-topology/frame.md`;
 - `.habitat/.active/workstreams/define-domain-blueprint-structure/slices/001-domain-root-immediate-ops-topology/inventory.md`
@@ -93,7 +97,7 @@ Known inputs:
 - `.habitat/.active/workstreams/define-domain-blueprint-structure/review-protocol.md`;
 - `.habitat/.active/workstreams/define-domain-blueprint-structure/scopes-and-slices-reference.md`.
 
-Hypotheses to seed the ecology ledger as standing positive-law candidates:
+Hypotheses to seed the authority cleanup ledger as standing positive-law candidates:
 
 - `require_domain_source_topology`;
 - `require_domain_ops_binding_surface`;
@@ -104,14 +108,14 @@ Hypotheses to seed the ecology ledger as standing positive-law candidates:
 - `require_artifact_index_aggregate_shape`;
 - `require_recipe_stage_authoring_file_shape`.
 
-Hypotheses to seed the ecology ledger as boundary-rail candidates:
+Hypotheses to seed the authority cleanup ledger as boundary-rail candidates:
 
 - adapter/runtime import blocks;
 - cross-operation runtime call blocks;
 - recipe/domain public-surface import rules;
 - generated map entrypoint protection rules.
 
-Other rule families that must be included in the ecology ledger:
+Other rule families that must be included in the authority cleanup ledger:
 
 - dependency/effect tag contract rules;
 - recipe runtime import rules;
@@ -121,7 +125,7 @@ Other rule families that must be included in the ecology ledger:
 - shipped catalog leakage rules;
 - any rule outside the just-closed domain-root lane.
 
-Hypotheses to seed the ecology ledger as cleanup candidates:
+Hypotheses to seed the authority cleanup ledger as cleanup candidates:
 
 - retired domain root/catalog guards;
 - old config facade prohibitions;
@@ -132,14 +136,16 @@ Hypotheses to seed the ecology ledger as cleanup candidates:
   file-shape rule.
 
 No keep, retire, replace, or split decision is authorized here. Every candidate
-requires row-level evidence and proof in the Rule Ecology Cleanup container.
+requires row-level evidence and proof in the Rule Authority Cleanup container.
 
 Required output when opened:
 
-- a rule ecology frame;
-- a rule-by-rule ledger with rule id/path, source authority, current evidence,
-  evidence/proof class, owner layer, keep/retire/replace/split disposition,
-  first falsifier, required proof commands, non-claims, and review disposition;
+- a rule authority cleanup frame;
+- a refreshed rule-by-rule authority cleanup pass over
+  `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
+  with rule id/path, source authority, current evidence, evidence/proof class,
+  owner layer, keep/retire/replace/split disposition, first falsifier, required
+  proof commands, non-claims, and review disposition;
 - a fresh read-only review loop, separate from implementation agents, covering
   product outcome, owner-boundary, proof, stale-record, and stack lanes, with
   accepted P1/P2 findings blocking closure;
@@ -147,7 +153,7 @@ Required output when opened:
 
 ## Container 2: Reusable Initiative Frame Capture
 
-Status: second container to open after the rule ecology direction is clear.
+Status: second container to open after the rule authority cleanup direction is clear.
 
 Objective:
 capture the reusable method from the completed descent so future blueprint work
@@ -181,7 +187,7 @@ Required capture points:
 - source paths are evidence, not authority;
 - tests prove behavior, not topology or file shape;
 - Habitat patterns and structure rules carry topology/file-shape law;
-- rule ecology cleanup is part of closure, not optional polish;
+- rule authority cleanup is part of closure, not optional polish;
 - temporary anchors and execution packets are retired when they stop doing work.
 
 Known inputs:
@@ -191,7 +197,7 @@ Known inputs:
   `cleanup-execution.md`;
 - Slice 002 prework frame, inventory, decision packets, and closed domino files;
 - `review-protocol.md` and `scopes-and-slices-reference.md`;
-- current `.habitat/blueprints/**/rule.json` state after the rule ecology pass;
+- current `.habitat/blueprints/**/rule.json` state after the rule authority cleanup pass;
 - current Graphite PR and commit history for the completed descent.
 
 Required output when opened:
@@ -204,7 +210,7 @@ Required output when opened:
 
 ## Container 3: Move Across, Not Down
 
-Status: third container to open after the rule ecology and reusable method are
+Status: third container to open after the rule authority cleanup and reusable method are
 captured enough to guide the next descent.
 
 Objective:
@@ -236,7 +242,7 @@ Expected candidates:
 Known inputs:
 
 - the reusable initiative frame produced by Container 2;
-- the rule ecology ledger from Container 1;
+- the rule authority cleanup ledger from Container 1;
 - current Habitat red/green output for enforced and candidate rules;
 - `scopes-and-slices-reference.md`;
 - active workstream slices and inventories under this workstream;
@@ -249,7 +255,7 @@ Required output when opened:
 - candidate comparison with one selected scope and explicit exterior;
 - exact first red-flip or corpus extraction command;
 - decision whether the selected container starts as a scope slice, prework
-  decision slice, or rule ecology follow-on.
+  decision slice, or rule authority cleanup follow-on.
 
 ## Tracked Lower-Order Dominoes
 
@@ -259,13 +265,13 @@ owner layer or makes them a proof blocker.
 
 | Domino | Why tracked | Open when | Must not become |
 | --- | --- | --- | --- |
-| Public TypeFest dependency and contract policy | The strict TypeScript ratchet introduced TypeFest as root developer tooling and used it safely in private/dev surfaces. Broader SDK and MapGen Core replacements touch exported type contracts, so they need owner/dependency policy rather than opportunistic cleanup. | A blueprint/rule-cleanup slice touches public type utilities, emitted declaration surfaces, package dependency policy, or a candidate replacement needs TypeFest to avoid custom type gymnastics. | The immediate next step ahead of rule ecology, reusable method capture, or next blueprint-level slice selection. |
+| Public TypeFest dependency and contract policy | The strict TypeScript ratchet introduced TypeFest as root developer tooling and used it safely in private/dev surfaces. Broader SDK and MapGen Core replacements touch exported type contracts, so they need owner/dependency policy rather than opportunistic cleanup. | A blueprint/rule-cleanup slice touches public type utilities, emitted declaration surfaces, package dependency policy, or a candidate replacement needs TypeFest to avoid custom type gymnastics. | The immediate next step ahead of rule authority cleanup, reusable method capture, or next blueprint-level slice selection. |
 
 ## Transition Closure
 
 This anchor can close when:
 
-- Rule Ecology Cleanup has a frame or execution packet with proof gates,
+- Rule Authority Cleanup has a frame or execution packet with proof gates,
   row-level ledger contract, and review disposition contract;
 - Reusable Initiative Frame Capture has a frame or document home with explicit
   scope, source provenance, non-claims, and retirement/promotion path;
@@ -284,7 +290,7 @@ This anchor can close when:
 - the worktree and stack state are clean, or an explicit handoff records the
   remaining dirty state;
 - `blueprint-authority-stewardship-frame.md` is promoted, superseded, archived,
-  or deleted once its decisions land in owning artifacts;
+  or deleted once its decisions land in owning records;
 - this file is deleted, or moved to archive only if it contains historical
   evidence that was not captured elsewhere.
 

--- a/.habitat/.active/workstreams/define-domain-blueprint-structure/blueprint-authority-stewardship-frame.md
+++ b/.habitat/.active/workstreams/define-domain-blueprint-structure/blueprint-authority-stewardship-frame.md
@@ -22,14 +22,14 @@ In scope:
 
 - The DRA role for the blueprint-authority transition above completed Slice 001.
 - The completed descent as method evidence: domain blueprint frame -> Slice 001 domain-root topology -> decision prework -> row disposition -> execution -> repair -> Habitat ratchet -> closure and ascent.
-- The active pressure set: rule ecology cleanup, reusable cascade capture, and next blueprint-level slice selection.
+- The active pressure set: rule authority cleanup, reusable cascade capture, and next blueprint-level slice selection.
 - Lower-order ratchet dominoes discovered while preparing the worktree, only when tracked as subordinate inputs to the authority cascade rather than promoted above the selected containers.
 - Agent-team operating discipline, including fresh evidence lanes, separate review lanes, and DRA-owned synthesis.
 - Proof-before-closure discipline for future authority containers.
 
 Out of scope:
 
-- Starting rule ecology cleanup in this frame.
+- Starting rule authority cleanup in this frame.
 - Reopening Slice 001 unless fresh repo or Habitat evidence falsifies its closure.
 - Moving source files, changing rules, editing `structure.toml`, changing runtime behavior, or changing public APIs.
 - Promoting transcript language into durable law without confirmation from current user instruction, active repo authority, sealed records, current source, or fresh command evidence.
@@ -62,17 +62,17 @@ This frame treats the current work as stewardship of a repeatable blueprint-auth
 
 ## WHY
 
-The completed domain-root topology descent proved the machine works, but it also created the exact risk Habitat exists to prevent: temporary scaffolding, negative guards, transition anchors, and narrative records can harden into accidental architecture if they are not classified while the descent is fresh. `active-transition-anchor.md` selects Rule Ecology Cleanup as the next container to open. A structurally different alternative would make that cleanup the whole frame. That alternative is too narrow: it would make one pressure salient and hide the larger job of turning a successful descent into a reusable authority practice.
+The completed domain-root topology descent proved the machine works, but it also created the exact risk Habitat exists to prevent: temporary scaffolding, negative guards, transition anchors, and narrative records can harden into accidental architecture if they are not classified while the descent is fresh. `active-transition-anchor.md` selects Rule Authority Cleanup as the next container to open. A structurally different alternative would make that cleanup the whole frame. That alternative is too narrow: it would make one pressure salient and hide the larger job of turning a successful descent into a reusable authority practice.
 
 ## Construction history
 
 Structural alternative considered:
 
-Frame the work as "Rule Ecology Cleanup" with the current rule set as the unit of analysis.
+Frame the work as "Rule Authority Cleanup" with the current rule set as the unit of analysis.
 
 Why rejected or demoted:
 
-Rule Ecology Cleanup is the selected next container to open, but it is not the whole transition. Making it the top-level frame would collapse DRA stewardship into task execution and would leave reusable method capture and next-slice selection as secondary afterthoughts.
+Rule Authority Cleanup is the selected next container to open, but it is not the whole transition. Making it the top-level frame would collapse DRA stewardship into task execution and would leave reusable method capture and next-slice selection as secondary afterthoughts.
 
 Perspective / discovery passes used:
 
@@ -130,18 +130,18 @@ Hard core:
 
 Protective belt:
 
-- Exact file names and homes for future rule ecology, initiative-frame, and next-slice artifacts.
+- Exact file names and homes for future rule authority cleanup, initiative-frame, and next-slice records.
 - Exact number and names of peer-agent lanes, as long as evidence and review remain fresh and separated.
-- Exact sequencing after the Rule Ecology Cleanup container, unless fresh source or Habitat evidence forces a reframe of the transition anchor.
-- Placement of subordinate ratchet dominoes such as public TypeFest dependency/contract policy, as long as they remain tracked without displacing blueprint topology, rule ecology, or next-slice selection.
+- Exact sequencing after the Rule Authority Cleanup container, unless fresh source or Habitat evidence forces a reframe of the transition anchor.
+- Placement of subordinate ratchet dominoes such as public TypeFest dependency/contract policy, as long as they remain tracked without displacing blueprint topology, rule authority cleanup, or next-slice selection.
 - Whether Narsil, `rg`, Git, Habitat classify, Habitat checks, or Graphite history supplies the first evidence pass for a given question.
-- Whether this frame later promotes into a more durable method document or retires after its decisions land in owning artifacts.
+- Whether this frame later promotes into a more durable method document or retires after its decisions land in owning records.
 
 ## Reframe conditions
 
 What would force a reframe:
 
-If fresh repo state, Habitat output, or sealed authority shows that Slice 001 did not actually close, or if a rule/workstream artifact cannot be classified without reopening source semantics, the stewardship frame must stop and open a dedicated reframe or slice instead of absorbing that anomaly into transition prose.
+If fresh repo state, Habitat output, or sealed authority shows that Slice 001 did not actually close, or if a rule/workstream record cannot be classified without reopening source semantics, the stewardship frame must stop and open a dedicated reframe or slice instead of absorbing that anomaly into transition prose.
 
 Degeneration trigger:
 
@@ -190,10 +190,10 @@ Assumptions committed:
   agent skill for Habitat DRA operation; project/workstream documents inform
   provenance, product intent, or sealed records according to the skill's
   authority map, but they are not skills.
-- Rule Ecology Cleanup is the selected next container to open, not an implementation task opened by this frame.
+- Rule Authority Cleanup is the selected next container to open, not an implementation task opened by this frame.
 - This frame is active-workstream authority for takeover and stewardship; it is not evergreen law until promoted or superseded by a more durable owner.
-- The active rule set may be green without being permanently classified; reusable-class proof belongs to the rule ecology container, not this frame.
+- The active rule set may be green without being permanently classified; reusable-class proof belongs to the rule authority cleanup container, not this frame.
 
 ## NOT HOW
 
-This frame does not prescribe the exact rule ecology edits, the next-slice selection, the rule-by-rule ledger, or any source movement. Those belong in the next opened container's frame, slice packet, ledger, implementation plan, review records, and Graphite layer.
+This frame does not prescribe the exact rule authority cleanup edits, the next-slice selection, the rule-by-rule ledger, or any source movement. Those belong in the next opened container's frame, slice packet, ledger, implementation plan, review records, and Graphite layer.

--- a/.habitat/.active/workstreams/establish-mapgen-product-authority/MAPGEN-PRODUCT-AUTHORITY-FRAME.md
+++ b/.habitat/.active/workstreams/establish-mapgen-product-authority/MAPGEN-PRODUCT-AUTHORITY-FRAME.md
@@ -22,7 +22,7 @@ Use this frame to decide whether a rule is:
 
 This frame is not the operational remediation matrix. The machine-readable
 source of remediation progress remains
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`.
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`.
 
 ## Evidence And Claim Status
 

--- a/.habitat/.active/workstreams/establish-mapgen-product-authority/corpus-inventory.md
+++ b/.habitat/.active/workstreams/establish-mapgen-product-authority/corpus-inventory.md
@@ -49,7 +49,7 @@ This inventory is the starting corpus for the product-authority framing investig
 - `.habitat/.active/frames/REMAINDER-REMEDIATION-ACTION-FRAME.md`
 - `.habitat/.active/frames/BLUEPRINT-KIND-GATHERING-FRAME.md`
 - `.habitat/.active/frames/PROJECTION-CONTRACT-SURFACE-FRAME.md`
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Engine Refactor V1 Authority Corpus
 

--- a/.habitat/.active/workstreams/establish-mapgen-product-authority/lane-artifacts/adversarial-review.md
+++ b/.habitat/.active/workstreams/establish-mapgen-product-authority/lane-artifacts/adversarial-review.md
@@ -15,7 +15,7 @@ No source, rule, test, generated output, or packet files were mutated.
   the active MapGen/Swooper Maps normalization baseline.
 - Current canonical MapGen docs under `docs/system/libs/mapgen/**` are authority
   only where they do not conflict with the packet or explicitly defer to it.
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json` is the
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json` is the
   machine-readable operational record for the current Layer 2 queue.
 - Source is implementation/constructibility evidence, not target authority.
 - Archive, research, old closed-slice prose, and generated output are discovery
@@ -43,7 +43,7 @@ Evidence:
   `placement` are projection/engine-facing surfaces.
 - `mods/mod-swooper-maps/src/recipes/standard/contract-manifest.ts`: source
   lists stage and step order, but no explicit `kind` or classification field.
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`: queues
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`: queues
   `prohibit_map_projection_dependencies_in_physics_contracts`,
   `prohibit_runtime_continent_contract_tokens`,
   `prohibit_hydrology_runtime_continent_step_tokens`, and
@@ -88,7 +88,7 @@ Evidence:
 - `docs/system/ADR.md` ADR-008: `domain/resources` owns resource planning; a
   future Gameplay consolidation may absorb starts/discoveries/wonders but does
   not re-own resources.
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`: queues
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`: queues
   `morphology-story-overlay-ownership-gate` and marks morphology/story overlay
   rows as sealed semantic blockers.
 
@@ -127,7 +127,7 @@ Evidence:
 - `docs/system/libs/mapgen/reference/domains/PLACEMENT.md`: policy data flows
   from generated `@civ7/map-policy` tables, regenerated via the owning verify
   command; recipe code should not read `globalThis.GameInfo`.
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`: queues
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`: queues
   `block_hand_edits_to_generated_civ7_types`,
   `block_hand_edits_to_generated_map_policy_tables`,
   `ensure_map_policy_dependency_independence`, and
@@ -208,7 +208,7 @@ Evidence:
   `mods/mod-swooper-maps/src/domain/foundation/lib/tectonics/shared.ts`,
   `mods/mod-swooper-maps/src/domain/hydrology/ops/compute-thermal-state/rules/index.ts`,
   and `mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/util.ts`.
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`: queues
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`: queues
   `mapgen-helper-surface-authority-consolidation` for
   `prohibit_runtime_helper_redeclarations` and
   `prohibit_foundation_duplicate_math_helper_redefinitions`.
@@ -243,7 +243,7 @@ Evidence:
   requires/provides strings must be registered/validated.
 - `mods/mod-swooper-maps/src/recipes/standard/tags.ts`: current source defines
   `STANDARD_TAG_DEFINITIONS` and `EFFECT_OWNERS` centrally.
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`: queues
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`: queues
   `dependency-effect-tag-family-authority`, while warning not to strengthen the
   root-catalog token scan.
 
@@ -276,7 +276,7 @@ Evidence:
   are current posture; wrapper-only `advanced` has been removed.
 - `docs/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md`: stages
   compile `stage.surfaceSchema` into knobs and raw step configs.
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`: says
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`: says
   `verify_standard_recipe_public_authoring_surface` already owns exact standard
   stage public keys, strict schemas, focus paths, and raw-envelope constraints.
 - `docs/system/libs/mapgen/reference/domains/FOUNDATION.md` still says each
@@ -316,7 +316,7 @@ Evidence:
   `/base-standard/**` and engine globals are in the adapter implementation.
 - `packages/civ7-adapter/src/types.ts`: adapter type surface documents
   official generator and runtime methods.
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`: says
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`: says
   `enforce_adapter_only_base_standard_imports` overclaims runtime by matching
   `import type` and declaration-file fixtures; it also queues Studio UI,
   devops, and build-currentness rows together.
@@ -342,7 +342,7 @@ ignored. A synthesis that treats it as a normal static import rule will
 overstate verification.
 
 Evidence:
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`: records an
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`: records an
   implementation falsifier from 2026-07-01: Habitat/Grit source execution obeys
   `.gritignore`, excluding `**/test/` and `**/*.test.ts`; a temporary forbidden
   deep import in a test file was ignored by Grit.

--- a/.habitat/.active/workstreams/establish-mapgen-product-authority/lane-artifacts/ontology-authority-model.md
+++ b/.habitat/.active/workstreams/establish-mapgen-product-authority/lane-artifacts/ontology-authority-model.md
@@ -40,7 +40,7 @@ source hierarchy.
 | Stratum | Meaning | Packet use |
 | --- | --- | --- |
 | Accepted authority | Current user instruction, AGENTS/process routing, accepted project baseline, canonical MapGen reference docs, accepted frames | Can define owner, accepted concept, relation semantics, or decision vocabulary |
-| Operational ledger | `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json` | Canonical operational source for Layer 1 rows, packet queue, blockers, and action decisions |
+| Operational ledger | `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json` | Canonical operational source for Layer 1 rows, packet queue, blockers, and action decisions |
 | Candidate authority | Ledger rows, queued slices, `_blueprints` pressure, local negative proxies, unresolved semantic blockers | Can seed Layer 2 packet design; cannot be treated as accepted kind until affirmed |
 | Raw evidence | Rule manifests, runners, generated output, code, tests, docs examples, official resources | Not inspected in this lane except listed docs/ledger; implementation status requires Lane 4 source-constructibility evidence |
 | Contradiction | Source or ledger fact that falsifies a proposed owner/action, e.g. Grit ignoring tests or source proof showing mixed owners | Must be preserved; cannot be smoothed into "no action" |

--- a/.habitat/.active/workstreams/establish-mapgen-product-authority/lane-design.md
+++ b/.habitat/.active/workstreams/establish-mapgen-product-authority/lane-design.md
@@ -206,7 +206,7 @@ Source scope:
 - .habitat/.active/frames/BLUEPRINT-KIND-GATHERING-FRAME.md
 - .habitat/.active/frames/RULE-ACTION-CLASSIFICATION-FRAME.md
 - .habitat/.active/frames/RULE-DECISION-PACKET-FRAME.md
-- .habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json
+- .habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json
 - docs/system/libs/mapgen/reference/GLOSSARY.md
 - docs/system/libs/mapgen/reference/ARTIFACTS.md
 - docs/system/libs/mapgen/reference/TAGS.md
@@ -245,7 +245,7 @@ Source scope:
 - .habitat/.active/workstreams/establish-mapgen-product-authority/investigation-brief.md
 - .habitat/.active/workstreams/establish-mapgen-product-authority/corpus-inventory.md
 - docs/projects/engine-refactor-v1/architecture-normalization-packet.md
-- .habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json
+- .habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json
 - docs/system/libs/mapgen/**/*.md, inspected through the search pass below
 - source anchors only when needed to validate a specific contradiction already identified from the docs/action matrix
 

--- a/.habitat/.active/workstreams/orient-layer3-authority-consolidation/scratchpad.md
+++ b/.habitat/.active/workstreams/orient-layer3-authority-consolidation/scratchpad.md
@@ -6,7 +6,7 @@ Built: 2026-07-01
 
 Owner: Habitat authority-tree workstream steward
 
-Operational ledger: `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+Operational ledger: `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Authority Model
 
@@ -23,7 +23,7 @@ Intent and concept authority:
 
 Operational selection authority:
 
-1. `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`.
+1. `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`.
 2. Current live `.habitat/**/rule.json` manifests and support files.
 3. Current generated execution-surface maps when a slice changes execution
    surface state.
@@ -452,4 +452,4 @@ closes, a blocker becomes implementation-ready, a source-owner decision changes
 the next-domino order, or the authority order itself changes.
 
 Do not copy the active queue here. The canonical operational queue remains in
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`.
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`.

--- a/.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json
+++ b/.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": 2,
-  "kind": "habitat.ruleRemediation.operationalLedger",
+  "kind": "habitat.ruleAuthorityCleanup.operationalLedger",
   "status": "canonical-operational-source",
-  "updatedOn": "2026-07-03",
-  "recordPolicy": "This JSON file is the only machine-readable operational source for rule-remediation progress. Markdown receipts may explain completed slices, but they must not duplicate or define active rule rows, queue, blockers, or counts.",
+  "updatedOn": "2026-07-06",
+  "recordPolicy": "This JSON file is the only machine-readable operational source for rule authority cleanup: live rule rows, retired/stale references, queued/completed slices, blockers, findings, counts, and gate state. Markdown receipts may explain completed slices, but they must not duplicate or define active rule rows, queue, blockers, or counts.",
   "controllingFrame": ".habitat/.active/frames/RULE-REMEDIATION-WORKSTREAM-FRAME.md",
   "layerMethod": ".habitat/.active/frames/RULE-ACTION-CLASSIFICATION-FRAME.md",
   "corpus": {
-    "liveManifestCount": 106,
-    "currentRowCount": 106,
+    "liveManifestCount": 114,
+    "currentRowCount": 114,
     "retiredHistoricalRowCount": 22,
     "missingLiveRows": [],
     "duplicateLiveRows": []
@@ -20,15 +20,15 @@
       "split by owner": 10,
       "runtime/source validation": 3,
       "retirement/garbage collection": 3,
-      "context admission": 18,
+      "context admission": 26,
       "boundary inversion": 3,
       "closed structure inversion": 1
     },
     "packetNeeded": {
-      "false": 106
+      "false": 114
     },
     "layer2Status": {
-      "none": 80,
+      "none": 88,
       "packet-complete": 19,
       "excluded-native-rail-not-semantic-remediation": 1,
       "implementation-ready": 1,
@@ -37,13 +37,13 @@
     }
   },
   "gateState": {
-    "currentLayer": "Narrative burn-down review repair complete.",
-    "currentGate": "Ready to select the next trusted Layer 3 slice from current implementation-ready/native-owner rows; story overlay owner rows retired with the deleted source surface.",
-    "mutationAuthorization": "This slice deleted the current MapGen story network, connected compatibility state, and three Habitat story-overlay packets with source-absence proof.",
+    "currentLayer": "Rule authority cleanup corpus grounded after the completed domain-root topology ratchets.",
+    "currentGate": "Ready to open the Rule Authority Cleanup container from the active transition anchor; every live rule row must be reclassified before keep/retire/replace/split decisions are authorized.",
+    "mutationAuthorization": "This grounding slice may rename and refresh the operational ledger only. It does not authorize rule deletion, runner changes, baseline growth, or source movement.",
     "nextSliceId": null,
-    "nextLegalAction": "Select the next trusted Layer 3 slice from the canonical ledger, likely domain-operation config-facade consolidation or another native-owner deletion/rail. Do not implement stage-kind sidecars, generic Habitat domain-operation promotion, morphology-local owner reshuffles, or workspace-hygiene cleanup as semantic remediation.",
-    "operationalSourceOfTruth": ".habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json",
-    "sourceCommit": "61126d664"
+    "nextLegalAction": "Open the Rule Authority Cleanup frame and run row-level review against the refreshed current ledger. Do not select a cleanup implementation slice until the ledger rows have fresh evidence and review disposition.",
+    "operationalSourceOfTruth": ".habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json",
+    "sourceCommit": "50f8db56c0"
   },
   "rules": [
     {
@@ -548,15 +548,6 @@
       "currentPath": ".habitat/civ7/mapgen/domains/foundation/rules/prohibit_legacy_compute_tectonics_token/rule.json"
     },
     {
-      "ruleId": "require_morphology_public_surface_imports",
-      "lane": "domains/nonfoundation",
-      "actionDecision": "no action",
-      "packetNeeded": false,
-      "expectedRemediation": "Stay live as morphology public-surface import boundary authority.",
-      "evidenceNote": "Domino 63 replaced the retired-path proxy with a single Grit public-surface import rule for non-domain consumers; G4 remains recipe-wide domain import authority, while this morphology row owns morphology-specific consumer relapse detection outside the domain internals.",
-      "currentPath": ".habitat/civ7/mapgen/domains/morphology/rules/require_morphology_public_surface_imports/rule.json"
-    },
-    {
       "ruleId": "prohibit_map_projection_dependencies_in_physics_contracts",
       "lane": "standard recipe top-level",
       "actionDecision": "split by owner",
@@ -814,6 +805,26 @@
       "currentPath": ".habitat/blueprints/mod-map/protect_generated_map_entrypoints_from_hand_edits/rule.json"
     },
     {
+      "ruleId": "require_artifact_file_shape",
+      "lane": "blueprints/artifact",
+      "actionDecision": "context admission",
+      "packetNeeded": false,
+      "expectedRemediation": "Keep as current positive artifact file-shape law pending rule-authority cleanup reusable-class proof.",
+      "evidenceNote": "Seeded from the completed domain-root topology descent and current live rule.json manifest; previous Layer 1 ledger was stale and missed this positive-law row.",
+      "currentPath": ".habitat/blueprints/artifact/require_artifact_file_shape/rule.json",
+      "layer2Status": "none"
+    },
+    {
+      "ruleId": "require_artifact_index_aggregate_shape",
+      "lane": "blueprints/artifact",
+      "actionDecision": "context admission",
+      "packetNeeded": false,
+      "expectedRemediation": "Keep as current positive artifact index aggregate law pending rule-authority cleanup reusable-class proof.",
+      "evidenceNote": "Seeded from the completed domain-root topology descent and current live rule.json manifest; previous Layer 1 ledger was stale and missed this positive-law row.",
+      "currentPath": ".habitat/blueprints/artifact/require_artifact_index_aggregate_shape/rule.json",
+      "layer2Status": "none"
+    },
+    {
       "ruleId": "require_docs_site_root_inputs",
       "lane": "non-Civ docs/global/toolkit",
       "actionDecision": "no action",
@@ -832,6 +843,46 @@
       "currentPath": ".habitat/blueprints/recipe-step/require_domain_contract_roots_in_step_contracts/rule.json"
     },
     {
+      "ruleId": "require_domain_model_schema_policy_owner_shape",
+      "lane": "blueprints/domain",
+      "actionDecision": "context admission",
+      "packetNeeded": false,
+      "expectedRemediation": "Keep as current positive domain model schema/policy owner-shape law pending rule-authority cleanup reusable-class proof.",
+      "evidenceNote": "Seeded from the completed domain-root topology descent and current live rule.json manifest; previous Layer 1 ledger was stale and missed this positive-law row.",
+      "currentPath": ".habitat/blueprints/domain/require_domain_model_schema_policy_owner_shape/rule.json",
+      "layer2Status": "none"
+    },
+    {
+      "ruleId": "require_domain_operation_contract_file_shape",
+      "lane": "blueprints/domain-operation",
+      "actionDecision": "context admission",
+      "packetNeeded": false,
+      "expectedRemediation": "Keep as current positive operation contract file-shape law pending rule-authority cleanup reusable-class proof.",
+      "evidenceNote": "Seeded from the completed domain-root topology descent and current live rule.json manifest; previous Layer 1 ledger was stale and missed this positive-law row.",
+      "currentPath": ".habitat/blueprints/domain-operation/require_domain_operation_contract_file_shape/rule.json",
+      "layer2Status": "none"
+    },
+    {
+      "ruleId": "require_domain_ops_binding_surface",
+      "lane": "blueprints/domain",
+      "actionDecision": "context admission",
+      "packetNeeded": false,
+      "expectedRemediation": "Keep as current positive domain ops binding-surface law pending rule-authority cleanup reusable-class proof.",
+      "evidenceNote": "Seeded from the completed domain-root topology descent and current live rule.json manifest; previous Layer 1 ledger was stale and missed this positive-law row.",
+      "currentPath": ".habitat/blueprints/domain/require_domain_ops_binding_surface/rule.json",
+      "layer2Status": "none"
+    },
+    {
+      "ruleId": "require_domain_ops_registry_surface",
+      "lane": "blueprints/domain-operation",
+      "actionDecision": "context admission",
+      "packetNeeded": false,
+      "expectedRemediation": "Keep as current positive domain operation registry-surface law pending rule-authority cleanup reusable-class proof.",
+      "evidenceNote": "Seeded from the completed domain-root topology descent and current live rule.json manifest; previous Layer 1 ledger was stale and missed this positive-law row.",
+      "currentPath": ".habitat/blueprints/domain-operation/require_domain_ops_registry_surface/rule.json",
+      "layer2Status": "none"
+    },
+    {
       "ruleId": "require_domain_ops_root_presence",
       "lane": "blueprints/domain-operation",
       "actionDecision": "no action",
@@ -839,6 +890,16 @@
       "expectedRemediation": "Stay live as structure authority.",
       "evidenceNote": "All expected domain `ops` roots exist.",
       "currentPath": ".habitat/blueprints/domain-operation/require_domain_ops_root_presence/rule.json"
+    },
+    {
+      "ruleId": "require_domain_source_topology",
+      "lane": "blueprints/domain",
+      "actionDecision": "context admission",
+      "packetNeeded": false,
+      "expectedRemediation": "Keep as current positive domain source topology law pending rule-authority cleanup reusable-class proof.",
+      "evidenceNote": "Seeded from the completed domain-root topology descent and current live rule.json manifest; previous Layer 1 ledger was stale and missed this positive-law row.",
+      "currentPath": ".habitat/blueprints/domain/require_domain_source_topology/rule.json",
+      "layer2Status": "none"
     },
     {
       "ruleId": "require_ecology_canonical_op_module_topology",
@@ -891,6 +952,15 @@
       "expectedRemediation": "Admit as morphology config facade surface rule.",
       "evidenceNote": "Script asserts exact exports and current source matches.",
       "currentPath": ".habitat/civ7/mapgen/domains/morphology/rules/require_morphology_config_facade_exports/rule.json"
+    },
+    {
+      "ruleId": "require_morphology_public_surface_imports",
+      "lane": "domains/nonfoundation",
+      "actionDecision": "no action",
+      "packetNeeded": false,
+      "expectedRemediation": "Stay live as morphology public-surface import boundary authority.",
+      "evidenceNote": "Domino 63 replaced the retired-path proxy with a single Grit public-surface import rule for non-domain consumers; G4 remains recipe-wide domain import authority, while this morphology row owns morphology-specific consumer relapse detection outside the domain internals.",
+      "currentPath": ".habitat/civ7/mapgen/domains/morphology/rules/require_morphology_public_surface_imports/rule.json"
     },
     {
       "ruleId": "require_narrow_game_ui_bridge_bootstrap",
@@ -961,6 +1031,16 @@
       "expectedRemediation": "Admit as Recipe-DAG operating-area authority.",
       "evidenceNote": "Runner passed; source routes through `studio-contracts` and `contract-manifest`. Corrective local-proxy review left this settled: graph-aware recipe-DAG metadata closure is a real operating-area boundary.",
       "currentPath": ".habitat/civ7/mapgen/studio/recipe-dag/rules/require_recipe_dag_contract_metadata/rule.json"
+    },
+    {
+      "ruleId": "require_recipe_stage_authoring_file_shape",
+      "lane": "blueprints/recipe-stage",
+      "actionDecision": "context admission",
+      "packetNeeded": false,
+      "expectedRemediation": "Keep as current positive recipe stage authoring file-shape law pending rule-authority cleanup reusable-class proof.",
+      "evidenceNote": "Seeded from the completed domain-root topology descent and current live rule.json manifest; previous Layer 1 ledger was stale and missed this positive-law row.",
+      "currentPath": ".habitat/blueprints/recipe-stage/require_recipe_stage_authoring_file_shape/rule.json",
+      "layer2Status": "none"
     },
     {
       "ruleId": "require_runtime_domain_op_bundle_imports",

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-cascade-stop-gate.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-cascade-stop-gate.md
@@ -3,7 +3,7 @@
 Status: superseded historical receipt.
 
 Superseded by the canonical operational ledger:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`.
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`.
 
 This file records a past stop gate only. Do not use it for current counts,
 queues, blockers, or next actions.

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-config-key-retirement-slice.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-config-key-retirement-slice.md
@@ -3,7 +3,7 @@
 Status: closed
 
 Canonical source of truth:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Slice Boundary
 
@@ -48,7 +48,7 @@ Deleted packets:
 
 Updated durable records:
 
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 - `.habitat/.active/dominoes/items/056-retire-config-key-literal-assertions.md`
 
 Updated method frames:

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-domain-import-matrix-slice.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-domain-import-matrix-slice.md
@@ -4,7 +4,7 @@ Status: closed
 
 Branch: `codex/habitat-g4-domain-import-matrix`
 
-Canonical source: `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+Canonical source: `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Purpose
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-domain-operation-strategy-slice.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-domain-operation-strategy-slice.md
@@ -4,7 +4,7 @@ Status: closed
 
 Branch: `codex/habitat-domain-operation-strategy-authority`
 
-Source matrix: `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+Source matrix: `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 Action class: product-backed blueprint authority creation
 
@@ -75,7 +75,7 @@ Changes made:
   blueprint authority.
 - Updated `.habitat/.active/frames/DESTINATION-SIMPLIFICATION-FRAME.md` so the old
   `domain-operation-strategy` exclusion is explicitly superseded.
-- Promoted `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+- Promoted `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
   as the single canonical operational matrix for current live-corpus queries.
 - Absorbed the former authority-tree rule ledger matrix into the canonical JSON
   operational ledger; no separate Markdown ledger is retained.
@@ -89,7 +89,7 @@ No rule manifests, runners, support files, or execution-surface docs changed.
 | --- | --- | --- | --- | --- |
 | `domain-operation-strategy` is constructible and product-backed. | P2 | accepted | Created the blueprint authority README and updated authority tree shape. | Future rows still need positive strategy-locality/strategy-contract packets before movement or deletion. |
 | No current live rule moves whole into the new authority. | P2 | accepted | Explicit non-move rows recorded for foundation strategy locality, foundation helper consolidation, and ecology contract quality. | The next implementation slice must not treat scan roots alone as strategy authority. |
-| The old Markdown rule ledger still looked like a second operational matrix. | P2 | accepted | Moved its unique process data into `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json` and removed the Markdown ledger. | None; the JSON is the only active source for current matrix/process queries. |
+| The old Markdown rule ledger still looked like a second operational matrix. | P2 | accepted | Moved its unique process data into `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json` and removed the Markdown ledger. | None; the JSON is the only active source for current matrix/process queries. |
 
 ## Closure
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-foundation-config-boundary-rail.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-foundation-config-boundary-rail.md
@@ -52,5 +52,5 @@ junk drawer for source-shape enforcement.
 ## Record
 
 The canonical operational record is
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`; this receipt
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`; this receipt
 does not duplicate the action matrix.

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-foundation-helper-rail-admission.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-foundation-helper-rail-admission.md
@@ -54,5 +54,5 @@ file scope so typed helper declarations are caught.
 ## Record
 
 The canonical operational record is
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`; this receipt
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`; this receipt
 does not duplicate the action matrix.

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-foundation-retired-token-garbage-collection.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-foundation-retired-token-garbage-collection.md
@@ -47,5 +47,5 @@ because it has a separate accepted Habitat Grit recurrence guard:
 ## Record
 
 The canonical operational record is
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`; this receipt
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`; this receipt
 does not duplicate the action matrix.

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-g9-advanced-guard-context-slice.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-g9-advanced-guard-context-slice.md
@@ -5,7 +5,7 @@ Status: closed
 Branch: `codex/habitat-g9-advanced-guard-context`
 
 Canonical source:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Purpose
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-mapgen-helper-surface-authority-consolidation.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-mapgen-helper-surface-authority-consolidation.md
@@ -3,7 +3,7 @@
 Status: Layer 2 decision packet complete; Layer 3 entry warrant recorded.
 
 Canonical operational record:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`.
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`.
 
 ## Purpose
 
@@ -204,7 +204,7 @@ requires a separate source-backed authority packet.
 ## Layer 3 Entry Warrant
 
 Operational ledger path:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 Selected rule ids:
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-morphology-belt-driver-contract-inversion.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-morphology-belt-driver-contract-inversion.md
@@ -3,7 +3,7 @@
 Status: closed on `codex/habitat-morphology-belt-driver-contract-inversion`
 
 Canonical record:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Purpose
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-morphology-overlay-implementation-rail.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-morphology-overlay-implementation-rail.md
@@ -3,7 +3,7 @@
 Status: closed on `codex/habitat-morphology-overlay-implementation-rail`.
 
 Canonical record:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`.
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`.
 
 This file is a receipt only. It is not a second operational matrix.
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-morphology-public-surface-boundary-slice.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-morphology-public-surface-boundary-slice.md
@@ -3,7 +3,7 @@
 Status: closed on `codex/habitat-morphology-public-surface-boundary`
 
 Canonical record:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Purpose
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-projection-and-morphology-boundary-rails.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-projection-and-morphology-boundary-rails.md
@@ -48,5 +48,5 @@ source-pattern boundary, not a package-owned behavior test.
 ## Record
 
 The canonical operational record is
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`; this receipt
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`; this receipt
 does not duplicate the action matrix.

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-recipe-dag-split-rail-reclassification.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-recipe-dag-split-rail-reclassification.md
@@ -3,7 +3,7 @@
 Status: closed on `codex/habitat-recipe-dag-split-rail-classification`
 
 Canonical record:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Purpose
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-residual-cascade-reread.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-residual-cascade-reread.md
@@ -3,13 +3,13 @@
 Status: superseded historical receipt.
 
 Superseded by the canonical operational ledger:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`.
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`.
 
 This file records a past re-read only. Do not use it for current counts,
 queues, blockers, or next actions.
 
 Canonical record:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`.
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`.
 
 This file is a receipt only. It is not a second operational ledger.
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-retirement-slice.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-retirement-slice.md
@@ -4,7 +4,7 @@ Status: closed
 
 Branch: `codex/habitat-rule-remediation-garbage-collection`
 
-Source matrix: `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+Source matrix: `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 Action class: `retirement/garbage collection`
 
@@ -154,7 +154,7 @@ Deleted packet directories:
 
 Record updates:
 
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json` removes the five retired
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json` removes the five retired
   rows from the live matrix and lists them as stale/retired references.
 - `.habitat/.active/dominoes/items/051-retire-clean-garbage-collection-rule-residue.md` records the garbage-collection disposition.
 - `tools/habitat/test/commands/habitat-commands.test.ts` no longer uses a

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-runtime-helper-redeclaration-source-slice.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-runtime-helper-redeclaration-source-slice.md
@@ -3,7 +3,7 @@
 Status: closed on `codex/habitat-runtime-helper-redeclaration-source`
 
 Canonical record:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Purpose
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-standard-recipe-context-guards.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-standard-recipe-context-guards.md
@@ -3,7 +3,7 @@
 Status: closed on `codex/habitat-standard-recipe-context-guards`
 
 Canonical record:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Purpose
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-standard-recipe-topology-slice.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-standard-recipe-topology-slice.md
@@ -5,7 +5,7 @@ Status: closed
 Branch: `codex/habitat-standard-recipe-topology-rail`
 
 Canonical source:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Purpose
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-standard-stage-key-freeze-retirement-slice.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-standard-stage-key-freeze-retirement-slice.md
@@ -5,7 +5,7 @@ Status: closed
 Branch: `codex/habitat-retire-standard-stage-key-freeze`
 
 Canonical source:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Purpose
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-standard-tag-catalog-retired-token-gc.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-standard-tag-catalog-retired-token-gc.md
@@ -52,5 +52,5 @@ script, and not a new negative Habitat assertion.
 ## Record
 
 The canonical operational record is
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`; this receipt
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`; this receipt
 does not duplicate the action matrix.

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-studio-devops-topology-source-watch-slice.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-studio-devops-topology-source-watch-slice.md
@@ -5,7 +5,7 @@ Status: closed
 Branch: `codex/habitat-studio-devops-topology-source-watch`
 
 Canonical source:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Purpose
 

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-studio-recipe-dag-owner-slice.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/rule-remediation-studio-recipe-dag-owner-slice.md
@@ -3,7 +3,7 @@
 Status: closed
 
 Canonical source of truth:
-`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+`.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 
 ## Slice Boundary
 
@@ -44,7 +44,7 @@ Updated packet:
 
 Updated durable records:
 
-- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-remediation-layer1-action-matrix.json`
+- `.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json`
 - `.habitat/.active/dominoes/items/057-repair-studio-recipe-dag-owner-metadata.md`
 
 Regenerated execution-surface analytics:

--- a/.habitat/.active/workstreams/remediate-rule-authority/rule-authority-corpus-grounding.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/rule-authority-corpus-grounding.md
@@ -1,0 +1,127 @@
+# Rule Authority Corpus Grounding
+
+Status: active grounding note for the upcoming Rule Authority Cleanup container.
+
+Purpose:
+establish where the live rule corpus and operational ledger live before the
+rule-by-rule authority cleanup pass starts. This note is not a disposition ledger and does
+not authorize rule deletion, runner changes, baseline growth, or source
+movement.
+
+## Corpus Home
+
+The executable corpus is the current live Habitat rule manifest set:
+
+```text
+.habitat/**/rule.json
+```
+
+The machine-readable operational ledger is:
+
+```text
+.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json
+```
+
+That ledger supersedes the old `rule-remediation-layer1-action-matrix.json`
+name. The old name described a prior workstream layer, not the current
+rule authority cleanup container. The ledger itself remains the single active
+machine-readable source for live rule rows, retired/stale references, slices,
+blockers, findings, counts, and gate state.
+
+Markdown receipts under `receipts/` remain historical explanation and evidence.
+They do not define active rule rows or current queue state.
+
+## Fresh Coverage Check
+
+Fresh disk evidence on 2026-07-06:
+
+| Measure | Count |
+| --- | ---: |
+| Current live `rule.json` manifests | 114 |
+| Current live ledger rows | 114 |
+| Missing live rows | 0 |
+| Extra live rows | 0 |
+| Retired historical rows retained in ledger | 22 |
+| Stale/superseded references retained in ledger | 16 |
+
+The previous ledger had 106 active rows and missed the eight positive-law rules
+created or ratcheted by the completed domain-root topology descent:
+
+- `require_artifact_file_shape`
+- `require_artifact_index_aggregate_shape`
+- `require_domain_model_schema_policy_owner_shape`
+- `require_domain_operation_contract_file_shape`
+- `require_domain_ops_binding_surface`
+- `require_domain_ops_registry_surface`
+- `require_domain_source_topology`
+- `require_recipe_stage_authoring_file_shape`
+
+Those rows are now seeded as `context admission` entries. That is a tracking
+state, not final standing-law classification. The Rule Authority Cleanup pass
+must still review each row with fresh evidence before keep, retire, replace, or
+split decisions are authorized.
+
+## Quick Analytics
+
+Current live manifest distribution:
+
+| Axis | High-signal counts |
+| --- | --- |
+| Top areas | `.habitat/blueprints`: 32; `.habitat/civ7/mapgen/pipeline`: 29; `.habitat/civ7/mapgen/domains`: 17; Studio: 7; workspace/global: 5; docs: 7; platform/resources/toolkit remainder: 17 |
+| Owner projects | `mod-swooper-maps`: 79; `habitat`: 18; `mapgen-studio`: 7; everything else: 10 |
+| Runners | `grit`: 71; `habitat:script`: 31; `habitat:structure`: 6; `habitat:file-layer`: 5; `nx`: 1 |
+| Categories | boundary: 39; contract: 28; structure: 14; execution: 13; output: 9; quality: 8; policy: 3 |
+| ID verbs | `prohibit`: 49; `require`: 32; `validate`: 7; `verify`: 6; `preserve`: 6; `block`: 5; `enforce`: 5; `ensure`: 3; `protect`: 1 |
+| Rough assertion polarity | positive-ish verbs: 60; `prohibit`/`block` guards: 54 |
+
+Interpretation:
+this is not a pure garbage-collection pass. Roughly half the corpus is already
+positive or preserving authority. The cleanup needs to separate durable positive
+law, durable boundary rails, transitional negative guards, split-owner rules,
+native-tool proof rails, and fossils.
+
+## Likely Overlap Lanes To Review First
+
+These are analytical hypotheses only. They seed review priority; they do not
+settle any row disposition.
+
+1. Domain topology and fossil guards:
+   `require_domain_source_topology` likely overlaps with retired-domain-root,
+   broad domain artifact module, and older domain topology guards.
+2. Domain operation surfaces:
+   `require_domain_ops_binding_surface`,
+   `require_domain_ops_registry_surface`, and
+   `require_domain_operation_contract_file_shape` likely overlap with
+   config-bag, root config facade, contract-root, and operation-local negative
+   guards.
+3. Artifact owner surfaces:
+   `require_artifact_file_shape` and
+   `require_artifact_index_aggregate_shape` likely absorb some old artifact
+   alias, tag, and validation-owner concerns, but generated recipe output
+   parity/currentness remains a separate proof class.
+4. Recipe-stage authoring:
+   `require_recipe_stage_authoring_file_shape` likely overlaps with wrapper-only
+   advanced config, stage config bag, sentinel passthrough, and standard public
+   authoring-surface checks.
+5. Runtime/build/generated-output rails:
+   rules that mention runtime, adapter, generated output, `dist`, or currentness
+   need proof-class review before any deletion; many likely belong in Nx,
+   package-local validation, generated-output protection, or file-layer rails
+   rather than semantic Habitat patterns.
+
+## Non-Claims
+
+- No rule disposition is final from this grounding pass.
+- No old receipt is re-promoted to current authority by being referenced here.
+- No rule is safe to retire merely because it is negative.
+- No positive rule is permanent standing law until it has reusable-class proof
+  in the Rule Authority Cleanup container.
+
+## Reproduction Commands
+
+```bash
+find .habitat -path '*/rule.json' -print | sort
+jq -r '.rules[]?.ruleId' .habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json | sort
+comm -23 <(find .habitat -path '*/rule.json' -print | while read p; do jq -r '.id' "$p"; done | sort) <(jq -r '.rules[]?.ruleId' .habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json | sort)
+comm -13 <(find .habitat -path '*/rule.json' -print | while read p; do jq -r '.id' "$p"; done | sort) <(jq -r '.rules[]?.ruleId' .habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json | sort)
+```


### PR DESCRIPTION
Renames the canonical rule authority operational ledger from `rule-remediation-layer1-action-matrix.json` to `rule-authority-cleanup-ledger.json` and updates every reference to it across domino receipts, workstream frames, lane artifacts, and process documents. The old name reflected a prior workstream layer structure that no longer describes the ledger's current role.

Alongside the rename, the ledger is refreshed to reflect the live rule corpus after the completed domain-root topology descent. Eight positive-law rules that were missing from the previous 106-row ledger are seeded as `context admission` entries, bringing the live row count to 114. The `kind`, `recordPolicy`, `gateState`, and corpus counts are updated accordingly.

A new `rule-authority-corpus-grounding.md` receipt documents the coverage check, quick analytics over the current manifest set, and likely overlap lanes to prioritize in the upcoming Rule Authority Cleanup pass. It also records the reproduction commands needed to verify ledger-to-manifest parity.

Terminology is normalized throughout: "rule ecology" is replaced with "rule authority cleanup" and "generated-artifact" is replaced with "generated-output" in frame and process documents.