### PR TITLE
feat(habitat): post-ratchet rule revalidation frame + domain-root topology instance draft

### DIFF
--- a/.habitat/.active/frames/POST-RATCHET-RULE-REVALIDATION-FRAME.md
+++ b/.habitat/.active/frames/POST-RATCHET-RULE-REVALIDATION-FRAME.md
@@ -1,0 +1,252 @@
+# Post-Ratchet Rule Revalidation Frame
+
+Status: normative method frame
+
+Durability: standalone method frame for revalidating Habitat rules after a
+blueprint or scope ratchet has landed.
+
+## Frame Identity
+
+Frame name: Post-Ratchet Rule Revalidation
+
+For situation: a bounded authority scope has just been ratcheted into positive
+or stricter Habitat law. Rules in the ratchet blast radius now need cleanup
+review so older guards, proxies, or split-owner checks do not remain live by
+accident.
+
+Mode: systematic method reference
+
+Object path: problem frame for one rule after one ratchet event
+
+Primary object: one live Habitat rule paired with one concrete ratchet event,
+not a whole-corpus audit and not an implementation slice.
+
+## Purpose
+
+Use this frame to decide whether one rule is affected by a completed ratchet
+and, if affected, what cleanup disposition the rule should receive before any
+mutation occurs. The frame is method-only: it supplies the review lens,
+decision order, and per-rule output. It must be paired with an instance
+workstream draft that names the ratchet event, admitted surfaces, absorbing
+authority, likely overlap lanes, and proof commands for that particular pass.
+
+This frame does not contain scope-specific decision criteria. It does not
+execute edits, delete rules, rewrite runners, change baselines, or classify the
+entire live corpus.
+
+## Selection Commitments
+
+In:
+
+- one completed ratchet event described by a paired workstream draft;
+- one candidate live rule and its manifest, pattern, baseline, support files,
+  ledger row, and current source evidence;
+- the positive or stricter authority created by the ratchet;
+- the cleanup action vocabulary already used by rule authority workstreams.
+
+Foreground:
+
+- whether the candidate rule is actually in the ratchet blast radius;
+- whether new authority fully absorbs the old rule;
+- whether concrete residual risk remains;
+- whether a negative rule can be deleted, rewritten as positive authority, or
+  incorporated into an existing authority surface;
+- owner layer and proof class before any mutation.
+
+Exterior:
+
+- rules outside the paired workstream draft's admitted surfaces;
+- general stale-rule review;
+- cosmetic label normalization;
+- implementation plans, file moves, runner migration, and baseline mutation;
+- historical receipt language that has not been revalidated against current
+  manifests, source, baselines, or command behavior.
+
+## Structural Alternative Considered
+
+Alternative:
+run the standard broad rule classification frame directly after each ratchet.
+
+Why rejected:
+standard classification is useful for a whole corpus, but a post-ratchet pass
+has a narrower purpose: test the specific blast radius of a newly landed
+authority surface. The reusable component should therefore select by ratchet
+effect first, then classify only admitted rules.
+
+## Required Pairing Document
+
+This frame is incomplete without a paired instance workstream draft. The draft
+must provide:
+
+- ratchet event name and closure claim;
+- current closure evidence proving the ratchet authority is live;
+- ratcheted authority surfaces;
+- candidate source areas and explicit exclusions;
+- scope-specific admission tests;
+- likely overlap lanes;
+- instance-specific proof commands or proof classes;
+- instance boundaries and stop conditions.
+
+If the paired draft does not name those surfaces, do not use this frame yet.
+Open or repair the workstream draft first.
+
+## Decision Method
+
+Apply the gates in order. The paired workstream draft supplies the concrete
+surface names and proof details. Current path overlap alone never admits a rule
+to a post-ratchet pass; the rule's manifest, selector, pattern, baseline,
+current source evidence, or command evidence must tie it to a ratcheted surface.
+
+1. Scope gate:
+   Does the rule overlap, conflict with, or fall within the ratchet blast
+   radius defined by the paired workstream draft?
+   If no, set `scope` to `out of scope`, leave `actionDecision` as `none`, and
+   stop.
+   If yes, continue.
+
+2. Absorption gate:
+   Is the rule fully absorbed by ratcheted authority at an equal or stronger
+   owner layer?
+   If yes, set `actionDecision` to `consolidation/dedup` and name the absorbing
+   authority.
+   If no, continue.
+
+3. Residual-risk gate:
+   Does the rule catch a concrete live risk that the ratcheted authority does
+   not catch?
+   If no, set `actionDecision` to `retirement/garbage collection`.
+   If yes, continue.
+
+4. Positive-assertion gate:
+   Can the residual intent be asserted positively rather than preserved as a
+   negative guard?
+   If an existing positive assertion already covers the intent, set
+   `actionDecision` to `consolidation/dedup`.
+   If a missing or materially incomplete positive assertion is required, choose
+   the exact action from `RULE-ACTION-CLASSIFICATION-FRAME.md`:
+   `positive authority creation`, `closed structure inversion`, or
+   `boundary inversion`. Do not record retirement until the positive assertion
+   exists and has proof.
+
+5. Split gate:
+   Does the rule contain more than one live invariant with different owners,
+   proof classes, or enforcement surfaces?
+   If yes, and those invariants cannot be represented by one existing positive
+   authority without overclaiming, set `actionDecision` to `split by owner`.
+   If the apparent split consists mostly of obsolete clauses and one absorbed
+   or deterministic rewrite clause, prefer the relevant consolidation,
+   retirement, or inversion action, not `split by owner`.
+
+6. Incorporation gate:
+   Does a live residual clause belong inside an existing positive authority
+   rule rather than as a standalone rule?
+   If yes, set `actionDecision` to `consolidation/dedup` and name the target
+   rule or owner surface.
+
+7. No-action gate:
+   If the rule is admitted, not absorbed, carries concrete residual risk,
+   cannot be represented by existing or deterministic positive authority, and
+   is already at the correct owner layer, set `actionDecision` to `no action`.
+
+## Diagnostic Questions
+
+Answer these before assigning any admitted action decision:
+
+1. Absorption:
+   Which ratcheted rule or owner surface, if any, makes this rule redundant?
+2. Residual risk:
+   What concrete violation still escapes the ratcheted authority?
+3. Owner layer:
+   Which layer should own the residual invariant: Habitat, `structure.toml`,
+   source code, package validation, TypeScript, Biome, Nx, generated-output
+   proof, or another named rail?
+4. Proof shape:
+   What proof class would make the disposition safe? If the required proof
+   belongs to another owner layer, name that dependency instead of recording a
+   Habitat cleanup disposition.
+5. Vocabulary collision:
+   Does the proposed wording conflict with source-domain terms? If yes, rename
+   the process term before recording the result.
+
+## Output Format Per Rule
+
+Return exactly one compact record per reviewed rule:
+
+```text
+rule: <rule id>
+scope: <admitted | out of scope>
+actionDecision: <none for out of scope | one existing action decision from RULE-ACTION-CLASSIFICATION-FRAME.md>
+rationale: <one sentence naming absorption, residual risk, or owner-layer reason>
+evidence: <current manifest/pattern/baseline/source path or command evidence>
+absorber: <absorbing rule id or owner surface | none>
+oldShape: <old forbidden shape absorbed or residual shape at issue | none>
+dependency: <none | required positive assertion / proof / owner decision>
+proof: <one named proof class or command family needed before mutation>
+falsifier: <specific condition that would invalidate this record>
+```
+
+For `consolidation/dedup` with expected old-rule deletion, `absorber`,
+`oldShape`, and `proof` are mandatory. For `retirement/garbage collection`,
+`oldShape` and `proof` are mandatory, while `absorber` may be `none` when the
+rule is retired residue rather than absorbed by a survivor. A
+deletion-oriented record without the required fields for its action decision is
+not valid.
+
+For `out of scope`, `rationale` must name the failed admission criterion or
+the exterior surface that excludes the rule.
+
+## Relationship To Existing Decision Frames
+
+This frame is a post-ratchet overlay. It does not replace:
+
+- `RULE-ACTION-CLASSIFICATION-FRAME.md`, which owns the action vocabulary;
+- `RULE-DECISION-PACKET-FRAME.md`, which owns deep semantic decision packets;
+- `RULE-REMEDIATION-SLICE-FRAME.md`, which owns implementation after decisions
+  are accepted.
+
+If this frame cannot produce a compact disposition without deep clause
+analysis, route to the decision-packet frame instead of expanding this frame.
+
+## Hard Core
+
+1. A post-ratchet pass reviews only the ratchet blast radius named by the
+   paired workstream draft.
+2. Ratcheted positive or stricter authority is the primary absorption test.
+3. Residual risk must be concrete and owner-layered before a rule can survive.
+4. Apparent splits that are semantically obsolete lean consolidation,
+   retirement, or inversion, not `split by owner`.
+5. No disposition is final without current evidence and a named proof class.
+
+## Protective Belt
+
+- The instance workstream draft may conservatively admit a rule for review, but
+  the per-rule record must still prove the scope gate.
+- Historical receipts can explain prior intent, but current source, manifests,
+  baselines, and commands decide current standing.
+- `actionDecision` must use the existing action vocabulary exactly.
+
+## Reframe Conditions
+
+What would force a reframe:
+if the paired workstream draft cannot name a bounded ratchet event and admitted
+surfaces, this frame has no unit of analysis and must not be used.
+
+Degeneration trigger:
+if a reviewed rule requires proof outside the paired workstream draft's ratchet
+surfaces, return `out of scope` with the exterior reason instead of forcing a
+disposition inside this frame.
+
+## Assumptions Committed
+
+- The ratchet event has actually closed and current authority is live.
+- The paired instance draft, not this generic frame, names the concrete source
+  surfaces and proof commands.
+- A negative rule is not stale merely because it is negative.
+- Missing positive authority is an inversion or positive-authority action, not
+  a retirement action.
+
+## NOT HOW
+
+This frame does not prescribe team structure, batching, file edits, branch
+strategy, or implementation order. Those belong to the paired workstream draft
+or a later remediation slice.

