### PR TITLE
docs(habitat): open domain-operation interior descent (frame, decision packets, row-ledger seed)

### DIFF
--- a/.habitat/.active/workstreams/README.md
+++ b/.habitat/.active/workstreams/README.md
@@ -14,6 +14,7 @@ This index routes active workstreams only and cannot reorder that authority.
 | Workstream | Status | Role |
 | --- | --- | --- |
 | `define-domain-blueprint-structure/` | active | Define the domain blueprint scope tree, qualify prework decisions, and prepare closed-structure enforcement. |
+| `descend-002-domain-operation-interior/` | selected / opening | Define the domain-operation interior law (support-directory grammars, strategy import law, contract metadata owner) and drive the second blueprint descent. |
 | `remediate-rule-authority/` | operational / mostly closed | Maintain the machine-readable rule-authority ledger and closed receipts for rule remediation state. |
 | `establish-mapgen-product-authority/` | supporting / mostly complete | Provide MapGen product and architecture authority evidence for Habitat decisions. |
 | `orient-layer3-authority-consolidation/` | supporting orientation | Preserve the Layer 3 takeover scratchpad and initiative frame. |

--- a/.habitat/.active/workstreams/descend-002-domain-operation-interior/decisions/001-strategy-container-law.md
+++ b/.habitat/.active/workstreams/descend-002-domain-operation-interior/decisions/001-strategy-container-law.md
@@ -1,0 +1,65 @@
+# Decision Packet 001: Strategy Container Law
+
+Status: open; awaiting user ruling
+
+Question:
+must every operation root contain a `strategies/` directory, or is an inline
+single implementation a valid operation shape?
+
+Why this is nondeterministic:
+the survivor structure law marks `strategies` as allowed, not required. The
+ecology exemplar rule requires it for ecology only. Source authority
+(`SPEC-step-domain-operation-modules`, ADR er1-031 strategy-config-encoding)
+treats strategies as implementations selected by the operation contract, but
+does not state whether a single-implementation operation must still route
+through the container. Current source is split: 92 of 101 operations have
+`strategies/`; 9 do not.
+
+Evidence (2026-07-06):
+
+- the nine operations without `strategies/` are all foundation `compute-*`:
+  `compute-crust-evolution`, `compute-crust`, `compute-mantle-forcing`,
+  `compute-mantle-potential`, `compute-mesh`, `compute-plate-graph`,
+  `compute-plate-motion`, `compute-plates-tensors`,
+  `compute-tectonic-segments`;
+- every one of those nine contracts declares a strategy envelope (grep
+  `strateg` in each `contract.ts`: all nonzero) — the contract surface already
+  models strategy selection even where the container is absent;
+- operation kind does not discriminate: 76 contracts declare `kind: "compute"`
+  and most of those do have `strategies/`;
+- 83 of the 92 existing `strategies/` directories are exactly
+  `default.ts + index.ts`, so the single-strategy wrap is already the dominant
+  idiom.
+
+Options:
+
+(a) `strategies/` required for every operation.
+Consequence: nine mechanical wraps in foundation (move the inline
+implementation into `strategies/default.ts`, add `strategies/index.ts`). One
+uniform shape; the exemplar rule's strongest clause generalizes cleanly; no
+exemption grammar. Blast radius: nine operations, no behavior change.
+
+(b) inline single implementation allowed as an alternate closed shape.
+Consequence: two valid operation shapes forever; the structure law needs an
+either/or expression; every future tool, generator, and agent must handle
+both; the contract-declared strategy envelope and the missing container
+disagree in nine places.
+
+(c) keyed to operation kind (for example, computes may inline).
+Consequence: rejected by evidence — most computes have `strategies/`, so kind
+does not predict the shape; this option would encode an accident as law.
+
+Recommended default: (a).
+Uniformity is cheap here (nine wraps), the contracts already declare strategy
+envelopes, and one closed shape is exactly the kind of positive assertion this
+initiative exists to make.
+
+Seal target once ruled:
+`.habitat/scopes/domain/scopes/ops/scopes/operation/scope.md` moves
+`strategies` from allowed to required (or records the alternate shape);
+the survivor `structure.toml` operation-roots scope updates to match; row D
+in `ledger.md` flips to defined destinations.
+
+Escalation:
+if any of the nine wraps turns out to require a behavior-bearing change (not a
+pure move), stop and record it as law back-talk against this packet.

