### PR TITLE
fix(studio): harden design-sync portal detection and extract README assertions

### DIFF
--- a/packages/mapgen-studio-ui/.ds-sync/storybook/compare.mjs
+++ b/packages/mapgen-studio-ui/.ds-sync/storybook/compare.mjs
@@ -121,6 +121,59 @@ catch {
 
 const squash = (s) => String(s ?? '').replace(/[^a-z0-9]/gi, '').toLowerCase();
 
+// Browser-realm render oracle shared by Storybook and preview capture. Content
+// is visible only when a rendered box intersects the viewport; DOM shape,
+// text, and IDs are not evidence of paint (portals commonly use an id-bearing
+// body child, while injected mounts commonly contain hidden/zero-size nodes).
+function inspectVisibleBodyContent({ rootSelectors, excludedBodyChildren = '', errorSelectors = [] }) {
+  const ignoredTags = new Set(['SCRIPT', 'STYLE', 'LINK', 'META', 'TEMPLATE', 'NOSCRIPT']);
+  const viewportWidth = document.documentElement.clientWidth || window.innerWidth;
+  const viewportHeight = document.documentElement.clientHeight || window.innerHeight;
+  const hasVisiblePaint = (root) =>
+    [root, ...root.querySelectorAll('*')].some((element) => {
+      if (ignoredTags.has(element.tagName)) return false;
+      const style = getComputedStyle(element);
+      if (
+        style.display === 'none' ||
+        style.visibility === 'hidden' ||
+        style.visibility === 'collapse' ||
+        Number(style.opacity) === 0
+      ) return false;
+      try {
+        if (element.checkVisibility && !element.checkVisibility({
+          checkOpacity: true,
+          checkVisibilityCSS: true,
+        })) return false;
+      } catch { /* geometry below remains the compatibility fallback */ }
+      return [...element.getClientRects()].some((rect) =>
+        rect.width > 0 &&
+        rect.height > 0 &&
+        rect.right > 0 &&
+        rect.bottom > 0 &&
+        rect.left < viewportWidth &&
+        rect.top < viewportHeight);
+    });
+
+  const roots = rootSelectors
+    .map((selector) => ({ selector, element: document.querySelector(selector) }))
+    .filter(({ element }) => element);
+  const visibleRoot = roots.find(({ element }) => hasVisiblePaint(element));
+  const visibleError = errorSelectors
+    .flatMap((selector) => [...document.querySelectorAll(selector)])
+    .find((element) => hasVisiblePaint(element));
+  const portal = [...document.body.children].some((element) =>
+    !roots.some(({ element: root }) => root === element) &&
+    !(excludedBodyChildren && element.matches(excludedBodyChildren)) &&
+    hasVisiblePaint(element));
+
+  if (!visibleRoot && !visibleError && !portal) return null;
+  return {
+    rootSelector: visibleRoot?.selector ?? null,
+    portal,
+    error: visibleError ? (visibleError.textContent ?? '').trim().slice(0, 160) : null,
+  };
+}
+
 // Input fingerprinting for the skip rule: BASE = the whole reference
 // storybook + everything shared in the bundle (by exclusion, so a new asset
 // dir is automatically covered — no list to maintain); per-component adds its
@@ -335,32 +388,45 @@ try {
   let dsErrs = [];
   dsPage.on('pageerror', (e) => dsErrs.push(String(e).split('\n')[0]));
 
-  // Capture one storybook story: the true root screenshot. Storybook 7+
-  // renders into #storybook-root; v6 into #root. CSS-in-JS runtimes often
-  // inject <style>/<script> as the first root child and waitForSelector
-  // locks onto the first match — wait for CONTENT, not any child.
-  const SB_ROOT = '#storybook-root, #root';
-  const SB_CONTENT = `:is(${SB_ROOT}) > :not(style,script,link,meta,template)`;
+  // Capture one Storybook story from what actually painted. Storybook 7+
+  // renders into #storybook-root; v6 into #root, but portal-only stories can
+  // legitimately leave both roots at zero height and paint directly in body.
+  const SB_RENDER_ORACLE = {
+    rootSelectors: ['#storybook-root', '#root'],
+    excludedBodyChildren: [
+      '.sb-wrapper',
+      '#storybook-docs',
+      '#storybook-highlights-root',
+      'script',
+      'style',
+      'link',
+      'meta',
+      'template',
+      'noscript',
+    ].join(','),
+    errorSelectors: ['.sb-errordisplay', '.sb-nopreview'],
+  };
   async function captureStory(id) {
     try {
       await sbPage.goto(`http://127.0.0.1:${sbPort}/iframe.html?id=${encodeURIComponent(id)}&viewMode=story`, { waitUntil: 'networkidle', timeout: 20_000 });
-    } catch { /* fall through to the selector wait — slow asset ≠ broken story */ }
-    const loaded = await sbPage.waitForSelector(SB_CONTENT, { timeout: 8_000 }).then(() => true).catch(() => false);
-    if (!loaded) {
-      // .sb-errordisplay is always present as a display:none template — only
-      // report its text when it's actually visible.
-      const err = await sbPage.evaluate(() => {
-        const e = document.querySelector('.sb-errordisplay');
-        return e && getComputedStyle(e).display !== 'none' ? e.textContent?.slice(0, 160) : 'no storybook root content';
-      }).catch(() => '?');
-      return { err };
-    }
+    } catch { /* fall through to the paint wait — slow asset ≠ broken story */ }
+    await sbPage.waitForFunction(inspectVisibleBodyContent, SB_RENDER_ORACLE, { timeout: 8_000 }).catch(() => {});
     await settleRender(sbPage);
+    const rendered = await sbPage.evaluate(inspectVisibleBodyContent, SB_RENDER_ORACLE).catch(() => null);
+    if (rendered?.error) return { err: rendered.error };
+    if (!rendered) return { err: 'no visible storybook output' };
+
     let png = null;
-    try {
-      const el = await sbPage.$(SB_ROOT);
-      png = await el.screenshot(SHOT);
-    } catch { /* full-page fallback below */ }
+    // A body portal is outside the Storybook root even when the root also
+    // paints a trigger. Capture the viewport so both layers stay in frame.
+    if (rendered.portal) {
+      try { png = await sbPage.screenshot({ ...SHOT, fullPage: false }); } catch { /* keep null */ }
+    } else if (rendered.rootSelector) {
+      try {
+        const el = await sbPage.$(rendered.rootSelector);
+        png = await el.screenshot(SHOT);
+      } catch { /* full-page fallback below */ }
+    }
     if (!png || png.length < 200) {
       try { png = await sbPage.screenshot({ ...SHOT, fullPage: false }); } catch { /* keep null */ }
     }
@@ -446,7 +512,11 @@ try {
     // keyed by export name) vs 'fallback' (the floor card — no compiled
     // preview module). Fallback still renders, but the
     // fix for a mismatch lives in the .tsx, so surface the kind loudly.
-    const pv = pageErr ? null : await dsPage.evaluate(() => {
+    const previewBody = pageErr ? null : await dsPage.evaluate(inspectVisibleBodyContent, {
+      rootSelectors: ['.ds-grid', '.ds-single'],
+      excludedBodyChildren: 'script,style,link,meta,template,noscript',
+    }).catch((e) => { pageErr = String(e).split('\n')[0]; return null; });
+    const pvFacts = pageErr ? null : await dsPage.evaluate(() => {
       const kind = document.querySelector('script[src*="_preview/"]') ? 'module' : 'fallback';
       // Module previews list every export in __dsCells (capture happens
       // per-story via ?story=, so pairing must not depend on the default
@@ -467,15 +537,9 @@ try {
               caught: (mount?.textContent ?? '').trim().startsWith('⚠'),
             };
           });
-      // Portal content (Dialog/Tooltip/Toast) renders outside the cells —
-      // cell crops would miss it, so pair shots fall back to full-page. Only
-      // counts foreign body children that actually hold content; empty
-      // injected containers (toast roots, style mounts) don't trip it.
-      const portal = [...document.body.children].some((el) =>
-        !el.matches('.ds-grid, .ds-single, section, script, style, link, h4, div[id]') &&
-        (el.childElementCount > 0 || (el.textContent ?? '').trim().length > 0));
-      return { kind, cells, portal, perStory: !!dsCells, mode: window.__dsMode ?? 'grid' };
+      return { kind, cells, perStory: !!dsCells, mode: window.__dsMode ?? 'grid' };
     }).catch((e) => { pageErr = String(e).split('\n')[0]; return null; });
+    const pv = pvFacts ? { ...pvFacts, portal: !!previewBody?.portal } : null;
 
     if (pageErr || !pv) {
       report.push({ name: c.name, group: c.group, verdict: 'error', reason: `preview page failed: ${pageErr}` });

--- a/packages/mapgen-studio-ui/scripts/design-sync-check.mjs
+++ b/packages/mapgen-studio-ui/scripts/design-sync-check.mjs
@@ -24,10 +24,8 @@
 //
 // Verdict semantics (resync.mjs): exit 0 = every mechanical stage green
 // (pendingGrade is the agent's job, not a failure). A factual capture
-// failure — including the four portal dialogs' known reference-capture limit
-// on a run where their sourceKeys moved — exits non-zero until they are
-// graded via the recorded manual path; steady-state (sources unchanged,
-// grades carried) runs green end to end.
+// failure exits non-zero; steady-state (sources unchanged, grades carried)
+// runs green end to end.
 //
 // Chromium: DS_CHROMIUM_PATH is respected; on macOS, Google Chrome is
 // auto-detected as a fallback (the Homebrew `chromium` wrapper is stale —
@@ -42,6 +40,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { findDesignSyncReadmeFailures } from "./design-sync-output-assertions.mjs";
 
 const PKG = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const run = (cmd, args, opts = {}) => {
@@ -138,17 +137,7 @@ const driverCode = run("node", args, { env });
   const readmePath = join(PKG, "ds-bundle", "README.md");
   if (existsSync(readmePath)) {
     const readme = readFileSync(readmePath, "utf8");
-    const tokensSection = readme.slice(readme.indexOf("\n## Tokens"));
-    const tokensBody = tokensSection.slice(0, tokensSection.indexOf("\n## ", 1));
-    // Emitted shape: one bullet per kind — `- **color** (14): \`--x\`, …`.
-    const leakedTw = [...tokensBody.matchAll(/^- \*\*(?!other\b)[\w-]+\*\*.*?(--tw-[\w-]+)/gm)].map(
-      ([, name]) => name
-    );
-    if (leakedTw.length) {
-      postFailures.push(
-        `README token buckets list Tailwind engine vars outside 'other' (${[...new Set(leakedTw)].join(", ")}) — the .ds-sync emit.mjs --tw- classifier patch was lost (re-stage?)`
-      );
-    }
+    postFailures.push(...findDesignSyncReadmeFailures(readme));
   } else {
     postFailures.push("ds-bundle/README.md missing after the driver run");
   }

--- a/packages/mapgen-studio-ui/scripts/design-sync-output-assertions.mjs
+++ b/packages/mapgen-studio-ui/scripts/design-sync-output-assertions.mjs
@@ -1,0 +1,29 @@
+/**
+ * Checks the generated design-sync README token section for repo-owned invariants.
+ *
+ * @param {string} readme Generated README contents.
+ * @returns {string[]} Assertion failures; empty when the token section is valid.
+ */
+export function findDesignSyncReadmeFailures(readme) {
+  const heading = /^## Tokens[ \t]*\r?$/m.exec(readme);
+  if (!heading) {
+    return [
+      "README is missing the required exact `## Tokens` section — token-table purity was not checked",
+    ];
+  }
+
+  const afterHeading = readme.slice(heading.index + heading[0].length);
+  const nextSectionOffset = afterHeading.search(/^##[ \t]+\S.*$/m);
+  const tokensBody =
+    nextSectionOffset === -1 ? afterHeading : afterHeading.slice(0, nextSectionOffset);
+
+  // Emitted shape: one bullet per kind — `- **color** (14): \`--x\`, …`.
+  const leakedTw = [...tokensBody.matchAll(/^- \*\*(?!other\b)[\w-]+\*\*.*?(--tw-[\w-]+)/gm)].map(
+    ([, name]) => name
+  );
+  if (leakedTw.length === 0) return [];
+
+  return [
+    `README token buckets list Tailwind engine vars outside 'other' (${[...new Set(leakedTw)].join(", ")}) — the .ds-sync emit.mjs --tw- classifier patch was lost (re-stage?)`,
+  ];
+}

--- a/packages/mapgen-studio-ui/src/components/forms/BrowserConfigArrayFieldTemplate.stories.tsx
+++ b/packages/mapgen-studio-ui/src/components/forms/BrowserConfigArrayFieldTemplate.stories.tsx
@@ -4,15 +4,15 @@ import {
   BrowserConfigArrayFieldTemplate,
   type BrowserConfigFormContext,
 } from "@swooper/mapgen-studio-ui";
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import { alwaysExpandedCollapse, mockFieldContent, noop } from "../../storybook/mockWidgetProps.js";
 
 /**
  * BrowserConfigArrayFieldTemplate is the config explorer's array section: the same
  * flat disclosure-row anatomy as object groups, with the "Add" button riding the
  * header's trailing action zone and hairline-divided item rows. Adapted from
- * `.design-sync/previews/BrowserConfigArrayFieldTemplate.tsx`. Each item's
- * `children` is the pre-rendered item element; the registry set-like forces
+ * `.design-sync/previews/BrowserConfigArrayFieldTemplate.tsx`. Each item is
+ * the pre-rendered element supplied by rjsf v6; the registry set-like forces
  * "always expanded".
  */
 // `args` is cast to the full ArrayFieldTemplateProps so Storybook's CSF3 type
@@ -61,8 +61,8 @@ export const WithItems: Story = {
         {...({
           ...base,
           items: [
-            { key: "0", children: mockFieldContent("seed 0", "0.42, 0.18") },
-            { key: "1", children: mockFieldContent("seed 1", "0.71, 0.66") },
+            <Fragment key="0">{mockFieldContent("seed 0", "0.42, 0.18")}</Fragment>,
+            <Fragment key="1">{mockFieldContent("seed 1", "0.71, 0.66")}</Fragment>,
           ],
         } as unknown as ArrayFieldTemplateProps<unknown, RJSFSchema, BrowserConfigFormContext>)}
       />

--- a/packages/mapgen-studio-ui/test/designSyncOutputAssertions.test.ts
+++ b/packages/mapgen-studio-ui/test/designSyncOutputAssertions.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+const assertionsUrl = new URL("../scripts/design-sync-output-assertions.mjs", import.meta.url).href;
+const { findDesignSyncReadmeFailures } = await import(assertionsUrl);
+
+describe("design-sync README output assertions", () => {
+  it.each([
+    ["absent", "# Bundle\n\n## Components\n\nComponent docs.\n"],
+    ["renamed", "# Bundle\n\n## Design Tokens\n\n- **color** (1): `--background`\n"],
+  ])("fails closed when the exact `## Tokens` section is %s", (_case, readme) => {
+    expect(findDesignSyncReadmeFailures(readme)).toEqual([
+      "README is missing the required exact `## Tokens` section — token-table purity was not checked",
+    ]);
+  });
+
+  it("checks only the exact token section and preserves the Tailwind bucket guard", () => {
+    const readme = [
+      "# Bundle",
+      "",
+      "## Tokens",
+      "",
+      "- **color** (2): `--background`, `--tw-leaked`",
+      "- **other** (1): `--tw-legitimate`",
+      "",
+      "## Components",
+      "",
+      "- **color** (1): `--tw-outside-token-section`",
+    ].join("\n");
+
+    expect(findDesignSyncReadmeFailures(readme)).toEqual([
+      "README token buckets list Tailwind engine vars outside 'other' (--tw-leaked) — the .ds-sync emit.mjs --tw- classifier patch was lost (re-stage?)",
+    ]);
+  });
+});

--- a/packages/mapgen-studio-ui/test/rjsfFieldTemplateErrors.test.tsx
+++ b/packages/mapgen-studio-ui/test/rjsfFieldTemplateErrors.test.tsx
@@ -154,7 +154,7 @@ describe("BrowserConfigObjectFieldTemplate collapse (Pass-4 config-collapse spec
       <BrowserConfigArrayFieldTemplate
         {...({
           title: "Range Seeds",
-          items: [{ key: "0", children: <div>array-item-marker</div> }],
+          items: [<div key="0">array-item-marker</div>],
           canAdd: true,
           onAddClick: () => {},
           disabled: false,


### PR DESCRIPTION
## Replace selector-based Storybook render detection with a paint-visibility oracle

The previous approach to detecting whether a Storybook story had rendered relied on a CSS selector wait (`waitForSelector`) targeting the first non-style/script child of `#storybook-root` or `#root`. This broke for portal-only stories (e.g. Dialog, Tooltip, Toast) that legitimately leave both roots empty and paint directly into `<body>`, causing false "no storybook root content" failures.

### Render oracle

A new `inspectVisibleBodyContent` function serves as a shared browser-realm render oracle for both Storybook capture and design-sync preview capture. Rather than checking DOM presence, it determines visibility by:

- Filtering out non-painting tags (`SCRIPT`, `STYLE`, etc.)
- Checking `display`, `visibility`, and `opacity` via `getComputedStyle`
- Using `checkVisibility()` where available, with a `getClientRects` geometry fallback
- Confirming at least one bounding rect intersects the viewport

This correctly handles portal content rendered outside the Storybook root, hidden injected containers (toast roots, style mounts), and zero-size nodes that appear in the DOM but produce no paint.

### Storybook capture

- `captureStory` now waits for `inspectVisibleBodyContent` to return a truthy result rather than waiting for a selector.
- When a portal is detected alongside or instead of a root, the capture falls back to a viewport screenshot so both layers remain in frame.
- The `SB_RENDER_ORACLE` config explicitly excludes known Storybook chrome elements (`.sb-wrapper`, `#storybook-docs`, `#storybook-highlights-root`) from the portal check.

### Design-sync preview capture

The inline portal detection logic (which matched against a hardcoded list of element selectors) is replaced by a call to `inspectVisibleBodyContent` with the `.ds-grid`/`.ds-single` roots, keeping portal detection consistent with the Storybook path.

### README assertion extraction

The Tailwind token-leak check previously inlined in `design-sync-check.mjs` is extracted into a dedicated `design-sync-output-assertions.mjs` module with a `findDesignSyncReadmeFailures` export. The extraction also fixes a latent bug: the old regex sliced from the first `## Tokens` occurrence to the next `## ` boundary using a fragile index approach; the new implementation uses an exact heading match and a proper next-section search so content outside the token section (e.g. a `## Components` section that happens to mention `--tw-` vars) does not trigger false positives. Unit tests cover the missing-section, renamed-section, and leaked-token cases.

### `BrowserConfigArrayFieldTemplate` story and test fixture

The `items` prop shape is updated to pass `ReactElement` nodes directly (wrapped in `<Fragment>` with a `key`) rather than `{ key, children }` objects, matching the rjsf v6 contract the component actually receives.