### PR TITLE
docs(habitat): add blueprint authority ratchet descent frame

### DIFF
--- a/.habitat/.active/frames/BLUEPRINT-AUTHORITY-RATCHET-DESCENT-FRAME.md
+++ b/.habitat/.active/frames/BLUEPRINT-AUTHORITY-RATCHET-DESCENT-FRAME.md
@@ -1,0 +1,530 @@
+# Blueprint Authority Ratchet Descent Frame
+
+Status: active normative method frame
+
+Built: 2026-07-06
+
+Owner: Habitat authority-tree workstream steward
+
+Durability: standalone method frame for repeated blueprint-authority ratchets
+
+## Frame Identity
+
+Frame name: Blueprint Authority Ratchet Descent
+
+For situation: one full blueprint structural-enforcement descent has closed:
+the domain-root topology slice moved from scope design through prework,
+execution, repair, Habitat enforcement, post-ratchet revalidation, absorbed
+duplicate-rule deletion, and ascent. Broader rule-authority cleanup remains
+transition work above the completed descent. The next useful move is to preserve
+the method at the authority layer so future blueprint descents can start from a
+sharper machine instead of rediscovering the method from transcript history.
+
+Mode: frame-discovery from the completed domain-root descent, with
+audience-export for future DRA stewards and peer agent teams.
+
+Object path: objective and method frame.
+
+Primary object: the repeatable container geometry for ratcheting one blueprint
+scope from open structural residue into enforceable Habitat law.
+
+## Current Boundary
+
+The completed domain-root descent is evidence that the ratchet works. It is not
+the whole method and it is not a template to copy blindly.
+
+The current state after one closed descent:
+
+- a selected blueprint depth has gone green under live Habitat topology and
+  file-shape rules;
+- nondeterministic rows were resolved through explicit prework instead of
+  hidden implementation judgment;
+- deterministic rows were burned down into defined destinations;
+- drift introduced during execution was repaired instead of normalized;
+- absorbed duplicate rules were deleted after survivor-authority proof;
+- old inventories and execution packets became historical evidence, not live
+  queues;
+- the workstream has moved back up one container level before selecting the
+  next descent.
+
+That state creates useful pressure. The next descent should not begin from a
+flat list of tasks. It should begin from a working coordinate system: which
+blueprint kind is selected, which depth is active, which law is being asserted,
+which red corpus exists, which rows are nondeterministic, which destinations
+are locked, which proof closes the ratchet, and which scaffolding retires after
+closure.
+
+## Future Boundary
+
+The future state this frame aims toward is a product whose software objects are
+legible to Habitat and to agents:
+
+- every blueprint kind has a defined topology and file-shape grammar at the
+  depths that have been ratcheted;
+- enforcement produces useful red because destinations already exist;
+- prework opens only where a row lacks a deterministic owner or destination;
+- source movement is mechanical once the row destination is locked;
+- rule cleanup reduces the authority surface after positive law absorbs older
+  symptom guards;
+- future agents can locate themselves inside the active container without
+  replaying the whole history.
+
+The frame's job is to turn the space between those two states into directional
+work: descend only as far as the selected authority can support, resolve the
+questions that block that descent, ratchet the result into law, clean the rule
+surface, then ascend before choosing the next scope.
+
+## Selection Commitments
+
+In:
+
+- one blueprint ratchet at a time, selected by kind, scope depth, and proof
+  boundary;
+- the authority tree that defines target shapes: scopes, files, patterns,
+  rule manifests, `structure.toml`, decision books, and sealed workstream
+  records;
+- current source paths, rule diagnostics, Narsil evidence, Git history, tests,
+  and command output as evidence;
+- red inventories, row dispositions, execution packets, review findings, and
+  closure receipts for the active descent;
+- post-ratchet rule-surface reduction and classification as part of closure,
+  not optional polish;
+- ascent and next-scope selection after closure.
+
+Foreground:
+
+- positive assertions first: declare what the selected object is allowed to be,
+  then let everything else go red;
+- current paths are evidence, not authority;
+- red is leverage when every red row has a destination, delete action, or named
+  owner-law gap;
+- prework is for nondeterministic destinations only;
+- row obligations remain visible even when grouped into lanes or classes;
+- file-shape law belongs in the owning Habitat rule surface: Grit pattern,
+  command check, or stronger owner rail; topology law belongs in
+  `structure.toml` when declarative tree shape fits; behavior tests prove
+  behavior;
+- proof classes use the exact labels in
+  `.agents/skills/civ7-habitat-dra-workstream/references/proof-classes.md`;
+  review disposition, Graphite state, and product readiness are closure or
+  workflow claims, not substitute proof classes.
+
+Exterior:
+
+- generic process improvement without a selected blueprint kind or ratchet
+  boundary;
+- task-list execution before target shape and row destinations exist;
+- broad simultaneous redesign of every blueprint kind;
+- operation-internal cleanup unless the selected blueprint scope admits it;
+- treating historical inventories, transcript language, or current file paths
+  as durable law;
+- preserving negative or one-off rules because they were historically useful;
+- using tests or scripts as topology/file-shape authority where Habitat
+  patterns or structure rules can carry the law.
+
+## Coordinate System
+
+An agent using this frame must be able to answer the following location
+questions before moving:
+
+| Coordinate | Question | Valid answer shape |
+| --- | --- | --- |
+| Blueprint kind | What kind of software object is being ratcheted? | `domain`, `artifact`, `recipe-stage`, `domain-operation`, or another kind admitted by `.habitat` authority ontology, sealed decision, or direct current user authority. |
+| Selected depth | Which layer of that kind is in frame? | Root topology, immediate child topology, file pattern, registry surface, operation contract shape, or another named depth. |
+| Authority owner | Which scope, file, pattern, rule, or decision book owns the destination shape? | A concrete authority path, or `owner-law gap` if no accepted owner exists. |
+| Red corpus | What becomes red under the selected assertion? | A row ledger with source pointers and proof class, not a prose impression. |
+| Row state | What is each row waiting for? | `defined destination`, `delete`, `replace`, `move`, `inline`, `external owner`, `needs prework`, `owner-law gap`, or `law correction`. |
+| Proof gate | What evidence closes this container? | Named proof classes from `proof-classes.md`: Habitat wrapper behavior, Injected violation proof, Clean sample proof, Unit behavior, Native tool behavior, Runtime/product proof, and Record truth proof where applicable; review disposition and Graphite state remain separate workflow claims. |
+| Ascent condition | What lets the steward move back up? | All active rows resolved or explicitly tracked outside the selected ratchet; survivor law green; overlapping scaffolding classified or retired. |
+
+If an agent cannot locate the work on these coordinates, the next move is not
+execution. The next move is frame repair or prework.
+
+## Descent States
+
+The descent is not a checklist. It is a sequence of state changes. Each state
+makes the next one more mechanical.
+
+### 1. Container Selected
+
+Progress exists when the steward can name the blueprint kind, selected depth,
+scope boundary, exterior, falsifier, and proof boundary.
+
+The selected container is narrow enough to produce actionable red and wide
+enough to reduce structural debt. A container that cannot produce red is only a
+topic. A container that produces red with no possible destinations is too deep
+or too early.
+
+### 2. Shape Asserted
+
+Progress exists when the selected object has a positive target shape: allowed
+children, allowed files, allowed imports, allowed exports, required aggregation
+surface, or required relationship.
+
+The assertion follows the DRA authority order in
+`.agents/skills/civ7-habitat-dra-workstream/references/authority-map.md`.
+Direct current user instruction, accepted Habitat authority, architecture
+authority, and sealed decisions can establish target law. AGENTS and workflow
+docs establish source order, routing, and process constraints unless they carry
+a direct applicable structural instruction. Fresh source and command evidence
+can falsify stale claims or prove semantic fit, but common current layout does
+not become topology or file-shape law merely because it exists.
+
+This is where `CLOSED-STRUCTURE-ENFORCEMENT-METHOD-FRAME.md` operates as a
+primitive inside the larger ratchet.
+
+### 3. Red Exposed
+
+Progress exists when the selected shape has been run against current reality
+and the red corpus is visible.
+
+Red is useful only when it is bounded. Each row carries source path, violated
+law, evidence, proof class, and suspected destination class. If a diagnostic
+does not map to a row, the corpus is not ready for execution.
+
+### 4. Red Classified
+
+Progress exists when every row has a state:
+
+- destination locked;
+- delete action locked;
+- replacement locked;
+- external owner identified;
+- row requires prework because destination is nondeterministic;
+- row proves the selected law is premature or too broad;
+- row is outside the selected container and tracked as such.
+
+Grouping is allowed. Hiding rows inside groups is not.
+
+### 5. Law Corrected Or Scope Split
+
+Progress exists when every row that challenges the selected law has forced an
+explicit structural response.
+
+Rows classified as `law correction`, premature law, too-broad law, blocking
+owner-law gap, or unresolved external-owner gap do not proceed through the
+happy path. The steward must narrow the assertion, revise the owner law, split
+the ratchet, open the exact prework decision, or ascend/reframe before
+execution can be authorized.
+
+This is where intentional red protects the work from overreach. A red row that
+proves the assertion is wrong is not implementation work. It is back-talk from
+the selected law.
+
+### 6. Questions Resolved
+
+Progress exists when prework has closed every nondeterministic row selected by
+the active ratchet.
+
+Prework is not a research dump. Its unit is the unresolved destination question.
+Its output is a concrete action, an owner-law update, a law correction, or a
+named out-of-scope domino. If prework produces only more categories, it has not
+closed the row.
+
+### 7. Execution Authorized
+
+Progress exists when implementation can proceed without inventing destinations.
+
+At this point, the work can be sliced by class, owner, write set, or proof
+shape. Agents may make local semantic judgments inside a locked destination
+class, but they may not create a new bucket, preserve garbage to keep imports
+green, or widen scope to avoid a red row.
+
+Before source-moving execution, every moved or deleted row must expand to
+exported symbols and non-exported behavior-bearing definitions. Each item is
+marked `Preserved`, `Intentional loss`, or `Unresolved loss`. `Unresolved loss`
+blocks execution and closure. `Intentional loss` requires consumer proof and
+authority rationale. Scope-crossing destinations require local owner evidence
+from the destination's own docs, router guidance, exports, and checks.
+
+### 8. Burn-Down Completed
+
+Progress exists when source, rules, docs, tests, and imports match the selected
+law and row dispositions.
+
+Behavior tests stay behavior-focused. Habitat carries topology and file-shape
+law. If a test asserts structure, either the assertion belongs in Habitat or it
+is not part of the ratchet.
+
+### 9. Drift Repaired
+
+Progress exists when the steward checks whether execution created new hiding
+places, weaker destinations, new negative sentries, broad helper buckets, or
+test-based topology enforcement.
+
+Repair is not embarrassment cleanup. It is part of ratcheting. A descent has
+not proven the method if it lets its own temporary compromises become the next
+layer of architecture.
+
+### 10. Law Ratcheted
+
+Progress exists when the positive law is enforced, Habitat wrapper behavior
+proof is green for the selected surface, and injected violation proof covers
+every injectable claimed failure class. Clean sample proof covers known-good
+exclusion and false-positive claims; it does not prove that bad cases fail.
+
+Advisory rules, candidate patterns, and narrative docs are not law. They can be
+evidence or preparation, but the ratchet lands only when the enforcement rail
+is real and the closure claim names what it proves.
+
+Habitat wrapper behavior is never sufficient by itself for closure. Every
+closure receipt names the proof limits and non-claims for each proof class. If
+injected violation proof is impossible, the receipt must name why, name the
+fallback proof used, and narrow the ratchet's claim so the law is not treated
+as fully proven beyond the evidence.
+
+### 11. Rule Surface Reduced
+
+Progress exists when overlapping rules, negative sentries, slice-specific
+guards, and stale ledgers are classified after the positive law lands.
+
+The useful question is not "does the old rule still match something?" The
+useful question is "is the old concern now owned by the new positive law?" If
+yes, retire or absorb it after proof. If no, name the distinct concern and keep
+or split it honestly.
+
+### 12. Closure And Ascent
+
+Progress exists when the descent can be closed without a hidden queue:
+
+- active rows are resolved, tracked outside the ratchet, or rejected with
+  evidence;
+- proof claims are labeled by proof class;
+- review findings are repaired or dispositioned;
+- stale records point to the survivor authority or historical evidence;
+- Graphite state is clean;
+- the next move is selected from one container level up.
+
+Ascent matters. Without ascent, the steward keeps drilling downward and loses
+the blueprint-level leverage the ratchet created.
+
+## Decision Apertures
+
+Open a prework decision only when one of these is true:
+
+- a row has no accepted owner or destination;
+- a destination class exists but its file shape or topology law is incomplete;
+- evidence suggests the selected law is too broad or too narrow;
+- a row may belong to an external package or blueprint kind;
+- deletion is plausible but liveness or behavior proof is not yet strong enough.
+
+Do not open prework when:
+
+- the row already has a defined destination and proof class;
+- the row is dead by consumer proof and accepted authority;
+- the row is a simple import consequence of a locked move;
+- the question is only "which agent should do it?";
+- the work is really execution discomfort, not unresolved ownership.
+
+The test is simple: if more investigation cannot change the destination class,
+execute. If the destination class itself is unknown, qualify before execution.
+
+## Ratchet Rules
+
+The ratchet is the moment positive authority starts excluding alternatives by
+force.
+
+Use these rules to decide whether a ratchet is real:
+
+1. The rule asserts allowed structure or shape; it does not merely list known
+   bad residue.
+2. The enforcement home is Habitat structure or pattern authority unless a
+   stronger owner rail is already established.
+3. The rule has Habitat wrapper behavior proof and injected violation proof for
+   every injectable failure class. Clean sample proof covers known-good
+   exclusion and false-positive claims. If injected violation proof is
+   impossible, the closure receipt names why, the fallback proof used, and the
+   non-claim.
+4. The rule creates deterministic destinations for the rows it turns red.
+5. The rule's blast radius is known. If it lights up unresolved unrelated
+   semantics, keep it advisory or split the scope until the selected ratchet
+   can close honestly.
+6. Absorbed duplicate rules are deleted or retired only after survivor proof.
+7. Any negative guard that remains must name the durable boundary it protects
+   or the trigger that will retire it.
+
+## Movement Rules
+
+After a ratchet closes, choose the next move deliberately:
+
+- move down when the selected scope has produced a nested owner question that
+  blocks closure;
+- move across when the method is proven for one scope and another blueprint
+  scope can now use the same positive-assertion machinery;
+- move up when a completed descent has accumulated rule-surface residue, method
+  capture, or next-slice selection work above the closed slice;
+- pause when proof says the active law is green but the authority surface has
+  not yet been reduced.
+
+The default after one full descent is to move up, clean and capture, then move
+across. Moving down too soon spends the leverage on details before the method
+has been reused.
+
+## Review Loop Gates
+
+Review is not a final ceremony. It is a phase gate wherever an error would
+compound downstream.
+
+Run fresh read-only review at minimum:
+
+- after row classification or prework, before source execution;
+- after burn-down and drift repair, before ratchet closure;
+- after rule-surface cleanup, before ascent.
+
+Reviewers must be distinct from implementers or drafting agents for the surface
+they review. Accepted P1/P2 findings block dependent execution or closure until
+repaired, rejected with source evidence, invalidated by later evidence, or
+explicitly moved out of scope by sealed authority or direct user decision.
+
+## Hard Core
+
+1. Blueprint authority descends through named nested containers and ascends only
+   after ratchet closure.
+2. Target shape is asserted before burn-down; current source paths are evidence,
+   not authority.
+3. Every red row must resolve to a destination, deletion, replacement, external
+   owner, law correction, or named owner-law gap before execution closes.
+4. Prework exists only for nondeterministic destinations.
+5. Closure requires positive law, proof-class separation, review disposition,
+   rule-surface cleanup, and clean Graphite state.
+
+## Protective Belt
+
+- Exact packet names and file homes for a future workstream.
+- Exact number of stages in an execution plan, as long as state transitions
+  remain visible.
+- Exact agent lane names, as long as evidence, implementation, and review are
+  separated.
+- Whether a particular proof uses Narsil, `rg`, Git, Habitat, Nx, or tests
+  first, as long as evidence authority and proof class are explicit.
+- Whether a descent uses one execution slice or several, as long as row
+  obligations stay visible and closure is not claimed early.
+- Whether the next move is up, down, or across, as long as the move is chosen
+  from the current container state rather than by inertia.
+
+## Structural Alternative Rejected
+
+Rejected alternative: a linear runbook.
+
+```text
+define container
+  -> activate scope
+  -> flip to red
+  -> classify
+  -> execute
+  -> ratchet
+  -> close
+```
+
+The sequence is useful as a mnemonic, but it is too weak as the frame. A
+runbook makes agents follow steps without knowing where they are. The stronger
+frame is geometric: selected kind, selected depth, authority owner, red corpus,
+row state, proof gate, ratchet status, and ascent condition.
+
+Rejected alternative: rule-by-rule cleanup as the parent frame.
+
+Rule cleanup is necessary after positive law lands, but it is not the parent
+unit. If rule cleanup becomes the frame, the work optimizes the residue instead
+of asserting the shape that makes residue disappear.
+
+Rejected alternative: full-depth topology enforcement before destinations are
+known.
+
+That creates improvisation pressure. The frame permits intentional red only
+when the red corpus can be driven into defined destinations or explicit
+prework. Otherwise the correct move is shallower scope, not heroic execution.
+
+## Completed Descent Exemplar
+
+The completed domain-root descent is an exemplar, not a template:
+
+| Coordinate | Domain-root exemplar |
+| --- | --- |
+| Blueprint kind | `domain` |
+| Selected depth | domain root plus immediate `ops/` child topology |
+| Survivor law | `.habitat/blueprints/domain/require_domain_source_topology/` |
+| Supporting rails | domain `ops.ts` binding surface, domain `ops/index.ts` registry surface, operation contract shape, model schema/policy owner shape, artifact file and index shape, public import surfaces |
+| Red corpus | Slice 001 inventory, later refined by Slice 002 prework and cleanup execution ledgers |
+| Prework aperture | narrative liveness, Foundation `lib/`/tectonics disposition, domain model config law, and related nondeterministic owner/destination rows |
+| Burn-down and repair | source moved/deleted into locked destinations; execution drift around artifact/config/stage surfaces was repaired rather than normalized |
+| Rule reduction | absorbed duplicate rules `prohibit_retired_domain_root_catalogs` and `require_domain_ops_root_presence` were deleted after survivor proof |
+| Proof classes | Habitat wrapper behavior for the survivor rule, injected violation proof inherited from post-ratchet revalidation, Record truth proof for manifest/ledger parity, Native tool behavior for lint/check/diff hygiene, review disposition, and Graphite closure as separate workflow claims |
+| Ascent | old inventories became historical evidence; residual adjacent rules became future descents or separate remediation frames |
+
+## Reframe Conditions
+
+What would force a reframe:
+
+If a future blueprint kind cannot use this frame to locate each active row as a
+defined destination, delete action, replacement, external owner, law correction,
+or named owner-law gap without inventing a generic bucket, this frame is not
+general enough and must be revised before reuse.
+
+Degeneration trigger:
+
+If three future descents using this frame produce artifacts that list tasks but
+do not name current container, selected depth, red corpus, authority owner,
+proof gate, and ascent condition, run a reframe diagnostic before continuing.
+
+## Relationship To Nearby Frames
+
+`CLOSED-STRUCTURE-ENFORCEMENT-METHOD-FRAME.md` is the local primitive inside
+this frame. It governs the act of selecting one kind and asserting its closed
+structure. This frame governs the larger descent: prework, execution, repair,
+ratchet, rule cleanup, closure, ascent, and next-scope selection.
+
+`.habitat/.active/workstreams/define-domain-blueprint-structure/blueprint-authority-stewardship-frame.md`
+is an instance-specific transition and DRA stewardship frame for the completed
+domain-root descent. It remains useful for current takeover and
+source-precedence context. It should not become the reusable method authority
+because it carries temporal branch/worktree and transition details.
+
+`.habitat/.active/workstreams/define-domain-blueprint-structure/active-transition-anchor.md`
+is a temporary controller for the immediate post-domain-root transition. It can
+point to this frame while the transition is active, then retire when its
+containers close.
+
+## Use Protocol
+
+Before opening a new blueprint ratchet, produce a compact container frame that
+answers:
+
+- current boundary;
+- future boundary;
+- selected blueprint kind;
+- selected depth;
+- authority owner;
+- exterior;
+- falsifier or reframe trigger;
+- expected red surface;
+- prework trigger;
+- proof gate;
+- ascent condition.
+
+During the ratchet, keep a row ledger. The ledger is the bridge between red
+diagnostics and deterministic execution. It must preserve row-level obligations
+through grouping, fanout, and review.
+
+Opened descents use the selected workstream's own scope and slice grammar. Until
+a reusable packet grammar is promoted, the completed
+`.habitat/.active/workstreams/define-domain-blueprint-structure/scopes-and-slices-reference.md`
+record is precedent only, not the required home or controlling authority for
+future descents. This frame owns method geometry; slice packets own the
+concrete HOW for the selected ratchet.
+
+At closure, write a receipt that states:
+
+- survivor law;
+- retired or retained overlapping rules;
+- proof commands, proof classes, and non-claims or proof limits for each class;
+- review findings and dispositions;
+- stale records updated or intentionally left historical;
+- explicit next container move.
+
+## NOT HOW
+
+This frame does not prescribe the exact implementation plan for any future
+blueprint kind, the exact GritQL or `structure.toml` implementation, the next
+scope to select, or the exact number of agents to use. Those belong to the
+opened workstream, slice frame, execution plan, and review protocol for the
+selected ratchet.

