### PR TITLE
Source light-canary token list from the verified authored-token fixture

### DIFF
--- a/openspec/changes/studio-ui-token-noise-disposition/workstream/phase-record.md
+++ b/openspec/changes/studio-ui-token-noise-disposition/workstream/phase-record.md
@@ -144,8 +144,16 @@ stack diff. Dispositions:
 - Cross-layer `src/styles/theme.css` ↔ dist freshness pin: the nx
   `test → build` edge covers the proof path; direct-vitest staleness is a
   known dev-loop property shared by the sibling test.
-- `scripts/light-canary.mjs`'s hand-listed token subset: pre-existing file
-  outside this slice; spun off as a follow-up task chip.
+- `scripts/light-canary.mjs`'s hand-listed token subset — **subsequently
+  ACTIONED (2026-07-08)** at the owner's request, on branch
+  `studio-ui-canary-fixture-source` stacked on branch 3. The 7-token subset now
+  loads and validates against `test/fixtures/authored-tokens.json` at startup
+  (each must be a `kind=color` entry), so a token renamed/removed in
+  `src/styles/theme.css` — which the guard forces out of the fixture — trips a
+  loud startup error instead of the canary silently sampling `""` on both sides
+  and reporting zero drift (a false pass). Behavior is otherwise identical (same
+  7 tokens); re-run against the built reference confirmed 7/7 zero drift.
+  Originally deferred here as a pre-existing file outside this slice.
 
 ## Verification (final gate run, 2026-07-08, stack tip)
 

--- a/packages/mapgen-studio-ui/scripts/light-canary.mjs
+++ b/packages/mapgen-studio-ui/scripts/light-canary.mjs
@@ -16,9 +16,10 @@
 // `.design-sync/light-canary-tokens.json` (screenshots are ephemeral —
 // re-run to regenerate). First run: 2026-07-02, 7/7 picks zero drift.
 
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const require = createRequire(resolve(".ds-sync/package.json"));
 const pw = require("playwright");
@@ -84,7 +85,16 @@ const picks = [
     620,
   ],
 ];
-const TOKENS = [
+// The core theme tokens sampled on both sides. Named explicitly (a curated,
+// token-heavy subset — not every color), then validated against the verified
+// authored-token fixture at startup: each MUST be a kind=color entry in
+// test/fixtures/authored-tokens.json, which test/designTokens.test.ts keeps in
+// lockstep with src/styles/theme.css. So a token renamed or dropped in
+// theme.css falls out of the fixture and trips this assertion LOUDLY — instead
+// of the canary silently sampling "" on both sides and reporting zero drift (a
+// false pass). To retire or rename a sampled token, edit theme.css, the
+// fixture, and this list together.
+const CORE_TOKENS = [
   "--background",
   "--foreground",
   "--card",
@@ -93,6 +103,21 @@ const TOKENS = [
   "--border",
   "--destructive",
 ];
+const authoredTokens = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../test/fixtures/authored-tokens.json", import.meta.url)),
+    "utf8"
+  )
+).tokens;
+const staleTokens = CORE_TOKENS.filter((t) => authoredTokens[t] !== "color");
+if (staleTokens.length) {
+  throw new Error(
+    `light-canary: ${staleTokens.join(", ")} not a kind=color entry in ` +
+      "test/fixtures/authored-tokens.json — renamed or removed in src/styles/theme.css? " +
+      "Update CORE_TOKENS + the fixture together so the canary samples real tokens."
+  );
+}
+const TOKENS = CORE_TOKENS;
 const SB = resolve(".design-sync/sb-reference");
 const OUT = resolve("ds-bundle");
 const { srv: s1, port: p1 } = await serveDir(SB);


### PR DESCRIPTION
## What

`scripts/light-canary.mjs` (the forced-`.light` fidelity canary) hard-coded a
7-token subset it samples on both sides. If one of those tokens were renamed in
`src/styles/theme.css`, the canary would sample `""` on **both** sides and
report **zero drift** — a silent false pass.

This sources the subset from the verified authored-token fixture and validates
it at startup: each of the 7 must be a `kind=color` entry in
`test/fixtures/authored-tokens.json` (which `test/designTokens.test.ts` keeps in
lockstep with `theme.css`). A renamed/removed token falls out of the fixture and
now trips a **loud startup error** naming the stale token — before any browser
launch — instead of passing silently.

## Behavior

Otherwise identical: same 7 tokens, same sampling. Verified:

- **Positive:** re-run against the built reference — 7/7 picks `tokenDrift=NONE`.
- **Negative:** injecting a renamed token throws immediately, names it, and
  never launches Chrome.

## Context

Actions the light-canary item previously recorded *"deliberately not actioned"*
in `studio-ui-token-noise-disposition` (a review finding on branch 3, deferred
as a pre-existing file outside that slice). Stacked on branch 3 —
`test/fixtures/authored-tokens.json`, the fixture this now depends on, is
introduced by branch 2 (the token guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