--- a/.habitat/.active/workstreams/descend-002-domain-operation-interior/decisions/002-strategy-dependency-classes.md
+++ b/.habitat/.active/workstreams/descend-002-domain-operation-interior/decisions/002-strategy-dependency-classes.md
@@ -1,0 +1,89 @@
+# Decision Packet 002: Strategy Dependency Classes
+
+Status: open; awaiting user ruling
+
+Question:
+which import classes are law for strategy files
+(`ops/<operation>/strategies/*.ts`)? This ruling becomes the generic positive
+strategy import law and retires the foundation-local negative guard.
+
+Why this is nondeterministic:
+the corrective audit rejected promoting
+`prohibit_foundation_strategy_nonlocal_imports` as-is because its allowlist is
+underbroad: "other strategies legitimately import support dirs, policy, local
+types, core libs, same-op strategies, and domain constants." Which of those
+observed classes is intended architecture and which is tolerated debt is a
+semantic call that current authority does not decide.
+
+Evidence — full census of 509 import specifiers across all strategy files
+(2026-07-06):
+
+| Count | Observed class | Example |
+| --- | --- | --- |
+| 162 | `@swooper/mapgen-core/*` package surfaces | `@swooper/mapgen-core/authoring` |
+| 108 | op-local sibling strategies (`./`) | `./default.js` |
+| 104 | own operation contract (`../contract.js`) | universal |
+| 56 | own operation `rules/` (`../rules/*`) | `../rules/index.js` |
+| 53 | own domain `model/*` (up three levels) | `../../../model/policy/geological-resource-signals.js` |
+| 13 | own operation `policy/` | `../policy/spacing-floors.js` |
+| 3 | own operation `types.js` | |
+| 3 | `@civ7/map-policy` package | resources domain |
+| 3 | anomalies (rows B1-B3 in the row ledger seed) | cross-domain and cross-operation reaches |
+
+The three anomalies: `placement/ops/plan-starts/strategies/default.ts:18`
+reaches `../../../../hydrology/index.js` (cross-domain relative);
+`placement/ops/plan-natural-wonders/strategies/default.ts:38` reaches
+`@mapgen/domain/hydrology/model/policy/river-class.js` (cross-domain package);
+`ecology/ops/plot-effects-score-snow/strategies/default.ts:3` reaches
+`../../plan-plot-effects/rules/index.js` (cross-operation).
+
+Proposed law (the recommended default):
+
+Allowed classes:
+
+1. own operation surfaces: `../contract.js`, `../types.js`, `../rules/*`,
+   `../policy/*`, sibling strategies `./*`;
+2. own domain model: `../../../model/**` (schemas, policy, data);
+3. `@swooper/mapgen-core` public surfaces;
+4. named external packages already accepted by domain law (currently
+   `@civ7/map-policy`).
+
+Forbidden classes (each with an injected-violation probe at ratchet time):
+
+5. any other domain's surfaces, by relative path or package specifier;
+6. any sibling operation's internals;
+7. adapter/engine runtime, recipe surfaces, root config facades (already
+   owned by existing domain-operation rules; the strategy law composes with
+   them rather than restating them).
+
+Rulings needed inside the default (the genuinely open sub-questions):
+
+- model breadth: whole own-domain `model/**`, or `model/schemas` +
+  `model/policy` only (excluding `model/data`)? Census shows only
+  schema/policy imports today; ruling whole-model is simpler, ruling
+  narrower is stricter.
+- core breadth: any `@swooper/mapgen-core` subpath, or a named subpath
+  allowlist? Census shows `authoring` dominates; a named list is stricter but
+  adds maintenance.
+- external packages: is `@civ7/map-policy` a durable allowance or
+  resources-domain debt?
+- cross-operation signals: rows B1-B3 need destinations — hoist the shared
+  signal into the owning domain's `model/`, or route it through the consuming
+  operation's contract inputs. This is per-row semantic work executed under
+  whichever boundary you rule.
+
+Consequence of the default: three red rows (B1-B3), everything else green by
+construction; the foundation guard retires after clean-sample plus
+injected-violation proof through the new law.
+
+Seal target once ruled:
+`.habitat/scopes/domain/scopes/ops/scopes/operation/scopes/strategies/patterns/strategy-uses-approved-local-surfaces.md`
+becomes the enforced pattern text; enforcement lands in
+`.habitat/blueprints/domain-operation/` as a positive rule;
+`prohibit_foundation_strategy_nonlocal_imports` retires after survivor proof;
+rows B1-B3 lock exact destinations.
+
+Escalation:
+if the fresh census at execution open finds new classes beyond this table, or
+if the ruled law would turn more than five percent of strategy imports red,
+stop: that is law back-talk, and the packet reopens with the new evidence.

