### PR TITLE
feat(foundation-orogeny): expose public `crustCharacter` config surface

### DIFF
--- a/.habitat/blueprints/mod-map/validate_generated_map_entrypoint_contracts/check.ts
+++ b/.habitat/blueprints/mod-map/validate_generated_map_entrypoint_contracts/check.ts
@@ -3,24 +3,20 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { CatalogSourceIndex } from "../../../../mods/mod-swooper-maps/src/maps/catalog/sourceIndex";
+import {
+  catalogConfigFileNameFromPath,
+  parseCatalogSourceIndex,
+} from "../../../../mods/mod-swooper-maps/src/maps/catalog/sources";
+import { validateCanonicalMapConfig } from "../../../../mods/mod-swooper-maps/src/maps/configs/canonical";
+import { STANDARD_STAGES } from "../../../../mods/mod-swooper-maps/src/recipes/standard/recipe";
+import { deriveRecipeConfigSchema } from "../../../../packages/mapgen-core/src/authoring/index";
 
 const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
   encoding: "utf8",
 }).trim();
 const modRoot = join(repoRoot, "mods/mod-swooper-maps");
-const TRANSIENT_STUDIO_CONFIGS = new Set(["studio-current.config.json"]);
 const failures: string[] = [];
-
-const { STANDARD_STAGES } = await import(
-  pathToFileURL(join(modRoot, "src/recipes/standard/recipe.ts")).href
-);
-const { deriveRecipeConfigSchema } = await import(
-  pathToFileURL(join(repoRoot, "packages/mapgen-core/src/authoring/index.ts")).href
-);
-const { validateCanonicalMapConfig } = await import(
-  pathToFileURL(join(modRoot, "src/maps/configs/canonical.ts")).href
-);
 
 function canonicalize(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(canonicalize);
@@ -64,29 +60,28 @@ function createMapConfigExpression(source: string): string | null {
   return source.match(/\n\s+config:\s*([^,\n]+),?\n\}\);/)?.[1]?.trim() ?? null;
 }
 
-const configsDir = join(modRoot, "src/maps/configs");
 const generatedDir = join(modRoot, "src/maps/generated");
-const configIds = readdirSync(configsDir)
-  .filter((entry) => entry.endsWith(".config.json"))
-  .filter((entry) => !TRANSIENT_STUDIO_CONFIGS.has(entry))
-  .map((entry) => entry.replace(/\.config\.json$/, ""))
+const catalogEntries = [...parseCatalogSourceIndex(CatalogSourceIndex).entries];
+const configIds = catalogEntries
+  .map((entry) => catalogConfigFileNameFromPath(entry.configPath).replace(/\.config\.json$/, ""))
   .sort();
 const generatedIds = readdirSync(generatedDir)
   .filter((entry) => entry.endsWith(".ts"))
-  .filter((entry) => !TRANSIENT_STUDIO_CONFIGS.has(entry.replace(/\.ts$/, ".config.json")))
   .map((entry) => entry.replace(/\.ts$/, ""))
   .sort();
 
 if (JSON.stringify(generatedIds) !== JSON.stringify(configIds)) {
   failures.push(
-    `generated map ids differ from config ids: ${JSON.stringify(generatedIds)} !== ${JSON.stringify(configIds)}`
+    `generated map ids differ from catalog source ids: ${JSON.stringify(generatedIds)} !== ${JSON.stringify(configIds)}`
   );
 }
 
