### PR TITLE
fix(studio): expose React types to isolated dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@nx/web": "23.1.0",
         "@types/node": "^22.19.21",
         "@types/picomatch": "4.0.3",
+        "@types/react": "^19.2.10",
         "@typescript-eslint/parser": "^8.54.0",
         "@typescript/native": "npm:typescript@7.0.2",
         "@vitest/ui": "^4.0.18",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@nx/web": "23.1.0",
     "@types/node": "^22.19.21",
     "@types/picomatch": "4.0.3",
+    "@types/react": "^19.2.10",
     "@typescript-eslint/parser": "^8.54.0",
     "@typescript/native": "npm:typescript@7.0.2",
     "@vitest/ui": "^4.0.18",


### PR DESCRIPTION
Make React's declaration package visible at the workspace root so TypeScript 7 can resolve RJSF's React peer through Bun's isolated linker. This keeps the CSP-safe RJSF component import honest and removes the need for a source-level type cast.