### PR TITLE
refactor(mapgen-studio): replace fill-derived tile border with shared graphite constant

### DIFF
--- a/apps/mapgen-studio/src/features/viz/deckgl/render.ts
+++ b/apps/mapgen-studio/src/features/viz/deckgl/render.ts
@@ -18,7 +18,7 @@ import type { Bounds, VizAssetResolver, VizLayerEntryV2, VizManifestV2 } from ".
 import {
   resolveVizPalettePresentation,
   selectVizScalarField,
-  tileBorderColorForFill,
+  tileBorderColorForPresentTile,
   type VizRenderedScalarPresentation,
   writeColorForScalarValue,
 } from "../presentation";
@@ -463,18 +463,11 @@ async function renderSingleLayer(options: RenderSingleLayerArgs): Promise<Render
           stroked: true,
           // Mesh contract: unfilled tiles draw nothing — the border follows
           // the fill's alpha so transparent tiles leave no phantom mesh.
-          // Filled tiles grout with their OWN fill darkened (the one
-          // tile-border rule) so the lattice stays legible at fit zoom.
+          // Every present tile uses the shared graphite border.
           getLineColor: (i) => {
             const base = Number(i) * 4;
             const alpha = colors[base + 3] ?? 0;
-            return alpha === 0
-              ? [0, 0, 0, 0]
-              : tileBorderColorForFill(
-                  colors[base] ?? 0,
-                  colors[base + 1] ?? 0,
-                  colors[base + 2] ?? 0
-                );
+            return alpha === 0 ? [0, 0, 0, 0] : tileBorderColorForPresentTile();
           },
           getLineWidth: 1,
           lineWidthUnits: "pixels",
@@ -729,18 +722,11 @@ async function renderSingleLayer(options: RenderSingleLayerArgs): Promise<Render
         stroked: true,
         // Mesh contract: unfilled tiles draw nothing — the border follows
         // the fill's alpha so transparent tiles leave no phantom mesh.
-        // Filled tiles grout with their OWN fill darkened (the one
-        // tile-border rule) so the lattice stays legible at fit zoom.
+        // Every present tile uses the shared graphite border.
         getLineColor: (i) => {
           const base = Number(i) * 4;
           const alpha = colors[base + 3] ?? 0;
-          return alpha === 0
-            ? [0, 0, 0, 0]
-            : tileBorderColorForFill(
-                colors[base] ?? 0,
-                colors[base + 1] ?? 0,
-                colors[base + 2] ?? 0
-              );
+          return alpha === 0 ? [0, 0, 0, 0] : tileBorderColorForPresentTile();
         },
         getLineWidth: 1,
         lineWidthUnits: "pixels",

--- a/apps/mapgen-studio/src/features/viz/presentation.ts
+++ b/apps/mapgen-studio/src/features/viz/presentation.ts
@@ -82,9 +82,9 @@ function collectResolvedCategoryIds(
 }
 
 const NEUTRAL_SCALAR_RAMP: ReadonlyArray<RgbaColor> = [
-  [241, 245, 249, 230],
-  [148, 163, 184, 230],
-  [30, 41, 59, 230],
+  [35, 35, 41, 72],
+  [35, 35, 41, 150],
+  [35, 35, 41, 230],
 ];
 
 // Nonfinite/no-data evidence remains transparent under the existing tile contract. A finite
@@ -156,29 +156,15 @@ export function resolveVizPalettePresentation(
 }
 
 /**
- * The one tile-border RULE (Pass-5 tile-orientation spec, retuned twice on
- * user feedback): the border is the tile's OWN fill pulled toward black —
- * self-grout. The previous constant graphite ink (#0d0d11, the page
- * substrate) vanished at map scale: at fit zoom a Huge map's tiles are a few
- * pixels wide, and a page-colored 1px seam between dark fills dissolved the
- * tessellation into disconnected dots — the grid disappeared everywhere the
- * Delaunay mesh (its own slate ink) wasn't drawn. A fill-derived seam is
- * darker than its fill BY CONSTRUCTION, so the hex lattice reads at every
- * zoom, in both themes, for every palette — and up close it still recedes
- * like etched grout instead of glowing slate. Unfilled tiles draw nothing
- * (mesh contract — stroke alpha follows fill alpha). All tile-space polygon
- * strokes use this rule — no per-call border literals.
+ * Canonical dark-theme `--border` color used to grout every present map tile.
+ * Keeping the border independent of semantic fill hue makes the hex lattice read as one matte
+ * graphite surface while transparent tiles continue to opt out at the renderer call site.
  */
-export const TILE_BORDER_FILL_RATIO = 0.55;
+export const TILE_BORDER_COLOR = [52, 52, 61, 255] as const satisfies Readonly<RgbaColor>;
 
