### PR TITLE
feat(studio-ui): enable Biome React lint, instance-scoped ids, and executing CI guards

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,15 +3,14 @@
   "configurations": [
     {
       "name": "mapgen-studio",
-      "runtimeExecutable": "bun",
-      "runtimeArgs": ["run", "dev"],
-      "cwd": "apps/mapgen-studio",
+      "runtimeExecutable": "bunx",
+      "runtimeArgs": ["nx", "run", "mapgen-studio:dev"],
       "port": 5173
     },
     {
       "name": "mapgen-studio-probe",
-      "runtimeExecutable": "bun",
-      "runtimeArgs": ["run", "dev:frontend", "--", "--port", "5199", "--strictPort"],
+      "runtimeExecutable": "bunx",
+      "runtimeArgs": ["vite", "--port", "5199", "--strictPort"],
       "cwd": "apps/mapgen-studio",
       "port": 5199,
       "autoPort": false

--- a/apps/mapgen-studio/src/app/hooks/useDeckAutofit.ts
+++ b/apps/mapgen-studio/src/app/hooks/useDeckAutofit.ts
@@ -50,6 +50,7 @@ export function useDeckAutofit({
   const hasEverSeenVizManifestRef = useRef(false);
   const lastAutoFitSpaceRef = useRef<string | null>(null);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deckApiRef is a stable ref read at fire time; the effect must fire only on space/bounds changes — the per-space guard (lastAutoFitSpaceRef) encodes the once-per-space contract.
   useEffect(() => {
     const spaceId = viz.effectiveLayer?.spaceId ?? null;
     if (!spaceId) return;
@@ -59,6 +60,7 @@ export function useDeckAutofit({
     deckApiRef.current?.fitToBounds(viz.activeBounds);
   }, [viz.activeBounds, viz.effectiveLayer?.spaceId]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deckApiRef is a stable ref; deckApiReadyTick/viewportSize are deliberate extra deps that RE-ARM the first-paint fit on deck remount/resize — the dep list is the re-arm contract, not the read set.
   useEffect(() => {
     if (!viz.manifest) return;
     if (hasEverSeenVizManifestRef.current) return;

--- a/apps/mapgen-studio/src/app/hooks/useKeyboardShortcuts.ts
+++ b/apps/mapgen-studio/src/app/hooks/useKeyboardShortcuts.ts
@@ -42,6 +42,7 @@ export type KeyboardShortcutContext = {
 export function useKeyboardShortcuts(context: KeyboardShortcutContext): void {
   const shortcutsRef = useLatestRef(context);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the listener is registered once (deps []) and reads every live value via shortcutsRef.current (useLatestRef) — re-subscribing per render would let a keydown fired between renders dispatch stale handlers (see the doc block above).
   useEffect(() => {
     const isEditableTarget = (target: EventTarget | null) => {
       const el = target as HTMLElement | null;

--- a/apps/mapgen-studio/src/features/viz/DeckCanvas.tsx
+++ b/apps/mapgen-studio/src/features/viz/DeckCanvas.tsx
@@ -196,6 +196,7 @@ export function DeckCanvas(props: DeckCanvasProps) {
   }, [apiRef, fitToBounds, onApiReady, resetView]);
 
   // Create + destroy the Deck instance.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deckLayers is intentionally excluded — layer updates ride setProps in the effect below; depending on deckLayers here would destroy/recreate the Deck (and its WebGL context) on every layer change.
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;

--- a/biome.json
+++ b/biome.json
@@ -44,6 +44,9 @@
   },
   "linter": {
     "enabled": true,
+    "domains": {
+      "react": "recommended"
+    },
     "rules": {
       "recommended": false,
       "correctness": {
@@ -54,10 +57,7 @@
         "noUnsafeFinally": "error",
         "noUnsafeOptionalChaining": "error",
         "useIsNan": "error",
-        "useValidTypeof": "error",
-        "useExhaustiveDependencies": "warn",
-        "useHookAtTopLevel": "error",
-        "useJsxKeyInIterable": "error"
+        "useValidTypeof": "error"
       },
       "suspicious": {
         "noDebugger": "error",
@@ -75,6 +75,18 @@
       }
     }
   },
+  "overrides": [
+    {
+      "includes": ["packages/mapgen-studio-ui/src/**", "!**/*.stories.tsx"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "useUniqueElementIds": "error"
+          }
+        }
+      }
+    }
+  ],
   "javascript": {
     "formatter": {
       "quoteStyle": "double",

--- a/docs/projects/studio-design-pipeline/INITIATIVE-setup-correctness.md
+++ b/docs/projects/studio-design-pipeline/INITIATIVE-setup-correctness.md
@@ -1,0 +1,157 @@
+# Initiative: Setup Correctness — one vocabulary, honest guards
+
+> **Status:** ACTIVE (opened 2026-07-21). Owner: the pipeline director (FRAME §8).
+> **Trigger:** Matei's directive after the sync-surface repair — every actor in this
+> pipeline's history was us; the tailwind pollution and the toast impossibility were
+> self-authored and survived because reviews checked artifacts, not mechanisms.
+> Directive: full review of the setup; fix categorical problems, not instances;
+> turn on Biome's React lint; verify the component breakdown against how a design
+> system should actually compose; resolve everything; end synced.
+>
+> **Evidence base:** categorical audit workflow `wf_09beb69d-f6a` (2026-07-21):
+> 6 lanes + web-researched rubric, 35 findings, 25 P1/P2 **all independently
+> verified against the worktree** (0 refuted), 10 P3 advisory. Full corpus in the
+> session journal; the load-bearing facts are restated here so this document
+> stands alone.
+
+## WHAT (commander's intent)
+
+Make the design-system setup *structurally honest*: every visual idiom the product
+uses is a named, exported component (no shadow string-primitives); every component
+API composes (compound parts and shared state hooks, not prop ladders and render
+hatches); the story surface actually exercises the public contract it claims to
+prove; and every recurrence guard that exists on paper actually runs. The unit of
+success is **classes eliminated**, not instances patched.
+
+## WHY
+
+Two categorical defects (token-registry pollution, unreachable toast) each
+survived many reviews because (a) the defect looked plausible at the artifact
+level and (b) no mechanism-level check existed. The audit found the same
+signature repeated across the setup: guards that claim CI enforcement but never
+run, idioms canonized in comments but not code, docs that assert behavior the
+code flipped eras ago, silent fallbacks that ship degraded output with a green
+verdict. Fixing the found instances without installing the checks would schedule
+the next incident.
+
+## Hard core (violating any of these voids the initiative)
+
+1. **Idiom = component.** A visual idiom used across ≥2 surfaces exists as an
+   exported component or it is a defect. String-constant pseudo-primitives are
+   banned as a category.
+2. **The barrel is honest inventory.** Everything the product's chrome depends on
+   is on it; nothing on it is a trap (exported but matching no shipped treatment).
+3. **Stories exercise the public contract.** Story value-imports ride the package
+   name; a story that needs ambient context the sync cannot supply is a broken
+   story, not a converter problem.
+4. **A guard that does not run is a lie.** Every recurrence guard lands as an
+   executing check (CI target, design-sync-check assertion, lint rule) — prose
+   reminders are not guards.
+5. **Behavior claims shipped to design agents are derived or tested,** never
+   hand-maintained in two prose homes.
+
+## Falsifier
+
+If, after execution, the next real domino (design intent, not cleanup) still
+requires hand-editing a vendored artifact, a manual grading fork, or a prose
+reminder to stay correct — this initiative failed and the pipeline shape itself
+(vendored converter + prose ledger) must be reframed, not re-audited.
+
+---
+
+## Corpus → dominos
+
+35 findings collapse into six dominos. Per-domino branches stacked on
+`agent-DS-sync-surface-repair` (Graphite law: branch = PR). Rails land first
+(FRAME S2–S3: rails before burn-down) so every later domino is born checked.
+
+### R1 — RAILS: lint + executing guards  (branch `agent-DS-init-rails`)
+
+| Row | Finding | Resolution |
+| --- | --- | --- |
+| R1.1 | Biome react domain off | `linter.domains.react = "recommended"` in root biome.json; fix the one new error (PipelineStage.tsx:411 `noArrayIndexKey` — drop the `-${index}` suffix; key is already compound). NOT `"all"` (166 diagnostics; `useComponentExportOnlyModules` structurally incompatible with CSF stories). |
+| R1.2 | Deduping hook rules silently escalates 5 intentional sites warn→error | Convert the 5 documented exhaustive-deps ref-pattern sites (useDeckAutofit ×3, useKeyboardShortcuts:45, DeckCanvas:198) to `biome-ignore` with reason, THEN remove the now-redundant hand-picked hook rules so the domain owns them. |
+| R1.3 | Package hardcodes DOM ids (19 sites — instance-unsafe in a multi-instance package) | `useId()` at the ~12 non-story sites; enable `correctness/useUniqueElementIds: error` via override scoped to `packages/mapgen-studio-ui/src/**`, stories excluded. |
+| R1.4 | verify.mjs claims "CI's fifth target"; CI never runs it — the toast recurrence guard is unenforced | Wire `verify` into the CI run set; add the meta-assertion (verify fails loudly if the root ci script drops it). |
+| R1.5 | Preview esbuild failures silently ship floor cards (bit us once already) | design-sync-check asserts `_preview/<Name>.js` exists for every story-map component; non-zero exit listing gaps. Repo-owned → survives converter re-stage. Upstream feedback: `previewBuildFailed` should force `ok:false`. |
+| R1.6 | emit.mjs `--tw-` classifier patch is local-only; a converter re-stage silently drops it (re-pollution) | design-sync-check asserts no `--tw-` name outside the `other` bucket in the emitted README token tables; file the one-liner upstream. Convention recorded: any local `.ds-sync` divergence pairs with a repo-side absence-detector. |
+| R1.7 | Story-import contract lives in a comment | Vitest: every `*.stories.tsx` value-import comes from the allowlist (package name, storybook, react, lucide-react, @rjsf/utils, local storybook helpers). |
+| R1.8 | Title taxonomy hand-typed ×3, already drifted | Vitest: story `title` matches `^(primitives|composites|forms|layout|panels|templates)/<Component>$`, segment equals export name, prefix agrees with the docsMap group; FieldRow's forms-folder/primitives-title exception is an explicit allowlist entry. Fix `Composites/MapConfigSaveDialog` casing. Correct EXCLUSIONS.md census (45). |
+| R1.9 | launch.json invokes dead scripts | Repoint both studio entries at the Nx `dev` target. |
+| R1.10 | conventions.md tells design agents AppFooter self-provides TooltipProvider; code relies on the ambient one | Fix the sentence; derive the tooltip-dependent component list from source at check time and diff against conventions.md. |
+
+### C1 — VOCABULARY: promote the shadow primitives  (branch `agent-DS-init-primitives`)
+
+| Row | Finding | Resolution |
+| --- | --- | --- |
+| C1.1 | Two icon-button systems, diverged, one barrel-invisible (17 raw sites) — the toast class again | `IconButton` in ui/ (cva over the calibrated muted-idle treatment + `active`), both barrels; migrate all raw `<button className={iconButton}>` sites; delete `lib/iconButton.ts`. |
+| C1.2 | Segmented control hand-rolled ×3 divergent; Tabs exported, consumed nowhere | `SegmentedControl` composite (role=group, aria-pressed items, size variants covering h-7 labeled + h-6 icon cases); rebuild StageViewTabs + both ExplorePanel groups on it. **Retire Tabs from the barrel** (a trap: matches none of the shipped treatments) with ledger note. |
+| C1.3 | Warning-chip literal ×5 verbatim; no Badge | `Badge` in ui/ (variants: warning / neutral / interactive); sweep the 7 chip sites. |
+| C1.4 | Three scroll idioms; two sites already fell back to native scrollbars | Make scrollbar theming **global** in theme.css (kill the opt-in class trap); **retire ScrollArea/ScrollBar from the barrel** (zero consumers, unexercised path) with ledger note. Keep Separator (honest, no competing idiom). |
+| C1.5 | Sweep residue | rg sweep for other 3+-site verbatim class literals; promote or explicitly ledger each. verify.mjs floor recount after barrel changes. |
+
+### C2 — COMPOSITION: compound APIs + state shape  (branch `agent-DS-init-compounds`)
+
+| Row | Finding | Resolution |
+| --- | --- | --- |
+| C2.1 | **P1** Disclosure-header ×3 shapes; trigger anatomy nests interactive content; render hatch yields role=button with button descendants | Compound rework: `Disclosure.Row` (row chrome) / `Disclosure.Trigger` (native button: chevron+icon+title, aria-expanded/controls) / `Disclosure.Actions` (sibling cluster). Delete the `render` prop. Migrate RecipePanel Config header (drops role=button div + stopPropagation) and rjsfTemplates' CollapsibleHeader. |
+| C2.2 | Optional-controlled pattern hand-rolled ×7 | `useControllableState` in lib/, replace all 7 copies (behavior-identical). |
+| C2.3 | ExplorePanel = 44-prop controlled monolith | Collapse to sectioned view-model objects behind a provider interface (composition-patterns §state); app injects one model. Exact shape at S2; prop names stable within sections where possible. |
+| C2.4 | rjsf FieldTemplate wraps containers in dead shells at every depth (the live wrapper chain Matei inspected) | Container branch in BrowserConfigFieldTemplate: object/array → return children (keep the rawErrors live region); clean chain per depth = `divide-y > section > header + body`. DOM-depth pin test. |
+| C2.5 | `<section data-config-section>` nameless at every depth (role generic; no landmark nav) | `configSectionLabelId(pointer)` helper; title span gets the id; all three section emitters get `aria-labelledby`. Axe check (region-name + nested-interactive) wired as a failing test over SchemaConfigForm + Disclosure stories. |
+| C2.6 | SelectWidget re-implements OptionSelect (duplicate sentinel machinery) | SelectWidget composes OptionSelect (`triggerClassName`/id pass-through; enum value-map stays in the widget); delete the second sentinel. README states forms→composites composition is sanctioned. |
+| C2.7 | AppBrand hover popover survived the E3 hand-rolled-popup sweep | Rebuild on Radix (Popover or HoverCard) — Escape/outside dismissal, portal stacking, touch. Confirm it is the last `useState+onMouseEnter` floating layer (sweep). |
+| C2.8 | ArrayFieldTemplate as-any chains (advisory) | Type as v6 `ArrayFieldTemplateItemType`; fix configWidgets registry typing. |
+
+### C3 — STORY ORACLE: reunify story and card  (branch rides `agent-DS-init-compounds` or its own if thick)
+
+| Row | Finding | Resolution |
+| --- | --- | --- |
+| C3.1 | Toaster dual-bookkeeping: story relies on the global decorator; sync patched by a permanent hand-owned preview fork + manual grading | Story self-mounts `<Toaster/>`; remove Toaster from StoryProviders (its comment says it exists only for this story); delete `.design-sync/previews/Toaster.tsx`; retire the manual grading path. |
+| C3.2 | sonner story imports toast from "sonner"; MapConfigSaveDialog story imports relatively | Both ride the package barrel (R1.7's test then pins the class). |
+| C3.3 | Primitive stories are zero-arg showcases; no play functions (advisory) | Record the tier policy in EXCLUSIONS.md/README — deliberate, not drift. No churn beyond the note this pass. |
+
+### A1 — APP: close the fossilized workarounds  (branch `agent-DS-init-app`)
+
+| Row | Finding | Resolution |
+| --- | --- | --- |
+| A1.1 | Dev serves package SOURCE while Tailwind scans package DIST — silent utility dropout in dev | Point `@source` at package src (superset, never stale); drop the dist scan. |
+| A1.2 | StrictMode structurally never active; comment encodes false React semantics | Enable StrictMode in dev; harden the deck.gl mount for double-mount (guard device/canvas init) — or if not feasible this pass, tracked exception with checkback, and fix the false comment either way. |
+| A1.3 | App-side hex palettes tunneled into WaterStatsSection as color-as-data; 2 of 3 fields dead | Contract becomes palette identity: package owns id→CSS mapping (`--viz-cat-*` tokens or classes); delete dead `inactiveColor`/`debugColor`. Guard: no exported package prop typed as CSS color string. |
+| A1.4 | formatErrorForUi copy-forked, drifted; three helper homes (advisory) | Superset impl into `src/shared/errorFormat.ts`; delete the fork; collapse `src/ui/utils` into shared so exactly one helper home exists. |
+| A1.5 | WaterStatsSection hard-codes app-domain key heuristics (advisory) | `shortLabel` rides `WaterStatsLayerRef.presentation` (app owns domain naming); delete `formatLayerButtonLabel` heuristics from the package. |
+
+### S1 — SYNC & SEAL  (after all dominos green)
+
+Full resync driver + grading (Toaster grades via the standard path for the first
+time — C3.1 is its own falsifier), atomic upload with the byte-verify refetch,
+anchor + NOTES + DEFERRALS + memory seal, draft PRs, runner/primary advance.
+Design-side deletions (`Tabs`, `ScrollArea` cards) ride the sync's deletePaths.
+
+## Sequencing
+
+R1 → C1 → C2 (+C3) → A1 → S1. R1 first: every later domino lands on a repo where
+the guards already run. C1 before C2: the compound rework consumes the new
+primitives (Disclosure.Actions renders IconButtons; SegmentedControl replaces
+hand-rolls the C2 files touch).
+
+## Judgment calls taken (protective belt; reversible, recorded)
+
+- **Tabs + ScrollArea retired, Separator kept.** The line: retire what misleads
+  (competing shipped idiom exists), keep what is honest. Re-adding later is one
+  export + one story.
+- **Scroll idiom = globally themed native scrollbars,** not ScrollArea adoption
+  (smallest diff, kills the opt-in failure mode entirely).
+- **ExplorePanel API break is sanctioned** — the package is repo-internal and the
+  44-prop flat surface is itself the defect. Design-side compositions re-learn
+  the API from the synced .d.ts/prompt on next use.
+- **react domain at "recommended", not "all"** — measured: +1 real defect at
+  recommended; +160 noise at all.
+
+## Verification gates (per FRAME S3/S6)
+
+Per domino: package build + typecheck + 204-test suite + the NEW guards green;
+C2 additionally: axe pass on SchemaConfigForm/Disclosure stories + live DOM
+inspection of the config panel (the wrapper chain Matei captured must be gone).
+Initiative close: full design-sync check green with **zero manual grading paths**
+and the export floor recounted.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "nx run-many -t build",
     "check": "nx run-many -t check",
-    "ci": "nx run-many -t build,check,test",
+    "ci": "nx run-many -t build,check,test,verify",
     "clean": "nx run-many -t clean",
     "deploy:mods": "nx run-many -t deploy",
     "docs:project": "nx run habitat:serve:project-docs",

--- a/packages/mapgen-studio-ui/.design-sync/conventions.md
+++ b/packages/mapgen-studio-ui/.design-sync/conventions.md
@@ -18,9 +18,10 @@ luminance focus ring. Every component is React, imported from the bundle as
   no theme prop or wrapper class is needed to get the dark look. (A `.dark` class
   on `<html>` still works for components that read it at runtime, e.g. `Toaster`.)
 - **Mount one `TooltipProvider` at the app root.** Any component that uses a
-  tooltip — `AppHeader`, `GameConsole`, `RecipePanel`, `ExplorePanel`,
-  `ViewControls`, `WaterStatsSection`, and `Tooltip` itself — renders **blank**
-  without a `TooltipProvider` ancestor. `AppFooter` self-provides one.
+  tooltip — `AppFooter`, `AppHeader`, `GameConsole`, `RecipePanel`,
+  `ExplorePanel`, `ViewControls`, `WaterStatsSection`, and `Tooltip` itself —
+  renders **blank** without a `TooltipProvider` ancestor. No component
+  self-provides one (one-provider policy).
 - **Notifications pair `Toaster` with the bundle's own `toast`.** Mount
   `Toaster` once, fire with `window.MapGenStudio.toast(...)` — both ship on
   the barrel so they share one sonner instance. A `toast` imported from

--- a/packages/mapgen-studio-ui/.storybook/EXCLUSIONS.md
+++ b/packages/mapgen-studio-ui/.storybook/EXCLUSIONS.md
@@ -5,7 +5,7 @@
 > fidelity oracle) and the app has zero story files. The components below are
 > **app-side hosts** that stay unstoried; their paths are app paths.
 
-The workbench stories the **47-component presentational surface** (every one a
+The workbench stories the **45-component presentational surface** (every one a
 pure, prop-driven leaf — now this package's public barrel; story titles are the
 sync's grouping authority). The components below are deliberately **not**
 storied, with reasons. These are orchestration hosts and deck.gl/WebGL surfaces
@@ -17,9 +17,9 @@ host given a story; StrictMode / live canvas in a story) or require live data.
 | `StudioShell` (`src/app/StudioShell.tsx`) | Top-level orchestration host — composes the whole app from hooks/stores, not a prop-driven leaf. Stop condition: an orchestration host is never given a story. (Its chrome *geometry* is packaged separately as the presentational `templates/StudioShellLayout`, which IS storied.) |
 | `StudioProviders` (`src/app/StudioProviders.tsx`) | Provider/orchestration host (theme effect + TooltipProvider + Toaster + shell). Its job is reproduced by the global decorator (`.storybook/preview.tsx`), not storied. |
 | `DeckCanvas` (`src/features/viz/DeckCanvas.tsx`) | deck.gl/luma WebGL surface. Cannot render as an isolated pure leaf; deck.gl double-mounts under StrictMode (which the app disables in dev) and needs a live viz manifest. Stop condition: no StrictMode/live-canvas story. |
-| `CanvasStage` (`src/app/CanvasStage.tsx`) | Wraps `DeckCanvas` (deck.gl). Its empty-state branch was a best-effort Tier-3 candidate (`design.md` §7) but is **deferred** in Stage 1: the deck.gl-free empty branch is low-value relative to the WebGL-host risk, and `CanvasStage` is not part of the 46-component design-sync surface this change covers. Revisit if the empty state earns a dedicated story. |
+| `CanvasStage` (`src/app/CanvasStage.tsx`) | Wraps `DeckCanvas` (deck.gl). Its empty-state branch was a best-effort Tier-3 candidate (`design.md` §7) but is **deferred** in Stage 1: the deck.gl-free empty branch is low-value relative to the WebGL-host risk, and `CanvasStage` is not part of the storied design-sync surface this change covers. Revisit if the empty state earns a dedicated story. |
 
-**Data-coupling exclusions:** none. The census confirmed all 46 in-scope
+**Data-coupling exclusions:** none. The census confirmed all 45 in-scope
 components are prop-driven and reach no `/rpc`/daemon data; none had to be
 excluded for live-data coupling. (The app-era per-story stub `QueryClient` and
 store reset were retired with the app Storybook at B7 — no storied component

--- a/packages/mapgen-studio-ui/scripts/design-sync-check.mjs
+++ b/packages/mapgen-studio-ui/scripts/design-sync-check.mjs
@@ -104,4 +104,60 @@ else
   console.error(
     "(no .design-sync/.cache/remote-sync.json — running unanchored: full first-sync scope)"
   );
-process.exit(run("node", args, { env }));
+const driverCode = run("node", args, { env });
+
+// 5. Repo-owned output assertions. These run even when the driver exits
+// non-zero (a pendingGrade verdict still produces a full ds-bundle), and they
+// exist REPO-SIDE deliberately: the converter under .ds-sync is a re-stageable
+// vendored artifact, so any guard that lives only inside it can be silently
+// lost to a re-stage. Both assert classes have already bitten once:
+//
+// (a) Preview reconciliation — the converter's per-file preview esbuild
+//     isolation treats transient failures (machine load, OOM) like authoring
+//     errors and silently ships floor cards in their place. Every component in
+//     config.json's docsMap must have a real compiled preview.
+// (b) Token-table purity — the emitted README's token tables must never list
+//     `--tw-*` engine variables outside the `other` bucket; the classifier
+//     patch for this lives in the vendored converter, so its silent loss to a
+//     re-stage would re-pollute the design-agent-facing token vocabulary.
+{
+  const { readFileSync } = await import("node:fs");
+  const postFailures = [];
+
+  const cfg = JSON.parse(readFileSync(join(PKG, ".design-sync", "config.json"), "utf8"));
+  const expected = Object.keys(cfg.docsMap ?? {});
+  const missingPreviews = expected.filter(
+    (name) => !existsSync(join(PKG, "ds-bundle", "_preview", `${name}.js`))
+  );
+  if (missingPreviews.length) {
+    postFailures.push(
+      `previews missing for ${missingPreviews.length} docsMap component(s) — a silent esbuild fallback shipped floor cards: ${missingPreviews.join(", ")}`
+    );
+  }
+
+  const readmePath = join(PKG, "ds-bundle", "README.md");
+  if (existsSync(readmePath)) {
+    const readme = readFileSync(readmePath, "utf8");
+    const tokensSection = readme.slice(readme.indexOf("\n## Tokens"));
+    const tokensBody = tokensSection.slice(0, tokensSection.indexOf("\n## ", 1));
+    // Emitted shape: one bullet per kind — `- **color** (14): \`--x\`, …`.
+    const leakedTw = [...tokensBody.matchAll(/^- \*\*(?!other\b)[\w-]+\*\*.*?(--tw-[\w-]+)/gm)].map(
+      ([, name]) => name
+    );
+    if (leakedTw.length) {
+      postFailures.push(
+        `README token buckets list Tailwind engine vars outside 'other' (${[...new Set(leakedTw)].join(", ")}) — the .ds-sync emit.mjs --tw- classifier patch was lost (re-stage?)`
+      );
+    }
+  } else {
+    postFailures.push("ds-bundle/README.md missing after the driver run");
+  }
+
+  if (postFailures.length) {
+    console.error("\n✗ design-sync-check output assertions failed:");
+    for (const f of postFailures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+  console.error("\n✓ output assertions: previews reconciled, token tables clean");
+}
+process.exit(driverCode);

--- a/packages/mapgen-studio-ui/scripts/verify.mjs
+++ b/packages/mapgen-studio-ui/scripts/verify.mjs
@@ -1,6 +1,11 @@
-// `verify` — fast artifact-contract assertions over dist/ (CI's fifth target).
+// `verify` — fast artifact-contract assertions over dist/, wired into the
+// root `ci` script (`nx run-many -t … verify`). Assertion 0 below checks that
+// wiring on every run: a guard that only claims enforcement is worse than no
+// guard (the export floor exists precisely because a missing barrel export —
+// `toast` — once shipped unnoticed).
 //
 // Asserts the built package still honors its published contract:
+//   0. The root package.json `ci` script actually runs the `verify` target.
 //   1. dist/index.js exists and carries at least EXPECTED_MIN_EXPORTS named
 //      exports (the floor RISES as each extraction branch lands components —
 //      currently: 45 components + TooltipProvider + lib exports).
@@ -52,6 +57,16 @@ const failures = [];
 const assert = (cond, msg) => {
   if (!cond) failures.push(msg);
 };
+
+// 0 — enforcement wiring: this guard must stay in the CI run set.
+{
+  const rootPkg = JSON.parse(readFileSync(join(pkgRoot, "..", "..", "package.json"), "utf8"));
+  const ciScript = rootPkg.scripts?.ci ?? "";
+  assert(
+    /\bverify\b/.test(ciScript),
+    `root package.json "ci" script does not run the verify target (got: "${ciScript}") — the artifact-contract guard is unenforced`
+  );
+}
 
 // 1 + 2 — JS artifact and its import discipline
 assert(existsSync(dist("index.js")), "dist/index.js missing — tsup did not run");

--- a/packages/mapgen-studio-ui/src/components/composites/AppHeader.tsx
+++ b/packages/mapgen-studio-ui/src/components/composites/AppHeader.tsx
@@ -101,6 +101,9 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   className,
 }) => {
   const headerRef = React.useRef<HTMLElement | null>(null);
+  // Instance-scoped id: docs pages and design compositions mount multiple
+  // headers — a hardcoded id would cross-wire aria-controls between them.
+  const setupPanelId = React.useId();
   const [setupOpen, setSetupOpen] = React.useState(false);
   // Token-driven chrome; theme follows the single `.dark` class. The header
   // docks float over the deck.gl map, so they ride the `popover` tier.
@@ -200,7 +203,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
                   variant="outline"
                   size="icon"
                   aria-expanded={setupOpen}
-                  aria-controls="app-header-setup-panel"
+                  aria-controls={setupPanelId}
                   aria-label="Game setup"
                   title="Game setup"
                   onClick={() => setSetupOpen((open) => !open)}
@@ -223,7 +226,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
 
         {setupOpen ? (
           <div
-            id="app-header-setup-panel"
+            id={setupPanelId}
             className={`flex min-h-10 max-w-full flex-wrap items-center justify-center gap-x-3 gap-y-2 px-3 py-1.5 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}
           >
             <div className="flex items-center gap-2">

--- a/packages/mapgen-studio-ui/src/components/composites/MapConfigSaveDialog.stories.tsx
+++ b/packages/mapgen-studio-ui/src/components/composites/MapConfigSaveDialog.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MapConfigSaveDialog } from "@swooper/mapgen-studio-ui";
 import { fn } from "storybook/test";
-import { MapConfigSaveDialog } from "./MapConfigSaveDialog.js";
 
 /** Keeps the save dialog open with realistic current-config defaults for interaction tests. */
 const meta = {
-  title: "Composites/MapConfigSaveDialog",
+  title: "composites/MapConfigSaveDialog",
   component: MapConfigSaveDialog,
   args: {
     open: true,

--- a/packages/mapgen-studio-ui/src/components/composites/WaterStatsSection.tsx
+++ b/packages/mapgen-studio-ui/src/components/composites/WaterStatsSection.tsx
@@ -11,6 +11,7 @@
 // ============================================================================
 
 import { Droplets } from "lucide-react";
+import { useId } from "react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip.js";
 import { DisclosureHeader } from "./DisclosureHeader.js";
 
@@ -113,6 +114,10 @@ export function WaterStatsSection<TRef extends WaterStatsLayerRef>({
   expanded,
   onExpandedChange,
 }: WaterStatsSectionProps<TRef>) {
+  // Instance-scoped id (before the early return — hooks are unconditional):
+  // the section renders on docs pages and in design compositions where
+  // multiple instances coexist; a hardcoded id would cross-wire aria-controls.
+  const listId = useId();
   const allRows = summary?.rows ?? [];
   const rows = allRows
     .map((row) => ({
@@ -144,7 +149,7 @@ export function WaterStatsSection<TRef extends WaterStatsLayerRef>({
           className="px-3 py-2"
           expanded={expanded}
           onToggle={onExpandedChange}
-          controls="explore-water-stats-list"
+          controls={listId}
           icon={<Droplets className={`w-3.5 h-3.5 shrink-0 ${textSecondary}`} />}
           title={
             <span className={`text-data font-semibold ${textSecondary} uppercase tracking-wider`}>
@@ -163,7 +168,7 @@ export function WaterStatsSection<TRef extends WaterStatsLayerRef>({
       </div>
       {expanded ? (
         <div
-          id="explore-water-stats-list"
+          id={listId}
           className={`flex-shrink-0 border-b ${borderSubtle} max-h-[220px] overflow-y-auto custom-scrollbar`}
         >
           {rows.map((row) => (

--- a/packages/mapgen-studio-ui/src/components/panels/ExplorePanel.tsx
+++ b/packages/mapgen-studio-ui/src/components/panels/ExplorePanel.tsx
@@ -17,7 +17,7 @@ import {
   Maximize,
   SquareStack,
 } from "lucide-react";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useId, useState } from "react";
 import { iconButton, iconButtonActive } from "../../lib/iconButton.js";
 import { LAYOUT } from "../../lib/layout.js";
 import { cn } from "../../lib/utils.js";
@@ -187,6 +187,13 @@ export function ExplorePanel<TRef extends WaterStatsLayerRef = WaterStatsLayerRe
   waterStatsExpanded: waterStatsExpandedProp,
   onWaterStatsExpandedChange,
 }: ExplorePanelProps<TRef>) {
+  // Instance-scoped ids: the panel renders on Storybook docs pages and in
+  // synced design compositions where multiple instances coexist — hardcoded
+  // ids would cross-wire aria-controls between instances.
+  const uid = useId();
+  const stageListId = `${uid}-stage-list`;
+  const stepListId = `${uid}-step-list`;
+  const layersListId = `${uid}-layers-list`;
   const [localStageExpanded, setLocalStageExpanded] = useState(true);
   const [localStepExpanded, setLocalStepExpanded] = useState(true);
   const [localLayersExpanded, setLocalLayersExpanded] = useState(true);
@@ -391,7 +398,7 @@ export function ExplorePanel<TRef extends WaterStatsLayerRef = WaterStatsLayerRe
           className="px-3 py-2.5"
           expanded={isStageExpanded}
           onToggle={setIsStageExpanded}
-          controls="explore-stage-list"
+          controls={stageListId}
           icon={<Compass className={cn("w-4 h-4 shrink-0", textSecondary)} />}
           title={<span className={cn("text-[13px] font-semibold", textPrimary)}>Stage</span>}
           summary={
@@ -404,7 +411,7 @@ export function ExplorePanel<TRef extends WaterStatsLayerRef = WaterStatsLayerRe
       </div>
       {isStageExpanded ? (
         <div
-          id="explore-stage-list"
+          id={stageListId}
           className={cn(
             "flex-shrink-0 py-1 border-b",
             borderSubtle,
@@ -435,7 +442,7 @@ export function ExplorePanel<TRef extends WaterStatsLayerRef = WaterStatsLayerRe
           className="px-3 py-2"
           expanded={isStepExpanded}
           onToggle={setIsStepExpanded}
-          controls="explore-step-list"
+          controls={stepListId}
           icon={<Layers className={cn("w-3.5 h-3.5 shrink-0", textSecondary)} />}
           title={
             <span
@@ -454,7 +461,7 @@ export function ExplorePanel<TRef extends WaterStatsLayerRef = WaterStatsLayerRe
       </div>
       {isStepExpanded ? (
         <div
-          id="explore-step-list"
+          id={stepListId}
           className={cn(
             "flex-shrink-0 pb-2 border-b",
             borderSubtle,
@@ -500,7 +507,7 @@ export function ExplorePanel<TRef extends WaterStatsLayerRef = WaterStatsLayerRe
           className="w-auto flex-1 min-w-0 pl-3 pr-2 py-2"
           expanded={isLayersExpanded}
           onToggle={setIsLayersExpanded}
-          controls="explore-layers-list"
+          controls={layersListId}
           icon={<SquareStack className={cn("w-3.5 h-3.5 shrink-0", textSecondary)} />}
           title={
             <span
@@ -534,7 +541,7 @@ export function ExplorePanel<TRef extends WaterStatsLayerRef = WaterStatsLayerRe
       </div>
       {isLayersExpanded ? (
         <div
-          id="explore-layers-list"
+          id={layersListId}
           className={cn(
             "flex-shrink-0 pb-2 border-b",
             borderSubtle,

--- a/packages/mapgen-studio-ui/src/components/panels/RecipePanel.tsx
+++ b/packages/mapgen-studio-ui/src/components/panels/RecipePanel.tsx
@@ -8,7 +8,7 @@
 
 import type { MapConfigSaveDeployStatus } from "@civ7/studio-contract";
 import { BookOpen, Eraser, Link, Power, Save, Settings, Undo2 } from "lucide-react";
-import React, { useState } from "react";
+import React, { useId, useState } from "react";
 import type { XSchema } from "typebox/schema";
 import { iconButton, iconButtonActive } from "../../lib/iconButton.js";
 import { LAYOUT } from "../../lib/layout.js";
@@ -132,6 +132,12 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
   // ==========================================================================
   // Local State
   // ==========================================================================
+  // Instance-scoped section ids: the panel renders on docs pages and in design
+  // compositions where multiple instances coexist — hardcoded ids would
+  // cross-wire the disclosure headers' aria-controls between instances.
+  const uid = useId();
+  const recipeSectionId = `${uid}-recipe-section`;
+  const configSectionId = `${uid}-config-section`;
   const [localRecipeCollapsed, setLocalRecipeCollapsed] = useState(false);
   const [localConfigCollapsed, setLocalConfigCollapsed] = useState(false);
   const [localConfigEditingEnabled, setLocalConfigEditingEnabled] = useState(true);
@@ -234,7 +240,7 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
             chevron={false}
             expanded={!recipeCollapsed}
             onToggle={() => setRecipeCollapsed(!recipeCollapsed)}
-            controls="recipe-panel-recipe-section"
+            controls={recipeSectionId}
             icon={<BookOpen className={cn("w-4 h-4 shrink-0", textSecondary)} aria-hidden="true" />}
             title={<span className={cn("text-[13px] font-semibold", textPrimary)}>Recipe</span>}
             trailing={
@@ -250,7 +256,7 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
         {/* Recipe and complete-config selection */}
         {!recipeCollapsed && (
           <div
-            id="recipe-panel-recipe-section"
+            id={recipeSectionId}
             className={cn("flex-shrink-0 px-4 py-3 space-y-2 border-b", borderSubtle)}
           >
             <div className="flex items-center gap-3">
@@ -307,7 +313,7 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
             chevron={false}
             expanded={!configCollapsed}
             onToggle={() => setConfigCollapsed(!configCollapsed)}
-            controls="recipe-panel-config-section"
+            controls={configSectionId}
             icon={<Settings className={cn("w-4 h-4 shrink-0", textSecondary)} aria-hidden="true" />}
             title={<span className={cn("text-[13px] font-semibold", textPrimary)}>Config</span>}
             // role="button" div (not a <button>) because the trailing zone nests
@@ -382,7 +388,7 @@ export const RecipePanel: React.FC<RecipePanelProps> = ({
         {/* Config Content */}
         {!configCollapsed && (
           <div
-            id="recipe-panel-config-section"
+            id={configSectionId}
             className="flex-1 overflow-y-auto overflow-x-hidden"
           >
             {/* Config form (flat-and-flush delta 1): flush — no horizontal

--- a/packages/mapgen-studio-ui/src/components/panels/recipe-dag/PipelineStage.tsx
+++ b/packages/mapgen-studio-ui/src/components/panels/recipe-dag/PipelineStage.tsx
@@ -1,6 +1,6 @@
 import type { RecipeDagResult } from "@civ7/studio-contract";
 import { AlertTriangle, ChevronDown, Loader2, Workflow } from "lucide-react";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useId, useMemo, useState } from "react";
 import { useResolvedTheme } from "../../../lib/useResolvedTheme.js";
 import { cn } from "../../../lib/utils.js";
 import { EmptyState } from "../../composites/EmptyState.js";
@@ -67,6 +67,11 @@ export interface PipelineStageProps {
 }
 
 export function PipelineStage(props: PipelineStageProps) {
+  // Instance-scoped SVG marker ids: docs pages render multiple DAGs on one
+  // document, and duplicate marker ids make `url(#…)` resolution ambiguous.
+  const uid = useId();
+  const arrowMarkerId = `${uid}-arrow`;
+  const arrowActiveMarkerId = `${uid}-arrow-active`;
   const {
     recipeId,
     dag,
@@ -245,7 +250,7 @@ export function PipelineStage(props: PipelineStageProps) {
               >
                 <defs>
                   <marker
-                    id="recipe-dag-arrow"
+                    id={arrowMarkerId}
                     markerWidth="10"
                     markerHeight="10"
                     refX="8"
@@ -256,7 +261,7 @@ export function PipelineStage(props: PipelineStageProps) {
                     <path d="M0,0 L0,6 L8,3 z" fill="context-stroke" />
                   </marker>
                   <marker
-                    id="recipe-dag-arrow-active"
+                    id={arrowActiveMarkerId}
                     markerWidth="10"
                     markerHeight="10"
                     refX="8"
@@ -329,6 +334,8 @@ export function PipelineStage(props: PipelineStageProps) {
                       selected={selected}
                       related={related}
                       focusActive={focusActive}
+                      arrowMarkerId={arrowMarkerId}
+                      arrowActiveMarkerId={arrowActiveMarkerId}
                       accent={
                         focusActive && related
                           ? getStageAccent(edge.fromStageId)
@@ -406,9 +413,9 @@ export function PipelineStage(props: PipelineStageProps) {
                     Artifact diagnostics
                   </div>
                   <ul className="grid gap-1 sm:grid-cols-2">
-                    {dag.diagnostics.slice(0, 6).map((diagnostic, index) => (
+                    {dag.diagnostics.slice(0, 6).map((diagnostic) => (
                       <li
-                        key={`${diagnostic.kind}-${diagnostic.artifact.id}-${index}`}
+                        key={`${diagnostic.kind}-${diagnostic.artifact.id}`}
                         className="flex min-w-0 items-center gap-1 truncate"
                       >
                         <span className="truncate">{diagnostic.kind}</span>
@@ -448,8 +455,11 @@ const StageEdge = React.memo(function StageEdge(props: {
   related: boolean;
   focusActive: boolean;
   accent: string;
+  arrowMarkerId: string;
+  arrowActiveMarkerId: string;
 }) {
-  const { edge, selected, related, focusActive, accent } = props;
+  const { edge, selected, related, focusActive, accent, arrowMarkerId, arrowActiveMarkerId } =
+    props;
   return (
     <g>
       <path
@@ -458,7 +468,7 @@ const StageEdge = React.memo(function StageEdge(props: {
         stroke={accent}
         strokeWidth={selected ? "3" : focusActive && related ? "2.4" : "1.35"}
         markerEnd={
-          focusActive && related ? "url(#recipe-dag-arrow-active)" : "url(#recipe-dag-arrow)"
+          focusActive && related ? `url(#${arrowActiveMarkerId})` : `url(#${arrowMarkerId})`
         }
         opacity={
           selected ? "0.96" : focusActive && related ? "0.82" : focusActive ? "0.22" : "0.42"
@@ -500,7 +510,10 @@ const StageNode = React.memo(function StageNode(props: {
   const stageAccent = getRecipeDagDomainLaneColors(stageDomainId, isLightMode).accent;
   const activeNodeAccent = selected || edgeActive ? stageAccent : null;
   const zIndex = selected || edgeActive ? (expanded ? 95 : 85) : expanded ? 70 : dimmed ? 20 : 30;
-  const expandedPanelId = `recipe-dag-stage-${stage.stageId}-steps`;
+  // Instance-scoped: stageId alone is unique within one DAG but collides when
+  // two PipelineStage instances render the same recipe on one docs page.
+  const uid = useId();
+  const expandedPanelId = `${uid}-steps`;
   return (
     <article
       className={cn(

--- a/packages/mapgen-studio-ui/src/components/ui/sonner.stories.tsx
+++ b/packages/mapgen-studio-ui/src/components/ui/sonner.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Toaster } from "@swooper/mapgen-studio-ui";
+// Both from the package barrel: the story exercises the SAME public contract
+// synced designs use — `toast` must ride the barrel (LEDGER adjudication 8) so
+// this story would catch it falling off, which importing "sonner" cannot.
+import { Toaster, toast } from "@swooper/mapgen-studio-ui";
 import { useEffect } from "react";
-import { toast } from "sonner";
 
 /**
  * Adapted from `.design-sync/previews/Toaster.tsx`. Toaster is sonner bound to the

--- a/packages/mapgen-studio-ui/test/PipelineStage.test.tsx
+++ b/packages/mapgen-studio-ui/test/PipelineStage.test.tsx
@@ -36,10 +36,18 @@ describe("PipelineStage", () => {
     expect(html).toContain(">hydrography<");
     expect(html).toContain('aria-pressed="true"');
     expect(html).toContain('aria-expanded="true"');
-    expect(html).toContain('aria-controls="recipe-dag-stage-shape-steps"');
+    // Ids are useId-derived (instance-scoped); assert the LINKAGE, not a
+    // literal: the expanded toggle controls a steps panel that exists.
+    const controlsMatch = html.match(/aria-controls="([^"]*-steps)"/);
+    expect(controlsMatch).not.toBeNull();
+    expect(html).toContain(`id="${(controlsMatch as RegExpMatchArray)[1]}"`);
     expect(html).toContain('data-stage-expanded="true"');
     expect(html).toContain("z-index:95");
-    expect(html).toContain('marker-end="url(#recipe-dag-arrow-active)"');
+    // Same for the SVG markers: the active edge's marker-end must reference
+    // the marker id the defs actually declare.
+    const activeMarker = html.match(/<marker id="([^"]*-arrow-active)"/);
+    expect(activeMarker).not.toBeNull();
+    expect(html).toContain(`marker-end="url(#${(activeMarker as RegExpMatchArray)[1]})"`);
     expect(html).toContain('stroke="#f59e0b"');
     expect(html).toContain('aria-label="Select dependency hydrography"');
     expect(html).toContain('data-edge-label-selected="false"');
@@ -68,7 +76,9 @@ describe("PipelineStage", () => {
     expect(html).toContain(`stroke="${PIPELINE_EDGE_INK}"`);
     expect(html).toContain("border-border bg-popover text-muted-foreground");
     expect(html).toContain(" L ");
-    expect(html).toContain('marker-end="url(#recipe-dag-arrow)"');
+    const idleMarker = html.match(/<marker id="([^"]*-arrow)"/);
+    expect(idleMarker).not.toBeNull();
+    expect(html).toContain(`marker-end="url(#${(idleMarker as RegExpMatchArray)[1]})"`);
     expect(html).not.toContain("border-color:#f59e0b");
   });
 

--- a/packages/mapgen-studio-ui/test/storyContract.test.ts
+++ b/packages/mapgen-studio-ui/test/storyContract.test.ts
@@ -1,0 +1,148 @@
+// Story-contract guards: the stories are the design-sync fidelity oracle, so
+// what they exercise and how they are grouped must be MACHINE-CHECKED, not
+// comment-enforced. Three invariant families, each of which has already
+// drifted once in this repo's history:
+//
+// 1. Import contract — story value-imports ride the package's public surface
+//    (or sanctioned tooling), never a component's relative path and never a
+//    third-party module the barrel re-exports (the `toast`-from-"sonner" case:
+//    the story stayed green while the public contract it claimed to prove was
+//    broken).
+// 2. Title taxonomy — story titles are the sync's card-group authority; each
+//    title must agree with .design-sync/config.json's docsMap, and docsMap
+//    must be a bijection with the story files (the "Composites/" case split).
+// 3. Doc truth — behavior claims shipped to design agents (conventions.md)
+//    are derived from source, not hand-maintained prose (the "AppFooter
+//    self-provides a TooltipProvider" case — flipped eras ago, doc never
+//    followed).
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const componentsRoot = join(pkgRoot, "src", "components");
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir).flatMap((name) => {
+    const full = join(dir, name);
+    return statSync(full).isDirectory() ? walk(full) : [full];
+  });
+
+const storyFiles = walk(componentsRoot).filter((f) => f.endsWith(".stories.tsx"));
+
+const config = JSON.parse(
+  readFileSync(join(pkgRoot, ".design-sync", "config.json"), "utf8")
+) as { docsMap: Record<string, string> };
+const docsMap = config.docsMap;
+
+/** Every `import … from "spec"` (and side-effect `import "spec"`), with type-only flag. */
+const parseImports = (source: string): Array<{ spec: string; typeOnly: boolean }> => {
+  const out: Array<{ spec: string; typeOnly: boolean }> = [];
+  const re = /import\s+(type\s+)?(?:[\w*{}\s,$]*?from\s+)?"([^"]+)"/g;
+  for (const m of source.matchAll(re)) out.push({ spec: m[2] as string, typeOnly: !!m[1] });
+  return out;
+};
+
+describe("story import contract (the public API is the story contract)", () => {
+  const EXACT = new Set(["@swooper/mapgen-studio-ui", "react", "lucide-react", "@rjsf/utils"]);
+  const PREFIXES = ["storybook", "@storybook/"];
+
+  it("every story value-import comes from the package name or sanctioned tooling", () => {
+    const violations: string[] = [];
+    for (const file of storyFiles) {
+      const source = readFileSync(file, "utf8");
+      for (const { spec, typeOnly } of parseImports(source)) {
+        if (typeOnly) continue;
+        if (EXACT.has(spec)) continue;
+        if (PREFIXES.some((p) => spec.startsWith(p))) continue;
+        // Relative imports may only reach the shared storybook helpers — a
+        // relative COMPONENT import bypasses the barrel and stops the story
+        // from proving the export exists.
+        if (spec.startsWith(".") && spec.includes("/storybook/")) continue;
+        violations.push(`${file.slice(pkgRoot.length + 1)}: "${spec}"`);
+      }
+    }
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+});
+
+describe("story title taxonomy (titles are the sync's card-group authority)", () => {
+  const titles = new Map<string, { file: string; prefix: string; component: string }>();
+  for (const file of storyFiles) {
+    const source = readFileSync(file, "utf8");
+    const m = source.match(/title:\s*"([^"]+)"/);
+    expect(m, `${file}: no title found`).toBeTruthy();
+    const title = (m as RegExpMatchArray)[1] as string;
+    const parts = title.split("/");
+    expect(parts, `${file}: title "${title}" must be exactly group/Component`).toHaveLength(2);
+    const [prefix, component] = parts as [string, string];
+    titles.set(component, { file, prefix, component });
+  }
+
+  it("titles use a lowercase group prefix and a PascalCase component segment", () => {
+    for (const { file, prefix, component } of titles.values()) {
+      expect(prefix, `${file}: group "${prefix}" must be lowercase`).toMatch(/^[a-z][a-z-]*$/);
+      expect(component, `${file}: segment "${component}" must be PascalCase`).toMatch(
+        /^[A-Z][A-Za-z0-9]*$/
+      );
+    }
+  });
+
+  it("every story component is in docsMap and its prefix matches the mapped group", () => {
+    for (const { file, prefix, component } of titles.values()) {
+      const group = docsMap[component];
+      expect(group, `${file}: "${component}" missing from .design-sync/config.json docsMap`)
+        .toBeTruthy();
+      expect(prefix, `${file}: title group "${prefix}" disagrees with docsMap ${group}`).toBe(
+        basename(group as string, ".md")
+      );
+    }
+  });
+
+  it("docsMap is a bijection with the story files", () => {
+    const storied = [...titles.keys()].sort();
+    const mapped = Object.keys(docsMap).sort();
+    expect(storied).toEqual(mapped);
+  });
+
+  it("EXCLUSIONS.md census numerals match the actual storied-component count", () => {
+    const exclusions = readFileSync(join(pkgRoot, ".storybook", "EXCLUSIONS.md"), "utf8");
+    for (const m of exclusions.matchAll(/\b(\d+)-component\b/g)) {
+      expect(Number(m[1]), `EXCLUSIONS.md claims a ${m[1]}-component surface`).toBe(titles.size);
+    }
+  });
+});
+
+describe("conventions.md truth (behavior claims shipped to design agents)", () => {
+  const conventions = readFileSync(join(pkgRoot, ".design-sync", "conventions.md"), "utf8");
+
+  // Components whose source composes the tooltip primitive need the ambient
+  // provider; the conventions doc must name every one of them. Derived from
+  // source so a new tooltip consumer (or a provider-policy flip) fails here
+  // instead of aging in prose.
+  it("names every tooltip-consuming component in the TooltipProvider bullet", () => {
+    const consumers = walk(componentsRoot)
+      .filter((f) => f.endsWith(".tsx") && !f.endsWith(".stories.tsx"))
+      .filter((f) => /from\s+"[^"]*\/ui\/tooltip\.js"/.test(readFileSync(f, "utf8")))
+      .map((f) => basename(f, ".tsx"))
+      .filter((name) => name in docsMap);
+    expect(consumers.length).toBeGreaterThan(0);
+    for (const name of consumers) {
+      expect(conventions, `conventions.md must list \`${name}\` as needing TooltipProvider`).toMatch(
+        new RegExp(`\`${name}\``)
+      );
+    }
+  });
+
+  it("never claims a component self-provides a TooltipProvider unless its source does", () => {
+    for (const m of conventions.matchAll(/`(\w+)`\s+self-provides/g)) {
+      const name = m[1] as string;
+      const file = walk(componentsRoot).find((f) => basename(f, ".tsx") === name);
+      const mounts = file ? /<TooltipProvider/.test(readFileSync(file, "utf8")) : false;
+      expect(mounts, `conventions.md claims \`${name}\` self-provides a TooltipProvider`).toBe(
+        true
+      );
+    }
+  });
+});


### PR DESCRIPTION
This PR lands the first domino (R1 — Rails) of the Setup Correctness initiative: turning on Biome's React lint domain, wiring all recurrence guards so they actually execute, and fixing the instance-safety violations the new rules surface.

## Biome React lint domain

Enables `linter.domains.react = "recommended"` in `biome.json`, which activates `useExhaustiveDependencies`, `useHookAtTopLevel`, `useJsxKeyInIterable`, and `useUniqueElementIds` (among others) through the domain rather than as hand-picked rules. The five intentional ref-pattern exhaustive-deps sites (`useDeckAutofit` ×2, `useKeyboardShortcuts`, `DeckCanvas`) are converted to `biome-ignore` with explanatory reasons, then the now-redundant hand-picked hook rules are removed so the domain owns them cleanly.

`useUniqueElementIds` is enabled as an error via an override scoped to `packages/mapgen-studio-ui/src/**` (stories excluded), enforcing instance-safe DOM ids across the package.

## Instance-safe DOM ids (`useId`)

Replaces every hardcoded `id=` string in the UI package with `React.useId()`-derived ids. Affected components: `AppHeader` (setup panel), `ExplorePanel` (stage/step/layers disclosure panels), `RecipePanel` (recipe/config sections), `WaterStatsSection` (stats list), `PipelineStage` (SVG arrow markers and per-node expanded panels). This matters because Storybook docs pages and design compositions render multiple instances on one document — hardcoded ids cross-wire `aria-controls` between them and make SVG `url(#…)` marker references ambiguous.

The `PipelineStage` test is updated to assert the aria-controls/id linkage and marker-end/marker-id linkage structurally rather than against literal strings, since the ids are now instance-derived.

The diagnostic list key in `PipelineStage` is simplified from `kind-id-index` to `kind-id` (the index suffix was the `noArrayIndexKey` violation the domain caught).

## Recurrence guards that now actually run

**`verify` wired into CI:** The root `package.json` `ci` script gains the `verify` target (`nx run-many -t build,check,test,verify`). `verify.mjs` gains assertion 0, which checks on every run that the root `ci` script actually includes `verify` — a guard that only claims enforcement is worse than no guard.

**`design-sync-check` output assertions:** Two repo-owned post-run assertions are added to `design-sync-check.mjs`:
- Preview reconciliation: every component in `config.json`'s `docsMap` must have a compiled `_preview/<Name>.js` in `ds-bundle`; missing files mean the converter silently shipped floor cards.
- Token-table purity: the emitted `README.md` token tables must not list `--tw-*` engine variables outside the `other` bucket; a re-staged converter would silently drop the classifier patch and re-pollute the design-agent-facing token vocabulary.

## Story contract tests

A new `storyContract.test.ts` enforces three invariant families that have each drifted in this repo's history:

1. **Import contract** — every story value-import must come from the package barrel (`@swooper/mapgen-studio-ui`) or sanctioned tooling (Storybook, React, lucide-react, @rjsf/utils). Relative component imports and third-party re-exports (the `toast` from `"sonner"` case) are violations.
2. **Title taxonomy** — story titles must be `lowercase-group/PascalCaseComponent`, the group must match the `docsMap` entry, and `docsMap` must be a bijection with the story files. The `EXCLUSIONS.md` component-count numerals are also checked against the actual storied count.
3. **Conventions.md truth** — the tooltip-consumer list in `conventions.md` is derived from source (files that import `ui/tooltip.js`) rather than hand-maintained; any component claiming to self-provide a `TooltipProvider` is verified against its source.

## Story and doc fixes caught by the new tests

- `MapConfigSaveDialog.stories.tsx`: relative import replaced with the package barrel; title casing fixed from `"Composites/MapConfigSaveDialog"` to `"composites/MapConfigSaveDialog"`.
- `sonner.stories.tsx`: `toast` import moved from `"sonner"` to the package barrel.
- `conventions.md`: the `AppFooter` self-provides claim is corrected (it does not self-provide a `TooltipProvider`; the one-provider policy applies uniformly); `AppFooter` is added to the tooltip-consumer list.
- `EXCLUSIONS.md`: component census corrected from 47 to 45; stale reference to the "46-component" surface removed.

## Launch config

Both `mapgen-studio` debug entries are repointed from dead `bun run dev` / `bun run dev:frontend` invocations to `bunx nx run mapgen-studio:dev` and `bunx vite` respectively.