--- a/.habitat/.active/workstreams/remediate-rule-authority/domain-root-topology-rule-revalidation-workstream-draft.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/domain-root-topology-rule-revalidation-workstream-draft.md
@@ -1,0 +1,194 @@
+# Domain-Root Topology Rule Revalidation Workstream Draft
+
+Status: draft instance input for `POST-RATCHET-RULE-REVALIDATION-FRAME.md`.
+
+Purpose:
+define the first concrete post-ratchet rule revalidation pass. The reusable
+frame supplies the method; this draft supplies the domain-root topology
+instance context, admission tests, agent lanes, stop conditions, and proof
+shape.
+
+## Ratchet Event
+
+Name: Domain-Root Topology Ratchet
+
+Closure premise:
+domain/root/topology consolidation was finalized and enforced. The descent
+ratcheted current positive law into Habitat. Rules in that blast radius now
+need revalidation against the new authority surface.
+
+Current closure evidence to reconfirm before per-rule disposition:
+
+```bash
+bun habitat check --json --rule require_domain_source_topology
+bun habitat check --json --rule require_domain_ops_binding_surface
+bun habitat check --json --rule require_domain_ops_registry_surface
+bun habitat check --json --rule require_domain_operation_contract_file_shape
+bun habitat classify .habitat/.active/workstreams/define-domain-blueprint-structure/slices/001-domain-root-immediate-ops-topology
+```
+
+Ratcheted authority surfaces:
+
+- `require_domain_source_topology`
+- `require_domain_ops_binding_surface`
+- `require_domain_ops_registry_surface`
+- `require_domain_operation_contract_file_shape`
+
+Related positive-law rows admitted by the prior grounding pass:
+
+- `require_artifact_file_shape`
+- `require_artifact_index_aggregate_shape`
+- `require_domain_model_schema_policy_owner_shape`
+- `require_recipe_stage_authoring_file_shape`
+
+Those related rows are contextual neighbors, not automatic inputs to this
+first pass. Admit them only if the source evidence ties the rule to domain-root
+topology or operation-surface authority.
+
+## Instance Scope
+
+In scope:
+
+- Live Habitat rules whose manifest, pattern, baseline, evidence record, or
+  source target names domain roots, domain source topology, domain operation
+  roots, retired domain-root catalogs, root facades, domain source imports, or
+  operation-surface topology.
+- Rules whose original purpose was to contain drift now addressed by the
+  ratcheted domain-root topology or domain operation surface rules.
+- Rules whose selector, manifest, baseline, pattern, or current evidence names
+  a domain-root topology surface touched by the completed descent.
+
+Out of scope:
+
+- Rules outside that blast radius, even if they look stale.
+- Runtime, generated-output, Studio, package, or docs rails unless the rule
+  also carries domain-root topology authority.
+- Broad rule cleanup, label normalization, runner migration, baseline growth,
+  or source movement.
+
+## Admission Tests
+
+Admit a rule into this instance pass only if at least one test is true:
+
+1. The rule id, manifest, pattern, baseline, or evidence record references a
+   domain-root topology surface: domain root, retired domain catalog, domain
+   source topology, domain operation root, root facade, domain source import,
+   or operation-surface topology.
+2. The rule's source scope overlaps files governed by the completed descent and
+   the rule's selector, manifest, pattern, baseline, or current evidence names
+   one of the topology surfaces above. Source path overlap alone is not enough.
+3. Current manifest, pattern, baseline, source, or command evidence confirms a
+   transitional containment concern that the ratcheted domain-root topology
+   authority may now absorb. Historical rationale alone is not admission
+   evidence.
+4. Static source inspection shows the rule can fire only because of shapes now
+   owned by the ratcheted topology authority.
+
+If none are true, the per-rule record should be `out of scope`.
+
+## Likely Overlap Lanes
+
+These are hypotheses for pre-filtering and review. They do not settle any row
+disposition.
+
+1. Domain topology and fossil guards:
+   `require_domain_source_topology` likely overlaps with retired-domain-root,
+   retired domain `artifacts.ts` modules, and older domain topology guards.
+2. Domain operation surfaces:
+   `require_domain_ops_binding_surface`,
+   `require_domain_ops_registry_surface`, and
+   `require_domain_operation_contract_file_shape` likely overlap with
+   config-bag, root config facade, contract-root, and operation-local negative
+   guards.
+3. MapGen artifact owner surfaces:
+   `require_artifact_file_shape` and
+   `require_artifact_index_aggregate_shape` may absorb some old artifact alias,
+   tag, and validation-owner concerns, but generated recipe output parity and
+   currentness remain a separate proof class.
+4. Recipe-stage authoring:
+   `require_recipe_stage_authoring_file_shape` may overlap with wrapper-only
+   advanced config, stage config bag, sentinel passthrough, and standard public
+   authoring-surface checks.
+5. Runtime/build/generated-output rails:
+   rules that mention runtime, adapter, generated output, `dist`, or currentness
+   need proof-class review before deletion. Many likely belong in Nx,
+   package-local validation, generated-output protection, or file-layer rails
+   rather than this semantic pass.
+
+## Instance Decision Notes
+
+Use `POST-RATCHET-RULE-REVALIDATION-FRAME.md` for each admitted rule.
+
+For this instance:
+
+- Absorbing authority must be one of the ratcheted domain-root topology or
+  domain operation surface rules, or a named existing owner surface directly
+  connected to them.
+- A deletion record must identify the old domain-root or operation-surface
+  shape and the ratcheted authority that now catches it.
+- If proof belongs to generated-output, runtime, Studio, package validation, or
+  another native rail, return `out of scope` unless the rule also has a
+  domain-root topology clause that can be separately dispositioned.
+
+## Proof Commands
+
+Closure proof commands are listed above and must be rerun before the first
+per-rule batch. Per-rule proof depends on the accepted `actionDecision`, but
+the instance proof menu is:
+
+```bash
+bun habitat check --json --rule <candidate-rule-id>
+bun habitat check --json --rule require_domain_source_topology
+bun habitat check --json --rule require_domain_ops_binding_surface
+bun habitat check --json --rule require_domain_ops_registry_surface
+bun habitat check --json --rule require_domain_operation_contract_file_shape
+bun habitat classify mods/mod-swooper-maps/src/domain
+git diff --check -- .habitat
+```
+
+Deletion-oriented dispositions also need an explicit old-shape proof: either
+an injected violation proof that the ratcheted authority catches the old shape,
+or a recorded reason why the old shape is retired residue with no live
+recurrence risk.
+
+## Execution Workstream Shape
+
+1. Pre-filter lane:
+   read live manifests, patterns, baselines, evidence records, and source
+   scopes to admit only rules touched by domain-root topology closure.
+2. Per-rule analysis lanes:
+   assign one admitted rule group per fresh read-only agent. Each agent applies
+   `POST-RATCHET-RULE-REVALIDATION-FRAME.md` and returns compact rule records.
+3. Synthesis lane:
+   the DRA owner reconciles agent records into the ledger ontology, rejects
+   unsupported dispositions, and identifies the first mutation slice.
+4. Review lane:
+   a separate fresh review team checks admission, action-decision choice,
+   residual-risk claims, owner-layer claims, vocabulary collisions, and
+   proof-class adequacy.
+5. Implementation lane:
+   only after review, a separate implementation group executes the accepted
+   mutation slice. Implementation agents must not be reused as reviewers.
+
+Each lane is bounded. No agent owns synthesis, authority calls, Graphite state,
+or closure claims except the DRA owner. Rule mutation begins only after a
+reviewed disposition set identifies the smallest safe domino.
+
+## Batch Degeneration Trigger
+
+If three admitted rules in one batch require proof classes outside domain-root
+topology, domain operation surfaces, or source topology, stop the batch and
+reframe the slice boundary before more per-rule analysis proceeds.
+
+## Expected Output
+
+The workstream should produce:
+
+- pre-filtered admitted rule set with excluded-neighbor notes;
+- one compact revalidation record per admitted rule;
+- synthesis into existing ledger action vocabulary;
+- review disposition for P1/P2 findings;
+- first mutation-slice recommendation, or an explicit no-mutation result if no
+  safe domino is proven.
+
+No implementation is authorized by this draft alone.

