### PR TITLE
docs(studio): seal C1 vocabulary and advance setup-correctness ledger

### DIFF
--- a/docs/projects/studio-design-pipeline/INITIATIVE-setup-correctness.md
+++ b/docs/projects/studio-design-pipeline/INITIATIVE-setup-correctness.md
@@ -2,19 +2,19 @@
 
 > **Status:** ACTIVE (opened 2026-07-21). Owner: the pipeline director (FRAME §8).
 >
-> **Execution ledger (live, 2026-07-21):** branches `agent-DS-init-rails`
-> (R1 complete, `3eedaf9e0e`) and `agent-DS-init-primitives` (C1a IconButton+
-> Badge `abd71e002c`; C2a rjsf shells+section naming+id scoping `d4a7dce0f8`;
-> C2b Disclosure anatomy+useControllableState `77d25d4d3b`; C2c SelectWidget→
-> OptionSelect+AppBrand dismissal+array de-any `1418f43a49`; C3a Toaster
-> reunification `c5f41f830e`; A1a Tailwind src scan+StrictMode honesty
-> `63ca371c1a` — StrictMode exception ledgered as root DEF-020; G1 gate repair
-> `edee8f8472`).
-> **Open rows:** C1.2 SegmentedControl + Tabs retirement, C1.4 scroll idiom +
-> ScrollArea retirement, C1.5 literal sweep, C2.3 ExplorePanel provider
-> collapse, C2.9 strategy-envelope collapse, C3.3 tier-policy note, A1.3 palette
-> identity contract, A1.4 errorFormat consolidation, A1.5 WaterStats shortLabel,
-> S1 sync & seal.
+> **Execution ledger (live, 2026-07-31):** `agent-DS-init-rails` owns R1
+> (`c0a6d705ac`); the restacked primitives lane owns IconButton/Badge
+> (`fc782d5232`), config structure (`0cfcdcb7d7`), disclosure/state
+> (`99eb5c1da2`), OptionSelect/AppBrand/array typing (`83a7d09e92`), Toaster
+> reunification (`486fc2c685`), Tailwind/StrictMode honesty (`0e20e37473`), and
+> the G1 repair (`8536a6f88e`). StrictMode is tracked as root DEF-022.
+> **C1 is locally sealed:** Storybook package resolution `a5c3779781`, complete
+> vocabulary closure `83687e3d01`, Save As concurrency correctness
+> `4d4968313f`, disabled restore admission `99ce12edc3`, and fail-closed
+> design-sync capture `d52ce86407`.
+> **Open rows:** C2.3 ExplorePanel provider collapse, C2.9 strategy-envelope
+> collapse, C3.3 tier-policy note, A1.3 palette identity contract, A1.4
+> errorFormat consolidation, A1.5 WaterStats shortLabel, and S1 sync & seal.
 > **Codex Sol adversarial pass: DEAD, not in flight.** Job task-mrv2a6c0-mfesmo
 > left no state on disk and returned no verdict, so the gate it held was never
 > going to lift on its own. C1.2, C1.4 and C2.3 are hereby UNGATED — re-run an
@@ -109,6 +109,17 @@ reminder to stay correct — this initiative failed and the pipeline shape itsel
 | C1.4 | Three scroll idioms; two sites already fell back to native scrollbars | Make scrollbar theming **global** in theme.css (kill the opt-in class trap); **retire ScrollArea/ScrollBar from the barrel** (zero consumers, unexercised path) with ledger note. Keep Separator (honest, no competing idiom). |
 | C1.5 | Sweep residue | rg sweep for other 3+-site verbatim class literals; promote or explicitly ledger each. verify.mjs floor recount after barrel changes. |
 
+**C1 seal, 2026-07-31.** The runtime barrel now has 99 value exports and the
+fidelity oracle has 46 components. The only remaining exact three-site visual
+literal is the warning contour used by AppHeader config drift, field drift, and
+GameConsole stale state. Those are different controls sharing one semantic
+state treatment, not one missing component, so the treatment remains local
+rather than creating another string-helper API. All other three-plus repeats
+are atomic icon sizing, truncation, or layout utilities. The full local
+design-sync pass rendered 46/46 previews with zero factual failures; 32 changed
+or new components remain intentionally ungraded until S1. The forced-light
+canary passed 7/7 with zero token drift.
+
 ### C2 — COMPOSITION: compound APIs + state shape  (branch `agent-DS-init-compounds`)
 
 | Row | Finding | Resolution |
@@ -169,8 +180,8 @@ hand-rolls the C2 files touch).
 ## Judgment calls taken (protective belt; reversible, recorded)
 
 - **Tabs + ScrollArea retired, Separator kept.** The line: retire what misleads
-  (competing shipped idiom exists), keep what is honest. Re-adding later is one
-  export + one story.
+  (competing shipped idiom exists), keep what is honest. Their source is gone;
+  reintroduction is a fresh capability decision rather than a dormant export.
 - **Scroll idiom = globally themed native scrollbars,** not ScrollArea adoption
   (smallest diff, kills the opt-in failure mode entirely).
 - **ExplorePanel API break is sanctioned** — the package is repo-internal and the

