### PR TITLE
Add effect-smol source submodule with init/status scripts and docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule ".civ7/outputs/resources"]
 	path = .civ7/outputs/resources
 	url = https://github.com/mateicanavra/civ7-official-resources.git
+[submodule ".repos/effect"]
+	path = .repos/effect
+	url = https://github.com/Effect-TS/effect-smol.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,11 @@ See `docs/process/GRAPHITE.md` and `docs/process/LINEAR.md` for full conventions
 - Official game resources are maintained as a git submodule at `.civ7/outputs/resources` (published at `mateicanavra/civ7-official-resources`).
 - One-time + recurring workflow: see `docs/process/resources-submodule.md`.
 
+## Effect Source
+
+- `.repos/effect` is a source-only reference submodule; the Effect skill is supplied globally by RAWR HQ and must not be copied into Civ7.
+- Initialize and verify it with `bun run effect:init` and `bun run effect:status`; see `docs/process/effect-source-submodule.md`.
+
 ## Domain Routers
 
 - MapGen / Swooper Maps mod: `mods/mod-swooper-maps/AGENTS.md`, `docs/system/mods/swooper-maps/`, `docs/system/libs/mapgen/`.

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -10,6 +10,7 @@
 - [Graphite Workflow](process/GRAPHITE.md) — Stacked PR workflow
 - [Linear Conventions](process/LINEAR.md) — Issue management conventions
 - [Civ7 Resources Submodule](process/resources-submodule.md) — One-time setup + maintenance workflow
+- [Effect Source Submodule](process/effect-source-submodule.md) — Pinned, source-only Effect reference checkout
 
 ## Development
 

--- a/docs/process/effect-source-submodule.md
+++ b/docs/process/effect-source-submodule.md
@@ -1,0 +1,53 @@
+# Effect Source Submodule
+
+This repository keeps the Effect source at `.repos/effect` as a read-only
+reference checkout. It is source-only: Civ7 does not vendor or publish the
+Effect skill. RAWR HQ supplies that skill globally.
+
+The submodule uses the official repository:
+
+- `https://github.com/Effect-TS/effect-smol.git`
+- Current pin: `3f0ccc04711b0a187b973e20fc9c3010c2560da2`
+
+## Clone and initialize
+
+Clone a new checkout with all submodules:
+
+```bash
+git clone --recurse-submodules <repo-url>
+```
+
+For an existing checkout, or after pulling a reviewed gitlink change, run:
+
+```bash
+bun run effect:init
+bun run effect:status
+```
+
+`effect:init` runs `git submodule update --init --recursive -- .repos/effect`
+and verifies the resulting checkout. It does not use `--remote`, reset dirty
+work, or replace a conflicting path. `effect:status` verifies that the checkout
+is the configured submodule, clean, and at the commit recorded by the
+superproject gitlink.
+
+## Pin and update policy
+
+Effect source moves only through a reviewed update to the `.repos/effect`
+gitlink. There is no automatic remote update and no `effect:publish` command.
+Do not use `git submodule update --remote`; select and review a specific commit,
+then record that exact gitlink change in the superproject.
+
+## Transitioning an ignored Studio checkout
+
+Some Studio worktrees may already have a local `.repos/effect` clone hidden by
+the shared repository's common `info/exclude`. Before a future restack that
+adopts this gitlink, require that clone to be clean and checked out at
+`3f0ccc04711b0a187b973e20fc9c3010c2560da2`.
+
+After the worktree adopts and initializes the gitlink, remove
+`/.repos/effect/` from the common `info/exclude`. Git may emit a non-fatal
+`unable to rmdir` warning while adopting the path. The safest fallback is to
+move the clean local clone aside, run `bun run effect:init`, compare the
+initialized submodule with the backup, and remove the backup only after
+verification. Do not use `git submodule absorbgitdirs` for this shared-worktree
+transition.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "resources:publish": "bash ./packages/cli/scripts/resources-submodule/publish-submodule.sh",
     "resources:status": "bash ./packages/cli/scripts/resources-submodule/status.sh",
     "resources:unlock": "python3 ./packages/cli/scripts/resources-submodule/unlock-submodule.py",