--- a/.habitat/.active/workstreams/remediate-rule-authority/rule-authority-corpus-grounding.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/rule-authority-corpus-grounding.md
@@ -28,8 +28,9 @@ rule authority cleanup container. The ledger itself remains the single active
 machine-readable source for live rule rows, retired/stale references, slices,
 blockers, findings, counts, and gate state.
 
-Markdown receipts under `receipts/` remain historical explanation and evidence.
-They do not define active rule rows or current queue state.
+Markdown receipts under `receipts/` remain historical explanation of prior
+intent. They are not current evidence until revalidated, and they do not define
+active rule rows or current queue state.
 
 ## Fresh Coverage Check
 
@@ -56,10 +57,10 @@ created or ratcheted by the completed domain-root topology descent:
 - `require_domain_source_topology`
 - `require_recipe_stage_authoring_file_shape`
 
-Those rows are now seeded as `context admission` entries. That is a tracking
-state, not final standing-law classification. The Rule Authority Cleanup pass
-must still review each row with fresh evidence before keep, retire, replace, or
-split decisions are authorized.
+Those rows are now `context admission` entries: live authority in their current
+context, not omission gaps. The Rule Authority Cleanup pass must still review
+each row with current evidence before keep, retire, replace, or split decisions
+are authorized.
 
 ## Quick Analytics
 