--- a/.habitat/.active/frames/README.md
+++ b/.habitat/.active/frames/README.md
@@ -65,3 +65,10 @@ Current frames:
 Workstream-specific method frames also live here. The current
 closed-structure enforcement frame is
 `CLOSED-STRUCTURE-ENFORCEMENT-METHOD-FRAME.md`.
+
+- `BLUEPRINT-AUTHORITY-RATCHET-DESCENT-FRAME.md`: use when opening or
+  stewarding a full blueprint-authority ratchet from selected scope through
+  prework, execution, repair, positive Habitat ratchet, rule-surface cleanup,
+  closure, ascent, and next-scope selection. It does not replace the
+  closed-structure enforcement frame; it composes that frame as the local
+  positive-assertion primitive and adds the larger descent/ascent geometry.

--- a/.habitat/.active/workstreams/define-domain-blueprint-structure/active-transition-anchor.md
+++ b/.habitat/.active/workstreams/define-domain-blueprint-structure/active-transition-anchor.md
@@ -162,25 +162,20 @@ Required output when opened:
 
 ## Container 2: Reusable Initiative Frame Capture
 
-Status: second container to open after the rule authority cleanup direction is clear.
+Status: candidate method frame captured at
+`.habitat/.active/frames/BLUEPRINT-AUTHORITY-RATCHET-DESCENT-FRAME.md`;
+review before promoting or retiring this temporary anchor.
 
 Objective:
 capture the reusable method from the completed descent so future blueprint work
 starts with the right container geometry instead of rediscovering it.
 