-/** Produces self-grout that remains legible against the tile's own fill color. */
-export function tileBorderColorForFill(r: number, g: number, b: number): RgbaColor {
-  return [
-    Math.round(r * TILE_BORDER_FILL_RATIO),
-    Math.round(g * TILE_BORDER_FILL_RATIO),
-    Math.round(b * TILE_BORDER_FILL_RATIO),
-    255,
-  ];
+/** Returns the shared graphite border for a present tile. */
+export function tileBorderColorForPresentTile(): RgbaColor {
+  return copyColor(TILE_BORDER_COLOR);
 }
 
 type ColorOut = { [index: number]: number };

--- a/apps/mapgen-studio/test/viz/palettePresentation.test.ts
+++ b/apps/mapgen-studio/test/viz/palettePresentation.test.ts
@@ -216,8 +216,9 @@ describe("resolved visualization palette presentation", () => {
       values: new Float32Array([0, 1]),
     });
 
-    expect(renderColor(0, palette)).toEqual([241, 245, 249, 230]);
-    expect(renderColor(1, palette)).toEqual([30, 41, 59, 230]);
+    expect(renderColor(0, palette)).toEqual([35, 35, 41, 72]);
+    expect(renderColor(0.5, palette)).toEqual([35, 35, 41, 150]);
+    expect(renderColor(1, palette)).toEqual([35, 35, 41, 230]);
   });
 
   it("labels declared palette domains", () => {

--- a/apps/mapgen-studio/test/viz/tileOrientation.test.ts
+++ b/apps/mapgen-studio/test/viz/tileOrientation.test.ts
@@ -2,7 +2,7 @@ import type { Layer } from "@deck.gl/core";
 import { describe, expect, it } from "vitest";
 import { boundsForTileGrid, renderDeckLayers } from "../../src/features/viz/deckgl/render";
 import type { VizLayerEntryV2, VizManifestV2 } from "../../src/features/viz/model";
-import { TILE_BORDER_FILL_RATIO } from "../../src/features/viz/presentation";
+import { TILE_BORDER_COLOR } from "../../src/features/viz/presentation";
 
 type GridLayerEntry = Extract<VizLayerEntryV2, { kind: "grid" }>;
 type HexLayerAccessors = {
@@ -186,7 +186,7 @@ describe("tile-space rendering orientation", () => {
     expect(filledLine[3]).toBeGreaterThan(0);
   });
 
-  it("grouts each filled tile with its OWN fill darkened (the one border rule)", async () => {
+  it("grouts every filled tile with the shared design-system graphite border", async () => {
     const layer = gridLayer("tile.hexOddR");
     const manifest: VizManifestV2 = {
       version: 2,
@@ -198,20 +198,18 @@ describe("tile-space rendering orientation", () => {
     const result = await renderDeckLayers({ manifest, layer, showEdgeOverlay: false });
     const hexLayer = requireHexLayer(result.layers);
 
-    // The previous CONSTANT graphite ink matched the page substrate, so at
-    // fit zoom the lattice dissolved into dots ("the grid disappeared" for
-    // every tile layer). The border must now derive from the tile's fill —
-    // strictly darker than it, fully opaque, and different per tile.
     for (const index of [0, 1]) {
-      const fill = hexLayer.props.getFillColor(index);
       const line = hexLayer.props.getLineColor(index);
-      expect(line[3]).toBe(255);
-      for (const channel of [0, 1, 2]) {
-        expect(line[channel]).toBe(Math.round((fill[channel] ?? 0) * TILE_BORDER_FILL_RATIO));
-      }
+      expect(line).toEqual(TILE_BORDER_COLOR);
     }
     const line0 = hexLayer.props.getLineColor(0);
     const line1 = hexLayer.props.getLineColor(1);
-    expect(line0).not.toEqual(line1);
+    expect(line0).toEqual(line1);
+
+    const neutralFill = hexLayer.props.getFillColor(3);
+    const neutralLine = hexLayer.props.getLineColor(3);
+    expect(neutralFill).toEqual([35, 35, 41, 230]);
+    expect(neutralLine).toEqual(TILE_BORDER_COLOR);
+    expect(neutralLine.slice(0, 3)).not.toEqual(neutralFill.slice(0, 3));
   });
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/viz.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/viz.ts
@@ -26,9 +26,9 @@ export const STANDARD_VIZ_COLORS = {
   vegetation: [34, 139, 94, 235],
   field: {
     negative: [59, 130, 246, 235],
-    neutral: [107, 114, 128, 230],
+    neutral: [35, 35, 41, 230],
     positive: [239, 68, 68, 235],
-    low: [107, 114, 128, 230],
+    low: [35, 35, 41, 96],
     moderate: [59, 130, 246, 235],
     elevated: [34, 197, 94, 235],
     high: [245, 158, 11, 235],


### PR DESCRIPTION
Tile borders now use a single shared graphite color (`#34343d`) for all present tiles rather than deriving the border from each tile's own fill color darkened by a fixed ratio. The neutral scalar ramp is also updated from a slate-blue range to a dark graphite ramp that varies only in opacity, and the standard viz neutral/low field colors are aligned to the same graphite value.

The previous self-grout approach was introduced to keep the hex lattice visible at fit zoom, where a constant page-colored border would dissolve between dark fills. The new approach instead uses a fixed design-system border color that sits visually distinct from the fill without being tied to it, making the lattice read as a consistent matte graphite surface regardless of palette or zoom level.

Transparent tiles continue to opt out of the border entirely at the renderer call site, preserving the existing mesh contract.