--- a/docs/system/DEFERRALS.md
+++ b/docs/system/DEFERRALS.md
@@ -263,7 +263,7 @@ authority.
 **Scope:** Deliver the feedback packet to the design-sync/claude.ai-design maintainers; when a classifier fix or a project-supplied classification input ships, re-sync and confirm the findings clear, then retire the noise-disposition sections in `packages/mapgen-studio-ui/docs/design-tokens.md` and `.design-sync/NOTES.md`. (Partially delivered 2026-07-18: the annotation input shipped and the repo emits it — see the `@kind` trigger outcome above; finding-#1 retirement awaits the post-upload check confirmation, finding-#2 remains open upstream.)
 **Impact:** Design agents see two known-noise findings per check (dispositioned in the synced guidelines); the repo-owned token guard (`packages/mapgen-studio-ui/test/designTokens.test.ts`) carries the real signal meanwhile.
 
-## DEF-020: React StrictMode disabled pending a remount-safe DeckCanvas
+## DEF-022: React StrictMode disabled pending a remount-safe DeckCanvas
 
 **Deferred:** 2026-07-21
 **Trigger:** DeckCanvas (`apps/mapgen-studio/src/features/viz/DeckCanvas.tsx`) guards its Deck/luma device + canvas initialization against StrictMode's dev double-mount (create → destroy → create on one canvas element), verified in a live dev session; then enable `<StrictMode>` unconditionally in `apps/mapgen-studio/src/main.tsx`. Also fires on a deck.gl/luma release note addressing StrictMode double-mount.

--- a/packages/mapgen-studio-ui/.design-sync/NOTES.md
+++ b/packages/mapgen-studio-ui/.design-sync/NOTES.md
@@ -647,3 +647,28 @@ drift plus a family of design-side loading hazards:
   (LANDED — lifecycle law says prune; not executed without his word since it
   deletes design-side work); run `check_design_system` after the recompile and
   record the DEF-017 outcome.
+
+## Setup-correctness C1 vocabulary seal (2026-07-31)
+
+- The package now exposes one 46-component vocabulary. `SegmentedControl`
+  replaces the three hand-authored option strips; `Badge.interactive` owns the
+  layer-reference chip; Tabs and ScrollArea are fully removed because neither
+  represented a shipped interaction idiom.
+- Native scrollbars are themed globally. No component opts into a private
+  scrollbar class, so an overflowing surface cannot silently lose the Studio
+  treatment.
+- The exact-literal sweep found no further missing component. The remaining
+  three-site warning contour is a shared semantic state across different
+  controls; the other repeats are atomic icon-size, truncation, or layout
+  utilities. No generic class-string helper was introduced.
+- Storybook package-root resolution now works under Bun's isolated linker.
+  Portal-only Dialog and MapConfigSaveDialog stories use the ordinary capture
+  path with visible-geometry admission and viewport screenshots; no manual
+  portal exception remains. Generated README assertions also fail closed when
+  the exact `## Tokens` section is absent.
+- Proof: package/app typecheck and 621 tests passed (222 UI, 399 app);
+  Storybook and the 99-export artifact contract built cleanly; React Compiler
+  reported 0 errors and 0 warnings across 96 files; design-sync rendered 46/46
+  previews with zero factual failures; forced-light canary passed 7/7 with
+  zero token drift. The 32 changed/new component grades and remote upload remain
+  S1 work, not hidden completion.


### PR DESCRIPTION
This PR advances the setup-correctness initiative by marking C1 as locally sealed and updating the execution ledger to reflect the current state of the primitives lane.

**C1 seal (2026-07-31):** The runtime barrel now exports 99 values across a 46-component vocabulary. `SegmentedControl` replaces hand-authored option strips, `Badge.interactive` owns the layer-reference chip, and Tabs and ScrollArea are fully removed — their source is gone, and reintroduction is a fresh capability decision rather than restoring a dormant export. Native scrollbars are globally themed, eliminating the opt-in failure mode entirely.

The exact-literal sweep found no further missing components. The remaining three-site warning contour is a shared semantic state across different controls rather than a missing abstraction, so it stays local. Storybook package-root resolution now works under Bun's isolated linker, portal-only stories use the ordinary capture path with visible-geometry admission, and generated README assertions fail closed when the `## Tokens` section is absent.

Verification: package and app typecheck passed, 621 tests passed (222 UI, 399 app), Storybook and the 99-export artifact contract built cleanly, React Compiler reported 0 errors and 0 warnings across 96 files, design-sync rendered 46/46 previews with zero factual failures, and the forced-light canary passed 7/7 with zero token drift.

The StrictMode deferral is renumbered from DEF-020 to DEF-022. Open rows are C2.3, C2.9, C3.3, A1.3, A1.4, A1.5, and S1. The 32 changed or new component grades and remote upload remain S1 work.