### PR TITLE
chore(studio-ui): normalize formatting and fix storybook require resolution

### DIFF
--- a/packages/mapgen-studio-ui/.storybook/main.ts
+++ b/packages/mapgen-studio-ui/.storybook/main.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import type { StorybookConfig } from "@storybook/react-vite";
 import tailwindcss from "@tailwindcss/vite";
 
-const requireFromPackage = createRequire(`${process.cwd()}/package.json`);
+const requireFromPackage = createRequire(import.meta.url);
 const packageRoot = (packageName: string): string =>
   dirname(requireFromPackage.resolve(`${packageName}/package.json`));
 

--- a/packages/mapgen-studio-ui/src/components/composites/DisclosureHeader.stories.tsx
+++ b/packages/mapgen-studio-ui/src/components/composites/DisclosureHeader.stories.tsx
@@ -1,5 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { DisclosureHeader, type DisclosureHeaderProps, IconButton } from "@swooper/mapgen-studio-ui";
+import {
+  DisclosureHeader,
+  type DisclosureHeaderProps,
+  IconButton,
+} from "@swooper/mapgen-studio-ui";
 import { Compass, Layers, Link, Power, Settings } from "lucide-react";
 import type { ReactNode } from "react";
 

--- a/packages/mapgen-studio-ui/src/components/composites/DisclosureHeader.tsx
+++ b/packages/mapgen-studio-ui/src/components/composites/DisclosureHeader.tsx
@@ -145,8 +145,7 @@ export function DisclosureHeader({
     return (
       <div className={cn(ROOT_CHROME, className)}>
         {trigger({
-        className:
-          "flex flex-1 min-w-0 items-center justify-between text-left cursor-pointer",
+          className: "flex flex-1 min-w-0 items-center justify-between text-left cursor-pointer",
         })}
         <div className={TRAILING_CHROME}>{actions}</div>
       </div>

--- a/packages/mapgen-studio-ui/src/components/panels/RecipePanel.tsx
+++ b/packages/mapgen-studio-ui/src/components/panels/RecipePanel.tsx
@@ -22,7 +22,6 @@ import { SchemaConfigForm } from "../forms/SchemaConfigForm.js";
 import { pointerToPath } from "../forms/schemaPresentation.js";
 import { useConfigCollapse } from "../forms/useConfigCollapse.js";
 import { Button } from "../ui/button.js";
-import { IconButton } from "../ui/icon-button.js";
 import {
   Dialog,
   DialogClose,
@@ -38,6 +37,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu.js";
+import { IconButton } from "../ui/icon-button.js";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip.js";
 import { formatMapConfigSaveDeployPhaseLabel } from "./statusLabels.js";
 // ============================================================================
@@ -360,10 +360,7 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
 
         {/* Config Content */}
         {!configCollapsed && (
-          <div
-            id={configSectionId}
-            className="flex-1 overflow-y-auto overflow-x-hidden"
-          >
+          <div id={configSectionId} className="flex-1 overflow-y-auto overflow-x-hidden">
             {/* Config form (flat-and-flush delta 1): flush — no horizontal
               gutter, so stage rows and dividers run edge-to-edge, and no
               trailing padding — the footer's own hairline closes the last

--- a/packages/mapgen-studio-ui/src/components/ui/icon-button.tsx
+++ b/packages/mapgen-studio-ui/src/components/ui/icon-button.tsx
@@ -36,7 +36,9 @@ export interface IconButtonProps
     VariantProps<typeof iconButtonVariants> {}
 
 function IconButton({ className, active, type = "button", ...props }: IconButtonProps) {
-  return <button type={type} className={cn(iconButtonVariants({ active }), className)} {...props} />;
+  return (
+    <button type={type} className={cn(iconButtonVariants({ active }), className)} {...props} />
+  );
 }
 
 export { IconButton, iconButtonVariants };

--- a/packages/mapgen-studio-ui/test/storyContract.test.ts
+++ b/packages/mapgen-studio-ui/test/storyContract.test.ts
@@ -15,7 +15,7 @@
 //    are derived from source, not hand-maintained prose (the "AppFooter
 //    self-provides a TooltipProvider" case — flipped eras ago, doc never
 //    followed).
-import { readFileSync, readdirSync, statSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -31,9 +31,9 @@ const walk = (dir: string): string[] =>
 
 const storyFiles = walk(componentsRoot).filter((f) => f.endsWith(".stories.tsx"));
 
-const config = JSON.parse(
-  readFileSync(join(pkgRoot, ".design-sync", "config.json"), "utf8")
-) as { docsMap: Record<string, string> };
+const config = JSON.parse(readFileSync(join(pkgRoot, ".design-sync", "config.json"), "utf8")) as {
+  docsMap: Record<string, string>;
+};
 const docsMap = config.docsMap;
 
 /** Every `import … from "spec"` (and side-effect `import "spec"`), with type-only flag. */
@@ -92,8 +92,10 @@ describe("story title taxonomy (titles are the sync's card-group authority)", ()
   it("every story component is in docsMap and its prefix matches the mapped group", () => {
     for (const { file, prefix, component } of titles.values()) {
       const group = docsMap[component];
-      expect(group, `${file}: "${component}" missing from .design-sync/config.json docsMap`)
-        .toBeTruthy();
+      expect(
+        group,
+        `${file}: "${component}" missing from .design-sync/config.json docsMap`
+      ).toBeTruthy();
       expect(prefix, `${file}: title group "${prefix}" disagrees with docsMap ${group}`).toBe(
         basename(group as string, ".md")
       );
@@ -129,9 +131,10 @@ describe("conventions.md truth (behavior claims shipped to design agents)", () =
       .filter((name) => name in docsMap);
     expect(consumers.length).toBeGreaterThan(0);
     for (const name of consumers) {
-      expect(conventions, `conventions.md must list \`${name}\` as needing TooltipProvider`).toMatch(
-        new RegExp(`\`${name}\``)
-      );
+      expect(
+        conventions,
+        `conventions.md must list \`${name}\` as needing TooltipProvider`
+      ).toMatch(new RegExp(`\`${name}\``));
     }
   });
 


### PR DESCRIPTION
Fixes the Storybook `createRequire` call to use `import.meta.url` instead of `process.cwd()`, ensuring module resolution is relative to the package rather than the working directory.

Also includes minor formatting cleanup across several files to improve readability and consistency.