--- a/.habitat/.active/workstreams/descend-002-domain-operation-interior/decisions/003-contract-quality-owner.md
+++ b/.habitat/.active/workstreams/descend-002-domain-operation-interior/decisions/003-contract-quality-owner.md
@@ -1,0 +1,65 @@
+# Decision Packet 003: Contract Quality Owner
+
+Status: open; awaiting user ruling
+
+Question:
+who owns operation contract schema metadata law — which surface enforces that
+contract schemas carry `description:` metadata (and any future quality bar)?
+
+Why this is nondeterministic:
+the corrective audit split `validate_ecology_op_contract_quality` into three
+clauses with different fates: the schema-description clause is real quality
+pressure with no accepted owner ("schema metadata policy must be
+source/package-verify owned before mutation"); the exported-function JSDoc
+clause and the stale `recipes/standard/stages/ecology/steps` path clause are
+not domain-operation invariants and should delete. The open question is only
+the owner of the surviving clause.
+
+Evidence (2026-07-06):
+
+- 95 of 101 operation contracts already carry `description:` metadata; the
+  bar is de facto met;
+- the six gaps: `foundation/ops/compute-hotspot-events`,
+  `compute-segment-events`, `compute-tectonic-provenance`,
+  `compute-tectonics-current`, `compute-tracer-advection`, and
+  `placement/ops/plan-wonders` (each `contract.ts`);
+- the current enforcement is an ecology-only script mixing all three clauses;
+- contracts are TypeBox schemas consumed by the op registry and Studio; the
+  metadata has runtime-visible consumers, which is why a source-owned check is
+  plausible.
+
+Options:
+
+(i) package-verify owned: a check in the owning package's verify/test surface
+asserts every registered operation contract carries the metadata.
+Consequence: quality law lives beside the code it governs, runs in the
+package's own gate, and can read the registry (typed, complete coverage by
+construction); Habitat routes to it rather than duplicating it. Matches the
+audit's direction and the house tool-separation authority (behavior and
+schema-value checks are native-rail territory).
+
+(ii) Habitat pattern rule: a Grit pattern over `contract.ts` files.
+Consequence: enforcement sits with the other shape law, but a text-level
+pattern asserting schema metadata is brittle (metadata can be composed,
+spread, or imported) and duplicates what the registry can verify natively.
+
+(iii) generator-owned: contract scaffolding emits the metadata and a
+generator-currentness check keeps it.
+Consequence: strongest ergonomics, but there is no operation generator today;
+this option creates tooling scope this descent does not want.
+
+Recommended default: (i) package-verify owned, with Habitat's role limited to
+routing (the existing ecology rule deletes; no Habitat replacement rule).
+The six gap contracts get their metadata completed as mechanical rows under
+the new check.
+
+Seal target once ruled:
+the ruled owner gains the check; the six gap rows in `ledger.md`
+flip to defined destinations; `validate_ecology_op_contract_quality` splits —
+surviving clause to the ruled owner, JSDoc and stale-path clauses deleted —
+and the rule id retires after survivor proof.
+
+Escalation:
+if the ruled owner cannot express the check without weakening it (for
+example, package verify cannot see unregistered contracts), reopen with that
+evidence rather than silently downgrading the bar.

