### PR TITLE
fix(studio): expose MathGL types to isolated dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@effect/tsgo": "0.24.2",
         "@fission-ai/openspec": "^1.3.1",
         "@getgrit/cli": "0.1.0-alpha.1743007075",
+        "@math.gl/types": "4.1.0",
         "@nx/eslint-plugin": "23.1.0",
         "@nx/storybook": "23.1.0",
         "@nx/web": "23.1.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@effect/tsgo": "0.24.2",
     "@fission-ai/openspec": "^1.3.1",
     "@getgrit/cli": "0.1.0-alpha.1743007075",
+    "@math.gl/types": "4.1.0",
     "@nx/eslint-plugin": "23.1.0",
     "@nx/storybook": "23.1.0",
     "@nx/web": "23.1.0",


### PR DESCRIPTION
Make the runtime @math.gl/types package visible at the workspace root because loaders.gl schema-utils imports it without declaring it. This preserves Bun's isolated linker while allowing Vite to optimize the Studio dependency graph from a clean install.