### PR TITLE
OpenSpec: studio-ui-token-value-form change

### DIFF
--- a/openspec/changes/studio-ui-token-value-form/design.md
+++ b/openspec/changes/studio-ui-token-value-form/design.md
@@ -1,0 +1,136 @@
+# Design — studio-ui token value-form migration
+
+## Frame
+
+The problem is not "the checker is wrong" and not "make findings go away." The
+design system ships its authored tokens in a legacy value dialect — bare HSL
+channel triplets consumed as `hsl(var(--token))` — and that dialect is the root
+cause of (a) perpetual color misclassification, (b) drift tax against the shadcn
+/ Tailwind v4 convention on every sync, and (c) an inverted consumption rule
+that already produced one silent-transparent bug class. The solution modernizes
+the dialect and leaves the checker alone. This design records the one real fork
+(value format) and the alpha-mechanism adjudication; both were decided with
+stated reasons, not averaged.
+
+## Ownership map (the decision spine)
+
+| Surface | Owner | Can this change touch it? |
+|---|---|---|
+| Authored token values + `@theme inline` map: `packages/mapgen-studio-ui/src/styles/theme.css` | this repo (`@swooper/mapgen-studio-ui`) | **Yes — sole palette owner; the whole flip lives here** |
+| TS/TSX consumers (`sonner.tsx`, `PipelineStage.tsx`, `StudioShellLayout.stories.tsx`, app `CanvasStage.tsx`) | this repo (Studio UI package + `apps/mapgen-studio`) | **Yes — migrate to `var(--x)` / `color-mix`** |
+| Token guard + fixtures (`test/designTokens.test.ts`, `token-contract.json`) | this repo | **Yes — re-pin value-shapes; `authored-tokens.json` unchanged** |
+| Knowledge/disposition docs (`docs/design-tokens.md`, `.design-sync/NOTES.md`, `DEFERRALS.md`, sibling `upstream-feedback.md`) | this repo | **Yes — value-form vocabulary + explorations rule** |
+| Compiled `dist/styles.css` (`@property` `--tw-*` rules + `@theme` defaults + authored tokens) | Tailwind v4 build | No content changes — fidelity gate; rebuilt only |
+| Classifier / `_adherence.oxlintrc.json` / `_ds_bundle.*` / synced `components/**` / `conventions.md` | claude.ai/design app + Claude Code binary | No — regenerated / app-contract; feedback + falsifier only |
+
+## Decision 1 — value format: full `hsl()` values consumed as `var()`, not blanket oklch
+
+The load-bearing fix is the **consumption architecture** (full color values +
+`var(--x)` consumption + `@theme inline` without wrappers), NOT the color space.
+shadcn's own official migration wraps existing values in `hsl()`; oklch is
+optional/cosmetic for upgraded projects ("Upgraded projects are not affected …
+can continue using the old colors"). The decision splits cleanly:
+
+- **Step A (this change): wrap → `hsl()` full values, consume via `var()`.**
+  `--primary: 216 18% 44%` → `--primary: hsl(216 18% 44%)`; the `@theme inline`
+  map drops the `hsl()` wrapper (`--color-primary: var(--primary)`); the two
+  aliases carry a bare `var(--other-token)`. Rendered colors are byte-identical
+  (a lossless HSL rewrap) → zero pixel drift → the 47-component compare grades
+  carry honestly; the classifier reads a real color function; JS consumes
+  `var(--x)` directly; the explorations rule un-inverts.
+- **Step B (deferred, separate design pass): re-author the palette in oklch.**
+  The palette comments describe a hand-tuned "cartographer's instrument"
+  lightness ladder; re-authoring it in oklch is a *design* decision (wider
+  gamut, perceptual uniformity), not a mechanical one. It is explicitly out of
+  scope here (see Decision 3).
+
+Rationale (why A-then-B, not blanket oklch): a blanket oklch conversion buys
+nothing visually — a lossless conversion produces the same sRGB pixels — while
+adding conversion-rounding risk in the 47-component compare and silently
+re-semanticizing a hand-tuned artifact. Full `hsl()` values capture 100% of the
+classifier / convention / JS wins at zero visual risk. Falsifier for this
+adjudication: if the app classifier special-cased oklch only. That is already
+refuted — `#000` classifies as a color, so any full color value suffices.
+
+Guard consequence (mechanical, decided): `test/designTokens.test.ts`
+`VALUE_SHAPES.color` becomes `/^hsl\(\d{1,3}(?:\.\d+)? \d{1,3}(?:\.\d+)?% \d{1,3}(?:\.\d+)?%\)$/`
+(full-hsl form — kept strict, no union with bare triplets) and
+`VALUE_SHAPES.alias` becomes `/^var\(--[\w-]+\)$/`. This tightens the value-shape
+leg; it does not touch the name/kind/scope partition (see Decision 4).
+
+## Decision 2 — alpha mechanism: `color-mix(in oklab, var(--x) N%, transparent)`
+
+All 14 opacity sites (1 in CSS at `theme.css` `hsl(var(--popover) / 0.95)`; 13
+in TS/TSX) adopt `color-mix(in oklab, var(--x) N%, transparent)`. Reasons:
+
+- It matches exactly what Tailwind v4 emits for opacity modifiers (verified in
+  the built `dist/styles.css`), so the authored alpha form and the
+  utility-generated alpha form are identical.
+- It works identically in hand-written CSS and in TS-built inline styles, which
+  is required because the alpha sites span both.
+- Its browser support floor equals Tailwind v4's own floor — evergreen for any
+  environment that already runs the build output.
+
+Rejected alpha mechanisms (decided, not left open): `--alpha()` is compile-time
+only and cannot express a runtime TS inline style; relative-color syntax
+(`hsl(from …)`) has a newer support floor and mixed serialization across
+engines. Neither is used.
+
+## Decision 3 — oklch re-authoring is Step B, explicitly deferred
+
+Step B is not an "optional" tail of this change and not a fallback — it is a
+distinct, design-led change with its own trigger: **a deliberate
+palette-evolution pass** (someone wants wider-gamut, perceptually-tuned colors).
+Until that pass is chartered, the palette stays in `hsl()`. Nothing in Step A
+depends on it, and Step A leaves the palette in a form (full values + `var()`)
+from which an oklch re-author is a clean, isolated diff. This change does not
+soften, pre-stage, or partially perform Step B.
+
+## Decision 4 — relationship to the existing `studio-ui-design-sync` spec
+
+The existing spec (added by `studio-ui-token-noise-disposition`) pins the
+authored/framework partition by **name, kind, and scope** only; it does not
+normatively pin token value form. This change's delta is therefore purely
+**ADDED**: a value-form requirement layered on top. The partition requirement
+survives unchanged and is not weakened — the guard still fails on any stray
+custom property and on any scope mismatch; the value-shape re-pin only makes the
+per-kind value assertion stricter. `authored-tokens.json` (the name→kind
+fixture) is untouched because it carries no values.
+
+## Review lanes
+
+Three lanes gate the implementation (B2–B4) before it ships, executed as a
+fan-out fold at the stack tip:
+
+1. **Owner lane** — design review against this frame: dialect modernization (not
+   checker-fixing); the zero-pixel-drift invariant; no hand-edits to synced or
+   generated artifacts; Step B stays out.
+2. **Correctness / cleanup fan-out** — independent finder angles over the flip
+   diff: every color value wrapped in both palette blocks; every `@theme inline`
+   entry and CSS rule unwrapped to `var(--x)`; the two aliases repointed; all 14
+   alpha sites on `color-mix`; the silent-failure hot spot (`sonner`'s
+   `--normal-bg`, which takes an invalid string if a site is missed) covered;
+   the guard value-shape regexes kept strict (no bare-triplet union).
+3. **Adversarial augmentation** — attack the claims the first two lanes take on
+   trust: pre/post render compare proving zero drift; the pre-commit trial-build
+   gate proving both compiles emit valid `color-mix` over the new map; the
+   `tokenKinds` falsifier (authored colors must classify as `"color"`);
+   sync-contract semantics (forced re-grade correctness; the two remote-only
+   explorations snapshotted before edit — the only irreversible edge); and an
+   OpenSpec cross-consistency check that the delta is additive and does not
+   weaken the partition requirement.
+
+## Rejected alternatives
+
+- **Blanket oklch conversion (Step B folded into Step A)** — buys nothing
+  visually, adds rounding risk across the 47-component compare, and
+  re-semanticizes a hand-tuned ladder. Deferred, not adopted.
+- **Leave the legacy dialect ("the checker is wrong")** — rejected on
+  drift-tax + silent-transparent bug-class grounds; documenting around the
+  dialect does not remove the recurring cost.
+- **`--alpha()` for opacity** — compile-time only; cannot express TS inline
+  styles.
+- **Relative-color syntax for opacity** — newer support floor + mixed
+  serialization.
+- **Chasing findings #1/#2 to zero / editing the classifier** — contract-enforced
+  noise, unreachable from the repo; DEF-017 disposition stands.

--- a/openspec/changes/studio-ui-token-value-form/proposal.md
+++ b/openspec/changes/studio-ui-token-value-form/proposal.md
@@ -1,0 +1,153 @@
+## Why
+
+`@swooper/mapgen-studio-ui` ships its authored design tokens in a legacy value
+dialect: bare HSL channel triplets (`--primary: 216 18% 44%`) consumed as
+`hsl(var(--token))`. That dialect is the root cause of three standing problems:
+
+1. **No value-reading classifier can recognize the tokens as colors.** The live
+   design-app self-check labels full color values (`oklch(...)`, `#000`)
+   correctly and every bare triplet `"other"`, so authored semantic colors are
+   perpetually misclassified — the exact blind spot the sibling change
+   `studio-ui-token-noise-disposition` routed upstream (DEF-017, upstream item 2).
+2. **It diverges from the current shadcn / Tailwind v4 convention** (full color
+   values consumed as `var(--token)`), creating drift tax on every future
+   component sync from the design project.
+3. **It forces an inverted consumption rule** (`hsl(var(--token))` mandatory,
+   bare `var(--token)` renders transparent) that already produced one
+   silent-transparent bug class, recorded in `.design-sync/NOTES.md`.
+
+This change modernizes the dialect: authored color tokens carry full CSS color
+values and are consumed as `var(--token)`; opacity uses `color-mix`. It leaves
+the classifier, the compiled bundle, and the two contract-enforced noise
+findings alone.
+
+## Authority
+
+- Direct user decision (2026-07-08): modernize the token value dialect (Step A),
+  leave the checker alone, keep visual fidelity as the gate; oklch re-authoring
+  is a separate later design pass.
+- `docs/projects/studio-ui-extraction/WORKSTREAM.md` — the design-sync contract
+  facts (upload format, grade-key recipe, re-sync ritual, conventions
+  validation) that this migration must ride without violating.
+- `openspec/changes/studio-ui-token-noise-disposition/` — the sibling change
+  that established the authored/framework token partition guard and the
+  `studio-ui-design-sync` spec this delta extends; its DEF-017 disposition and
+  `workstream/upstream-feedback.md` are updated here, not re-adjudicated.
+- `openspec/specs/change-management/spec.md`: this change is implementation
+  control downstream of the above; it does not redefine sync architecture.
+
+## What Changes
+
+- **Value form (the load-bearing flip).** `packages/mapgen-studio-ui/src/styles/theme.css`
+  (the sole palette owner; the app's `index.css` only imports it): the dark
+  (`:root, .dark`) and light (`.light`) palette blocks wrap every bare color
+  triplet in `hsl()`; the `@theme inline` map drops its `hsl()` wrappers
+  (`hsl(var(--x))` → `var(--x)`, 27 sites); the two aliases carry a bare
+  `var(--other-token)` reference; the five base/component rules consume
+  `var(--x)`; the single CSS alpha site (`hsl(var(--popover) / 0.95)`) becomes
+  `color-mix`. Rendered colors are byte-identical (a lossless HSL rewrap), so
+  there is zero pixel drift.
+- **Consumers.** 19 TS/TSX sites across four files (`src/components/ui/sonner.tsx`,
+  `src/components/panels/recipe-dag/PipelineStage.tsx`,
+  `src/components/templates/StudioShellLayout.stories.tsx`,
+  `apps/mapgen-studio/src/app/CanvasStage.tsx`) move to `var(--x)`; the 14 alpha
+  sites among them adopt `color-mix(in oklab, var(--x) N%, transparent)`.
+- **Guard re-pin (same commit as the flip).** `test/designTokens.test.ts`
+  `VALUE_SHAPES.color` moves to the full-`hsl()` regex and `VALUE_SHAPES.alias`
+  to `var(--...)`; `test/fixtures/token-contract.json` is re-captured from the
+  new build with its `$comment` recording the re-capture reason;
+  `authored-tokens.json` is unchanged (it is value-free). The
+  name/kind/scope partition it enforces is preserved.
+- **Knowledge surfaces.** `docs/design-tokens.md`, `.design-sync/NOTES.md` (the
+  explorations rule un-inverts), `docs/system/DEFERRALS.md` (DEF-017 records
+  upstream item 2 mooted, with a falsifier trigger), and the sibling change's
+  `workstream/upstream-feedback.md` are updated.
+- **Spec.** A value-form requirement is ADDED to `studio-ui-design-sync`.
+
+## What Does Not Change
+
+- The design-app classifier / `_adherence.oxlintrc.json` / findings #1 (`--tw-*`
+  and `@theme` defaults) and #2 (selector-scoped custom props): contract-enforced
+  noise; DEF-017 disposition stands.
+- oklch re-authoring of the palette (Step B): a separate, design-led change.
+- The compiled `dist/styles.css`, `_ds_bundle.*`, synced `components/**`,
+  `conventions.md`, `.ds-sync/**` staged scripts: generated / app-contract
+  surfaces, never hand-edited. No `--tw-*` hoisting to `:root`.
+
+## Affected Owners
+
+- `packages/mapgen-studio-ui/src/styles/theme.css` (palette owner)
+- `packages/mapgen-studio-ui/src/components/ui/sonner.tsx`,
+  `src/components/panels/recipe-dag/PipelineStage.tsx`,
+  `src/components/templates/StudioShellLayout.stories.tsx`
+- `apps/mapgen-studio/src/app/CanvasStage.tsx`
+- `packages/mapgen-studio-ui/test/designTokens.test.ts`,
+  `test/fixtures/token-contract.json`
+- `packages/mapgen-studio-ui/.design-sync/light-canary-tokens.json` (regenerated,
+  no script change)
+- `packages/mapgen-studio-ui/docs/design-tokens.md`,
+  `packages/mapgen-studio-ui/.design-sync/NOTES.md`, `docs/system/DEFERRALS.md`
+- `openspec/changes/studio-ui-token-noise-disposition/workstream/upstream-feedback.md`
+  (addendum)
+- `openspec/changes/studio-ui-token-value-form/**`
+
+## Forbidden Owners
+
+- `packages/mapgen-studio-ui/dist/**`, `styles.css`, `_ds_bundle.*`,
+  synced `components/**`, `_adherence.oxlintrc.json`
+- `packages/mapgen-studio-ui/.ds-sync/**` (staged skill scripts),
+  `.design-sync/conventions.md`
+- The live DS project's synced artifacts (read-only by contract)
+- Any `--tw-*` hoist to `:root`; any oklch re-authoring (Step B)
+
+## Dependencies
+
+- Requires: composes with `studio-ui-token-noise-disposition` (extends its
+  `studio-ui-design-sync` spec and re-pins the guard it introduced). Base is
+  current `main`.
+- Enables parallel work: Step B (oklch palette re-authoring) becomes a clean,
+  isolated design pass once the consumption architecture is `var(--x)`.
+  Packetization: the flip, the guard re-pin, and the knowledge/disposition edits
+  share one decision spine (dialect modernization at zero pixel drift) and one
+  verification story, so they ship as one change executed as a small Graphite
+  stack (this docs-only record first).
+
+## Consumer Impact
+
+- Rendered colors are byte-identical → the 47-component compare grades carry
+  honestly; the only expected re-grade is the two story files whose bytes change
+  (`StudioShellLayout.stories.tsx`), moving their sourceKeys/gradeKeys — a small,
+  expected regrade, not a storm.
+- JS consumers gain direct `var(--x)` consumption; the explorations rule
+  un-inverts (bare `var(--token)` becomes correct).
+- Design agents inherit a corrected value-form vocabulary in the synced
+  guidelines.
+
+## Verification Gates
+
+- **Pre-commit trial build** (open question from the sweep): both compiles — the
+  package Tailwind CLI and the app Vite build — emit valid
+  `color-mix(in oklab, var(--x) N%, transparent)` over the new map for
+  opacity-modifier utilities. If the app compile misbehaves, stop and reassess.
+- `bunx nx run mapgen-studio-ui:test` green with the re-pinned value-shapes;
+  negative proof (mutate one token value-shape → the guard trips).
+- `light-canary` 7/7 zero drift after regenerating
+  `.design-sync/light-canary-tokens.json`.
+- `design-sync:check` green with a forced re-grade (internals-wave rule);
+  47/47 grades match; four portal dialogs verified via the manual full-page path.
+- `bun run openspec -- validate studio-ui-token-value-form --strict`.
+- **Falsifier:** after the app self-check regenerates `_adherence.oxlintrc.json`,
+  authored colors classify as `"color"`. If still `"other"`, the value-form
+  hypothesis is wrong — record in DEF-017 and stop repo-side.
+- `git diff --check`.
+
+## Stop Conditions
+
+- The app Vite compile emits invalid or drifted `color-mix` output over the new
+  map — stop; do not commit a half-migrated theme (mid-states are mutually
+  invalid).
+- Any pixel drift beyond the two expected story re-grades — stop; the flip is
+  meant to be lossless.
+- The falsifier check still labels authored colors `"other"` — record in
+  DEF-017; do not iterate further repo-side.
+- Any step would require hand-editing a synced or generated artifact — stop.

--- a/openspec/changes/studio-ui-token-value-form/specs/studio-ui-design-sync/spec.md
+++ b/openspec/changes/studio-ui-token-value-form/specs/studio-ui-design-sync/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Authored Color And Alias Tokens Carry Full Values Consumed As var()
+
+Authored color tokens in `@swooper/mapgen-studio-ui` SHALL declare complete,
+self-contained CSS color values (for example `--primary: hsl(216 18% 44%)`)
+rather than bare channel triplets, and every downstream consumer — the
+`@theme inline` map, base and component CSS rules, and TS/TSX inline styles —
+SHALL reference them as `var(--token)` and MUST NOT re-wrap a token in a color
+function (`hsl(var(--token))`). Authored alias tokens SHALL carry a bare
+`var(--other-token)` reference as their value and be consumed identically as
+`var(--token)`. Opacity-modified consumption of an authored token SHALL use
+`color-mix(in oklab, var(--token) N%, transparent)`.
+
+This requirement is additive. The authored/framework partition verified by the
+`studio-ui-token-noise-disposition` change — every custom property in
+`dist/styles.css` classifies as an authored token pinned by name, kind, and
+scope, or as a framework-owned property — remains in force unchanged; this
+requirement adds a value-form constraint on top of that partition and does not
+relax it.
+
+#### Scenario: An authored color token is declared
+- **WHEN** a color token is added or re-authored in the package theme CSS
+- **THEN** its declared value is a full CSS color function (for example
+  `hsl(...)`), not a bare channel triplet
+- **AND** the package token guard's color value-shape check accepts the full
+  value and rejects a bare triplet
+
+#### Scenario: A component consumes an authored token
+- **WHEN** the `@theme inline` map, a CSS rule, or a TS/TSX inline style
+  references an authored color or alias token
+- **THEN** it uses `var(--token)` directly
+- **AND** it does not wrap the token in `hsl(var(--token))`
+
+#### Scenario: A consumer applies an opacity modifier to a token
+- **WHEN** a consumer needs a translucent form of an authored color token
+- **THEN** it composes it as `color-mix(in oklab, var(--token) N%, transparent)`
+- **AND** it does not rely on channel-triplet slash-alpha
+  (`hsl(var(--token) / a)`) or on compile-time-only `--alpha()`
+
+#### Scenario: The classifier reads an authored color token after migration
+- **WHEN** the design app's token classifier processes the migrated
+  `dist/styles.css`
+- **THEN** authored color tokens present a recognizable CSS color value
+- **AND** they are no longer forced to the `"other"` kind by a bare channel
+  triplet
+
+#### Scenario: The name, kind, and scope partition is preserved
+- **WHEN** the package token guard runs after the value-form migration
+- **THEN** it still fails on any custom property that is neither an authored
+  token pinned by name and kind nor a framework-owned property
+- **AND** the value-form re-pin only tightens the per-kind value-shape check,
+  leaving the name/kind/scope partition intact

--- a/openspec/changes/studio-ui-token-value-form/tasks.md
+++ b/openspec/changes/studio-ui-token-value-form/tasks.md
@@ -1,0 +1,92 @@
+## 1. OpenSpec Change (docs-only, this commit)
+
+- [x] 1.1 Author `proposal.md`, `design.md`, `tasks.md`, and the
+  `specs/studio-ui-design-sync/spec.md` delta (ADD the value-form requirement;
+  the name/kind/scope partition requirement from
+  `studio-ui-token-noise-disposition` survives unchanged).
+- [x] 1.2 Validate `bun run openspec -- validate studio-ui-token-value-form
+  --strict`; `git diff --check`; commit as the first stack branch.
+
+## 2. Atomic value-form flip (package + app, ONE branch — mid-states are mutually invalid)
+
+- [ ] 2.1 `packages/mapgen-studio-ui/src/styles/theme.css` (sole palette owner):
+  wrap every bare color triplet in the dark (`:root, .dark`) and light
+  (`.light`) palette blocks in `hsl()`; drop the `hsl()` wrapper on the 27
+  `@theme inline` entries (`hsl(var(--x))` → `var(--x)`); repoint the two
+  aliases (`--color-border-secondary`, `--color-text-muted`) to bare
+  `var(--other-token)`; consume `var(--x)` in the five base/component rules;
+  convert the single CSS alpha site (`hsl(var(--popover) / 0.95)`) to
+  `color-mix(in oklab, var(--popover) 95%, transparent)`.
+- [ ] 2.2 Migrate the 19 TS/TSX consumer sites across four files to `var(--x)`,
+  with the 14 alpha sites on `color-mix(in oklab, var(--x) N%, transparent)`:
+  `src/components/ui/sonner.tsx` (3 plain — `--normal-bg` is the silent-failure
+  hot spot); `src/components/panels/recipe-dag/PipelineStage.tsx` (6, incl. the
+  exported `PIPELINE_EDGE_INK`, gradients, and 4 SVG alpha);
+  `src/components/templates/StudioShellLayout.stories.tsx` (2 alpha — expect
+  these story bytes to change, moving their sourceKeys/gradeKeys);
+  `apps/mapgen-studio/src/app/CanvasStage.tsx` (7, all alpha).
+- [ ] 2.3 Re-pin the guard in the SAME commit as the flip:
+  `test/designTokens.test.ts` `VALUE_SHAPES.color` → the full-`hsl()` regex
+  (kept strict, no bare-triplet union), `VALUE_SHAPES.alias` → `/^var\(--[\w-]+\)$/`;
+  re-capture `test/fixtures/token-contract.json` from the new build and update
+  its `$comment` with the re-capture reason; leave `authored-tokens.json`
+  unchanged (it is value-free).
+- [ ] 2.4 Regenerate the committed `.design-sync/light-canary-tokens.json` by
+  re-running `scripts/light-canary.mjs` once (no script change — it is a
+  symmetric string compare).
+- [ ] 2.5 **Pre-commit trial-build gate:** confirm both compiles — the package
+  Tailwind CLI and the app Vite build — emit valid
+  `color-mix(in oklab, var(--x) N%, transparent)` over the new map for
+  opacity-modifier utilities before committing. If the app compile misbehaves,
+  STOP and reassess (do not commit a half-migrated theme).
+
+## 3. Knowledge surfaces + disposition revisions (docs-only branch)
+
+- [ ] 3.1 `packages/mapgen-studio-ui/docs/design-tokens.md`: rewrite the
+  value-form section (full `hsl()` values consumed as `var(--token)`; alpha =
+  `color-mix`); delete the mooted oxlint HSL-triplet note; keep the two
+  noise-finding classes (still true).
+- [ ] 3.2 `.design-sync/NOTES.md`: invert the explorations rule (bare
+  `var(--token)` is now correct; `hsl(var(--token))` is the broken legacy form)
+  and append the migration bullet.
+- [ ] 3.3 `docs/system/DEFERRALS.md` DEF-017: note upstream-feedback item 2
+  (triplet recognition) mooted by the migration; findings #1/#2 disposition
+  unchanged; add the trigger "post-upload check re-run shows `tokenKinds` now
+  labels authored colors correctly — else the value-form hypothesis is
+  falsified."
+- [ ] 3.4 Append the addendum to
+  `openspec/changes/studio-ui-token-noise-disposition/workstream/upstream-feedback.md`.
+
+## 4. Sync + upload + remote surgery (GATED on the user's explicit upload go-ahead)
+
+- [ ] 4.1 Build + `design-sync:check`; **force re-grade** per the NOTES
+  internals-wave rule (`compare.mjs --force`; four portal dialogs via the manual
+  full-page path) — this wave changes component internals and two story files.
+- [ ] 4.2 `light-canary` 7/7 zero drift; negative proof (mutate one token
+  value-shape → `designTokens` trips).
+- [ ] 4.3 **Snapshot first**, then edit the two remote-only explorations in the
+  live DS project: `DesignSync get_file` each → save under
+  `.design-sync/.cache/exploration-snapshots/` BEFORE any edit (they have no
+  repo copies — the only irreversible edge); rewrite `hsl(var(--x))` →
+  `var(--x)` and `hsl(var(--x) / a)` → `color-mix`; screenshot-verify.
+- [ ] 4.4 Atomic upload (`_ds_sync.json` last, `deletes: []`).
+- [ ] 4.5 **Falsifier check:** after the app self-check regenerates
+  `_adherence.oxlintrc.json` (or via a fresh design-check run), fetch it —
+  authored colors should now classify as `"color"`. If still `"other"`, the
+  value-form hypothesis is wrong; record in DEF-017 and do NOT iterate further
+  repo-side.
+
+## 5. Verification and closure
+
+- [ ] 5.1 Package suite + typecheck green at the stack tip with the re-pinned
+  value-shapes.
+- [ ] 5.2 Both builds green; the app Vite build emits valid `color-mix` over the
+  new map.
+- [ ] 5.3 `design-sync:check` 47/47 grades match post-force-regrade; `light-canary`
+  7/7.
+- [ ] 5.4 `bun run openspec -- validate studio-ui-token-value-form --strict` and
+  `git diff --check` green across the stack.
+- [ ] 5.5 Append the outcome to the `ds-sync-token-noise-disposition` memory file
+  after ship.
+- [ ] 5.6 Archive this change after the gated upload lands and its delta is
+  promoted per the change-management spec.


### PR DESCRIPTION
Docs-only control record for the token value-form migration (Step A of the adjudicated two-step: wrap authored values in full `hsl()`, consume via `var(--x)`; oklch re-authoring deferred to a separate design-led Step B).

- `proposal.md` / `design.md` / `tasks.md` + spec delta on `studio-ui-design-sync`: ADDs the requirement that authored color/alias tokens SHALL carry full CSS color values consumed as `var(--x)`. The existing name/kind/fixture-partition requirement survives unchanged.
- `design.md` records the Step-A/Step-B fork and the alpha adjudication (`color-mix(in oklab, var(--x) N%, transparent)` — Tailwind v4's own compiled form) with reasons.
- Validated: `openspec validate studio-ui-token-value-form --strict` → valid (openspec 1.5.0).

Stack: 1/3 (base). Implementation rides #2049; knowledge surfaces ride #2050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
