### PR TITLE
refactor(civ7-orpc-control-architecture): delegate generic oRPC guidance to global skills

### DIFF
--- a/.agents/skills/civ7-orpc-control-architecture/SKILL.md
+++ b/.agents/skills/civ7-orpc-control-architecture/SKILL.md
@@ -13,6 +13,13 @@ support. The frame is: oRPC is a typed procedure/router/context layer over
 repo-owned control capabilities; it is not the authority for Civ7 runtime
 behavior and it is not a replacement transport for `@civ7/direct-control`.
 
+General oRPC semantics and current vendor guidance are owned by the global
+`dev:orpc` skill. When an Effect computation crosses the procedure boundary,
+the provider bridge is owned by global `dev:effect-orpc` together with the
+matching `dev:effect-ts` lane. This skill is the Civ7 overlay: package
+ownership, control topology, caller boundaries, live-play safety, and proof
+classification. Do not duplicate generic vendor guidance here.
+
 This layer is IMPLEMENTED: `@civ7/control-orpc`
 (`packages/civ7-control-orpc`) is the native oRPC+Effect procedure
 composition over direct-control atoms — contract-first TypeBox schemas
@@ -45,8 +52,10 @@ plain async.
 
 ## Default Workflow
 
-1. **Ground authority.** Read root `AGENTS.md`, the closest package router, and
-   the Civ7 architecture/product authority skills.
+1. **Ground authority.** Read root `AGENTS.md`, the closest package router,
+   global `dev:orpc`, and the Civ7 architecture/product authority skills. For
+   an Effect-backed procedure, also load global `dev:effect-orpc` and the
+   matching `dev:effect-ts` lane after identifying the installed package tuple.
 2. **Name the capability.** Identify the repo-owned behavior: runtime read,
    mutating operation, live-play decision view, Studio endpoint, or CLI command
    orchestration.
@@ -80,7 +89,9 @@ plain async.
 
 | Reference | Path | Open When |
 |---|---|---|
-| ORPC server shape | `references/orpc-server-shape.md` | You need the exact official oRPC concepts to apply: procedure, router, middleware, context, server-side calls, tests. |
+| Global oRPC authority | `dev:orpc` | Always, before interpreting or changing native oRPC contracts, routers, middleware, context, transports, clients, or tests. |
+| Global Effect-oRPC authority | `dev:effect-orpc` + `dev:effect-ts` | An Effect computation crosses an oRPC procedure boundary; select the exact installed provider and Effect lane. |
+| Civ7 oRPC integration boundary | `references/orpc-server-shape.md` | You need the repo-specific package wiring and caller boundary after loading the applicable global authority. |
 | Civ7 procedure map | `references/civ7-procedure-map.md` | You are mapping direct-control/CLI/Studio behavior into procedure/router/context/middleware atoms. |
 | Migration gates | `references/migration-gates.md` | You are planning an incremental slice or deciding what tests/proof must pass before handoff. |
 | Failure patterns | `references/failure-patterns.md` | A proposed oRPC refactor smells like a wrapper, broad transport, unsafe mutation, or relationship-authority leak. |
@@ -106,9 +117,11 @@ plain async.
 
 ## Quick Start
 
-1. Open `references/orpc-server-shape.md`.
-2. Open `references/civ7-procedure-map.md` for the affected surface.
-3. Copy `assets/procedure-slice-preflight.md` into the project note if the slice
+1. Load global `dev:orpc`; for an Effect-backed procedure, also load
+   `dev:effect-orpc` and the matching `dev:effect-ts` lane.
+2. Open `references/orpc-server-shape.md` for Civ7-specific integration facts.
+3. Open `references/civ7-procedure-map.md` for the affected surface.
+4. Copy `assets/procedure-slice-preflight.md` into the project note if the slice
    will be implemented.
-4. Run `references/migration-gates.md` before handoff.
-5. Check `references/failure-patterns.md` during review.
+5. Run `references/migration-gates.md` before handoff.
+6. Check `references/failure-patterns.md` during review.

--- a/.agents/skills/civ7-orpc-control-architecture/references/orpc-server-shape.md
+++ b/.agents/skills/civ7-orpc-control-architecture/references/orpc-server-shape.md
@@ -1,60 +1,17 @@
-# ORPC Server Shape
+# Civ7 oRPC Integration Boundary
 
-## Version And Source Posture
+## Authority Boundary
 
-Official docs were checked on 2026-06-02. The current npm version observed for
-`@orpc/server`, `@orpc/client`, and `@orpc/openapi` was `1.14.4`.
-Re-check versions and official docs before implementation because oRPC moves
-quickly.
+Load global `dev:orpc` for native oRPC contracts, builders, routers,
+middleware, context, transports, clients, testing, and current vendor guidance.
+When an Effect computation crosses the procedure boundary, load global
+`dev:effect-orpc` and the matching `dev:effect-ts` lane after identifying the
+exact installed package tuple.
 
