### PR TITLE
docs(civ7,engine): record Habitat authority handoff to Template

### DIFF
--- a/docs/projects/civ7-capability-realization/FRAME.md
+++ b/docs/projects/civ7-capability-realization/FRAME.md
@@ -1,6 +1,6 @@
 # Civ7 Capability Realization Frame
 
-**Status:** Accepted; implementation gated on the shared Habitat successor
+**Status:** Accepted; implementation gated on the Template-owned Habitat successor
 **Date:** 2026-07-30
 **Owner:** Civ7 platform architecture and product stewardship
 
@@ -38,15 +38,26 @@ authority by themselves.
 **Attractors:** Intent. Capability. Authority. Environment. Kind. Boundary.
 Chain. Destination. Collapse. Proof. Closure.
 
-**Current container:** construct and accept the corrected shared Habitat
-successor in RAWR HQ-Template. That successor must provide the generic package,
-resource, provider, service, API projection, app, and CLI-topic construction
-laws selected by this frame; use `plugins/cli/topics/*`; close every admitted
-test root around finite, disjoint, kind-relevant confidence axes; and expose an
-executable versioned adoption seam. Civ7 does not begin a product source move
-until that shared prerequisite is sealed. The first Civ7 implementation
-container afterward is the coupled capability-chain cutover, not an isolated
-CLI, service, Studio, resource, or mod move.
+**Current container:** complete the owner-correct Habitat handoff, then accept
+the corrected shared successor from RAWR HQ-Template. That successor must
+provide the generic package, resource, provider, service, API projection, app,
+and CLI-topic construction laws selected by this frame; use
+`plugins/cli/topics/*`; close every admitted test root around finite, disjoint,
+kind-relevant confidence axes; and expose one executable versioned adoption
+seam. Civ7 does not begin a product source move until that shared prerequisite
+is sealed. The first Civ7 implementation container afterward is the coupled
+capability-chain cutover, not an isolated CLI, service, Studio, resource, or
+mod move.
+
+The active subcontainer is the source-and-authority handoff. RAWR HQ-Template
+owns `@habitat/cli` source, package identity, releases, ordinary consumer
+integration, generic blueprint policy, and the data-only policy pack. Civ7's
+admission, resolved-application, execution, and classification commits are
+scoped implementation evidence for Template's extraction; they are not a
+release train. Blueprint-aware production loading, generation, Nx projection,
+the idempotent consumer initializer, vendor modernization, and release belong
+to Template. Civ7 does not add a local C5 projection or harden the temporary
+compatibility-only activation seam.
 
 **Gradient:** current behavior -> capability owner -> execution realm -> target
 kind -> positive law -> destination -> parity proof -> source deletion.

--- a/docs/projects/engine-refactor-v1/post-it.md
+++ b/docs/projects/engine-refactor-v1/post-it.md
@@ -20,16 +20,27 @@ anchor; path placement and Nx tags never admit them. Each accepted kind closes
 its own proof topology around disjoint confidence axes; domain-qualified kinds
 such as MapGen keep their stronger domain-shaped testing grammar.
 
-**Current container:** construct and accept the corrected shared Habitat
-successor in RAWR HQ-Template before any Civ7 capability source move. The
-shared container owns generic package, resource, provider, service, API
-projection, app, and CLI-topic construction law, plus an executable versioned
-adoption seam. `plugins/cli/topics/*` is the only CLI projection root. Every
-kind that admits `test/` closes it around finite, disjoint, kind-relevant
-confidence axes; generic kinds define reusable layers and qualified kinds
-refine them without open or case-by-case test cabinets. When that prerequisite
-seals, Civ7 pins it and begins the coupled capability-chain cutover rather than
-hardening an isolated CLI, service, Studio, resource, or mod transition.
+**Current container:** complete the owner-correct Habitat handoff, then accept
+the corrected shared successor from RAWR HQ-Template before any Civ7
+capability source move. The shared container owns generic package, resource,
+provider, service, API projection, app, and CLI-topic construction law, plus
+one executable versioned adoption seam. `plugins/cli/topics/*` is the only CLI
+projection root. Every kind that admits `test/` closes it around finite,
+disjoint, kind-relevant confidence axes; generic kinds define reusable layers
+and qualified kinds refine them without open or case-by-case test cabinets.
+When that prerequisite seals, Civ7 pins it and begins the coupled
+capability-chain cutover rather than hardening an isolated CLI, service,
+Studio, resource, or mod transition.
+
+The current active subcontainer is the source-and-authority handoff. RAWR
+HQ-Template owns `@habitat/cli` source, package identity, releases, ordinary
+consumer integration, generic blueprint policy, and its data-only pack.
+Civ7's four clean admission-through-classification commits are scoped
+implementation evidence, not a release train. Blueprint-aware production
+loading, generation, Nx projection, the idempotent consumer initializer,
+vendor modernization, and release stay with Template. Civ7 does not start a
+local C5 projection or harden the temporary compatibility-only activation
+seam.
 
 **Stable ownership:** Swooper remains a portable mod definition realized by
 its mod app. The CLI remains a commandless `cli-shell` composed from
@@ -95,6 +106,17 @@ tests.
 
 <details>
 <summary>Prior focus pivots</summary>
+
+### 2026-07-30 - Habitat Package Authority Handed Off
+
+The earlier delegated-release premise was superseded by the cross-lane
+authority decision: RAWR HQ-Template owns Habitat source, package identity,
+releases, generic policy distribution, and ordinary consumer integration.
+Civ7 completed four clean evidence layers through application classification
+and stopped before Nx projection. Template now owns scoped extraction,
+deproductization, blueprint-aware production loading, generation, Nx
+projection, the idempotent initializer, vendor modernization, and the first
+owner-correct release.
 
 ### 2026-07-30 - Habitat Rule-Ledger Parity Sealed
 


### PR DESCRIPTION
RAWR HQ-Template is now explicitly named as the owner of `@habitat/cli` source, package identity, releases, generic blueprint policy, and the data-only policy pack. The previous framing described a "shared Habitat successor" without clearly assigning ownership; this corrects that by establishing Template as the authoritative lane for all extraction, deproductization, blueprint-aware production loading, generation, Nx projection, the idempotent consumer initializer, vendor modernization, and release.

Both the Civ7 Capability Realization frame and the Engine Refactor post-it are updated to reflect the source-and-authority handoff as the active subcontainer. Civ7's four admission-through-classification commits are recharacterized as scoped implementation evidence for Template's extraction rather than a release train. The constraint that Civ7 must not add a local C5 projection or harden the temporary compatibility-only activation seam is made explicit.

A prior focus pivot entry is added to the Engine Refactor post-it recording the 2026-07-30 authority decision and the point at which Civ7 stopped (after application classification, before Nx projection).