### PR TITLE
feat(habitat): seal compiler ownership, blank preflight retry, and Graphite merge preparation

### DIFF
--- a/.habitat/AUTHORITY-TOOL-SEPARATION.md
+++ b/.habitat/AUTHORITY-TOOL-SEPARATION.md
@@ -48,9 +48,10 @@ owner checks project local rule execution and graph-backed work as sibling
 dependencies, then expose dependency-only public targets. They never start a
 second Nx scheduler.
 
-Habitat-executed rules remain Habitat runners. When a rule consumes generated
-output, its closed `graphDependencies` list schedules only the exact producers;
-the generated rule target and owner-local batch still execute and report the
+Habitat-executed rules remain Habitat runners. When a rule consumes tracked
+generated output, its closed `graphDependencies` list schedules the exact
+non-mutating currentness target; ephemeral output schedules its exact producer.
+The generated rule target and owner-local batch still execute and report the
 rule through Habitat.
 
 Direct `bun habitat check --rule <id>` remains a diagnostic surface and may

--- a/.habitat/blueprints/mod-map/block_studio_config_leakage_into_shipped_catalog/rule.json
+++ b/.habitat/blueprints/mod-map/block_studio_config_leakage_into_shipped_catalog/rule.json
@@ -32,7 +32,7 @@
   "graphDependencies": [
     {
       "project": "mod-swooper-maps",
-      "target": "gen:map-artifacts"
+      "target": "generated:check"
     }
   ],
   "supportFiles": {

--- a/.habitat/habitat/toolkit/_blueprints/service-module/validate_habitat_service_module_file_shape/check.ts
+++ b/.habitat/habitat/toolkit/_blueprints/service-module/validate_habitat_service_module_file_shape/check.ts
@@ -107,7 +107,7 @@ function validateKnownDirectory(directory: string, kind: string): void {
       );
       continue;
     }