-Primary official docs:
-
-- Procedure: https://orpc.dev/docs/procedure
-- Router: https://orpc.dev/docs/router
-- Middleware: https://orpc.dev/docs/middleware
-- Context: https://orpc.dev/docs/context
-- RPC handler: https://orpc.dev/docs/rpc-handler
-- RPC link: https://orpc.dev/docs/client/rpc-link
-- Server-side clients: https://orpc.dev/docs/client/server-side
-- Testing and mocking: https://orpc.dev/docs/advanced/testing-mocking
-
-## Concepts To Apply
-
-**Procedure:** a typed function-like unit with optional input/output validation,
-middleware, dependency injection, handler logic, and callable/server-action
-helpers. Only `.handler` is required, but Civ7 control procedures should usually
-declare input/output shape explicitly to keep command/API drift visible.
-
-**Router:** a plain, nestable object of procedures. Routers can be wrapped with
-middleware, but do not apply the same middleware at router and procedure levels
-without checking for duplicate execution.
-
-**Middleware:** reusable code that calls `next`, can run before/after a handler,
-can inject or guard context, can inspect typed input, can modify output, and can
-be concatenated/mapped. This is the right place for repeated Civ7 policy:
-readiness, approval, validator-first mutation, proof collection, relationship
-label authority, and error normalization.
-
-**Context:** type-safe dependency injection. Initial context is passed by the
-caller/handler invocation; execution context is computed during procedure
-execution, usually via middleware. For Civ7, use context for direct-control
-facades, endpoint defaults, live-session policy, approval metadata, logger/proof
-sinks, clocks, and fakes.
-
-**Server-side clients:** oRPC supports local procedure invocation without a
-network proxy using `.callable`, `call`, and `createRouterClient`. This is the
-default migration target for CLI, tests, and Studio server-side code that does
-not cross a browser/network boundary.
-
-**RPC HTTP boundary:** oRPC also supports `RPCHandler` plus `RPCLink` over
-HTTP/Fetch. This is the natural Studio browser-to-server boundary: the browser
-gets a typed client, the server keeps the same router/procedure policy, and the
-runtime direct-control surface stays server-side.
-
-**Testing/mocking:** official docs support direct procedure invocation in tests
-and alternative implementations through the implementer. Use this to test
-procedure atoms with fake direct-control dependencies before wiring CLI/Studio
-callers.
+This reference owns only Civ7-specific integration facts. The workspace
+manifest and lockfile own installed versions; the global skills do not authorize
+an implicit dependency upgrade. Do not add vendor documentation summaries or
+generic oRPC examples here.
 
 ## In-Repo Implementation (effect-orpc)
 
@@ -81,7 +38,7 @@ which lets procedures be Effect programs instead of plain async handlers:
   fibers — prefer them over hand-rolled async coordination when orchestration
   grows.
 
-## Civ7 Implication
+## Civ7 Caller Boundary
 
 Start with the shared router/procedure core, then choose the caller boundary.
 CLI and tests should normally use server-side/in-process calls


### PR DESCRIPTION
## Summary

- Route generic oRPC authority to the global `dev:orpc` skill.
- Route Effect-backed oRPC integration to global `dev:effect-orpc` plus the matching `dev:effect-ts` lane.
- Remove the dated vendor summary from the Civ7 reference while retaining Civ7 package wiring, direct-control ownership, caller boundaries, live-play policy, and proof classification.

## Behavior

Agents now load the global skills before applying Civ7's local architecture overlay. The workspace manifest and lockfile remain the installed-version authority, so global guidance cannot silently upgrade Civ7 dependencies. No runtime code, package version, or generated artifact changed.

This is the Civ7 lifecycle follow-through for the landed RAWR HQ oRPC/effect-oRPC skillset (rawr-ai/rawr-hq#168; personal main `cb808ece6ccc8418fe141d0a180318a9572ab8a4`).

## Verification

- `bun install --frozen-lockfile`
- `bun run build`
- `bun run lint`
- `bun habitat verify --base main` (112 Habitat rules, 0 failures; no affected Nx tasks)
- `git diff --check`

## Review

1. Confirm `.agents/skills/civ7-orpc-control-architecture/SKILL.md` routes generic and provider guidance to the global skills.
2. Confirm `references/orpc-server-shape.md` contains only Civ7-specific integration facts and local policy.
3. Confirm the diff contains no dependency, runtime, or copied vendor-guidance changes.