### PR TITLE
refactor(swooper-physics): replace label RNG with deterministic FNV1a seeded rolls

### DIFF
--- a/plugins/mod/map/swooper-physics/src/domain/hydrology/modules/climate/ops/compute-atmospheric-circulation/rules/index.ts
+++ b/plugins/mod/map/swooper-physics/src/domain/hydrology/modules/climate/ops/compute-atmospheric-circulation/rules/index.ts
@@ -11,8 +11,8 @@ import {
   vec2LengthSquared,
   vec2Scale,
 } from "@swooper/mapgen-core/lib/grid";
+import { fnv1a32Int32Values, fnv1a32String } from "@swooper/mapgen-core/lib/hash";
 import { clamp01, clampInt, lerp } from "@swooper/mapgen-core/lib/math";
-import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 
 /**
  * Per-sample perturbation ceiling relative to the analytic circulation backbone.
@@ -39,6 +39,13 @@ const FERREL_MERIDIONAL_WEIGHT = 0.6;
 const POLAR_MERIDIONAL_WEIGHT = 0.5;
 const EQUATORIAL_TAPER_DEFAULT_DEG = 18;
 const PRESSURE_SMOOTHING_BLEND = 0.55;
+const JET_STREAK_ROLL_SALT = fnv1a32String("hydrology:circulation:jet-streak");
+const WIND_U_VARIANCE_ROLL_SALT = fnv1a32String("hydrology:circulation:wind-u-variance");
+const WIND_V_VARIANCE_ROLL_SALT = fnv1a32String("hydrology:circulation:wind-v-variance");
+
+function seededRoll(seed: number, salt: number, sampleIndex: number, rollSize: number): number {
+  return fnv1a32Int32Values([seed, salt, sampleIndex]) % Math.max(1, rollSize | 0);
+}
 
 /**
  * Builds the inexpensive latitude-band wind field used by the fallback circulation strategy.
@@ -66,14 +73,14 @@ export function computeWinds(
   const jetStrength = options.jetStrength;
   const variance = options.variance;
 
-  const rng = createLabelRng(options.seed | 0);
   const streakLats: number[] = [];
   for (let s = 0; s < streaks; s++) {
     const base =
       HADLEY_CELL_END_DEG +
       s * ((FERREL_CELL_END_DEG - HADLEY_CELL_END_DEG) / Math.max(1, streaks - 1));
     const jitter =
-      rng(JET_STREAK_JITTER_RANGE_DEG, "JetJit") - JET_STREAK_JITTER_RANGE_DEG / 2;
+      seededRoll(options.seed, JET_STREAK_ROLL_SALT, s, JET_STREAK_JITTER_RANGE_DEG) -
+      JET_STREAK_JITTER_RANGE_DEG / 2;
     streakLats.push(
       Math.max(
         JET_STREAK_MIN_LATITUDE_DEG,
@@ -102,12 +109,14 @@ export function computeWinds(
 
     const varU =
       Math.round(
-        (rng(WIND_U_VARIANCE_ROLL_SIZE, "WindUVar") - (WIND_U_VARIANCE_ROLL_SIZE - 1) / 2) *
+        (seededRoll(options.seed, WIND_U_VARIANCE_ROLL_SALT, y, WIND_U_VARIANCE_ROLL_SIZE) -
+          (WIND_U_VARIANCE_ROLL_SIZE - 1) / 2) *
           variance
       ) | 0;
     const varV =
       Math.round(
-        (rng(WIND_V_VARIANCE_ROLL_SIZE, "WindVVar") - (WIND_V_VARIANCE_ROLL_SIZE - 1) / 2) *
+        (seededRoll(options.seed, WIND_V_VARIANCE_ROLL_SALT, y, WIND_V_VARIANCE_ROLL_SIZE) -
+          (WIND_V_VARIANCE_ROLL_SIZE - 1) / 2) *
           variance
       ) | 0;
 

--- a/plugins/mod/map/swooper-physics/test/domains/hydrology/climate/ops/compute-atmospheric-circulation/latitude.test.ts
+++ b/plugins/mod/map/swooper-physics/test/domains/hydrology/climate/ops/compute-atmospheric-circulation/latitude.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+
+import hydrologyOpsPublic from "../../../../../../src/domain/hydrology/router.js";
+import {
+  deriveTestOperationSeed,
+  TEST_MAP_LATITUDE_BOUNDS,
+  TEST_MAP_SIZE,
+} from "../../../../../setup.js";
+
+const { computeAtmosphericCirculation } = hydrologyOpsPublic.climate.ops;
+const { width: WIDTH, height: HEIGHT } = TEST_MAP_SIZE.dimensions;
+const OPERATION_SEED = deriveTestOperationSeed(
+  "test:hydrology:atmospheric-circulation:latitude"
+);
+const LATITUDE_CONFIG = {
+  windJetStreaks: 3,
+  windJetStrength: 1,
+  windVariance: 0.6,
+} as const;
+
+function latitudeRamp(): Float32Array {
+  const latitudeByRow = new Float32Array(HEIGHT);
+  const { topLatitude, bottomLatitude } = TEST_MAP_LATITUDE_BOUNDS;
+  for (let row = 0; row < HEIGHT; row += 1) {
+    latitudeByRow[row] =
+      topLatitude + (bottomLatitude - topLatitude) * (row / Math.max(1, HEIGHT - 1));
+  }
+  return latitudeByRow;
+}
+
+function runLatitude(rngSeed: number): { windU: Int8Array; windV: Int8Array } {
+  return computeAtmosphericCirculation.run(
+    {
+      width: WIDTH,
+      height: HEIGHT,
+      latitudeByRow: latitudeRamp(),
+      rngSeed,
+      pressureField: new Float32Array(WIDTH * HEIGHT),
+    },
+    { strategy: "latitude", config: LATITUDE_CONFIG }
+  );
+}
+
+describe("hydrology/compute-atmospheric-circulation (latitude)", () => {
+  it("derives stable row variation from the complete explicit seed", () => {
+    const first = runLatitude(OPERATION_SEED);
+    const repeated = runLatitude(OPERATION_SEED);
+    const changedHighByte = runLatitude(OPERATION_SEED ^ 0x100);
+
+    expect(first.windU).toEqual(repeated.windU);
+    expect(first.windV).toEqual(repeated.windV);
+    expect(changedHighByte.windU).not.toEqual(first.windU);
+    expect(changedHighByte.windV).not.toEqual(first.windV);
+  });
+});


### PR DESCRIPTION
Replaces the stateful `createLabelRng` RNG with deterministic `fnv1a32`-based hashing for jet streak jitter and per-row wind variance rolls in the latitude circulation strategy. Each roll is now derived from a fixed combination of the operation seed, a named salt constant, and a sample index, eliminating sequential RNG state that could cause results to shift when call order changes.

Adds a test confirming that repeated runs with the same seed produce identical `windU` and `windV` outputs, and that flipping a single bit in the seed produces different results.