### PR TITLE
fix(studio): preserve edits made during Save As round-trip

### DIFF
--- a/apps/mapgen-studio/src/app/hooks/useSaveDeploy.ts
+++ b/apps/mapgen-studio/src/app/hooks/useSaveDeploy.ts
@@ -13,6 +13,7 @@ import {
 } from "../../features/mapConfigSave/status";
 import type { AuthoringState } from "../../stores/authoringStore";
 import { mergeSaveDeployFailureResponse, mergeSaveDeployOperation } from "../operationAdoption";
+import { useLatestRef } from "./useLatestRef";
 import type { StudioOperations } from "./useStudioOperations";
 import type { ToastFn } from "./useToast";
 
@@ -33,9 +34,10 @@ export type UseSaveDeployArgs = {
   runInGameRunning: StudioOperations["runInGameRunning"];
   canonicalConfig: MapConfigEnvelope;
   /**
-   * Whole-envelope install for save-as-new: adopting the renamed envelope is
-   * an identity change, so it replaces the canonical config and refreshes
-   * the working-change baseline together.
+   * Whole-envelope install for save-as-new identity adoption. When working
+   * values changed during the save, the install receives those latest values;
+   * `adoptSavedBaseline` then restores the values that were actually saved as
+   * the working-change baseline.
    */
   installCanonicalConfig: AuthoringState["installCanonicalConfig"];
   /**
@@ -80,6 +82,7 @@ export function useSaveDeploy(args: UseSaveDeployArgs): UseSaveDeployResult {
   const saveDeployWaitersRef = useRef<Map<string, SaveDeployTerminalWaiter>>(new Map());
   const saveDeployInFlightRef = useRef(false);
   const mountedRef = useRef(true);
+  const canonicalConfigRef = useLatestRef(canonicalConfig);
 
   const adoptSaveDeployOperation = useCallback<StudioOperations["setSaveDeployOperation"]>(
     (update) => {
@@ -249,7 +252,23 @@ export function useSaveDeploy(args: UseSaveDeployArgs): UseSaveDeployResult {
       }
       const result = await saveCanonicalConfig(next);
       if (!mountedRef.current) return;
-      if (result.ok) installCanonicalConfig(next);
+      if (result.ok) {
+        const current = canonicalConfigRef.current;
+        if (current === canonicalConfig) {
+          installCanonicalConfig(next);
+        } else {
+          const renamedCurrent = createNamedCanonicalConfig({
+            current,
+            id: next.id,
+            name: next.name,
+            description: next.description,
+          });
+          if (renamedCurrent !== undefined) {
+            installCanonicalConfig(renamedCurrent);
+            adoptSavedBaseline(next.config);
+          }
+        }
+      }
       presentSaveResult(result);
       closeSaveDialog();
     },
@@ -258,6 +277,8 @@ export function useSaveDeploy(args: UseSaveDeployArgs): UseSaveDeployResult {
       closeSaveDialog,
       presentSaveResult,
       saveCanonicalConfig,
+      adoptSavedBaseline,
+      canonicalConfigRef,
       installCanonicalConfig,
       toast,
     ]

--- a/apps/mapgen-studio/test/controllers/useSaveDeploy.test.tsx
+++ b/apps/mapgen-studio/test/controllers/useSaveDeploy.test.tsx
@@ -10,9 +10,13 @@ vi.mock("../../src/features/mapConfigSave/api", async (importOriginal) => {
 });
 
 import { type UseSaveDeployArgs, useSaveDeploy } from "../../src/app/hooks/useSaveDeploy";
-import { getRecipeDefaultCanonicalConfig } from "../../src/features/configAuthoring/canonicalConfig";
+import {
+  getRecipeDefaultCanonicalConfig,
+  replaceCanonicalConfig,
+} from "../../src/features/configAuthoring/canonicalConfig";
 import { saveRepoBackedConfig } from "../../src/features/mapConfigSave/api";
 import { createMapConfigSaveDeployStatus } from "../../src/features/mapConfigSave/status";
+import { getRecipeArtifacts } from "../../src/recipes/catalog";
 
 const canonicalConfig = getRecipeDefaultCanonicalConfig("standard");
 const saveRpc = vi.mocked(saveRepoBackedConfig);
@@ -117,6 +121,41 @@ describe("useSaveDeploy config ownership", () => {
     expect(deployed).toBe(saved);
     expect(deployed).toMatchObject({ id: "new-config", name: "New Config" });
     expect(saveRpc.mock.calls[0]?.[0]).not.toHaveProperty("sourcePath");
+  });
+
+  it("preserves edits made while Save As is awaiting its result", async () => {
+    const response = deferred<Awaited<ReturnType<typeof saveRepoBackedConfig>>>();
+    saveRpc.mockReturnValue(response.promise);
+    const { result, props, rerender } = setup();
+    let save: Promise<void> | undefined;
+
+    await act(async () => {
+      save = result.current.handleSaveDialogConfirm({
+        name: "New Config",
+        description: "Test save",
+      });
+      await Promise.resolve();
+    });
+    const deployed = saveRpc.mock.calls[0]?.[0].canonicalConfig;
+    if (!deployed) throw new Error("Expected Save As to submit a canonical config");
+
+    const alternate = getRecipeArtifacts("standard").catalogConfigs[0];
+    if (!alternate) throw new Error("Expected a standard recipe catalog config");
+    const edited = replaceCanonicalConfig(canonicalConfig, alternate.config);
+    if (!edited) throw new Error("Expected the edited canonical config to remain valid");
+    rerender({ ...props, canonicalConfig: edited });
+
+    await act(async () => {
+      response.resolve({ ok: true, status: completeStatus("save-as") });
+      await save;
+    });
+
+    const installed = vi.mocked(props.installCanonicalConfig).mock.calls[0]?.[0];
+    expect(installed).toMatchObject({ id: "new-config", name: "New Config" });
+    expect(installed?.config).toStrictEqual(edited.config);
+    expect(installed?.config).not.toStrictEqual(deployed.config);
+    expect(props.adoptSavedBaseline).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(props.adoptSavedBaseline).mock.calls[0]?.[0]).toBe(deployed.config);
   });
 
   it("leaves the visible config unchanged when Save As fails", async () => {


### PR DESCRIPTION
When a Save As operation is in flight, the user may continue editing the map config before the save completes. Previously, when the save succeeded, `installCanonicalConfig` was always called with the saved envelope, which would silently discard any edits made during the async wait.

Now, when the save succeeds, the hook checks whether the canonical config has changed since the save was initiated. If it has, the saved identity (id, name, description) is applied to the current in-progress config rather than replacing it, and `adoptSavedBaseline` is called with the originally saved config so the working-change baseline reflects what was actually persisted. This ensures in-flight edits are preserved while the baseline remains accurate.

A test is added to verify that edits made while Save As is awaiting its result are retained in the installed config, and that `adoptSavedBaseline` is called with the config that was actually saved.