--- a/.habitat/.active/workstreams/descend-002-domain-operation-interior/decisions/004-rules-entrypoint-export-policy.md
+++ b/.habitat/.active/workstreams/descend-002-domain-operation-interior/decisions/004-rules-entrypoint-export-policy.md
@@ -1,0 +1,67 @@
+# Decision Packet 004: Support-Directory Aggregation Grammar
+
+Status: open; expected to close deterministically — escalates only on contrary evidence
+
+Question:
+what is the closed grammar for `rules/` and `policy/` internals — is
+`index.ts` aggregation required, and does the tectonics shim-re-export sentry
+delete by absence?
+
+Why this is a decision packet at all:
+the drafted scope files
+(`.habitat/scopes/domain/scopes/ops/scopes/operation/scopes/{rules,policy}/`)
+already sketch the grammar, and the evidence below points one way. It is held
+as a packet only because the grammar choice interacts with decision packet 002
+(whether strategy imports go through `../rules/index.js` or may reach
+individual rule files) and because deleting a sentry requires an explicit
+ruling, not a shrug.
+
+Evidence (2026-07-06):
+
+- `rules/` internals across all operations: 41 directories are `index.ts`
+  only; most others are `index.ts` plus named rule files; exactly four lack
+  `index.ts` (`foundation/ops/compute-plates-tensors/rules/`,
+  `morphology/ops/compute-belt-drivers/rules/`,
+  `morphology/ops/plan-foothills/rules/`, `morphology/ops/plan-ridges/rules/`);
+- `policy/` internals: two directories lack `index.ts`
+  (`placement/ops/plan-starts/policy/`,
+  `resources/ops/select-resource-sites/policy/`);
+- strategy imports of rules split 56 ways, most through `../rules/index.js`,
+  some reaching named files directly;
+- zero live re-exports of `lib/tectonics` from foundation ops `rules/`
+  (`rg "export .* from" mods/mod-swooper-maps/src/domain/foundation/ops/*/rules/*.ts`
+  finds only local `./` re-exports), so
+  `prohibit_foundation_rules_tectonics_shim_reexports` currently guards an
+  absent shape.
+
+Proposed ruling (the recommended default):
+
+1. `rules/` and `policy/` are closed to `.ts` files with a required `index.ts`
+   aggregation surface; no nested directories;
+2. sibling files import each other freely inside the directory; consumers
+   outside the directory (strategies, `index.ts` of the operation) import
+   through the aggregation surface;
+3. the six gap rows (C1-C6 in the row ledger seed) get mechanical `index.ts`
+   aggregations;
+4. `prohibit_foundation_rules_tectonics_shim_reexports` deletes after the
+   grammar ratchets, with an injected shim re-export probe failing the
+   survivor law and the absence evidence quoted in the closure receipt;
+5. `prohibit_domain_artifacts_modules` (row A2) deletes in the same pass once
+   the closed file grammar makes a nested `artifacts.ts` fail the survivor
+   law — reusing the exact probe the post-ratchet revalidation used.
+
+Consequence: six mechanical rows, two sentry deletions with survivor proof,
+and one grammar that both decision packet 002 and the structure law can cite.
+
+Seal target once ruled:
+the drafted `rules/` and `policy/` scope files become enforced grammar (via
+`structure.toml` scopes and, if needed, file-shape patterns) under
+`.habitat/blueprints/domain-operation/`; rows A2, A4, C1-C6 flip to defined
+destinations.
+
+Escalation:
+this packet escalates to a real user ruling only if the fresh census finds a
+`rules/` or `policy/` internal that the proposed grammar cannot express
+(nested directories with live consumers, non-TypeScript assets, or a live
+re-export whose consumers depend on the shim path). Absent that, the DRA may
+seal the default and record it here.

