### PR TITLE
docs(civ7): restate current container as entry convergence with concurrent Habitat cutover gate

### DIFF
--- a/docs/projects/civ7-capability-realization/FRAME.md
+++ b/docs/projects/civ7-capability-realization/FRAME.md
@@ -1,6 +1,6 @@
 # Civ7 Capability Realization Frame
 
-**Status:** Accepted; implementation gated on the Template-owned Habitat successor
+**Status:** Accepted; entry convergence active, coupled cutover gated on the Template-owned Habitat successor
 **Date:** 2026-07-30
 **Owner:** Civ7 platform architecture and product stewardship
 
@@ -38,26 +38,24 @@ authority by themselves.
 **Attractors:** Intent. Capability. Authority. Environment. Kind. Boundary.
 Chain. Destination. Collapse. Proof. Closure.
 
-**Current container:** complete the owner-correct Habitat handoff, then accept
-the corrected shared successor from RAWR HQ-Template. That successor must
-provide the generic package, resource, provider, service, API projection, app,
-and CLI-topic construction laws selected by this frame; use
-`plugins/cli/topics/*`; close every admitted test root around finite, disjoint,
-kind-relevant confidence axes; and expose one executable versioned adoption
-seam. Civ7 does not begin a product source move until that shared prerequisite
-is sealed. The first Civ7 implementation container afterward is the coupled
-capability-chain cutover, not an isolated CLI, service, Studio, resource, or
-mod move.
+**Current container:** converge the independent product lanes that must be
+settled before their capability roots move. First, restack and re-prove the
+remaining Studio design-sync stack on current `main`, then merge it before any
+Studio API or app relocation. Second, reconstruct the accepted wind/pressure
+behavior and metric proof in the current Swooper topology; the obsolete
+flat-path branch is evidence, not an integration candidate. The active Fluree
+inquiry lane remains independently owned and non-blocking until its owner
+finishes a clean package-shaped result.
 
-The active subcontainer is the source-and-authority handoff. RAWR HQ-Template
-owns `@habitat/cli` source, package identity, releases, ordinary consumer
-integration, generic blueprint policy, and the data-only policy pack. Civ7's
-admission, resolved-application, execution, and classification commits are
-scoped implementation evidence for Template's extraction; they are not a
-release train. Blueprint-aware production loading, generation, Nx projection,
-the idempotent consumer initializer, vendor modernization, and release belong
-to Template. Civ7 does not add a local C5 projection or harden the temporary
-compatibility-only activation seam.
+RAWR HQ-Template concurrently owns the corrected Habitat successor:
+`@habitat/cli` source and releases, generic blueprint policy, its data-only
+policy pack, production loading, generation, Nx projection, initialization,
+and vendor modernization. Civ7's four admission-through-classification commits
+remain scoped implementation evidence on a sibling stack. Civ7 does not add
+local Habitat machinery or move capability-owner source into a transition
+shape while waiting. Once entry convergence and the shared release both seal,
+the first source migration is the coupled capability-chain cutover, not an
+isolated CLI, service, Studio, resource, or mod move.
 
 **Gradient:** current behavior -> capability owner -> execution realm -> target
 kind -> positive law -> destination -> parity proof -> source deletion.

--- a/docs/projects/engine-refactor-v1/post-it.md
+++ b/docs/projects/engine-refactor-v1/post-it.md
@@ -20,27 +20,23 @@ anchor; path placement and Nx tags never admit them. Each accepted kind closes
 its own proof topology around disjoint confidence axes; domain-qualified kinds
 such as MapGen keep their stronger domain-shaped testing grammar.
 
