### PR TITLE
docs(habitat): domain-root topology post-ratchet rule revalidation (Container 8 handoff; no mutation)

### DIFF
--- a/.habitat/.active/workstreams/remediate-rule-authority/domain-root-topology-rule-revalidation-workstream.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/domain-root-topology-rule-revalidation-workstream.md
@@ -361,7 +361,7 @@ old shapes remain outside its proof.
 Run first because deletion-oriented `consolidation/dedup` records require a
 named absorber and old shape.
 
-### Lane 1. Domain Root Fossil Guards
+### Lane 1. Retired Domain-Root Layout Guards
 
 Purpose:
 review rules about retired domain-root layouts potentially absorbed by
@@ -500,7 +500,7 @@ Lane obligation:
 reject path-only admission and preserve source-domain owner distinctions.
 
 Deletion potential:
-low to moderate. Some fossils may delete, but many recurrence guards are
+low to moderate. Some retired-shape rows may delete, but many recurrence guards are
 domain-specific live law.
 
 ### Lane 7. Runtime And Generated-Output Exclusion Guard

--- a/.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json
+++ b/.habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json
@@ -15,33 +15,38 @@
   },
   "counts": {
     "actionDecision": {
-      "no action": 60,
-      "positive authority creation": 8,
-      "split by owner": 10,
-      "runtime/source validation": 3,
-      "retirement/garbage collection": 3,
-      "context admission": 26,
       "boundary inversion": 3,
-      "closed structure inversion": 1
+      "closed structure inversion": 2,
+      "consolidation/dedup": 3,
+      "context admission": 26,
+      "no action": 57,
+      "positive authority creation": 8,
+      "retirement/garbage collection": 3,
+      "runtime/source validation": 3,
+      "split by owner": 9
     },
     "packetNeeded": {
       "false": 114
     },
     "layer2Status": {
-      "none": 88,
-      "packet-complete": 19,
-      "excluded-native-rail-not-semantic-remediation": 1,
-      "implementation-ready": 1,
+      "blocked-prior-source-owner-design": 2,
       "complete-no-generic-domain-operation-slice": 2,
-      "blocked-prior-source-owner-design": 3
+      "decision-packet-accepted; absorber-proof-needed": 1,
+      "decision-packet-accepted; blocked-prior-source-owner-design": 1,
+      "decision-packet-accepted; deletion-blocked-partial-absorber": 1,
+      "decision-packet-accepted; review-accepted; queued-no-mutation": 2,
+      "decision-packet-accepted; split-generalization-needed": 1,
+      "excluded-native-rail-not-semantic-remediation": 1,
+      "none": 85,
+      "packet-complete": 18
     }
   },
   "gateState": {
-    "currentLayer": "Rule authority cleanup corpus grounded after the completed domain-root topology ratchets.",
-    "currentGate": "Ready to open the Rule Authority Cleanup container from the active transition anchor; every live rule row must be reclassified before keep/retire/replace/split decisions are authorized.",
-    "mutationAuthorization": "This grounding slice may rename and refresh the operational ledger only. It does not authorize rule deletion, runner changes, baseline growth, or source movement.",
-    "nextSliceId": null,
-    "nextLegalAction": "Open the Rule Authority Cleanup frame and run row-level review against the refreshed current ledger. Do not select a cleanup implementation slice until the ledger rows have fresh evidence and review disposition.",
+    "currentLayer": "Post-ratchet rule revalidation for the completed domain-root topology ratchet.",
+    "currentGate": "Container 8 handoff complete: two review-accepted domain-root topology duplicates are queued for a later deletion slice; no rule packets are mutated in this branch.",
+    "mutationAuthorization": "This revalidation execution may update ledger and receipt records only. It does not authorize rule deletion, runner changes, baseline growth, package-test cleanup, or source movement.",
+    "nextSliceId": "domain-root-topology-delete-absorbed-root-shape-rules-001",
+    "nextLegalAction": "Open the named remediation slice on a new Graphite layer and delete only prohibit_retired_domain_root_catalogs and require_domain_ops_root_presence after live-reference reconciliation and focused absorber checks. Do not include Foundation stage Grit rows unless a separate admission frame is opened.",
     "operationalSourceOfTruth": ".habitat/.active/workstreams/remediate-rule-authority/ledgers/rule-authority-cleanup-ledger.json",
     "sourceCommit": "50f8db56c0"
   },
