### PR TITLE
feat(habitat): surface normalized stderr excerpt on Grit command failure

### DIFF
--- a/tools/habitat/docs/CAPABILITIES.md
+++ b/tools/habitat/docs/CAPABILITIES.md
@@ -233,6 +233,11 @@ Current active Grit state:
   ceilings do not cause unrelated or protected repository trees to be walked.
 - Patterns are diagnostic/enforcing checks, not automatic transforms.
 - Habitat reports Grit diagnostics back to Habitat rule IDs.
+- Named predicates must be unique within each selected multi-pattern catalog. Native
+  Grit owns grammar and namespace admission; Habitat preserves a short normalized
+  compiler stderr excerpt on `DiagnosticCommandFailed` so collisions are actionable.
+  Pattern authors should prefix helpers with `<patternName>_` so assets remain
+  composable as batching changes.
 
 The active pattern checks cover families such as:
 

--- a/tools/habitat/src/resources/rule-diagnostics/providers/grit/request.ts
+++ b/tools/habitat/src/resources/rule-diagnostics/providers/grit/request.ts
@@ -104,7 +104,7 @@ export const captureGritCommandEffect = Effect.fn("grit.command.capture")(functi
         Effect.succeed({
           kind: "command-failed" as const,
           failure: "DiagnosticCommandFailed" as const,
-          detail: `Grit command ${error.commandId} exited ${error.exitCode}.`,
+          detail: commandFailedDetail(error.commandId, error.exitCode, error.stderr),
           command: diagnosticFailedCommandObservation({
             ...commandErrorMetadata(error, request),
             exitCode: error.exitCode,
@@ -189,7 +189,7 @@ function commandResultCapture(result: HabitatCommandResult): GritCommandCapture 
     Match.when({ kind: "failed" }, (failed) => ({
       kind: "command-failed" as const,
       failure: "DiagnosticCommandFailed" as const,
-      detail: `Grit command ${result.commandId} exited ${result.exit.code}.`,
+      detail: commandFailedDetail(result.commandId, result.exit.code, result.stderr.text),
       command: failed,
     })),
     Match.when({ kind: "completed" }, (completed) => ({
@@ -199,6 +199,18 @@ function commandResultCapture(result: HabitatCommandResult): GritCommandCapture 
     })),
     Match.exhaustive
   );
+}
+
+const MAX_FAILURE_STDERR_EXCERPT_CHARACTERS = 300;
+const ANSI_ESCAPE_SEQUENCE = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
+
+function commandFailedDetail(commandId: string, exitCode: number, stderr: string): string {
+  const normalized = stderr.replace(ANSI_ESCAPE_SEQUENCE, "").replace(/\s+/g, " ").trim();
+  const excerpt =
+    normalized.length <= MAX_FAILURE_STDERR_EXCERPT_CHARACTERS
+      ? normalized
+      : `${normalized.slice(0, MAX_FAILURE_STDERR_EXCERPT_CHARACTERS - 3)}...`;
+  return `Grit command ${commandId} exited ${exitCode}.${excerpt ? ` Stderr excerpt: ${excerpt}` : ""}`;
 }
 
 function commandErrorMetadata(

--- a/tools/habitat/test/lib/grit-provider-current-tree-execution.test.ts
+++ b/tools/habitat/test/lib/grit-provider-current-tree-execution.test.ts
@@ -120,15 +120,26 @@ describe("generic Grit current-tree execution", () => {
     );
   });
 
-  test("executes a pinned multi-pattern catalog once and projects matching plus clean peers", async () => {
-    const fixture = checkFixture("const value = forbidden_fixture_marker;\n");
+  test("batches distinct pattern-qualified predicate helpers in one native catalog", async () => {
+    const fixture = checkFixture(
+      "const value = forbidden_fixture_marker;\n",
+      false,
+      true,
+      qualifiedCheckPattern
+    );
     const cleanPatternPath = path.join(fixture.repoRoot, ".habitat/patterns/clean.md");
     writeFileSync(
       cleanPatternPath,
       `\`\`\`grit
 language js
 
-\`absent_fixture_marker\`
+predicate clean_fixture_marker_is_scanned_source() {
+  $filename <: r".*"
+}
+
+\`absent_fixture_marker\` where {
+  clean_fixture_marker_is_scanned_source()
+}
 \`\`\`
 `
     );
@@ -158,6 +169,64 @@ language js
       "clean_fixture_marker",
       "fixture_marker",
     ]);
+    expect(treeDigest(fixture.repoRoot)).toBe(before);
+  });
+
+  test("reports a native duplicate-predicate catalog failure with compiler detail", async () => {
+    const fixture = checkFixture(
+      "const value = forbidden_fixture_marker;\n",
+      false,
+      true,
+      duplicatePredicateCheckPattern
+    );
+    const peerPatternPath = path.join(fixture.repoRoot, ".habitat/patterns/peer.md");
+    writeFileSync(
+      peerPatternPath,
+      `\`\`\`grit
+language js
+
+predicate shared_catalog_helper() {
+  $filename <: r".*"
+}
+
+\`absent_fixture_marker\` where {
+  shared_catalog_helper()
+}
+\`\`\`
+`
+    );
+    const peerRule = sourceRule(
+      "fixture-peer-check",
+      "peer_fixture_marker",
+      ".habitat/patterns/peer.md",
+      ["scan"],
+      "check"
+    );
+    const before = treeDigest(fixture.repoRoot);
+    const observation: BoundaryObservation = {};
+    const outcomes = await Effect.runPromise(
+      Effect.gen(function* () {
+        const liveGrit = yield* makeGritCommandService(workspaceRepoRoot);
+        return yield* runGritDiagnosticOutcomesEffect([peerRule, fixture.rule], {
+          repoRoot: fixture.repoRoot,
+          grit: observingGrit(liveGrit, observation),
+        });
+      }).pipe(Effect.provide(LiveGritPrerequisites))
+    );
+
+    for (const selected of [peerRule, fixture.rule]) {
+      expect(outcomes.get(selected.id)).toMatchObject({
+        kind: "provider-failed",
+        failure: "DiagnosticCommandFailed",
+        detail: expect.stringMatching(/Stderr excerpt:.*shared_catalog_helper/),
+      });
+    }
+    expect(observation.checkCallCount).toBe(1);
+    expect(observation.checkRequest?.patternNames).toEqual([
+      "peer_fixture_marker",
+      "fixture_marker",
+    ]);
+    expect(observation.checkCommand?.exit.code).not.toBe(0);
     expect(treeDigest(fixture.repoRoot)).toBe(before);
   });
 
@@ -638,6 +707,32 @@ const checkPattern = `\`\`\`grit
 language js
 
 \`forbidden_fixture_marker\`
+\`\`\`
+`;
+
+const qualifiedCheckPattern = `\`\`\`grit
+language js
+
+predicate fixture_marker_is_scanned_source() {
+  $filename <: r".*"
+}
+
+\`forbidden_fixture_marker\` where {
+  fixture_marker_is_scanned_source()
+}
+\`\`\`
+`;
+
+const duplicatePredicateCheckPattern = `\`\`\`grit
+language js
+
+predicate shared_catalog_helper() {
+  $filename <: r".*"
+}
+
+\`forbidden_fixture_marker\` where {
+  shared_catalog_helper()
+}
 \`\`\`
 `;
 

--- a/tools/habitat/test/lib/grit-provider.test.ts
+++ b/tools/habitat/test/lib/grit-provider.test.ts
@@ -14,6 +14,7 @@ import { FileSystem } from "@effect/platform";
 import * as PlatformError from "@effect/platform/Error";
 import { NodeContext } from "@effect/platform-node";
 import {
+  CommandFailed,
   CommandInterrupted,
   CommandRunner,
   type CommandRunnerService,
@@ -558,6 +559,53 @@ describe("Grit closed wire decoders", () => {
 
     expect(matchingCapture).toMatchObject({ command: { scanRoots: request.scanRoots } });
     expect(mismatchedCapture).toMatchObject({ command: { scanRoots: [] } });
+  });
+
+  test("preserves a bounded normalized stderr excerpt for command failures", async () => {
+    const request = baseRequest();
+    const ansiRed = `${String.fromCharCode(27)}[31m`;
+    const ansiReset = `${String.fromCharCode(27)}[0m`;
+    const returned = await Effect.runPromise(
+      captureGritCommandEffect(
+        request,
+        Effect.succeed(
+          makeHabitatCommandResult(request, {
+            exit: { code: 2, signal: null, interrupted: false },
+            stderr: captureOutput(
+              `${ansiRed}duplicate predicate declaration${ansiReset}\n  shared_helper\n`
+            ),
+          })
+        )
+      )
+    );
+    expect(returned).toMatchObject({
+      kind: "command-failed",
+      failure: "DiagnosticCommandFailed",
+      detail:
+        "Grit command grit-test exited 2. Stderr excerpt: duplicate predicate declaration shared_helper",
+    });
+
+    const typed = await Effect.runPromise(
+      captureGritCommandEffect(
+        request,
+        Effect.fail(
+          new CommandFailed({
+            commandId: request.commandId,
+            executable: request.executable,
+            argv: request.argv,
+            cwd: request.cwd,
+            exitCode: 3,
+            stderr: `compiler failure ${"x".repeat(400)}`,
+          })
+        )
+      )
+    );
+    if (typed.kind !== "command-failed") throw new Error("Expected typed command failure.");
+    expect(
+      typed.detail.startsWith("Grit command grit-test exited 3. Stderr excerpt: compiler failure ")
+    ).toBe(true);
+    expect(typed.detail.endsWith("...")).toBe(true);
+    expect(typed.detail.length).toBeLessThan(360);
   });
 
   test("decodes the closed compact event union and rejects DoneFile", () => {


### PR DESCRIPTION
When a Grit multi-pattern catalog fails due to a duplicate named predicate, the previous `DiagnosticCommandFailed` detail only reported the exit code, giving pattern authors no actionable information about what went wrong. This change enriches that detail by attaching a normalized excerpt of the compiler's stderr output.

A new `commandFailedDetail` helper strips ANSI escape sequences, collapses whitespace, and truncates the result to 300 characters before appending it to the existing exit-code message. Both failure paths — the caught `CommandFailed` error and the `commandResultCapture` branch — now use this helper.

The documentation for the Grit capability is updated to note that named predicates must be unique within a shared catalog and recommends that pattern authors prefix helper predicates with `<patternName>_` to avoid collisions as batching combines patterns.

Tests cover the normalized excerpt behavior directly (ANSI stripping, truncation with trailing ellipsis, clean output when stderr is empty) and add an integration-level case that verifies a duplicate-predicate catalog failure surfaces the conflicting predicate name in the `detail` field for every rule in the batch. The existing batching test is updated so its fixture patterns use properly qualified predicate names, matching the new naming guidance.