-The reusable method:
-
-```text
-define container
-  -> activate scope
-  -> flip to red
-  -> classify red by owner and destination
-  -> open prework only for nondeterministic destinations
-  -> execute deterministic burn-down
-  -> repair drift
-  -> ratchet with Habitat
-  -> close and move back up
-```
+Canonical method:
+`.habitat/.active/frames/BLUEPRINT-AUTHORITY-RATCHET-DESCENT-FRAME.md`
+now owns the full descent state machine, including law-correction/scope-split
+back-talk, source-movement preservation gates, review gates, rule-surface
+reduction, and ascent. Do not maintain a second compressed method copy in this
+temporary anchor.
 
 Key lesson to preserve:
 prework is not information gathering for its own sake. Prework exists only where


### PR DESCRIPTION
Adds a reusable Blueprint Authority Ratchet Descent frame to `.habitat/.active/frames/`, capturing the method geometry proven by the completed domain-root descent.

The new frame defines the full descent lifecycle as a sequence of named state changes—container selection, shape assertion, red exposure, row classification, law correction or scope split, prework, execution authorization, burn-down, drift repair, law ratcheting, rule-surface reduction, and closure with ascent—rather than a linear runbook. It establishes a coordinate system (blueprint kind, selected depth, authority owner, red corpus, row state, proof gate, ascent condition) that agents must be able to answer before moving, and specifies when prework is and is not warranted, how proof classes stay separated, and what a valid closure receipt must contain.

The frame composes `CLOSED-STRUCTURE-ENFORCEMENT-METHOD-FRAME.md` as its local positive-assertion primitive and adds the larger descent/ascent geometry around it. The domain-root descent is included as a completed exemplar with its coordinates filled in, not as a template to copy.

The `active-transition-anchor.md` is updated to point to the new frame as the canonical method authority, removing the compressed inline method copy that would have diverged from it.