-**Current container:** complete the owner-correct Habitat handoff, then accept
-the corrected shared successor from RAWR HQ-Template before any Civ7
-capability source move. The shared container owns generic package, resource,
-provider, service, API projection, app, and CLI-topic construction law, plus
-one executable versioned adoption seam. `plugins/cli/topics/*` is the only CLI
-projection root. Every kind that admits `test/` closes it around finite,
-disjoint, kind-relevant confidence axes; generic kinds define reusable layers
-and qualified kinds refine them without open or case-by-case test cabinets.
-When that prerequisite seals, Civ7 pins it and begins the coupled
-capability-chain cutover rather than hardening an isolated CLI, service,
-Studio, resource, or mod transition.
+**Current container:** converge the independent product lanes required before
+the coupled capability-chain cutover. Restack and re-prove the remaining Studio
+design-sync stack on current `main`, then merge it before moving Studio API or
+app paths. Reconstruct the accepted wind/pressure behavior and metric proof in
+the current Swooper topology rather than restacking its obsolete flat-path
+branch. The active Fluree inquiry lane remains independently owned and
+non-blocking until it produces a clean package-shaped result.
 
-The current active subcontainer is the source-and-authority handoff. RAWR
-HQ-Template owns `@habitat/cli` source, package identity, releases, ordinary
-consumer integration, generic blueprint policy, and its data-only pack.
-Civ7's four clean admission-through-classification commits are scoped
-implementation evidence, not a release train. Blueprint-aware production
-loading, generation, Nx projection, the idempotent consumer initializer,
-vendor modernization, and release stay with Template. Civ7 does not start a
-local C5 projection or harden the temporary compatibility-only activation
-seam.
+RAWR HQ-Template concurrently owns the corrected Habitat successor:
+`@habitat/cli` source and releases, generic blueprint policy, its data-only
+pack, production loading, generation, Nx projection, initialization, and
+vendor modernization. Civ7's four admission-through-classification commits
+remain scoped evidence on a sibling stack. Civ7 adds no local Habitat machinery
+and moves no capability-owner source into a transition shape while waiting.
+Once product convergence and the shared release both seal, Civ7 begins the
+coupled cutover rather than hardening an isolated CLI, service, Studio,
+resource, or mod transition.
 
 **Stable ownership:** Swooper remains a portable mod definition realized by
 its mod app. The CLI remains a commandless `cli-shell` composed from
@@ -106,6 +102,16 @@ tests.
 
 <details>
 <summary>Prior focus pivots</summary>
+
+### 2026-07-31 - Civ7 Product Convergence Resumed
+
+The Habitat handoff is sealed and the Civ7 product lane no longer descends from
+the four implementation-evidence commits. Active attention returned to the
+entry-convergence owners: finish the current-topology Studio design work,
+reconstruct accepted wind/pressure behavior in the current Swooper product,
+and leave the unfinished Fluree inquiry with its active owner. The shared
+Habitat release proceeds concurrently under Template authority; it gates the
+coupled source cutover, not these independent product convergence packets.
 
 ### 2026-07-30 - Habitat Package Authority Handed Off
 


### PR DESCRIPTION
The Civ7 Capability Realization frame and engine refactor post-it have been updated to reflect that the project has moved past the Habitat handoff phase and into active entry convergence.

The "current container" in both documents now describes three independent product lanes that must settle before the coupled capability-chain cutover begins:

- The remaining Studio design-sync stack must be restacked and re-proved on current `main` before any Studio API or app relocation occurs.
- Swooper's accepted wind/pressure behavior and metric proof must be reconstructed in the current topology; the obsolete flat-path branch is treated as evidence only, not an integration candidate.
- The Fluree inquiry lane remains independently owned and non-blocking until its owner delivers a clean package-shaped result.

The Habitat successor work continues concurrently under RAWR HQ-Template authority, covering source and releases, blueprint policy, production loading, generation, Nx projection, initialization, and vendor modernization. Civ7's four admission-through-classification commits remain scoped implementation evidence on a sibling stack. Civ7 adds no local Habitat machinery and does not move capability-owner source into a transition shape while waiting. The coupled cutover begins only once both product convergence and the shared release are sealed.

A new pivot entry dated 2026-07-31 records that the Habitat handoff is sealed, the Civ7 product lane no longer descends from the four implementation-evidence commits, and active attention has returned to the entry-convergence owners.