--- a/.habitat/.active/workstreams/descend-002-domain-operation-interior/frame.md
+++ b/.habitat/.active/workstreams/descend-002-domain-operation-interior/frame.md
@@ -1,0 +1,165 @@
+# Domain-Operation Interior Descent: Opening Frame
+
+Status: opening frame; execution gated on pre-descent readiness slices R2, R3, R4, R5, R6
+
+Built: 2026-07-06
+
+Owner: DRA Habitat authority-tree workstream steward
+
+Method authority:
+`.habitat/.active/frames/BLUEPRINT-AUTHORITY-RATCHET-DESCENT-FRAME.md` owns the
+descent state machine this workstream instantiates.
+`.habitat/.active/frames/CLOSED-STRUCTURE-ENFORCEMENT-METHOD-FRAME.md` operates
+as the positive-assertion primitive inside it. The completed domain-root
+descent is precedent; its packet grammar is precedent only, not controlling
+authority.
+
+Runway gate:
+`.habitat/.active/workstreams/remediate-rule-authority/pre-descent-readiness-plan.md`
+slices R2 (config-facade consolidation), R3 (aggregate check runnability),
+R4 (stale-blocker record refresh), R5 (descent workspace shape), and R6
+(post-merge reconciliation) must close before descent execution begins.
+Decision packets in this workstream may be ruled in parallel with the runway;
+source and rule mutation may not start before it is clear.
+
+## Current Boundary
+
+Already law (survivor structure authority
+`.habitat/blueprints/domain/require_domain_source_topology/structure.toml`):
+
+- domain roots are closed: `index.ts`, `ops.ts`, `ops/`, `model/`, optional
+  `artifacts/`;
+- domain ops roots are closed: `contracts.ts`, `index.ts`, plus operation
+  child directories;
+- operation roots are closed at depth one: `contract.ts`, `index.ts` required;
+  `types.ts`, `rules/`, `strategies/`, `policy/` allowed;
+- model roots and artifact roots are closed.
+
+Already enforced boundary law (`.habitat/blueprints/domain-operation/`):
+adapter/engine-runtime import blocks, cross-operation runtime call
+prohibition, projection/effect dependency prohibition, root config facade
+import prohibition (widened by readiness slice R2), runtime orchestration
+helper prohibition, operation contract file shape, and the domain ops registry
+surface.
+
+Not yet law:
+
+- `strategies/`, `rules/`, and `policy/` internals have no enforced grammar:
+  no required `index.ts` aggregation, no file-shape law, nothing preventing
+  arbitrary nested modules inside an operation;
+- strategy import law exists only as the foundation-local, underbroad
+  `prohibit_foundation_strategy_nonlocal_imports`;
+- operation topology law exists only as the ecology-local exemplar proxy
+  `require_ecology_canonical_op_module_topology` (mode `open`, one domain);
+- contract quality exists only as the ecology-local mixed script
+  `validate_ecology_op_contract_quality`;
+- `prohibit_domain_artifacts_modules` survives as a sentry because the
+  topology law does not reach inside support directories (a nested
+  `rules/artifacts.ts` probe passed topology and failed only the sentry).
+
+## Future Boundary
+
+Every operation interior is legible and enforced: support directories have a
+closed grammar, strategy files have a positive import law, contract metadata
+has a named owner, and the five residual rules above are absorbed, split, or
+deleted with survivor proof. An agent editing any of the 101 operations knows
+what is allowed without reading history.
+
+## Coordinates
+
+| Coordinate | Answer |
+| --- | --- |
+| Blueprint kind | `domain-operation` |
+| Selected depth | operation interior: `strategies/`, `rules/`, `policy/` internals, the strategy import surface, and contract metadata ownership |
+| Authority owner | drafted scope law under `.habitat/scopes/domain/scopes/ops/scopes/operation/**` (scope.md, file grammars, strategy pattern); enforcement home `.habitat/blueprints/domain-operation/` |
+| Red corpus | `ledger.md` in this workstream; re-derived by evidence lanes at execution open |
+| Row state | each seed row carries `defined destination`, `needs decision D1-D4`, `delete candidate`, or `law correction candidate` |
+| Proof gate | Habitat wrapper behavior for each ratcheted surface; Injected violation proof per injectable failure class; Clean sample proof for allowed shapes; Record truth proof for ledger/manifest parity; Native tool behavior for lint/check/diff hygiene. Review disposition and Graphite state are workflow claims. Aggregate proof per readiness slice R3's accepted gate, else focused checks plus a named non-claim. |
+| Ascent condition | residual cluster rows resolved or tracked outside this ratchet; survivor law green with injected-violation coverage; overlapping scaffolding classified or retired; roadmap updated |
+
+## Selection Commitments
+
+In:
+
+- the operation interior grammar for all six domains' `ops/<operation>/`
+  directories;
+- the strategy import law as generic domain-operation authority;
+- contract metadata ownership (the schema-description clause of the ecology
+  quality script);
+- absorption/retirement of the five residual rules named above;
+- the drafted operation scope files as the starting assertion text.
+
+Foreground:
+
+- positive grammar first: assert what `strategies/`, `rules/`, `policy/` may
+  contain, then let violations go red with destinations;
+- the four decision packets are the only intended judgment apertures;
+- census evidence in the row ledger seed is evidence, not authority.
+
+Exterior:
+
+- recipe, recipe-stage, and recipe-step work, including
+  `prohibit_foundation_step_contract_config_bags` (named handoff domino to the
+  recipes-and-stages descent);
+- domain `model/` internals (queued as descent 3);
+- broad strategy semantics redesign (which strategies exist, their behavior,
+  their config values);
+- schema/JSDoc quality beyond the owner ruling in decision packet 003;
+- mod-map, Studio, toolkit, and workspace lanes;
+- any behavior change in any operation.
+
+## Expected Red Surface
+
+From the 2026-07-06 censuses (exact rows in `ledger.md`):
+
+- 3 strategy import anomalies: one cross-domain relative reach, one
+  cross-domain package reach, one cross-operation reach;
+- 4 `rules/` directories without `index.ts` aggregation;
+- 2 `policy/` directories without `index.ts` aggregation;
+- 9 operations without `strategies/` (all foundation `compute-*`; their
+  contracts declare strategy envelopes) — red only under decision packet 001
+  option (a);
+- 6 contracts without schema description metadata — red only under the owner
+  chosen in decision packet 003;
+- 5 residual rules awaiting absorption, split, or deletion.
+
+This is a bounded corpus. If execution-time censuses reveal a materially
+larger red surface, that is law back-talk: stop and re-scope rather than
+widening silently.
+
+## Prework Aperture
+
+Prework exists only for nondeterministic destinations. Exactly four are open,
+each a decision packet in `decisions/`:
+
+1. `001-strategy-container-law.md` — is `strategies/` required for every
+   operation?
+2. `002-strategy-dependency-classes.md` — the positive strategy import
+   allowlist.
+3. `003-contract-quality-owner.md` — who owns contract schema metadata law.
+4. `004-rules-entrypoint-export-policy.md` — `rules/` aggregation grammar and
+   the shim-re-export sentry's fate.
+
+Every other seed row has a deterministic destination. Do not open new decision
+packets for execution discomfort; a genuinely new nondeterministic destination
+is a scope event recorded against this frame.
+
+## Falsifiers And Reframe Triggers
+
+- If the import census cannot cover at least ninety-five percent of observed
+  strategy imports with the ruled dependency classes and named red rows, the
+  law is premature: narrow the assertion or split the ratchet.
+- If Injected violation proof is impossible for a claimed failure class, the
+  closure receipt must name why, the fallback proof, and the narrowed claim.
+- If law-correction rows come to outnumber defined-destination rows, stop and
+  reframe; the selected depth is wrong.
+- If enforcing support-directory grammar lights up surfaces owned by other
+  kinds (stage visualization, projection, adapters), those rows are exterior
+  by definition; track them, do not absorb them.
+
+## NOT HOW
+
+This frame does not prescribe the slice count, agent lane names, the exact
+GritQL or `structure.toml` implementation, or the order of burn-down within a
+locked destination class. Those belong to this workstream's execution plan
+once the runway is clear and the decision packets are ruled.

