### PR TITLE
fix(mapgen-studio): make neutral scalar ramp fully opaque at max stop

### DIFF
--- a/apps/mapgen-studio/.interface-design/system.md
+++ b/apps/mapgen-studio/.interface-design/system.md
@@ -254,10 +254,9 @@ supersedes the Pass-4 dock placement, keeps the console split + icon contract:
   geometry — regular pointy-top hexes on the odd-R row-offset lattice (the
   hex-convention audit proved `tile.hexOddQ` mislabels that grid; the model's
   column-offset projection is not a regular tiling, hence the "squished"
-  look it produced). Border ink: see the Y-wave amendment below — the X6
-  constant-graphite ink (`#0d0d11`, α200) is superseded by the fill-derived
-  border rule (a page-colored seam dissolved the lattice into dots at fit
-  zoom). Unfilled tiles draw nothing (unchanged).
+  look it produced). Border ink: every present tile uses the shared
+  design-system graphite border (`#34343d`, fully opaque), independent of its
+  semantic fill hue. Unfilled tiles draw nothing (unchanged).
 
 ## DAG-tab amendment (2026-06-12, handoff-mandated): stage views
 
@@ -282,16 +281,14 @@ Decisions (see `openspec/changes/mapgen-studio-dag-tab/design.md`):
   recipe; pipeline selection/expansion live in `viewStore` as
   pipeline-prefixed fields, distinct from map-explore selection.
 
-## Y-wave amendment (2026-06-12, user-grounded): tile border rule, flat config accordion, selector drift
+## Y-wave amendment (2026-06-12, user-grounded): tile presentation, flat config accordion, selector drift
 
-- **The one tile-border RULE (supersedes X6's constant ink):** a tile's
-  border is its OWN fill pulled toward black (`fill × 0.55`, fully opaque) —
-  self-grout, owned by `tileBorderColorForFill` in `presentation.ts`. The X6
-  page-substrate constant was invisible between dark fills at fit zoom
-  (Huge-map tiles are a few pixels wide), dissolving the tessellation into
-  dots; a fill-derived seam is darker than its fill BY CONSTRUCTION, so the
-  lattice reads at every zoom, both themes, every palette — and still
-  recedes like etched grout up close. Unfilled tiles still draw nothing.
+- **The one tile-presentation RULE (supersedes X6 and the fill-derived
+  amendment):** omitted scalar palettes resolve to one dark-graphite ramp
+  (`#232329`) from translucent to fully opaque. Every present tile uses the
+  shared design-system graphite border (`#34343d`, fully opaque), independent
+  of its semantic fill hue, so the map reads as one matte survey surface while
+  preserving the hex lattice. Unfilled/no-data tiles still draw nothing.
 - **Default layer preference: the map studio defaults to the MAP.** When
   layer selection resets (step/stage switch, fresh manifest), prefer the
   step's tile-space GRID layer over whichever layer the worker emitted

--- a/apps/mapgen-studio/src/features/viz/presentation.ts
+++ b/apps/mapgen-studio/src/features/viz/presentation.ts
@@ -84,7 +84,7 @@ function collectResolvedCategoryIds(
 const NEUTRAL_SCALAR_RAMP: ReadonlyArray<RgbaColor> = [
   [35, 35, 41, 72],
   [35, 35, 41, 150],
-  [35, 35, 41, 230],
+  [35, 35, 41, 255],
 ];
 
 // Nonfinite/no-data evidence remains transparent under the existing tile contract. A finite

--- a/apps/mapgen-studio/test/viz/palettePresentation.test.ts
+++ b/apps/mapgen-studio/test/viz/palettePresentation.test.ts
@@ -218,7 +218,7 @@ describe("resolved visualization palette presentation", () => {
 
     expect(renderColor(0, palette)).toEqual([35, 35, 41, 72]);
     expect(renderColor(0.5, palette)).toEqual([35, 35, 41, 150]);
-    expect(renderColor(1, palette)).toEqual([35, 35, 41, 230]);
+    expect(renderColor(1, palette)).toEqual([35, 35, 41, 255]);
   });
 
   it("labels declared palette domains", () => {

--- a/apps/mapgen-studio/test/viz/tileOrientation.test.ts
+++ b/apps/mapgen-studio/test/viz/tileOrientation.test.ts
@@ -208,7 +208,7 @@ describe("tile-space rendering orientation", () => {
 
     const neutralFill = hexLayer.props.getFillColor(3);
     const neutralLine = hexLayer.props.getLineColor(3);
-    expect(neutralFill).toEqual([35, 35, 41, 230]);
+    expect(neutralFill).toEqual([35, 35, 41, 255]);
     expect(neutralLine).toEqual(TILE_BORDER_COLOR);
     expect(neutralLine.slice(0, 3)).not.toEqual(neutralFill.slice(0, 3));
   });

--- a/mods/mod-swooper-maps/src/recipes/standard/viz.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/viz.ts
@@ -26,7 +26,7 @@ export const STANDARD_VIZ_COLORS = {
   vegetation: [34, 139, 94, 235],
   field: {
     negative: [59, 130, 246, 235],
-    neutral: [35, 35, 41, 230],
+    neutral: [35, 35, 41, 255],
     positive: [239, 68, 68, 235],
     low: [35, 35, 41, 96],
     moderate: [59, 130, 246, 235],


### PR DESCRIPTION
The neutral scalar ramp's fully-opaque stop was previously set to alpha 230 instead of 255, leaving the darkest end of the ramp slightly translucent. This inconsistency meant that at full value, tiles were not truly opaque, which could cause subtle blending artifacts against the page substrate.

This change sets the top stop of the neutral scalar ramp to fully opaque (`[35, 35, 41, 255]`) across the ramp definition, the standard viz color constants, and the corresponding tests. The design system documentation is updated to reflect that the tile-border rule is now a fixed shared graphite (`#34343d`, fully opaque) independent of semantic fill hue, and that omitted scalar palettes resolve to a single dark-graphite ramp from translucent to fully opaque — replacing the earlier fill-derived border approach.