-for (const id of configIds) {
-  const rawConfig = JSON.parse(readFileSync(join(configsDir, `${id}.config.json`), "utf8"));
+for (const entry of catalogEntries) {
+  const fileName = catalogConfigFileNameFromPath(entry.configPath);
+  const id = fileName.replace(/\.config\.json$/, "");
+  const rawConfig = JSON.parse(readFileSync(join(repoRoot, entry.configPath), "utf8"));
   const mapConfig = validateCanonicalMapConfig({
-    fileName: `${id}.config.json`,
+    fileName,
     raw: rawConfig,
     recipeSchema: deriveRecipeConfigSchema(STANDARD_STAGES),
     stages: STANDARD_STAGES,

--- a/.habitat/civ7/mapgen/pipeline/swooper-maps-standard-recipe/rules/verify_standard_recipe_public_authoring_surface/check.ts
+++ b/.habitat/civ7/mapgen/pipeline/swooper-maps-standard-recipe/rules/verify_standard_recipe_public_authoring_surface/check.ts
@@ -1,18 +1,6 @@
 #!/usr/bin/env bun
-import { execFileSync } from "node:child_process";
-import { join } from "node:path";
-import { pathToFileURL } from "node:url";
-
-const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
-  encoding: "utf8",
-}).trim();
-
-const { STANDARD_STAGES } = await import(
-  pathToFileURL(join(repoRoot, "mods/mod-swooper-maps/src/recipes/standard/recipe.ts")).href
-);
-const { deriveStageAuthoringModel } = await import(
-  pathToFileURL(join(repoRoot, "packages/mapgen-core/src/authoring/index.ts")).href
-);
+import { STANDARD_STAGES } from "../../../../../../../mods/mod-swooper-maps/src/recipes/standard/recipe";
+import { deriveStageAuthoringModel } from "../../../../../../../packages/mapgen-core/src/authoring/index";
 
 const STANDARD_PUBLIC_KEYS: Record<string, readonly string[]> = {
   "foundation-mantle": ["knobs", "mantleForcing", "mantleSources", "meshResolution"],
@@ -25,7 +13,7 @@ const STANDARD_PUBLIC_KEYS: Record<string, readonly string[]> = {
     "tectonicRollups",
     "tectonicSegmentation",
   ],
-  "foundation-orogeny": ["knobs", "crust-evolution"],
+  "foundation-orogeny": ["knobs", "crustCharacter"],
   "foundation-projection": ["knobs"],
   "morphology-coasts": [
     "knobs",

--- a/apps/mapgen-studio/test/config/defaultConfigSchema.test.ts
+++ b/apps/mapgen-studio/test/config/defaultConfigSchema.test.ts
@@ -789,7 +789,7 @@ describe("Studio default config", () => {
         "tectonicRollups",
         "tectonicSegmentation",
       ],
-      "foundation-orogeny": ["knobs", "crust-evolution"],
+      "foundation-orogeny": ["knobs", "crustCharacter"],
       "foundation-projection": ["knobs"],
     };
 
@@ -811,10 +811,8 @@ describe("Studio default config", () => {
       expect(stageProps).not.toHaveProperty("plate-graph");
       expect(stageProps).not.toHaveProperty("plate-motion");
       expect(stageProps).not.toHaveProperty("tectonics");
-      if (stageId !== "foundation-orogeny") {
-        expect(JSON.stringify(stageProps)).not.toContain('"strategy"');
-        expect(JSON.stringify(stageProps)).not.toContain('"config"');
-      }
+      expect(JSON.stringify(stageProps)).not.toContain('"strategy"');
+      expect(JSON.stringify(stageProps)).not.toContain('"config"');
     }
     const foundationProps = (
       rootProps["foundation-mantle"] as { properties?: Record<string, unknown> }
@@ -857,6 +855,10 @@ describe("Studio default config", () => {
         "regimeMinIntensity",
       ]),
       "foundation-tectonics.tectonicSegmentation.regimeMinIntensity"
+    );
+    expectSchemaHasDescription(
+      getSchemaAtPath(STANDARD_RECIPE_CONFIG_SCHEMA, ["foundation-orogeny", "crustCharacter"]),
+      "foundation-orogeny.crustCharacter"
     );
 
     const rootProps =

--- a/apps/mapgen-studio/test/config/standardRecipeArtifactGuards.test.ts
+++ b/apps/mapgen-studio/test/config/standardRecipeArtifactGuards.test.ts
@@ -7,6 +7,7 @@ import {
 import { describe, expect, it } from "vitest";
 import { getRuntimeRecipe } from "../../src/browser-runner/recipeRuntime";
 import { migratePipelineConfigUnknown } from "../../src/features/configMigrations/pipelineConfig";
+import { applyPresetConfig } from "../../src/features/configOverrides/configBuilders";
 import {
   DEFAULT_STUDIO_RECIPE_ID,
   getRecipeArtifacts,
@@ -103,6 +104,13 @@ describe("standard recipe generated artifact guardrails", () => {
         getConfigAtPath(stageDefaults, focusPath);
       }
     }
+
+    const foundationOrogenyDefaults = (STANDARD_RECIPE_CONFIG as Record<string, unknown>)[
+      "foundation-orogeny"
+    ];
+    expect(foundationOrogenyDefaults).toHaveProperty("crustCharacter");
+    expect(foundationOrogenyDefaults).not.toHaveProperty("crust-evolution");
+    expect(hasRawOpEnvelope(foundationOrogenyDefaults)).toBe(false);
   });
 
   it("keeps built-in standard map presets on generated public schema", () => {
@@ -114,12 +122,25 @@ describe("standard recipe generated artifact guardrails", () => {
       expect(hasRawOpEnvelope(preset.config), `${preset.id} public config raw envelopes`).toBe(
         false
       );
+      expect(
+        (preset.config as Record<string, unknown>)["foundation-orogeny"] ?? {}
+      ).not.toHaveProperty("crust-evolution");
       const { errors } = normalizeStrict<Record<string, unknown>>(
         STANDARD_RECIPE_CONFIG_SCHEMA,
         preset.config,
         `/studio/presets/${preset.id}`
       );
       expect(errors).toEqual([]);
+
+      const applied = applyPresetConfig({
+        schema: STANDARD_RECIPE_CONFIG_SCHEMA,
+        uiMeta: STANDARD_RECIPE_UI_META,
+        presetConfig: preset.config,
+        label: preset.id,
+      });
+      expect(applied.errors, `${preset.id} applied preset errors`).toEqual([]);
+      expect(applied.value?.["foundation-orogeny"]).not.toHaveProperty("crust-evolution");
+      expect(hasRawOpEnvelope(applied.value?.["foundation-orogeny"])).toBe(false);
     }
   });
 

--- a/apps/mapgen-studio/test/presets/importFlow.test.ts
+++ b/apps/mapgen-studio/test/presets/importFlow.test.ts
@@ -40,4 +40,42 @@ describe("resolveImportedPreset", () => {
       expect(result.details?.length ?? 0).toBeGreaterThan(0);
     }
   });
+
+  it("rejects imported legacy Foundation Orogeny envelopes instead of migrating them", () => {
+    const presetFile: StudioPresetExportFileV1 = {
+      $schema: "https://civ7.tools/schemas/mapgen-studio/studio-preset-export.v1.schema.json",
+      version: 1,
+      recipeId: "mod-swooper-maps/standard",
+      preset: {
+        label: "Legacy Foundation Orogeny",
+        config: {
+          "foundation-orogeny": {
+            "crust-evolution": {
+              computeCrustEvolution: {
+                strategy: "default",
+                config: {
+                  continentalSurvivalMaturity: 0.6,
+                  continentalFreeboard: 0.35,
+                  hyperextensionBreakupBase: 0.1,
+                  thinningThicknessLoss: 0.55,
+                  oceanicAbyssalDepth: 0.75,
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = resolveImportedPreset({ presetFile, findRecipeArtifacts });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.kind).toBe("invalid-config");
+      expect(result.details).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("/preset/import/foundation-orogeny/crust-evolution"),
+        ])
+      );
+    }
+  });
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-orogeny/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-orogeny/index.ts
@@ -1,9 +1,12 @@
 import { createStage, Type } from "@swooper/mapgen-core/authoring";
 import { orderStandardStageSteps } from "../../contract-manifest.js";
+import {
+  compileFoundationOrogenyPublicConfig,
+  FoundationOrogenyPublicSchema,
+} from "../foundation-public-config.js";
 import { crustEvolution } from "./steps/index.js";
 
 const FoundationContinentalAbundanceKnobSchema = Type.Number({
-  default: 0.5,
   minimum: 0,
   maximum: 1,
   description:
@@ -11,20 +14,14 @@ const FoundationContinentalAbundanceKnobSchema = Type.Number({
 });
 
 const FoundationContinentalReliefKnobSchema = Type.Number({
-  default: 0.5,
   minimum: 0,
   maximum: 1,
   description:
     "Continental relief scalar in [0..1]. Couples freeboard (up) + shelf/basin depth (up) + abyssal depth (up): 0.5 = earthlike, →1 tall continents/deep shelves/deep ocean, →0 low/shallow. foundation-orogeny.",
 });
 
-/** Foundation / Orogeny — final crust from initial crust + tectonic history (the merge stage). */
 export default createStage({
   id: "foundation-orogeny",
-  // High-level coupled crust-character levers. Each expresses one author intent across coupled
-  // compute-crust-evolution properties (abundance → survival + breakup-resistance; relief → freeboard
-  // + shelf depth + abyssal depth). 0.5 = earthlike. Optional: unset ⇒ the raw op config (surfaced)
-  // is left untouched; set ⇒ the lever overrides its coupled pair.
   knobsSchema: Type.Object(
     {
       continentalAbundance: Type.Optional(FoundationContinentalAbundanceKnobSchema),
@@ -36,6 +33,9 @@ export default createStage({
         "Crust-character levers: continentalAbundance (land vs ocean) and continentalRelief (continent/shelf drama).",
     }
   ),
+  public: FoundationOrogenyPublicSchema,
+  compile: ({ config }: { config: Record<string, unknown> }) =>
+    compileFoundationOrogenyPublicConfig(config),
   steps: orderStandardStageSteps("foundation-orogeny", {
     "crust-evolution": crustEvolution,
   }),

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-orogeny/steps/crustEvolution.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-orogeny/steps/crustEvolution.ts
@@ -19,10 +19,8 @@ export default createStep(CrustEvolutionStepContract, {
       validate: (value) => foundationArtifactValidators.crust(value),
     },
   }),
-  // The crust-character knobs are high-level coupled levers: each, when an author sets it, overrides
-  // its coupled compute-crust-evolution properties (abundance → survival + breakup-resistance;
-  // relief → freeboard + shelf depth + abyssal depth). Unset levers leave the raw op config (internal-as-public)
-  // untouched, so granular per-property authoring still works.
+  // Explicit knobs remain late semantic overrides over public crustCharacter; omitted knobs stay
+  // undefined so they cannot replace authored crust-character fields with neutral defaults.
   normalize: (config, ctx) => {
     const { continentalAbundance, continentalRelief } = ctx.knobs as Readonly<{
       continentalAbundance?: number;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-public-config.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation-public-config.ts
@@ -1,6 +1,7 @@
-import { type TSchema, Type } from "typebox";
+import { type Static, type TSchema, Type } from "typebox";
 import { crust, plateGraph } from "./foundation-lithosphere/steps/index.js";
 import { mantleForcing, mantlePotential, mesh } from "./foundation-mantle/steps/index.js";
+import { crustEvolution } from "./foundation-orogeny/steps/index.js";
 import { plateMotion, tectonics } from "./foundation-tectonics/steps/index.js";
 
 function defaultStrategyConfigSchema(
@@ -97,6 +98,11 @@ const TectonicRollupsSchema = defaultStrategyConfigSchema(
   "Tectonic rollup controls. These fields determine how per-era activity is summarized into current history scalars."
 );
 
+const CrustCharacterSchema = defaultStrategyConfigSchema(
+  opConfigSchema(crustEvolution.contract.ops, "computeCrustEvolution"),
+  "Crust character controls. These semantic fields shape continental abundance, freeboard, fragmentation, shelf depth, and abyssal relief."
+);
+
 function defaultOp(config: unknown) {
   return {
     strategy: "default" as const,
@@ -157,6 +163,19 @@ export const FoundationTectonicsPublicSchema = Type.Object(
   }
 );
 
+export const FoundationOrogenyPublicSchema = Type.Object(
+  {
+    crustCharacter: Type.Optional(CrustCharacterSchema),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Foundation orogeny authoring controls for final crust character after initial crust and tectonic history are merged.",
+  }
+);
+
+export type FoundationOrogenyPublicConfig = Static<typeof FoundationOrogenyPublicSchema>;
+
 export function compileFoundationMantlePublicConfig(config: Record<string, unknown>) {
   const rawSteps: Record<string, unknown> = {};
   assignIfDefined(rawSteps, "mesh", stepOp("computeMesh", config.meshResolution));
@@ -204,5 +223,18 @@ export function compileFoundationTectonicsPublicConfig(config: Record<string, un
   );
   if (Object.keys(tectonicsConfig).length > 0) rawSteps.tectonics = tectonicsConfig;
 
+  return rawSteps;
+}
+
+// Foundation Orogeny is public as semantic crustCharacter config. The raw
+// compute-crust-evolution operation envelope is emitted only at this compile
+// boundary so Studio and presets never author it directly.
+export function compileFoundationOrogenyPublicConfig(config: FoundationOrogenyPublicConfig) {
+  const rawSteps: Record<string, unknown> = {};
+  assignIfDefined(
+    rawSteps,
+    "crust-evolution",
+    stepOp("computeCrustEvolution", config.crustCharacter)
+  );
   return rawSteps;
 }

--- a/mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts
+++ b/mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts
@@ -30,6 +30,7 @@ const RETIRED_RAW_STAGE_KEYS: Record<string, readonly string[]> = {
   "foundation-mantle": ["mesh"],
   "foundation-lithosphere": ["plate-graph"],
   "foundation-tectonics": ["plate-motion", "tectonics"],
+  "foundation-orogeny": ["crust-evolution"],
   "hydrology-climate-baseline": ["climate-baseline"],
   "hydrology-hydrography": ["rivers"],
   "hydrology-climate-refine": ["climate-refine"],
@@ -175,6 +176,11 @@ describe("Shipped map configs", () => {
       errorPathsFor(
         {
           "hydrology-climate-baseline": { "climate-baseline": { seasonality: { modeCount: 2 } } },
+          "foundation-orogeny": {
+            "crust-evolution": {
+              computeCrustEvolution: { strategy: "default", config: {} },
+            },
+          },
           "map-ecology": { "plot-biomes": { bindings: { marine: "BIOME_DESERT" } } },
           placement: {
             resources: { candidateResourceTypes: [1, 2, 3] },
@@ -186,6 +192,7 @@ describe("Shipped map configs", () => {
     ).toEqual(
       expect.arrayContaining([
         "/maps/retired-shape/hydrology-climate-baseline/climate-baseline",
+        "/maps/retired-shape/foundation-orogeny/crust-evolution",
         "/maps/retired-shape/map-ecology/plot-biomes",
         "/maps/retired-shape/placement/resources/candidateResourceTypes",
         "/maps/retired-shape/placement/starts/overrides",

--- a/mods/mod-swooper-maps/test/config/standard-authoring-surface-guards.test.ts
+++ b/mods/mod-swooper-maps/test/config/standard-authoring-surface-guards.test.ts
@@ -4,13 +4,16 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { deriveRecipeConfigSchema } from "@swooper/mapgen-core/authoring";
+import { CatalogSourceIndex } from "../../src/maps/catalog/sourceIndex";
+import {
+  catalogConfigFileNameFromPath,
+  parseCatalogSourceIndex,
+} from "../../src/maps/catalog/sources";
 import {
   type ValidatedMapConfig,
   validateCanonicalMapConfig,
 } from "../../src/maps/configs/canonical.js";
 import { STANDARD_STAGES } from "../../src/recipes/standard/recipe";
-
-const TRANSIENT_STUDIO_CONFIGS = new Set(["studio-current.config.json"]);
 
 function canonicalize(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(canonicalize);
@@ -53,27 +56,28 @@ function createMapConfigExpression(source: string, id: string): string {
 
 describe("standard map config artifacts", () => {
   it("keeps generated SDK map entrypoints bound to canonical source config envelopes", () => {
-    const configsDir = join(import.meta.dir, "../../src/maps/configs");
     const generatedDir = join(import.meta.dir, "../../src/maps/generated");
-    const configIds = readdirSync(configsDir)
-      .filter((entry) => entry.endsWith(".config.json"))
-      .filter((entry) => !TRANSIENT_STUDIO_CONFIGS.has(entry))
-      .map((entry) => entry.replace(/\.config\.json$/, ""))
+    const catalogEntries = [...parseCatalogSourceIndex(CatalogSourceIndex).entries];
+    const configIds = catalogEntries
+      .map((entry) =>
+        catalogConfigFileNameFromPath(entry.configPath).replace(/\.config\.json$/, "")
+      )
       .sort();
     const generatedIds = readdirSync(generatedDir)
       .filter((entry) => entry.endsWith(".ts"))
-      .filter((entry) => !TRANSIENT_STUDIO_CONFIGS.has(entry.replace(/\.ts$/, ".config.json")))
       .map((entry) => entry.replace(/\.ts$/, ""))
       .sort();
 
     expect(generatedIds).toEqual(configIds);
 
-    for (const id of configIds) {
+    for (const entry of catalogEntries) {
+      const fileName = catalogConfigFileNameFromPath(entry.configPath);
+      const id = fileName.replace(/\.config\.json$/, "");
       const rawConfig = JSON.parse(
-        readFileSync(join(configsDir, `${id}.config.json`), "utf8")
+        readFileSync(join(import.meta.dir, "../../../..", entry.configPath), "utf8")
       ) as unknown;
       const mapConfig = validateCanonicalMapConfig({
-        fileName: `${id}.config.json`,
+        fileName,
         raw: rawConfig,
         recipeSchema: deriveRecipeConfigSchema(STANDARD_STAGES),
         stages: STANDARD_STAGES,

--- a/mods/mod-swooper-maps/test/config/standard-recipe-artifact-guards.test.ts
+++ b/mods/mod-swooper-maps/test/config/standard-recipe-artifact-guards.test.ts
@@ -123,6 +123,9 @@ describe("standard recipe source artifact guards", () => {
       "/standard/defaults"
     );
     expect(errors).toEqual([]);
-    expect(STANDARD_RECIPE_CONFIG).toEqual(stripSchemaMetadataRoot(value));
+    const sourceDefaults = stripSchemaMetadataRoot(value) as Record<string, any>;
+    expect(sourceDefaults["foundation-orogeny"]).toHaveProperty("crustCharacter");
+    expect(sourceDefaults["foundation-orogeny"]).not.toHaveProperty("crust-evolution");
+    expect(STANDARD_RECIPE_CONFIG).toEqual(sourceDefaults);
   });
 });

--- a/mods/mod-swooper-maps/test/m11-config-knobs-and-presets.test.ts
+++ b/mods/mod-swooper-maps/test/m11-config-knobs-and-presets.test.ts
@@ -195,6 +195,51 @@ describe("M11 config layering: knobs-last (foundation + morphology)", () => {
     }
   });
 
+  it("compiles Foundation Orogeny crustCharacter into the internal crust-evolution op envelope", () => {
+    const crustCharacter = {
+      continentalSurvivalMaturity: 0.72,
+      continentalFreeboard: 0.2,
+      hyperextensionBreakupBase: 0.18,
+      thinningThicknessLoss: 0.62,
+      oceanicAbyssalDepth: 0.84,
+    };
+
+    const compiled = standardRecipe.compileConfig(env, {
+      ...foundationBaseConfig,
+      "foundation-orogeny": { crustCharacter },
+    });
+
+    const op = compiled["foundation-orogeny"]["crust-evolution"].computeCrustEvolution;
+    expect(op.strategy).toBe("default");
+    expect(op.config).toEqual(crustCharacter);
+  });
+
+  it("lets explicit Foundation Orogeny knobs override their coupled crustCharacter fields", () => {
+    const compiled = standardRecipe.compileConfig(env, {
+      ...foundationBaseConfig,
+      "foundation-orogeny": {
+        knobs: {
+          continentalAbundance: 1,
+          continentalRelief: 0,
+        },
+        crustCharacter: {
+          continentalSurvivalMaturity: 0.72,
+          continentalFreeboard: 0.5,
+          hyperextensionBreakupBase: 0.18,
+          thinningThicknessLoss: 0.62,
+          oceanicAbyssalDepth: 0.84,
+        },
+      },
+    });
+
+    const config = compiled["foundation-orogeny"]["crust-evolution"].computeCrustEvolution.config;
+    expect(config.continentalSurvivalMaturity).toBeCloseTo(0.4, 6);
+    expect(config.hyperextensionBreakupBase).toBeCloseTo(0.3, 6);
+    expect(config.continentalFreeboard).toBeCloseTo(0.15, 6);
+    expect(config.thinningThicknessLoss).toBeCloseTo(0.4, 6);
+    expect(config.oceanicAbyssalDepth).toBeCloseTo(0.35, 6);
+  });
+
   it("rejects stale internal ridge/foothill mountain-family config on the public surface", () => {
     expect(() =>
       standardRecipe.compileConfig(env, {

--- a/mods/mod-swooper-maps/test/standard-compile-errors.test.ts
+++ b/mods/mod-swooper-maps/test/standard-compile-errors.test.ts
@@ -42,6 +42,9 @@ describe("standard recipe compile errors", () => {
       ...foundationConfig,
       "foundation-mantle": { mesh: { computeMesh: { strategy: "default", config: {} } } },
       "foundation-lithosphere": { "plate-graph": { computePlateGraph: {} } },
+      "foundation-orogeny": {
+        "crust-evolution": { computeCrustEvolution: { strategy: "default", config: {} } },
+      },
       "hydrology-climate-baseline": {
         "climate-baseline": { computeRadiativeForcing: { strategy: "default", config: {} } },
       },
@@ -65,6 +68,7 @@ describe("standard recipe compile errors", () => {
       expect.arrayContaining([
         "/config/foundation-mantle/mesh",
         "/config/foundation-lithosphere/plate-graph",
+        "/config/foundation-orogeny/crust-evolution",
         "/config/hydrology-climate-baseline/climate-baseline",
         "/config/hydrology-hydrography/rivers",
         "/config/hydrology-climate-refine/climate-refine",

--- a/openspec/changes/foundation-orogeny-public-config-surface/tasks.md
+++ b/openspec/changes/foundation-orogeny-public-config-surface/tasks.md
@@ -1,33 +1,33 @@
 ## 1. Public Config Boundary
 
-- [ ] 1.1 Read the Foundation stage authoring surface and adjacent stage public
+- [x] 1.1 Read the Foundation stage authoring surface and adjacent stage public
       config helpers.
-- [ ] 1.2 Add the `foundation-orogeny` public schema and compile function at
+- [x] 1.2 Add the `foundation-orogeny` public schema and compile function at
       the stage owner with public fields `knobs` and `crustCharacter`.
-- [ ] 1.3 Update default config and preset builders to consume the public
+- [x] 1.3 Update default config and preset builders to consume the public
       shape without Studio-side scrubbing.
-- [ ] 1.4 Regenerate or repair checked-in config artifacts through normal
+- [x] 1.4 Regenerate or repair checked-in config artifacts through normal
       commands when required.
 
 ## 2. Authority And Tests
 
-- [ ] 2.1 Remove the existing behavior-test exception for Foundation Orogeny.
-- [ ] 2.2 Update the existing Habitat public-authoring-surface rule in place
+- [x] 2.1 Remove the existing behavior-test exception for Foundation Orogeny.
+- [x] 2.2 Update the existing Habitat public-authoring-surface rule in place
       so it asserts the semantic public surface instead of allowing the old
       envelope.
-- [ ] 2.3 Add behavior tests for default config materialization, preset
+- [x] 2.3 Add behavior tests for default config materialization, preset
       application, first-party legacy migration, and imported legacy-envelope
       rejection.
 
 ## 3. Verification
 
-- [ ] 3.1 Run `bun run openspec -- validate foundation-orogeny-public-config-surface --strict`.
-- [ ] 3.2 Run `bun habitat classify` for the packet write set and all reported
+- [x] 3.1 Run `bun run openspec -- validate foundation-orogeny-public-config-surface --strict`.
+- [x] 3.2 Run `bun habitat classify` for the packet write set and all reported
       commands.
-- [ ] 3.3 Run focused `nx run mapgen-studio:test` config/preset suites and any
+- [x] 3.3 Run focused `nx run mapgen-studio:test` config/preset suites and any
       map config validation commands reported by Habitat.
-- [ ] 3.4 Run `nx run mod-swooper-maps:build:studio-recipes` and
+- [x] 3.4 Run `nx run mod-swooper-maps:build:studio-recipes` and
       classify-reported Swooper config tests.
-- [ ] 3.5 Run and record TypeScript refactoring, code quality/structure,
+- [x] 3.5 Run and record TypeScript refactoring, code quality/structure,
       library correctness, and Habitat/authority review lanes.
-- [ ] 3.6 Record every gate in `workstream/verification-evidence.md`.
+- [x] 3.6 Record every gate in `workstream/verification-evidence.md`.

--- a/openspec/changes/foundation-orogeny-public-config-surface/workstream/verification-evidence.md
+++ b/openspec/changes/foundation-orogeny-public-config-surface/workstream/verification-evidence.md
@@ -1,9 +1,48 @@
 # Verification Evidence
 
+Packet: `foundation-orogeny-public-config-surface`
+
+Date: 2026-07-08
+
 | Gate | Required | Command Or Protocol | Preconditions | Result | Artifact | Oracle | Verdict |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| openspec-strict | required | `bun run openspec -- validate foundation-orogeny-public-config-surface --strict` | packet files written | not run | n/a | change validates strictly | open |
-| habitat-classify | required | `bun habitat classify <write-set>` | implementation diff exists | not run | n/a | reported authority checks are known | open |
-| classify-reported-commands | required | append one row per Habitat-reported Nx/Biome/Grit/Habitat command | `habitat-classify` completed | not run | n/a | every classify-reported command has its own closed verification row | open |
-| config-tests | required | focused `nx run mapgen-studio:test` config/preset suites | implementation diff exists | not run | n/a | public config has no internal envelopes | open |
-| review-lanes | required | reviewer prompts | implementation diff exists | not run | n/a | material findings dispositioned | open |
+| openspec-strict | required | `bun run openspec -- validate foundation-orogeny-public-config-surface --strict` | packet files written | passed | terminal output: `Change 'foundation-orogeny-public-config-surface' is valid` | change validates strictly | passed |
+| habitat-classify | required | `bun habitat classify <write-set>` for the Packet 1 source, test, and Habitat files | implementation diff exists | passed | `/tmp/mapgen-packet1-classify/*.txt`; reported commands were `nx run mapgen-studio:check`, `nx run mapgen-studio:test`, `nx run mod-swooper-maps:check`, `nx run mod-swooper-maps:test`, `bun run lint` | reported authority checks are known | passed |
+| generated-recipe-artifacts | required | `nx run mod-swooper-maps:build:studio-recipes` | public schema changed | passed | generated 9 Studio catalog map configs and rebuilt standard recipe bundle; no tracked generated diff remained | artifacts derive from stage owner schema/compile code | passed |
+| focused-studio-config-tests | required | `nx run mapgen-studio:test -- test/config/defaultConfigSchema.test.ts test/config/standardRecipeArtifactGuards.test.ts test/presets/importFlow.test.ts` | generated recipe artifacts refreshed | passed | 3 files, 27 tests | Studio default config, presets, and import flow expose only public config and reject imported legacy envelopes | passed |
+| focused-swooper-config-tests | required | `bun test mods/mod-swooper-maps/test/m11-config-knobs-and-presets.test.ts mods/mod-swooper-maps/test/standard-compile-errors.test.ts mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts mods/mod-swooper-maps/test/config/standard-recipe-artifact-guards.test.ts` | generated recipe artifacts refreshed | passed | 4 files, 19 tests | public `crustCharacter` compiles to internal `crust-evolution` only at recipe compile; stale raw stage keys are rejected | passed |
+| generated-entrypoint-selector | required | `bun .habitat/blueprints/mod-map/validate_generated_map_entrypoint_contracts/check.ts`; `bun test mods/mod-swooper-maps/test/config/standard-authoring-surface-guards.test.ts` | untracked scratch config present in `src/maps/configs` | passed | Habitat check passed; 2 tests passed | shipped generated map entrypoints are selected from `CatalogSourceIndex`, not incidental files in the config directory | passed |
+| public-authoring-surface-rule | required | `bun .habitat/civ7/mapgen/pipeline/swooper-maps-standard-recipe/rules/verify_standard_recipe_public_authoring_surface/check.ts` | public key matrix updated | passed | no findings | Foundation Orogeny public keys are `knobs` and `crustCharacter`; old `crust-evolution` key is not public | passed |
+| mapgen-studio-check | classify-reported | `nx run mapgen-studio:check` | implementation diff exists | passed | TypeScript project check completed | Studio touched tests and imports typecheck | passed |
+| mapgen-studio-test | classify-reported | `nx run mapgen-studio:test` | implementation diff exists | passed | 69 files, 412 tests | full Studio test suite remains green | passed |
+| mod-swooper-maps-check | classify-reported | `nx run mod-swooper-maps:check` | implementation diff exists | passed | TypeScript project check completed | Swooper Maps source/tests typecheck | passed |
+| mod-swooper-maps-test | classify-reported | `nx run mod-swooper-maps:test` | implementation diff exists | passed | 144 files, 519 passed, 2 skipped, 0 failed; Habitat owner check also passed 85 rules | full Swooper Maps test suite remains green under catalog-index-generated entrypoint selection | passed |
+| changed-file-lint | classify-related | `bunx biome check <Packet 1 changed files>` | Packet 1 files formatted and imports organized | passed | 13 files checked | Packet 1 files satisfy current Biome/Effect plugin lint rules | passed |
+| workspace-lint | classify-reported | `bun run lint` | dedicated downstack `codex/effect-biome-lint-baseline-stabilization` branch inserted above the Effect audit branch | passed | root lint ran 9 project lint targets successfully | workspace lint is green at the Packet 1 stack head without folding repo-wide Effect lint remediation into this packet | passed |
+| review-type-script-refactoring | required | Dedicated TypeScript refactoring review lane | implementation diff exists | completed | reviewer reported no blocking findings; low findings accepted for typed Foundation Orogeny public config and new `any` removal | TypeScript boundary is not unnecessarily loose | passed |
+| review-code-quality-structure | required | Dedicated code quality/structure review lane | implementation diff exists | completed | reviewer reported no blocking findings | packet is minimal, owns the stage boundary, and avoids Studio-side scrubbing | passed |
+| review-library-correctness | required | Dedicated library/API correctness review lane | implementation diff exists | completed | reviewer reported no blocking findings in packet files; high note on untracked `earthlike-wowza.config.json` dispositioned as scratch-only and excluded from commit | TypeBox, authoring API, oRPC/Effect non-touch, and generated artifact expectations are correct | passed |
+| review-habitat-entrypoint-selector | required after red gate | Dedicated Habitat authority investigation lane | `mod-swooper-maps:test` initially failed in generated-entrypoint check | completed | reviewer confirmed guardrail is valid and selector should use `CatalogSourceIndex`; fix implemented in Habitat check and package-local test | scratch config files must not become implicit shipped SDK map membership | passed |
+| sequencing-review | required after workspace lint red | Dedicated verification sequencing lane | workspace lint failed from lower stack | completed | reviewer recommended keeping Packet 1 focused, committing it as an upstack checkpoint, and inserting a dedicated Effect lint baseline stabilization branch below it | repo-wide Effect lint remediation is a separate changeset | passed |
+
+## Stack Baseline Resolution
+
+`bun run lint` is green at this stack head after inserting the dedicated
+`codex/effect-biome-lint-baseline-stabilization` branch below Packet 1 and above
+the Effect audit branch. That branch is scoped to the repo-wide Effect Biome
+diagnostics introduced by the audit layer; Packet 1 remains scoped to the
+Foundation Orogeny public config surface.
+
+The Packet 1 verification rerun after restacking confirmed:
+
+- `bun run openspec -- validate foundation-orogeny-public-config-surface --strict`
+  passed;
+- `bun run lint` passed;
+- `bunx biome check <Packet 1 changed files>` passed;
+- `nx run mapgen-studio:check` and `nx run mod-swooper-maps:check` passed;
+- `nx run mapgen-studio:test` passed with 69 files and 412 tests;
+- `nx run mod-swooper-maps:test` passed with 144 files, 519 passed, 2 skipped,
+  and 0 failed; the Habitat owner check inside that target passed 85 rules;
+- direct generated-entrypoint and public-authoring-surface Habitat checks
+  passed after `nx run mod-swooper-maps:gen:maps` materialized generated map
+  sources.


### PR DESCRIPTION
## Foundation Orogeny Public Config Surface

Promotes the `foundation-orogeny` stage from exposing its raw internal `crust-evolution` operation envelope directly to authors, to a proper semantic public config surface matching the pattern established by the other Foundation stages.

### Public Schema

A new `crustCharacter` field is added to the `foundation-orogeny` public schema alongside the existing `knobs`. This field accepts the `computeCrustEvolution` operation config properties directly (continental survival, freeboard, fragmentation, shelf depth, abyssal relief) without wrapping them in a strategy/config envelope. The raw `crust-evolution` op envelope is now emitted exclusively at the recipe compile boundary via `compileFoundationOrogenyPublicConfig`, so Studio, presets, and map configs never author it directly.

Explicit `knobs` (`continentalAbundance`, `continentalRelief`) remain as late semantic overrides that apply on top of any authored `crustCharacter` fields at normalize time.

### Breaking Change for Authored Configs

The raw `crust-evolution` key is now a retired stage key. Configs and presets containing it are rejected at validation. Imported preset files carrying the old envelope shape are rejected at import rather than silently migrated.

### Catalog-Based Entrypoint Selection

The generated map entrypoint validation in the Habitat blueprint and the package-local authoring surface guard test are updated to derive the canonical set of shipped map configs from `CatalogSourceIndex` rather than by scanning the `src/maps/configs` directory. This prevents scratch or transient Studio config files from being treated as implicit shipped SDK map members.

### Test Coverage

- Behavior tests confirm `crustCharacter` compiles to the internal `crust-evolution` op envelope and that explicit knobs override their coupled `crustCharacter` fields.
- Artifact guard tests assert that default config and all built-in presets expose `crustCharacter` and contain no `crust-evolution` keys or raw op envelopes.
- The preset import flow test asserts that a legacy `crust-evolution` envelope in an imported file produces an `invalid-config` rejection with a path-specific error.
- The retired raw stage key registry is extended to include `foundation-orogeny/crust-evolution`, and compile error tests cover the rejection path.