@@ -80,34 +81,24 @@ positive or preserving authority. The cleanup needs to separate durable positive
 law, durable boundary rails, transitional negative guards, split-owner rules,
 native-tool proof rails, and fossils.
 
-## Likely Overlap Lanes To Review First
+## First Revalidation Pair
 
-These are analytical hypotheses only. They seed review priority; they do not
-settle any row disposition.
+The reusable method frame for post-ratchet cleanup is:
 
-1. Domain topology and fossil guards:
-   `require_domain_source_topology` likely overlaps with retired-domain-root,
-   broad domain artifact module, and older domain topology guards.
-2. Domain operation surfaces:
-   `require_domain_ops_binding_surface`,
-   `require_domain_ops_registry_surface`, and
-   `require_domain_operation_contract_file_shape` likely overlap with
-   config-bag, root config facade, contract-root, and operation-local negative
-   guards.
-3. Artifact owner surfaces:
-   `require_artifact_file_shape` and
-   `require_artifact_index_aggregate_shape` likely absorb some old artifact
-   alias, tag, and validation-owner concerns, but generated recipe output
-   parity/currentness remains a separate proof class.
-4. Recipe-stage authoring:
-   `require_recipe_stage_authoring_file_shape` likely overlaps with wrapper-only
-   advanced config, stage config bag, sentinel passthrough, and standard public
-   authoring-surface checks.
-5. Runtime/build/generated-output rails:
-   rules that mention runtime, adapter, generated output, `dist`, or currentness
-   need proof-class review before any deletion; many likely belong in Nx,
-   package-local validation, generated-output protection, or file-layer rails
-   rather than semantic Habitat patterns.
+```text
+.habitat/.active/frames/POST-RATCHET-RULE-REVALIDATION-FRAME.md
+```
+
+The first instance draft paired with that method frame is:
+
+```text
+.habitat/.active/workstreams/remediate-rule-authority/domain-root-topology-rule-revalidation-workstream-draft.md
+```
+
+The frame is the reusable component. The draft is the instance-specific input
+for the completed domain-root topology ratchet. Keep future ratchet-specific
+admission criteria, agent lanes, stop conditions, and proof commands in their
+own workstream draft rather than in the generic frame or this grounding note.
 
 ## Non-Claims
 