@@ -319,11 +324,18 @@
     {
       "ruleId": "prohibit_domain_artifacts_modules",
       "lane": "blueprints/domain",
-      "actionDecision": "no action",
+      "actionDecision": "closed structure inversion",
       "packetNeeded": false,
-      "expectedRemediation": "Stay as domain topology guard.",
-      "evidenceNote": "No `artifacts.ts`; positive layout is `artifacts/contract/<artifact>.contract.ts`.",
-      "currentPath": ".habitat/blueprints/domain/prohibit_domain_artifacts_modules/rule.json"
+      "expectedRemediation": "retain until nested domain-source/domain-operation topology positively asserts the residual artifacts.ts support-directory shape",
+      "evidenceNote": "Post-ratchet revalidation found partial absorption only. A refined injected probe under ecology/ops/resource-score-balance/rules/artifacts.ts passed require_domain_source_topology and failed this rule, proving residual coverage remains.",
+      "currentPath": ".habitat/blueprints/domain/prohibit_domain_artifacts_modules/rule.json",
+      "layer2Status": "decision-packet-accepted; deletion-blocked-partial-absorber",
+      "packetSliceId": "domain-root-topology-post-ratchet-revalidation",
+      "wholeRuleFit": "partial absorption; keep until positive nested topology exists",
+      "ruleIdPlan": "preserve id now; later split absorbed root clause or replace with expanded positive topology",
+      "semanticDecision": "The direct-root artifacts.ts clause is absorbed, but nested artifacts.ts risk remains outside current source topology.",
+      "residualFollowUp": "Design whether nested rules/, strategies/, policy/, model/schemas, and model/policy should be closed by generic topology.",
+      "implementationReadiness": "not implementation-ready for deletion"
     },
     {
       "ruleId": "prohibit_domain_entrypoint_self_reexports",
@@ -418,18 +430,18 @@
     {
       "ruleId": "prohibit_foundation_op_contract_config_bags",
       "lane": "domains/foundation",
-      "actionDecision": "split by owner",
+      "actionDecision": "consolidation/dedup",
       "packetNeeded": false,
-      "expectedRemediation": "Consolidate config-facade import clause into existing domain-operation config-facade rail and delete FoundationConfigSchema token residue.",
-      "evidenceNote": "Corrective audit: existing owner is .habitat/blueprints/domain-operation/prohibit_root_config_facade_imports_in_domain_ops; FoundationConfigSchema is retired literal residue unless concrete recurrence risk is proven.",
+      "expectedRemediation": "consolidate op-contract import clauses into require_domain_operation_contract_file_shape only after injected absorber proof for exact import forms",
+      "evidenceNote": "Post-ratchet revalidation found likely absorption by positive operation contract shape, but did not run injected absolute config-facade import probes; retired FoundationConfigSchema token remains deletion residue after proof.",
       "currentPath": ".habitat/civ7/mapgen/domains/foundation/rules/prohibit_foundation_op_contract_config_bags/rule.json",
-      "layer2Status": "implementation-ready",
-      "packetSliceId": "domain-operation-generic-surfaces",
-      "wholeRuleFit": "split/consolidate",
-      "ruleIdPlan": "replace by widening existing domain-operation config-facade import rule, then delete local Foundation id after proof; do not preserve FoundationConfigSchema blacklist",
-      "semanticDecision": "Operation contracts should expose local typed schemas and may use op-local/named-family config, but must not import recipe-facing root/domain config facades.",
-      "residualFollowUp": "Layer 3 should extend prohibit_root_config_facade_imports_in_domain_ops to alias imports, preserve allowed op-local config imports, prove absence, then retire this Foundation row.",
-      "implementationReadiness": "implementation-ready as config-facade consolidation plus retired-token deletion"
+      "layer2Status": "decision-packet-accepted; absorber-proof-needed",
+      "packetSliceId": "domain-root-topology-post-ratchet-revalidation",
+      "wholeRuleFit": "consolidate plus retired-literal deletion, pending proof",
+      "ruleIdPlan": "replace by positive operation contract authority, then delete id after absorber proof and review acceptance",
+      "semanticDecision": "Operation contracts should own local schema envelopes and only import allowed contract primitives; Foundation config-schema token is obsolete.",
+      "residualFollowUp": "Deletion proof should include injected import forms for absolute config facade imports.",
+      "implementationReadiness": "not deletion-ready until injected absorber proof and review acceptance"
     },
     {
       "ruleId": "prohibit_foundation_projection_legacy_motion_source",
@@ -493,16 +505,16 @@
       "lane": "standard recipe stage foundation/hydrology/map/placement",
       "actionDecision": "split by owner",
       "packetNeeded": false,
-      "expectedRemediation": "generalize live config-facade import clauses into standard recipe step-contract config-bag authority; delete FoundationConfigSchema retired-token clause",
-      "evidenceNote": "Stage/step config schemas are step-owned and shared fragments belong to closest real owners. A Foundation-only contract config-bag guard is a repeated stage special case until generalized or narrowed. Layer 2 packet standard-stage-public-config-and-contract-surface: Step contracts should not import broad root/domain config-bag facades as contract surfaces, but the current Foundation-only packet is underbroad. Stage indexes and step implementations may legitimately import closest-owner domain config helpers; the target is contract files only.",
+      "expectedRemediation": "split/generalize live recipe-step contract import-boundary pressure and delete retired FoundationConfigSchema token only after the new owner is proven",
+      "evidenceNote": "Post-ratchet revalidation found step contracts should depend on domain contract roots, not config facades. The retired FoundationConfigSchema literal does not need replacement, but the @mapgen/domain/config.js gap needs owner design.",
       "currentPath": ".habitat/civ7/mapgen/pipeline/swooper-maps-standard-recipe/stages/foundation/rules/prohibit_foundation_step_contract_config_bags/rule.json",
-      "layer2Status": "packet-complete",
-      "packetSliceId": "standard-stage-public-config-and-contract-surface",
-      "wholeRuleFit": "split/consolidate",
-      "ruleIdPlan": "generalize live config-facade import clauses into standard recipe step-contract config-bag authority; delete FoundationConfigSchema retired-token clause",
-      "semanticDecision": "Step contracts should not import broad root/domain config-bag facades as contract surfaces, but the current Foundation-only packet is underbroad. Stage indexes and step implementations may legitimately import closest-owner domain config helpers; the target is contract files only.",
-      "residualFollowUp": "Define config bag narrowly before Layer 3. Preserve live import-boundary clauses for contract files, remove retired FoundationConfigSchema token residue, and avoid banning legitimate stage-level knob imports.",
-      "implementationReadiness": "implementation-ready as a narrow split/generalization slice, but it only collapses this local packet group"
+      "layer2Status": "decision-packet-accepted; split-generalization-needed",
+      "packetSliceId": "domain-root-topology-post-ratchet-revalidation",
+      "wholeRuleFit": "split required",
+      "ruleIdPlan": "split/generalize into recipe-step authority, then delete Foundation-local id",
+      "semanticDecision": "Live import-boundary pressure belongs in recipe-step contract authority; retired literal residue should be deleted once separated.",
+      "residualFollowUp": "Define config facade/bag narrowly before mutation.",
+      "implementationReadiness": "not deletion-ready; implementation-ready only as a future split/generalization slice"
     },
     {
       "ruleId": "prohibit_foundation_strategy_nonlocal_imports",
@@ -688,11 +700,18 @@
     {
       "ruleId": "prohibit_retired_domain_root_catalogs",
       "lane": "blueprints/domain",
-      "actionDecision": "no action",
+      "actionDecision": "consolidation/dedup",
       "packetNeeded": false,
-      "expectedRemediation": "Stay as G2 root-catalog guard.",
-      "evidenceNote": "No root `tags.ts` / `artifacts.ts`; guardrail docs name this cleanup.",
-      "currentPath": ".habitat/blueprints/domain/prohibit_retired_domain_root_catalogs/rule.json"
+      "expectedRemediation": "delete after live-reference reconciliation in domain-root-topology-delete-absorbed-root-shape-rules-001; require_domain_source_topology remains the positive owner",
+      "evidenceNote": "Post-ratchet revalidation accepted this as absorbed by require_domain_source_topology. Injected direct root tags.ts and artifacts.ts both failed the absorber with unexpected-child diagnostics and failed this old rule.",
+      "currentPath": ".habitat/blueprints/domain/prohibit_retired_domain_root_catalogs/rule.json",
+      "layer2Status": "decision-packet-accepted; review-accepted; queued-no-mutation",
+      "packetSliceId": "domain-root-topology-post-ratchet-revalidation",
+      "wholeRuleFit": "consolidate/delete into positive domain-root topology",
+      "ruleIdPlan": "delete in domain-root-topology-delete-absorbed-root-shape-rules-001 after live-reference reconciliation; do not delete in the revalidation branch",
+      "semanticDecision": "Direct domain-root tags.ts and artifacts.ts catalogs are fully absorbed by the closed domain-root scope in require_domain_source_topology.",
+      "residualFollowUp": "Deletion slice must update live ledger/workstream references and preserve historical references as history or archive/regenerate through their owner.",
+      "implementationReadiness": "queued for domain-root-topology-delete-absorbed-root-shape-rules-001; no mutation authorized in this revalidation branch"
     },
     {
       "ruleId": "prohibit_rng_callback_state_in_ops",
@@ -885,11 +904,18 @@
     {
       "ruleId": "require_domain_ops_root_presence",
       "lane": "blueprints/domain-operation",
-      "actionDecision": "no action",
+      "actionDecision": "consolidation/dedup",
       "packetNeeded": false,
-      "expectedRemediation": "Stay live as structure authority.",
-      "evidenceNote": "All expected domain `ops` roots exist.",
-      "currentPath": ".habitat/blueprints/domain-operation/require_domain_ops_root_presence/rule.json"
+      "expectedRemediation": "delete after live-reference reconciliation in domain-root-topology-delete-absorbed-root-shape-rules-001; require_domain_source_topology remains the positive owner",
+      "evidenceNote": "Post-ratchet revalidation accepted this as absorbed by require_domain_source_topology. Injected missing ecology ops root failed the absorber with missing-required-child and failed this old enumerated rule.",
+      "currentPath": ".habitat/blueprints/domain-operation/require_domain_ops_root_presence/rule.json",
+      "layer2Status": "decision-packet-accepted; review-accepted; queued-no-mutation",
+      "packetSliceId": "domain-root-topology-post-ratchet-revalidation",
+      "wholeRuleFit": "consolidate/delete into positive domain-root topology",
+      "ruleIdPlan": "delete in domain-root-topology-delete-absorbed-root-shape-rules-001 after live-reference reconciliation; do not delete in the revalidation branch",
+      "semanticDecision": "The hardcoded six-domain ops-root presence rule is fully absorbed by require_domain_source_topology, which requires ops for every domain root.",
+      "residualFollowUp": "Deletion slice must update live operational records and preserve historical references as history.",
+      "implementationReadiness": "queued for domain-root-topology-delete-absorbed-root-shape-rules-001; no mutation authorized in this revalidation branch"
     },
     {
       "ruleId": "require_domain_source_topology",
@@ -906,16 +932,16 @@
       "lane": "domains/nonfoundation",
       "actionDecision": "closed structure inversion",
       "packetNeeded": false,
-      "expectedRemediation": "Design source-owned operation-module topology verifier/generator with support-directory exceptions before replacing Ecology-only structure rail.",
-      "evidenceNote": "Corrective audit: Ecology structure.toml checks one domain instance; source authority lives in SPEC-step-domain-operation-modules, createOp, and domain op registries.",
+      "expectedRemediation": "replace later with generic domain-operation module topology authority after source-owned topology design",
+      "evidenceNote": "Post-ratchet revalidation found the actual Ecology rule is an exemplar proxy. require_domain_source_topology partially absorbs contract.ts/index.ts, but strategies and support-directory index clauses still require source-owned design.",
       "currentPath": ".habitat/civ7/mapgen/domains/ecology/rules/require_ecology_canonical_op_module_topology/rule.json",
-      "layer2Status": "blocked-prior-source-owner-design",
-      "packetSliceId": "domain-operation-generic-surfaces",
-      "wholeRuleFit": "split/consolidate into source-owned topology authority",
-      "ruleIdPlan": "do not move Ecology rule as-is; later replace by source-owned op-module topology proof and delete Ecology rule after replacement proof",
-      "semanticDecision": "Contract/index/strategy binding is live domain-operation authority, but must be enforced through TS registry, generator, or package verify, not Ecology sidecar topology.",
-      "residualFollowUp": "Design operation-module verifier/generator and support-directory exception model for score-shared/shared/mountains-shared before Layer 3.",
-      "implementationReadiness": "not implementation-ready; needs source-owned operation-module verifier/generator and support-directory exception model"
+      "layer2Status": "decision-packet-accepted; blocked-prior-source-owner-design",
+      "packetSliceId": "domain-root-topology-post-ratchet-revalidation",
+      "wholeRuleFit": "replace by positive authority, but not implementation-ready",
+      "ruleIdPlan": "do not move Ecology id as-is; replace by generic positive authority, then delete Ecology rule after replacement proof",
+      "semanticDecision": "The rule is admitted as an actual Ecology proxy for all-domain op-module topology; current source topology is not a full absorber.",
+      "residualFollowUp": "Design support-directory exception model and generic contract.ts/index.ts/optional rules index/strategies index topology across domains.",
+      "implementationReadiness": "not implementation-ready; requires source-owned topology design"
     },
     {
       "ruleId": "require_explicit_mapgen_sdk_opt_in",
@@ -2925,6 +2951,49 @@
           "Rejected stopping the Layer 2 cascade; this is a sealed tooling blocker, not a user decision gate."
         ]
       }
+    },
+    {
+      "sliceId": "domain-root-topology-delete-absorbed-root-shape-rules-001",
+      "status": "queued-no-mutation",
+      "actionClass": "consolidation/dedup",
+      "receipt": ".habitat/.active/workstreams/remediate-rule-authority/receipts/domain-root-topology-post-ratchet-revalidation-execution.md",
+      "branch": "future Graphite layer",
+      "commit": null,
+      "rules": [
+        "prohibit_retired_domain_root_catalogs",
+        "require_domain_ops_root_presence"
+      ],
+      "createdRows": [],
+      "survivorRows": [
+        "require_domain_source_topology"
+      ],
+      "excludedRows": [
+        {
+          "ruleId": "prohibit_foundation_stage_cast_merge_hacks",
+          "reason": "Out of scope for the domain-root/domain-operation topology ratchet; prior context-admission and package-test coverage remain live."
+        },
+        {
+          "ruleId": "prohibit_foundation_stage_sentinel_passthrough",
+          "reason": "Out of scope for the domain-root/domain-operation topology ratchet; prior context-admission and package-test coverage remain live."
+        },
+        {
+          "ruleId": "prohibit_domain_artifacts_modules",
+          "reason": "Residual nested artifacts.ts shape remains unabsorbed."
+        },
+        {
+          "ruleId": "prohibit_foundation_op_contract_config_bags",
+          "reason": "Injected absorber proof still needed."
+        },
+        {
+          "ruleId": "prohibit_foundation_step_contract_config_bags",
+          "reason": "Split/generalization needed."
+        },
+        {
+          "ruleId": "require_ecology_canonical_op_module_topology",
+          "reason": "Source-owned operation-module topology design needed."
+        }
+      ],
+      "outcome": "Queued by post-ratchet revalidation; no deletion or runner mutation performed in the revalidation branch."
     }
   ],
   "blockers": [
@@ -3148,6 +3217,20 @@
       ],
       "summary": "Deleted three retired runtime/projection literal Habitat rules without replacement after scoped source-absence proof. Valid adjacent concepts remain owned by Hydrology/Morphology source contracts, map artifacts, and placement/adapter projection rather than Habitat token blacklists.",
       "handling": "Removed rule packets from the live authority tree, removed their live rows from rules[], and recorded retired historical rows in this canonical JSON only."
