### PR TITLE
feat(habitat): batch multi-pattern check catalogs, bound stream output capture, and add command lifecycle cancellation

### DIFF
--- a/docs/projects/habitat-harness/execution-surface-map/execution-surface-map.json
+++ b/docs/projects/habitat-harness/execution-surface-map/execution-surface-map.json
@@ -5391,7 +5391,7 @@
       ]
     },
     {
-      "target": "grit-selected-rule-json-check",
+      "target": "grit-selected-rules-json-check",
       "targetClass": "workspace-tool",
       "references": 1,
       "sourceCount": 1,
@@ -5661,6 +5661,33 @@
       ]
     },
     {
+      "target": "grit.check.acquireBatch",
+      "targetClass": "workspace-tool",
+      "references": 1,
+      "sourceCount": 1,
+      "sampleSources": [
+        "tools/habitat/src/resources/rule-diagnostics/providers/grit/check.ts"
+      ]
+    },
+    {
+      "target": "grit.check.acquireMaterialized",
+      "targetClass": "workspace-tool",
+      "references": 1,
+      "sourceCount": 1,
+      "sampleSources": [
+        "tools/habitat/src/resources/rule-diagnostics/providers/grit/check.ts"
+      ]
+    },
+    {
+      "target": "grit.check.acquireShared",
+      "targetClass": "workspace-tool",
+      "references": 1,
+      "sourceCount": 1,
+      "sampleSources": [
+        "tools/habitat/src/resources/rule-diagnostics/providers/grit/check.ts"
+      ]
+    },
+    {
       "target": "grit.check.canonicalize",
       "targetClass": "workspace-tool",
       "references": 1,
@@ -5685,6 +5712,24 @@
       "sourceCount": 1,
       "sampleSources": [
         "tools/habitat/src/resources/rule-diagnostics/providers/grit/check.ts"
+      ]
+    },
+    {
+      "target": "grit.check.runMaterializedBatch",
+      "targetClass": "workspace-tool",
+      "references": 1,
+      "sourceCount": 1,
+      "sampleSources": [
+        "tools/habitat/src/resources/rule-diagnostics/providers/grit/check.ts"
+      ]
+    },
+    {
+      "target": "grit.checkGroup.executeTimed",
+      "targetClass": "workspace-tool",
+      "references": 1,
+      "sourceCount": 1,
+      "sampleSources": [
+        "tools/habitat/src/resources/rule-diagnostics/providers/grit/runner.ts"
       ]
     },
     {
@@ -5725,6 +5770,15 @@
     },
     {
       "target": "grit.diagnosticOutcomes.run",
+      "targetClass": "workspace-tool",
+      "references": 1,
+      "sourceCount": 1,
+      "sampleSources": [
+        "tools/habitat/src/resources/rule-diagnostics/providers/grit/runner.ts"
+      ]
+    },
+    {
+      "target": "grit.executionUnit.execute",
       "targetClass": "workspace-tool",
       "references": 1,
       "sourceCount": 1,
@@ -5784,6 +5838,15 @@
       "sourceCount": 1,
       "sampleSources": [
         "tools/habitat/src/resources/rule-diagnostics/providers/grit/command.ts"
+      ]
+    },
+    {
+      "target": "grit.pattern.materialize",
+      "targetClass": "workspace-tool",
+      "references": 1,
+      "sourceCount": 1,
+      "sampleSources": [
+        "tools/habitat/src/resources/rule-diagnostics/providers/grit/scoped-config.ts"
       ]
     },
     {
@@ -5877,12 +5940,30 @@
       ]
     },
     {
+      "target": "grit.scopedCatalog.acquire",
+      "targetClass": "workspace-tool",
+      "references": 1,
+      "sourceCount": 1,
+      "sampleSources": [
+        "tools/habitat/src/resources/rule-diagnostics/providers/grit/scoped-config.ts"
+      ]
+    },
+    {
       "target": "grit.scopedWorkspace.acquire",
       "targetClass": "workspace-tool",
       "references": 1,
       "sourceCount": 1,
       "sampleSources": [
         "tools/habitat/src/resources/rule-diagnostics/providers/grit/scoped-config.ts"
+      ]
+    },
+    {
+      "target": "grit.singleExecutionUnit.execute",
+      "targetClass": "workspace-tool",
+      "references": 1,
+      "sourceCount": 1,
+      "sampleSources": [
+        "tools/habitat/src/resources/rule-diagnostics/providers/grit/runner.ts"
       ]
     },
     {
@@ -59389,6 +59470,7 @@
           "./observation.js",
           "./types.js",
           "@habitat/cli/providers/git/state",
+          "effect",
           "node:crypto",
           "node:path"
         ],
@@ -59419,6 +59501,11 @@
             "kind": "import",
             "value": "@habitat/cli/providers/git/state",
             "targetClass": "habitat-toolkit"