-    if (kind === "policy" && !isPolicyFile(relativeToKind)) {
+    if (kind === "policy" && !isPolicyFile(relativeToKind, { strictPolicyNames: false })) {
       report(
         relativePath,
         "policy/ files must be *.policy.ts, known policy implementation files, index.ts, or schemas owned by that policy."

--- a/.habitat/tsconfig.json
+++ b/.habitat/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "types": ["node", "bun-types"]
+  },
+  "include": ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "string-width": "4.2.3",
         "tsup": "^8.5.1",
         "type-fest": "^5.7.0",
+        "typebox": "catalog:",
         "typescript": "6.0.3",
         "vitest": "^4.0.18",
       },

--- a/docs/projects/mapgen-studio-runtime-transition/NEXT-PACKET.md
+++ b/docs/projects/mapgen-studio-runtime-transition/NEXT-PACKET.md
@@ -1,7 +1,7 @@
 # Next Packet: Close The Studio Product Outcome
 
-Status: A.3 compiler ownership closing; package-ownership normalization precedes
-A.2; final P21 remains open
+Status: pre-A.2 foundation certified; semantic Graphite merge preparation active;
+final P21 remains open
 
 Normative frame:
 `docs/projects/mapgen-studio-runtime-transition/WORKSTREAM.md`
@@ -24,9 +24,10 @@ The coherent continuation stack is sealed through A.3a, A.4, RuleFixPreview,
 native Nx/toolchain authority, G.1/G.2, control-oRPC lifecycle and Studio
 adoption, Tuner session/admission repair, P19 generated-mod visibility, P20
 saved-config reconciliation, P21 deterministic proof, source-independent A.3
-static coverage, Habitat hook diagnostics, and lossless operation-event adoption.
-The A.2 sibling still equals the split base; no A.2 Authority rule, live
-violation corpus, or domain migration is present.
+static coverage, Habitat hook diagnostics, lossless operation-event adoption,
+MapGen capability/package boundaries, operation admission, test authority, and
+compiler ownership. No A.2 Authority rule, live violation corpus, or domain
+migration is present.
 
 The historical source recovery remains reference evidence. No current-tree
 rendered browser/Civ7 matrix has closed, so none of these layers claims the
@@ -36,18 +37,18 @@ product result.
 
 Proceed in this order:
 
-1. seal A.3 test and tool compiler ownership;
-2. normalize repository compiler ownership around one discoverable
-   `tsconfig.json` per real compiler environment;
-3. define and execute the package-ownership migration that leaves reusable
-   MapGen capabilities in Core, Civ7 policy in Civ7 packages, and authored maps,
-   recipes, packaging, and live proof in Swooper;
-4. certify and restack the resulting pre-A.2 foundation with native Graphite.
+1. approve the exact semantic fold families and protected-sibling treatment;
+2. fold and rename the local-only delivery branches with native Graphite, without
+   replaying or reconstructing the repository;
+3. rerun the one Nx-owned certification graph plus strict OpenSpec, then obtain
+   explicit approval for submission shape and merge mode;
+4. only after that approval, submit with Graphite and merge bottom to top after CI;
+5. drain only the allowlisted merged branches and clean worktrees, preserve
+   independent owner lanes, and start A.2 from merged `main`.
 
-This package move does not execute A.2 Authority, normalize operation interiors,
-or begin the domain descent. A.2 starts later from the corrected package
-topology. Do not replay the repository, reconstruct a replacement stack, or
-invent a return/integration protocol.
+This foundation does not execute A.2 Authority, normalize operation interiors,
+or begin the domain descent. Do not replay the repository, reconstruct a
+replacement stack, or invent a return/integration protocol.
 
 ## Prepared Findings
 
@@ -261,9 +262,10 @@ runtime behavior.
 
 The validator-ownership and rule-introduction prerequisites are sealed. The old
 mixed Authority candidate was excluded after its unique settled evidence was
-reconciled. From the reviewed split-base sibling, the user's A.2 team creates
-Authority from current evidence, then executes Ecology, Foundation, Morphology,
-Hydrology, Resources, and Placement under the settled descent contract.
+reconciled. After the independent foundation merges, the user's A.2 team creates
+Authority from current evidence on merged `main`, then executes Ecology,
+Foundation, Morphology, Hydrology, Resources, and Placement under the settled
+descent contract.
 
 ### A.3. Close Static Test And Tool Coverage
 
@@ -359,10 +361,10 @@ application PID. P21's three final rows still own product closure.
 
 C is the umbrella across Stages 5 through 8, not a standalone matrix packet.
 First certify every accepted branch and close P01-P20 against the current
-contracts while making P21 `authority-ready`. After A.2 and A.3 reconverge,
-integrated gates promote P21 to `runtime-ready`; then run its three-row matrix once
-on the frozen runtime-relevant candidate, reconcile active records without
-changing that tree, and submit and merge bottom to top. Any later
+contracts while making P21 `authority-ready`. After A.2 completes on the merged
+foundation, integrated gates promote P21 to `runtime-ready`; then run its
+three-row matrix once on the frozen runtime-relevant candidate, reconcile active
+records without changing that tree, and submit and merge bottom to top. Any later
 runtime-relevant change invalidates all three rows so the accepted matrix remains
 bound to one exact tree. Record-only changes do not replay Civ7.
 Any semantic surprise returns to its owning product slice.

--- a/docs/projects/mapgen-studio-runtime-transition/TAKEOVER-FRAME.md
+++ b/docs/projects/mapgen-studio-runtime-transition/TAKEOVER-FRAME.md
@@ -244,13 +244,13 @@ exact Habitat topology as the future realization.
 | A.1 test topology | Closed-passed candidate | Tests aligned to semantic owners; brittle mirrors removed; A.3 debt retained. |
 | A.1a dev freshness | Closed-passed candidate | Serve resolves Studio contract source; build remains artifact-owned. |
 | Lifecycle alignment child | Closed-passed candidate | Private worktree lifecycle composes canonical Nx daemon ownership. |
-| A.2 frame | Restored and adapted in the sealed split base | The target topology, separate D1-D4 decisions, and descent state model are preserved without beginning Authority implementation. |
+| A.2 frame | Restored and adapted in the pre-A.2 foundation | The target topology, separate D1-D4 decisions, and descent state model are preserved without beginning Authority implementation. |
 | A.2 generated-validator ownership prerequisite | Sealed at `dd38de22e` | Package/Nx owners retain behavior; three wrong-owner Habitat checks retired. |
 | A.2 rule-introduction-manifest prerequisite | Sealed at `9ff0f711e` | Habitat can admit explicit nonempty shrink-only baselines. |
 | Generic Grit capabilities | Sealed | Pinned acquisition, `RuleDiagnostics`, generic fix admission, and `RuleFixPreview` are ratcheted prerequisites. |
 | Nx output ownership | Sealed at `d40cd82a8` | One Nx graph owns output-materializing proof order; parallel output graphs use separate worktrees. |
-| A.2 split-base reconciliation | Sealed | Current readiness semantics and the nine-document descent container are preserved above the sealed prerequisites. A.2 implementation has not begun. |
-| A.2 Authority | Not started | The sibling A.2 track begins only from the reviewed split base. |
+| A.2 launch reconciliation | Sealed | Current readiness semantics and the nine-document descent container are preserved above the sealed prerequisites. The foundation merges before A.2 begins. |
+| A.2 Authority | Not started | A.2 begins from merged `main` after the independent foundation merge. |
 | A.2 domain slices | Not started | 34 Ecology, 18 Foundation, 19 Morphology, 19 Hydrology, 8 Resources, 3 Placement operations. |
 | A.3 static coverage | Closing candidate | Semantic test owners plus discoverable Swooper test/script/dev compiler projects close the static-authority gap. |
 | A.3a atomic reroll | Sealed at `93b1153ca` | One user command produces one worker start with Auto-run on or off. |
@@ -258,8 +258,8 @@ exact Habitat topology as the future realization.
 | A.5 browser payload/worker readiness | Proposed; cohesion unproven | Lazy selected config loading and worker warmup may need separate units. |
 | B control-oRPC ownership | Planned | Daemon-owned typed setup/start/soft-restart capability; no caller-local direct-control choreography. |
 | C rendered acceptance | Planned umbrella | Expands across Stages 5-8: branch certification, integrated deterministic readiness, one final exact-tree matrix, archive, and merge. |
-| Workstream Stage 1 control/corpus | Closed for the split boundary | Current control records agree; the absent historical `TRANSITION.md` filename is not a reason to invent another artifact. |
-| Workstream Stage 2 semantic lock | Active product closeout | The admitted scope includes A/A.1/A.1a/lifecycle and the ratcheted Habitat prerequisites; the split base opens the two remaining semantic tracks. |
+| Workstream Stage 1 control/corpus | Closed for the foundation merge boundary | Current control records agree; the absent historical `TRANSITION.md` filename is not a reason to invent another artifact. |
+| Workstream Stage 2 semantic lock | Foundation complete; A.2 not started | The independent product/capability foundation is certified. A.2 begins later from merged `main`. |
 | Workstream Stages 3-9 | Not started | Targeted Graphite normalization only if concrete inspection requires it, then branch certification, integrated readiness, one final matrix, archive, submit/merge, and Habitat handoff. |
 
 Historical `checked` means task state, not current product acceptance. The config
@@ -415,53 +415,41 @@ exists. These are integration facts, not closure receipts.
 
 The current stack preserves the sealed product, Habitat, Nx, TypeScript, and
 lint authority layers. The bounded descent container and active-ledger
-reconciliation are sealed in the split base. A.2 Authority, its live violation
-corpus, and domain migration have not begun.
+reconciliation are sealed in the certified independent foundation. A.2
+Authority, its live violation corpus, and domain migration have not begun.
 
-The reviewed semantic tip is the split base. Create ordinary sibling Graphite
-children from it: one for the user's A.2 track and one for this DRA's independent
-product-closeout continuation. Keep them parallel while independent. If a real
-dependency later appears, use native Graphite to move the continuation's first
-unique branch above the completed A.2 tip. There is no returned stack, wholesale
-replay, replacement stack, or mandatory recut.
+Normalize, certify, submit, and merge the independent foundation through native
+Graphite after explicit approval. A.2 then begins from merged `main`. There is no
+split-base sibling, returned stack, wholesale replay, replacement stack, or
+mandatory recut.
 
-The user's A.2 orchestrator owns Authority, the advisory file/clause/predicate
-census, deterministic destination/action classification, and the six domain
-migrations on its sibling. The takeover DRA protects those surfaces, continues
-the independent product track, and retains final P21, submission, merge, drain,
-and initiative-closure authority.
+After the independent foundation merges, the user's A.2 orchestrator owns
+Authority, the advisory file/clause/predicate census, deterministic
+destination/action classification, and the six domain migrations from merged
+`main`. The takeover DRA retains final combined-tree readiness, P21, submission,
+merge, drain, and initiative-closure authority.
 
 ## Remaining Order
 
 The initiative proceeds by dependency, not by numeric label alone.
 
-1. **Create the sibling branches.** Preserve the sealed split base and open
-   ordinary A.2 and independent-continuation children. Do not add A.2
-   implementation or live-corpus machinery to the common parent.
-2. **Run two protected sibling tracks.** The user's team implements and seals A.2
+1. **Merge the independent foundation.** Preserve coherent layers; use targeted
+   native Graphite fold, split, move, or restack only where the inspected stack
+   requires it. Rerun certification, obtain explicit remote-mutation approval,
+   submit, and merge bottom to top. Do not replay or reconstruct the repository.
+2. **Execute A.2 from merged `main`.** The user's team implements and seals A.2
    Authority, freezes the zero-unknown advisory corpus, and executes Ecology ->
-   Foundation -> Morphology -> Hydrology -> Resources -> Placement. The takeover
-   DRA closes only source-independent A.3 surfaces, A.4, separately admitted A.5
-   concerns, control-oRPC, P19, and P20.
-3. **Finish semantic lock.** Keep the tracks parallel unless source dependencies
-   require native Graphite movement, finish A.2-sensitive A.3 scopes, and reach
-   P21 semantic readiness with zero undecided semantic rows.
-4. **Inspect the current stack.** Preserve coherent layers. Use targeted native
-   Graphite restack, move, split, or fold only when concrete inspection requires
-   it; do not replay the repository or rebuild a replacement stack.
-5. **Stage 5 branch certification.** Re-review and gate every accepted layer, close
-   P01-P20 against current contracts, and make P21 genuinely ready. This is the
-   first bounded portion of umbrella C.
-6. **Stage 6 integrated readiness.** Reconverge A.2/A.3, run deterministic
-   product gates, and make P21 runtime-ready. P19/P20 are the preliminary live
-   support; do not spend another Civ7 matrix here.
-7. **Stages 7-8 archive, final matrix, and merge.** Reconcile completed records,
+   Foundation -> Morphology -> Hydrology -> Resources -> Placement.
+3. **Stage 6 integrated readiness.** On the combined merged-foundation plus A.2
+   tree, run deterministic product gates and make P21 runtime-ready. P19/P20 are
+   preliminary live support; do not spend another Civ7 matrix here.
+4. **Stages 7-8 archive, final matrix, and merge.** Reconcile completed records,
    then run the three accepted P21 rows once on the frozen runtime-relevant
-   submission candidate and merge bottom-to-top with post-merge tree checks.
-   Any runtime-relevant change invalidates all three rows so the final evidence
-   remains bound to one exact tree. Record-only changes do not replay Civ7.
-8. **Stage 9 handoff.** Drain worktrees/processes, write the zero-context
-    continuation, and return to the parked Habitat authority initiative.
+   candidate and merge the final closure layer with post-merge tree checks. Any
+   runtime-relevant change invalidates all three rows; record-only changes do not
+   replay Civ7.
+5. **Stage 9 handoff.** Drain worktrees/processes, write the zero-context
+   continuation, and return to the parked Habitat authority initiative.
 
 ## Development Philosophy
 
@@ -726,7 +714,7 @@ context. It contains only behavior-changing context:
 - the decision or integration point returned to the DRA.
 
 Only the accountable track owner stages, commits, or mutates Graphite. Peers do
-not stash, reset, rewrite worktrees, touch sibling tracks, or start persistent
+not stash, reset, rewrite worktrees, touch other owner lanes, or start persistent
 Studio/Civ7 processes unless their bounded assignment explicitly owns that
 operation.
 

--- a/docs/projects/mapgen-studio-runtime-transition/WORKSTREAM.md
+++ b/docs/projects/mapgen-studio-runtime-transition/WORKSTREAM.md
@@ -23,26 +23,26 @@ verification, the product loop wins.
 project files provide method, snapshots, corpora, decisions, or handoff context;
 they do not independently declare the current gate.
 
-### Current Graphite Law (2026-07-13)
+### Current Graphite Law (2026-07-20)
 
-The final reconciled semantic tip becomes the A.2 split base only after its
-current checks and reviews pass. From that tip, create ordinary sibling Graphite
-children for A.2 and for the independent product-closeout continuation. Keep the
-siblings parallel while their code is independent. If a real dependency later
-appears, move the continuation's first unique branch above the completed A.2 tip
-with native Graphite, then restack only its descendants.
+The certified independent foundation merges before A.2 begins. Normalize its
+local-only branches with native Graphite, rerun the required proof, and obtain
+explicit submission and merge-mode approval before remote mutation. After the
+foundation merges, A.2 starts from merged `main`; do not preserve or create an
+A.2 split-base sibling merely to carry the old sequencing model.
 
 Preserve every coherent existing layer. Use normal Graphite operations to
 restack, move, split, fold, submit, and merge only where inspection shows a
 concrete need. Do not construct a replacement stack, replay the repository from
 `main`, rebuild the tree from a manifest, create a dedicated recut worktree, or
-treat one sibling as a returned stack to integrate. The sibling branches already
-belong to one Graphite topology.
+treat an owner lane as a returned stack to integrate. All retained branches
+already belong to one Graphite topology.
 
-This law supersedes every later reference to sink-stack reconstruction,
-wholesale replay, mechanical recut, returned-stack integration, or mandatory
-source-to-sink ceremony. Those passages remain only as historical planning
-evidence. They are not executable authority.
+This law supersedes every later reference to an A.2 split base, parallel sibling
+tracks, later A.2/A.3 reconvergence, sink-stack reconstruction, wholesale replay,
+mechanical recut, returned-stack integration, or mandatory source-to-sink
+ceremony. Those passages remain only as historical planning evidence. They are
+not executable authority.
 
 ### Current Scope And Authority Amendment
 
@@ -71,12 +71,12 @@ readiness. Admission is unit-scoped: every disposition needed by the unit being
 executed must be final before that unit mutates. Stage 2 as a whole closes only
 when the complete admitted corpus has zero undecided semantic rows.
 
-Ownership amendment (2026-07-13): from the reviewed split base, the user's A.2
-orchestrator owns A.2 Authority, advisory census/classification, and the six
-domain migrations on one sibling track. The takeover DRA protects those
-surfaces, advances the independent product track on the other sibling, and
-retains final product and initiative closure. The Current Graphite Law governs
-any later dependency-driven movement between them.
+Ownership amendment (2026-07-20): after the independent foundation merges, the
+user's A.2 orchestrator owns A.2 Authority, advisory census/classification, and
+the six domain migrations from merged `main`. The takeover DRA retains final
+combined-tree readiness, P21, submission, merge, drain, and initiative closure.
+The Current Graphite Law governs any later work without a return-stack or replay
+protocol.
 
 ## Opening Packet
 
@@ -516,9 +516,9 @@ not authorize replacement branches. `Future target architecture` is reserved
 for the RAWR/Habitat destination. No lifecycle value implies the next.
 `authority-ready` is P21's Stage 5 state: its executable acceptance contract and
 pre-integration reviews are closed while integrated gates and all live rows
-remain open. `runtime-ready` is its Stage 6 state: the reconverged product tree
-and deterministic gates are green while the three final Stage 8 rows remain
-open.
+remain open. `runtime-ready` is its Stage 6 state: A.2 is complete on the merged
+foundation and deterministic gates are green while the three final Stage 8 rows
+remain open.
 
 ## Operating Model
 
@@ -528,10 +528,10 @@ This is a single-accountability systematic workstream:
 | --- | --- | --- | --- |
 | Takeover DRA | Current orchestrator | frame and authority, corpus synthesis, semantic decisions, sequencing, Git/Graphite and process state, evidence claims, finding disposition, commits, merge, drain, and closure | cannot self-approve required review lanes or delegate final synthesis and closure |
 
-The reviewed split base creates two ordinary sibling tracks. The A.2
-orchestrator owns A.2 synthesis, reviews, and Graphite layers; the takeover DRA
-owns the independent continuation and final product closure. Neither mutates
-the common ancestors or duplicates the other's implementation.
+The independent foundation merges before A.2 begins. The A.2 orchestrator owns
+A.2 synthesis, reviews, and Graphite layers from merged `main`; the takeover DRA
+owns final combined-tree readiness and product closure. Neither duplicates the
+other's implementation or rewrites merged ancestors.
 
 The three stable review roles are TypeScript/state-space simplification,
 architecture/authority simplification, and product/runtime/library verification.
@@ -629,8 +629,8 @@ classification is uncertain, use semantic backflow.
 The accountable track owner is the sole Graphite mutator for that track. Check
 current branch, stack, index, and worktree state before and after each operation;
 keep each branch one coherent semantic unit. Use native Graphite normally.
-Independent sibling tracks remain untouched, and dependency movement occurs
-only when current code proves it necessary.
+Independent owner lanes remain untouched, and dependency movement occurs only
+when current code proves it necessary.
 
 ## Durable Artifact Set
 
@@ -856,17 +856,13 @@ trunk checkpoint plus one immutable opening source chain.
 
 ```mermaid
 flowchart LR
-  A["Reviewed split base"] --> B["A.2 sibling"]
-  A --> C["Independent continuation sibling"]
-  B --> D["A.2 semantic layers"]
-  C --> E["Product closeout layers"]
-  D --> F["Dependency-earned Graphite movement, only if needed"]
-  E --> F
-  F --> G["S5: individually closed change units"]
-  G --> H["S6: integrated product readiness"]
-  H --> I["S7: reconcile completed change records"]
-  I --> J["S8: final P21 matrix, merge, and drain"]
-  J --> K["S9: closeout and Habitat continuation"]
+  A["Certified independent foundation"] --> B["Semantic Graphite normalization"]
+  B --> C["Approved submission and foundation merge"]
+  C --> D["A.2 from merged main"]
+  D --> E["S6: integrated product readiness"]
+  E --> F["S7: reconcile completed change records"]
+  F --> G["S8: final P21 matrix and closure merge"]
+  G --> H["S9: closeout and Habitat continuation"]
 ```
 
 Each arrow is a gate. Work does not advance merely because activity occurred;
@@ -1193,13 +1189,11 @@ own semantic loop rather than being hidden inside topology operations.
 
 The sealed Stage 2 spine includes control reconciliation, generic diagnostic
 acquisition, `RuleDiagnostics`, authority-derived fix admission,
-`RuleFixPreview`, A.3a, and Nx output ownership. Current readiness
-reconciliation produces the split base. From there A.2
-Authority/census/six domains and the disjoint
-A.3/A.4/A.5/control-oRPC/P19/P20 track advance as ordinary sibling Graphite
-children. Operation-sensitive A.3 waits for A.2 only when source dependencies
-prove that ordering. Dependency evidence may refine this order, but numeric
-labels and inherited branch shape do not.
+`RuleFixPreview`, A.3a, and Nx output ownership. The independent product and
+capability foundation is complete and merges first. A.2 Authority, its advisory
+census, and the six domain migrations then begin from merged `main`. Dependency
+evidence may refine later work, but numeric labels and inherited branch shape do
+not.
 
 **Candidate construction**
 
@@ -1544,8 +1538,9 @@ risks require them. Required lanes are never replaced by DRA self-review.
   unchecked OpenSpec, Habitat, review, and ledger rows close.
 - Treat `studio-run-real-user-matrix-closure` as `authority-ready` only when its
   executable matrix contract and pre-integration reviews are green. Stage 6
-  promotes it to `runtime-ready` after the reconverged static and behavior gates;
-  Stage 8 owns its three live rows, final review, commit, and packet closure.
+  promotes it to `runtime-ready` after A.2 completes on the merged foundation and
+  the combined static and behavior gates pass; Stage 8 owns its three live rows,
+  final review, commit, and packet closure.
 
 **Config single-source behavior**
 
@@ -1596,8 +1591,9 @@ behavioral and tooling units.
 
 ## Stage 6: Integrated Product Readiness
 
-**Purpose:** reconverge the accepted product tree, close deterministic gates,
-and make P21 runtime-ready before one final live matrix at Stage 8. P19 and P20
+**Purpose:** verify the merged foundation plus completed A.2 tree, close
+deterministic gates, and make P21 runtime-ready before one final live matrix at
+Stage 8. P19 and P20
 already provide preliminary rendered/Civ7 support; Stage 6 does not duplicate
 those rows or manufacture live failures.
 
@@ -1609,8 +1605,8 @@ those rows or manufacture live failures.
 
 ### Native Readiness Preflight
 
-1. Confirm the intended Graphite siblings have reconverged and the
-   runtime-relevant source tree is clean.
+1. Confirm A.2 is complete on the merged foundation and the runtime-relevant
+   source tree is clean.
 2. Run output-materializing proof through one Nx graph so Nx owns ordering,
    caching, deduplication, and parallelism.
 3. Run Habitat boundaries/policy, OpenSpec, generated-currentness, and
@@ -1907,7 +1903,7 @@ protocol, or future-hash assertion.
 
 **Post-closeout readiness consumer**
 
-The current split base already adopts the readiness semantics that remain live.
+The merged foundation adopts the readiness semantics that remain live.
 The separate readiness ref stays historical and untouched; it is not restacked,
 merged, replayed, or consumed after closeout.
 
@@ -2059,7 +2055,7 @@ Stop and reframe the affected stage if any of these becomes true:
 - [ ] Future initiatives and transitional risks have owners and re-entry
       triggers.
 - [ ] The readiness reference remains untouched after its settled semantics are
-      adopted into the current split base.
+      adopted into the merged foundation.
 - [ ] Zero-context Habitat return packet is reviewed and usable.
 - [ ] All agents, scratch paths, temporary worktrees, Studio processes,
       listeners, watchers, and tmux sessions are closed or explicitly handed

--- a/docs/projects/mapgen-studio-runtime-transition/verification-ledger.md
+++ b/docs/projects/mapgen-studio-runtime-transition/verification-ledger.md
@@ -1,6 +1,6 @@
 # Verification Ledger
 
-Status: pre-A.2 package foundation in progress; final P21 remains open
+Status: pre-A.2 foundation certified; Graphite merge preparation active; final P21 remains open
 
 Normative method:
 `docs/projects/mapgen-studio-runtime-transition/WORKSTREAM.md`
@@ -10,30 +10,34 @@ Current scope and DRA frame:
 
 ## Live Control State
 
-- Last updated: 2026-07-16 EDT
-- Current phase: `pre-a2-package-foundation`
-- Ratcheted foundation: the split base, native Nx/toolchain layers, G.1/G.2,
+- Last updated: 2026-07-20 EDT
+- Current phase: `pre-a2-foundation-merge`
+- Ratcheted foundation: the certified pre-A.2 foundation, native Nx/toolchain layers, G.1/G.2,
   RuleFixPreview, A.3a, A.4, control-oRPC lifecycle and Studio adoption, Tuner
   session/admission repair, P19 generated-mod visibility, and P20 saved-config
   reconciliation, P21 deterministic proof, source-independent A.3 static
-  coverage, hook diagnostics, and lossless operation-event adoption are sealed
-  Graphite layers.
-- Current gate: the independent-track census found no further admitted product
-  slice. One native workspace typecheck graph passes all 25 projects and 82
-  tasks; deterministic proof and operation-event adoption passed fresh review.
-  A.5 remains unadmitted because neither lazy payload loading nor a worker
-  readiness state earned complexity from valid product evidence.
-- Next action: seal A.3 compiler ownership, normalize repository TypeScript
-  project ownership, then move reusable MapGen capabilities and tooling to their
-  correct package owners before A.2 begins.
+  coverage, hook diagnostics, lossless operation-event adoption, MapGen
+  capability/package boundaries, operation admission, test authority, and
+  compiler ownership are sealed Graphite layers.
+- Current gate: the complete foundation certification graph, strict OpenSpec,
+  generated-currentness, and permanent review roles passed. The subsequent
+  Habitat authority-script compiler repair passed its owning Nx check graph and
+  exact-tree review. A.5 remains unadmitted because neither lazy payload loading
+  nor a worker readiness state earned complexity from valid product evidence.
+- Next action: consolidate the local-only delivery stack into reviewable semantic
+  Graphite branches, rerun certification, then obtain explicit submission and
+  merge-mode approval. After the approved foundation merge, drain only the
+  explicitly allowlisted local state and begin A.2 from merged `main`.
 - Graphite law: preserve coherent layers. No returned-stack protocol,
   replacement stack, full replay, or wholesale recut. Native Graphite operations
   handle only concrete branch dependencies.
-- A.2 owner after the split: the user's A.2 orchestrator owns Authority, the
-  advisory census and deterministic classification, and six domain migrations.
-  This DRA owns the independent closeout track and final product closure.
-- Blocked by: nothing. A.2 has not begun and remains outside this package
-  ownership work.
+- A.2 owner after the foundation merge: the user's A.2 orchestrator owns
+  Authority, the advisory census and deterministic classification, and six
+  domain migrations.
+  This DRA owns final combined-tree readiness and product closure.
+- Blocked by: explicit fold, protected-owner-lane, submission, merge-mode, and
+  drain dispositions only. A.2 has not begun and remains outside this foundation
+  merge.
 - Product state: the complete rendered browser/endpoint/Civ7 matrix remains
   open, so no product closure is claimed.
 
@@ -296,11 +300,11 @@ prerequisite without admitting dependent authority mutation.
 | --- | --- | --- |
 | 0 Opening census | complete; historical recovery is verified and the current continuation lineage is reconciled through takeover | recovery artifact remains readable and every later source addition stays explicit |
 | 1 Semantic disposition | open only for unresolved legacy rows or a unit whose authority is not final | every disposition required by the unit being admitted is final; complete corpus has zero unresolved rows before Stage 2 exit |
-| 2 Semantic product tree | active; A.2 split base sealed and product semantic closure continues | no known accepted product defect or undecided semantic row at the product tree |
-| 3 Current-stack inspection | not started | coherent layers preserved; real dependencies identified |
-| 4 Targeted Graphite normalization | not started; may be unnecessary | only concretely required moves, splits, folds, or restacks complete |
-| 5 Change-unit closure | not started | P01-P20/tooling branches closed and P21 `authority-ready` |
-| 6 Integrated readiness | not started | A.2/A.3 reconverged, deterministic gates green, P21 runtime-ready |
+| 2 Semantic product tree | complete for the independent pre-A.2 foundation; A.2 remains a separate post-merge track | no known accepted product defect or undecided semantic row at the product tree |
+| 3 Current-stack inspection | complete; local-only ancestry, protected owner lanes, worktrees, and drain ownership audited | coherent layers preserved; real dependencies identified |
+| 4 Targeted Graphite normalization | ready; exact semantic folds and protected-owner-lane handling await explicit disposition | only concretely required moves, splits, folds, or restacks complete |
+| 5 Change-unit closure | current foundation complete; submission CI pending | P01-P20/tooling branches closed and P21 `authority-ready` |
+| 6 Integrated readiness | not started | A.2 complete on the merged foundation, deterministic gates green, P21 runtime-ready |
 | 7 Record/archive | not started | completed packet/spec/archive state reconciled; P21 remains active |
 | 8 Final runtime/merge | not started | one final three-row P21 matrix green; accepted branches merged; current stack terminal |
 | 9 Habitat return | not started | closeout records current and zero-context continuation usable |
@@ -453,7 +457,7 @@ database.
 | Effect diagnostics | `TOOL-EFFECT` source accounting and native Biome output | independent corpus open | every in-scope diagnostic dispositioned without hiding or elaborating disposable topology |
 | touched Habitat rules | authority manifests, cleanup rows, rule fixtures, and native Habitat output | per-unit; provider and A.2 rows open | every retained/retired rule has one authority owner and complete lifecycle evidence |
 | packet obligations | P01-P21 task/evidence records plus this ledger | P01-P18 historically checked; P19-P20 closed; P21 authority corrected with final live rows open | every declared gate has current evidence at the required proof class |
-| control inputs | current frame/workstream plus historical opening-stack, gate, cleanup, and wave records | current through the sealed split base | current semantic claims agree before the dependent slice closes |
+| control inputs | current frame/workstream plus historical opening-stack, gate, cleanup, and wave records | current through the certified pre-A.2 foundation | current semantic claims agree before the dependent slice closes |
 
 ## Runtime Matrix Register
 
@@ -466,9 +470,9 @@ support; they do not create a second mutable checkpoint.
 
 | Row id | Authority | Final runtime state |
 | --- | --- | --- |
-| `success-earthlike` | P21 fixed tuple | pending A.2/A.3 and runtime freeze |
-| `success-latest-juicy` | P21 fixed tuple | pending A.2/A.3 and runtime freeze |
-| `success-desert-mountains` | P21 fixed tuple | pending A.2/A.3 and runtime freeze |
+| `success-earthlike` | P21 fixed tuple | pending A.2 and runtime freeze |
+| `success-latest-juicy` | P21 fixed tuple | pending A.2 and runtime freeze |
+| `success-desert-mountains` | P21 fixed tuple | pending A.2 and runtime freeze |
 
 Validation, ownership, cancellation, terminal adoption, row/config mismatch,
 freshness, route projection, and redaction are behavior-test gates. They are not

--- a/eslint.boundaries.config.mjs
+++ b/eslint.boundaries.config.mjs
@@ -129,6 +129,29 @@ const allow = [
   "../../rules/**",
 ];
 
+// Habitat's virtual projects expose the admitted architectural layers inside one package.
+// Their direction is owned by the tag constraints below, not Nx's library-cycle heuristic.
+const habitatVirtualProjectCycles = [
+  ["habitat-providers", "habitat-resources"],
+  ["habitat-resources", "habitat-service-model"],
+  ["habitat-runtime", "habitat-service"],
+  ["habitat-service", "habitat-service-check"],
+  ["habitat-service", "habitat-service-classify"],
+  ["habitat-service", "habitat-service-fix"],
+  ["habitat-service", "habitat-service-graph"],
+  ["habitat-service", "habitat-service-hook"],
+  ["habitat-service", "habitat-service-verify"],
+];
+
+const habitatLazyCommandImports = [
+  "@habitat/cli/cli/commands/check",
+  "@habitat/cli/cli/commands/classify",
+  "@habitat/cli/cli/commands/fix",
+  "@habitat/cli/cli/commands/graph",
+  "@habitat/cli/cli/commands/hook",
+  "@habitat/cli/cli/commands/verify",
+];
+
 export default [
   {
     linterOptions: {
@@ -165,6 +188,12 @@ export default [
           // H3 enforces the project plane. Same-project package-entry imports
           // are left to intra-project Grit/file rules when they matter.
           allowCircularSelfDependency: true,
+          ignoredCircularDependencies: habitatVirtualProjectCycles,
+          // Habitat's CLI boot table lazy-loads its command projects. Other
+          // Habitat layers may still import their admitted public surfaces;
+          // this exception suppresses only the lazy-load heuristic, not tag
+          // or project-boundary enforcement.
+          checkDynamicDependenciesExceptions: habitatLazyCommandImports,
           // Civ7 engine virtual modules are imported by absolute path by design;
           // WHO may import them is the adapter-boundary rule's concern (grit/H5),
           // not the project-tag plane.
@@ -183,6 +212,7 @@ export default [
         {
           enforceBuildableLibDependency: false,
           allowCircularSelfDependency: true,
+          ignoredCircularDependencies: habitatVirtualProjectCycles,
           allow,
           depConstraints,
         },

--- a/openspec/changes/normalize-swooper-map-config-generation/tasks.md
+++ b/openspec/changes/normalize-swooper-map-config-generation/tasks.md
@@ -96,17 +96,17 @@
 
 ## 8. Portable Canonical Envelope Correction
 
-- [ ] 8.1 Restrict `@civ7/studio-contract` to the portable recursive-JSON
+- [x] 8.1 Restrict `@civ7/studio-contract` to the portable recursive-JSON
   envelope wire schema, type, and predicate; keep Standard defaults and strict
   recipe admission in Swooper Maps.
-- [ ] 8.2 Land the catalog-authority slice: the index carries ordered source
+- [x] 8.2 Land the catalog-authority slice: the index carries ordered source
   paths only, and each admitted catalog result carries one complete envelope
   without mirrored metadata.
-- [ ] 8.3 Land one atomic vertical envelope cutover across Studio saved/editor
+- [x] 8.3 Land one atomic vertical envelope cutover across Studio saved/editor
   construction, Run in Game, launch, and manifest paths. Reject malformed,
   incomplete, unknown, and old persisted data; add no partial DTO, merge,
   `unknown` tunnel, migration, fallback, or equality/digest routing.
-- [ ] 8.4 Bind diagnostics and attribution to request and operation-revision
+- [x] 8.4 Bind diagnostics and attribution to request and operation-revision
   identity, retaining envelope digests only as derived evidence.
 - [ ] 8.5 Replace legacy parity/source-snapshot inputs with the exact manifest
   launch envelope and derived evidence, then collect the required focused and

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "string-width": "4.2.3",
     "tsup": "^8.5.1",
     "type-fest": "^5.7.0",
+    "typebox": "catalog:",
     "typescript": "6.0.3",
     "vitest": "^4.0.18"
   },

--- a/tools/habitat/package.json
+++ b/tools/habitat/package.json
@@ -94,7 +94,7 @@
   "scripts": {
     "analyze:execution-surface": "bun run scripts/execution-surface-map.ts --repo-root ../.. --out-json ../../docs/projects/habitat-harness/execution-surface-map/execution-surface-map.json --out-md ../../docs/projects/habitat-harness/execution-surface-map/execution-surface-map.md --out-anatomy-md ../../docs/projects/habitat-harness/execution-surface-map/execution-surface-anatomy.md",
     "check:test": "tsc -p test/tsconfig.json --noEmit",
-    "check:tools": "tsc -p bin/tsconfig.json --noEmit && tsc -p scripts/tsconfig.json --noEmit",
+    "check:tools": "tsc -p bin/tsconfig.json --noEmit && tsc -p scripts/tsconfig.json --noEmit && tsc -p ../../.habitat/tsconfig.json --noEmit",
     "clean": "rimraf dist oclif.manifest.json",
     "clean:dist": "rimraf dist",
     "generate:schemas": "bun run ../../.habitat/habitat/toolkit/_blueprints/generator/generate_generator_schema_contracts/generate.ts",

--- a/tools/habitat/src/resources/rule-diagnostics/providers/grit/command.ts
+++ b/tools/habitat/src/resources/rule-diagnostics/providers/grit/command.ts
@@ -241,8 +241,10 @@ const preflightPinnedGritEffect = Effect.fn("grit.native.preflight")(function* <
     .pipe(Effect.mapError((error) => preflightUnavailable(preflightRequest, String(error))));
   const packageJson = yield* parsePinnedPackage(packageSource, preflightRequest);
   yield* Effect.succeed(packageJson satisfies GritPackage);
-  const result = yield* run(preflightRequest);
-  const completed = yield* classifyPreflightExecution(result);
+  const firstResult = yield* observePinnedGritIdentity(run, preflightRequest);
+  const result = isCompletedBlankPreflight(firstResult)
+    ? yield* observePinnedGritIdentity(run, preflightRequest)
+    : firstResult;
   const validIdentity = !(
     result.stdout.truncated ||
     result.stderr.truncated ||
@@ -253,17 +255,39 @@ const preflightPinnedGritEffect = Effect.fn("grit.native.preflight")(function* <
     Match.when("", () => "no version"),
     Match.orElse((version) => version)
   );
-  return yield* Effect.succeed(completed).pipe(
+  return yield* Effect.succeed(result).pipe(
     Effect.filterOrFail(
       () => validIdentity,
       () =>
         nativeIdentityMismatchFromCompleted(
-          completed,
+          result,
           `Pinned Grit preflight expected completed exit 0 with ${pinnedGritIdentity.nativeVersion}, observed exit ${result.exit.code} with ${observedVersion}.`
         )
     )
   );
 });
+
+const observePinnedGritIdentity = Effect.fn("grit.native.preflight.observe")(function* <
+  Run extends CommandRunnerService["run"],
+>(run: Run, request: HabitatProcessRequest) {
+  const result = yield* run(request);
+  return yield* classifyPreflightExecution(result);
+});
+
+/**
+ * Identifies an inconclusive identity observation: exit zero with two untruncated blank streams.
+ * Preflight confirms it exactly once; contradictory or persistently blank evidence fails closed.
+ */
+function isCompletedBlankPreflight(result: HabitatCommandResult): boolean {
+  return (
+    !result.exit.interrupted &&
+    result.exit.code === 0 &&
+    !result.stdout.truncated &&
+    !result.stderr.truncated &&
+    result.stdout.text.trim().length === 0 &&
+    result.stderr.text.trim().length === 0
+  );
+}
 
 const classifyPreflightExecution = Effect.fn("grit.native.preflight.classify")(function* (
   result: HabitatCommandResult

--- a/tools/habitat/src/service/model/validation/policy/target-routing.policy.ts
+++ b/tools/habitat/src/service/model/validation/policy/target-routing.policy.ts
@@ -30,10 +30,21 @@ export function prePushTargetPlanForChangedPaths(
   authorityRules: readonly HabitatAuthorityRulePathInput[]
 ): ValidationTargetPlan {
   const plan = habitatAuthorityPathPlan(changedPaths, authorityRules);
+  if (plan.allHabitatAuthorityFiles && requiresHabitatAuthorityCompiler(changedPaths)) {
+    return { kind: "affected", targets: ["check"] };
+  }
   if (plan.allHabitatAuthorityFiles) {
     return authorityTargetPlan(plan, targetNames, authorityRules);
   }
   return { kind: "affected", targets: ["check"] };
+}
+
+function requiresHabitatAuthorityCompiler(changedPaths: readonly string[]): boolean {
+  return changedPaths.some(
+    (path) =>
+      path === ".habitat/tsconfig.json" ||
+      (path.startsWith(".habitat/") && /\.(?:[cm]?ts|tsx)$/.test(path))
+  );
 }
 
 function authorityTargetPlan(

--- a/tools/habitat/src/service/modules/hook/model/policy/procedure-operations.policy.ts
+++ b/tools/habitat/src/service/modules/hook/model/policy/procedure-operations.policy.ts
@@ -377,7 +377,9 @@ export const prePushChangedPaths = Effect.fn("hook.prePush.changedPaths")(functi
   base: string
 ) {
   const result = yield* context.git
-    .command(["diff", "--name-only", "-z", base, "HEAD"], { cwd: context.platform.repoRoot })
+    .command(["diff", "--no-renames", "--name-only", "-z", base, "HEAD"], {
+      cwd: context.platform.repoRoot,
+    })
     .pipe(Effect.catchAll(() => Effect.succeed(undefined)));
   return Option.match(
     Option.fromNullable(result).pipe(Option.filter((command) => command.exit.code === 0)),

--- a/tools/habitat/test/lib/grit-provider.test.ts
+++ b/tools/habitat/test/lib/grit-provider.test.ts
@@ -1559,6 +1559,80 @@ describe("Grit generic acquisition and public disposition", () => {
     ).toHaveLength(2);
   });
 
+  test("re-observes one completed blank preflight and caches the recovered identity", async () => {
+    const observed: HabitatProcessRequest[] = [];
+    const runner = {
+      run: (request: HabitatProcessRequest) => {
+        const priorPreflights = observed.filter(
+          ({ commandId }) => commandId === "grit-pinned-native-preflight"
+        ).length;
+        observed.push(request);
+        const kind =
+          request.commandId === "grit-pinned-native-preflight" && priorPreflights === 0
+            ? "blank"
+            : "exact";
+        return preflightScenarioEffect(kind, request);
+      },
+    };
+    const request = {
+      scanRoots: [providerRoot] as const,
+      cwd: repoRoot,
+      gritDir: path.join(repoRoot, ".grit"),
+      cacheDir: path.join(repoRoot, ".cache"),
+      gritUserConfigDir: path.join(repoRoot, ".grit-user"),
+    };
+
+    const results = await Effect.runPromise(
+      makeGritCommandTestService(runner).pipe(
+        Effect.flatMap((grit) => Effect.all([grit.check(request), grit.check(request)]))
+      )
+    );
+
+    expect(results).toHaveLength(2);
+    expect(observed.map(({ commandId }) => commandId)).toEqual([
+      "grit-pinned-native-preflight",
+      "grit-pinned-native-preflight",
+      "grit-selected-rule-json-check",
+      "grit-selected-rule-json-check",
+    ]);
+  });
+
+  test("fails a persistently blank completed preflight after exactly two observations", async () => {
+    const observed: HabitatProcessRequest[] = [];
+    const runner = {
+      run: (request: HabitatProcessRequest) => {
+        observed.push(request);
+        return preflightScenarioEffect("blank", request);
+      },
+    };
+    const request = {
+      scanRoots: [providerRoot] as const,
+      cwd: repoRoot,
+      gritDir: path.join(repoRoot, ".grit"),
+      cacheDir: path.join(repoRoot, ".cache"),
+      gritUserConfigDir: path.join(repoRoot, ".grit-user"),
+    };
+
+    const result = await Effect.runPromise(
+      makeGritCommandTestService(runner).pipe(
+        Effect.flatMap((grit) => Effect.either(grit.check(request)))
+      )
+    );
+
+    expect(result).toMatchObject({
+      _tag: "Left",
+      left: {
+        _tag: "CommandUnavailable",
+        mismatchKind: "native-identity-mismatch",
+        observation: { kind: "completed" },
+      },
+    });
+    expect(observed.map(({ commandId }) => commandId)).toEqual([
+      "grit-pinned-native-preflight",
+      "grit-pinned-native-preflight",
+    ]);
+  });
+
   test("retries a failed preflight and reuses the first successful observation", async () => {
     const selected = rule("alpha", "alpha_pattern", providerPattern, [providerRoot]);
     const root = path.join(repoRoot, providerRoot);
@@ -2159,6 +2233,7 @@ function preflightScenarioEffect(
     | "wrong-version"
     | "wrong-stream"
     | "truncated"
+    | "blank"
     | "exact",
   request: HabitatProcessRequest
 ) {
@@ -2211,6 +2286,7 @@ function preflightScenarioEffect(
         })
       )
     ),
+    Match.when("blank", () => Effect.succeed(makeHabitatCommandResult(request))),
     Match.when("exact", () => Effect.succeed(exactPreflightOrTargetResult(request))),
     Match.exhaustive
   );

--- a/tools/habitat/test/service/hook-service.test.ts
+++ b/tools/habitat/test/service/hook-service.test.ts
@@ -125,7 +125,7 @@ describe("Habitat hook service", () => {
     expect(gitCalls).toEqual([
       "symbolic-ref --quiet --short refs/remotes/origin/HEAD",
       "merge-base HEAD origin/main",
-      "diff --name-only -z abc123mergebase HEAD",
+      "diff --no-renames --name-only -z abc123mergebase HEAD",
     ]);
   });
 
@@ -254,7 +254,7 @@ describe("Habitat hook service", () => {
       makeFakeGitProviderLayer((argv, options) => {
         const stdout = stdoutForCommand(
           argv,
-          "diff --name-only -z HEAD~1 HEAD",
+          "diff --no-renames --name-only -z HEAD~1 HEAD",
           renderPathList([...changedPaths])
         );
         return commandResult(argv, options.cwd, stdout);
@@ -289,7 +289,7 @@ describe("Habitat hook service", () => {
       makeFakeGitProviderLayer((argv, options) => {
         const stdout = stdoutForCommand(
           argv,
-          "diff --name-only -z HEAD~1 HEAD",
+          "diff --no-renames --name-only -z HEAD~1 HEAD",
           renderPathList([...changedPaths])
         );
         return commandResult(argv, options.cwd, stdout);
@@ -329,7 +329,7 @@ describe("Habitat hook service", () => {
       makeFakeGitProviderLayer((argv, options) => {
         const stdout = stdoutForCommand(
           argv,
-          "diff --name-only -z HEAD~1 HEAD",
+          "diff --no-renames --name-only -z HEAD~1 HEAD",
           renderPathList(["packages/sdk/src/deleted.ts"])
         );
         return commandResult(argv, options.cwd, stdout);
@@ -375,7 +375,7 @@ describe("Habitat hook service", () => {
       makeFakeGitProviderLayer((argv, options) => {
         const stdout = stdoutForCommand(
           argv,
-          "diff --name-only -z HEAD~1 HEAD",
+          "diff --no-renames --name-only -z HEAD~1 HEAD",
           renderPathList([...changedPaths])
         );
         return commandResult(argv, options.cwd, stdout);
@@ -402,7 +402,7 @@ describe("Habitat hook service", () => {
       makeFakeGitProviderLayer((argv, options) => {
         const stdout = stdoutForCommand(
           argv,
-          "diff --name-only -z HEAD~1 HEAD",
+          "diff --no-renames --name-only -z HEAD~1 HEAD",
           renderPathList([...changedPaths])
         );
         return commandResult(argv, options.cwd, stdout);
@@ -431,7 +431,7 @@ describe("Habitat hook service", () => {
       makeFakeGitProviderLayer((argv, options) => {
         const stdout = stdoutForCommand(
           argv,
-          "diff --name-only -z HEAD~1 HEAD",
+          "diff --no-renames --name-only -z HEAD~1 HEAD",
           renderPathList(changedPaths)
         );
         return commandResult(argv, options.cwd, stdout);
@@ -464,7 +464,7 @@ describe("Habitat hook service", () => {
       makeFakeGitProviderLayer((argv, options) => {
         const stdout = stdoutForCommand(
           argv,
-          "diff --name-only -z HEAD~1 HEAD",
+          "diff --no-renames --name-only -z HEAD~1 HEAD",
           renderPathList([...changedPaths])
         );
         return commandResult(argv, options.cwd, stdout);
@@ -490,7 +490,7 @@ describe("Habitat hook service", () => {
       makeFakeGitProviderLayer((argv, options) => {
         const stdout = stdoutForCommand(
           argv,
-          "diff --name-only -z HEAD~1 HEAD",
+          "diff --no-renames --name-only -z HEAD~1 HEAD",
           renderPathList([...changedPaths])
         );
         return commandResult(argv, options.cwd, stdout);
@@ -501,6 +501,53 @@ describe("Habitat hook service", () => {
     expect(result.exitCode).toBe(0);
     expect(runManyRequests).toEqual([{ targets: ["check:policy"] }]);
     expect(affectedRequests).toEqual([]);
+  });
+
+  test.each([
+    ["compiler config", [".habitat/tsconfig.json"]],
+    [
+      "authority script",
+      [
+        ".habitat/habitat/toolkit/_blueprints/service-module/validate_habitat_service_module_file_shape/check.ts",
+      ],
+    ],
+    ["ES module authority script", [".habitat/example/check.mts"]],
+    ["CommonJS authority script", [".habitat/example/check.cts"]],
+    ["TSX authority script", [".habitat/example/check.tsx"]],
+    [
+      "renamed authority script",
+      [
+        ".habitat/habitat/toolkit/_blueprints/service-module/validate_habitat_service_module_file_shape/check.ts",
+        ".habitat/habitat/toolkit/_blueprints/service-module/validate_habitat_service_module_file_shape/check.sh",
+      ],
+    ],
+  ] as const)("uses the owner-complete affected graph for Habitat %s", async (_label, changedPaths) => {
+    const affectedRequests: NxAffectedRequest[] = [];
+    const runManyRequests: NxRunManyRequest[] = [];
+
+    const result = await runPrePushHookServiceInTest(
+      { base: "HEAD~1" },
+      {},
+      makeFakeGitProviderLayer((argv, options) => {
+        const stdout = stdoutForCommand(
+          argv,
+          "diff --no-renames --name-only -z HEAD~1 HEAD",
+          renderPathList([...changedPaths])
+        );
+        return commandResult(argv, options.cwd, stdout);
+      }),
+      trackingNxLayer(affectedRequests, runManyRequests)
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(affectedRequests).toEqual([
+      {
+        base: "HEAD~1",
+        targets: ["check"],
+        head: "HEAD",
+      },
+    ]);
+    expect(runManyRequests).toEqual([]);
   });
 
   test.each([
@@ -517,7 +564,7 @@ describe("Habitat hook service", () => {
       makeFakeGitProviderLayer((argv, options) => {
         const stdout = stdoutForCommand(
           argv,
-          "diff --name-only -z HEAD~1 HEAD",
+          "diff --no-renames --name-only -z HEAD~1 HEAD",
           renderPathList([changedPath])
         );
         return commandResult(argv, options.cwd, stdout);


### PR DESCRIPTION
This PR advances the pre-A.2 foundation to merge-ready state and delivers several behavioral fixes across Habitat tooling.

## Workstream Sequencing

The workstream documents are updated to reflect that the certified independent foundation merges before A.2 begins. References to a "split-base sibling" model and parallel A.2/continuation tracks are replaced throughout with the current sequencing: normalize and merge the foundation via native Graphite, then start A.2 from merged `main`. The Graphite Law, ownership amendment, stage descriptions, flowchart, and ledger control state are all updated to match. The verification ledger advances to `pre-a2-foundation-merge` phase with the full sealed layer list including MapGen capability/package boundaries, operation admission, test authority, and compiler ownership.

## Habitat Authority Compiler Coverage

A `tsconfig.json` is added to `.habitat/` so the authority scripts directory has its own discoverable compiler project. The `check:tools` script in `tools/habitat` is extended to typecheck this project. The pre-push hook routing policy is updated so that changes to `.habitat/tsconfig.json` or any `.ts`/`.mts`/`.cts`/`.tsx` file under `.habitat/` route to the owner-complete affected graph rather than the authority-only target plan. Tests cover the compiler config path, standard and variant-extension authority scripts, and a mixed rename scenario.

## Grit Preflight Blank-Output Retry

The pinned Grit preflight now handles the case where a completed exit-zero run produces blank stdout and stderr. On a first blank observation the preflight re-runs once; if the second observation also returns blank the check fails closed with a native-identity-mismatch error. Two new tests cover the recovery path (blank first, valid second) and the persistent-blank failure path, verifying the exact sequence of command invocations in each case.

## Git Diff Rename Suppression

`--no-renames` is added to the `git diff` invocation in the pre-push hook so renamed files are reported as a delete and an add rather than a rename entry. All hook service tests are updated to expect the new flag.

## ESLint Boundary Configuration

Habitat's virtual project cycles and lazy CLI command imports are explicitly declared in the ESLint boundaries config so the import-graph linter does not flag the admitted architectural layering inside the Habitat package as violations.

## Rule Graph Dependency Update

The `block_studio_config_leakage_into_shipped_catalog` rule's graph dependency is updated from `gen:map-artifacts` to `generated:check`, aligning it with the non-mutating currentness target model described in the authority-tool separation document.

## Policy File Validation Relaxation

The service-module file shape validator passes `{ strictPolicyNames: false }` when checking policy directory contents, allowing known policy implementation files that do not match the strict naming pattern to pass validation.

## OpenSpec Task Completion

Tasks 8.1 through 8.4 of the portable canonical envelope correction section are marked complete.