+    },
+    {
+      "findingId": "2026-07-06-domain-root-topology-post-ratchet-review-gate",
+      "recordedOn": "2026-07-06",
+      "ruleId": null,
+      "kind": "post-ratchet-review-disposition",
+      "finding": "Fresh adversarial review accepted the two root-shape deletion candidates after direct tags.ts, direct artifacts.ts, and missing ops-root absorber proof. Review rejected Foundation stage cast/sentinel rows from this ratchet admission frame because prior context-admission and package-test coverage remain live.",
+      "handling": "Queued only prohibit_retired_domain_root_catalogs and require_domain_ops_root_presence for a later no-mutation handoff slice; left Foundation stage rows unchanged from prior ledger state.",
+      "rules": [
+        "prohibit_retired_domain_root_catalogs",
+        "require_domain_ops_root_presence",
+        "prohibit_foundation_stage_cast_merge_hacks",
+        "prohibit_foundation_stage_sentinel_passthrough"
+      ]
     }
   ],
   "retiredRules": [

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/domain-root-topology-post-ratchet-revalidation-execution.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/domain-root-topology-post-ratchet-revalidation-execution.md
@@ -1,0 +1,344 @@
+# Domain-Root Topology Post-Ratchet Rule Revalidation Execution
+
+Status: reviewed execution record; no rule packets mutated
+
+Scope:
+run the active post-ratchet rule revalidation workstream for the completed
+Domain-Root Topology ratchet. This record captures classification, DRA
+synthesis, decision packets, review disposition, and the next remediation-slice
+handoff. It does not delete rule packets, mutate runners, grow baselines, or
+move source.
+
+## Container 0: Orientation And Authority Seal
+
+Branch:
+`codex/domain-root-rule-revalidation-execution`
+
+Stack:
+opened above `codex/rule-revalidation-workstream-plan`.
+
+Corpus parity:
+
+| Measure | Result |
+| --- | --- |
+| Live `.habitat/**/rule.json` manifests | 114 |
+| Ledger rows | 114 |
+| Missing live rows | 0 |
+| Stale live-ledger rows | 0 |
+
+Ratchet authority proof:
+
+| Command | Result | Proof label | Proof limit |
+| --- | --- | --- | --- |
+| `bun habitat check --json --rule require_domain_source_topology` | pass | Habitat wrapper behavior | Does not by itself prove absorption or safe deletion. |
+| `bun habitat check --json --rule require_domain_ops_binding_surface` | pass | Habitat wrapper behavior | Does not by itself prove absorption or safe deletion. |
+| `bun habitat check --json --rule require_domain_ops_registry_surface` | pass | Habitat wrapper behavior | Does not by itself prove absorption or safe deletion. |
+| `bun habitat check --json --rule require_domain_operation_contract_file_shape` | pass | Habitat wrapper behavior | Does not by itself prove absorption or safe deletion. |
+| `bun habitat classify mods/mod-swooper-maps/src/domain` | pass | Routing/classification evidence | Names relevant routing, not semantic deletion authority. |
+
+NARSIL:
+`mcp__narsil_code_intel_civ7.validate_repo` confirmed the worktree is a readable
+Git repository. `search_chunks` was used as discovery only and cross-checked
+against current files and Habitat commands.
+
+## Containers 1-3: Pre-Filter And Lane Analysis
+
+Candidate formation:
+
+- 33 rule ids had current `.habitat` rule-file term evidence tied to domain
+  source topology, domain operation surfaces, artifact surfaces, public domain
+  surfaces, recipe-stage authoring, or adjacent residuals.
+- Additional lane candidates were admitted from the active workstream lane
+  definitions when current manifest/path evidence made them plausible.
+- Broad ledger text search was rejected as too permissive because it returned
+  103 rows and mostly reflected old receipt vocabulary.
+
+Lane agents were read-only. They did not edit, stage, or commit.
+
+| Lane | Agent label | Outcome |
+| --- | --- | --- |
+| Retired Domain-Root Layout Guards | Lane 1 agent | Six row records returned. |
+| Domain Operation Surface Law | Lane 2 agent | Eleven row records returned. |
+| Public Domain Import Boundaries | Lane 3 agent | Six row records returned. |
+| MapGen Artifact Owner Surfaces | Lane 4 agent | Six row records returned. |
+| Recipe Stage Authoring Surface | Lane 5 agent | Eight row records returned. |
+| Source-Domain Residuals And Exclusion Guard | Lane 6 agent | Nine row records returned. |
+
+### Compact Row Records
+
+These compact records are the durable audit surface for this execution. They do
+not replace the operational ledger row text.
+
+| Rule | Scope result | Action decision | Rationale | Residual risk or dependency |
+| --- | --- | --- | --- | --- |
+| `require_domain_source_topology` | admitted context | context admission | Positive topology ratchet is the absorber for direct domain-root shape. | None for this pass. |
+| `require_domain_model_schema_policy_owner_shape` | admitted context | context admission | Confirms model/schema/policy ownership adjacent to the topology ratchet. | None for this pass. |
+| `require_domain_ops_binding_surface` | admitted context | context admission | Live operation binding surface law after the ratchet. | None for this pass. |
+| `require_domain_ops_registry_surface` | admitted context | context admission | Live operation registry surface law after the ratchet. | None for this pass. |
+| `require_domain_operation_contract_file_shape` | admitted context | context admission | Positive operation contract file-shape authority. | Possible absorber for op-contract config-bag row needs injected proof. |
+| `prohibit_domain_entrypoint_self_reexports` | admitted live | no action | Still protects domain public entrypoint self-reexport shape. | No deletion dependency. |
+| `block_adapter_context_imports_from_domain_ops` | admitted live | no action | Domain ops still must not reach adapter context. | No deletion dependency. |
+| `block_engine_runtime_imports_from_domain_ops` | admitted live | no action | Domain ops still must stay runtime-neutral. | No deletion dependency. |
+| `prohibit_cross_op_runtime_calls` | admitted live | no action | Cross-op runtime execution remains prohibited. | No deletion dependency. |
+| `prohibit_domain_ops_projection_effect_dependencies` | admitted live | no action | Projection/effect dependencies remain outside domain ops. | No deletion dependency. |
+| `prohibit_rng_callback_state_in_ops` | admitted live | no action | RNG callback state remains outside op implementation. | No deletion dependency. |
+| `prohibit_root_config_facade_imports_in_domain_ops` | admitted live | no action | Root config facade import guard remains adjacent to op-contract shape. | May overlap later with op-contract config-bag absorber proof. |
+| `prohibit_runtime_orchestration_helpers_in_domain_ops` | admitted live | no action | Runtime orchestration helpers remain outside domain ops. | No deletion dependency. |
+| `require_public_domain_surfaces_in_recipes_and_maps` | admitted live | no action | Recipe/map imports remain routed through public domain surfaces. | No deletion dependency. |
+| `require_public_domain_surfaces_in_tests` | admitted live | split by owner | Test-file scan remains native because current Grit execution ignores test files. | Existing blocker remains. |
+| `require_domain_contract_roots_in_step_contracts` | admitted live | no action | Recipe step contracts still require domain contract roots. | May become home for future step-contract config-facade split. |
+| `require_runtime_domain_op_bundle_imports` | admitted live | no action | Runtime import bundle law remains live. | No deletion dependency. |
+| `prohibit_recipe_imports_in_domain_source` | admitted live | no action | Domain source must not import recipe layer. | No deletion dependency. |
+| `require_morphology_public_surface_imports` | admitted live | no action | Morphology public-surface import law remains live. | No deletion dependency. |
+| `require_artifact_file_shape` | admitted context | context admission | Artifact file-shape authority remains green after topology work. | No deletion dependency. |
+| `require_artifact_index_aggregate_shape` | admitted context | context admission | Artifact index aggregate shape remains green after topology work. | No deletion dependency. |
+| `prohibit_realized_map_artifact_tags` | admitted live | no action | Realized-map artifact-tag guard remains separate from domain topology. | No deletion dependency. |
+| `require_recipe_stage_authoring_file_shape` | admitted context | context admission | Recipe-stage authoring shape is adjacent context, not a domain-root deletion owner. | Foundation stage Grit rows are not acted on in this pass. |
+| `verify_standard_recipe_public_authoring_surface` | admitted context | runtime/source validation | Public-authoring verification remains a native/currentness rail, not a static Grit absorber. | Does not authorize deleting Foundation stage Grit rows here. |
+| `require_public_ecology_surfaces_and_retired_topology_removal` | admitted context | context admission | Actual Ecology public surface guard remains context for domain topology. | No action in this pass. |
+| `prohibit_foundation_decomposed_ops_legacy_internal_imports` | admitted live | no action | Foundation ops legacy-internal import guard remains outside root topology deletion. | No deletion dependency. |
+| `prohibit_foundation_legacy_aggregate_tectonic_op_surface` | admitted live | no action | Foundation aggregate op surface guard remains live. | No deletion dependency. |
+| `prohibit_foundation_legacy_aggregate_tectonics` | admitted live | no action | Foundation aggregate tectonics guard remains live. | No deletion dependency. |
+| `prohibit_retired_domain_root_catalogs` | admitted decision packet | consolidation/dedup | Direct root `tags.ts` and `artifacts.ts` are absorbed by `require_domain_source_topology`. | Review accepted after both injected old shapes failed the absorber. |
+| `require_domain_ops_root_presence` | admitted decision packet | consolidation/dedup | Enumerated ops-root presence is absorbed by generic domain-root topology. | Review accepted after injected missing `ops` failed the absorber. |
+| `prohibit_domain_artifacts_modules` | admitted decision packet | closed structure inversion | Direct-root clause is absorbed, but nested `artifacts.ts` residual remains. | Deletion blocked until nested topology is positively asserted. |
+| `require_ecology_canonical_op_module_topology` | admitted decision packet | closed structure inversion | Actual Ecology rule is a proxy for generic operation-module topology. | Blocked by source-owned topology design. |
+| `prohibit_foundation_step_contract_config_bags` | admitted decision packet | split by owner | Step-contract import-boundary pressure and retired token clause require separation. | Future split/generalization slice. |
+| `prohibit_foundation_op_contract_config_bags` | admitted decision packet | consolidation/dedup | Op-contract config imports likely consolidate into positive operation contract shape. | Needs injected absorber proof before deletion. |
+| `prohibit_foundation_stage_cast_merge_hacks` | out of scope for this ratchet | split by owner | Recipe-stage/Foundation-Studio literal rule lacks a separable domain-root/domain-operation clause. | Prior context-admission records and package tests remain live; no ledger change in this execution. |
+| `prohibit_foundation_stage_sentinel_passthrough` | out of scope for this ratchet | boundary inversion | Recipe-stage/Foundation-Studio literal rule lacks a separable domain-root/domain-operation clause. | Prior context-admission records and package tests remain live; no ledger change in this execution. |
+| `prohibit_unknown_bag_config_usage` | out of scope | no action | Not tied to the completed domain-root/domain-operation topology ratchet. | Skip. |
+| `require_studio_ui_recipe_artifact_imports` | out of scope | no action | Studio recipe-DAG boundary, not this topology blast radius. | Skip. |
+| `verify_standard_recipe_artifacts_match_source_stages` | out of scope | no action | Generated-output/source-stage currentness, not this topology blast radius. | Skip. |
+| `verify_visualization_runtime_build_artifacts` | out of scope | no action | Runtime/build generated-output verification, not this topology blast radius. | Skip. |
+| `prohibit_sibling_stage_private_step_imports` | out of scope | no action | Recipe-stage internal import law without separable domain-root/domain-operation clause. | Skip. |
+| `require_shared_visualization_contracts_at_stage_surfaces` | out of scope | no action | Visualization/stage contract surface, not this topology blast radius. | Skip. |
+| `prohibit_wrapper_only_advanced_config` | out of scope | no action | Recipe-stage wrapper config guard, not this topology blast radius. | Skip. |
+| `preserve_decomposed_foundation_contract_surfaces` | out of scope | split by owner | Foundation contract currentness bundle is larger than this topology pass. | Skip. |
+| `prohibit_morphology_stage_config_bag_imports` | out of scope | no action | Morphology stage boundary, not this topology blast radius. | Skip. |
+| `prohibit_runtime_local_config_default_merging` | out of scope | no action | Runtime/source validation, not this topology blast radius. | Skip. |
+
+## Container 4: DRA Synthesis
+
+Fresh semantic-decision agents produced read-only packets for rows whose compact
+records were insufficient. The DRA synthesis accepted or revised the packet
+outcomes below after review.
+
+| Rule | Action decision | Outcome | Implementation state |
+| --- | --- | --- | --- |
+| `prohibit_retired_domain_root_catalogs` | consolidation/dedup | Consolidate/delete into `require_domain_source_topology`. | Review accepted; queued for a later deletion slice. |
+| `require_domain_ops_root_presence` | consolidation/dedup | Consolidate/delete into `require_domain_source_topology`. | Review accepted; queued for a later deletion slice. |
+| `prohibit_domain_artifacts_modules` | closed structure inversion | Retain; root clause is absorbed, nested `artifacts.ts` residual remains. | Deletion blocked. |
+| `require_ecology_canonical_op_module_topology` | closed structure inversion | Replace later with generic operation-module topology authority. | Blocked by source-owned topology design. |
+| `prohibit_foundation_step_contract_config_bags` | split by owner | Split/generalize live step-contract import boundary; delete retired token clause. | Future split/generalization slice. |
+| `prohibit_foundation_op_contract_config_bags` | consolidation/dedup | Consolidate operation-contract import clauses into positive operation contract shape; delete retired token residue. | Needs injected absorber proof before deletion. |
+| `prohibit_foundation_stage_cast_merge_hacks` | split by owner | Review rejected admission into this ratchet pass. | Out of scope here; prior ledger state stands. |
+| `prohibit_foundation_stage_sentinel_passthrough` | boundary inversion | Review rejected admission into this ratchet pass. | Out of scope here; prior ledger state stands. |
+
+## Container 6: Deletion-Proof Candidate Stage
+
+The first detached-worktree probe was invalid because the temporary worktree
+lacked the active dependency layout and failed before rule execution. It is not
+counted as proof.
+
+The valid proof path used focused injected bad shapes, Habitat checks, and
+immediate cleanup. One follow-up direct-root `artifacts.ts` proof was run in the
+active worktree and removed before closure.
+
+### Review-Accepted Deletion Candidates
+
+#### `prohibit_retired_domain_root_catalogs`
+
+deleteReason:
+direct domain-root `tags.ts` and `artifacts.ts` catalogs are fully absorbed by
+the closed domain-root scope in `require_domain_source_topology`.
+
+oldShape:
+`mods/mod-swooper-maps/src/domain/<domain>/tags.ts` and direct
+`artifacts.ts`.
+
+absorber:
+`require_domain_source_topology`.
+
+recurrenceRisk:
+denied inside direct domain-root shape because the positive topology rejects
+both files at the owner layer.
+
+liveReferenceReconciliation:
+rule packet, ledger row, authority-slice receipts, active Slice 001 docs,
+domino item 042, and historical Habitat execution-surface/source-check docs
+reference the id. A deletion slice must update live ledger/active workstream
+references and leave older historical docs as history or archive/regenerate
+through their owner.
+
+proof:
+injected `mods/mod-swooper-maps/src/domain/ecology/tags.ts` failed
+`require_domain_source_topology` with `[unexpected-child]` and also failed the
+old rule. A follow-up injected
+`mods/mod-swooper-maps/src/domain/ecology/artifacts.ts` also failed
+`require_domain_source_topology` with `[unexpected-child]` and failed the old
+rule. Current source has no live direct root catalog files.
+
+reviewAcceptance:
+accepted after the direct `artifacts.ts` proof was added.
+
+blockedBy:
+later remediation-slice opening and live-reference reconciliation.
+
+#### `require_domain_ops_root_presence`
+
+deleteReason:
+hardcoded six-domain ops-root presence is fully absorbed by
+`require_domain_source_topology`, which requires `ops` for every domain root.
+
+oldShape:
+explicit open structure scopes for ecology, foundation, hydrology, morphology,
+placement, and resources ops roots.
+
+absorber:
+`require_domain_source_topology`.
+
+recurrenceRisk:
+denied for missing current or future domain `ops` roots covered by the generic
+domain-root topology.
+
+liveReferenceReconciliation:
+rule packet, ledger row, operation authority-slice receipt, and Slice 002
+prework/execution/review records reference the id. A deletion slice must update
+live operational records and preserve historical references as history.
+
+proof:
+renaming `mods/mod-swooper-maps/src/domain/ecology/ops` caused
+`require_domain_source_topology` to fail with `[missing-required-child]`. The
+old rule also failed, proving duplicate coverage for the old shape.
+
+reviewAcceptance:
+accepted.
+
+blockedBy:
+later remediation-slice opening and live-reference reconciliation.
+
+### Review-Rejected Or Blocked Deletion Candidates
+
+#### `prohibit_foundation_stage_cast_merge_hacks`
+
+Blocked:
+review found this recipe-stage/Foundation-Studio literal rule is outside the
+domain-root/domain-operation topology admission frame. Existing context-admission
+records and package tests still treat the exact predicates as live coverage.
+This execution does not change the ledger row or queue deletion.
+
+#### `prohibit_foundation_stage_sentinel_passthrough`
+
+Blocked:
+review found this recipe-stage/Foundation-Studio literal rule is outside the
+domain-root/domain-operation topology admission frame. Existing context-admission
+records and package tests still treat the exact predicates as live coverage.
+This execution does not change the ledger row or queue deletion.
+
+#### `prohibit_domain_artifacts_modules`
+
+Blocked:
+deletion is unsafe. A refined injected probe placed
+`artifacts.ts` under an existing operation support directory:
+
+```text
+mods/mod-swooper-maps/src/domain/ecology/ops/resource-score-balance/rules/artifacts.ts
+```
+
+`require_domain_source_topology` passed and
+`prohibit_domain_artifacts_modules` failed, proving the rule still owns a
+residual nested filename guard that current positive topology does not catch.
+
+#### `prohibit_foundation_op_contract_config_bags`
+
+Blocked:
+semantic packet says operation-contract import clauses likely consolidate into
+`require_domain_operation_contract_file_shape`, but this pass did not run
+injected absolute config-facade import probes. Deletion waits for absorber proof
+over the exact import forms and retired-token reconciliation.
+
+#### `prohibit_foundation_step_contract_config_bags`
+
+Blocked:
+rule needs split/generalization. Live step-contract config-facade import
+pressure belongs in recipe-step contract boundary authority; the
+`FoundationConfigSchema` clause is retired residue.
+
+#### `require_ecology_canonical_op_module_topology`
+
+Blocked:
+actual Ecology rule is an exemplar proxy for generic operation-module topology.
+Current positive source topology only partially absorbs it. A generic
+source-owned verifier/generator and support-directory exception model must be
+designed before mutation.
+
+## Container 7: Fresh Review Gate
+
+Fresh review agents were adversarial and read-only.
+
+| Finding | Disposition |
+| --- | --- |
+| Foundation stage cast/sentinel rows were falsely selected for deletion in this topology pass. | Accepted. Both rows are removed from the selected deletion slice and left unchanged in the ledger. |
+| Direct-root `artifacts.ts` absorber proof was missing for `prohibit_retired_domain_root_catalogs`. | Accepted. Added focused injected proof for direct `artifacts.ts`. |
+| Pending-review language could be consumed as mutation authorization. | Accepted. This receipt now uses review-accepted candidate language only after review and keeps mutation in a later slice. |
+| Ledger gate state and counts were stale. | Accepted. The ledger now queues a named no-mutation slice and refreshed counts. |
+| Compact per-row records were missing. | Accepted. Added compact row records in this receipt. |
+| Decision table did not expose exact action labels. | Accepted. Added exact `actionDecision` column. |
+
+## Container 8: Remediation-Slice Handoff
+
+Next slice id:
+`domain-root-topology-delete-absorbed-root-shape-rules-001`
+
+Status:
+queued for a later remediation branch; no mutation in this execution branch.
+
+Selected rows:
+
+- `prohibit_retired_domain_root_catalogs`
+- `require_domain_ops_root_presence`
+
+Excluded adjacent rows:
+
+- `prohibit_foundation_stage_cast_merge_hacks`: out of scope for this ratchet;
+  live prior context-admission and package-test coverage remain.
+- `prohibit_foundation_stage_sentinel_passthrough`: out of scope for this
+  ratchet; live prior context-admission and package-test coverage remain.
+- `prohibit_domain_artifacts_modules`: residual nested shape not absorbed.
+- `prohibit_foundation_op_contract_config_bags`: absorber proof still needed.
+- `prohibit_foundation_step_contract_config_bags`: split/generalization needed.
+- `require_ecology_canonical_op_module_topology`: source-owned topology design
+  needed.
+
+Allowed write set for later remediation slice:
+
+- selected rule packet directories under `.habitat`;
+- active ledger rows and slice metadata;
+- active receipt references where they are live operational records;
+- generated execution-surface docs only through their owning regeneration path.
+
+Forbidden write set for later remediation slice:
+
+- Foundation stage Grit rule packets selected above as excluded adjacent rows;
+- package tests unless the slice is explicitly reframed to include native test
+  owner cleanup;
+- Habitat baselines except to prove no baseline growth;
+- source movement or runner mutation.
+
+Verification for later remediation slice:
+
+- focused checks for surviving absorber rules;
+- live manifest/ledger parity;
+- no live references to deleted ids outside historical records or regenerated
+  docs;
+- `bun habitat classify .habitat`;
+- `git diff --check`;
+- review disposition with accepted P1/P2 findings cleared.
+
+Stop conditions:
+
+- review contests deletion proof;
+- live references cannot be reconciled without broad generated-doc churn;
+- deleting a packet changes current `bun habitat check` behavior outside the
+  selected old shapes.


### PR DESCRIPTION
This branch completes the post-ratchet rule revalidation execution for the domain-root topology ratchet. No rule packets are deleted, runners mutated, baselines grown, or source moved in this branch.

The execution ran lane-by-lane classification across the revalidation corpus, produced compact per-row audit records, and ran focused injected-probe absorber checks for the deletion candidates. Two rules — `prohibit_retired_domain_root_catalogs` and `require_domain_ops_root_presence` — were review-accepted as fully absorbed by `require_domain_source_topology` and are queued for a named follow-on deletion slice (`domain-root-topology-delete-absorbed-root-shape-rules-001`) on a future Graphite layer.

Four additional candidates were blocked from deletion:

- `prohibit_domain_artifacts_modules`: a nested `artifacts.ts` shape under operation support directories remains outside current positive topology, proven by an injected probe that passed the absorber and failed the old rule.
- `prohibit_foundation_op_contract_config_bags`: action decision revised from `split by owner` to `consolidation/dedup`; deletion waits for injected absorber proof over the exact config-facade import forms.
- `prohibit_foundation_step_contract_config_bags`: requires a split/generalization slice to separate live step-contract import-boundary pressure from the retired `FoundationConfigSchema` token clause.
- `require_ecology_canonical_op_module_topology`: admitted as an exemplar proxy for generic operation-module topology; blocked by source-owned verifier/generator and support-directory exception model design.

Two Foundation stage rows (`prohibit_foundation_stage_cast_merge_hacks` and `prohibit_foundation_stage_sentinel_passthrough`) were rejected from this ratchet admission frame by the fresh review gate; their ledger rows are unchanged from prior state.

The ledger gate state, action-decision counts, and `layer2Status` values are refreshed to reflect the post-ratchet revalidation outcome, and the new queued slice is registered in the slice history with its allowed and forbidden write sets.