--- a/.habitat/.active/workstreams/descend-002-domain-operation-interior/ledger.md
+++ b/.habitat/.active/workstreams/descend-002-domain-operation-interior/ledger.md
@@ -1,0 +1,100 @@
+# Row Ledger Seed
+
+Status: seed corpus from 2026-07-06 censuses; evidence lanes re-derive at execution open
+
+Staleness rule:
+every count and pointer below is dated evidence, not authority. The first
+execution act of this descent is a fresh census that confirms or supersedes
+each row. A row that no longer reproduces is closed as stale with the fresh
+command output quoted.
+
+Terrain baseline (2026-07-06):
+
+- 101 operation roots under `mods/mod-swooper-maps/src/domain/*/ops/*/`;
+- every operation root conforms to the enforced depth-one grammar
+  (`contract.ts`, `index.ts` + allowed `types.ts`, `rules/`, `strategies/`,
+  `policy/`);
+- zero ops children lack `contract.ts` (the old shared/support pockets are
+  gone);
+- 92 operations have `strategies/`; 83 of those are exactly
+  `default.ts + index.ts`;
+- zero `artifacts.ts` files currently exist inside operation directories.
+
+## A. Residual Rule Rows
+
+| Row | Rule | Current state (ledger) | Destination class | Waiting on |
+| --- | --- | --- | --- | --- |
+| A1 | `require_ecology_canonical_op_module_topology` | blocked-prior-source-owner-design; exemplar proxy, mode `open`, ecology-only | replace: generalize its three clauses into the operation scope grammar, then delete after survivor proof | D1, D4 |
+| A2 | `prohibit_domain_artifacts_modules` | deletion-blocked-partial-absorber; a nested `rules/artifacts.ts` probe passed topology and failed only this sentry | delete after support-directory grammar closes the gap it guards, with the same injected probe failing the survivor law | D4 (grammar), execution |
+| A3 | `prohibit_foundation_strategy_nonlocal_imports` | complete-no-generic-domain-operation-slice; foundation-local allowlist, underbroad | replace: generic positive strategy import law, then retire the foundation row after clean-sample plus injected-violation proof | D2 |
+| A4 | `prohibit_foundation_rules_tectonics_shim_reexports` | complete-no-generic-domain-operation-slice; exact blacklist | delete by absence (zero live `lib/tectonics` re-exports in foundation ops `rules/` on 2026-07-06) or absorb into the `rules/` grammar | D4 |
+| A5 | `validate_ecology_op_contract_quality` | blocked-prior-source-owner-design; mixed script: schema descriptions + JSDoc + stale stage path | split: schema-description clause to the ruled owner; JSDoc and stale-path clauses delete | D3 |
+
+`prohibit_foundation_op_contract_config_bags` is not a row here: readiness
+slice R2 retires it before this descent executes.
+
+## B. Source Rows: Strategy Import Anomalies
+
+Census command:
+
+```bash
+rg -o "from ['\"]([^'\"]+)['\"]" -r '$1' --no-filename \
+  mods/mod-swooper-maps/src/domain/*/ops/*/strategies/*.ts
+```
+
+Observed class distribution (509 specifiers): 162 `@swooper/mapgen-core/*`,
+108 op-local `./`, 104 `../contract.js`, 56 `../rules/*`, 53 own-domain
+`model/*`, 13 `../policy/*`, 3 `../types.js`, 3 `@civ7/map-policy`, and the
+anomalies below.
+
+| Row | Pointer | Violation under the expected law | Destination class |
+| --- | --- | --- | --- |
+| B1 | `placement/ops/plan-starts/strategies/default.ts:18` imports `../../../../hydrology/index.js` | cross-domain reach from a strategy | needs semantic move: consume via contract inputs or placement model policy; exact destination locked during D2 execution |
+| B2 | `placement/ops/plan-natural-wonders/strategies/default.ts:38` imports `@mapgen/domain/hydrology/model/policy/river-class.js` | cross-domain reach via package specifier | same class as B1 |
+| B3 | `ecology/ops/plot-effects-score-snow/strategies/default.ts:3` imports `../../plan-plot-effects/rules/index.js` | cross-operation reach from a strategy | move the shared signal to ecology `model/` or the consuming contract; lock during D2 execution |
+| B4 | one census specifier parsed as bare `mountain` | parse artifact, not a confirmed violation | re-derive in the fresh census; close as stale if it does not reproduce |
+
+## C. Source Rows: Support-Directory Grammar Gaps
+
+| Row | Pointer | Gap | Destination class | Waiting on |
+| --- | --- | --- | --- | --- |
+| C1 | `foundation/ops/compute-plates-tensors/rules/` | no `index.ts` aggregation | defined destination: add aggregation or ruled files-only grammar | D4 |
+| C2 | `morphology/ops/compute-belt-drivers/rules/` | same | same | D4 |
+| C3 | `morphology/ops/plan-foothills/rules/` | same | same | D4 |
+| C4 | `morphology/ops/plan-ridges/rules/` | same | same | D4 |
+| C5 | `placement/ops/plan-starts/policy/` | no `index.ts` aggregation | same grammar decision applied to `policy/` | D4 |
+| C6 | `resources/ops/select-resource-sites/policy/` | same | same | D4 |
+
+## D. Source Rows: Strategy Container Presence
+
+Nine operations have no `strategies/` directory; all are foundation
+`compute-*` and every one of their contracts declares a strategy envelope:
+
+`compute-crust-evolution`, `compute-crust`, `compute-mantle-forcing`,
+`compute-mantle-potential`, `compute-mesh`, `compute-plate-graph`,
+`compute-plate-motion`, `compute-plates-tensors`, `compute-tectonic-segments`.
+
+Row state: red only under decision packet 001 option (a); destination is a
+mechanical single-strategy wrap per operation. Under option (b) these rows
+close green with the alternate shape recorded.
+
+## E. Source Rows: Contract Metadata Gaps
+
+95 of 101 contracts carry `description:` metadata. The six gaps:
+
+`foundation/ops/compute-hotspot-events/contract.ts`,
+`foundation/ops/compute-segment-events/contract.ts`,
+`foundation/ops/compute-tectonic-provenance/contract.ts`,
+`foundation/ops/compute-tectonics-current/contract.ts`,
+`foundation/ops/compute-tracer-advection/contract.ts`,
+`placement/ops/plan-wonders/contract.ts`.
+
+Row state: red only under the owner ruled in decision packet 003; destination
+is mechanical metadata completion under that owner's proof surface.
+
+## Row Obligations
+
+Rows stay individually visible through grouping, fanout, and review. Before
+any source-moving execution, moved or deleted rows expand to exported symbols
+and behavior-bearing definitions, each marked Preserved, Intentional loss, or
+Unresolved loss, per the descent frame's execution-authorization gate.

