### PR TITLE
docs(mapgen-studio-ui): ship token-noise disposition via synced knowledge surfaces

### DIFF
--- a/docs/system/DEFERRALS.md
+++ b/docs/system/DEFERRALS.md
@@ -193,8 +193,12 @@ Some deferrals are intentionally scoped to a specific project/milestone (e.g., E
 
 ## DEF-017: Upstream design-sync token classifier over-captures Tailwind v4 internals
 
+> Numbering note: this is the ROOT ledger's DEF-017. The engine-refactor-v1
+> project ledger (`docs/projects/engine-refactor-v1/deferrals.md`) has its own,
+> unrelated DEF-017 — qualify the ledger when citing this entry.
+
 **Deferred:** 2026-07-08
 **Trigger:** A new Claude Code / design-sync skill version (binary-grep for `@kind` or a token-classification/metadata surface), or any claude.ai/design changelog touching `check_design_system` token classification.
 **Context:** `check_design_system` in the MapGen Studio DS project permanently reports ~80 "unclassified tokens" and 33 "selector-scoped custom properties" — all Tailwind v4 engine internals in the compiled bundle. The classifier is app-side (the claude.ai/design self-check that regenerates `_adherence.oxlintrc.json`); no repo-side surface exists to fix or suppress it (verified: no token classifier in the bundled converter, no `@kind` annotation support anywhere in CC v2.1.197). Feedback packet: `openspec/changes/studio-ui-token-noise-disposition/workstream/upstream-feedback.md`.
-**Scope:** Deliver the feedback packet to the design-sync/claude.ai-design maintainers; when a classifier fix or a project-supplied classification input ships, re-sync and confirm the findings clear, then retire the noise-disposition sections in `.design-sync/guidelines/design-tokens.md` and NOTES.md.
+**Scope:** Deliver the feedback packet to the design-sync/claude.ai-design maintainers; when a classifier fix or a project-supplied classification input ships, re-sync and confirm the findings clear, then retire the noise-disposition sections in `packages/mapgen-studio-ui/docs/design-tokens.md` and `.design-sync/NOTES.md`.
 **Impact:** Design agents see two known-noise findings per check (dispositioned in the synced guidelines); the repo-owned token guard (`packages/mapgen-studio-ui/test/designTokens.test.ts`) carries the real signal meanwhile.

--- a/docs/system/DEFERRALS.md
+++ b/docs/system/DEFERRALS.md
@@ -190,3 +190,11 @@ Some deferrals are intentionally scoped to a specific project/milestone (e.g., E
 **Impact:**
 - Today, large payloads may incur extra copies and allocation churn (worker clone + main upload), especially for frequently updated layers.
 - We retain maximum browser compatibility and simplest deployment posture for now.
+
+## DEF-017: Upstream design-sync token classifier over-captures Tailwind v4 internals
+
+**Deferred:** 2026-07-08
+**Trigger:** A new Claude Code / design-sync skill version (binary-grep for `@kind` or a token-classification/metadata surface), or any claude.ai/design changelog touching `check_design_system` token classification.
+**Context:** `check_design_system` in the MapGen Studio DS project permanently reports ~80 "unclassified tokens" and 33 "selector-scoped custom properties" — all Tailwind v4 engine internals in the compiled bundle. The classifier is app-side (the claude.ai/design self-check that regenerates `_adherence.oxlintrc.json`); no repo-side surface exists to fix or suppress it (verified: no token classifier in the bundled converter, no `@kind` annotation support anywhere in CC v2.1.197). Feedback packet: `openspec/changes/studio-ui-token-noise-disposition/workstream/upstream-feedback.md`.
+**Scope:** Deliver the feedback packet to the design-sync/claude.ai-design maintainers; when a classifier fix or a project-supplied classification input ships, re-sync and confirm the findings clear, then retire the noise-disposition sections in `.design-sync/guidelines/design-tokens.md` and NOTES.md.
+**Impact:** Design agents see two known-noise findings per check (dispositioned in the synced guidelines); the repo-owned token guard (`packages/mapgen-studio-ui/test/designTokens.test.ts`) carries the real signal meanwhile.

--- a/openspec/changes/studio-ui-token-noise-disposition/design.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/design.md
@@ -9,40 +9,62 @@
 | Compiled `dist/styles.css` (78 `@property` `--tw-*` rules + `@theme` defaults + authored tokens) | Tailwind v4 build of package source | No content changes — fidelity gate |
 | `.design-sync/config.json`, `guidelines/**`, `NOTES.md`, package tests, repo docs | this repo | **Yes — the entire write set lives here** |
 
-## Decision 1 — guard shape: fixture-pinned partition, not heuristics
+## Decision 1 — guard shape: exact-name partition, zero prefix heuristics
 
-The test extracts every `--name:` declaration and every `@property` rule from
-`dist/styles.css` (brace-tracking scan, same method as the handoff inventory),
-then partitions:
+The test (`test/designTokens.test.ts`, `// @vitest-environment node` per the
+sibling `themeTokens.test.ts` pattern) extracts every `--name:` declaration
+with its selector stack plus every `@property`-registered name from
+`dist/styles.css` (comment-stripped, string-safe, block-final-declaration-safe
+brace-tracking scan), then partitions every custom property into exactly one
+of three buckets:
 
-- **framework-owned** := `@property`-registered ∪ name matches
-  `^--(tw|default|animate|blur)-` ∪ Tailwind numeric scales emitted by the
-  build (`--tracking-*`, `--leading-*`, `--text-*` + `--text-*--line-height`,
-  `--container-*`, `--spacing`, `--color-<palette>-<n>`, `--font-weight-*`,
-  `--font-sans/mono` as classified in the fixture).
-- **authored** := exact names in `test/fixtures/authored-tokens.json`, each
-  with a kind (`color | spacing | radius | shadow | font | alias`) and a value
-  shape check (HSL triplets `^\d{1,3}\s+\d{1,3}%\s+\d{1,3}%$` for colors;
-  `var()` for aliases).
+- **authored** := exact names in `test/fixtures/authored-tokens.json`, a flat
+  name → kind map (`color | alias | radius | font`; adding a new kind requires
+  extending `KIND_SCOPES`/`VALUE_SHAPES`, enforced by a named failure).
+  Scopes derive from kind (`color` → dark + light, `alias`/`radius` →
+  invariant `:root`, `font` → `@layer theme`), so a dark-only color token is
+  unrepresentable in the fixture; the scope check is bidirectional (every
+  expected scope declared AND no declaration outside the expected scopes).
+  Value shapes per kind (HSL triplet with decimals for colors, `hsl(var())`
+  for aliases, rem for radius, brand family for fonts).
+- **`@property`-registered** := harvested structurally from the stylesheet's
+  own `@property` rule preludes — definitionally engine plumbing. A sanity
+  assertion requires this set to be non-empty so the structural leg can never
+  silently regress to dead code.
+- **framework snapshot** := `test/fixtures/framework-tokens.json`, the exact
+  names of the non-`@property` Tailwind `@theme` defaults the build emits.
+  Checked in both directions (no strays in CSS; no stale snapshot entries).
 
-Assertions: (1) every fixture name is declared under an authored scope
-(`:root`, `:root, .dark`, `.light`); (2) every custom property in the file is
-authored-or-framework — a stray name fails with a message telling the author to
-either add it to the fixture (new real token) or recognize a Tailwind surface
-change (version bump). Both false-positive directions are proven in the
-negative test.
+Anything outside the three buckets fails with guidance. There are deliberately
+NO name-prefix heuristics: review probing proved a prefix predicate silently
+absorbs authored tokens named inside Tailwind's `@theme` authoring namespaces
+(`--text-hero`, `--animate-brand-*`, …) — with exact-name snapshots such a
+token surfaces as a stray and is forced into the authored fixture, while a
+Tailwind upgrade becomes a visible, reviewed snapshot regeneration.
 
-Why fixture over pure regex: the Tailwind palette (`--color-red-500`) and the
-authored aliases (`--color-border-secondary`) collide under any prefix rule;
-exact names make intent reviewable and make Tailwind upgrades a visible diff.
+Two cross-surface pins tie the guard to its siblings: the fixture's color
+names must equal `token-contract.json`'s dark-palette names (the value-pinning
+sibling test), and every authored token name must appear in the synced
+`docs/design-tokens.md` vocabulary table (so the design-agent-facing doc
+cannot rot against the fixture).
 
 ## Decision 2 — knowledge channels: two, matched to the two audiences
 
-- `guidelines/design-tokens.md` → design agents inside the DS project (the
-  converter ships `guidelines/**` and the README points agents at it "before
-  composing larger layouts"). Content: authored vocabulary table + the noise
-  disposition + the two hard prohibitions (no `:root` hoisting, no synced-file
-  edits).
+- `docs/design-tokens.md` (shipped as `guidelines/docs/design-tokens.md` via
+  `cfg.guidelinesGlob: "docs/*.md"`) → design agents inside the DS project
+  (the converter ships `guidelines/**` and the README points agents at it
+  "before composing larger layouts"). Content: authored vocabulary table + the
+  noise disposition + the two hard prohibitions (no `:root` hoisting, no
+  synced-file edits) + a scope note (the repo guard pins `dist/styles.css`; a
+  findings shift with no repo diff is app-side).
+  **Placement constraint (review-proven):** the source must NOT live under a
+  dot-directory. `emitGuidelines` preserves the package-relative subpath, and
+  `sync-hashes.mjs`'s `hashDir` skips dot-entries — a `.design-sync/`-nested
+  guideline would upload once and then never re-ship on edits (aux-hash blind
+  spot), besides risking dot-path exclusion in upload globs and file listings.
+  Living surfaces (this doc, NOTES.md) describe finding CLASSES, not counts —
+  counts drift with Tailwind versions and are pinned only in point-in-time
+  workstream records.
 - `.design-sync/NOTES.md` append → sync operators (its Re-sync risks section is
   required reading in the re-sync ritual). Content: findings are expected,
   docs-tier delta, do not chase; pointer to this change.
@@ -60,6 +82,22 @@ authored-token scan; classify HSL-triplet values as colors; fix the
 `tokenKinds` heuristic. The `docs/system/DEFERRALS.md` entry pins the re-check
 trigger (new Claude Code / design-sync versions) so the frame's falsifier is
 monitored instead of forgotten.
+
+## Review lanes
+
+Three lanes gate this change before it ships (executed as a fan-out fold at
+the stack tip; evidence and adjudications in `workstream/phase-record.md`):
+
+1. **Owner lane** — the orchestrating agent's design review against the frame
+   (ownership map, fidelity gate, no-hand-edit contract).
+2. **Correctness/cleanup fan-out** — eight independent finder angles
+   (line-scan, removed-behavior, cross-file tracer, reuse, simplification,
+   efficiency, altitude, conventions) over the full stack diff, each finding
+   verified or refuted with cited evidence.
+3. **Adversarial augmentation** — a five-dimension orchestrated sweep
+   (prose-fact audit, guard mutation probing, sync-contract semantics,
+   OpenSpec cross-consistency, independent partition re-derivation) designed
+   to attack the claims the first two lanes take on trust.
 
 ## Rejected alternatives
 

--- a/openspec/changes/studio-ui-token-noise-disposition/proposal.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/proposal.md
@@ -34,18 +34,23 @@ owns.
 ## What Changes
 
 - **Token-signal guard (repo-owned truth).** A package test in
-  `@swooper/mapgen-studio-ui` parses built `dist/styles.css`, classifies every
-  CSS custom property as either *authored* (must match a committed fixture of
-  names + kinds) or *framework-owned* (`@property`-registered or Tailwind
-  internal prefixes), and fails on any stray. This gives the repo a correct,
-  strict token check independent of the noisy upstream one.
+  `@swooper/mapgen-studio-ui` parses built `dist/styles.css` and requires
+  every CSS custom property to fall into exactly one of three buckets:
+  *authored* (a committed name → kind fixture; scopes derived from kind so a
+  dark-only color token is unrepresentable), *`@property`-registered* (engine
+  vars, detected structurally), or *framework snapshot* (the exact
+  non-`@property` Tailwind defaults, a second committed fixture). Strays fail
+  in both directions; no name-prefix heuristics. This gives the repo a
+  correct, strict token check independent of the noisy upstream one.
 - **Synced knowledge surfaces.** Author
-  `.design-sync/guidelines/design-tokens.md` (wired via `cfg.guidelinesGlob`)
-  documenting the authored token vocabulary and the known-noise disposition, so
-  every future design agent in the DS project inherits "these findings are
-  framework noise — do not chase, do not hoist `--tw-*` to `:root`." Append the
-  same disposition to `.design-sync/NOTES.md` (the sync operator's required
-  reading).
+  `packages/mapgen-studio-ui/docs/design-tokens.md` (shipped as
+  `guidelines/docs/design-tokens.md` via `cfg.guidelinesGlob: "docs/*.md"` —
+  a non-dot path, required for aux-hash change detection) documenting the
+  authored token vocabulary and the known-noise disposition, so every future
+  design agent in the DS project inherits "these findings are framework noise
+  — do not chase, do not hoist `--tw-*` to `:root`." The guard asserts the
+  doc names every authored token. Append the same disposition to
+  `.design-sync/NOTES.md` (the sync operator's required reading).
 - **Upstream routing.** A polished defect report for the design-sync /
   claude.ai-design maintainers (`workstream/upstream-feedback.md`) with the
   exact exclusion predicate and evidence, plus a `docs/system/DEFERRALS.md`
@@ -64,9 +69,9 @@ owns.
 
 ## Affected Owners
 
-- `packages/mapgen-studio-ui/test/**` (new guard test + fixture)
+- `packages/mapgen-studio-ui/test/**` (new guard test + two fixtures)
 - `packages/mapgen-studio-ui/.design-sync/config.json` (`guidelinesGlob` key)
-- `packages/mapgen-studio-ui/.design-sync/guidelines/**` (new)
+- `packages/mapgen-studio-ui/docs/**` (new — the synced guidelines source)
 - `packages/mapgen-studio-ui/.design-sync/NOTES.md` (append-only)
 - `docs/system/DEFERRALS.md`
 - `openspec/changes/studio-ui-token-noise-disposition/**`

--- a/openspec/changes/studio-ui-token-noise-disposition/tasks.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/tasks.md
@@ -71,16 +71,17 @@
 
 ## 5. Verification And Closure
 
-- [ ] 5.1 `bunx nx run mapgen-studio-ui:test --outputStyle=static` and
-  `bunx nx run mapgen-studio-ui:check --outputStyle=static` at the stack tip.
-- [ ] 5.2 `bunx nx run mapgen-studio-ui:design-sync:check --outputStyle=static`
-  (re-run after the guidelines relocation).
-- [ ] 5.3 `bun run openspec -- validate studio-ui-token-noise-disposition
-  --strict` and `git diff --check` across the stack.
-- [ ] 5.4 Submit the stack as draft PRs (`gt submit --draft --no-interactive`),
-  parent-verified against `main`.
-- [ ] 5.5 Record in the phase record: the next re-sync ships `guidelines/**`
-  (docs-tier); the live upload remains gated on the user's explicit go-ahead.
-- [ ] 5.6 Update task checkboxes; archiving happens only after the gated
-  re-sync lands and the change's deltas are promoted per change-management
-  spec.
+- [x] 5.1 Package suite + typecheck green at the stack tip (17 files / 174
+  tests; `tsc` for both configs).
+- [x] 5.2 `design-sync:check` re-run green after the guidelines relocation
+  (exit 0, `anchor: ok`, changed 0, `guidelines/docs/design-tokens.md` +
+  `guidelines/index.md` staged).
+- [x] 5.3 `openspec validate studio-ui-token-noise-disposition --strict` and
+  `git diff --check` green across the stack.
+- [x] 5.4 Stack submitted as draft PRs, parent-verified against `main`:
+  #2044 (openspec) → #2045 (guard) → #2046 (knowledge surfaces + review
+  fold).
+- [x] 5.5 Recorded: the next re-sync ships `guidelines/**` (docs-tier); the
+  live upload remains gated on the user's explicit go-ahead.
+- [ ] 5.6 Archive after the gated re-sync lands and the change's deltas are
+  promoted per change-management spec.

--- a/openspec/changes/studio-ui-token-noise-disposition/tasks.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/tasks.md
@@ -28,17 +28,22 @@
 
 ## 3. Knowledge surfaces + upstream routing (stack branch 3)
 
-- [ ] 3.1 Author `.design-sync/guidelines/design-tokens.md` (authored
+- [x] 3.1 Author `.design-sync/guidelines/design-tokens.md` (authored
   vocabulary table + noise disposition + prohibitions).
-- [ ] 3.2 Add `"guidelinesGlob"` to `.design-sync/config.json`; prove
-  render-neutrality: `design-sync:check` green and driver classifies the delta
-  as docs-tier (no component render hashes moved, no grade-key change).
-- [ ] 3.3 Append the disposition bullet to `.design-sync/NOTES.md` (append-only
+- [x] 3.2 Add `"guidelinesGlob"` to `.design-sync/config.json`; proven
+  render-neutral against the freshly fetched live anchor (2026-07-08):
+  `design-sync:check` exit 0, verdict `anchor: ok`,
+  `changed/added/removed: []`, `guidelines: 1 file(s)` shipped under
+  aux/docs, all 47 anchor render hashes matched on disk. (The 7
+  artifact-churned-with-stable-sources entries are fresh-worktree rebuild
+  byte-churn — canary spot-check with grades kept, pre-existing behavior.)
+- [x] 3.3 Append the disposition bullet to `.design-sync/NOTES.md` (append-only
   convention; bottom-up read order).
-- [ ] 3.4 Add `docs/system/DEFERRALS.md` entry: upstream classifier fix with
-  re-check trigger on Claude Code / design-sync version bumps.
-- [ ] 3.5 Finalize `workstream/upstream-feedback.md` (corrected fix surface;
-  exclusion predicate; evidence appendix).
+- [x] 3.4 Add `docs/system/DEFERRALS.md` entry DEF-017: upstream classifier fix
+  with re-check trigger on Claude Code / design-sync version bumps.
+- [x] 3.5 Finalize `workstream/upstream-feedback.md` (corrected fix surface;
+  exclusion predicate; evidence appendix) — landed with branch 1; confirmed
+  against the live `x-omelette` map.
 
 ## 4. Verification And Closure
 

--- a/openspec/changes/studio-ui-token-noise-disposition/tasks.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/tasks.md
@@ -15,28 +15,37 @@
   stacks) — the handoff's "~46 KEEP" list mixed in Tailwind-emitted scale
   defaults (`--text-sm`, `--spacing`, `--container-*`, `--font-weight-*`,
   palette `--color-*-N`), which the fixture classifies as framework-owned.
-- [x] 2.2 Add `test/designTokens.test.ts`: brace-tracking extraction of custom
-  properties + `@property` rules; partition authored/framework; assert fixture
-  exactness, no strays, kind value-shapes (HSL triplet, `var()` alias); plus a
-  predicate-does-not-swallow-fixture assertion and dual-scope (dark+light)
-  coverage pinning both palettes.
-- [x] 2.3 Negative proof: dropping `--warning` fails the partition test (stray
-  named); adding `--fake-token` fails the scope test (both scopes named);
-  restored fixture green (evidence in phase record).
-- [x] 2.4 Package test suite green: 17 files, 172 tests (168 pre-existing + 4
-  guard).
+- [x] 2.2 Add `test/designTokens.test.ts` (final shape after the review fold):
+  comment-stripped, string-safe, block-final-safe brace-tracking scan;
+  structural `@property` harvesting (non-empty sanity assertion); three-bucket
+  exact-name partition (authored kind-map fixture with kind-derived scopes +
+  `framework-tokens.json` snapshot checked in both directions); bidirectional
+  scope assertions; kind value-shapes with named unknown-kind failures;
+  cross-fixture pin against `token-contract.json`; synced-guidelines
+  vocabulary pin. No name-prefix heuristics.
+- [x] 2.3 Negative proof re-run against the final guard (evidence in phase
+  record): dropping `--warning` → stray named; appending a `--text-accent`
+  declaration to a scratch CSS copy → stray named (the prefix-swallow hole is
+  closed); removing `--animate-spin` from the snapshot → stray named; scope
+  narrowing is unrepresentable (scopes derive from kind).
+- [x] 2.4 Package test suite green after the fold (count recorded in the phase
+  record).
 
 ## 3. Knowledge surfaces + upstream routing (stack branch 3)
 
-- [x] 3.1 Author `.design-sync/guidelines/design-tokens.md` (authored
-  vocabulary table + noise disposition + prohibitions).
-- [x] 3.2 Add `"guidelinesGlob"` to `.design-sync/config.json`; proven
-  render-neutral against the freshly fetched live anchor (2026-07-08):
+- [x] 3.1 Author `docs/design-tokens.md` (authored vocabulary table + noise
+  disposition + prohibitions + guard-scope note). Relocated out of
+  `.design-sync/` by the review fold: `emitGuidelines` preserves the
+  package-relative subpath and `sync-hashes.mjs` skips dot-entries, so a
+  dot-nested guideline would upload once and never re-ship on edits.
+- [x] 3.2 Add `"guidelinesGlob": "docs/*.md"` to `.design-sync/config.json`;
+  proven render-neutral against the freshly fetched live anchor (2026-07-08):
   `design-sync:check` exit 0, verdict `anchor: ok`,
   `changed/added/removed: []`, `guidelines: 1 file(s)` shipped under
-  aux/docs, all 47 anchor render hashes matched on disk. (The 7
-  artifact-churned-with-stable-sources entries are fresh-worktree rebuild
-  byte-churn — canary spot-check with grades kept, pre-existing behavior.)
+  aux/docs at `guidelines/docs/design-tokens.md`, all 47 anchor render hashes
+  matched on disk. (The 7 artifact-churned-with-stable-sources entries are
+  fresh-worktree rebuild byte-churn — canary spot-check with grades kept,
+  pre-existing behavior.)
 - [x] 3.3 Append the disposition bullet to `.design-sync/NOTES.md` (append-only
   convention; bottom-up read order).
 - [x] 3.4 Add `docs/system/DEFERRALS.md` entry DEF-017: upstream classifier fix
@@ -45,16 +54,33 @@
   exclusion predicate; evidence appendix) — landed with branch 1; confirmed
   against the live `x-omelette` map.
 
-## 4. Verification And Closure
+## 4. Review Fold (design.md review lanes 2 + 3)
 
-- [ ] 4.1 `bunx nx run mapgen-studio-ui:test --outputStyle=static`.
-- [ ] 4.2 `bunx nx run mapgen-studio-ui:design-sync:check --outputStyle=static`.
-- [ ] 4.3 `bun run openspec -- validate studio-ui-token-noise-disposition
+- [x] 4.1 Eight-angle finder fan-out over the stack diff (line-scan,
+  removed-behavior, cross-file tracer, reuse, simplification, efficiency,
+  altitude, conventions) + five-dimension adversarial augmentation workflow
+  (prose-facts, guard mutations, sync-contract, OpenSpec consistency,
+  partition re-derivation).
+- [x] 4.2 Fold all confirmed findings (dead `@property` harvesting,
+  prefix-swallow hole, dot-path aux-hash blind spot, one-directional scope
+  assertion, unknown-kind TypeError, scanner string/comment/block-final
+  hardening, cwd-dependent path resolution, DEF-017 ledger ambiguity, doc
+  drift, dangling evidence pointer, stale phase-record status, missing review
+  lanes in design.md); record refuted findings and adjudicated non-actions in
+  the phase record.
+
+## 5. Verification And Closure
+
+- [ ] 5.1 `bunx nx run mapgen-studio-ui:test --outputStyle=static` and
+  `bunx nx run mapgen-studio-ui:check --outputStyle=static` at the stack tip.
+- [ ] 5.2 `bunx nx run mapgen-studio-ui:design-sync:check --outputStyle=static`
+  (re-run after the guidelines relocation).
+- [ ] 5.3 `bun run openspec -- validate studio-ui-token-noise-disposition
   --strict` and `git diff --check` across the stack.
-- [ ] 4.4 Submit the stack as draft PRs (`gt submit --draft --no-interactive`),
+- [ ] 5.4 Submit the stack as draft PRs (`gt submit --draft --no-interactive`),
   parent-verified against `main`.
-- [ ] 4.5 Record in the phase record: the next re-sync ships `guidelines/**`
+- [ ] 5.5 Record in the phase record: the next re-sync ships `guidelines/**`
   (docs-tier); the live upload remains gated on the user's explicit go-ahead.
-- [ ] 4.6 Update task checkboxes; archiving happens only after the gated
+- [ ] 5.6 Update task checkboxes; archiving happens only after the gated
   re-sync lands and the change's deltas are promoted per change-management
   spec.

--- a/openspec/changes/studio-ui-token-noise-disposition/workstream/frame.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/workstream/frame.md
@@ -15,8 +15,10 @@ re-deriving it, and the actual defect routed to the only party that can fix it.
 
 ## Diagnostic of the prior frame (why a reframe, not a plan against the handoff)
 
-The handoff packet (`scraps/design_handoff_ds_sync_token_noise/README.md`, plus
-the two alternate messages) frames this as: *scope the `/design-sync` token
+The handoff packet (the `2026-07-02_ds-sync-tailwind-fix.zip` archive —
+`design_handoff_ds_sync_token_noise/{README,token-inventory}.md`, the inventory
+now committed as `workstream/token-inventory.md` — plus the two alternate
+messages) frames this as: *scope the `/design-sync` token
 extractor (Option A) or annotate tokens with `/* @kind */` comments (Option B);
 acceptance = 0 unclassified + 0 selector-scoped findings after re-sync.* Two
 load-bearing assumptions were falsified by direct evidence:
@@ -65,7 +67,8 @@ classifier* (not ours) to *the signal economy of design sessions* (ours).
 ## Selection / salience / exterior
 
 - **In:** the two findings; ownership evidence; the authored token inventory
-  (~46 names incl. 25 HSL-triplet semantic colors); repo-owned sync surfaces
+  (32 names incl. 27 HSL-triplet color tokens — the handoff's larger "~46
+  KEEP" list mixed in Tailwind-emitted defaults); repo-owned sync surfaces
   (`guidelinesGlob`, `.design-sync/NOTES.md`, package tests); the upstream
   feedback channel; the acceptance-criterion rewrite.
 - **Foregrounded:** the ownership boundary (app vs repo); the falsified

--- a/openspec/changes/studio-ui-token-noise-disposition/workstream/phase-record.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/workstream/phase-record.md
@@ -147,6 +147,25 @@ stack diff. Dispositions:
 - `scripts/light-canary.mjs`'s hand-listed token subset: pre-existing file
   outside this slice; spun off as a follow-up task chip.
 
-## Verification
+## Verification (final gate run, 2026-07-08, stack tip)
 
-- (final gate run recorded at closure)
+- `mapgen-studio-ui` package suite: 17 files / 174 tests green (168
+  pre-existing + 6 guard); `tsc -p tsconfig.json` + `tsc -p
+  tsconfig.test.json` clean.
+- Four-direction negative proof against the final guard: drop `--warning`
+  from the authored fixture → partition + cross-fixture tests fail naming it;
+  append `--text-accent` to a scratch `.light` block → partition test fails
+  naming it (prefix-swallow hole closed); add a fake snapshot entry → stale
+  check fails naming it; set an unknown kind → named failures (no TypeError).
+  Restore → 6/6 green, clean tree.
+- `design-sync:check`: exit 0 against the live anchor (`anchor: ok`,
+  changed/added/removed 0); staged output contains
+  `guidelines/docs/design-tokens.md` + `guidelines/index.md` (non-dot,
+  aux-hashed). `[REFERENCE_STALE?]` warn is the expected fresh-worktree
+  bundle-rebuild note, non-blocking.
+- `openspec validate studio-ui-token-noise-disposition --strict` valid;
+  `git diff --check` clean.
+- Stack submitted as draft PRs off `main`: #2044 → #2045 → #2046.
+- Outstanding: the live re-sync/upload of `guidelines/**` to DS project
+  `531d158d…` awaits the user's explicit go-ahead (standing upload gate);
+  archiving waits for that re-sync + delta promotion.

--- a/openspec/changes/studio-ui-token-noise-disposition/workstream/phase-record.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/workstream/phase-record.md
@@ -64,6 +64,19 @@
   Path resolution note: `import.meta.url` is not a `file:` URL under the
   root vitest transform — the test resolves `dist/styles.css` from cwd
   (package dir or repo root).
+- **Branch 3 (`studio-ui-token-knowledge-surfaces`).** Guidelines channel
+  wired (`guidelinesGlob: ".design-sync/guidelines/*.md"` →
+  `guidelines/design-tokens.md`), NOTES.md disposition appended, DEF-017
+  recorded. Render-neutrality proof: fetched the live `_ds_sync.json` anchor
+  (bundleSha12 `2040d4d634b7`) into `.design-sync/.cache/remote-sync.json`,
+  ran `design-sync:check` → exit 0, verdict `anchor: ok`,
+  `changed/added/removed: []`, `guidelines: 1 file(s)` in the aux/docs tier,
+  47/47 anchor render hashes recomputed and matched. Fresh-worktree rebuild
+  byte-churn produced 7 artifact-churned-with-stable-sources entries
+  (render_churn canary spot-checked 5 with grades kept — environmental,
+  pre-existing driver behavior, not caused by this change). Known
+  non-blocking `[RENDER_BLANK] Toaster` heuristic warning (0x0 toast
+  anchor), pre-existing.
 
 ## Verification
 

--- a/openspec/changes/studio-ui-token-noise-disposition/workstream/phase-record.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/workstream/phase-record.md
@@ -9,7 +9,9 @@
 - Objective: end the recurring `check_design_system` token-noise tax with the
   three repo-owned levers (guard, synced knowledge, upstream routing); the
   handoff's "0/0 findings" criterion is recorded as unreachable from this repo.
-- Status: opening.
+- Status: implemented + review fold applied (lanes 2–3 of design.md executed
+  2026-07-08); awaiting draft-PR submit; the live re-sync/upload remains gated
+  on the user's explicit go-ahead.
 
 ## Authority And Inputs
 
@@ -53,31 +55,98 @@
 
 ## Implementation
 
-- **Branch 2 (`studio-ui-token-guard`).** Fixture generated from the built
-  `dist/styles.css` (64,809 bytes; 136 unique custom properties; 78
-  `@property` rules — byte-consistent with the handoff inventory). Partition:
-  32 authored / 104 framework-owned / 0 strays. Guard test
-  `test/designTokens.test.ts` (4 assertions). Negative proof (2026-07-08):
-  drop `--warning` → partition test fails naming `--warning`; add
-  `--fake-token` → scope test fails naming `--fake-token @ dark, @ light`;
-  restore → 4/4 green. Full package suite: 17 files / 172 tests green.
-  Path resolution note: `import.meta.url` is not a `file:` URL under the
-  root vitest transform — the test resolves `dist/styles.css` from cwd
-  (package dir or repo root).
+- **Branch 2 (`studio-ui-token-guard`).** Fixtures generated from the built
+  `dist/styles.css` (64,809 bytes as of this run; 136 unique custom
+  properties = 32 authored + 26 framework snapshot + 78 `@property` —
+  byte-consistent with the handoff inventory). Guard test
+  `test/designTokens.test.ts` (six assertions; final shape per design.md
+  Decision 1 after the review fold — see Review Fold section for the folded
+  findings and re-run negative proofs). Runs under
+  `// @vitest-environment node` (project default jsdom is why
+  `import.meta.url` is not a `file:` URL for component tests — same note as
+  the sibling `themeTokens.test.ts`).
 - **Branch 3 (`studio-ui-token-knowledge-surfaces`).** Guidelines channel
-  wired (`guidelinesGlob: ".design-sync/guidelines/*.md"` →
-  `guidelines/design-tokens.md`), NOTES.md disposition appended, DEF-017
-  recorded. Render-neutrality proof: fetched the live `_ds_sync.json` anchor
+  wired (`guidelinesGlob: "docs/*.md"` → `docs/design-tokens.md` ships as
+  `guidelines/docs/design-tokens.md`; relocated from a dot-path by the review
+  fold — see Review Fold), NOTES.md disposition appended, DEF-017 recorded
+  (root ledger, disambiguated from the project ledger's DEF-017).
+  Render-neutrality proof: fetched the live `_ds_sync.json` anchor
   (bundleSha12 `2040d4d634b7`) into `.design-sync/.cache/remote-sync.json`,
   ran `design-sync:check` → exit 0, verdict `anchor: ok`,
   `changed/added/removed: []`, `guidelines: 1 file(s)` in the aux/docs tier,
-  47/47 anchor render hashes recomputed and matched. Fresh-worktree rebuild
-  byte-churn produced 7 artifact-churned-with-stable-sources entries
-  (render_churn canary spot-checked 5 with grades kept — environmental,
-  pre-existing driver behavior, not caused by this change). Known
-  non-blocking `[RENDER_BLANK] Toaster` heuristic warning (0x0 toast
-  anchor), pre-existing.
+  47/47 anchor render hashes recomputed and matched (re-run green after the
+  relocation). Fresh-worktree rebuild byte-churn produced 7
+  artifact-churned-with-stable-sources entries (render_churn canary
+  spot-checked 5 with grades kept — environmental, pre-existing driver
+  behavior, not caused by this change). Known non-blocking
+  `[RENDER_BLANK] Toaster` heuristic warning (0x0 toast anchor), pre-existing.
+
+## Review Fold (2026-07-08 — design.md lanes 2 + 3)
+
+Eight finder angles + a five-dimension adversarial workflow ran over the full
+stack diff. Dispositions:
+
+**Confirmed and folded:**
+- `@property` harvesting was dead code (0 of 78 names collected — `@property`
+  bodies hold only descriptors, so declaration stacks never see the frame;
+  three independent empirical confirmations). Fixed: names harvested from rule
+  preludes at frame push, plus a non-empty sanity assertion so the structural
+  leg can never silently die again.
+- Name-prefix framework predicate silently swallowed authored tokens in
+  Tailwind `@theme` namespaces (mutation-proven: appended `--text-accent`,
+  `--animate-brand-shimmer`, etc. all stayed green). Fixed: prefixes deleted;
+  exact-name `framework-tokens.json` snapshot (26 names), checked stale-proof
+  in both directions.
+- Scope assertion was one-directional (fixture-only edit could drop `light`
+  silently; mutation-proven). Fixed: scopes derive from kind (dark-only
+  unrepresentable) + reverse containment (no declaration outside the kind's
+  scopes).
+- Guidelines dot-path was a functional bug, not cosmetics: `emitGuidelines`
+  preserves the package-relative subpath and `sync-hashes.mjs` `hashDir`
+  skips dot-entries — the doc would land at
+  `guidelines/.design-sync/guidelines/…`, upload once, then never re-ship on
+  edits (aux-hash blind spot, empirically verified with a control file).
+  Fixed: source moved to `docs/design-tokens.md`, `guidelinesGlob: "docs/*.md"`,
+  ships as `guidelines/docs/design-tokens.md`.
+- Scanner hardening: block-final declarations (minified CSS) now flushed at
+  `}`; quoted strings skipped; comments stripped (latent stack-corruption
+  class). Selector normalization made comma-insensitive.
+- Path resolution was cwd-dependent (reproduced failing from a third
+  directory). Fixed with the sibling `themeTokens.test.ts` pattern:
+  `// @vitest-environment node` + `import.meta.url`.
+- Unknown fixture kind crashed with an opaque TypeError → named failure.
+- DEF-017 collides with engine-refactor-v1's project-ledger DEF-017 →
+  disambiguation notes on every citing surface.
+- design.md lacked the config-required review-lanes section; Decision 1 prose
+  had drifted from the implementation → both rewritten.
+- Upstream feedback's evidence pointer dangled (the handoff inventory was
+  never committed) → archived as `workstream/token-inventory.md`.
+- Living surfaces (guidelines, NOTES.md) de-counted — finding classes instead
+  of exact numbers; counts stay pinned only in point-in-time records.
+- Cross-surface pins added: fixture ↔ `token-contract.json` name equality;
+  fixture ↔ synced guidelines vocabulary.
+
+**Refuted:**
+- "Fixture pins `--background` dark-only" — a race artifact: the prose-facts
+  agent read the fixture mid-mutation while the mutation-probe agent (running
+  in parallel) had it temporarily edited; the committed fixture was intact
+  (verified post-run: clean tree, 27 dual-scope colors). Orchestration lesson
+  recorded: mutation probes get an isolated copy or a serialized slot.
+- "Module-top-level scan is wasted collection work" — matches the accepted
+  sibling pattern (`themeTokens.test.ts` reads dist at module scope); the
+  node-env pragma removes the jsdom cost.
+
+**Adjudicated, deliberately not actioned:**
+- Consolidating this scanner with `themeTokens.test.ts`'s `tokensOf()` parser:
+  the two tests pin different contracts (values vs kinds/partition); the
+  cross-fixture name-equality pin closes the drift risk without rewriting a
+  shipped green test in this slice.
+- Cross-layer `src/styles/theme.css` ↔ dist freshness pin: the nx
+  `test → build` edge covers the proof path; direct-vitest staleness is a
+  known dev-loop property shared by the sibling test.
+- `scripts/light-canary.mjs`'s hand-listed token subset: pre-existing file
+  outside this slice; spun off as a follow-up task chip.
 
 ## Verification
 
-- (to be filled at closure)
+- (final gate run recorded at closure)

--- a/openspec/changes/studio-ui-token-noise-disposition/workstream/token-inventory.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/workstream/token-inventory.md
@@ -1,0 +1,100 @@
+# Token inventory — extracted from the current `_ds_bundle.css`
+
+> Provenance: archived verbatim from the 2026-07-02 handoff packet
+> (`2026-07-02_ds-sync-tailwind-fix.zip` →
+> `scraps/design_handoff_ds_sync_token_noise/token-inventory.md`), the exact
+> allow/deny material behind this change. The repo's live equivalents are
+> `packages/mapgen-studio-ui/test/fixtures/authored-tokens.json` and
+> `test/fixtures/framework-tokens.json`, verified against `dist/styles.css`
+> on every build. Note: the KEEP list below (section B) mixes authored tokens
+> with Tailwind-emitted scale defaults; the committed fixtures partition those
+> apart (32 authored / 26 snapshot / 78 `@property`) — see tasks.md 2.1.
+
+Source: MapGen Studio DS project, compiled `_ds_bundle.css` (Tailwind CSS v4.3.0).
+Extraction: brace-tracking scan of every `--name:` declaration + every `@property` at-rule.
+
+## Summary counts
+| Metric | Count |
+|---|---|
+| Unique custom-property names declared | 136 |
+| `@property`-registered (`--tw-*` composition vars) | 78 |
+| Names appearing at `:root` / `:host` | 58 |
+| Names appearing under utility/class/`&` selectors | 53 |
+| Names appearing in the universal `*, ::before, ::after` reset | 78 |
+
+Prefix groups: `--tw-*` = 78 · `--color-*` = 9 · `--tracking-*` = 5 · `--default-*` = 4 ·
+`--font-*` = 4 · `--container-*` = 2 · `--text-*` = 2 · `--animate-*` = 1 · `--blur-*` = 1 ·
+`--leading-*` = 1 · (other / authored semantic) = 29.
+
+---
+
+## A. EXCLUDE from the authored-token scan — Tailwind generated plumbing
+
+### A1. `@property`-registered composition/animation vars (78) — the "selector-scoped" finding
+These are declared inside utility rules and reset on `*`. They must NOT move to `:root`.
+```
+--tw-animation-delay, --tw-animation-direction, --tw-animation-duration, --tw-animation-fill-mode,
+--tw-animation-iteration-count, --tw-backdrop-blur, --tw-backdrop-brightness, --tw-backdrop-contrast,
+--tw-backdrop-grayscale, --tw-backdrop-hue-rotate, --tw-backdrop-invert, --tw-backdrop-opacity,
+--tw-backdrop-saturate, --tw-backdrop-sepia, --tw-blur, --tw-border-style, --tw-brightness,
+--tw-contrast, --tw-divide-y-reverse, --tw-drop-shadow, --tw-drop-shadow-alpha, --tw-drop-shadow-color,
+--tw-drop-shadow-size, --tw-duration, --tw-enter-blur, --tw-enter-opacity, --tw-enter-rotate,
+--tw-enter-scale, --tw-enter-translate-x, --tw-enter-translate-y, --tw-exit-blur, --tw-exit-opacity,
+--tw-exit-rotate, --tw-exit-scale, --tw-exit-translate-x, --tw-exit-translate-y, --tw-font-weight,
+--tw-gradient-from, --tw-gradient-from-position, --tw-gradient-position, --tw-gradient-stops,
+--tw-gradient-to, --tw-gradient-to-position, --tw-gradient-via, --tw-gradient-via-position,
+--tw-gradient-via-stops, --tw-grayscale, --tw-hue-rotate, --tw-inset-ring-color, --tw-inset-ring-shadow,
+--tw-inset-shadow, --tw-inset-shadow-alpha, --tw-inset-shadow-color, --tw-invert, --tw-leading,
+--tw-opacity, --tw-outline-style, --tw-ring-color, --tw-ring-inset, --tw-ring-offset-color,
+--tw-ring-offset-shadow, --tw-ring-offset-width, --tw-ring-shadow, --tw-rotate-x, --tw-rotate-y,
+--tw-rotate-z, --tw-saturate, --tw-sepia, --tw-shadow, --tw-shadow-alpha, --tw-shadow-color,
+--tw-skew-x, --tw-skew-y, --tw-space-y-reverse, --tw-tracking, --tw-translate-x, --tw-translate-y,
+--tw-translate-z
+```
+
+### A2. Tailwind `@theme` framework defaults (~12) — part of the "unclassified" finding
+Emitted into the compiled `:root`/`@theme` block; framework-owned, not authored here.
+```
+--animate-spin, --blur-sm, --default-font-family, --default-mono-font-family,
+--default-transition-duration, --default-transition-timing-function, --leading-relaxed,
+--tracking-tight, --tracking-normal, --tracking-wide, --tracking-wider, --tracking-widest
+```
+(If using Option B / repo annotation instead of exclusion:
+font → `--default-font-family`, `--default-mono-font-family`, `--tracking-*`, `--leading-relaxed`;
+spacing → `--blur-sm`; other → `--animate-spin`, `--default-transition-duration`,
+`--default-transition-timing-function`.)
+
+---
+
+## B. KEEP — genuine authored tokens (must still classify correctly)
+These are the real design tokens; the exclusion in Option A must not catch them.
+
+**Colors / semantic surfaces** (currently mis-tagged `"other"` in `_adherence.oxlintrc.json`):
+```
+--background, --foreground, --card, --card-foreground, --popover, --popover-foreground,
+--primary, --primary-foreground, --secondary, --secondary-foreground, --muted, --muted-foreground,
+--accent, --accent-foreground, --destructive, --destructive-foreground, --success, --warning,
+--border, --border-subtle, --border-strong, --input, --input-background, --ring, --surface-sunken
+```
+**Palette colors:** `--color-*` (9).
+**Radius:** `--radius`.
+**Shadow / elevation:** `--elevation-1`, `--elevation-2`.
+**Spacing:** `--spacing`, `--container-sm`, `--container-lg`.
+**Type scale:** `--text-*`, `--font-sans`, `--font-mono`, `--font-weight-medium`, `--font-weight-semibold`.
+
+---
+
+## C. Known miscategorizations in `_adherence.oxlintrc.json` (secondary cleanup)
+Auto-generated map with a flawed name heuristic. Representative errors:
+```
+--tw-translate-y        : "color"   → should be excluded (or "other"); cf. --tw-translate-x: "spacing"
+--tw-backdrop-blur      : "color"   → other
+--tw-duration           : "color"   → other
+--tw-gradient-position  : "color"   → other
+--background            : "other"   → color
+--primary               : "other"   → color
+--destructive           : "other"   → color
+--foreground/--card/--popover/--secondary/--muted/--accent/--border/... : "other" → color
+```
+Fix the generator (framework-prefix exclusion + real color detection), or correct by hand if
+the file is not generated.

--- a/openspec/changes/studio-ui-token-noise-disposition/workstream/upstream-feedback.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/workstream/upstream-feedback.md
@@ -58,9 +58,10 @@ converter contain no token classifier and no annotation mechanism).
 ## Evidence appendix
 
 - Exact token lists (78 `@property` `--tw-*`, 12 `@theme` defaults, authored
-  set): `scraps/design_handoff_ds_sync_token_noise/token-inventory.md` in the
-  DS project — regenerated counts verified against the package's
-  `dist/styles.css` (78 `@property` rules).
+  set): `workstream/token-inventory.md` next to this file (archived from the
+  2026-07-02 handoff packet) — counts verified against the package's
+  `dist/styles.css` (78 `@property` rules), and pinned live by
+  `packages/mapgen-studio-ui/test/fixtures/{authored,framework}-tokens.json`.
 - Live `x-omelette.tokenKinds` mis-map: fetched 2026-07-08 via
   `DesignSync(get_file, "_adherence.oxlintrc.json")`.
 - The check ignores the uploaded/edited map (hand-editing it does not clear

--- a/packages/mapgen-studio-ui/.design-sync/NOTES.md
+++ b/packages/mapgen-studio-ui/.design-sync/NOTES.md
@@ -285,20 +285,28 @@ historical.
 
 ## Token-noise disposition (2026-07-08)
 - **`check_design_system`'s two recurring token findings are permanent framework
-  noise — do not chase them on any re-sync.** The "~80 unclassified tokens" and
-  "33 selector-scoped custom properties" are Tailwind v4 engine internals
-  (78 `@property` `--tw-*` vars + `@theme` defaults) in the compiled bundle;
-  the classifier is app-side (the claude.ai/design self-check that regenerates
-  `_adherence.oxlintrc.json`), so no repo or project edit clears them. The
-  `x-omelette.tokenKinds` map it emits is also wrong (semantic colors tagged
-  "other") — ignore it. Authority + evidence:
-  `openspec/changes/studio-ui-token-noise-disposition/` (frame, upstream
-  feedback packet, DEF-017 trigger). Repo-side truth: the token guard
-  `test/designTokens.test.ts` + `test/fixtures/authored-tokens.json` (32
-  authored names; update the fixture when adding a token to
-  `src/styles/theme.css`).
-- **Guidelines channel is now wired**: `cfg.guidelinesGlob =
-  ".design-sync/guidelines/*.md"` ships `guidelines/design-tokens.md` (token
-  vocabulary + the noise disposition for design agents). Guidelines are
-  docs-tier for the driver (aux/README change, sampled render check, no grade
-  re-key — `guidelinesGlob` is not a grade-contract key).
+  noise — do not chase them on any re-sync.** The "unclassified tokens" and
+  "selector-scoped custom properties" findings (counts drift with Tailwind
+  versions) are Tailwind v4 engine internals (`@property`-registered `--tw-*`
+  vars + `@theme` defaults) in the compiled bundle; the classifier is app-side
+  (the claude.ai/design self-check that regenerates `_adherence.oxlintrc.json`),
+  so no repo or project edit clears them. The `x-omelette.tokenKinds` map it
+  emits is also wrong (semantic colors tagged "other") — ignore it. Authority +
+  evidence: `openspec/changes/studio-ui-token-noise-disposition/` (frame,
+  upstream feedback packet; deferral DEF-017 in the ROOT ledger
+  `docs/system/DEFERRALS.md` — distinct from engine-refactor-v1's DEF-017).
+  Repo-side truth: the token guard `test/designTokens.test.ts` +
+  `test/fixtures/authored-tokens.json` (authored name → kind; scopes derived
+  from kind) + `test/fixtures/framework-tokens.json` (exact snapshot of the
+  non-`@property` Tailwind defaults; regenerate as a reviewed diff on Tailwind
+  bumps). Add a token to `src/styles/theme.css` → the guard forces a fixture
+  entry AND a row in `docs/design-tokens.md`.
+- **Guidelines channel is now wired**: `cfg.guidelinesGlob = "docs/*.md"` ships
+  `docs/design-tokens.md` → `guidelines/docs/design-tokens.md` (token
+  vocabulary + the noise disposition for design agents). The path is
+  deliberately NOT under a dot-directory: `sync-hashes.mjs` `hashDir` skips
+  dot-entries, so a dot-nested guideline would upload once and then silently
+  never re-ship on edits (aux hash blind spot); dot-paths also risk being
+  hidden from upload globs/file listings. Guidelines are docs-tier for the
+  driver (aux/README change, sampled render check, no grade re-key —
+  `guidelinesGlob` is not a grade-contract key).

--- a/packages/mapgen-studio-ui/.design-sync/NOTES.md
+++ b/packages/mapgen-studio-ui/.design-sync/NOTES.md
@@ -282,3 +282,23 @@ historical.
     concurrent-React `createRoot` pages; run one Chrome per invocation with a
     unique `--user-data-dir` and a hard background `kill -9` after ~12s, then
     read the written PNG.
+
+## Token-noise disposition (2026-07-08)
+- **`check_design_system`'s two recurring token findings are permanent framework
+  noise — do not chase them on any re-sync.** The "~80 unclassified tokens" and
+  "33 selector-scoped custom properties" are Tailwind v4 engine internals
+  (78 `@property` `--tw-*` vars + `@theme` defaults) in the compiled bundle;
+  the classifier is app-side (the claude.ai/design self-check that regenerates
+  `_adherence.oxlintrc.json`), so no repo or project edit clears them. The
+  `x-omelette.tokenKinds` map it emits is also wrong (semantic colors tagged
+  "other") — ignore it. Authority + evidence:
+  `openspec/changes/studio-ui-token-noise-disposition/` (frame, upstream
+  feedback packet, DEF-017 trigger). Repo-side truth: the token guard
+  `test/designTokens.test.ts` + `test/fixtures/authored-tokens.json` (32
+  authored names; update the fixture when adding a token to
+  `src/styles/theme.css`).
+- **Guidelines channel is now wired**: `cfg.guidelinesGlob =
+  ".design-sync/guidelines/*.md"` ships `guidelines/design-tokens.md` (token
+  vocabulary + the noise disposition for design agents). Guidelines are
+  docs-tier for the driver (aux/README change, sampled render check, no grade
+  re-key — `guidelinesGlob` is not a grade-contract key).

--- a/packages/mapgen-studio-ui/.design-sync/config.json
+++ b/packages/mapgen-studio-ui/.design-sync/config.json
@@ -12,7 +12,7 @@
   "extraFonts": ["dist/fonts.css"],
   "buildCmd": "bunx nx run mapgen-studio-ui:build",
   "readmeHeader": ".design-sync/conventions.md",
-  "guidelinesGlob": ".design-sync/guidelines/*.md",
+  "guidelinesGlob": "docs/*.md",
   "provider": {
     "component": "TooltipProvider",
     "props": { "delayDuration": 300 }

--- a/packages/mapgen-studio-ui/.design-sync/config.json
+++ b/packages/mapgen-studio-ui/.design-sync/config.json
@@ -12,6 +12,7 @@
   "extraFonts": ["dist/fonts.css"],
   "buildCmd": "bunx nx run mapgen-studio-ui:build",
   "readmeHeader": ".design-sync/conventions.md",
+  "guidelinesGlob": ".design-sync/guidelines/*.md",
   "provider": {
     "component": "TooltipProvider",
     "props": { "delayDuration": 300 }

--- a/packages/mapgen-studio-ui/.design-sync/guidelines/design-tokens.md
+++ b/packages/mapgen-studio-ui/.design-sync/guidelines/design-tokens.md
@@ -1,0 +1,62 @@
+# Design tokens — vocabulary and known linter noise
+
+## The authored token vocabulary (32 names — everything else in the stylesheets is framework plumbing)
+
+All color tokens are HSL channel triplets consumed as `hsl(var(--token))` (or
+`hsl(var(--token) / alpha)`). Dark is the default (`:root, .dark`); `.light`
+re-skins every color token with the hand-tuned light palette. Never hardcode
+hex/oklch values — compose from these.
+
+| Token | Kind | Role |
+|---|---|---|
+| `--background` / `--foreground` | color | page substrate (the map-canvas backdrop) / primary text |
+| `--card` / `--card-foreground` | color | panel surface — one felt step above the page |
+| `--popover` / `--popover-foreground` | color | floating layers — a step above panels |
+| `--primary` / `--primary-foreground` | color | the one accent: elevated cool-steel slate |
+| `--secondary` / `--secondary-foreground` | color | quiet secondary surface |
+| `--muted` / `--muted-foreground` | color | de-emphasized surface / text |
+| `--accent` / `--accent-foreground` | color | ghost/hover surface |
+| `--destructive` / `--destructive-foreground` | color | destructive actions |
+| `--success` · `--warning` | color | status signals |
+| `--border` · `--border-subtle` · `--border-strong` | color | hairline ladder: findable / within-surface divider / emphasis+focus |
+| `--input` · `--input-background` | color | control border / inset control fill (darker than its panel) |
+| `--ring` | color | focus contour — a luminance step, not a hue |
+| `--elevation-1` · `--elevation-2` | color | felt elevation tiers (panel / floating) |
+| `--surface-sunken` | color | nested cards: between page and panel |
+| `--radius` | radius | 0.25rem default (inputs, buttons, tags) |
+| `--font-sans` · `--font-mono` | font | Inter / JetBrains Mono — the only two families |
+| `--color-border-secondary` · `--color-text-muted` | alias | legacy `hsl(var())` aliases used by the custom scrollbar |
+
+The repo verifies this inventory on every build (`test/designTokens.test.ts`
+against `dist/styles.css`): any custom property that is neither in this list
+nor Tailwind-owned fails CI, and both the dark and light declarations of every
+color token are pinned.
+
+## Known `check_design_system` findings — framework noise, do not chase
+
+Running the design-system check in this project will report, on every sync:
+
+1. **"~80 of ~200 tokens couldn't be classified"** — the unclassifiable names
+   (`--tw-*`, `--animate-spin`, `--default-transition-*`, `--tracking-*`, …)
+   are Tailwind CSS v4's own `@theme` defaults and `@property`-registered
+   engine variables baked into the compiled `_ds_bundle.css`. They are not
+   MapGen Studio tokens.
+2. **"33 custom properties declared under component-style selectors … move
+   them under `:root`"** — these are Tailwind utility-state variables (e.g.
+   `--tw-space-y-reverse` inside `.space-y-* :where(& > :not(:last-child))`)
+   and the universal reset. They are **required** to be selector-scoped.
+   **Do not follow the finding's advice**: hoisting `--tw-*` variables to
+   `:root` breaks the `space-*`/`divide-*`/transform/gradient/ring/filter
+   utilities.
+
+Also known: the generated `_adherence.oxlintrc.json` token→kind map mislabels
+the semantic color tokens as `"other"` (they are colors; the HSL-triplet value
+form isn't recognized). Treat the table above as the authority on kinds.
+
+These findings cannot be cleared from this project: the classifier runs
+app-side over regenerated artifacts, and the stylesheets here are build
+artifacts of `@swooper/mapgen-studio-ui` — **never hand-edit `_ds_bundle.css`,
+`styles.css`, or anything under `components/`**; edits are overwritten by the
+next sync. The upstream fix request is tracked in the repo
+(`openspec/changes/studio-ui-token-noise-disposition/workstream/upstream-feedback.md`,
+deferral DEF-017).

--- a/packages/mapgen-studio-ui/docs/design-tokens.md
+++ b/packages/mapgen-studio-ui/docs/design-tokens.md
@@ -1,6 +1,6 @@
 # Design tokens — vocabulary and known linter noise
 
-## The authored token vocabulary (32 names — everything else in the stylesheets is framework plumbing)
+## The authored token vocabulary — everything else in the stylesheets is framework plumbing
 
 All color tokens are HSL channel triplets consumed as `hsl(var(--token))` (or
 `hsl(var(--token) / alpha)`). Dark is the default (`:root, .dark`); `.light`
@@ -27,21 +27,24 @@ hex/oklch values — compose from these.
 | `--font-sans` · `--font-mono` | font | Inter / JetBrains Mono — the only two families |
 | `--color-border-secondary` · `--color-text-muted` | alias | legacy `hsl(var())` aliases used by the custom scrollbar |
 
-The repo verifies this inventory on every build (`test/designTokens.test.ts`
-against `dist/styles.css`): any custom property that is neither in this list
-nor Tailwind-owned fails CI, and both the dark and light declarations of every
-color token are pinned.
+The repo verifies this vocabulary on every build
+(`test/designTokens.test.ts` against `dist/styles.css`): every custom property
+must be authored (pinned with a kind, both palettes required for colors),
+`@property`-registered engine plumbing, or a snapshotted Tailwind default —
+anything else fails CI, and this table is asserted to name every authored
+token, so it cannot silently drift from the fixture.
 
 ## Known `check_design_system` findings — framework noise, do not chase
 
-Running the design-system check in this project will report, on every sync:
+Running the design-system check in this project will report, on every sync
+(counts drift with Tailwind versions; the classes are what matter):
 
-1. **"~80 of ~200 tokens couldn't be classified"** — the unclassifiable names
+1. **"N tokens couldn't be classified"** — the unclassifiable names
    (`--tw-*`, `--animate-spin`, `--default-transition-*`, `--tracking-*`, …)
    are Tailwind CSS v4's own `@theme` defaults and `@property`-registered
    engine variables baked into the compiled `_ds_bundle.css`. They are not
    MapGen Studio tokens.
-2. **"33 custom properties declared under component-style selectors … move
+2. **"Custom properties declared under component-style selectors … move
    them under `:root`"** — these are Tailwind utility-state variables (e.g.
    `--tw-space-y-reverse` inside `.space-y-* :where(& > :not(:last-child))`)
    and the universal reset. They are **required** to be selector-scoped.
@@ -53,10 +56,16 @@ Also known: the generated `_adherence.oxlintrc.json` token→kind map mislabels
 the semantic color tokens as `"other"` (they are colors; the HSL-triplet value
 form isn't recognized). Treat the table above as the authority on kinds.
 
+Scope note: the repo guard pins `dist/styles.css` (the package's compiled
+stylesheet). If the check's findings ever shift without a matching repo-side
+diff, the delta happened in the app-side bundling step — treat it as app-side,
+not something to chase in the repo.
+
 These findings cannot be cleared from this project: the classifier runs
 app-side over regenerated artifacts, and the stylesheets here are build
 artifacts of `@swooper/mapgen-studio-ui` — **never hand-edit `_ds_bundle.css`,
 `styles.css`, or anything under `components/`**; edits are overwritten by the
 next sync. The upstream fix request is tracked in the repo
-(`openspec/changes/studio-ui-token-noise-disposition/workstream/upstream-feedback.md`,
-deferral DEF-017).
+(`openspec/changes/studio-ui-token-noise-disposition/workstream/upstream-feedback.md`;
+deferral DEF-017 in the root ledger `docs/system/DEFERRALS.md` — distinct from
+the engine-refactor project's own DEF-017).

--- a/packages/mapgen-studio-ui/test/designTokens.test.ts
+++ b/packages/mapgen-studio-ui/test/designTokens.test.ts
@@ -1,35 +1,49 @@
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+// @vitest-environment node
+// (pure artifact test — reads dist/ from disk; the project default is jsdom
+// for component tests, where import.meta.url is not a file: URL)
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-import fixture from "./fixtures/authored-tokens.json" with { type: "json" };
+import authoredFixture from "./fixtures/authored-tokens.json" with { type: "json" };
+import frameworkFixture from "./fixtures/framework-tokens.json" with { type: "json" };
+import themeContract from "./fixtures/token-contract.json" with { type: "json" };
 
 // Repo-owned token-signal guard (openspec: studio-ui-token-noise-disposition).
 //
 // The claude.ai/design app's check_design_system cannot classify compiled
-// Tailwind v4 output (78 @property-registered --tw-* vars + @theme defaults
-// read as "unclassified tokens" / "selector-scoped custom properties") — that
-// classifier is app-side and its findings over this package are permanent
-// framework noise. This test is the signal that check cannot give us: every
-// custom property in the built stylesheet must be either an authored token
-// pinned in test/fixtures/authored-tokens.json (name + kind + scopes) or
-// framework-owned per the predicate below. A stray name fails; a Tailwind
-// upgrade that changes the engine surface fails until absorbed as a reviewed
-// fixture/predicate diff.
+// Tailwind v4 output — its recurring "unclassified tokens" / "selector-scoped
+// custom properties" findings over this package are permanent framework noise
+// (see .design-sync/NOTES.md and docs/design-tokens.md). This test is the
+// signal that check cannot give us. Every custom property in the built
+// stylesheet must fall into exactly one of three buckets:
+//
+//   1. authored — pinned in fixtures/authored-tokens.json as name → kind;
+//      scopes derive from kind (KIND_SCOPES), so a dark-only color token is
+//      unrepresentable in the fixture, and the scope check is bidirectional.
+//   2. @property-registered — Tailwind's engine vars, detected structurally
+//      from the stylesheet's own @property rules.
+//   3. framework snapshot — the non-@property @theme defaults Tailwind emits
+//      for used utilities, pinned exactly in fixtures/framework-tokens.json.
+//
+// Anything else is a stray and fails. There are deliberately NO name-prefix
+// heuristics: an authored token named inside a Tailwind namespace (e.g. a
+// future --text-hero) surfaces as a stray instead of being silently absorbed,
+// and a Tailwind upgrade that changes the engine surface is a reviewed
+// snapshot diff. Siblings: test/themeTokens.test.ts pins the palette VALUES
+// against the token-contract fixture (this test pins names/kinds/scopes);
+// .ds-sync/lib/emit.mjs carries the skill-owned "--tw-* is engine plumbing"
+// classification for the upload docs — not reusable here (the skill refreshes
+// that surface), but the same partition idea.
 
-// Resolves from either the package dir (direct vitest run) or the repo root
-// (root-config project run); the nx test target's build dependency guarantees
-// dist/ exists.
-const CSS_PATH = [
-  resolve(process.cwd(), "dist/styles.css"),
-  resolve(process.cwd(), "packages/mapgen-studio-ui/dist/styles.css"),
-].find((candidate) => existsSync(candidate));
-if (!CSS_PATH) {
-  throw new Error("dist/styles.css not found — run the mapgen-studio-ui build first");
-}
+const css = readFileSync(fileURLToPath(new URL("../dist/styles.css", import.meta.url)), "utf8");
+const guidelinesDoc = readFileSync(
+  fileURLToPath(new URL("../docs/design-tokens.md", import.meta.url)),
+  "utf8",
+);
 
-// Scope labels in the fixture map to the exact selector contexts the theme
-// authors own in src/styles/theme.css (as they appear in the built CSS).
+// Scope labels map to the exact selector contexts authored in
+// src/styles/theme.css, as they appear in the built CSS.
 const SCOPE_SELECTORS: Record<string, (stack: readonly string[]) => boolean> = {
   dark: (stack) => stack.some((s) => normalizeSelector(s) === ":root, .dark"),
   light: (stack) => stack.some((s) => normalizeSelector(s) === ".light"),
@@ -41,8 +55,18 @@ const SCOPE_SELECTORS: Record<string, (stack: readonly string[]) => boolean> = {
     stack.some((s) => normalizeSelector(s) === ":root, :host"),
 };
 
+// Scopes are a function of kind: every color token must ship BOTH palettes
+// (the dark-only regression class), aliases/radius live in the theme-invariant
+// :root block, font stacks in Tailwind's @layer theme block.
+const KIND_SCOPES: Record<string, readonly (keyof typeof SCOPE_SELECTORS)[]> = {
+  color: ["dark", "light"],
+  alias: ["invariant"],
+  radius: ["invariant"],
+  font: ["theme"],
+};
+
 const VALUE_SHAPES: Record<string, RegExp> = {
-  // HSL channel triplet ("240 14% 6%"), consumed as hsl(var(--x)).
+  // HSL channel triplet ("240 14% 6%", decimals allowed), consumed as hsl(var(--x)).
   color: /^\d{1,3}(?:\.\d+)?\s+\d{1,3}(?:\.\d+)?%\s+\d{1,3}(?:\.\d+)?%$/,
   // Resolved-color alias over another authored token.
   alias: /^hsl\(var\(--[\w-]+\)\)$/,
@@ -51,24 +75,8 @@ const VALUE_SHAPES: Record<string, RegExp> = {
   font: /^"(?:Inter|JetBrains Mono)",/,
 };
 
-// Framework-owned custom properties: Tailwind v4 engine plumbing and @theme
-// defaults emitted because used utilities reference them. @property-registered
-// names are definitionally engine vars; the rest are the known internal
-// namespaces. A new Tailwind namespace lands as a stray and fails the
-// partition test — extend this predicate (or the fixture) as a reviewed diff.
-function isFrameworkOwned(name: string, atPropertyRegistered: ReadonlySet<string>): boolean {
-  if (atPropertyRegistered.has(name)) return true;
-  if (/^--(?:tw|default|animate|blur)-/.test(name)) return true;
-  if (/^--(?:tracking|leading|text|container|font-weight)-/.test(name)) return true;
-  if (name === "--spacing") return true;
-  if (/^--color-[a-z]+-\d+$/.test(name) || name === "--color-black" || name === "--color-white") {
-    return true;
-  }
-  return false;
-}
-
 function normalizeSelector(selector: string): string {
-  return selector.replace(/\s+/g, " ").trim();
+  return selector.replace(/\s+/g, " ").replace(/\s*,\s*/g, ", ").trim();
 }
 
 interface Declaration {
@@ -77,48 +85,62 @@ interface Declaration {
   readonly stack: readonly string[];
 }
 
-// Brace-tracking scan (same method as the change's token inventory): records
-// every `--name: value` declaration with its selector stack, plus every
-// @property-registered name. Regex-free CSS parsing is deliberate — the file
-// is generated, and the scan only needs custom-property declarations.
-function scanStylesheet(css: string): {
+// Brace-tracking scan of the generated stylesheet: records every
+// `--name: value` declaration with its selector stack, and every
+// @property-registered name (harvested from the rule prelude when the frame
+// is pushed — @property bodies hold only syntax/inherits/initial-value, so
+// declaration stacks alone would never see them). Comments are stripped
+// first; quoted strings are skipped so braces/semicolons inside values can't
+// corrupt the stack; a block-final declaration without a trailing `;` (the
+// minified form) is flushed at `}`.
+function scanStylesheet(source: string): {
   declarations: Declaration[];
   atPropertyRegistered: Set<string>;
 } {
+  const text = source.replace(/\/\*[\s\S]*?\*\//g, "");
   const declarations: Declaration[] = [];
   const atPropertyRegistered = new Set<string>();
   const stack: string[] = [];
   let buf = "";
-  for (const char of css) {
-    if (char === "{") {
-      stack.push(buf.trim());
+  const flushDeclaration = () => {
+    const decl = /^(--[\w-]+)\s*:\s*([\s\S]+)$/.exec(buf.trim());
+    if (decl) {
+      declarations.push({ name: decl[1], value: decl[2].trim(), stack: [...stack] });
+    }
+    buf = "";
+  };
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    if (char === '"' || char === "'") {
+      buf += char;
+      for (i++; i < text.length; i++) {
+        buf += text[i];
+        if (text[i] === "\\") {
+          i++;
+          if (i < text.length) buf += text[i];
+        } else if (text[i] === char) break;
+      }
+    } else if (char === "{") {
+      const frame = buf.trim();
+      stack.push(frame);
+      const atProperty = /^@property\s+(--[\w-]+)$/.exec(normalizeSelector(frame));
+      if (atProperty) atPropertyRegistered.add(atProperty[1]);
       buf = "";
     } else if (char === "}") {
+      flushDeclaration();
       stack.pop();
-      buf = "";
     } else if (char === ";") {
-      const decl = /^(--[\w-]+)\s*:\s*([\s\S]+)$/.exec(buf.trim());
-      if (decl) {
-        declarations.push({ name: decl[1], value: decl[2].trim(), stack: [...stack] });
-      }
-      buf = "";
+      flushDeclaration();
     } else {
       buf += char;
     }
   }
-  for (const frame of declarations.flatMap((d) => d.stack)) {
-    const at = /^@property\s+(--[\w-]+)$/.exec(normalizeSelector(frame));
-    if (at) atPropertyRegistered.add(at[1]);
-  }
   return { declarations, atPropertyRegistered };
 }
 
-const css = readFileSync(CSS_PATH, "utf8");
 const { declarations, atPropertyRegistered } = scanStylesheet(css);
-const authoredTokens = fixture.tokens as Record<
-  string,
-  { kind: keyof typeof VALUE_SHAPES; scopes: readonly (keyof typeof SCOPE_SELECTORS)[] }
->;
+const authoredTokens = authoredFixture.tokens as Record<string, keyof typeof KIND_SCOPES>;
+const frameworkTokens = new Set<string>(frameworkFixture.tokens);
 
 const byName = new Map<string, Declaration[]>();
 for (const decl of declarations) {
@@ -127,45 +149,87 @@ for (const decl of declarations) {
   byName.set(decl.name, list);
 }
 
+function fixtureKindError(name: string, kind: string): string | null {
+  if (KIND_SCOPES[kind] && VALUE_SHAPES[kind]) return null;
+  return `${name} has unknown kind "${kind}" — add it to KIND_SCOPES and VALUE_SHAPES first`;
+}
+
 describe("design token surface (dist/styles.css)", () => {
-  it("partitions every custom property as authored (fixture) or framework-owned", () => {
+  it("partitions every custom property as authored, @property-registered, or snapshot framework", () => {
+    // The structural leg must actually fire — an empty set here means the
+    // @property harvesting regressed (it is the definitional engine-var
+    // detector, not decoration).
+    expect(atPropertyRegistered.size).toBeGreaterThan(0);
+
     const strays = [...byName.keys()].filter(
-      (name) => !(name in authoredTokens) && !isFrameworkOwned(name, atPropertyRegistered),
+      (name) =>
+        !(name in authoredTokens) && !atPropertyRegistered.has(name) && !frameworkTokens.has(name),
     );
     expect(
       strays,
-      `Custom properties in dist/styles.css that are neither in test/fixtures/authored-tokens.json nor framework-owned: ${strays.join(", ")}. ` +
-        "New authored token → add it to the fixture with a kind. " +
-        "New Tailwind engine surface → extend the framework predicate as a reviewed diff.",
+      `Custom properties in dist/styles.css that are neither authored (fixtures/authored-tokens.json), @property-registered, nor in the framework snapshot (fixtures/framework-tokens.json): ${strays.join(", ")}. ` +
+        "New authored token → add it to authored-tokens.json with a kind. " +
+        "Tailwind surface change → regenerate framework-tokens.json as a reviewed diff.",
+    ).toEqual([]);
+
+    // Keep the snapshot honest in the other direction too: entries that no
+    // longer exist in the build are stale and must be pruned.
+    const stale = [...frameworkTokens].filter((name) => !byName.has(name));
+    expect(
+      stale,
+      `framework-tokens.json entries absent from dist/styles.css (stale snapshot): ${stale.join(", ")}`,
     ).toEqual([]);
   });
 
-  it("declares every authored token in each of its owned scopes", () => {
-    const missing: string[] = [];
-    for (const [name, spec] of Object.entries(authoredTokens)) {
+  it("keeps the authored fixture disjoint from the framework buckets", () => {
+    const conflicts = Object.keys(authoredTokens).filter(
+      (name) => atPropertyRegistered.has(name) || frameworkTokens.has(name),
+    );
+    expect(
+      conflicts,
+      `Authored tokens colliding with a framework bucket (rename the token or resolve the snapshot): ${conflicts.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("declares every authored token in exactly its kind's scopes (both directions)", () => {
+    const problems: string[] = [];
+    for (const [name, kind] of Object.entries(authoredTokens)) {
+      const kindError = fixtureKindError(name, kind);
+      if (kindError) {
+        problems.push(kindError);
+        continue;
+      }
+      const expected = KIND_SCOPES[kind];
       const occurrences = byName.get(name) ?? [];
-      for (const scope of spec.scopes) {
+      for (const scope of expected) {
         if (!occurrences.some((d) => SCOPE_SELECTORS[scope](d.stack))) {
-          missing.push(`${name} @ ${scope}`);
+          problems.push(`${name} missing from ${scope}`);
+        }
+      }
+      // Reverse containment: every declaration of an authored token must sit
+      // in one of its kind's scopes — a declaration leaking into another
+      // context (or a fixture kind understating real scopes) fails loudly
+      // instead of narrowing the guard.
+      for (const decl of occurrences) {
+        if (!expected.some((scope) => SCOPE_SELECTORS[scope](decl.stack))) {
+          problems.push(`${name} declared outside its ${kind} scopes: "${decl.stack.join(" > ")}"`);
         }
       }
     }
-    // Dual-scope color tokens missing their `.light` declaration re-create the
-    // shipped dark-only regression — this assertion pins both palettes.
-    expect(missing, `Authored tokens missing from an owned scope: ${missing.join(", ")}`).toEqual(
-      [],
-    );
+    expect(problems, `Authored token scope violations: ${problems.join("; ")}`).toEqual([]);
   });
 
   it("keeps every authored token's value in its kind's shape", () => {
     const violations: string[] = [];
-    for (const [name, spec] of Object.entries(authoredTokens)) {
+    for (const [name, kind] of Object.entries(authoredTokens)) {
+      const kindError = fixtureKindError(name, kind);
+      if (kindError) {
+        violations.push(kindError);
+        continue;
+      }
       for (const decl of byName.get(name) ?? []) {
-        // Only check declarations in owned scopes; framework re-registrations
-        // of the same name elsewhere are covered by the partition test.
-        const inOwnedScope = spec.scopes.some((scope) => SCOPE_SELECTORS[scope](decl.stack));
-        if (inOwnedScope && !VALUE_SHAPES[spec.kind].test(decl.value)) {
-          violations.push(`${name} (${spec.kind}) = "${decl.value}"`);
+        if (!VALUE_SHAPES[kind].test(decl.value)) {
+          violations.push(`${name} (${kind}) = "${decl.value}"`);
         }
       }
     }
@@ -174,13 +238,32 @@ describe("design token surface (dist/styles.css)", () => {
     );
   });
 
-  it("does not misclassify authored tokens as framework-owned", () => {
-    const swallowed = Object.keys(authoredTokens).filter((name) =>
-      isFrameworkOwned(name, atPropertyRegistered),
+  it("agrees with the theme token contract fixture on the authored surface", () => {
+    // themeTokens.test.ts pins palette VALUES against token-contract.json;
+    // this pin ties the two fixtures' name sets together so a token added to
+    // one cannot silently miss the other.
+    const contractDark = Object.keys(themeContract.dark).filter((k) => k.startsWith("--"));
+    const fixtureColors = Object.entries(authoredTokens)
+      .filter(([, kind]) => kind === "color")
+      .map(([name]) => name);
+    expect(fixtureColors.sort()).toEqual(contractDark.sort());
+
+    const fixtureInvariants = Object.entries(authoredTokens)
+      .filter(([, kind]) => kind === "alias" || kind === "radius")
+      .map(([name]) => name)
+      .sort();
+    expect(fixtureInvariants).toEqual(
+      ["--color-border-secondary", "--color-text-muted", "--radius"].sort(),
     );
+  });
+
+  it("keeps the synced guidelines doc's vocabulary in step with the fixture", () => {
+    // docs/design-tokens.md ships to the claude.ai/design project on every
+    // re-sync (cfg.guidelinesGlob); its table must name every authored token.
+    const missing = Object.keys(authoredTokens).filter((name) => !guidelinesDoc.includes(name));
     expect(
-      swallowed,
-      `Fixture tokens caught by the framework predicate (the exclusion must not swallow genuine tokens): ${swallowed.join(", ")}`,
+      missing,
+      `Authored tokens missing from docs/design-tokens.md (the synced vocabulary table): ${missing.join(", ")}`,
     ).toEqual([]);
   });
 });

--- a/packages/mapgen-studio-ui/test/fixtures/authored-tokens.json
+++ b/packages/mapgen-studio-ui/test/fixtures/authored-tokens.json
@@ -1,224 +1,37 @@
 {
-  "$comment": "Authored design-token inventory for @swooper/mapgen-studio-ui, verified against built dist/styles.css by test/designTokens.test.ts. Every custom property in the built stylesheet must be either listed here or framework-owned (see the test's framework predicate). Adding a token to src/styles/theme.css requires adding it here with a kind; a Tailwind upgrade that changes the engine-variable surface must be absorbed as a reviewed diff. Authority: openspec/changes/studio-ui-token-noise-disposition.",
+  "$comment": "Authored design tokens for @swooper/mapgen-studio-ui as name -> kind, verified against built dist/styles.css by test/designTokens.test.ts. Scopes are derived from kind (see KIND_SCOPES in the test) so a dark-only color token is unrepresentable. Adding a token to src/styles/theme.css requires adding it here; the test fails on any stray. Authority: openspec/changes/studio-ui-token-noise-disposition.",
   "tokens": {
-    "--background": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--foreground": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--card": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--card-foreground": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--popover": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--popover-foreground": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--primary": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--primary-foreground": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--secondary": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--secondary-foreground": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--muted": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--muted-foreground": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--accent": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--accent-foreground": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--destructive": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--destructive-foreground": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--border": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--input": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--ring": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--border-subtle": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--border-strong": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--input-background": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--elevation-1": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--elevation-2": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--surface-sunken": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--success": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--warning": {
-      "kind": "color",
-      "scopes": [
-        "dark",
-        "light"
-      ]
-    },
-    "--color-border-secondary": {
-      "kind": "alias",
-      "scopes": [
-        "invariant"
-      ]
-    },
-    "--color-text-muted": {
-      "kind": "alias",
-      "scopes": [
-        "invariant"
-      ]
-    },
-    "--radius": {
-      "kind": "radius",
-      "scopes": [
-        "invariant"
-      ]
-    },
-    "--font-sans": {
-      "kind": "font",
-      "scopes": [
-        "theme"
-      ]
-    },
-    "--font-mono": {
-      "kind": "font",
-      "scopes": [
-        "theme"
-      ]
-    }
+    "--accent": "color",
+    "--accent-foreground": "color",
+    "--background": "color",
+    "--border": "color",
+    "--border-strong": "color",
+    "--border-subtle": "color",
+    "--card": "color",
+    "--card-foreground": "color",
+    "--color-border-secondary": "alias",
+    "--color-text-muted": "alias",
+    "--destructive": "color",
+    "--destructive-foreground": "color",
+    "--elevation-1": "color",
+    "--elevation-2": "color",
+    "--font-mono": "font",
+    "--font-sans": "font",
+    "--foreground": "color",
+    "--input": "color",
+    "--input-background": "color",
+    "--muted": "color",
+    "--muted-foreground": "color",
+    "--popover": "color",
+    "--popover-foreground": "color",
+    "--primary": "color",
+    "--primary-foreground": "color",
+    "--radius": "radius",
+    "--ring": "color",
+    "--secondary": "color",
+    "--secondary-foreground": "color",
+    "--success": "color",
+    "--surface-sunken": "color",
+    "--warning": "color"
   }
 }

--- a/packages/mapgen-studio-ui/test/fixtures/framework-tokens.json
+++ b/packages/mapgen-studio-ui/test/fixtures/framework-tokens.json
@@ -1,0 +1,31 @@
+{
+  "$comment": "Snapshot of the non-@property framework-owned custom properties Tailwind v4 emits into dist/styles.css (@theme defaults pulled in by used utilities). The @property-registered engine vars (--tw-*) are detected structurally by the test and are NOT listed. A Tailwind upgrade that changes this surface fails test/designTokens.test.ts until this snapshot is regenerated as a reviewed diff. Authority: openspec/changes/studio-ui-token-noise-disposition.",
+  "tokens": [
+    "--animate-spin",
+    "--blur-sm",
+    "--color-black",
+    "--color-blue-500",
+    "--color-emerald-500",
+    "--color-gray-400",
+    "--color-red-500",
+    "--color-red-600",
+    "--color-rose-400",
+    "--container-lg",
+    "--container-sm",
+    "--default-font-family",
+    "--default-mono-font-family",
+    "--default-transition-duration",
+    "--default-transition-timing-function",
+    "--font-weight-medium",
+    "--font-weight-semibold",
+    "--leading-relaxed",
+    "--spacing",
+    "--text-sm",
+    "--text-sm--line-height",
+    "--tracking-normal",
+    "--tracking-tight",
+    "--tracking-wide",
+    "--tracking-wider",
+    "--tracking-widest"
+  ]
+}


### PR DESCRIPTION
Wires the design-sync guidelines channel: `cfg.guidelinesGlob: "docs/*.md"` ships `docs/design-tokens.md` as `guidelines/docs/design-tokens.md` — the authored token vocabulary plus the disposition of the two permanent `check_design_system` framework-noise findings (do not chase; never hoist `--tw-*` to `:root`; never hand-edit synced stylesheets). Placement is deliberately non-dot: `sync-hashes.mjs` skips dot-entries, so a dot-nested guideline would upload once and never re-ship on edits (review-fold catch). Appends the sync-operator disposition to `.design-sync/NOTES.md` and records DEF-017 (root ledger, disambiguated from engine-refactor-v1's DEF-017).

Render-neutrality proven against the freshly fetched live anchor: `design-sync:check` exit 0, `anchor: ok`, changed/added/removed 0, guidelines land docs-tier, grade keys untouched. The tip commit folds the full 13-lane review (dispositions in `workstream/phase-record.md`).

**The live upload of `guidelines/**` rides the next re-sync and stays gated on Matei's explicit go-ahead.**

Stack: 3/3 — on #2045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