+    "effect:init": "bash ./scripts/effect-submodule/init-submodule.sh",
+    "effect:status": "bash ./scripts/effect-submodule/status.sh",
     "refresh:data": "bun run resources:init && nx run civ7-cli:data:zip:default && nx run civ7-cli:data:unzip:default",
     "ci:architecture-strict-core": "bun habitat check --runner grit && bun habitat check --runner habitat",
     "deploy:mods": "nx run-many --targets=deploy",

--- a/scripts/effect-submodule/init-submodule.sh
+++ b/scripts/effect-submodule/init-submodule.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
+
+ROOT="$(git rev-parse --show-toplevel)"
+ROOT="$(cd "$ROOT" && pwd -P)"
+cd "$ROOT"
+
+SUBMODULE_REL=".repos/effect"
+EXPECTED_URL="https://github.com/Effect-TS/effect-smol.git"
+
+if [[ ! -f ".gitmodules" ]]; then
+  echo "effect-submodule: not configured (.gitmodules missing); nothing to init"
+  exit 0
+fi
+
+CONFIGURED_PATH="$(git config -f ".gitmodules" --get "submodule.${SUBMODULE_REL}.path" 2>/dev/null || true)"
+if [[ "$CONFIGURED_PATH" != "$SUBMODULE_REL" ]]; then
+  echo "effect-submodule: not configured ($SUBMODULE_REL missing from .gitmodules); nothing to init"
+  exit 0
+fi
+
+CONFIGURED_URL="$(git config -f ".gitmodules" --get "submodule.${SUBMODULE_REL}.url" 2>/dev/null || true)"
+if [[ "$CONFIGURED_URL" != "$EXPECTED_URL" ]]; then
+  echo "effect-submodule: unexpected URL for $SUBMODULE_REL" >&2
+  echo "Expected: $EXPECTED_URL" >&2
+  echo "Actual:   ${CONFIGURED_URL:-<missing>}" >&2
+  exit 1
+fi
+
+GITLINK_ENTRY="$(git ls-files --stage -- "$SUBMODULE_REL")"
+if [[ -z "$GITLINK_ENTRY" || "$GITLINK_ENTRY" == *$'\n'* ]]; then
+  echo "effect-submodule: $SUBMODULE_REL does not have one recorded gitlink" >&2
+  exit 1
+fi
+
+read -r GITLINK_MODE RECORDED_COMMIT GITLINK_STAGE _ <<< "$GITLINK_ENTRY"
+if [[ "$GITLINK_MODE" != "160000" || "$GITLINK_STAGE" != "0" ]]; then
+  echo "effect-submodule: $SUBMODULE_REL is not a stage-0 gitlink" >&2
+  exit 1
+fi
+
+checkout_is_expected() {
+  [[ -d "$SUBMODULE_REL" ]] || return 1
+
+  local expected_toplevel actual_toplevel superproject_toplevel expected_git_dir actual_git_dir
+  expected_toplevel="$(cd "$SUBMODULE_REL" && pwd -P)"
+  actual_toplevel="$(git -C "$SUBMODULE_REL" rev-parse --show-toplevel 2>/dev/null || true)"
+  superproject_toplevel="$(git -C "$SUBMODULE_REL" rev-parse --show-superproject-working-tree 2>/dev/null || true)"
+  expected_git_dir="$(git rev-parse --git-path "modules/$SUBMODULE_REL")"
+  actual_git_dir="$(git -C "$SUBMODULE_REL" rev-parse --absolute-git-dir 2>/dev/null || true)"
+
+  if [[ "$expected_git_dir" != /* ]]; then
+    expected_git_dir="$ROOT/$expected_git_dir"
+  fi
+
+  [[ "$actual_toplevel" == "$expected_toplevel" &&
+    "$superproject_toplevel" == "$ROOT" &&
+    "$actual_git_dir" == "$expected_git_dir" ]]
+}
+
+if [[ -e "$SUBMODULE_REL" || -L "$SUBMODULE_REL" ]]; then
+  if [[ ! -d "$SUBMODULE_REL" ]]; then
+    echo "effect-submodule: conflicting non-directory path at $SUBMODULE_REL" >&2
+    echo "Move it aside, then run: bun run effect:init" >&2
+    exit 1
+  fi
+
+  if [[ -n "$(find "$SUBMODULE_REL" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    if ! checkout_is_expected; then
+      echo "effect-submodule: $SUBMODULE_REL is not the configured submodule checkout" >&2
+      echo "The existing path was left unchanged. Move it aside, then run: bun run effect:init" >&2
+      exit 1
+    fi
+
+    if [[ -n "$(git -C "$SUBMODULE_REL" status --porcelain=v1 --untracked-files=all)" ]]; then
+      echo "effect-submodule: dirty source checkout; local edits were preserved" >&2
+      exit 2
+    fi
+  fi
+fi
+
+git submodule update --init --recursive -- "$SUBMODULE_REL"
+
+if ! checkout_is_expected; then
+  echo "effect-submodule: initialization did not produce the configured submodule checkout" >&2
+  exit 1
+fi
+
+if [[ -n "$(git -C "$SUBMODULE_REL" status --porcelain=v1 --untracked-files=all)" ]]; then
+  echo "effect-submodule: dirty source checkout after initialization; local edits were preserved" >&2
+  exit 2
+fi
+
+ACTUAL_COMMIT="$(git -C "$SUBMODULE_REL" rev-parse HEAD)"
+if [[ "$ACTUAL_COMMIT" != "$RECORDED_COMMIT" ]]; then
+  echo "effect-submodule: checkout does not match the recorded gitlink" >&2
+  echo "Expected: $RECORDED_COMMIT" >&2
+  echo "Actual:   $ACTUAL_COMMIT" >&2
+  exit 3
+fi
+
+echo "effect-submodule: initialized and clean at $ACTUAL_COMMIT"

--- a/scripts/effect-submodule/status.sh
+++ b/scripts/effect-submodule/status.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
+
+ROOT="$(git rev-parse --show-toplevel)"
+ROOT="$(cd "$ROOT" && pwd -P)"
+cd "$ROOT"
+
+SUBMODULE_REL=".repos/effect"
+EXPECTED_URL="https://github.com/Effect-TS/effect-smol.git"
+
+if [[ ! -f ".gitmodules" ]]; then
+  echo "effect-submodule: not configured (.gitmodules missing); nothing to check"
+  exit 0
+fi
+
+CONFIGURED_PATH="$(git config -f ".gitmodules" --get "submodule.${SUBMODULE_REL}.path" 2>/dev/null || true)"
+if [[ "$CONFIGURED_PATH" != "$SUBMODULE_REL" ]]; then
+  echo "effect-submodule: not configured ($SUBMODULE_REL missing from .gitmodules); nothing to check"
+  exit 0
+fi
+
+CONFIGURED_URL="$(git config -f ".gitmodules" --get "submodule.${SUBMODULE_REL}.url" 2>/dev/null || true)"
+if [[ "$CONFIGURED_URL" != "$EXPECTED_URL" ]]; then
+  echo "effect-submodule: unexpected URL for $SUBMODULE_REL" >&2
+  echo "Expected: $EXPECTED_URL" >&2
+  echo "Actual:   ${CONFIGURED_URL:-<missing>}" >&2
+  exit 1
+fi
+
+GITLINK_ENTRY="$(git ls-files --stage -- "$SUBMODULE_REL")"
+if [[ -z "$GITLINK_ENTRY" || "$GITLINK_ENTRY" == *$'\n'* ]]; then
+  echo "effect-submodule: $SUBMODULE_REL does not have one recorded gitlink" >&2
+  echo "Run: bun run effect:init" >&2
+  exit 1
+fi
+
+read -r GITLINK_MODE RECORDED_COMMIT GITLINK_STAGE _ <<< "$GITLINK_ENTRY"
+if [[ "$GITLINK_MODE" != "160000" || "$GITLINK_STAGE" != "0" ]]; then
+  echo "effect-submodule: $SUBMODULE_REL is not a stage-0 gitlink" >&2
+  echo "Run: bun run effect:init" >&2
+  exit 1
+fi
+
+if [[ ! -d "$SUBMODULE_REL" ]]; then
+  echo "effect-submodule: not initialized (directory missing)" >&2
+  echo "Run: bun run effect:init" >&2
+  exit 1
+fi
+
+if [[ -z "$(find "$SUBMODULE_REL" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+  echo "effect-submodule: not initialized (directory empty)" >&2
+  echo "Run: bun run effect:init" >&2
+  exit 1
+fi
+
+EXPECTED_TOPLEVEL="$(cd "$SUBMODULE_REL" && pwd -P)"
+ACTUAL_TOPLEVEL="$(git -C "$SUBMODULE_REL" rev-parse --show-toplevel 2>/dev/null || true)"
+SUPERPROJECT_TOPLEVEL="$(git -C "$SUBMODULE_REL" rev-parse --show-superproject-working-tree 2>/dev/null || true)"
+EXPECTED_GIT_DIR="$(git rev-parse --git-path "modules/$SUBMODULE_REL")"
+ACTUAL_GIT_DIR="$(git -C "$SUBMODULE_REL" rev-parse --absolute-git-dir 2>/dev/null || true)"
+if [[ "$EXPECTED_GIT_DIR" != /* ]]; then
+  EXPECTED_GIT_DIR="$ROOT/$EXPECTED_GIT_DIR"
+fi
+
+if [[ "$ACTUAL_TOPLEVEL" != "$EXPECTED_TOPLEVEL" ||
+  "$SUPERPROJECT_TOPLEVEL" != "$ROOT" ||
+  "$ACTUAL_GIT_DIR" != "$EXPECTED_GIT_DIR" ]]; then
+  echo "effect-submodule: $SUBMODULE_REL is not the configured submodule checkout" >&2
+  echo "The existing path was left unchanged. Move it aside, then run: bun run effect:init" >&2
+  exit 1
+fi
+
+if [[ -n "$(git -C "$SUBMODULE_REL" status --porcelain=v1 --untracked-files=all)" ]]; then
+  echo "effect-submodule: dirty source checkout; local edits were preserved" >&2
+  exit 2
+fi
+
+ACTUAL_COMMIT="$(git -C "$SUBMODULE_REL" rev-parse HEAD)"
+if [[ "$ACTUAL_COMMIT" != "$RECORDED_COMMIT" ]]; then
+  echo "effect-submodule: checkout does not match the recorded gitlink" >&2
+  echo "Expected: $RECORDED_COMMIT" >&2
+  echo "Actual:   $ACTUAL_COMMIT" >&2
+  echo "Run: bun run effect:init" >&2
+  exit 3
+fi
+
+echo "effect-submodule: clean at $ACTUAL_COMMIT"


### PR DESCRIPTION
Adds `.repos/effect` as a pinned, read-only git submodule pointing to `Effect-TS/effect-smol` at commit `3f0ccc047`. This submodule serves as a source-only reference; the Effect skill is supplied globally by RAWR HQ and is not vendored into Civ7.

Two scripts back the submodule lifecycle:

- `effect:init` (`scripts/effect-submodule/init-submodule.sh`) — validates the `.gitmodules` configuration and URL, checks for conflicting or dirty paths, runs `git submodule update --init --recursive`, and confirms the resulting checkout matches the recorded gitlink. Refuses to overwrite a non-submodule directory and exits with a distinct code if the checkout is dirty.
- `effect:status` (`scripts/effect-submodule/status.sh`) — verifies that the submodule is initialized, linked to the correct git dir, clean, and at the commit recorded by the superproject gitlink.

Both scripts are exposed as `bun run effect:init` and `bun run effect:status`. The pin advances only through a reviewed gitlink change; `--remote` updates are explicitly disallowed.

`AGENTS.md` and `docs/PROCESS.md` are updated to document the submodule's purpose and point to the new `docs/process/effect-source-submodule.md` guide, which covers clone setup, the update policy, and the transition path for Studio worktrees that already have a local `.repos/effect` clone excluded via `info/exclude`.