### PR TITLE
test(mapgen-studio-ui): repo-owned design-token signal guard

### DIFF
--- a/openspec/changes/studio-ui-token-noise-disposition/tasks.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/tasks.md
@@ -8,17 +8,23 @@
 
 ## 2. Token-signal guard (stack branch 2)
 
-- [ ] 2.1 Generate `test/fixtures/authored-tokens.json` from the built
+- [x] 2.1 Generate `test/fixtures/authored-tokens.json` from the built
   `dist/styles.css` authored scopes (names + kinds + scopes), reconciled
-  against the handoff inventory (`~46` authored names; 25 HSL-triplet color
-  tokens).
-- [ ] 2.2 Add `test/designTokens.test.ts`: brace-tracking extraction of custom
+  against the handoff inventory. Reconciliation outcome: 32 authored names
+  (27 dual-scope HSL color tokens, 2 `hsl(var())` aliases, `--radius`, 2 font
+  stacks) — the handoff's "~46 KEEP" list mixed in Tailwind-emitted scale
+  defaults (`--text-sm`, `--spacing`, `--container-*`, `--font-weight-*`,
+  palette `--color-*-N`), which the fixture classifies as framework-owned.
+- [x] 2.2 Add `test/designTokens.test.ts`: brace-tracking extraction of custom
   properties + `@property` rules; partition authored/framework; assert fixture
-  exactness, no strays, kind value-shapes (HSL triplet, `var()` alias).
-- [ ] 2.3 Negative proof: temporarily mutate fixture both directions (drop one
-  authored name; add one fake) and record both failures in the phase record;
-  restore.
-- [ ] 2.4 `bunx nx run mapgen-studio-ui:test --outputStyle=static` green.
+  exactness, no strays, kind value-shapes (HSL triplet, `var()` alias); plus a
+  predicate-does-not-swallow-fixture assertion and dual-scope (dark+light)
+  coverage pinning both palettes.
+- [x] 2.3 Negative proof: dropping `--warning` fails the partition test (stray
+  named); adding `--fake-token` fails the scope test (both scopes named);
+  restored fixture green (evidence in phase record).
+- [x] 2.4 Package test suite green: 17 files, 172 tests (168 pre-existing + 4
+  guard).
 
 ## 3. Knowledge surfaces + upstream routing (stack branch 3)
 

--- a/openspec/changes/studio-ui-token-noise-disposition/workstream/phase-record.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/workstream/phase-record.md
@@ -53,7 +53,17 @@
 
 ## Implementation
 
-- (to be filled per stack branch)
+- **Branch 2 (`studio-ui-token-guard`).** Fixture generated from the built
+  `dist/styles.css` (64,809 bytes; 136 unique custom properties; 78
+  `@property` rules — byte-consistent with the handoff inventory). Partition:
+  32 authored / 104 framework-owned / 0 strays. Guard test
+  `test/designTokens.test.ts` (4 assertions). Negative proof (2026-07-08):
+  drop `--warning` → partition test fails naming `--warning`; add
+  `--fake-token` → scope test fails naming `--fake-token @ dark, @ light`;
+  restore → 4/4 green. Full package suite: 17 files / 172 tests green.
+  Path resolution note: `import.meta.url` is not a `file:` URL under the
+  root vitest transform — the test resolves `dist/styles.css` from cwd
+  (package dir or repo root).
 
 ## Verification
 

