### PR TITLE
fix(studio): disable stage restore controls when config editing is disabled

### DIFF
--- a/packages/mapgen-studio-ui/src/components/forms/rjsfTemplates.tsx
+++ b/packages/mapgen-studio-ui/src/components/forms/rjsfTemplates.tsx
@@ -8,13 +8,13 @@ import { deepEquals } from "@rjsf/utils";
 import { Braces, ChevronDown, ChevronRight, EllipsisVertical, Eraser, Undo2 } from "lucide-react";
 import { Fragment, type ReactNode, useMemo, useState } from "react";
 import { cn } from "../../lib/utils.js";
-import { IconButton } from "../ui/icon-button.js";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu.js";
+import { IconButton } from "../ui/icon-button.js";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/tooltip.js";
 import { FieldRow } from "./FieldRow.js";
 import { type FieldBaseline, FieldBaselineContext } from "./fieldBaseline.js";
@@ -456,6 +456,8 @@ function StageObjectSection(args: {
   description?: ReactNode;
   collapse: ConfigCollapseContext | undefined;
   expanded: boolean;
+  disabled: boolean;
+  readonly: boolean;
   baseline?: FieldBaseline;
   onStageRestoreRequest?: (request: StageRestoreRequest) => void;
 }): ReactNode {
@@ -469,6 +471,8 @@ function StageObjectSection(args: {
     description,
     collapse,
     expanded,
+    disabled,
+    readonly,
     baseline,
     onStageRestoreRequest,
   } = args;
@@ -478,6 +482,7 @@ function StageObjectSection(args: {
 
   const defaults = schemaDefaultsFor(schema);
   const atDefaults = defaults !== undefined && deepEquals(formData ?? {}, defaults);
+  const allowMutations = !disabled && !readonly;
   // `baseline.value` arrives already normalized (the object template resolves
   // the slice with `?? {}`), so the value this gate compares against is
   // byte-identical to the one the rollback request carries — one resolution.
@@ -492,6 +497,7 @@ function StageObjectSection(args: {
         <Tooltip>
           <TooltipTrigger asChild>
             <IconButton
+              disabled={!allowMutations}
               onClick={() =>
                 onStageRestoreRequest({
                   pointer,
@@ -539,7 +545,7 @@ function StageObjectSection(args: {
           </Tooltip>
           <DropdownMenuContent align="end">
             <DropdownMenuItem
-              disabled={defaults === undefined || atDefaults}
+              disabled={!allowMutations || defaults === undefined || atDefaults}
               onSelect={() =>
                 onStageRestoreRequest({ pointer, label: title, values: defaults, mode: "defaults" })
               }
@@ -714,6 +720,8 @@ export function BrowserConfigObjectFieldTemplate(
         description={description}
         collapse={collapse}
         expanded={expanded}
+        disabled={props.disabled ?? false}
+        readonly={props.readonly ?? false}
         baseline={baseline}
         onStageRestoreRequest={props.registry.formContext?.onStageRestoreRequest}
       />

--- a/packages/mapgen-studio-ui/test/RecipePanel.test.tsx
+++ b/packages/mapgen-studio-ui/test/RecipePanel.test.tsx
@@ -82,7 +82,7 @@ describe("RecipePanel scoped stage restore (flat-and-flush deltas 5+8, re-cut)",
     climate: { rainfall: "temperate" },
   };
 
-  const renderPanel = (onConfigChange: (next: unknown) => void) =>
+  const renderPanel = (onConfigChange: (next: unknown) => void, configEditingEnabled = true) =>
     render(
       <TooltipProvider>
         <RecipePanel
@@ -105,7 +105,7 @@ describe("RecipePanel scoped stage restore (flat-and-flush deltas 5+8, re-cut)",
           onImportConfig={vi.fn()}
           onExportConfig={vi.fn()}
           isDirty={false}
-          configEditingEnabled={true}
+          configEditingEnabled={configEditingEnabled}
           onConfigEditingEnabledChange={vi.fn()}
         />
       </TooltipProvider>
@@ -157,5 +157,23 @@ describe("RecipePanel scoped stage restore (flat-and-flush deltas 5+8, re-cut)",
       elevation: { seaLevel: 0.6, mountainDensity: 0.3 },
       climate: { rainfall: "temperate" },
     });
+  });
+
+  it("keeps stage restore controls observational while overrides are disabled", () => {
+    const onConfigChange = vi.fn();
+    renderPanel(onConfigChange, false);
+
+    const discard = screen.getByRole("button", { name: "Discard Changes to Elevation" });
+    expect((discard as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(discard);
+
+    const optionsTrigger = screen.getByRole("button", { name: "Elevation Options" });
+    fireEvent.keyDown(optionsTrigger, { key: "Enter" });
+    const reset = screen.getByRole("menuitem", { name: /Reset to Defaults/ });
+    expect(reset.getAttribute("aria-disabled")).toBe("true");
+    fireEvent.click(reset);
+
+    expect(onConfigChange).not.toHaveBeenCalled();
+    expect(screen.queryByText(/This will (discard|reset)/)).toBeNull();
   });
 });


### PR DESCRIPTION
When `configEditingEnabled` is `false`, the "Discard Changes" icon button and the "Reset to Defaults" dropdown item inside `StageObjectSection` remained interactive. This meant users could trigger stage restore dialogs and mutate config even when editing was supposed to be locked.

`StageObjectSection` now accepts `disabled` and `readonly` props, derives an `allowMutations` flag from them, and gates both controls behind that flag. `BrowserConfigObjectFieldTemplate` forwards `props.disabled` and `props.readonly` down to the section.

A new test confirms that when `configEditingEnabled` is `false`, both the discard button and the reset menu item are disabled, clicks on them do not invoke `onConfigChange`, and no confirmation dialog appears.