### PR DESCRIPTION
Introduces a reusable post-ratchet rule revalidation method frame and pairs it with a concrete instance workstream draft for the completed domain-root topology ratchet.

The new `POST-RATCHET-RULE-REVALIDATION-FRAME.md` defines a systematic, gate-ordered review lens for deciding whether a single live Habitat rule is affected by a completed ratchet event and, if so, what cleanup disposition it should receive. It establishes scope, absorption, residual-risk, positive-assertion, split, and incorporation gates; specifies a required pairing document contract; defines a mandatory compact output record format; and clarifies its relationship to the existing action-classification, decision-packet, and remediation-slice frames. The frame deliberately contains no instance-specific criteria and does not authorize any mutations.

The new `domain-root-topology-rule-revalidation-workstream-draft.md` is the first concrete instance input for that frame. It names the domain-root topology ratchet as the closed event, lists the four ratcheted authority surfaces and their closure proof commands, defines admission tests that require manifest, pattern, baseline, or source evidence rather than path overlap alone, enumerates likely overlap lanes as pre-filtering hypotheses, and describes the bounded execution shape with separate pre-filter, per-rule analysis, synthesis, review, and implementation lanes.

The grounding document is updated to reflect that the overlap-lane hypotheses previously embedded there now live in the instance workstream draft where they belong, that receipts represent prior intent rather than current evidence until revalidated, and that the `context admission` rows represent live authority rather than omission gaps.