+          },
+          {
+            "kind": "import",
+            "value": "effect",
+            "targetClass": "external"
           },
           {
             "kind": "import",
@@ -59602,7 +59689,6 @@
           "./types.js",
           "@effect/platform",
           "@effect/platform/CommandExecutor",
-          "@effect/platform/Error",
           "@habitat/cli/providers/git/state",
           "@habitat/cli/resources/config/index",
           "@habitat/cli/resources/platform/index",
@@ -59654,11 +59740,6 @@
           {
             "kind": "import",
             "value": "@effect/platform/CommandExecutor",
-            "targetClass": "external"
-          },
-          {
-            "kind": "import",
-            "value": "@effect/platform/Error",
             "targetClass": "external"
           },
           {
@@ -60499,9 +60580,13 @@
         "childProcessCalls": [],
         "shellCommandCalls": [
           "grit.check.acquire",
+          "grit.check.acquireBatch",
+          "grit.check.acquireMaterialized",
+          "grit.check.acquireShared",
           "grit.check.canonicalize",
           "grit.check.canonicalPaths",
           "grit.check.completeCapture",
+          "grit.check.runMaterializedBatch",
           "node:path"
         ],
         "directHabitatPathCalls": [],
@@ -60622,6 +60707,21 @@
           },
           {
             "kind": "shell-command",
+            "value": "grit.check.acquireBatch",
+            "targetClass": "workspace-tool"
+          },
+          {
+            "kind": "shell-command",
+            "value": "grit.check.acquireMaterialized",
+            "targetClass": "workspace-tool"
+          },
+          {
+            "kind": "shell-command",
+            "value": "grit.check.acquireShared",
+            "targetClass": "workspace-tool"
+          },
+          {
+            "kind": "shell-command",
             "value": "grit.check.canonicalize",
             "targetClass": "workspace-tool"
           },
@@ -60633,6 +60733,11 @@
           {
             "kind": "shell-command",
             "value": "grit.check.completeCapture",
+            "targetClass": "workspace-tool"
+          },
+          {
+            "kind": "shell-command",
+            "value": "grit.check.runMaterializedBatch",
             "targetClass": "workspace-tool"
           },
           {
@@ -60757,7 +60862,7 @@
           "grit",
           "grit 0.1.1",
           "grit-pinned-native-preflight",
-          "grit-selected-rule-json-check",
+          "grit-selected-rules-json-check",
           "grit.commandService.make",
           "grit.live.run",
           "grit.native.preflight",
@@ -60874,7 +60979,7 @@
           },
           {
             "kind": "shell-command",
-            "value": "grit-selected-rule-json-check",
+            "value": "grit-selected-rules-json-check",
             "targetClass": "workspace-tool"
           },
           {
@@ -61983,13 +62088,16 @@
         "shellCommandCalls": [
           "grit.acquisitionPolicy.execute",
           "grit.applyPolicy.execute",
+          "grit.checkGroup.executeTimed",
           "grit.checkPolicy.execute",
           "grit.diagnosticExecutions.run",
           "grit.diagnosticOutcomes.run",
+          "grit.executionUnit.execute",
           "grit.plan.execute",
           "grit.plan.executeTimed",
           "grit.plan.executeUntimed",
           "grit.rules.run",
+          "grit.singleExecutionUnit.execute",
           "node:path"
         ],
         "directHabitatPathCalls": [],
@@ -62125,6 +62233,11 @@
           },
           {
             "kind": "shell-command",
+            "value": "grit.checkGroup.executeTimed",
+            "targetClass": "workspace-tool"
+          },
+          {
+            "kind": "shell-command",
             "value": "grit.checkPolicy.execute",
             "targetClass": "workspace-tool"
           },
@@ -62136,6 +62249,11 @@
           {
             "kind": "shell-command",
             "value": "grit.diagnosticOutcomes.run",
+            "targetClass": "workspace-tool"
+          },
+          {
+            "kind": "shell-command",
+            "value": "grit.executionUnit.execute",
             "targetClass": "workspace-tool"
           },
           {
@@ -62156,6 +62274,11 @@
           {
             "kind": "shell-command",
             "value": "grit.rules.run",
+            "targetClass": "workspace-tool"
+          },
+          {
+            "kind": "shell-command",
+            "value": "grit.singleExecutionUnit.execute",
             "targetClass": "workspace-tool"
           },
           {
@@ -62397,7 +62520,9 @@
           "contents"
         ],
         "shellCommandCalls": [
+          "grit.pattern.materialize",
           "grit.patternAsset.canonicalize",
+          "grit.scopedCatalog.acquire",
           "grit.scopedWorkspace.acquire",
           "grit.yaml",
           "node:path"
@@ -62405,7 +62530,7 @@
         "directHabitatPathCalls": [],
         "cwdAssumptions": [],
         "knownMutationVerbs": [
-          "fs\n      .writeFileString(path.join(gritDir, \"grit.yaml\"), renderConfig(rule, body)).pipe",
+          "fs\n    .writeFileString(path.join(gritDir, \"grit.yaml\"), renderConfig(patterns)).pipe",
           "fs.writeFileString",
           "rm"
         ],
@@ -62452,7 +62577,7 @@
           },
           {
             "kind": "mutation-verb",
-            "value": "fs\n      .writeFileString(path.join(gritDir, \"grit.yaml\"), renderConfig(rule, body)).pipe",
+            "value": "fs\n    .writeFileString(path.join(gritDir, \"grit.yaml\"), renderConfig(patterns)).pipe",
             "targetClass": "unknown"
           },
           {
@@ -62482,7 +62607,17 @@
           },
           {
             "kind": "shell-command",
+            "value": "grit.pattern.materialize",
+            "targetClass": "workspace-tool"
+          },
+          {
+            "kind": "shell-command",
             "value": "grit.patternAsset.canonicalize",
+            "targetClass": "workspace-tool"
+          },
+          {
+            "kind": "shell-command",
+            "value": "grit.scopedCatalog.acquire",
             "targetClass": "workspace-tool"
           },
           {

--- a/tools/habitat/src/cli/base/HabitatCommand.ts
+++ b/tools/habitat/src/cli/base/HabitatCommand.ts
@@ -1,13 +1,32 @@
 import { createLiveHabitatServiceContext } from "@habitat/cli/runtime/service-context";
+import { habitatServiceManagedRuntime } from "@habitat/cli/runtime/service-runtime";
 import type { HabitatServiceContext } from "@habitat/cli/service/base";
 import { habitatServiceRouter } from "@habitat/cli/service/router";
 import { Command, Flags } from "@oclif/core";
 import { createRouterClient } from "@orpc/server";
+import { installHabitatCommandLifecycle } from "./command-lifecycle.js";
 
 export abstract class HabitatCommand extends Command {
   static override baseFlags = {
     help: Flags.help({ char: "h" }),
   };
+
+  private commandLifecycle: ReturnType<typeof installHabitatCommandLifecycle> | undefined;
+
+  protected override async init(): Promise<void> {
+    await super.init();
+    this.commandLifecycle = installHabitatCommandLifecycle(() =>
+      habitatServiceManagedRuntime.dispose()
+    );
+  }
+
+  protected override async finally(error: Error | undefined): Promise<void> {
+    try {
+      await this.commandLifecycle?.finish();
+    } finally {
+      await super.finally(error);
+    }
+  }
 
   protected rawArgv(): string[] {
     return ((this as unknown as { argv?: string[] }).argv ?? []).slice();
@@ -27,5 +46,13 @@ export abstract class HabitatCommand extends Command {
 
   protected habitatServiceClientForContext(context: HabitatServiceContext) {
     return createRouterClient(habitatServiceRouter, { context });
+  }
+
+  /** Supplies command-scoped cancellation to every local Habitat oRPC procedure call. */
+  protected habitatServiceCallerOptions(): { readonly signal: AbortSignal } {
+    if (!this.commandLifecycle) {
+      throw new Error("Habitat command lifecycle is unavailable before oclif initialization.");
+    }
+    return this.commandLifecycle.callerOptions;
   }
 }

--- a/tools/habitat/src/cli/base/command-lifecycle.ts
+++ b/tools/habitat/src/cli/base/command-lifecycle.ts
@@ -1,0 +1,60 @@
+const habitatCommandSignals = ["SIGINT", "SIGTERM"] as const;
+
+type HabitatCommandSignal = (typeof habitatCommandSignals)[number];
+type SignalListener = () => void;
+
+interface HabitatSignalTarget {
+  readonly pid: number;
+  on(signal: HabitatCommandSignal, listener: SignalListener): unknown;
+  removeListener(signal: HabitatCommandSignal, listener: SignalListener): unknown;
+  kill(pid: number, signal: HabitatCommandSignal): boolean;
+}
+
+/**
+ * Owns one Habitat command's cancellation and runtime-disposal boundary.
+ *
+ * SIGINT/SIGTERM first abort the active local oRPC call. Oclif's `finally` hook then calls
+ * `finish`, which removes these listeners, disposes the shared Effect runtime, and re-delivers
+ * the original signal so the host preserves its native signal exit status.
+ */
+export function installHabitatCommandLifecycle(
+  disposeRuntime: () => Promise<void>,
+  signalTarget: HabitatSignalTarget = process
+) {
+  const abortController = new AbortController();
+  let interruptedBy: HabitatCommandSignal | undefined;
+  let finishPromise: Promise<void> | undefined;
+
+  const interrupt = (signal: HabitatCommandSignal) => {
+    if (interruptedBy !== undefined) return;
+    interruptedBy = signal;
+    abortController.abort();
+  };
+  const onSigint = () => interrupt("SIGINT");
+  const onSigterm = () => interrupt("SIGTERM");
+  const listeners = [
+    ["SIGINT", onSigint],
+    ["SIGTERM", onSigterm],
+  ] as const;
+
+  for (const [signal, listener] of listeners) signalTarget.on(signal, listener);
+
+  return {
+    callerOptions: { signal: abortController.signal },
+    finish: () => {
+      finishPromise ??= (async () => {
+        try {
+          await disposeRuntime();
+        } finally {
+          for (const [signal, listener] of listeners) {
+            signalTarget.removeListener(signal, listener);
+          }
+          if (interruptedBy !== undefined) {
+            signalTarget.kill(signalTarget.pid, interruptedBy);
+          }
+        }
+      })();
+      return finishPromise;
+    },
+  };
+}

--- a/tools/habitat/src/cli/commands/check.ts
+++ b/tools/habitat/src/cli/commands/check.ts
@@ -54,23 +54,29 @@ export default class Check extends HabitatCommand {
     const context = await this.habitatServiceContext();
     const client = this.habitatServiceClientForContext(context);
     if (flags["expand-baseline"]) {
-      const expansion = await client.check.expandBaseline({
-        selectors: selection,
-        base,
-      });
+      const expansion = await client.check.expandBaseline(
+        {
+          selectors: selection,
+          base,
+        },
+        this.habitatServiceCallerOptions()
+      );
       if (expansion.kind === "refused") this.error(expansion.message, { exit: 1 });
       for (const message of expansion.messages) this.log(message);
       return;
     }
 
     const baselineIntegrity = flags["baseline-integrity"] || Boolean(flags.base);
-    const report = await client.check.report({
-      selectors: selection,
-      ...(baselineIntegrity ? { base } : {}),
-      baselineIntegrity,
-      command: checkCommandContext(this.rawArgv()),
-      staged: flags.staged,
-    });
+    const report = await client.check.report(
+      {
+        selectors: selection,
+        ...(baselineIntegrity ? { base } : {}),
+        baselineIntegrity,
+        command: checkCommandContext(this.rawArgv()),
+        staged: flags.staged,
+      },
+      this.habitatServiceCallerOptions()
+    );
     const rendered = renderCheckReport(report, { json: flags.json });
     if (flags.output) {
       writeFileSync(

--- a/tools/habitat/src/cli/commands/classify.ts
+++ b/tools/habitat/src/cli/commands/classify.ts
@@ -19,6 +19,10 @@ export default class Classify extends HabitatCommand {
   async run(): Promise<void> {
     const { args } = await this.parse(Classify);
     const client = await this.habitatServiceClient();
-    this.log(stringifyClassifyResult(await client.classify.target({ target: args.path })));
+    this.log(
+      stringifyClassifyResult(
+        await client.classify.target({ target: args.path }, this.habitatServiceCallerOptions())
+      )
+    );
   }
 }

--- a/tools/habitat/src/cli/commands/fix.ts
+++ b/tools/habitat/src/cli/commands/fix.ts
@@ -29,7 +29,8 @@ export default class Fix extends HabitatCommand {
     }
     const client = await this.habitatServiceClient();
     const result = await client.fix.previewPatterns(
-      flags.rule && flags.rule.length > 0 ? { rules: flags.rule } : {}
+      flags.rule && flags.rule.length > 0 ? { rules: flags.rule } : {},
+      this.habitatServiceCallerOptions()
     );
     process.stdout.write(result.stdout);
     process.stderr.write(result.stderr);

--- a/tools/habitat/src/cli/commands/graph.ts
+++ b/tools/habitat/src/cli/commands/graph.ts
@@ -14,7 +14,7 @@ export default class Graph extends HabitatCommand {
   async run(): Promise<void> {
     const { flags } = await this.parse(Graph);
     const client = await this.habitatServiceClient();
-    const result = await client.graph.workspaceGraph({});
+    const result = await client.graph.workspaceGraph({}, this.habitatServiceCallerOptions());
     if (result.kind === "command-failed") {
       process.stdout.write(result.stdout);
       process.stderr.write(result.stderr);

--- a/tools/habitat/src/cli/commands/hook.ts
+++ b/tools/habitat/src/cli/commands/hook.ts
@@ -28,11 +28,11 @@ export default class Hook extends HabitatCommand {
   private async runHookAction(name: string | undefined, base: string | undefined) {
     if (name === "pre-commit") {
       const client = await this.habitatServiceClient();
-      return client.hook.preCommit({});
+      return client.hook.preCommit({}, this.habitatServiceCallerOptions());
     }
     if (name === "pre-push") {
       const client = await this.habitatServiceClient();
-      return client.hook.prePush({ base });
+      return client.hook.prePush({ base }, this.habitatServiceCallerOptions());
     }
     return unknownHookResult(name);
   }

--- a/tools/habitat/src/cli/commands/verify.ts
+++ b/tools/habitat/src/cli/commands/verify.ts
@@ -24,10 +24,13 @@ export default class Verify extends HabitatCommand {
   async run(): Promise<void> {
     const { flags } = await this.parse(Verify);
     const service = await this.habitatServiceClient();
-    const result = await service.verify.changes({
-      base: flags.base,
-      affectedExecution: flags.json ? "plan-only" : "run",
-    });
+    const result = await service.verify.changes(
+      {
+        base: flags.base,
+        affectedExecution: flags.json ? "plan-only" : "run",
+      },
+      this.habitatServiceCallerOptions()
+    );
     if (result.kind === "base-refused") this.error(result.message, { exit: 1 });
     const checkSummary = verifyCheckSummary(result.checkReport);
     const exitCode = result.receipt.command.exitCode;

--- a/tools/habitat/src/resources/command/output.ts
+++ b/tools/habitat/src/resources/command/output.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { type HabitatCommandGitState, unknownGitState } from "@habitat/cli/providers/git/state";
+import { Effect, Stream } from "effect";
 import { commandObservationFromExit } from "./observation.js";
 import type {
   HabitatCommandResult,
@@ -9,7 +10,10 @@ import type {
   RedactedEnvValue,
 } from "./types.js";
 
-const CAPTURE_LIMIT_BYTES = 4 * 1024 * 1024;
+/** Maximum stdout or stderr prefix retained by one command observation. */
+export const COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES = 4 * 1024 * 1024;
+
+const OUTPUT_CAPTURE_BLOCK_BYTES = 64 * 1024;
 const SENSITIVE_ENV_KEY = /(TOKEN|SECRET|PASSWORD|PASS|KEY|AUTH|CREDENTIAL|SESSION)/i;
 
 export function makeHabitatCommandResult(
@@ -64,8 +68,8 @@ export function makeCommandResultFromObservation(
     readonly exitCode: number;
     readonly signal?: string | null;
     readonly interrupted?: boolean;
-    readonly stdout: string;
-    readonly stderr: string;
+    readonly stdout: OutputCapture;
+    readonly stderr: OutputCapture;
   }
 ): HabitatCommandResult {
   return makeHabitatCommandResult(request, {
@@ -83,24 +87,89 @@ export function makeCommandResultFromObservation(
       signal: observation.signal ?? null,
       interrupted: observation.interrupted ?? false,
     },
-    stdout: captureOutput(observation.stdout),
-    stderr: captureOutput(observation.stderr),
+    stdout: observation.stdout,
+    stderr: observation.stderr,
   });
 }
 
 export function captureOutput(text: string): OutputCapture {
-  const bytes = Buffer.byteLength(text, "utf8");
-  const buffer = Buffer.from(text, "utf8");
-  const captured =
-    buffer.length > CAPTURE_LIMIT_BYTES
-      ? buffer.subarray(0, CAPTURE_LIMIT_BYTES).toString("utf8")
-      : text;
+  const accumulator = makeOutputCaptureAccumulator();
+  accumulator.append(Buffer.from(text, "utf8"));
+  return accumulator.finish();
+}
+
+/**
+ * Drains a byte stream while retaining only its bounded prefix.
+ *
+ * Every byte contributes to the total and SHA-256 digest. UTF-8 decoding is
+ * deferred until the stream completes so code points split across chunks remain
+ * intact. Retained blocks grow on demand and never exceed the capture limit.
+ */
+export function collectOutputCapture<E, R>(stream: Stream.Stream<Uint8Array, E, R>) {
+  return Effect.suspend(() =>
+    Stream.runFold(stream, makeOutputCaptureAccumulator(), appendOutputChunk).pipe(
+      Effect.map(finishOutputCapture)
+    )
+  );
+}
+
+function makeOutputCaptureAccumulator() {
+  const hash = createHash("sha256");
+  const retainedBlocks: Buffer[] = [];
+  let bytes = 0;
+  let retainedBytes = 0;
+
   return {
-    text: captured,
-    truncated: buffer.length > CAPTURE_LIMIT_BYTES,
-    sha256: createHash("sha256").update(text).digest("hex"),
-    bytes,
+    append(chunk: Uint8Array): void {
+      hash.update(chunk);
+      bytes += chunk.byteLength;
+
+      let chunkOffset = 0;
+      const bytesToRetain = Math.min(
+        chunk.byteLength,
+        COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES - retainedBytes
+      );
+      while (chunkOffset < bytesToRetain) {
+        const blockIndex = Math.floor(retainedBytes / OUTPUT_CAPTURE_BLOCK_BYTES);
+        const blockOffset = retainedBytes % OUTPUT_CAPTURE_BLOCK_BYTES;
+        const block =
+          retainedBlocks[blockIndex] ??
+          allocateCaptureBlock(retainedBlocks, blockIndex * OUTPUT_CAPTURE_BLOCK_BYTES);
+        const copyBytes = Math.min(bytesToRetain - chunkOffset, block.byteLength - blockOffset);
+        block.set(chunk.subarray(chunkOffset, chunkOffset + copyBytes), blockOffset);
+        chunkOffset += copyBytes;
+        retainedBytes += copyBytes;
+      }
+    },
+    finish(): OutputCapture {
+      return {
+        text: Buffer.concat(retainedBlocks, retainedBytes).toString("utf8"),
+        truncated: bytes > retainedBytes,
+        sha256: hash.digest("hex"),
+        bytes,
+      };
+    },
   };
+}
+
+function allocateCaptureBlock(retainedBlocks: Buffer[], retainedBytes: number): Buffer {
+  const block = Buffer.allocUnsafe(
+    Math.min(OUTPUT_CAPTURE_BLOCK_BYTES, COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES - retainedBytes)
+  );
+  retainedBlocks.push(block);
+  return block;
+}
+
+function appendOutputChunk(
+  accumulator: ReturnType<typeof makeOutputCaptureAccumulator>,
+  chunk: Uint8Array
+) {
+  accumulator.append(chunk);
+  return accumulator;
+}
+
+function finishOutputCapture(accumulator: ReturnType<typeof makeOutputCaptureAccumulator>) {
+  return accumulator.finish();
 }
 
 export function redactEnvDelta(

--- a/tools/habitat/src/resources/command/runner.ts
+++ b/tools/habitat/src/resources/command/runner.ts
@@ -4,7 +4,6 @@ import {
   CommandExecutor,
   type CommandExecutor as CommandExecutorService,
 } from "@effect/platform/CommandExecutor";
-import type { PlatformError } from "@effect/platform/Error";
 import {
   GitStateProvider,
   type GitStateProviderService,
@@ -13,10 +12,10 @@ import {
 } from "@habitat/cli/providers/git/state";
 import { HabitatConfig, type HabitatConfigService } from "@habitat/cli/resources/config/index";
 import { epochMillisToIsoString } from "@habitat/cli/resources/platform/index";
-import { Chunk, Clock, Context, Duration, Effect, Layer, Stream } from "effect";
+import { Clock, Context, Duration, Effect, Layer } from "effect";
 import { CommandInterrupted, CommandUnavailable } from "./errors.js";
 import { materializeHabitatCommandWithConfig } from "./materialize.js";
-import { makeCommandResultFromObservation } from "./output.js";
+import { collectOutputCapture, makeCommandResultFromObservation } from "./output.js";
 import type { CommandRunnerService } from "./service.js";
 import type { HabitatCommandResult, HabitatProcessRequest } from "./types.js";
 
@@ -101,7 +100,11 @@ function executeLiveCommand(
             )
           );
           const [stdout, stderr, exitCode] = yield* Effect.all(
-            [collectStream(process.stdout), collectStream(process.stderr), process.exitCode],
+            [
+              collectOutputCapture(process.stdout),
+              collectOutputCapture(process.stderr),
+              process.exitCode,
+            ],
             { concurrency: "unbounded" }
           );
           const endedMs = yield* Clock.currentTimeMillis;
@@ -181,14 +184,6 @@ export function interruptCommandOnTimeout<R>(
           cause: `command exceeded timeout policy (${timeoutMs}ms)`,
         }),
     })
-  );
-}
-
-function collectStream(
-  stream: Stream.Stream<Uint8Array, PlatformError>
-): Effect.Effect<string, PlatformError> {
-  return Stream.runCollect(stream).pipe(
-    Effect.map((chunks) => Buffer.concat(Chunk.toReadonlyArray(chunks)).toString("utf8"))
   );
 }
 

--- a/tools/habitat/src/resources/rule-diagnostics/index.ts
+++ b/tools/habitat/src/resources/rule-diagnostics/index.ts
@@ -2,6 +2,7 @@ export { makeFakeRuleDiagnosticsLayer } from "./fake.js";
 export {
   type RuleDiagnosticDemand,
   type RuleDiagnosticExecutionResult,
+  type RuleDiagnosticExecutionTiming,
   RuleDiagnostics,
   type RuleDiagnosticsService,
 } from "./resource.js";

--- a/tools/habitat/src/resources/rule-diagnostics/providers/grit/check.ts
+++ b/tools/habitat/src/resources/rule-diagnostics/providers/grit/check.ts
@@ -19,57 +19,194 @@ import {
 import { pathIsWithinRoot } from "./path.js";
 import { captureGritCommandEffect } from "./request.js";
 import {
-  acquireScopedGritWorkspaceEffect,
-  GritPatternAssetInvalid,
-  GritScopedConfigInvalid,
+  acquireScopedGritCatalogEffect,
+  type MaterializedGritPattern,
+  materializeGritPatternEffect,
 } from "./scoped-config.js";
 import type { GritReport } from "./types.js";
 
+type NonEmptyGritRules = readonly [RuleGritFacts, ...RuleGritFacts[]];
+
+interface MaterializedRule {
+  readonly kind: "materialized";
+  readonly rule: RuleGritFacts;
+  readonly pattern: MaterializedGritPattern;
+}
+
+interface FailedRuleMaterialization {
+  readonly kind: "failed";
+  readonly rule: RuleGritFacts;
+  readonly acquisition: GritDiagnosticAcquisition;
+}
+
+type RuleMaterialization = MaterializedRule | FailedRuleMaterialization;
+
+/** Acquires the closed native-check evidence for one selected rule. */
 export const runGritCheckAcquisitionEffect = Effect.fn("grit.check.acquire")(function* (
   rule: RuleGritFacts,
   roots: readonly [string, ...string[]],
   options: { readonly repoRoot: string; readonly grit: GritCommandService }
 ) {
-  return yield* Effect.gen(function* () {
-    const workspace = yield* acquireScopedGritWorkspaceEffect(rule, options.repoRoot);
-    const fs = yield* FileSystem.FileSystem;
-    const providerRequest = {
-      scanRoots: roots,
-      cwd: workspace.cwd,
-      gritDir: workspace.gritDir,
-      cacheDir: workspace.cacheDir,
-      gritUserConfigDir: workspace.userConfigDir,
-    };
-    const processRequest = options.grit.checkRequest(providerRequest);
-    const nativeRequest = nativeGritCommandRequestFromProcessRequest({
-      request: processRequest,
-      commandFamily: "selected-rule-json-check",
-    });
-    const capture = yield* captureGritCommandEffect(
-      processRequest,
-      options.grit.check(providerRequest)
-    );
-    return yield* Match.value(capture).pipe(
-      Match.when({ kind: "command-failed" }, (failure) =>
-        Effect.succeed(commandFailure(nativeRequest, failure))
-      ),
-      Match.when({ kind: "completed" }, ({ result, command }) =>
-        continueCompletedCheckEffect(rule, roots, result, nativeRequest, command, fs)
-      ),
-      Match.exhaustive
-    );
-  }).pipe(
-    Effect.catchTags({
-      GritPatternAssetInvalid: (error) =>
-        Effect.succeed(preCommandFailure("DiagnosticRuleMaterializationFailed", error.detail)),
-      GritScopedConfigInvalid: (error) =>
-        Effect.succeed(preCommandFailure("DiagnosticProviderSetupFailed", error.detail)),
-    })
+  const acquisitions = yield* runGritCheckAcquisitionsEffect([rule], roots, options);
+  return Option.getOrElse(Option.fromNullable(acquisitions.get(rule.id)), () =>
+    preCommandFailure(
+      "DiagnosticProviderSetupFailed",
+      `Grit check produced no acquisition for selected rule ${rule.id}.`
+    )
   );
 });
 
+/**
+ * Acquires one check report for rules with exactly equal ordered scan roots.
+ * Asset admission remains per rule; provider execution is shared only by valid peers.
+ */
+export const runGritCheckAcquisitionsEffect = Effect.fn("grit.check.acquireBatch")(function* (
+  rules: NonEmptyGritRules,
+  roots: readonly [string, ...string[]],
+  options: { readonly repoRoot: string; readonly grit: GritCommandService }
+) {
+  const materializations: readonly RuleMaterialization[] = yield* Effect.forEach(
+    rules,
+    (rule) =>
+      materializeGritPatternEffect(rule, options.repoRoot).pipe(
+        Effect.map((pattern): RuleMaterialization => ({ kind: "materialized", rule, pattern })),
+        Effect.catchTag("GritPatternAssetInvalid", (error) =>
+          Effect.succeed({
+            kind: "failed",
+            rule,
+            acquisition: preCommandFailure("DiagnosticRuleMaterializationFailed", error.detail),
+          } satisfies FailedRuleMaterialization)
+        )
+      ),
+    { concurrency: 1 }
+  );
+  const valid = materializations.flatMap(materializedRuleEntry);
+  const shared = yield* acquireSharedCheckEffect(nonEmptyMaterializations(valid), roots, options);
+  return new Map(
+    materializations.map((materialization) =>
+      materializationAcquisitionEntry(materialization, shared)
+    )
+  );
+});
+
+function materializationAcquisitionEntry(
+  materialization: RuleMaterialization,
+  shared: Option.Option<GritDiagnosticAcquisition>
+): readonly [string, GritDiagnosticAcquisition] {
+  const acquisition = Match.value(materialization).pipe(
+    Match.when({ kind: "failed" }, ({ acquisition: failure }) => failure),
+    Match.when({ kind: "materialized" }, ({ rule }) =>
+      Option.getOrElse(shared, () =>
+        preCommandFailure(
+          "DiagnosticProviderSetupFailed",
+          `Grit check produced no acquisition for materialized rule ${rule.id}.`
+        )
+      )
+    ),
+    Match.exhaustive
+  );
+  return [materialization.rule.id, acquisition];
+}
+
+const acquireSharedCheckEffect = Effect.fn("grit.check.acquireShared")(function* (
+  materializations: Option.Option<readonly [MaterializedRule, ...MaterializedRule[]]>,
+  roots: readonly [string, ...string[]],
+  options: { readonly repoRoot: string; readonly grit: GritCommandService }
+) {
+  return yield* Match.value(materializations).pipe(
+    Match.when({ _tag: "None" }, () => Effect.succeed(Option.none<GritDiagnosticAcquisition>())),
+    Match.orElse(({ value }) => acquireMaterializedCheckEffect(value, roots, options))
+  );
+});
+
+const acquireMaterializedCheckEffect = Effect.fn("grit.check.acquireMaterialized")(function* (
+  materializations: readonly [MaterializedRule, ...MaterializedRule[]],
+  roots: readonly [string, ...string[]],
+  options: { readonly repoRoot: string; readonly grit: GritCommandService }
+) {
+  const acquisition = yield* runMaterializedCheckEffect(materializations, roots, options).pipe(
+    Effect.catchTag("GritScopedConfigInvalid", (error) =>
+      Effect.succeed(preCommandFailure("DiagnosticProviderSetupFailed", error.detail))
+    )
+  );
+  return Option.some(acquisition);
+});
+
+function materializedRuleEntry(materialization: RuleMaterialization): readonly MaterializedRule[] {
+  return Match.value(materialization).pipe(
+    Match.when({ kind: "materialized" }, (value) => [value]),
+    Match.orElse(() => [])
+  );
+}
+
+function nonEmptyMaterializations(
+  materializations: readonly MaterializedRule[]
+): Option.Option<readonly [MaterializedRule, ...MaterializedRule[]]> {
+  const [first, ...rest] = materializations;
+  return Option.fromNullable(first).pipe(Option.map((value) => [value, ...rest]));
+}
+
+function materializedPatterns(
+  materializations: readonly [MaterializedRule, ...MaterializedRule[]]
+): readonly [MaterializedGritPattern, ...MaterializedGritPattern[]] {
+  const [first, ...rest] = materializations;
+  return [first.pattern, ...rest.map(({ pattern }) => pattern)];
+}
+
+const runMaterializedCheckEffect = Effect.fn("grit.check.runMaterializedBatch")(function* (
+  materializations: readonly [MaterializedRule, ...MaterializedRule[]],
+  roots: readonly [string, ...string[]],
+  options: { readonly repoRoot: string; readonly grit: GritCommandService }
+) {
+  const workspace = yield* acquireScopedGritCatalogEffect(materializedPatterns(materializations));
+  const fs = yield* FileSystem.FileSystem;
+  const rules = materializedRules(materializations);
+  const patternNames = materializedPatternNames(materializations);
+  const providerRequest = {
+    patternNames,
+    scanRoots: roots,
+    cwd: workspace.cwd,
+    gritDir: workspace.gritDir,
+    cacheDir: workspace.cacheDir,
+    gritUserConfigDir: workspace.userConfigDir,
+  };
+  const processRequest = options.grit.checkRequest(providerRequest);
+  const nativeRequest = nativeGritCommandRequestFromProcessRequest({
+    request: processRequest,
+    commandFamily: "selected-rules-json-check",
+    patternNames,
+  });
+  const capture = yield* captureGritCommandEffect(
+    processRequest,
+    options.grit.check(providerRequest)
+  );
+  return yield* Match.value(capture).pipe(
+    Match.when({ kind: "command-failed" }, (failure) =>
+      Effect.succeed(commandFailure(nativeRequest, failure))
+    ),
+    Match.when({ kind: "completed" }, ({ result, command }) =>
+      continueCompletedCheckEffect(rules, roots, result, nativeRequest, command, fs)
+    ),
+    Match.exhaustive
+  );
+});
+
+function materializedRules(
+  materializations: readonly [MaterializedRule, ...MaterializedRule[]]
+): NonEmptyGritRules {
+  const [first, ...rest] = materializations;
+  return [first.rule, ...rest.map(({ rule }) => rule)];
+}
+
+function materializedPatternNames(
+  materializations: readonly [MaterializedRule, ...MaterializedRule[]]
+): readonly [string, ...string[]] {
+  const [first, ...rest] = materializations;
+  return [first.rule.patternName, ...rest.map(({ rule }) => rule.patternName)];
+}
+
 function continueCompletedCheckEffect(
-  rule: RuleGritFacts,
+  rules: NonEmptyGritRules,
   roots: readonly [string, ...string[]],
   result: Parameters<typeof parseGritCheckCommand>[0],
   request: Parameters<typeof checkAcquisitionEvidence>[0],
@@ -79,14 +216,14 @@ function continueCompletedCheckEffect(
   return Match.value(checkAcquisitionEvidence(request, command)).pipe(
     Match.when({ kind: "failed" }, ({ acquisition }) => Effect.succeed(acquisition)),
     Match.when({ kind: "accepted" }, ({ evidence }) =>
-      completeCapturedCheckEffect(rule, roots, result, evidence, fs)
+      completeCapturedCheckEffect(rules, roots, result, evidence, fs)
     ),
     Match.exhaustive
   );
 }
 
 const completeCapturedCheckEffect = Effect.fn("grit.check.completeCapture")(function* (
-  rule: RuleGritFacts,
+  rules: NonEmptyGritRules,
   roots: readonly [string, ...string[]],
   result: Parameters<typeof parseGritCheckCommand>[0],
   evidence: GritCheckAcquisitionEvidence,
@@ -113,7 +250,7 @@ const completeCapturedCheckEffect = Effect.fn("grit.check.completeCapture")(func
   return Match.value(observation).pipe(
     Match.when({ kind: "terminal" }, ({ acquisition }) => acquisition),
     Match.orElse(({ report, processed, results }) =>
-      reconcileCheckObservation(rule, roots, report, processed, results, evidence)
+      reconcileCheckObservation(rules, roots, report, processed, results, evidence)
     )
   );
 });
@@ -148,7 +285,7 @@ const canonicalCheckObservationEffect = Effect.fn("grit.check.canonicalize")(fun
 });
 
 function reconcileCheckObservation(
-  rule: RuleGritFacts,
+  rules: NonEmptyGritRules,
   roots: readonly string[],
   report: GritReport,
   processed: CanonicalPaths,
@@ -160,6 +297,8 @@ function reconcileCheckObservation(
     Match.orElse(() => [])
   );
   const processedSet = new Set(processedPaths);
+  const selectedPatternNames = new Set(rules.map(({ patternName }) => patternName));
+  const selectedPatternLabel = rules.map(({ patternName }) => patternName).join(", ");
   const validationFailures = [
     ...Match.value(processed).pipe(
       Match.when({ kind: "failed" }, ({ detail }) => [
@@ -182,7 +321,13 @@ function reconcileCheckObservation(
       )
     ),
     ...report.results.flatMap((result, index) =>
-      resultValidationFailures(rule, result, resultPaths[index] ?? Option.none(), processedSet)
+      resultValidationFailures(
+        selectedPatternNames,
+        selectedPatternLabel,
+        result,
+        resultPaths[index] ?? Option.none(),
+        processedSet
+      )
     ),
   ];
   return Match.value(Option.fromNullable(validationFailures[0])).pipe(
@@ -263,7 +408,8 @@ function validationFailure(
 }
 
 function resultValidationFailures(
-  rule: RuleGritFacts,
+  selectedPatternNames: ReadonlySet<string>,
+  selectedPatternLabel: string,
   result: GritReport["results"][number],
   resultPath: Option.Option<string>,
   processed: ReadonlySet<string>
@@ -283,9 +429,9 @@ function resultValidationFailures(
     ),
     ...validationFailure(
       observed.kind === "observed-identity-mismatch" ||
-        observed.observedPatternIdentity !== rule.patternName,
+        !selectedPatternNames.has(observed.observedPatternIdentity),
       "DiagnosticUnexpectedIdentity",
-      `unexpected-identity: result did not belong to ${rule.patternName}.`
+      `unexpected-identity: result did not belong to selected patterns ${selectedPatternLabel}.`
     ),
   ];
 }

--- a/tools/habitat/src/resources/rule-diagnostics/providers/grit/command.schema.ts
+++ b/tools/habitat/src/resources/rule-diagnostics/providers/grit/command.schema.ts
@@ -32,7 +32,7 @@ export const DiagnosticOutputMetadataSchema = Type.Object(
 );
 
 export const NativeGritCommandFamilySchema = Type.Union([
-  Type.Literal("selected-rule-json-check"),
+  Type.Literal("selected-rules-json-check"),
   Type.Literal("selected-rule-apply-dry-run-observation"),
   Type.Literal("pinned-native-preflight"),
 ]);
@@ -53,12 +53,17 @@ const NativeGritCommandRequestMetadataSchema = Type.Interface(
   { additionalProperties: false }
 );
 
-export const NativeGritSelectedRuleJsonCheckRequestSchema = Type.Interface(
+/** Closed evidence for one hermetic native check over an ordered selected-rule catalog. */
+export const NativeGritSelectedRulesJsonCheckRequestSchema = Type.Interface(
   [NativeGritCommandRequestMetadataSchema],
   {
-    commandFamily: Type.Literal("selected-rule-json-check"),
+    commandFamily: Type.Literal("selected-rules-json-check"),
     outputContract: Type.Literal("json-report-on-stderr"),
     scanRoots: DiagnosticSelectedScanRootsSchema,
+    patternNames: Type.Array(Type.String({ minLength: 1 }), {
+      minItems: 1,
+      uniqueItems: true,
+    }),
   },
   { additionalProperties: false }
 );
@@ -84,12 +89,12 @@ export const NativeGritPinnedNativePreflightRequestSchema = Type.Interface(
 );
 
 export const NativeGritTargetCommandRequestSchema = Type.Union([
-  NativeGritSelectedRuleJsonCheckRequestSchema,
+  NativeGritSelectedRulesJsonCheckRequestSchema,
   NativeGritSelectedRuleApplyDryRunObservationRequestSchema,
 ]);
 
 export const NativeGritCommandRequestSchema = Type.Union([
-  NativeGritSelectedRuleJsonCheckRequestSchema,
+  NativeGritSelectedRulesJsonCheckRequestSchema,
   NativeGritSelectedRuleApplyDryRunObservationRequestSchema,
   NativeGritPinnedNativePreflightRequestSchema,
 ]);
@@ -191,9 +196,14 @@ export const DiagnosticCommandObservationSchema = Type.Union([
 export type DiagnosticOutputMetadata = Static<typeof DiagnosticOutputMetadataSchema>;
 export type NativeGritCommandFamily = Static<typeof NativeGritCommandFamilySchema>;
 export type NativeGritOutputContract = Static<typeof NativeGritOutputContractSchema>;
-export type NativeGritSelectedRuleJsonCheckRequest = Static<
-  typeof NativeGritSelectedRuleJsonCheckRequestSchema
-> & { readonly scanRoots: DiagnosticSelectedScanRoots };
+/** Parsed native-check evidence with nonempty selected pattern identities and admitted roots. */
+export type NativeGritSelectedRulesJsonCheckRequest = Omit<
+  Static<typeof NativeGritSelectedRulesJsonCheckRequestSchema>,
+  "patternNames" | "scanRoots"
+> & {
+  readonly patternNames: [string, ...string[]];
+  readonly scanRoots: DiagnosticSelectedScanRoots;
+};
 export type NativeGritSelectedRuleApplyDryRunObservationRequest = Static<
   typeof NativeGritSelectedRuleApplyDryRunObservationRequestSchema
 > & { readonly scanRoots: DiagnosticSelectedScanRoots };
@@ -201,7 +211,7 @@ export type NativeGritPinnedNativePreflightRequest = Static<
   typeof NativeGritPinnedNativePreflightRequestSchema
 >;
 export type NativeGritTargetCommandRequest =
-  | NativeGritSelectedRuleJsonCheckRequest
+  | NativeGritSelectedRulesJsonCheckRequest
   | NativeGritSelectedRuleApplyDryRunObservationRequest;
 export type NativeGritCommandRequest =
   | NativeGritTargetCommandRequest
@@ -223,15 +233,16 @@ export type DiagnosticExecutedCommandObservation =
   | DiagnosticFailedCommandObservation
   | DiagnosticInterruptedCommandObservation;
 const nativeGritOutputContractByFamily = {
-  "selected-rule-json-check": "json-report-on-stderr",
+  "selected-rules-json-check": "json-report-on-stderr",
   "selected-rule-apply-dry-run-observation": "compact-jsonl-on-stdout",
   "pinned-native-preflight": "version-on-stdout",
 } as const satisfies Record<NativeGritCommandFamily, NativeGritOutputContract>;
 
 export function nativeGritCommandRequestFromProcessRequest(input: {
   readonly request: HabitatProcessRequest;
-  readonly commandFamily: "selected-rule-json-check";
-}): NativeGritSelectedRuleJsonCheckRequest;
+  readonly commandFamily: "selected-rules-json-check";
+  readonly patternNames: readonly [string, ...string[]];
+}): NativeGritSelectedRulesJsonCheckRequest;
 export function nativeGritCommandRequestFromProcessRequest(input: {
   readonly request: HabitatProcessRequest;
   readonly commandFamily: "selected-rule-apply-dry-run-observation";
@@ -240,10 +251,20 @@ export function nativeGritCommandRequestFromProcessRequest(input: {
   readonly request: HabitatProcessRequest;
   readonly commandFamily: "pinned-native-preflight";
 }): NativeGritPinnedNativePreflightRequest;
-export function nativeGritCommandRequestFromProcessRequest(input: {
-  readonly request: HabitatProcessRequest;
-  readonly commandFamily: NativeGritCommandFamily;
-}): NativeGritCommandRequest {
+export function nativeGritCommandRequestFromProcessRequest(
+  input:
+    | {
+        readonly request: HabitatProcessRequest;
+        readonly commandFamily: "selected-rules-json-check";
+        readonly patternNames: readonly [string, ...string[]];
+      }
+    | {
+        readonly request: HabitatProcessRequest;
+        readonly commandFamily:
+          | "selected-rule-apply-dry-run-observation"
+          | "pinned-native-preflight";
+      }
+): NativeGritCommandRequest {
   const metadata = {
     commandFamily: input.commandFamily,
     commandInvocationId: input.request.commandId,
@@ -259,7 +280,18 @@ export function nativeGritCommandRequestFromProcessRequest(input: {
     });
   }
   const scanRoots = parseDiagnosticSelectedScanRoots(input.request.scanRoots ?? []);
-  const parsed = Value.Parse(NativeGritTargetCommandRequestSchema, { ...metadata, scanRoots });
+  if (input.commandFamily === "selected-rules-json-check") {
+    const parsed = Value.Parse(NativeGritSelectedRulesJsonCheckRequestSchema, {
+      ...metadata,
+      scanRoots,
+      patternNames: input.patternNames,
+    });
+    return { ...parsed, patternNames: [...input.patternNames], scanRoots };
+  }
+  const parsed = Value.Parse(NativeGritSelectedRuleApplyDryRunObservationRequestSchema, {
+    ...metadata,
+    scanRoots,
+  });
   return { ...parsed, scanRoots };
 }
 

--- a/tools/habitat/src/resources/rule-diagnostics/providers/grit/command.ts
+++ b/tools/habitat/src/resources/rule-diagnostics/providers/grit/command.ts
@@ -28,7 +28,10 @@ const pinnedGritIdentity = {
   nativeVersion: "grit 0.1.1",
 } as const;
 
+/** Provider-local request for one hermetic native check over an ordered rule catalog. */
 export interface GritCheckProviderRequest {
+  /** Ordered catalog identities selected by this hermetic check invocation. */
+  readonly patternNames: readonly [string, ...string[]];
   readonly scanRoots: Readonly<DiagnosticSelectedScanRoots>;
   readonly cwd: string;
   readonly gritDir: string;
@@ -128,7 +131,7 @@ export function gritCheckRequest(
   request: GritCheckProviderRequest
 ): HabitatProcessRequest {
   return {
-    commandId: "grit-selected-rule-json-check",
+    commandId: "grit-selected-rules-json-check",
     kind: "pattern-check",
     executable: pinnedGritNativePath(repoRoot),
     argv: [
@@ -242,9 +245,10 @@ const preflightPinnedGritEffect = Effect.fn("grit.native.preflight")(function* <
   const packageJson = yield* parsePinnedPackage(packageSource, preflightRequest);
   yield* Effect.succeed(packageJson satisfies GritPackage);
   const firstResult = yield* observePinnedGritIdentity(run, preflightRequest);
-  const result = isCompletedBlankPreflight(firstResult)
-    ? yield* observePinnedGritIdentity(run, preflightRequest)
-    : firstResult;
+  const result = yield* Match.value(isCompletedBlankPreflight(firstResult)).pipe(
+    Match.when(true, () => observePinnedGritIdentity(run, preflightRequest)),
+    Match.orElse(() => Effect.succeed(firstResult))
+  );
   const validIdentity = !(
     result.stdout.truncated ||
     result.stderr.truncated ||

--- a/tools/habitat/src/resources/rule-diagnostics/providers/grit/env.ts
+++ b/tools/habitat/src/resources/rule-diagnostics/providers/grit/env.ts
@@ -1,3 +1,4 @@
+/** Hermetic provider environment, including a fixed two-thread native Grit worker pool. */
 export const gritHermeticEnv = {
   CLICOLOR: "0",
   FORCE_COLOR: "0",
@@ -5,4 +6,5 @@ export const gritHermeticEnv = {
   GRIT_DOWNLOADS_DISABLED: "true",
   GRIT_TELEMETRY_DISABLED: "true",
   GRIT_MAX_FILE_SIZE_BYTES: "0",
+  RAYON_NUM_THREADS: "2",
 } as const;

--- a/tools/habitat/src/resources/rule-diagnostics/providers/grit/output.ts
+++ b/tools/habitat/src/resources/rule-diagnostics/providers/grit/output.ts
@@ -12,8 +12,8 @@ import {
   DiagnosticToolUnavailableCommandObservationSchema,
   type NativeGritSelectedRuleApplyDryRunObservationRequest,
   NativeGritSelectedRuleApplyDryRunObservationRequestSchema,
-  type NativeGritSelectedRuleJsonCheckRequest,
-  NativeGritSelectedRuleJsonCheckRequestSchema,
+  type NativeGritSelectedRulesJsonCheckRequest,
+  NativeGritSelectedRulesJsonCheckRequestSchema,
   type NativeGritTargetCommandRequest,
   NativeGritTargetCommandRequestSchema,
 } from "./command.schema.js";
@@ -26,7 +26,7 @@ import {
 
 const GritCheckAcquisitionEvidenceSchema = Type.Object(
   {
-    request: NativeGritSelectedRuleJsonCheckRequestSchema,
+    request: NativeGritSelectedRulesJsonCheckRequestSchema,
     command: DiagnosticCompletedCommandObservationSchema,
   },
   { additionalProperties: false }
@@ -230,7 +230,7 @@ export type GritParseFailure = Static<typeof GritParseFailureSchema>;
 export type GritIncompleteFailure = Static<typeof GritIncompleteFailureSchema>;
 
 export interface GritCheckAcquisitionEvidence {
-  readonly request: NativeGritSelectedRuleJsonCheckRequest;
+  readonly request: NativeGritSelectedRulesJsonCheckRequest;
   readonly command: DiagnosticCompletedCommandObservation;
 }
 
@@ -607,7 +607,7 @@ function assertNeverEvent(event: never): never {
 }
 
 export function checkAcquisitionEvidence(
-  request: NativeGritSelectedRuleJsonCheckRequest,
+  request: NativeGritSelectedRulesJsonCheckRequest,
   command: DiagnosticCompletedCommandObservation
 ): GritAcquisitionEvidenceResult<GritCheckAcquisitionEvidence> {
   return validateAcquisitionEvidence(GritCheckAcquisitionEvidenceSchema, { request, command });

--- a/tools/habitat/src/resources/rule-diagnostics/providers/grit/runner.ts
+++ b/tools/habitat/src/resources/rule-diagnostics/providers/grit/runner.ts
@@ -1,5 +1,8 @@
 import path from "node:path";
-import type { RuleDiagnosticExecutionResult } from "@habitat/cli/resources/rule-diagnostics/resource";
+import type {
+  RuleDiagnosticExecutionResult,
+  RuleDiagnosticExecutionTiming,
+} from "@habitat/cli/resources/rule-diagnostics/resource";
 import {
   diagnosticProviderFailureDiagnostic,
   renderDiagnosticScanRootRefusal,
@@ -7,7 +10,7 @@ import {
 import type { RuleGritFacts } from "@habitat/cli/service/model/rules/index";
 import { Clock, Effect, Match, Option } from "effect";
 import { runGritApplyDryRunAcquisitionEffect } from "./apply-dry-run.js";
-import { runGritCheckAcquisitionEffect } from "./check.js";
+import { runGritCheckAcquisitionEffect, runGritCheckAcquisitionsEffect } from "./check.js";
 import type { GritCommandService } from "./command.js";
 import {
   gritDiagnosticOutcomesFromReport,
@@ -42,14 +45,35 @@ export const runGritDiagnosticOutcomesEffect = Effect.fn("grit.diagnosticOutcome
 ) {
   const executions = yield* runGritDiagnosticExecutionsEffect(selectedRules, options);
   return new Map(
-    [...executions].map(([ruleId, execution]) => [ruleId, execution.outcome] as const)
+    selectedRules.map((rule) => [rule.id, executions.get(rule.id)?.outcome ?? missingOutcome(rule)])
   );
 });
 
 interface GritDiagnosticExecution {
   readonly outcome: DiagnosticRunOutcome;
   readonly durationMs: number;
+  readonly timing?: RuleDiagnosticExecutionTiming;
 }
+
+function selectedRuleExecutionEntry(
+  rule: RuleGritFacts,
+  executions: ReadonlyMap<string, GritDiagnosticExecution>
+): readonly [string, GritDiagnosticExecution] {
+  const execution = Option.getOrElse(Option.fromNullable(executions.get(rule.id)), () => ({
+    outcome: missingOutcome(rule),
+    durationMs: 0,
+  }));
+  return [rule.id, execution];
+}
+
+type ExecuteGritPlan = Extract<PlannedGritRule, { kind: "execute" }>;
+type CheckGritPlan = ExecuteGritPlan & {
+  readonly rule: RuleGritFacts & { readonly diagnosticAcquisition: { readonly kind: "check" } };
+};
+
+type GritExecutionUnit =
+  | { readonly kind: "check-group"; readonly plans: readonly [CheckGritPlan, ...CheckGritPlan[]] }
+  | { readonly kind: "single"; readonly plan: PlannedGritRule };
 
 const runGritDiagnosticExecutionsEffect = Effect.fn("grit.diagnosticExecutions.run")(function* (
   selectedRules: readonly RuleGritFacts[],
@@ -59,11 +83,214 @@ const runGritDiagnosticExecutionsEffect = Effect.fn("grit.diagnosticExecutions.r
     repoRoot: options.repoRoot,
     scanRoots: options.scanRoots,
   });
-  const executions = yield* Effect.forEach(plans, (plan) => executeTimedPlanEffect(plan, options), {
-    concurrency: 2,
-  });
-  return new Map(executions.map((execution) => [execution.outcome.ruleId, execution]));
+  const executions = yield* Effect.forEach(
+    executionUnits(plans),
+    (unit) => executeUnitEffect(unit, options),
+    { concurrency: 1 }
+  );
+  const executionByRuleId = new Map(
+    executions.flat().map((execution) => [execution.outcome.ruleId, execution])
+  );
+  return new Map(selectedRules.map((rule) => selectedRuleExecutionEntry(rule, executionByRuleId)));
 });
+
+const executeUnitEffect = Effect.fn("grit.executionUnit.execute")(function* (
+  unit: GritExecutionUnit,
+  options: GritRunOptions
+) {
+  return yield* Match.value(unit).pipe(
+    Match.when({ kind: "check-group" }, ({ plans }) =>
+      executeTimedCheckGroupEffect(plans, options)
+    ),
+    Match.when({ kind: "single" }, ({ plan }) => executeSingleUnitEffect(plan, options)),
+    Match.exhaustive
+  );
+});
+
+const executeSingleUnitEffect = Effect.fn("grit.singleExecutionUnit.execute")(function* (
+  plan: PlannedGritRule,
+  options: GritRunOptions
+) {
+  const execution = yield* executeTimedPlanEffect(plan, options);
+  return [execution];
+});
+
+const executeTimedCheckGroupEffect = Effect.fn("grit.checkGroup.executeTimed")(function* (
+  plans: readonly [CheckGritPlan, ...CheckGritPlan[]],
+  options: GritRunOptions
+) {
+  const started = yield* Clock.currentTimeMillis;
+  const canonicalOptions = { ...options, repoRoot: plans[0].repoRoot };
+  const acquisitions = yield* runGritCheckAcquisitionsEffect(
+    checkGroupRules(plans),
+    plans[0].roots,
+    canonicalOptions
+  ).pipe(Effect.scoped);
+  const durationMs = Math.max(0, (yield* Clock.currentTimeMillis) - started);
+  const timing = sharedCheckTiming(plans, durationMs);
+  const observedRules = plans.flatMap((plan) =>
+    observedCheckRuleEntry(plan, acquisitions.get(plan.rule.id))
+  );
+  const projected = Option.match(Option.fromNullable(observedRules[0]), {
+    onNone: () => new Map<string, DiagnosticRunOutcome>(),
+    onSome: (firstObservation) =>
+      gritDiagnosticOutcomesFromReport(
+        observedRules.map(({ rule }) => rule),
+        firstObservation.report,
+        { repoRoot: canonicalOptions.repoRoot }
+      ),
+  });
+  return plans.map((plan) =>
+    checkGroupExecution(
+      plan,
+      acquisitions,
+      projected,
+      canonicalOptions.repoRoot,
+      durationMs,
+      timing
+    )
+  );
+});
+
+function sharedCheckTiming(
+  plans: readonly [CheckGritPlan, ...CheckGritPlan[]],
+  durationMs: number
+): RuleDiagnosticExecutionTiming | undefined {
+  return Match.value(plans.length).pipe(
+    Match.when(1, () => undefined),
+    Match.orElse(() => ({
+      kind: "shared" as const,
+      groupId: `rule-diagnostics:${plans.map(({ rule }) => rule.id).join(",")}`,
+      durationMs,
+      ruleCount: plans.length,
+    }))
+  );
+}
+
+function checkGroupExecution(
+  plan: CheckGritPlan,
+  acquisitions: ReadonlyMap<string, GritDiagnosticAcquisition>,
+  projected: ReadonlyMap<string, DiagnosticRunOutcome>,
+  repoRoot: string,
+  durationMs: number,
+  timing: RuleDiagnosticExecutionTiming | undefined
+): GritDiagnosticExecution {
+  const fallback = Option.match(Option.fromNullable(acquisitions.get(plan.rule.id)), {
+    onNone: () => missingOutcome(plan.rule),
+    onSome: (acquisition) => outcomeFromAcquisition(plan.rule, acquisition, repoRoot),
+  });
+  const outcome = Option.getOrElse(
+    Option.fromNullable(projected.get(plan.rule.id)),
+    () => fallback
+  );
+  return { outcome, durationMs, ...optionalTiming(timing) };
+}
+
+function optionalTiming(timing: RuleDiagnosticExecutionTiming | undefined) {
+  return Match.value(timing).pipe(
+    Match.when(undefined, () => ({})),
+    Match.orElse((shared) => ({ timing: shared }))
+  );
+}
+
+function observedCheckRuleEntry(
+  plan: CheckGritPlan,
+  acquisition: GritDiagnosticAcquisition | undefined
+) {
+  return Match.value(acquisition).pipe(
+    Match.when({ kind: "observed-complete", observation: { kind: "check" } }, ({ observation }) => [
+      { rule: plan.rule, report: observation.report },
+    ]),
+    Match.orElse(() => [])
+  );
+}
+
+function checkGroupRules(
+  plans: readonly [CheckGritPlan, ...CheckGritPlan[]]
+): readonly [RuleGritFacts, ...RuleGritFacts[]] {
+  const [first, ...rest] = plans;
+  return [first.rule, ...rest.map(({ rule }) => rule)];
+}
+
+function executionUnits(plans: readonly PlannedGritRule[]): readonly GritExecutionUnit[] {
+  const checkPlans = plans.filter(isCheckPlan);
+  const patternCounts = new Map<string, number>();
+  for (const plan of checkPlans) {
+    const key = plan.rule.patternName;
+    patternCounts.set(key, (patternCounts.get(key) ?? 0) + 1);
+  }
+  const groups = new Map<string, CheckGritPlan[]>();
+  for (const plan of checkPlans) {
+    if ((patternCounts.get(plan.rule.patternName) ?? 0) > 1) continue;
+    const key = rootsKey(plan.roots);
+    groups.set(key, [...(groups.get(key) ?? []), plan]);
+  }
+  const emittedGroups = new Set<string>();
+  return plans.flatMap((plan) => planExecutionUnits(plan, patternCounts, groups, emittedGroups));
+}
+
+function planExecutionUnits(
+  plan: PlannedGritRule,
+  patternCounts: ReadonlyMap<string, number>,
+  groups: ReadonlyMap<string, readonly CheckGritPlan[]>,
+  emittedGroups: Set<string>
+): readonly GritExecutionUnit[] {
+  return Option.match(Option.liftPredicate(plan, isCheckPlan), {
+    onNone: () => singleExecutionUnit(plan),
+    onSome: (checkPlan) => checkPlanExecutionUnits(checkPlan, patternCounts, groups, emittedGroups),
+  });
+}
+
+function checkPlanExecutionUnits(
+  plan: CheckGritPlan,
+  patternCounts: ReadonlyMap<string, number>,
+  groups: ReadonlyMap<string, readonly CheckGritPlan[]>,
+  emittedGroups: Set<string>
+): readonly GritExecutionUnit[] {
+  const duplicatedPattern = (patternCounts.get(plan.rule.patternName) ?? 0) > 1;
+  return Match.value(duplicatedPattern).pipe(
+    Match.when(true, () => singleExecutionUnit(plan)),
+    Match.orElse(() => groupedCheckExecutionUnits(plan, groups, emittedGroups))
+  );
+}
+
+function groupedCheckExecutionUnits(
+  plan: CheckGritPlan,
+  groups: ReadonlyMap<string, readonly CheckGritPlan[]>,
+  emittedGroups: Set<string>
+): readonly GritExecutionUnit[] {
+  const key = rootsKey(plan.roots);
+  return Match.value(emittedGroups.has(key)).pipe(
+    Match.when(true, () => []),
+    Match.orElse(() => emitCheckGroupExecutionUnit(key, plan, groups, emittedGroups))
+  );
+}
+
+function emitCheckGroupExecutionUnit(
+  key: string,
+  plan: CheckGritPlan,
+  groups: ReadonlyMap<string, readonly CheckGritPlan[]>,
+  emittedGroups: Set<string>
+): readonly GritExecutionUnit[] {
+  emittedGroups.add(key);
+  const [first, ...rest] = groups.get(key) ?? [];
+  return Option.match(Option.fromNullable(first), {
+    onNone: () => singleExecutionUnit(plan),
+    onSome: (head) => [{ kind: "check-group", plans: [head, ...rest] }],
+  });
+}
+
+function singleExecutionUnit(plan: PlannedGritRule): readonly GritExecutionUnit[] {
+  return [{ kind: "single", plan }];
+}
+
+function isCheckPlan(plan: PlannedGritRule): plan is CheckGritPlan {
+  return plan.kind === "execute" && plan.rule.diagnosticAcquisition.kind === "check";
+}
+
+function rootsKey(roots: readonly string[]): string {
+  return roots.join("\u0000");
+}
 
 const executeTimedPlanEffect = Effect.fn("grit.plan.executeTimed")(function* (
   plan: PlannedGritRule,
@@ -315,55 +542,63 @@ function ruleDiagnosticExecutionFromOutcome(
   rule: RuleGritFacts,
   execution: GritDiagnosticExecution
 ): RuleDiagnosticExecutionResult {
-  const { outcome, durationMs } = execution;
+  const { outcome } = execution;
+  const measurement = diagnosticExecutionMeasurement(execution);
   return Match.value(outcome).pipe(
     Match.when({ kind: "not-applicable" }, ({ reason }) => ({
       kind: "not-applicable" as const,
       reason,
-      durationMs,
+      ...measurement,
     })),
     Match.when({ kind: "scan-root-refused" }, ({ decision, detail }) => ({
       kind: "refused" as const,
       decision,
       detail,
-      durationMs,
+      ...measurement,
     })),
     Match.when({ kind: "provider-failed" }, ({ failure, detail }) =>
-      failedRuleDiagnosticExecution(rule, failure, detail, durationMs)
+      failedRuleDiagnosticExecution(rule, failure, detail, execution)
     ),
     Match.when({ kind: "unexpected-diagnostic-identity" }, ({ unexpectedIdentity }) =>
       failedRuleDiagnosticExecution(
         rule,
         "DiagnosticUnexpectedIdentity",
         renderUnexpectedObservedGritIdentity(unexpectedIdentity),
-        durationMs
+        execution
       )
     ),
     Match.when({ kind: "clean" }, () => ({
       kind: "executed" as const,
       result: ruleRunResultFromDiagnosticOutcome(rule, outcome),
-      durationMs,
+      ...measurement,
     })),
     Match.when({ kind: "findings" }, () => ({
       kind: "executed" as const,
       result: ruleRunResultFromDiagnosticOutcome(rule, outcome),
-      durationMs,
+      ...measurement,
     })),
     Match.exhaustive
   );
+}
+
+function diagnosticExecutionMeasurement(execution: GritDiagnosticExecution) {
+  return {
+    durationMs: execution.durationMs,
+    ...optionalTiming(execution.timing),
+  };
 }
 
 function failedRuleDiagnosticExecution(
   rule: RuleGritFacts,
   failure: Extract<RuleDiagnosticExecutionResult, { kind: "failed" }>["failure"],
   detail: string,
-  durationMs: number
+  execution: GritDiagnosticExecution
 ): Extract<RuleDiagnosticExecutionResult, { kind: "failed" }> {
   return {
     kind: "failed",
     failure,
     detail,
     diagnostics: [diagnosticProviderFailureDiagnostic(rule, failure, detail)],
-    durationMs,
+    ...diagnosticExecutionMeasurement(execution),
   };
 }

--- a/tools/habitat/src/resources/rule-diagnostics/providers/grit/scoped-config.ts
+++ b/tools/habitat/src/resources/rule-diagnostics/providers/grit/scoped-config.ts
@@ -6,45 +6,80 @@ import { Data, Effect, Match, Option } from "effect";
 import { pathIsWithinRoot } from "./path.js";
 import { quoteGritYamlScalar } from "./types.js";
 
-export interface ScopedGritWorkspace {
+/** Isolated catalog, user-config, and cache roots held for one native Grit command. */
+export interface ScopedGritCatalogWorkspace {
   readonly cwd: string;
   readonly gritDir: string;
   readonly userConfigDir: string;
   readonly cacheDir: string;
+}
+
+/** Single-pattern workspace retaining the admitted asset path required by dry-run apply. */
+export interface ScopedGritWorkspace extends ScopedGritCatalogWorkspace {
   readonly patternPath: string;
+}
+
+/** One admitted rule asset ready to become an entry in an isolated Grit catalog. */
+export interface MaterializedGritPattern {
+  readonly rule: RuleGritFacts;
+  readonly patternPath: string;
+  readonly body: string;
 }
 
 export const acquireScopedGritWorkspaceEffect = Effect.fn("grit.scopedWorkspace.acquire")(
   function* (rule: RuleGritFacts, repoRoot: string) {
-    const fs = yield* FileSystem.FileSystem;
-    const asset = yield* canonicalPatternAssetEffect(rule, repoRoot, fs);
-    const source = yield* fs
-      .readFileString(asset)
-      .pipe(Effect.mapError((error) => patternAssetFailure(asset, error)));
-    const body = yield* extractGritBody(source, asset);
-
-    const cwd = yield* acquireTempDirectory("habitat-grit-diagnostic-").pipe(
-      Effect.mapError((error) => scopedConfigFailure("allocate temporary workspace", error))
-    );
-    const gritDir = path.join(cwd, ".grit");
-    const userConfigDir = path.join(cwd, "user-config");
-    const cacheDir = path.join(cwd, "cache");
-    yield* Effect.all(
-      [gritDir, userConfigDir, cacheDir].map((directory) => fs.makeDirectory(directory)),
-      { concurrency: 1 }
-    ).pipe(Effect.mapError((error) => scopedConfigFailure("create isolated directories", error)));
-    yield* fs
-      .writeFileString(path.join(gritDir, "grit.yaml"), renderConfig(rule, body))
-      .pipe(Effect.mapError((error) => scopedConfigFailure("write scoped catalog", error)));
-    return {
-      cwd,
-      gritDir,
-      userConfigDir,
-      cacheDir,
-      patternPath: asset,
-    } satisfies ScopedGritWorkspace;
+    const pattern = yield* materializeGritPatternEffect(rule, repoRoot);
+    const workspace = yield* acquireScopedGritCatalogEffect([pattern]);
+    return { ...workspace, patternPath: pattern.patternPath } satisfies ScopedGritWorkspace;
   }
 );
+
+/**
+ * Resolves one registered rule's authored asset into a closed Grit catalog entry.
+ * This happens before workspace acquisition so one invalid asset cannot block valid peers.
+ */
+export const materializeGritPatternEffect = Effect.fn("grit.pattern.materialize")(function* (
+  rule: RuleGritFacts,
+  repoRoot: string
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const patternPath = yield* canonicalPatternAssetEffect(rule, repoRoot, fs);
+  const source = yield* fs
+    .readFileString(patternPath)
+    .pipe(Effect.mapError((error) => patternAssetFailure(patternPath, error)));
+  const body = yield* extractGritBody(source, patternPath);
+  return { rule, patternPath, body } satisfies MaterializedGritPattern;
+});
+
+/**
+ * Acquires one hermetic Grit workspace for an ordered, already-materialized catalog.
+ * No catalog entry is privileged after acquisition; apply recombines its one admitted path.
+ */
+export const acquireScopedGritCatalogEffect = Effect.fn("grit.scopedCatalog.acquire")(function* (
+  patterns: readonly [MaterializedGritPattern, ...MaterializedGritPattern[]]
+) {
+  const fs = yield* FileSystem.FileSystem;
+
+  const cwd = yield* acquireTempDirectory("habitat-grit-diagnostic-").pipe(
+    Effect.mapError((error) => scopedConfigFailure("allocate temporary workspace", error))
+  );
+  const gritDir = path.join(cwd, ".grit");
+  const userConfigDir = path.join(cwd, "user-config");
+  const cacheDir = path.join(cwd, "cache");
+  yield* Effect.all(
+    [gritDir, userConfigDir, cacheDir].map((directory) => fs.makeDirectory(directory)),
+    { concurrency: 1 }
+  ).pipe(Effect.mapError((error) => scopedConfigFailure("create isolated directories", error)));
+  yield* fs
+    .writeFileString(path.join(gritDir, "grit.yaml"), renderConfig(patterns))
+    .pipe(Effect.mapError((error) => scopedConfigFailure("write scoped catalog", error)));
+  return {
+    cwd,
+    gritDir,
+    userConfigDir,
+    cacheDir,
+  } satisfies ScopedGritCatalogWorkspace;
+});
 
 const canonicalPatternAssetEffect = Effect.fn("grit.patternAsset.canonicalize")(function* (
   rule: RuleGritFacts,
@@ -89,15 +124,19 @@ const canonicalPatternAssetEffect = Effect.fn("grit.patternAsset.canonicalize")(
   return canonicalAsset;
 });
 
-function renderConfig(rule: RuleGritFacts, body: string): string {
+function renderConfig(
+  patterns: readonly [MaterializedGritPattern, ...MaterializedGritPattern[]]
+): string {
   return [
     "version: 0.0.2",
     "patterns:",
-    `  - name: ${quoteGritYamlScalar(rule.patternName)}`,
-    `    title: ${quoteGritYamlScalar(rule.id)}`,
-    "    level: error",
-    "    body: |",
-    ...body.split("\n").map((line) => `      ${line}`),
+    ...patterns.flatMap(({ rule, body }) => [
+      `  - name: ${quoteGritYamlScalar(rule.patternName)}`,
+      `    title: ${quoteGritYamlScalar(rule.id)}`,
+      "    level: error",
+      "    body: |",
+      ...body.split("\n").map((line) => `      ${line}`),
+    ]),
     "",
   ].join("\n");
 }

--- a/tools/habitat/src/resources/rule-diagnostics/resource.ts
+++ b/tools/habitat/src/resources/rule-diagnostics/resource.ts
@@ -13,30 +13,42 @@ export type RuleDiagnosticDemand = {
     | { readonly kind: "paths"; readonly paths: readonly string[] };
 };
 
-export type RuleDiagnosticExecutionResult =
-  | {
-      readonly kind: "executed";
-      readonly result: RuleRunResult;
-      readonly durationMs: number;
-    }
-  | {
-      readonly kind: "not-applicable";
-      readonly reason: "no-matched-scan-roots";
-      readonly durationMs: number;
-    }
-  | {
-      readonly kind: "failed";
-      readonly failure: DiagnosticProviderFailureKind;
-      readonly detail: string;
-      readonly diagnostics: readonly [HabitatDiagnostic, ...HabitatDiagnostic[]];
-      readonly durationMs: number;
-    }
-  | {
-      readonly kind: "refused";
-      readonly decision: DiagnosticScanRootRefusal;
-      readonly detail: string;
-      readonly durationMs: number;
-    };
+/** Provider-neutral evidence that several demanded rules shared one diagnostic execution. */
+export type RuleDiagnosticExecutionTiming = Readonly<{
+  kind: "shared";
+  groupId: string;
+  durationMs: number;
+  ruleCount: number;
+}>;
+
+interface RuleDiagnosticExecutionMeasurement {
+  readonly durationMs: number;
+  readonly timing?: RuleDiagnosticExecutionTiming;
+}
+
+/** One terminal diagnostic disposition plus truthful dedicated or shared timing evidence. */
+export type RuleDiagnosticExecutionResult = RuleDiagnosticExecutionMeasurement &
+  (
+    | {
+        readonly kind: "executed";
+        readonly result: RuleRunResult;
+      }
+    | {
+        readonly kind: "not-applicable";
+        readonly reason: "no-matched-scan-roots";
+      }
+    | {
+        readonly kind: "failed";
+        readonly failure: DiagnosticProviderFailureKind;
+        readonly detail: string;
+        readonly diagnostics: readonly [HabitatDiagnostic, ...HabitatDiagnostic[]];
+      }
+    | {
+        readonly kind: "refused";
+        readonly decision: DiagnosticScanRootRefusal;
+        readonly detail: string;
+      }
+  );
 
 /** Stable diagnostic capability consumed by rule execution. */
 export interface RuleDiagnosticsService {

--- a/tools/habitat/src/service/model/check/policy/structural/diagnostic-execution.policy.ts
+++ b/tools/habitat/src/service/model/check/policy/structural/diagnostic-execution.policy.ts
@@ -44,20 +44,24 @@ export function ruleDiagnosticExecutionRecord(
   rule: RuleDiagnosticFacts,
   execution: RuleDiagnosticExecutionResult
 ): RuleExecutionRecord {
+  const timing = diagnosticTimingField(execution.timing);
   return Match.value(execution).pipe(
     Match.when({ kind: "executed" }, ({ result, durationMs }) => ({
       result,
       durationMs,
+      ...timing,
       disposition: { kind: "executed" as const, durationMs },
     })),
     Match.when({ kind: "not-applicable" }, ({ reason, durationMs }) => ({
       result: { exitCode: 0, diagnostics: [] },
       durationMs,
+      ...timing,
       disposition: { kind: "not-applicable" as const, reason },
     })),
     Match.when({ kind: "failed" }, ({ failure, detail, diagnostics, durationMs }) => ({
       result: { exitCode: 1, diagnostics: [...diagnostics] },
       durationMs,
+      ...timing,
       disposition: {
         kind: "execution-failed" as const,
         source: "diagnostic-provider" as const,
@@ -68,6 +72,7 @@ export function ruleDiagnosticExecutionRecord(
     Match.when({ kind: "refused" }, ({ decision, detail, durationMs }) => ({
       result: { exitCode: 1, diagnostics: [dependencyRefusalDiagnostic(rule, detail)] },
       durationMs,
+      ...timing,
       disposition: {
         kind: "dependency-refused" as const,
         source: "diagnostic-scan-root" as const,
@@ -76,6 +81,13 @@ export function ruleDiagnosticExecutionRecord(
       },
     })),
     Match.exhaustive
+  );
+}
+
+function diagnosticTimingField(timing: RuleDiagnosticExecutionResult["timing"]) {
+  return Match.value(timing).pipe(
+    Match.when(undefined, () => ({})),
+    Match.orElse((shared) => ({ timing: shared }))
   );
 }
 

--- a/tools/habitat/src/service/model/structure-check/policy/structure-check.policy.ts
+++ b/tools/habitat/src/service/model/structure-check/policy/structure-check.policy.ts
@@ -7,7 +7,7 @@ import type {
 import type { HabitatDiagnostic } from "@habitat/cli/service/model/check/index";
 import type { RuleRunResult } from "@habitat/cli/service/model/diagnostics/policy/rule-runtime/architecture.policy";
 import type { RuleStructureFacts } from "@habitat/cli/service/model/rules/index";
-import { Effect } from "effect";
+import { Effect, Match } from "effect";
 import { parse as parseToml } from "smol-toml";
 import { type Static, Type } from "typebox";
 import { Value } from "typebox/value";
@@ -61,6 +61,12 @@ interface MatchedRoot {
   readonly kind: "directory" | "file" | "other" | "missing";
 }
 
+interface StructureTraversalCache {
+  readonly kindsByRepoPath: Map<string, MatchedRoot["kind"]>;
+  readonly childrenByRepoPath: Map<string, readonly HabitatDirectoryEntry[]>;
+  readonly walksByLiteralBase: Map<string, readonly MatchedRoot[]>;
+}
+
 export function parseStructureCheckSpec(
   contents: string
 ): { ok: true; spec: StructureCheckSpec } | { ok: false; message: string } {
@@ -88,8 +94,12 @@ export function runStructureRulesEffect<R>(
   options: StructureCheckOptions<R>
 ): Effect.Effect<Map<string, RuleRunResult>, never, R> {
   return Effect.gen(function* () {
+    const cache = makeStructureTraversalCache();
     const entries = yield* Effect.forEach(rules, (rule) =>
-      Effect.map(runStructureRuleEffect<R>(rule, options), (result) => [rule.id, result] as const)
+      Effect.map(
+        runStructureRuleEffect<R>(rule, options, cache),
+        (result) => [rule.id, result] as const
+      )
     );
     return new Map(entries);
   });
@@ -97,7 +107,8 @@ export function runStructureRulesEffect<R>(
 
 function runStructureRuleEffect<R>(
   rule: RuleStructureFacts,
-  options: StructureCheckOptions<R>
+  options: StructureCheckOptions<R>,
+  cache: StructureTraversalCache
 ): Effect.Effect<RuleRunResult, never, R> {
   return Effect.gen(function* () {
     const structurePath = path.resolve(options.repoRoot, rule.runner.files.structure);
@@ -123,7 +134,7 @@ function runStructureRuleEffect<R>(
       ];
       return { exitCode: 1, diagnostics };
     }
-    return yield* evaluateStructureCheckEffect<R>(rule, parsed.spec, options);
+    return yield* evaluateStructureCheckWithCacheEffect<R>(rule, parsed.spec, options, cache);
   });
 }
 
@@ -132,10 +143,21 @@ export function evaluateStructureCheckEffect<R>(
   spec: StructureCheckSpec,
   options: StructureCheckOptions<R>
 ): Effect.Effect<RuleRunResult, never, R> {
+  return Effect.suspend(() =>
+    evaluateStructureCheckWithCacheEffect(rule, spec, options, makeStructureTraversalCache())
+  );
+}
+
+function evaluateStructureCheckWithCacheEffect<R>(
+  rule: RuleStructureFacts,
+  spec: StructureCheckSpec,
+  options: StructureCheckOptions<R>,
+  cache: StructureTraversalCache
+): Effect.Effect<RuleRunResult, never, R> {
   return Effect.gen(function* () {
     const diagnostics: HabitatDiagnostic[] = [];
     for (const scope of spec.scopes) {
-      diagnostics.push(...(yield* evaluateScopeEffect<R>(rule, scope, options)));
+      diagnostics.push(...(yield* evaluateScopeEffect<R>(rule, scope, options, cache)));
     }
     return { exitCode: diagnostics.length > 0 ? 1 : 0, diagnostics };
   });
@@ -144,11 +166,12 @@ export function evaluateStructureCheckEffect<R>(
 function evaluateScopeEffect<R>(
   rule: RuleStructureFacts,
   scope: StructureCheckScope,
-  options: StructureCheckOptions<R>
+  options: StructureCheckOptions<R>,
+  cache: StructureTraversalCache
 ): Effect.Effect<HabitatDiagnostic[], never, R> {
   return Effect.gen(function* () {
     const diagnostics: HabitatDiagnostic[] = [];
-    const roots = yield* matchedRootsEffect<R>(scope.root, options);
+    const roots = yield* matchedRootsEffect<R>(scope.root, options, cache);
     const matchingKindRoots = roots.filter((root) => root.kind === scope.kind);
     const wrongKindRoots = roots.filter(
       (root) => root.kind !== "missing" && root.kind !== scope.kind
@@ -173,9 +196,7 @@ function evaluateScopeEffect<R>(
     }
     for (const root of matchingKindRoots) {
       if (scope.kind === "file") continue;
-      const children = yield* options.fileSystem
-        .readDirectory(path.resolve(options.repoRoot, root.repoPath))
-        .pipe(Effect.catchAll(() => Effect.succeed([])));
+      const children = yield* readDirectoryCachedEffect<R>(root.repoPath, options, cache);
       diagnostics.push(...evaluateDirectoryChildren(rule, scope, root.repoPath, children));
     }
     return diagnostics;
@@ -237,19 +258,18 @@ function evaluateDirectoryChildren(
 
 function matchedRootsEffect<R>(
   rootGlob: string,
-  options: StructureCheckOptions<R>
-): Effect.Effect<MatchedRoot[], never, R> {
+  options: StructureCheckOptions<R>,
+  cache: StructureTraversalCache
+): Effect.Effect<readonly MatchedRoot[], never, R> {
   return Effect.gen(function* () {
     const normalizedRoot = normalizeRepoPath(rootGlob);
     const isGlob = hasGlobSyntax(normalizedRoot);
     if (!isGlob) {
-      const kind = yield* pathKindEffect<R>(normalizedRoot, options);
+      const kind = yield* pathKindEffect<R>(normalizedRoot, options, cache);
       return kind === "missing" ? [] : [{ repoPath: normalizedRoot, kind }];
     }
     const base = literalWalkBase(normalizedRoot);
-    const baseKind = yield* pathKindEffect<R>(base, options);
-    if (baseKind === "missing") return [];
-    const candidates = yield* walkRepoPathsEffect<R>(base, options);
+    const candidates = yield* walkRepoPathsEffect<R>(base, options, cache);
     const rootMatches = picomatch(normalizedRoot, { contains: false, dot: true });
     return candidates.filter((candidate) => rootMatches(candidate.repoPath));
   });
@@ -257,39 +277,110 @@ function matchedRootsEffect<R>(
 
 function walkRepoPathsEffect<R>(
   repoPath: string,
-  options: StructureCheckOptions<R>
-): Effect.Effect<MatchedRoot[], never, R> {
+  options: StructureCheckOptions<R>,
+  cache: StructureTraversalCache
+): Effect.Effect<readonly MatchedRoot[], never, R> {
   return Effect.gen(function* () {
-    const kind = yield* pathKindEffect<R>(repoPath, options);
-    if (kind === "missing") return [];
+    const cached = cache.walksByLiteralBase.get(repoPath);
+    if (cached) return cached;
+
+    const kind = yield* pathKindEffect<R>(repoPath, options, cache);
+    if (kind === "missing") {
+      const missingWalk: readonly MatchedRoot[] = [];
+      cache.walksByLiteralBase.set(repoPath, missingWalk);
+      return missingWalk;
+    }
+
     const out: MatchedRoot[] = [{ repoPath, kind }];
-    if (kind !== "directory") return out;
+    if (kind === "directory") {
+      yield* appendDescendantPathsEffect<R>(repoPath, options, cache, out);
+    }
+    const completedWalk: readonly MatchedRoot[] = out;
+    cache.walksByLiteralBase.set(repoPath, completedWalk);
+    return completedWalk;
+  });
+}
+
+function appendDescendantPathsEffect<R>(
+  repoPath: string,
+  options: StructureCheckOptions<R>,
+  cache: StructureTraversalCache,
+  out: MatchedRoot[]
+): Effect.Effect<void, never, R> {
+  return Effect.gen(function* () {
+    const children = yield* readDirectoryCachedEffect<R>(repoPath, options, cache);
+    for (const child of children) {
+      const { name, kind } = child;
+      const childRepoPath = `${repoPath}/${name}`;
+      cacheListedPathKind(childRepoPath, kind, cache);
+      out.push({ repoPath: childRepoPath, kind });
+      if (kind === "directory") {
+        yield* appendDescendantPathsEffect<R>(childRepoPath, options, cache, out);
+      }
+    }
+  });
+}
+
+function cacheListedPathKind(
+  repoPath: string,
+  kind: HabitatDirectoryEntry["kind"],
+  cache: StructureTraversalCache
+): void {
+  if (kind === "other" || cache.kindsByRepoPath.has(repoPath)) return;
+  cache.kindsByRepoPath.set(repoPath, kind);
+}
+
+function readDirectoryCachedEffect<R>(
+  repoPath: string,
+  options: StructureCheckOptions<R>,
+  cache: StructureTraversalCache
+): Effect.Effect<readonly HabitatDirectoryEntry[], never, R> {
+  return Effect.gen(function* () {
+    const cached = cache.childrenByRepoPath.get(repoPath);
+    if (cached) return cached;
     const children = yield* options.fileSystem
       .readDirectory(path.resolve(options.repoRoot, repoPath))
       .pipe(Effect.catchAll(() => Effect.succeed([])));
-    for (const child of children) {
-      out.push(...(yield* walkRepoPathsEffect<R>(`${repoPath}/${child.name}`, options)));
-    }
-    return out;
+    cache.childrenByRepoPath.set(repoPath, children);
+    return children;
   });
 }
 
 function pathKindEffect<R>(
   repoPath: string,
-  options: StructureCheckOptions<R>
+  options: StructureCheckOptions<R>,
+  cache: StructureTraversalCache
 ): Effect.Effect<MatchedRoot["kind"], never, R> {
   return Effect.gen(function* () {
+    const cached = cache.kindsByRepoPath.get(repoPath);
+    if (cached) return cached;
+
     const absolute = path.resolve(options.repoRoot, repoPath);
     const isDirectory = yield* options.fileSystem
       .isDirectory(absolute)
       .pipe(Effect.catchAll(() => Effect.succeed(false)));
-    if (isDirectory) return "directory" as const;
+    if (isDirectory) {
+      cache.kindsByRepoPath.set(repoPath, "directory");
+      return "directory" as const;
+    }
     const isFile = yield* options.fileSystem
       .isFile(absolute)
       .pipe(Effect.catchAll(() => Effect.succeed(false)));
-    if (isFile) return "file" as const;
-    return "missing" as const;
+    const kind: "file" | "missing" = Match.value(isFile).pipe(
+      Match.when(true, (): "file" => "file"),
+      Match.orElse((): "missing" => "missing")
+    );
+    cache.kindsByRepoPath.set(repoPath, kind);
+    return kind;
   });
+}
+
+function makeStructureTraversalCache(): StructureTraversalCache {
+  return {
+    kindsByRepoPath: new Map(),
+    childrenByRepoPath: new Map(),
+    walksByLiteralBase: new Map(),
+  };
 }
 
 function matchers(patterns: readonly string[]): Map<string, (candidate: string) => boolean> {

--- a/tools/habitat/test/commands/habitat-commands.test.ts
+++ b/tools/habitat/test/commands/habitat-commands.test.ts
@@ -26,6 +26,7 @@ const mockHookPreCommit = vi.hoisted(() => vi.fn());
 const mockHookPrePush = vi.hoisted(() => vi.fn());
 const mockVerifyChanges = vi.hoisted(() => vi.fn());
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockHabitatRuntimeDispose = vi.hoisted(() => vi.fn(async () => {}));
 
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
@@ -91,6 +92,10 @@ vi.mock("../../src/runtime/service-context.js", async () => {
   }));
   return { createLiveHabitatServiceContext: mockCreateLiveHabitatServiceContext };
 });
+
+vi.mock("../../src/runtime/service-runtime.js", () => ({
+  habitatServiceManagedRuntime: { dispose: mockHabitatRuntimeDispose },
+}));
 
 import Check from "@habitat/cli/cli/commands/check";
 import Classify from "@habitat/cli/cli/commands/classify";
@@ -230,7 +235,8 @@ describe("Habitat oclif commands", () => {
           runner: "habitat",
         },
         staged: true,
-      })
+      }),
+      expectHabitatCallerOptions()
     );
     expect(checkReport.renderCheckReport).toHaveBeenCalledWith(mockReport, {
       json: true,
@@ -275,7 +281,8 @@ describe("Habitat oclif commands", () => {
           serialized:
             "habitat check --rule prohibit_cross_op_runtime_calls --rule prohibit_runtime_validation_and_compiler_imports --rule require_recipe_stage_source_topology",
         },
-      })
+      }),
+      expectHabitatCallerOptions()
     );
   });
 
@@ -290,7 +297,8 @@ describe("Habitat oclif commands", () => {
           runner: undefined,
         },
         base: "main",
-      })
+      }),
+      expectHabitatCallerOptions()
     );
     expect(mockCheckReport).not.toHaveBeenCalled();
     expect(capturedOutput()).toContain("baseline written: demo-rule");
@@ -312,7 +320,7 @@ describe("Habitat oclif commands", () => {
     await Fix.run(["--dry-run"]);
 
     expect(createRouterClient).toHaveBeenCalled();
-    expect(mockFixPreviewPatterns).toHaveBeenCalledWith({});
+    expect(mockFixPreviewPatterns).toHaveBeenCalledWith({}, expectHabitatCallerOptions());
     expect(stdout.join("")).toContain("biome ok");
     expect(stderr.join("")).toBe("");
   });
@@ -320,7 +328,10 @@ describe("Habitat oclif commands", () => {
   test("fix forwards repeatable rule selection in first-seen CLI order", async () => {
     await Fix.run(["--dry-run", "--rule", "second", "--rule", "first", "--rule", "second"]);
 
-    expect(mockFixPreviewPatterns).toHaveBeenCalledWith({ rules: ["second", "first", "second"] });
+    expect(mockFixPreviewPatterns).toHaveBeenCalledWith(
+      { rules: ["second", "first", "second"] },
+      expectHabitatCallerOptions()
+    );
   });
 
   test("fix help describes the no-write diagnostic path and live-mutation refusal", async () => {
@@ -356,7 +367,10 @@ describe("Habitat oclif commands", () => {
       oclif: { exit: 1 },
     });
 
-    expect(mockFixPreviewPatterns).toHaveBeenCalledWith({ rules: ["missing"] });
+    expect(mockFixPreviewPatterns).toHaveBeenCalledWith(
+      { rules: ["missing"] },
+      expectHabitatCallerOptions()
+    );
     expect(stdout.join("")).toBe("");
     expect(stderr.join("")).toContain("invalid-rule-selection");
   });
@@ -365,10 +379,13 @@ describe("Habitat oclif commands", () => {
     await Verify.run(["--base", "HEAD~1"]);
 
     expect(createRouterClient).toHaveBeenCalled();
-    expect(mockVerifyChanges).toHaveBeenCalledWith({
-      base: "HEAD~1",
-      affectedExecution: "run",
-    });
+    expect(mockVerifyChanges).toHaveBeenCalledWith(
+      {
+        base: "HEAD~1",
+        affectedExecution: "run",
+      },
+      expectHabitatCallerOptions()
+    );
     expect(checkReport.verifyCheckSummary).toHaveBeenCalledWith(mockReport);
     expect(checkReport.renderCheckReport).toHaveBeenCalledWith(mockReport);
     expect(stdout.join("")).toContain("affected ok");
@@ -377,10 +394,13 @@ describe("Habitat oclif commands", () => {
   test("verify can emit structured receipt JSON", async () => {
     await Verify.run(["--base", "HEAD~1", "--json"]);
 
-    expect(mockVerifyChanges).toHaveBeenCalledWith({
-      base: "HEAD~1",
-      affectedExecution: "plan-only",
-    });
+    expect(mockVerifyChanges).toHaveBeenCalledWith(
+      {
+        base: "HEAD~1",
+        affectedExecution: "plan-only",
+      },
+      expectHabitatCallerOptions()
+    );
     expect(checkReport.verifyCheckSummary).toHaveBeenCalledWith(mockReport);
     expect(verifyReceipt.stringifyVerifyReceipt).toHaveBeenCalledWith(
       expect.objectContaining({ schemaVersion: 2 })
@@ -393,7 +413,7 @@ describe("Habitat oclif commands", () => {
     await Graph.run(["--json"]);
 
     expect(createRouterClient).toHaveBeenCalled();
-    expect(mockGraphWorkspaceGraph).toHaveBeenCalledWith({});
+    expect(mockGraphWorkspaceGraph).toHaveBeenCalledWith({}, expectHabitatCallerOptions());
     expect(stdout.join("")).toContain('{"nodes":{}}');
   });
 
@@ -408,17 +428,26 @@ describe("Habitat oclif commands", () => {
     expect(result.owner.project).toBe("habitat");
     expect(result.owner.tags).toEqual(["kind:tooling"]);
     expect(createRouterClient).toHaveBeenCalled();
-    expect(mockClassifyTarget).toHaveBeenCalledWith({
-      target: "tools/habitat/src/cli/commands/check.ts",
-    });
+    expect(mockClassifyTarget).toHaveBeenCalledWith(
+      {
+        target: "tools/habitat/src/cli/commands/check.ts",
+      },
+      expectHabitatCallerOptions()
+    );
   });
 
   test("hook dispatches through the Habitat service router", async () => {
     await Hook.run(["pre-push", "--base", "HEAD~1"]);
 
     expect(createRouterClient).toHaveBeenCalled();
-    expect(mockHookPrePush).toHaveBeenCalledWith({ base: "HEAD~1" });
+    expect(mockHookPrePush).toHaveBeenCalledWith({ base: "HEAD~1" }, expectHabitatCallerOptions());
     expect(stdout.join("")).toContain("hook ok");
+  });
+
+  test("pre-commit forwards command cancellation to its Habitat service call", async () => {
+    await Hook.run(["pre-commit"]);
+
+    expect(mockHookPreCommit).toHaveBeenCalledWith({}, expectHabitatCallerOptions());
   });
 
   test("hook rejects unknown names before calling the service router", async () => {
@@ -435,10 +464,76 @@ describe("Habitat oclif commands", () => {
     await expect(Classify.run([])).rejects.toThrow(/Missing 1 required arg/);
   });
 
+  test("normal command completion disposes the managed runtime and removes signal listeners", async () => {
+    const before = {
+      sigint: process.listenerCount("SIGINT"),
+      sigterm: process.listenerCount("SIGTERM"),
+    };
+
+    await Classify.run(["tools/habitat/src"]);
+
+    expect(mockHabitatRuntimeDispose).toHaveBeenCalledTimes(1);
+    expect(process.listenerCount("SIGINT")).toBe(before.sigint);
+    expect(process.listenerCount("SIGTERM")).toBe(before.sigterm);
+  });
+
+  test("interrupts the exact check caller signal before runtime disposal and signal replay", async () => {
+    const originalSigintListeners = new Set(process.listeners("SIGINT"));
+    const events: string[] = [];
+    let callerSignal: AbortSignal | undefined;
+    mockCheckReport.mockImplementationOnce(
+      async (_input: unknown, options: { readonly signal: AbortSignal }) => {
+        callerSignal = options.signal;
+        await new Promise<void>((resolve) => {
+          options.signal.addEventListener(
+            "abort",
+            () => {
+              events.push("service-finalizer");
+              resolve();
+            },
+            { once: true }
+          );
+        });
+        return mockReport;
+      }
+    );
+    mockHabitatRuntimeDispose.mockImplementationOnce(async () => {
+      events.push("runtime-dispose");
+    });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      events.push("signal-replay");
+      return true;
+    });
+
+    try {
+      const command = Check.run(["--rule", "block_unapproved_base_standard_boundary_leaks"]);
+      await vi.waitFor(() => expect(mockCheckReport).toHaveBeenCalledTimes(1));
+
+      const commandListeners = process
+        .listeners("SIGINT")
+        .filter((listener) => !originalSigintListeners.has(listener));
+      expect(commandListeners).toHaveLength(1);
+      commandListeners[0]?.("SIGINT");
+
+      await command;
+
+      expect(callerSignal?.aborted).toBe(true);
+      expect(events).toEqual(["service-finalizer", "runtime-dispose", "signal-replay"]);
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+
   function capturedOutput(): string {
     return `${stdout.join("")}${logs.join("\n")}`;
   }
 });
+
+function expectHabitatCallerOptions() {
+  return expect.objectContaining({
+    signal: expect.objectContaining({ aborted: false }),
+  });
+}
 
 function verifyReceiptPayload(base: string, input: { base?: string; affectedExecution?: string }) {
   const planned = input.affectedExecution === "plan-only";

--- a/tools/habitat/test/lib/command-lifecycle.test.ts
+++ b/tools/habitat/test/lib/command-lifecycle.test.ts
@@ -1,0 +1,115 @@
+import { installHabitatCommandLifecycle } from "@habitat/cli/cli/base/command-lifecycle";
+import { describe, expect, test, vi } from "vitest";
+
+type TestSignal = "SIGINT" | "SIGTERM";
+
+class TestSignalTarget {
+  readonly pid = 4242;
+  readonly kills: Array<Readonly<{ pid: number; signal: TestSignal }>> = [];
+  private readonly listeners = new Map<TestSignal, Set<() => void>>();
+
+  on(signal: TestSignal, listener: () => void): void {
+    const listeners = this.listeners.get(signal) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(signal, listeners);
+  }
+
+  removeListener(signal: TestSignal, listener: () => void): void {
+    this.listeners.get(signal)?.delete(listener);
+  }
+
+  kill(pid: number, signal: TestSignal): boolean {
+    this.kills.push({ pid, signal });
+    return true;
+  }
+
+  emit(signal: TestSignal): void {
+    for (const listener of this.listeners.get(signal) ?? []) listener();
+  }
+
+  listenerCount(signal: TestSignal): number {
+    return this.listeners.get(signal)?.size ?? 0;
+  }
+}
+
+describe("Habitat command lifecycle", () => {
+  test("aborts once, then disposes before re-delivering the first signal", async () => {
+    const target = new TestSignalTarget();
+    const events: string[] = [];
+    const lifecycle = installHabitatCommandLifecycle(async () => {
+      events.push("dispose");
+    }, target);
+    lifecycle.callerOptions.signal.addEventListener("abort", () => events.push("abort"));
+
+    target.emit("SIGINT");
+    target.emit("SIGTERM");
+
+    expect(lifecycle.callerOptions.signal.aborted).toBe(true);
+    expect(events).toEqual(["abort"]);
+    expect(target.kills).toEqual([]);
+
+    await lifecycle.finish();
+    await lifecycle.finish();
+
+    expect(events).toEqual(["abort", "dispose"]);
+    expect(target.kills).toEqual([{ pid: 4242, signal: "SIGINT" }]);
+    expect(target.listenerCount("SIGINT")).toBe(0);
+    expect(target.listenerCount("SIGTERM")).toBe(0);
+  });
+
+  test("normal completion disposes once, removes listeners, and does not synthesize a signal", async () => {
+    const target = new TestSignalTarget();
+    const dispose = vi.fn(async () => {});
+    const lifecycle = installHabitatCommandLifecycle(dispose, target);
+
+    expect(target.listenerCount("SIGINT")).toBe(1);
+    expect(target.listenerCount("SIGTERM")).toBe(1);
+
+    await Promise.all([lifecycle.finish(), lifecycle.finish()]);
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(lifecycle.callerOptions.signal.aborted).toBe(false);
+    expect(target.kills).toEqual([]);
+    expect(target.listenerCount("SIGINT")).toBe(0);
+    expect(target.listenerCount("SIGTERM")).toBe(0);
+  });
+
+  test("keeps signal ownership until runtime disposal completes", async () => {
+    const target = new TestSignalTarget();
+    let releaseDispose: (() => void) | undefined;
+    const disposal = new Promise<void>((resolve) => {
+      releaseDispose = resolve;
+    });
+    const lifecycle = installHabitatCommandLifecycle(() => disposal, target);
+
+    target.emit("SIGINT");
+    const finished = lifecycle.finish();
+    await Promise.resolve();
+
+    expect(target.listenerCount("SIGINT")).toBe(1);
+    expect(target.listenerCount("SIGTERM")).toBe(1);
+    target.emit("SIGTERM");
+    expect(target.kills).toEqual([]);
+
+    releaseDispose?.();
+    await finished;
+
+    expect(target.kills).toEqual([{ pid: 4242, signal: "SIGINT" }]);
+    expect(target.listenerCount("SIGINT")).toBe(0);
+    expect(target.listenerCount("SIGTERM")).toBe(0);
+  });
+
+  test("preserves signal termination even if runtime disposal rejects", async () => {
+    const target = new TestSignalTarget();
+    const lifecycle = installHabitatCommandLifecycle(async () => {
+      throw new Error("dispose failed");
+    }, target);
+
+    target.emit("SIGTERM");
+
+    await expect(lifecycle.finish()).rejects.toThrow("dispose failed");
+    expect(target.kills).toEqual([{ pid: 4242, signal: "SIGTERM" }]);
+    expect(target.listenerCount("SIGINT")).toBe(0);
+    expect(target.listenerCount("SIGTERM")).toBe(0);
+  });
+});

--- a/tools/habitat/test/lib/command-lifecycle.test.ts
+++ b/tools/habitat/test/lib/command-lifecycle.test.ts
@@ -1,5 +1,6 @@
-import { installHabitatCommandLifecycle } from "@habitat/cli/cli/base/command-lifecycle";
 import { describe, expect, test, vi } from "vitest";
+
+const { installHabitatCommandLifecycle } = await import("@habitat/cli/cli/base/command-lifecycle");
 
 type TestSignal = "SIGINT" | "SIGTERM";
 

--- a/tools/habitat/test/lib/command-runner.test.ts
+++ b/tools/habitat/test/lib/command-runner.test.ts
@@ -1,6 +1,9 @@
+import { createHash } from "node:crypto";
+import { NodeContext } from "@effect/platform-node";
 import { makeFakeGitStateProviderLayer } from "@habitat/cli/providers/git/index";
 import {
   CommandRunner,
+  CommandRunnerLive,
   captureCommandGitStateAround,
   captureOutput,
   commandUnavailableFromCause,
@@ -13,10 +16,14 @@ import {
   redactEnvDelta,
   renderCommandObservation,
 } from "@habitat/cli/resources/command/index";
-import { makeHabitatConfig } from "@habitat/cli/resources/config/index";
+import {
+  COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES,
+  collectOutputCapture,
+} from "@habitat/cli/resources/command/output";
+import { makeHabitatConfig, makeHabitatConfigLayer } from "@habitat/cli/resources/config/index";
 import { CommandInterrupted, CommandUnavailable } from "@habitat/cli/resources/errors/index";
 import { repoRoot } from "@habitat/cli/resources/paths";
-import { Duration, Effect, Fiber, TestClock, TestContext } from "effect";
+import { Duration, Effect, Fiber, Layer, Stream, TestClock, TestContext } from "effect";
 import { describe, expect, test } from "vitest";
 
 describe("CommandRunner", () => {
@@ -101,19 +108,104 @@ describe("CommandRunner", () => {
     expect(renderCommandObservation(interrupted.observation)).toBe("interrupted by SIGTERM");
   });
 
-  test("redacts sensitive env values and preserves output digests under truncation", () => {
+  test("redacts sensitive env values and captures in-memory output", () => {
     const env = redactEnvDelta({
       HABITAT_TOKEN: "secret-token",
       HABITAT_MODE: "local",
     });
-    const output = captureOutput("x".repeat(4 * 1024 * 1024 + 8));
+    const output = captureOutput("visible 🌊\n");
 
     expect(env.HABITAT_TOKEN).toEqual({ value: "<redacted>", redacted: true });
     expect(env.HABITAT_MODE).toEqual({ value: "local", redacted: false });
-    expect(output.truncated).toBe(true);
-    expect(output.text.length).toBe(4 * 1024 * 1024);
-    expect(output.bytes).toBe(4 * 1024 * 1024 + 8);
+    expect(output).toMatchObject({
+      text: "visible 🌊\n",
+      truncated: false,
+      bytes: Buffer.byteLength("visible 🌊\n", "utf8"),
+    });
     expect(output.sha256).toHaveLength(64);
+  });
+
+  test("decodes Unicode only after all output chunks have been retained", async () => {
+    const encoded = Buffer.from("alpha 🌊 omega\n", "utf8");
+    const splitInsideWave = Buffer.byteLength("alpha ", "utf8") + 2;
+    const chunks = [
+      encoded.subarray(0, splitInsideWave),
+      encoded.subarray(splitInsideWave, splitInsideWave + 1),
+      encoded.subarray(splitInsideWave + 1),
+    ];
+
+    const output = await Effect.runPromise(collectOutputCapture(Stream.fromIterable(chunks)));
+
+    expect(output).toEqual({
+      text: encoded.toString("utf8"),
+      truncated: false,
+      sha256: createHash("sha256").update(encoded).digest("hex"),
+      bytes: encoded.byteLength,
+    });
+  });
+
+  test("bounds retained output while hashing and counting the complete stream", async () => {
+    const block = Buffer.alloc(64 * 1024, "x");
+    const overflow = Buffer.from("overflow-🌊", "utf8");
+    const blockCount = COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES / block.byteLength;
+    const chunks = [...Array.from({ length: blockCount }, () => block), overflow];
+    const expectedHash = createHash("sha256");
+    for (const chunk of chunks) expectedHash.update(chunk);
+
+    const output = await Effect.runPromise(collectOutputCapture(Stream.fromIterable(chunks)));
+
+    expect(output.truncated).toBe(true);
+    expect(output.text).toHaveLength(COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES);
+    expect(output.text[0]).toBe("x");
+    expect(output.text.at(-1)).toBe("x");
+    expect(output.bytes).toBe(COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES + overflow.byteLength);
+    expect(output.sha256).toBe(expectedHash.digest("hex"));
+  });
+
+  test("captures a live command through the bounded stream collector", async () => {
+    const encoded = Buffer.from("live 🌊 output\n", "utf8");
+    const script = [
+      'const bytes = Buffer.from("live \\u{1f30a} output\\n", "utf8");',
+      "process.stdout.write(bytes.subarray(0, 7));",
+      "process.stdout.write(bytes.subarray(7, 9));",
+      "process.stdout.write(bytes.subarray(9));",
+    ].join("");
+    const dependencies = Layer.mergeAll(
+      NodeContext.layer,
+      makeHabitatConfigLayer(makeHabitatConfig({ repoRoot })),
+      makeFakeGitStateProviderLayer(() => ({
+        branch: null,
+        head: null,
+        dirty: false,
+        statusShort: "",
+        statusDigest: "fixture",
+      }))
+    );
+    const liveRunner = CommandRunnerLive.pipe(Layer.provide(dependencies));
+
+    const result = await Effect.runPromise(
+      CommandRunner.pipe(
+        Effect.flatMap((runner) =>
+          runner.run({
+            commandId: "bounded-live-output",
+            kind: "workspace-tool",
+            executable: process.execPath,
+            argv: ["-e", script],
+            cwd: repoRoot,
+            captureGitState: false,
+          })
+        ),
+        Effect.provide(liveRunner)
+      )
+    );
+
+    expect(result.exit.code).toBe(0);
+    expect(result.stdout).toEqual({
+      text: encoded.toString("utf8"),
+      truncated: false,
+      sha256: createHash("sha256").update(encoded).digest("hex"),
+      bytes: encoded.byteLength,
+    });
   });
 
   test("captures command git state through the Git state provider", async () => {

--- a/tools/habitat/test/lib/grit-provider-current-tree-execution.test.ts
+++ b/tools/habitat/test/lib/grit-provider-current-tree-execution.test.ts
@@ -120,6 +120,47 @@ describe("generic Grit current-tree execution", () => {
     );
   });
 
+  test("executes a pinned multi-pattern catalog once and projects matching plus clean peers", async () => {
+    const fixture = checkFixture("const value = forbidden_fixture_marker;\n");
+    const cleanPatternPath = path.join(fixture.repoRoot, ".habitat/patterns/clean.md");
+    writeFileSync(
+      cleanPatternPath,
+      `\`\`\`grit
+language js
+
+\`absent_fixture_marker\`
+\`\`\`
+`
+    );
+    const cleanRule = sourceRule(
+      "fixture-clean-check",
+      "clean_fixture_marker",
+      ".habitat/patterns/clean.md",
+      ["scan"],
+      "check"
+    );
+    const before = treeDigest(fixture.repoRoot);
+    const observation: BoundaryObservation = {};
+    const outcomes = await Effect.runPromise(
+      Effect.gen(function* () {
+        const liveGrit = yield* makeGritCommandService(workspaceRepoRoot);
+        return yield* runGritDiagnosticOutcomesEffect([cleanRule, fixture.rule], {
+          repoRoot: fixture.repoRoot,
+          grit: observingGrit(liveGrit, observation),
+        });
+      }).pipe(Effect.provide(LiveGritPrerequisites))
+    );
+
+    expect(outcomes.get(fixture.rule.id)).toMatchObject({ kind: "findings" });
+    expect(outcomes.get(cleanRule.id)).toMatchObject({ kind: "clean", diagnostics: [] });
+    expect(observation.checkCallCount).toBe(1);
+    expect(observation.checkRequest?.patternNames).toEqual([
+      "clean_fixture_marker",
+      "fixture_marker",
+    ]);
+    expect(treeDigest(fixture.repoRoot)).toBe(before);
+  });
+
   test("keeps an empty eligible root parsed-incomplete rather than clean", async () => {
     const fixture = checkFixture("", false, false);
     const execution = await executeFixture(fixture);
@@ -390,6 +431,7 @@ interface Fixture {
 interface BoundaryObservation {
   checkRequest?: GritCheckProviderRequest;
   checkCommand?: HabitatCommandResult;
+  checkCallCount?: number;
   applyRequest?: GritApplyDryRunProviderRequest;
   applyCommand?: HabitatCommandResult;
   applyCallCount?: number;
@@ -466,6 +508,7 @@ function observingGrit(
   return {
     ...live,
     check: (request) => {
+      observation.checkCallCount = (observation.checkCallCount ?? 0) + 1;
       observation.checkRequest = request;
       return live.check(request).pipe(
         Effect.tap((command) =>

--- a/tools/habitat/test/lib/grit-provider.test.ts
+++ b/tools/habitat/test/lib/grit-provider.test.ts
@@ -1322,6 +1322,7 @@ describe("Grit generic acquisition and public disposition", () => {
       GRIT_DOWNLOADS_DISABLED: "true",
       GRIT_TELEMETRY_DISABLED: "true",
       GRIT_MAX_FILE_SIZE_BYTES: "0",
+      RAYON_NUM_THREADS: "2",
     });
     expect(observedRequest?.cwd).not.toBe(repoRoot);
     expect(existsSync(observedRequest?.cwd ?? repoRoot)).toBe(false);

--- a/tools/habitat/test/lib/grit-provider.test.ts
+++ b/tools/habitat/test/lib/grit-provider.test.ts
@@ -30,8 +30,8 @@ import {
   NativeGritPinnedNativePreflightRequestSchema,
   type NativeGritSelectedRuleApplyDryRunObservationRequest,
   NativeGritSelectedRuleApplyDryRunObservationRequestSchema,
-  type NativeGritSelectedRuleJsonCheckRequest,
-  NativeGritSelectedRuleJsonCheckRequestSchema,
+  type NativeGritSelectedRulesJsonCheckRequest,
+  NativeGritSelectedRulesJsonCheckRequestSchema,
   nativeGritCommandRequestFromProcessRequest,
 } from "@habitat/cli/resources/rule-diagnostics/providers/grit/command.schema";
 import { defaultGritCommandTimeoutMs } from "@habitat/cli/resources/rule-diagnostics/providers/grit/constants";
@@ -40,6 +40,7 @@ import {
   makeGritRuleFixPreviewService,
 } from "@habitat/cli/resources/rule-diagnostics/providers/grit/fix-preview";
 import {
+  type GritCommandRequest,
   gritDiagnosticOutcomesFromReport,
   makeFakeGritCommandService,
   makeGritCommandService,
@@ -230,19 +231,24 @@ describe("Grit closed wire decoders", () => {
 
   test("correlates native command families, output contracts, and failed exits", () => {
     const contracts = [
-      ["selected-rule-json-check", "json-report-on-stderr"],
+      ["selected-rules-json-check", "json-report-on-stderr"],
       ["selected-rule-apply-dry-run-observation", "compact-jsonl-on-stdout"],
       ["pinned-native-preflight", "version-on-stdout"],
     ] as const;
     const request = nativeRequestFixture();
+    const { patternNames, ...requestWithoutPatternNames } = request;
     for (const [family, outputContract] of contracts) {
       const scanRoots = Match.value(family).pipe(
         Match.when("pinned-native-preflight", () => []),
         Match.orElse(() => request.scanRoots)
       );
+      const familyRequest = Match.value(family).pipe(
+        Match.when("selected-rules-json-check", () => request),
+        Match.orElse(() => requestWithoutPatternNames)
+      );
       expect(
         Value.Check(NativeGritCommandRequestSchema, {
-          ...request,
+          ...familyRequest,
           commandFamily: family,
           outputContract,
           scanRoots,
@@ -252,7 +258,7 @@ describe("Grit closed wire decoders", () => {
         if (wrongOutputContract === outputContract) continue;
         expect(
           Value.Check(NativeGritCommandRequestSchema, {
-            ...request,
+            ...familyRequest,
             commandFamily: family,
             outputContract: wrongOutputContract,
             scanRoots,
@@ -263,9 +269,21 @@ describe("Grit closed wire decoders", () => {
     expect(Value.Check(DiagnosticCommandObservationSchema, failedCommandFixture(7))).toBe(true);
     expect(Value.Check(DiagnosticCommandObservationSchema, failedCommandFixture(0))).toBe(false);
     expect(
-      Value.Check(NativeGritSelectedRuleJsonCheckRequestSchema, {
+      Value.Check(NativeGritSelectedRulesJsonCheckRequestSchema, {
         ...request,
         scanRoots: [],
+      })
+    ).toBe(false);
+    expect(
+      Value.Check(NativeGritSelectedRulesJsonCheckRequestSchema, {
+        ...request,
+        patternNames: [],
+      })
+    ).toBe(false);
+    expect(
+      Value.Check(NativeGritSelectedRulesJsonCheckRequestSchema, {
+        ...request,
+        patternNames: ["alpha_pattern", "alpha_pattern"],
       })
     ).toBe(false);
     expect(
@@ -279,8 +297,9 @@ describe("Grit closed wire decoders", () => {
     const processRequest = baseRequest();
     const checkRequest = nativeGritCommandRequestFromProcessRequest({
       request: processRequest,
-      commandFamily: "selected-rule-json-check",
-    }) satisfies NativeGritSelectedRuleJsonCheckRequest;
+      commandFamily: "selected-rules-json-check",
+      patternNames: ["alpha_pattern"],
+    }) satisfies NativeGritSelectedRulesJsonCheckRequest;
     const applyRequest = nativeGritCommandRequestFromProcessRequest({
       request: processRequest,
       commandFamily: "selected-rule-apply-dry-run-observation",
@@ -289,7 +308,8 @@ describe("Grit closed wire decoders", () => {
       request: processRequest,
       commandFamily: "pinned-native-preflight",
     }) satisfies NativeGritPinnedNativePreflightRequest;
-    expect(Value.Check(NativeGritSelectedRuleJsonCheckRequestSchema, checkRequest)).toBe(true);
+    expect(Value.Check(NativeGritSelectedRulesJsonCheckRequestSchema, checkRequest)).toBe(true);
+    expect(checkRequest.patternNames).toEqual(["alpha_pattern"]);
     expect(
       Value.Check(NativeGritSelectedRuleApplyDryRunObservationRequestSchema, applyRequest)
     ).toBe(true);
@@ -444,7 +464,8 @@ describe("Grit closed wire decoders", () => {
     const command = completedCommandFixture();
     const checkRequest = nativeGritCommandRequestFromProcessRequest({
       request: processRequest,
-      commandFamily: "selected-rule-json-check",
+      commandFamily: "selected-rules-json-check",
+      patternNames: ["alpha_pattern"],
     });
     const applyRequest = nativeGritCommandRequestFromProcessRequest({
       request: processRequest,
@@ -474,7 +495,7 @@ describe("Grit closed wire decoders", () => {
     );
     expect(checkComplete).toMatchObject({
       kind: "observed-complete",
-      request: { commandFamily: "selected-rule-json-check", cwd: repoRoot },
+      request: { commandFamily: "selected-rules-json-check", cwd: repoRoot },
       command: { cwd: repoRoot },
       observation: { kind: "check" },
     });
@@ -500,7 +521,7 @@ describe("Grit closed wire decoders", () => {
           kind: "evidence-mismatch",
           failure: "DiagnosticProviderContractViolation",
           detail: expect.stringContaining(fixture.field),
-          request: { commandFamily: "selected-rule-json-check" },
+          request: { commandFamily: "selected-rules-json-check" },
           command: { kind: "completed" },
         },
       });
@@ -1484,7 +1505,7 @@ describe("Grit generic acquisition and public disposition", () => {
       expect(acquisition).toMatchObject({
         kind: "command-failed",
         failure: fixture.expectedFailure,
-        request: { commandInvocationId: "grit-selected-rule-json-check" },
+        request: { commandInvocationId: "grit-selected-rules-json-check" },
         command: {
           kind: fixture.expectedCommand,
           commandId: "grit-pinned-native-preflight",
@@ -1512,12 +1533,12 @@ describe("Grit generic acquisition and public disposition", () => {
     );
     expect(completed).toMatchObject({
       kind: "observed-complete",
-      request: { commandInvocationId: "grit-selected-rule-json-check" },
-      command: { kind: "completed", commandId: "grit-selected-rule-json-check" },
+      request: { commandInvocationId: "grit-selected-rules-json-check" },
+      command: { kind: "completed", commandId: "grit-selected-rules-json-check" },
     });
     expect(observed.map(({ commandId }) => commandId)).toEqual([
       "grit-pinned-native-preflight",
-      "grit-selected-rule-json-check",
+      "grit-selected-rules-json-check",
     ]);
     expect(observed[0]?.timeoutMs).toEqual(observed[1]?.timeoutMs);
     expect(observed[0]?.timeoutMs).toBeGreaterThan(0);
@@ -1531,6 +1552,7 @@ describe("Grit generic acquisition and public disposition", () => {
         preflightScenarioEffect("exact", recordAndReturn(observed, request, request)),
     };
     const request = {
+      patternNames: ["alpha_pattern"] as const,
       scanRoots: [providerRoot] as const,
       cwd: repoRoot,
       gritDir: path.join(repoRoot, ".grit"),
@@ -1547,8 +1569,8 @@ describe("Grit generic acquisition and public disposition", () => {
     await Effect.runPromise(realization);
     expect(observed.map(({ commandId }) => commandId)).toEqual([
       "grit-pinned-native-preflight",
-      "grit-selected-rule-json-check",
-      "grit-selected-rule-json-check",
+      "grit-selected-rules-json-check",
+      "grit-selected-rules-json-check",
     ]);
     expect(observed[0]?.timeoutMs).toBe(defaultGritCommandTimeoutMs);
     expect(observed.slice(1).map(({ timeoutMs }) => timeoutMs)).toEqual([123, 123]);
@@ -1567,14 +1589,17 @@ describe("Grit generic acquisition and public disposition", () => {
           ({ commandId }) => commandId === "grit-pinned-native-preflight"
         ).length;
         observed.push(request);
-        const kind =
+        const kind = Match.value(
           request.commandId === "grit-pinned-native-preflight" && priorPreflights === 0
-            ? "blank"
-            : "exact";
+        ).pipe(
+          Match.when(true, () => "blank" as const),
+          Match.orElse(() => "exact" as const)
+        );
         return preflightScenarioEffect(kind, request);
       },
     };
     const request = {
+      patternNames: ["alpha_pattern"] as const,
       scanRoots: [providerRoot] as const,
       cwd: repoRoot,
       gritDir: path.join(repoRoot, ".grit"),
@@ -1592,8 +1617,8 @@ describe("Grit generic acquisition and public disposition", () => {
     expect(observed.map(({ commandId }) => commandId)).toEqual([
       "grit-pinned-native-preflight",
       "grit-pinned-native-preflight",
-      "grit-selected-rule-json-check",
-      "grit-selected-rule-json-check",
+      "grit-selected-rules-json-check",
+      "grit-selected-rules-json-check",
     ]);
   });
 
@@ -1606,6 +1631,7 @@ describe("Grit generic acquisition and public disposition", () => {
       },
     };
     const request = {
+      patternNames: ["alpha_pattern"] as const,
       scanRoots: [providerRoot] as const,
       cwd: repoRoot,
       gritDir: path.join(repoRoot, ".grit"),
@@ -1663,7 +1689,7 @@ describe("Grit generic acquisition and public disposition", () => {
       observed.filter(({ commandId }) => commandId === "grit-pinned-native-preflight")
     ).toHaveLength(2);
     expect(
-      observed.filter(({ commandId }) => commandId === "grit-selected-rule-json-check")
+      observed.filter(({ commandId }) => commandId === "grit-selected-rules-json-check")
     ).toHaveLength(2);
   });
 
@@ -1813,13 +1839,16 @@ describe("Grit generic acquisition and public disposition", () => {
     expect(commandCalled).toBe(false);
   });
 
-  test("executes one immutable catalog per rule without cross-catalog leakage", async () => {
+  test("executes one immutable catalog for exact-root rules with distinct identities", async () => {
     const alpha = rule("alpha", "alpha_pattern", providerPattern, [providerRoot]);
     const beta = rule("beta", "beta_pattern", providerPattern, [providerRoot]);
     const catalogs: string[] = [];
+    const selectedPatternNames: string[][] = [];
     const grit = makeFakeGritCommandService(
-      (request) => {
+      (request, providerRequest) => {
+        const checkRequest = requireCheckProviderRequest(providerRequest);
         catalogs.push(readFileSync(path.join(request.cwd, ".grit/grit.yaml"), "utf8"));
+        selectedPatternNames.push([...checkRequest.patternNames]);
         return makeHabitatCommandResult(request, {
           stderr: captureOutput(
             jsonDocument({ paths: [path.join(repoRoot, providerFile)], results: [] })
@@ -1832,13 +1861,240 @@ describe("Grit generic acquisition and public disposition", () => {
       runGritRulesEffect([alpha, beta], { repoRoot, grit }).pipe(Effect.provide(NodeContext.layer))
     );
     expect([...executions.values()].every((execution) => execution.kind === "executed")).toBe(true);
-    expect(catalogs).toHaveLength(2);
-    const alphaCatalog = catalogs.find((catalog) => catalog.includes("alpha_pattern"));
-    const betaCatalog = catalogs.find((catalog) => catalog.includes("beta_pattern"));
-    expect(alphaCatalog).toBeDefined();
-    expect(alphaCatalog).not.toContain("beta_pattern");
-    expect(betaCatalog).toBeDefined();
-    expect(betaCatalog).not.toContain("alpha_pattern");
+    expect(catalogs).toHaveLength(1);
+    expect(catalogs[0]).toContain("alpha_pattern");
+    expect(catalogs[0]).toContain("beta_pattern");
+    expect(selectedPatternNames).toEqual([["alpha_pattern", "beta_pattern"]]);
+    expect(executions.get("alpha")?.durationMs).toBe(executions.get("beta")?.durationMs);
+    expect(executions.get("alpha")?.timing).toEqual({
+      kind: "shared",
+      groupId: "rule-diagnostics:alpha,beta",
+      durationMs: executions.get("alpha")?.durationMs,
+      ruleCount: 2,
+    });
+    expect(executions.get("beta")?.timing).toEqual(executions.get("alpha")?.timing);
+  });
+
+  test("keeps different roots and duplicate pattern identities in sequential commands", async () => {
+    const cases = [
+      [
+        rule("alpha", "alpha_pattern", providerPattern, [providerRoot]),
+        rule("docs", "docs_pattern", providerPattern, ["docs"]),
+      ],
+      [
+        rule("duplicate-a", "duplicate_pattern", providerPattern, [providerRoot]),
+        rule("duplicate-b", "duplicate_pattern", providerPattern, [providerRoot]),
+      ],
+    ] as const;
+    for (const selectedRules of cases) {
+      const observed: Array<readonly string[]> = [];
+      const catalogs: string[] = [];
+      const grit = makeFakeGritCommandService(
+        (request, providerRequest) => {
+          const checkRequest = requireCheckProviderRequest(providerRequest);
+          observed.push([...checkRequest.scanRoots]);
+          catalogs.push(readFileSync(path.join(request.cwd, ".grit/grit.yaml"), "utf8"));
+          return makeHabitatCommandResult(request, {
+            stderr: captureOutput(
+              jsonDocument({ paths: [...checkRequest.scanRoots], results: [] })
+            ),
+          });
+        },
+        { repoRoot }
+      );
+
+      const executions = await Effect.runPromise(
+        runGritRulesEffect(selectedRules, { repoRoot, grit }).pipe(
+          Effect.provide(NodeContext.layer)
+        )
+      );
+
+      expect([...executions.keys()]).toEqual(selectedRules.map(({ id }) => id));
+      expect(observed).toHaveLength(2);
+      expect(catalogs).toHaveLength(2);
+      expect(catalogs.every((catalog) => catalog.split("  - name:").length === 2)).toBe(true);
+    }
+  });
+
+  test("keeps duplicate pattern identities singleton across different root groups", async () => {
+    const selectedRules = [
+      rule("duplicate-provider", "duplicate_pattern", providerPattern, [providerRoot]),
+      rule("provider-peer", "provider_peer_pattern", providerPattern, [providerRoot]),
+      rule("duplicate-docs", "duplicate_pattern", providerPattern, ["docs"]),
+      rule("docs-peer", "docs_peer_pattern", providerPattern, ["docs"]),
+    ] as const;
+    const observedPatternNames: string[][] = [];
+    const grit = makeFakeGritCommandService(
+      (request, providerRequest) => {
+        const checkRequest = requireCheckProviderRequest(providerRequest);
+        observedPatternNames.push([...checkRequest.patternNames]);
+        return makeHabitatCommandResult(request, {
+          stderr: captureOutput(jsonDocument({ paths: [...checkRequest.scanRoots], results: [] })),
+        });
+      },
+      { repoRoot }
+    );
+
+    const executions = await Effect.runPromise(
+      runGritRulesEffect(selectedRules, { repoRoot, grit }).pipe(Effect.provide(NodeContext.layer))
+    );
+
+    expect([...executions.keys()]).toEqual(selectedRules.map(({ id }) => id));
+    expect(observedPatternNames).toEqual([
+      ["duplicate_pattern"],
+      ["provider_peer_pattern"],
+      ["duplicate_pattern"],
+      ["docs_peer_pattern"],
+    ]);
+  });
+
+  test("isolates invalid rule assets before valid peers acquire a shared catalog", async () => {
+    const invalid = rule("invalid", "invalid_pattern", ".habitat/missing-pattern.md", [
+      providerRoot,
+    ]);
+    const valid = rule("valid", "valid_pattern", providerPattern, [providerRoot]);
+    const catalogs: string[] = [];
+    const grit = makeFakeGritCommandService(
+      (request, providerRequest) => {
+        const checkRequest = requireCheckProviderRequest(providerRequest);
+        catalogs.push(readFileSync(path.join(request.cwd, ".grit/grit.yaml"), "utf8"));
+        return makeHabitatCommandResult(request, {
+          stderr: captureOutput(jsonDocument({ paths: [...checkRequest.scanRoots], results: [] })),
+        });
+      },
+      { repoRoot }
+    );
+
+    const executions = await Effect.runPromise(
+      runGritRulesEffect([invalid, valid], { repoRoot, grit }).pipe(
+        Effect.provide(NodeContext.layer)
+      )
+    );
+
+    expect([...executions.keys()]).toEqual(["invalid", "valid"]);
+    expect(executions.get("invalid")).toMatchObject({
+      kind: "failed",
+      failure: "DiagnosticRuleMaterializationFailed",
+    });
+    expect(executions.get("valid")).toMatchObject({ kind: "executed" });
+    expect(catalogs).toHaveLength(1);
+    expect(catalogs[0]).toContain("valid_pattern");
+    expect(catalogs[0]).not.toContain("invalid_pattern");
+  });
+
+  test("contains command, wire, path, and identity failures to one exact-root group", async () => {
+    const alpha = rule("alpha", "alpha_pattern", providerPattern, [providerRoot]);
+    const beta = rule("beta", "beta_pattern", providerPattern, [providerRoot]);
+    const docs = rule("docs", "docs_pattern", providerPattern, ["docs"]);
+    const fixtures = [
+      {
+        expected: "DiagnosticCommandFailed",
+        result: (request: HabitatProcessRequest) =>
+          makeHabitatCommandResult(request, {
+            exit: { code: 7, signal: null, interrupted: false },
+          }),
+      },
+      {
+        expected: "DiagnosticOutputMalformed",
+        result: (request: HabitatProcessRequest) =>
+          makeHabitatCommandResult(request, { stderr: captureOutput("{") }),
+      },
+      {
+        expected: "DiagnosticOutputIncomplete",
+        result: (request: HabitatProcessRequest) =>
+          makeHabitatCommandResult(request, {
+            stderr: captureOutput(
+              jsonDocument({ paths: [path.join(repoRoot, "docs/PRODUCT.md")], results: [] })
+            ),
+          }),
+      },
+      {
+        expected: "DiagnosticUnexpectedIdentity",
+        result: (request: HabitatProcessRequest) =>
+          makeHabitatCommandResult(request, {
+            stderr: captureOutput(
+              jsonDocument(checkReport(path.join(repoRoot, providerFile), "foreign_pattern"))
+            ),
+          }),
+      },
+    ] as const;
+
+    for (const fixture of fixtures) {
+      let callCount = 0;
+      const grit = makeFakeGritCommandService(
+        (request, providerRequest) => {
+          const checkRequest = requireCheckProviderRequest(providerRequest);
+          callCount += 1;
+          return Match.value(
+            checkRequest.scanRoots.includes(path.join(repoRoot, providerRoot))
+          ).pipe(
+            Match.when(true, () => fixture.result(request)),
+            Match.orElse(() =>
+              makeHabitatCommandResult(request, {
+                stderr: captureOutput(
+                  jsonDocument({ paths: [...checkRequest.scanRoots], results: [] })
+                ),
+              })
+            )
+          );
+        },
+        { repoRoot }
+      );
+
+      const executions = await Effect.runPromise(
+        runGritRulesEffect([alpha, beta, docs], { repoRoot, grit }).pipe(
+          Effect.provide(NodeContext.layer)
+        )
+      );
+
+      expect(callCount).toBe(2);
+      expect(executions.get("alpha")).toMatchObject({ kind: "failed", failure: fixture.expected });
+      expect(executions.get("beta")).toMatchObject({ kind: "failed", failure: fixture.expected });
+      expect(executions.get("docs")).toMatchObject({ kind: "executed" });
+    }
+  });
+
+  test("preserves selected order across batched check, apply, and not-applicable plans", async () => {
+    const check = rule("check", "check_pattern", providerPattern, [providerRoot]);
+    const apply = rule("apply", "apply_pattern", applyPattern, ["docs"], "apply-dry-run");
+    const unmatched = rule("unmatched", "unmatched_pattern", providerPattern, ["packages"]);
+    const observedKinds: string[] = [];
+    const grit = makeFakeGritCommandService(
+      (request, providerRequest) => {
+        observedKinds.push(providerRequest.kind);
+        return Match.value(providerRequest).pipe(
+          Match.when({ kind: "check" }, ({ scanRoots }) =>
+            makeHabitatCommandResult(request, {
+              stderr: captureOutput(jsonDocument({ paths: [...scanRoots], results: [] })),
+            })
+          ),
+          Match.when({ kind: "apply-dry-run" }, () =>
+            makeHabitatCommandResult(request, {
+              stdout: captureOutput(jsonl(allDone(1, 0))),
+            })
+          ),
+          Match.exhaustive
+        );
+      },
+      { repoRoot }
+    );
+
+    const executions = await Effect.runPromise(
+      runGritRulesEffect([check, apply, unmatched], {
+        repoRoot,
+        grit,
+        scanRoots: [providerFile, "docs/PRODUCT.md"],
+      }).pipe(Effect.provide(NodeContext.layer))
+    );
+
+    expect([...executions.keys()]).toEqual(["check", "apply", "unmatched"]);
+    expect(executions.get("check")).toMatchObject({ kind: "executed" });
+    expect(executions.get("apply")).toMatchObject({ kind: "executed" });
+    expect(executions.get("unmatched")).toMatchObject({
+      kind: "not-applicable",
+      reason: "no-matched-scan-roots",
+    });
+    expect(observedKinds).toEqual(["check", "apply-dry-run"]);
   });
 
   test("dispatches apply dry-run from manifest policy without rule-id branching", async () => {
@@ -2532,14 +2788,28 @@ function compactEventFixtures() {
   ];
 }
 
+function requireCheckProviderRequest(
+  request: GritCommandRequest
+): Extract<GritCommandRequest, { readonly kind: "check" }> {
+  return Match.value(request).pipe(
+    Match.when({ kind: "check" }, (checkRequest) => checkRequest),
+    Match.orElse(unexpectedCheckProviderRequest)
+  );
+}
+
+function unexpectedCheckProviderRequest(request: GritCommandRequest): never {
+  throw new Error(`Expected a check acquisition, observed ${request.kind}.`);
+}
+
 function nativeRequestFixture() {
   return {
-    commandFamily: "selected-rule-json-check",
+    commandFamily: "selected-rules-json-check",
     commandInvocationId: "grit-test",
     executable: pinnedGritNativePath(repoRoot),
     argv: ["--json", "check"],
     cwd: repoRoot,
     scanRoots: [providerRoot],
+    patternNames: ["alpha_pattern"],
     outputContract: "json-report-on-stderr",
   };
 }

--- a/tools/habitat/test/lib/rule-selection.test.ts
+++ b/tools/habitat/test/lib/rule-selection.test.ts
@@ -570,6 +570,29 @@ describe("rule selector boundary", () => {
     });
   });
 
+  test("rule diagnostics preserve shared provider timing as one execution group", () => {
+    const rule = fakeSourceRuleFact("batched", ["packages"]);
+    const timing = {
+      kind: "shared" as const,
+      groupId: "rule-diagnostics:batched,peer",
+      durationMs: 11,
+      ruleCount: 2,
+    };
+    const record = ruleDiagnosticExecutionRecord(rule, {
+      kind: "executed",
+      result: { exitCode: 0, diagnostics: [] },
+      durationMs: 11,
+      timing,
+    });
+
+    expect(record).toEqual({
+      result: { exitCode: 0, diagnostics: [] },
+      durationMs: 11,
+      timing,
+      disposition: { kind: "executed", durationMs: 11 },
+    });
+  });
+
   test("diagnostic provider failures always carry a reportable diagnostic", () => {
     const rule = fakeSourceRuleFact("provider-contract", ["packages"]);
     const record = ruleDiagnosticExecutionRecord(rule, {

--- a/tools/habitat/test/lib/structure-check.test.ts
+++ b/tools/habitat/test/lib/structure-check.test.ts
@@ -178,6 +178,153 @@ describe("structure-check evaluator", () => {
     expect(messages(result)).toContain("[wrong-root-kind]");
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  test("reuses one ordered glob traversal across scopes and trusts listed entry kinds", async () => {
+    const fixture = fixtures({
+      directories: new Map([
+        [
+          `${repoRoot}/pkg`,
+          [
+            { name: "alpha", kind: "directory" },
+            { name: "socket", kind: "other" },
+          ],
+        ],
+        [
+          `${repoRoot}/pkg/alpha`,
+          [
+            { name: "zeta.txt", kind: "file" },
+            { name: "alpha.txt", kind: "file" },
+          ],
+        ],
+      ]),
+    });
+    const result = await runWithFs(
+      {
+        schemaVersion: 1,
+        scopes: [
+          {
+            name: "closed-roots",
+            root: "pkg/*",
+            kind: "directory",
+            mode: "closed",
+          },
+          {
+            name: "forbidden-roots",
+            root: "pkg/*",
+            kind: "directory",
+            mode: "open",
+            forbidden: ["alpha.txt"],
+          },
+        ],
+      },
+      fixture
+    );
+
+    expect(result.diagnostics.map((diagnostic) => diagnostic.path)).toEqual([
+      "pkg/socket",
+      "pkg/alpha/zeta.txt",
+      "pkg/alpha/alpha.txt",
+      "pkg/socket",
+      "pkg/alpha/alpha.txt",
+    ]);
+    expect(result.diagnostics[0]?.message).toContain("is other");
+    expect(fixture.events.filter((event) => event.startsWith("readdir:"))).toEqual([
+      `readdir:${repoRoot}/pkg`,
+      `readdir:${repoRoot}/pkg/alpha`,
+    ]);
+    expect(fixture.events.filter((event) => event.startsWith("stat:"))).toEqual([
+      `stat:${repoRoot}/pkg`,
+    ]);
+  });
+
+  test("keeps literal other entries missing regardless of scope order", async () => {
+    const globScope = {
+      name: "glob-roots",
+      root: "pkg/*",
+      kind: "directory",
+      mode: "open",
+    } as const;
+    const literalScope = {
+      name: "literal-other",
+      root: "pkg/socket",
+      kind: "directory",
+      mode: "open",
+    } as const;
+
+    for (const scopes of [
+      [globScope, literalScope],
+      [literalScope, globScope],
+    ]) {
+      const result = await runWithFs(
+        { schemaVersion: 1, scopes },
+        fixtures({
+          directories: new Map([[`${repoRoot}/pkg`, [{ name: "socket", kind: "other" }]]]),
+        })
+      );
+      const rendered = messages(result);
+
+      expect(rendered).toContain(
+        'Structure scope "literal-other" matched no directory roots for pkg/socket.'
+      );
+      expect(rendered).toContain(
+        'Structure scope "glob-roots" expected directory root, but pkg/socket is other.'
+      );
+    }
+  });
+
+  test("reuses the completed in-memory walk for identical literal bases", async () => {
+    let entryAccesses = 0;
+    const observeEntryAccess = () => {
+      entryAccesses += 1;
+    };
+    const fixture = fixtures({
+      directories: new Map([
+        [
+          `${repoRoot}/pkg`,
+          [
+            observedDirectoryEntry("alpha.ts", "file", observeEntryAccess),
+            observedDirectoryEntry("beta.ts", "file", observeEntryAccess),
+          ],
+        ],
+      ]),
+    });
+    const result = await runWithFs(
+      {
+        schemaVersion: 1,
+        scopes: [
+          { name: "first-files", root: "pkg/*", kind: "file", mode: "open" },
+          { name: "second-files", root: "pkg/*", kind: "file", mode: "open" },
+        ],
+      },
+      fixture
+    );
+
+    expect(result).toEqual({ exitCode: 0, diagnostics: [] });
+    expect(entryAccesses).toBe(4);
+  });
+
+  test("starts a fresh traversal cache for each evaluator invocation", async () => {
+    const fixture = fixtures({
+      directories: new Map([
+        [`${repoRoot}/pkg`, [{ name: "alpha", kind: "directory" }]],
+        [`${repoRoot}/pkg/alpha`, []],
+      ]),
+    });
+    const spec = {
+      schemaVersion: 1,
+      scopes: [{ name: "roots", root: "pkg/*", kind: "directory", mode: "open" }],
+    } as const satisfies StructureCheckSpec;
+
+    await runWithFs(spec, fixture);
+    await runWithFs(spec, fixture);
+
+    expect(fixture.events.filter((event) => event.startsWith("readdir:"))).toEqual([
+      `readdir:${repoRoot}/pkg`,
+      `readdir:${repoRoot}/pkg/alpha`,
+      `readdir:${repoRoot}/pkg`,
+      `readdir:${repoRoot}/pkg/alpha`,
+    ]);
+  });
 });
 
 describe("structure-check rule execution", () => {
@@ -215,18 +362,101 @@ required = ["src"]
     expect(results.get(rule.id)).toEqual({ exitCode: 0, diagnostics: [] });
     expect(fixture.events).toContain(`read:${repoRoot}/.habitat/sample/sample.structure.toml`);
   });
+
+  test("shares one rule-run walk without retaining it across executions", async () => {
+    const firstRule = structureRule("first-structure-rule", ".habitat/sample/first.structure.toml");
+    const secondRule = structureRule(
+      "second-structure-rule",
+      ".habitat/sample/second.structure.toml"
+    );
+    const structureToml = `
+schemaVersion = 1
+
+[[scopes]]
+name = "roots"
+root = "pkg/*"
+kind = "directory"
+mode = "open"
+`;
+    const fixture = fixtures({
+      files: new Map([
+        [`${repoRoot}/.habitat/sample/first.structure.toml`, structureToml],
+        [`${repoRoot}/.habitat/sample/second.structure.toml`, structureToml],
+      ]),
+      directories: new Map([
+        [`${repoRoot}/pkg`, [{ name: "alpha", kind: "directory" }]],
+        [`${repoRoot}/pkg/alpha`, []],
+      ]),
+    });
+
+    const execution = runStructureRulesEffect([firstRule, secondRule], {
+      repoRoot,
+      fileSystem: port(fixture),
+    });
+    const results = await Effect.runPromise(execution);
+
+    expect([...results.keys()]).toEqual([firstRule.id, secondRule.id]);
+    expect([...results.values()]).toEqual([
+      { exitCode: 0, diagnostics: [] },
+      { exitCode: 0, diagnostics: [] },
+    ]);
+    expect(fixture.events.filter((event) => event.startsWith("readdir:"))).toEqual([
+      `readdir:${repoRoot}/pkg`,
+      `readdir:${repoRoot}/pkg/alpha`,
+    ]);
+
+    const repeatedResults = await Effect.runPromise(execution);
+    expect([...repeatedResults.keys()]).toEqual([firstRule.id, secondRule.id]);
+    expect(fixture.events.filter((event) => event.startsWith("readdir:"))).toEqual([
+      `readdir:${repoRoot}/pkg`,
+      `readdir:${repoRoot}/pkg/alpha`,
+      `readdir:${repoRoot}/pkg`,
+      `readdir:${repoRoot}/pkg/alpha`,
+    ]);
+  });
 });
 
 async function runWithFs(
   spec: StructureCheckSpec,
   fixture: ReturnType<typeof fixtures>
-): Promise<{ exitCode: number; diagnostics: readonly { message: string }[] }> {
+): Promise<{
+  exitCode: number;
+  diagnostics: readonly { path: string; message: string }[];
+}> {
   return Effect.runPromise(
     evaluateStructureCheckEffect(rule, spec, {
       repoRoot,
       fileSystem: port(fixture),
     })
   );
+}
+
+function structureRule(id: string, structure: string): RuleStructureFacts {
+  return {
+    ...rule,
+    id,
+    runner: {
+      ...rule.runner,
+      files: { structure },
+    },
+  };
+}
+
+function observedDirectoryEntry(
+  name: string,
+  kind: HabitatDirectoryEntry["kind"],
+  onAccess: () => void
+): HabitatDirectoryEntry {
+  return {
+    get name() {
+      onAccess();
+      return name;
+    },
+    get kind() {
+      onAccess();
+      return kind;
+    },
+  };
 }
 
 function fixtures(

--- a/tools/habitat/test/lib/vendor-providers.test.ts
+++ b/tools/habitat/test/lib/vendor-providers.test.ts
@@ -283,6 +283,7 @@ describe("vendor providers", () => {
 
   test("the Grit command service owns the direct-native hermetic check request", async () => {
     const providerRequest = {
+      patternNames: ["fixture_pattern"],
       scanRoots: ["/tmp/habitat-grit-target"],
       cwd: "/tmp/habitat-grit-catalog-parent",
       gritDir: "/tmp/habitat-grit-catalog-parent/.grit",
@@ -334,6 +335,7 @@ describe("vendor providers", () => {
 
   test("Grit preflight rejects nonzero exit even with the exact native version", async () => {
     const providerRequest: GritCheckProviderRequest = {
+      patternNames: ["fixture_pattern"],
       scanRoots: [repoRoot],
       cwd: repoRoot,
       gritDir: path.join(repoRoot, ".grit"),


### PR DESCRIPTION
This PR introduces batched multi-pattern Grit check execution, command-scoped cancellation for all CLI commands, bounded streaming output capture, and a structure-check traversal cache.

**Batched Grit check execution**

Rules sharing identical scan roots and distinct pattern identities are now grouped into a single native Grit invocation rather than one invocation per rule. The `grit.yaml` catalog written to the hermetic workspace includes all patterns in the group. Result projection maps each pattern's findings back to its originating rule. Rules with duplicate pattern identities, mismatched roots, or failed asset materialization are excluded from the group and executed individually. A new `RuleDiagnosticExecutionTiming` type carries shared-group evidence (`groupId`, `ruleCount`, `durationMs`) on every execution result that participated in a batch, enabling callers to attribute wall-clock cost accurately. The command family identifier is renamed from `selected-rule-json-check` to `selected-rules-json-check` to reflect the multi-pattern contract, and the native request schema gains a required, non-empty, unique `patternNames` field.

**Command-scoped cancellation**

A new `command-lifecycle.ts` module installs `SIGINT`/`SIGTERM` listeners at command startup. The first signal aborts an `AbortController` whose signal is forwarded to every oRPC procedure call via `habitatServiceCallerOptions()`. The `finally` hook disposes the shared Effect runtime, removes the listeners, and re-delivers the original signal so the host process preserves its native exit status. All CLI commands (`check`, `classify`, `fix`, `graph`, `hook`, `verify`) now pass `habitatServiceCallerOptions()` as the second argument to their service calls.

**Bounded streaming output capture**

`collectOutputCapture` replaces the previous `collectStream` helper in the command runner. It drains a `Stream<Uint8Array>` into a fixed-size block accumulator, hashing and counting every byte while retaining only the first `COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES` (4 MiB). UTF-8 decoding is deferred until the stream is fully consumed so code points split across chunk boundaries are preserved. `makeCommandResultFromObservation` now accepts pre-captured `OutputCapture` values directly instead of raw strings.

**Structure-check traversal cache**

`runStructureRulesEffect` allocates one `StructureTraversalCache` per invocation and threads it through all scope evaluations. The cache stores resolved path kinds, directory listings, and completed glob-walk results. A single `readDirectory` call now serves all scopes that share the same literal walk base, and kind lookups populated by directory listings avoid redundant `isDirectory`/`isFile` stat calls. The public `evaluateStructureCheckEffect` entry point allocates its own fresh cache so isolated callers remain unaffected. The native Grit worker pool is capped at two threads via `RAYON_NUM_THREADS=2` in the hermetic environment.