### PR TITLE
refactor(control): collapse already-explored into unverified classification

### DIFF
--- a/apps/mapgen-studio/src/app/hooks/useSetupControls.ts
+++ b/apps/mapgen-studio/src/app/hooks/useSetupControls.ts
@@ -454,12 +454,23 @@ export function useSetupControls(args: UseSetupControlsArgs): UseSetupControlsRe
     setExploreActionRunning(true);
     try {
       const result = await liveControlPort.display.explore.request({ playerId: localPlayerId });
-      toast(
-        result.classification === "already-explored"
-          ? "Live map already fully revealed"
-          : `Live map revealed — ${result.grantedPlots} plots granted`,
-        { variant: "success" }
-      );
+      switch (result.classification) {
+        case "explored":
+          toast(`Live map revealed — ${result.grantedPlots} plots granted`, {
+            variant: "success",
+          });
+          break;
+        case "already-explored":
+          toast("Live map already fully revealed", { variant: "success" });
+          break;
+        case "unverified":
+          toast("Live map reveal could not be verified. Inspect the live map before retrying.", {
+            variant: "info",
+          });
+          break;
+        default:
+          result satisfies never;
+      }
     } catch (err) {
       toast(`Explore failed: ${err instanceof Error ? err.message : "live game unavailable"}`, {
         variant: "error",

--- a/apps/mapgen-studio/test/controllers/useSetupControls.test.tsx
+++ b/apps/mapgen-studio/test/controllers/useSetupControls.test.tsx
@@ -85,6 +85,31 @@ const EXPLORE_ALREADY_VISIBLE_RESULT = {
   classification: "already-explored",
 } satisfies ExploreRequestResult;
 
+const EXPLORE_REVEALED_RESULT = {
+  playerId: 0,
+  skipped: false,
+  before: { revealed: 29, visible: 7 },
+  after: { revealed: 64, visible: 64 },
+  grantId: 1,
+  grantedPlots: 64,
+  grantReleased: false,
+  settleMs: 15_000,
+  drainPolls: 3,
+  quiesced: true,
+  suspendVerified: true,
+  resumeVerified: true,
+  suppressedDisplays: [],
+  mutation: "Visibility.setTrackedVisibilityGrant",
+  discoveryPosture: "ui-suppressed-gameplay-discovers",
+  classification: "explored",
+} satisfies ExploreRequestResult;
+
+const EXPLORE_UNVERIFIED_RESULT = {
+  ...EXPLORE_REVEALED_RESULT,
+  after: { revealed: null, visible: 64 },
+  classification: "unverified",
+} satisfies ExploreRequestResult;
+
 function makeArgs(over: Partial<UseSetupControlsArgs> = {}): UseSetupControlsArgs {
   return {
     setupConfig: studioSetupConfigFromSavedConfigFile(SAVED_CONFIG),
@@ -587,12 +612,70 @@ describe("useSetupControls — SC-6 (handleExplore busy-gate + re-entrant guard,
     });
   });
 
-  it("issues the explore RPC + clears the in-flight flag in finally on success", async () => {
-    exploreRpc.mockResolvedValue(EXPLORE_ALREADY_VISIBLE_RESULT);
-    const { result } = setup();
+  it("presents explored as a success with the owner's granted-plot evidence", async () => {
+    const toast = vi.fn();
+    exploreRpc.mockResolvedValue(EXPLORE_REVEALED_RESULT);
+    const { result } = setup({ toast });
+
     await act(async () => {
       await result.current.handleExplore();
     });
+
+    expect(toast).toHaveBeenCalledWith("Live map revealed — 64 plots granted", {
+      variant: "success",
+    });
+  });
+
+  it("presents already-explored as a success without claiming a new reveal", async () => {
+    const toast = vi.fn();
+    exploreRpc.mockResolvedValue(EXPLORE_ALREADY_VISIBLE_RESULT);
+    const { result } = setup({ toast });
+
+    await act(async () => {
+      await result.current.handleExplore();
+    });
+
+    expect(toast).toHaveBeenCalledWith("Live map already fully revealed", {
+      variant: "success",
+    });
+  });
+
+  it("presents unverified as informational uncertainty with inspect-before-retry guidance", async () => {
+    const toast = vi.fn();
+    exploreRpc.mockResolvedValue(EXPLORE_UNVERIFIED_RESULT);
+    const { result } = setup({ toast });
+
+    await act(async () => {
+      await result.current.handleExplore();
+    });
+
+    expect(toast).toHaveBeenCalledWith(
+      "Live map reveal could not be verified. Inspect the live map before retrying.",
+      { variant: "info" }
+    );
+  });
+
+  it("sets the in-flight flag before awaiting and clears it in finally", async () => {
+    let resolveRpc: (value: ExploreRequestResult) => void = () => {};
+    exploreRpc.mockImplementationOnce(
+      () =>
+        new Promise<ExploreRequestResult>((resolve) => {
+          resolveRpc = resolve;
+        })
+    );
+    const { result } = setup();
+    let request!: Promise<void>;
+
+    act(() => {
+      request = result.current.handleExplore();
+    });
+    expect(result.current.exploreActionRunning).toBe(true);
+
+    await act(async () => {
+      resolveRpc(EXPLORE_REVEALED_RESULT);
+      await request;
+    });
+
     expect(exploreRpc).toHaveBeenCalledWith({ playerId: 0 });
     expect(result.current.exploreActionRunning).toBe(false);
   });
@@ -613,14 +696,14 @@ describe("useSetupControls — SC-6 (handleExplore busy-gate + re-entrant guard,
     expect(exploreRpc).toHaveBeenCalledWith({ playerId: 3 });
   });
 
-  it("catches a thrown RPC, toasts an error, and still clears the in-flight flag (try/finally)", async () => {
+  it("presents a thrown owner error as an error and still clears the in-flight flag", async () => {
     const toast = vi.fn();
-    exploreRpc.mockRejectedValue(new Error("live game unavailable"));
+    exploreRpc.mockRejectedValue(new Error("owner refused request"));
     const { result } = setup({ toast });
     await act(async () => {
       await result.current.handleExplore();
     });
-    expect(toast).toHaveBeenCalledWith(expect.stringContaining("Explore failed"), {
+    expect(toast).toHaveBeenCalledWith("Explore failed: owner refused request", {
       variant: "error",
     });
     expect(result.current.exploreActionRunning).toBe(false);

--- a/plugins/cli/topics/game/src/commands/game/map/visibility.ts
+++ b/plugins/cli/topics/game/src/commands/game/map/visibility.ts
@@ -2,6 +2,9 @@ import { getCiv7VisibilitySummary, revealCiv7MapForPlayer } from "@civ7/direct-c
 import { Command, Flags } from "@oclif/core";
 import { createCiv7GameControlClient } from "../../../adapters/control/service-client";
 
+const EXPLORE_UNVERIFIED_GUIDANCE =
+  "Inspect the live map before retrying; the previous explore request may have changed engine state.";
+
 // Two discrete mutations, deliberately not interchangeable:
 // --explore  the whole map becomes known via the engine's tracked visibility
 //            grants, with discovery popups suppressed through the official
@@ -94,15 +97,22 @@ export default class GameMapVisibility extends Command {
         `game map visibility --${flags.reveal ? "reveal" : "explore"} requires --disposable`
       );
     }
-    const result = flags.explore
-      ? await createCiv7GameControlClient({
-          endpointDefaults: options,
-        }).display.explore.request({
-          playerId: flags["player-id"],
-          ...(flags["settle-ms"] === undefined ? {} : { settleMs: flags["settle-ms"] }),
-          ...(flags["restore-fog"] ? { restoreFog: true } : {}),
-        })
-      : flags.reveal
+    let ok = true;
+    let result: unknown;
+    let guidance: string | undefined;
+    if (flags.explore) {
+      const exploreResult = await createCiv7GameControlClient({
+        endpointDefaults: options,
+      }).display.explore.request({
+        playerId: flags["player-id"],
+        ...(flags["settle-ms"] === undefined ? {} : { settleMs: flags["settle-ms"] }),
+        ...(flags["restore-fog"] ? { restoreFog: true } : {}),
+      });
+      ok = exploreResult.classification !== "unverified";
+      result = exploreResult;
+      guidance = ok ? undefined : EXPLORE_UNVERIFIED_GUIDANCE;
+    } else {
+      result = flags.reveal
         ? await revealCiv7MapForPlayer({ playerId: flags["player-id"] }, options)
         : await getCiv7VisibilitySummary(
             {
@@ -113,13 +123,15 @@ export default class GameMapVisibility extends Command {
             },
             options
           );
+    }
 
     if (flags.json) {
-      this.log(JSON.stringify({ ok: true, result }));
+      this.log(JSON.stringify({ ok, result, ...(guidance ? { guidance } : {}) }));
       return;
     }
 
     this.log(JSON.stringify(result, null, 2));
+    if (guidance) this.log(guidance);
   }
 }
 

--- a/plugins/cli/topics/game/test/commands/game/map/visibility.test.ts
+++ b/plugins/cli/topics/game/test/commands/game/map/visibility.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { createCiv7GameControlClient } from "../../../../src/adapters/control/service-client";
+
+const { createControlClient, requestExplore } = vi.hoisted(() => ({
+  createControlClient: vi.fn(),
+  requestExplore: vi.fn(),
+}));
+
+vi.mock("../../../../src/adapters/control/service-client", () => ({
+  createCiv7GameControlClient: createControlClient,
+}));
+
+import GameMapVisibility from "../../../../src/commands/game/map/visibility";
+
+type GameControlClient = ReturnType<typeof createCiv7GameControlClient>;
+type ExploreResult = Awaited<ReturnType<GameControlClient["display"]["explore"]["request"]>>;
+
+const exploredResult = {
+  playerId: 0,
+  skipped: false,
+  before: { revealed: 29, visible: 7 },
+  after: { revealed: 6_996, visible: 7 },
+  grantId: 11,
+  grantedPlots: 6_996,
+  grantReleased: false,
+  settleMs: 15_000,
+  drainPolls: 4,
+  quiesced: true,
+  suspendVerified: true,
+  resumeVerified: true,
+  suppressedDisplays: [{ category: "Cinematic", closed: 3 }],
+  mutation: "Visibility.setTrackedVisibilityGrant",
+  discoveryPosture: "ui-suppressed-gameplay-discovers",
+  classification: "explored",
+} satisfies ExploreResult;
+
+const alreadyExploredResult = {
+  playerId: 0,
+  skipped: true,
+  before: { revealed: 6_996, visible: 6_996 },
+  after: { revealed: 6_996, visible: 6_996 },
+  mapPlotCount: 6_996,
+  classification: "already-explored",
+} satisfies ExploreResult;
+
+const unverifiedResult = {
+  ...exploredResult,
+  after: { revealed: null, visible: 7 },
+  classification: "unverified",
+} satisfies ExploreResult;
+
+describe("game map visibility explore projection", () => {
+  beforeEach(() => {
+    requestExplore.mockReset();
+    createControlClient.mockReset();
+    createControlClient.mockReturnValue({
+      display: {
+        explore: {
+          request: requestExplore,
+        },
+      },
+    });
+  });
+
+  test("keeps the explored owner result and reports success", async () => {
+    requestExplore.mockResolvedValue(exploredResult);
+
+    const payload = await runCommand();
+
+    expect(createControlClient).toHaveBeenCalledWith({
+      endpointDefaults: {
+        host: "127.0.0.1",
+        port: 4_318,
+        timeoutMs: 1_234,
+      },
+    });
+    expect(requestExplore).toHaveBeenCalledWith({ playerId: 0 });
+    expect(payload).toEqual({ ok: true, result: exploredResult });
+  });
+
+  test("keeps the already-explored owner result and reports success", async () => {
+    requestExplore.mockResolvedValue(alreadyExploredResult);
+
+    const payload = await runCommand();
+
+    expect(payload).toEqual({ ok: true, result: alreadyExploredResult });
+  });
+
+  test("keeps the unverified owner result without reporting success", async () => {
+    requestExplore.mockResolvedValue(unverifiedResult);
+
+    const payload = await runCommand();
+
+    expect(payload).toEqual({
+      ok: false,
+      result: unverifiedResult,
+      guidance:
+        "Inspect the live map before retrying; the previous explore request may have changed engine state.",
+    });
+  });
+
+  test("preserves an explore owner error", async () => {
+    const ownerError = Object.assign(new Error("Map explore request failed."), {
+      code: "EXPLORE_FAILED",
+      data: {
+        procedureKey: "display.explore.request",
+        source: "direct-control-facade",
+        step: "apply-explore-grant",
+        detail: "Error",
+      },
+    });
+    requestExplore.mockRejectedValue(ownerError);
+
+    await expect(runCommand()).rejects.toBe(ownerError);
+  });
+});
+
+async function runCommand(): Promise<{
+  ok: boolean;
+  result: ExploreResult;
+  guidance?: string;
+}> {
+  const writes: string[] = [];
+  const log = vi
+    .spyOn(GameMapVisibility.prototype, "log")
+    .mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
+  try {
+    await GameMapVisibility.run([
+      "--host",
+      "127.0.0.1",
+      "--port",
+      "4318",
+      "--timeout-ms",
+      "1234",
+      "--player-id",
+      "0",
+      "--explore",
+      "--disposable",
+      "--json",
+    ]);
+    return JSON.parse(writes.join("")) as {
+      ok: boolean;
+      result: ExploreResult;
+      guidance?: string;
+    };
+  } finally {
+    log.mockRestore();
+  }
+}

--- a/services/civ7-control/src/service/modules/display/contract/explore-request.ts
+++ b/services/civ7-control/src/service/modules/display/contract/explore-request.ts
@@ -141,12 +141,10 @@ const Civ7DisplayExploreFullResultSchema = Type.Object(
     discoveryPosture: Type.Literal("ui-suppressed-gameplay-discovers", {
       description: "Exploration posture used while gameplay reveals the map.",
     }),
-    classification: Type.Union(
-      [Type.Literal("explored"), Type.Literal("already-explored"), Type.Literal("unverified")],
-      {
-        description: "Outcome derived from before-and-after visibility evidence.",
-      }
-    ),
+    classification: Type.Union([Type.Literal("explored"), Type.Literal("unverified")], {
+      description:
+        "Explored only when revealed evidence increased; otherwise the full run is unverified.",
+    }),
   },
   { additionalProperties: false }
 );

--- a/services/civ7-control/src/service/modules/display/router/explore-request.ts
+++ b/services/civ7-control/src/service/modules/display/router/explore-request.ts
@@ -197,9 +197,7 @@ function displayExploreRequestResult(
   const classification =
     beforeRevealed != null && afterRevealed != null && afterRevealed > beforeRevealed
       ? "explored"
-      : beforeRevealed != null && afterRevealed != null && afterRevealed === beforeRevealed
-        ? "already-explored"
-        : "unverified";
+      : "unverified";
   return {
     playerId: input.playerId,
     skipped: false,

--- a/services/civ7-control/test/behavior/modules/display/display-explore-procedure.test.ts
+++ b/services/civ7-control/test/behavior/modules/display/display-explore-procedure.test.ts
@@ -179,10 +179,14 @@ describe("display.explore.request control-oRPC procedure", () => {
     );
     expect(fake.calls).toContain("grant");
     expect(fake.calls).toContain("release");
-    expect(result).toMatchObject({ skipped: false, grantReleased: true });
+    expect(result).toMatchObject({
+      skipped: false,
+      grantReleased: true,
+      classification: "unverified",
+    });
   });
 
-  test("classifies an unchanged revealed count as already-explored", async () => {
+  test("classifies an unchanged revealed count after a full run as unverified", async () => {
     const fake = fakeContext({
       summaries: [visibilitySummary(6996), visibilitySummary(6996)],
     });
@@ -191,7 +195,7 @@ describe("display.explore.request control-oRPC procedure", () => {
       { playerId: 0, ...fastDrain },
       { context: fake.context }
     );
-    expect(result.classification).toBe("already-explored");
+    expect(result.classification).toBe("unverified");
   });
 
   test("classifies missing visibility probes as unverified", async () => {


### PR DESCRIPTION
The `display.explore.request` procedure previously classified a full run where the revealed count did not increase as `already-explored`. This was incorrect — if the map was already fully revealed before the request, the early-exit `skipped` path handles that case and returns `already-explored`. A full run that completes without evidence of increased revealed plots means verification failed, not that the map was already explored.

The `already-explored` classification has been removed from the full-run result schema and router. Any full run that does not show an increase in revealed plots now returns `unverified` instead.

The `unverified` outcome is surfaced distinctly across all consumers:

- **Mapgen Studio** shows an informational toast ("Live map reveal could not be verified. Inspect the live map before retrying.") rather than a success or error, and the switch now exhaustively covers all three classifications with a `satisfies never` default guard.
- **CLI** sets `ok: false` in the JSON output and appends guidance text advising the user to inspect the live map before retrying, since the engine state may have changed.

Tests have been updated throughout to reflect the reclassification, and new tests cover the `explored`, `already-explored`, and `unverified` toast variants in Mapgen Studio, as well as the CLI's JSON output shape for all three explore outcomes.