### PR TITLE
docs(civ7-capability-realization): accept frame and gate on shared Habitat successor

### DIFF
--- a/docs/projects/civ7-capability-realization/FRAME.md
+++ b/docs/projects/civ7-capability-realization/FRAME.md
@@ -1,6 +1,6 @@
 # Civ7 Capability Realization Frame
 
-**Status:** Proposed authority gate
+**Status:** Accepted; implementation gated on the shared Habitat successor
 **Date:** 2026-07-30
 **Owner:** Civ7 platform architecture and product stewardship
 
@@ -38,12 +38,15 @@ authority by themselves.
 **Attractors:** Intent. Capability. Authority. Environment. Kind. Boundary.
 Chain. Destination. Collapse. Proof. Closure.
 
-**Current container:** freeze the current capability chains and the target role
-model; then classify every `direct-control` consumer before migrating the live-
-control chain through one proven resource, one semantic service, its actual CLI
-and Studio projections, and canonical runtime realization. Delete the
-mega-facade and the mixed package only after every shipped semantic,
-diagnostic, and host capability has a proved destination.
+**Current container:** construct and accept the corrected shared Habitat
+successor in RAWR HQ-Template. That successor must provide the generic package,
+resource, provider, service, API projection, app, and CLI-topic construction
+laws selected by this frame; use `plugins/cli/topics/*`; close every admitted
+test root around finite, disjoint, kind-relevant confidence axes; and expose an
+executable versioned adoption seam. Civ7 does not begin a product source move
+until that shared prerequisite is sealed. The first Civ7 implementation
+container afterward is the coupled capability-chain cutover, not an isolated
+CLI, service, Studio, resource, or mod move.
 
 **Gradient:** current behavior -> capability owner -> execution realm -> target
 kind -> positive law -> destination -> parity proof -> source deletion.

--- a/docs/projects/civ7-capability-realization/KIND-LAW-MATRIX.md
+++ b/docs/projects/civ7-capability-realization/KIND-LAW-MATRIX.md
@@ -1,6 +1,7 @@
 # Civ7 Capability Realization Kind-Law Matrix
 
-**Status:** Proposed authority artifact
+**Status:** Accepted target; implementation waits for the corrected shared
+successor
 **Verdict:** `LAW_CORRECTION`
 **Date:** 2026-07-30
 **Scope:** Kinds required by the selected capability-port topology only

--- a/docs/projects/civ7-capability-realization/TOPOLOGY.md
+++ b/docs/projects/civ7-capability-realization/TOPOLOGY.md
@@ -1,6 +1,6 @@
 # Civ7 Capability Realization Topology
 
-**Status:** Proposed decision
+**Status:** Accepted decision
 **Date:** 2026-07-30
 
 This comparison expands each plausible topology far enough to expose its real

--- a/docs/projects/civ7-capability-realization/WORKSTREAM.md
+++ b/docs/projects/civ7-capability-realization/WORKSTREAM.md
@@ -1,6 +1,6 @@
 # Civ7 Capability Realization Workstream
 
-**Status:** Proposed
+**Status:** Active; accepted target, shared-substrate prerequisite in progress
 **Frame:** [FRAME.md](./FRAME.md)
 **Current chains:** [CURRENT-CAPABILITY-CHAINS.md](./CURRENT-CAPABILITY-CHAINS.md)
 **Topology decision:** [TOPOLOGY.md](./TOPOLOGY.md)

--- a/docs/projects/engine-refactor-v1/post-it.md
+++ b/docs/projects/engine-refactor-v1/post-it.md
@@ -20,16 +20,16 @@ anchor; path placement and Nx tags never admit them. Each accepted kind closes
 its own proof topology around disjoint confidence axes; domain-qualified kinds
 such as MapGen keep their stronger domain-shaped testing grammar.
 
-**Current container:** restore exact identity parity between the live Habitat
-rule-manifest corpus and the canonical rule-authority ledger before authorizing
-another kind-law mutation. Run a fresh no-edit Layer 1 classification by stable
-tree lane for all 46 live rules without rows and all 45 manifestless current
-rows, reconcile only evidence-backed admissions, absorptions, relocations, and
-retirements, and seal the ledger at one row per live rule. Add only the
-lifecycle-bound self-check that keeps this active cleanup ledger in exact
-identity parity with Habitat's canonical registry discovery; retire that check
-when the cleanup ledger retires. This container does not redesign, weaken, or
-otherwise mutate any governed rule.
+**Current container:** construct and accept the corrected shared Habitat
+successor in RAWR HQ-Template before any Civ7 capability source move. The
+shared container owns generic package, resource, provider, service, API
+projection, app, and CLI-topic construction law, plus an executable versioned
+adoption seam. `plugins/cli/topics/*` is the only CLI projection root. Every
+kind that admits `test/` closes it around finite, disjoint, kind-relevant
+confidence axes; generic kinds define reusable layers and qualified kinds
+refine them without open or case-by-case test cabinets. When that prerequisite
+seals, Civ7 pins it and begins the coupled capability-chain cutover rather than
+hardening an isolated CLI, service, Studio, resource, or mod transition.
 
 **Stable ownership:** Swooper remains a portable mod definition realized by
 its mod app. The CLI remains a commandless `cli-shell` composed from
@@ -95,6 +95,17 @@ tests.
 
 <details>
 <summary>Prior focus pivots</summary>
+
+### 2026-07-30 - Habitat Rule-Ledger Parity Sealed
+
+The live Habitat registry and canonical rule-authority ledger now agree at
+exact identity parity: 122 live manifests have 122 current rows, manifestless
+historical rows moved to retired evidence, and stale active slices and blockers
+no longer reference retired rules. The lifecycle-bound parity guard and focused
+comparator passed, as did the full Habitat test corpus. With rule mutation
+unblocked, the focus moved to the only honest prerequisite for capability
+realization: the corrected shared Habitat successor. No Civ7 product-semantic
+container is constructible before that substrate lands.
 
 ### 2026-07-30 - Unconsumed Controller Provider Retired
 


### PR DESCRIPTION
The Civ7 capability realization project documents have been advanced from "Proposed" to accepted status across FRAME.md, KIND-LAW-MATRIX.md, TOPOLOGY.md, and WORKSTREAM.md. The topology and kind-law matrix are now accepted decisions, and the workstream is marked active.

The current container definition has been reoriented: rather than freezing capability chains and migrating through individual resources or services, the immediate work is constructing and accepting the corrected shared Habitat successor in RAWR HQ-Template. That successor must deliver the generic package, resource, provider, service, API projection, app, and CLI-topic construction laws; enforce `plugins/cli/topics/*` as the sole CLI projection root; close every admitted test root around finite, disjoint, kind-relevant confidence axes; and expose an executable versioned adoption seam. No Civ7 product source move begins until that shared prerequisite is sealed. The first Civ7 implementation container after that is the coupled capability-chain cutover, not any isolated CLI, service, Studio, resource, or mod transition.

The engine-refactor-v1 post-it reflects the same pivot. The prior container focused on restoring rule-ledger parity, which is now complete — 122 live manifests align with 122 current rows, manifestless historical rows are retired, and stale references are cleared. With rule mutation unblocked, the focus shifts to the shared Habitat successor as the only honest prerequisite before any capability realization work proceeds in Civ7.