--- a/.habitat/.active/workstreams/remediate-rule-authority/receipts/readiness-r5-descent-workspace-shape.md
+++ b/.habitat/.active/workstreams/remediate-rule-authority/receipts/readiness-r5-descent-workspace-shape.md
@@ -1,0 +1,97 @@
+# Readiness R5 Descent Workspace Shape Receipt
+
+Date: 2026-07-07
+
+Slice: R5, apply the descent workspace shape.
+
+Authority:
+`.habitat/.active/workstreams/remediate-rule-authority/pre-descent-readiness-plan.md`
+R5 and `.habitat/.active/workstreams/descent-workspace-shape.md`.
+
+## Changes
+
+Descent 002 now uses the reviewed repeatable descent container shape:
+
+`descend-002-domain-operation-interior/`
+
+The tracked opening artifacts are:
+
+- `frame.md`
+- `ledger.md`
+- `decisions/`
+
+No `execution/`, `receipts/`, or `ascent.md` artifact was created in the
+descent container; those still appear only at first use. The workstreams
+README, roadmap, transition anchor, readiness plan, R4 pointer record, and
+internal descent references now point at the born-conformant shape.
+
+## Proof
+
+Record truth proof:
+
+```bash
+find .habitat/.active/workstreams/descend-002-domain-operation-interior -maxdepth 3 -print | sort
+```
+
+Output: the container contains only `frame.md`, `ledger.md`, and the four
+decision packets under `decisions/`.
+
+Record truth proof:
+
+```bash
+test ! -e .habitat/.active/workstreams/descend-002-domain-operation-interior/execution
+test ! -e .habitat/.active/workstreams/descend-002-domain-operation-interior/receipts
+test ! -e .habitat/.active/workstreams/descend-002-domain-operation-interior/ascent.md
+```
+
+Output: exited 0. Phase artifacts that are created by first use are absent.
+
+Record truth proof:
+
+```bash
+old_container="$(printf '%s%s' 'define-domain-operation-blueprint-' 'structure')"
+old_decisions="$(printf '%s%s' 'decision-' 'packets')"
+old_frame="$(printf '%s%s' 'opening-' 'frame.md')"
+old_ledger="$(printf '%s%s' 'row-ledger-' 'seed.md')"
+rg -n "$old_container|$old_decisions|$old_frame|$old_ledger" .habitat/.active
+```
+
+Output: exited 1 with zero matches.
+
+Habitat wrapper behavior:
+
+```bash
+bun habitat classify .habitat
+```
+
+Output: exited 0 and routed `.habitat` as `habitat-authority` with the
+expected workspace gates.
+
+Native tool behavior:
+
+```bash
+git diff --check
+```
+
+Output: exited 0.
+
+## Review
+
+Fresh review lane: Sartre (`019f39f4-b254-71c3-b547-216bf50f3b0f`).
+
+| Finding | Severity | Disposition | Repair Evidence |
+| --- | --- | --- | --- |
+| The descent frame still stated execution was gated only on R2, R3, and R4. | P2 | accepted | Updated `frame.md` status and runway gate to include R2, R3, R4, R5, and R6. |
+| The shape doc's non-claim said all shared-lane records were untouched, but R5 correctly updates pointers and adds this receipt. | P2 | accepted | Reworded the non-claim to preserve no move/no semantic mutation while allowing R5 pointer updates and the R5 receipt. |
+| Receipt review section still said pending. | P3 | accepted | Replaced the pending note with this review disposition. |
+
+The reviewer found no P1 issues and confirmed the physical container shape
+matches R5. After the accepted fixes above, no accepted unresolved P1/P2
+findings remain for R5.
+
+## Non-Claims
+
+This does not begin descent execution, open execution slices, or decide any of
+the four descent decision packets. It does not migrate descent 1 or move shared
+rule-remediation records. It applies only the physical container shape for
+descent 002 and path references needed to keep the active records truthful.