--- a/packages/mapgen-studio-ui/test/designTokens.test.ts
+++ b/packages/mapgen-studio-ui/test/designTokens.test.ts
@@ -1,0 +1,186 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import fixture from "./fixtures/authored-tokens.json" with { type: "json" };
+
+// Repo-owned token-signal guard (openspec: studio-ui-token-noise-disposition).
+//
+// The claude.ai/design app's check_design_system cannot classify compiled
+// Tailwind v4 output (78 @property-registered --tw-* vars + @theme defaults
+// read as "unclassified tokens" / "selector-scoped custom properties") — that
+// classifier is app-side and its findings over this package are permanent
+// framework noise. This test is the signal that check cannot give us: every
+// custom property in the built stylesheet must be either an authored token
+// pinned in test/fixtures/authored-tokens.json (name + kind + scopes) or
+// framework-owned per the predicate below. A stray name fails; a Tailwind
+// upgrade that changes the engine surface fails until absorbed as a reviewed
+// fixture/predicate diff.
+
+// Resolves from either the package dir (direct vitest run) or the repo root
+// (root-config project run); the nx test target's build dependency guarantees
+// dist/ exists.
+const CSS_PATH = [
+  resolve(process.cwd(), "dist/styles.css"),
+  resolve(process.cwd(), "packages/mapgen-studio-ui/dist/styles.css"),
+].find((candidate) => existsSync(candidate));
+if (!CSS_PATH) {
+  throw new Error("dist/styles.css not found — run the mapgen-studio-ui build first");
+}
+
+// Scope labels in the fixture map to the exact selector contexts the theme
+// authors own in src/styles/theme.css (as they appear in the built CSS).
+const SCOPE_SELECTORS: Record<string, (stack: readonly string[]) => boolean> = {
+  dark: (stack) => stack.some((s) => normalizeSelector(s) === ":root, .dark"),
+  light: (stack) => stack.some((s) => normalizeSelector(s) === ".light"),
+  invariant: (stack) =>
+    stack.some((s) => normalizeSelector(s) === ":root") &&
+    !stack.some((s) => s.startsWith("@layer")),
+  theme: (stack) =>
+    stack.some((s) => s.startsWith("@layer theme")) &&
+    stack.some((s) => normalizeSelector(s) === ":root, :host"),
+};
+
+const VALUE_SHAPES: Record<string, RegExp> = {
+  // HSL channel triplet ("240 14% 6%"), consumed as hsl(var(--x)).
+  color: /^\d{1,3}(?:\.\d+)?\s+\d{1,3}(?:\.\d+)?%\s+\d{1,3}(?:\.\d+)?%$/,
+  // Resolved-color alias over another authored token.
+  alias: /^hsl\(var\(--[\w-]+\)\)$/,
+  radius: /^\d*\.?\d+rem$/,
+  // Authored font stacks lead with the brand family.
+  font: /^"(?:Inter|JetBrains Mono)",/,
+};
+
+// Framework-owned custom properties: Tailwind v4 engine plumbing and @theme
+// defaults emitted because used utilities reference them. @property-registered
+// names are definitionally engine vars; the rest are the known internal
+// namespaces. A new Tailwind namespace lands as a stray and fails the
+// partition test — extend this predicate (or the fixture) as a reviewed diff.
+function isFrameworkOwned(name: string, atPropertyRegistered: ReadonlySet<string>): boolean {
+  if (atPropertyRegistered.has(name)) return true;
+  if (/^--(?:tw|default|animate|blur)-/.test(name)) return true;
+  if (/^--(?:tracking|leading|text|container|font-weight)-/.test(name)) return true;
+  if (name === "--spacing") return true;
+  if (/^--color-[a-z]+-\d+$/.test(name) || name === "--color-black" || name === "--color-white") {
+    return true;
+  }
+  return false;
+}
+
+function normalizeSelector(selector: string): string {
+  return selector.replace(/\s+/g, " ").trim();
+}
+
+interface Declaration {
+  readonly name: string;
+  readonly value: string;
+  readonly stack: readonly string[];
+}
+
+// Brace-tracking scan (same method as the change's token inventory): records
+// every `--name: value` declaration with its selector stack, plus every
+// @property-registered name. Regex-free CSS parsing is deliberate — the file
+// is generated, and the scan only needs custom-property declarations.
+function scanStylesheet(css: string): {
+  declarations: Declaration[];
+  atPropertyRegistered: Set<string>;
+} {
+  const declarations: Declaration[] = [];
+  const atPropertyRegistered = new Set<string>();
+  const stack: string[] = [];
+  let buf = "";
+  for (const char of css) {
+    if (char === "{") {
+      stack.push(buf.trim());
+      buf = "";
+    } else if (char === "}") {
+      stack.pop();
+      buf = "";
+    } else if (char === ";") {
+      const decl = /^(--[\w-]+)\s*:\s*([\s\S]+)$/.exec(buf.trim());
+      if (decl) {
+        declarations.push({ name: decl[1], value: decl[2].trim(), stack: [...stack] });
+      }
+      buf = "";
+    } else {
+      buf += char;
+    }
+  }
+  for (const frame of declarations.flatMap((d) => d.stack)) {
+    const at = /^@property\s+(--[\w-]+)$/.exec(normalizeSelector(frame));
+    if (at) atPropertyRegistered.add(at[1]);
+  }
+  return { declarations, atPropertyRegistered };
+}
+
+const css = readFileSync(CSS_PATH, "utf8");
+const { declarations, atPropertyRegistered } = scanStylesheet(css);
+const authoredTokens = fixture.tokens as Record<
+  string,
+  { kind: keyof typeof VALUE_SHAPES; scopes: readonly (keyof typeof SCOPE_SELECTORS)[] }
+>;
+
+const byName = new Map<string, Declaration[]>();
+for (const decl of declarations) {
+  const list = byName.get(decl.name) ?? [];
+  list.push(decl);
+  byName.set(decl.name, list);
+}
+
+describe("design token surface (dist/styles.css)", () => {
+  it("partitions every custom property as authored (fixture) or framework-owned", () => {
+    const strays = [...byName.keys()].filter(
+      (name) => !(name in authoredTokens) && !isFrameworkOwned(name, atPropertyRegistered),
+    );
+    expect(
+      strays,
+      `Custom properties in dist/styles.css that are neither in test/fixtures/authored-tokens.json nor framework-owned: ${strays.join(", ")}. ` +
+        "New authored token → add it to the fixture with a kind. " +
+        "New Tailwind engine surface → extend the framework predicate as a reviewed diff.",
+    ).toEqual([]);
+  });
+
+  it("declares every authored token in each of its owned scopes", () => {
+    const missing: string[] = [];
+    for (const [name, spec] of Object.entries(authoredTokens)) {
+      const occurrences = byName.get(name) ?? [];
+      for (const scope of spec.scopes) {
+        if (!occurrences.some((d) => SCOPE_SELECTORS[scope](d.stack))) {
+          missing.push(`${name} @ ${scope}`);
+        }
+      }
+    }
+    // Dual-scope color tokens missing their `.light` declaration re-create the
+    // shipped dark-only regression — this assertion pins both palettes.
+    expect(missing, `Authored tokens missing from an owned scope: ${missing.join(", ")}`).toEqual(
+      [],
+    );
+  });
+
+  it("keeps every authored token's value in its kind's shape", () => {
+    const violations: string[] = [];
+    for (const [name, spec] of Object.entries(authoredTokens)) {
+      for (const decl of byName.get(name) ?? []) {
+        // Only check declarations in owned scopes; framework re-registrations
+        // of the same name elsewhere are covered by the partition test.
+        const inOwnedScope = spec.scopes.some((scope) => SCOPE_SELECTORS[scope](decl.stack));
+        if (inOwnedScope && !VALUE_SHAPES[spec.kind].test(decl.value)) {
+          violations.push(`${name} (${spec.kind}) = "${decl.value}"`);
+        }
+      }
+    }
+    expect(violations, `Token values outside their kind's shape: ${violations.join("; ")}`).toEqual(
+      [],
+    );
+  });
+
+  it("does not misclassify authored tokens as framework-owned", () => {
+    const swallowed = Object.keys(authoredTokens).filter((name) =>
+      isFrameworkOwned(name, atPropertyRegistered),
+    );
+    expect(
+      swallowed,
+      `Fixture tokens caught by the framework predicate (the exclusion must not swallow genuine tokens): ${swallowed.join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/mapgen-studio-ui/test/fixtures/authored-tokens.json
+++ b/packages/mapgen-studio-ui/test/fixtures/authored-tokens.json
@@ -1,0 +1,224 @@
+{
+  "$comment": "Authored design-token inventory for @swooper/mapgen-studio-ui, verified against built dist/styles.css by test/designTokens.test.ts. Every custom property in the built stylesheet must be either listed here or framework-owned (see the test's framework predicate). Adding a token to src/styles/theme.css requires adding it here with a kind; a Tailwind upgrade that changes the engine-variable surface must be absorbed as a reviewed diff. Authority: openspec/changes/studio-ui-token-noise-disposition.",
+  "tokens": {
+    "--background": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--foreground": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--card": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--card-foreground": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--popover": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--popover-foreground": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--primary": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--primary-foreground": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--secondary": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--secondary-foreground": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--muted": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--muted-foreground": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--accent": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--accent-foreground": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--destructive": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--destructive-foreground": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--border": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--input": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--ring": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--border-subtle": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--border-strong": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--input-background": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--elevation-1": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--elevation-2": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--surface-sunken": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--success": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--warning": {
+      "kind": "color",
+      "scopes": [
+        "dark",
+        "light"
+      ]
+    },
+    "--color-border-secondary": {
+      "kind": "alias",
+      "scopes": [
+        "invariant"
+      ]
+    },
+    "--color-text-muted": {
+      "kind": "alias",
+      "scopes": [
+        "invariant"
+      ]
+    },
+    "--radius": {
+      "kind": "radius",
+      "scopes": [
+        "invariant"
+      ]
+    },
+    "--font-sans": {
+      "kind": "font",
+      "scopes": [
+        "theme"
+      ]
+    },
+    "--font-mono": {
+      "kind": "font",
+      "scopes": [
+        "theme"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds `test/designTokens.test.ts` + two fixtures: every custom property in built `dist/styles.css` must be **authored** (name → kind map; scopes derive from kind, so a dark-only color token is unrepresentable), **@property-registered** (harvested structurally, non-empty sanity assertion), or in the **framework snapshot** (exact non-@property Tailwind defaults, stale-checked both ways). No name-prefix heuristics — an authored token named inside a Tailwind namespace surfaces as a stray instead of being silently absorbed (mutation-proven). Cross-pins tie the fixture to `token-contract.json` and the synced guidelines vocabulary.

The stack's review fold lands as the tip commit on #2046: dead @property harvesting fixed, prefix predicate replaced by the snapshot, bidirectional scopes, scanner hardening (comments/strings/block-final), node-env + import.meta.url resolution per the `themeTokens` sibling.

Gates: 17 files / 174 tests green; four-direction negative proof recorded in the phase record.

Stack: 2/3 — on #2044, under #2046.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