### PR DESCRIPTION
Opens the second blueprint descent — the domain-operation interior — as a documentation packet instantiating `.habitat/.active/frames/BLUEPRINT-AUTHORITY-RATCHET-DESCENT-FRAME.md`. No source, rule, or `structure.toml` mutation; execution is explicitly gated on readiness slices R2/R3/R4 from the stacked readiness plan.

**Opening frame** (`opening-frame.md`): coordinates (kind `domain-operation`, depth = `strategies/`/`rules/`/`policy/` internals + strategy import surface + contract metadata ownership), current/future boundary, selection commitments with a named exterior (recipe-side work including `prohibit_foundation_step_contract_config_bags` is the handoff domino to the recipes descent), expected red surface, proof gate with canonical proof classes, falsifiers, and NOT HOW.

**Row ledger seed** (`row-ledger-seed.md`): census-backed rows dated 2026-07-06 — 5 residual rule rows; 3 confirmed strategy-import anomalies (cross-domain relative, cross-domain package, cross-operation) plus one parse artifact to re-derive; 6 support-directory aggregation gaps; 9 strategy-container-absent operations (all foundation `compute-*`, all with contract-declared strategy envelopes); 6 contracts missing schema description metadata. Staleness rule: evidence lanes re-derive every row at execution open.

**Decision packets** (`decision-packets/001-004`): the descent's only judgment apertures — strategy container law, strategy dependency classes (full 509-specifier import census included), contract quality owner, and support-directory aggregation grammar (expected to seal deterministically). Each packet carries evidence, options with consequences, a recommended default, seal targets, and escalation conditions.

Verification: `git diff --check` clean; `bun habitat classify .habitat` routes to `habitat-authority` (exit 0); `bun run lint` green (9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)