### PR TITLE
fix(habitat): bound shared grit acquisition

### DIFF
--- a/tools/habitat/README.md
+++ b/tools/habitat/README.md
@@ -37,7 +37,7 @@ nx run habitat:verify:package
 ```
 
 `pack` retains the exact release candidate and digest at
-`tools/habitat/artifacts/habitat-cli-0.1.0.tgz{,.sha256}`. `verify:package`
+`tools/habitat/artifacts/habitat-cli-0.1.1.tgz{,.sha256}`. `verify:package`
 consumes those files, rebuilds the exact committed Git tree from a disposable
 archive and frozen lockfile, and requires its package bytes to match before
 installing the retained tarball into two isolated-linker Nx workspaces. The
@@ -52,6 +52,12 @@ Packing uses a disposable staging tree with canonical modes: `bin/run.js` is
 `0755` and every ordinary package file is `0644`. Verification asserts every
 archive entry, so ambient worktree permissions cannot change the retained
 artifact.
+
+Version `0.1.1` is a compatibility release on the historical Civ7 portable
+line. It bounds and shares native Grit acquisition for current consumers while
+the Template-owned Habitat substrate is not yet distributable. It adds no new
+Habitat authority and must be retired when the first consumable Template
+release supplies equivalent aggregate evaluation.
 
 The runtime proof matrix is:
 

--- a/tools/habitat/package.json
+++ b/tools/habitat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@habitat/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Portable structural-policy CLI and Nx plugin for Habitat authority workspaces.",
   "repository": {
     "type": "git",

--- a/tools/habitat/src/resources/rule-diagnostics/providers/grit/check.ts
+++ b/tools/habitat/src/resources/rule-diagnostics/providers/grit/check.ts
@@ -27,9 +27,22 @@ import type { GritReport } from "./types.js";
 
 type NonEmptyGritRules = readonly [RuleGritFacts, ...RuleGritFacts[]];
 
+interface GritCheckPlan {
+  readonly rule: RuleGritFacts;
+  readonly roots: readonly [string, ...string[]];
+}
+
+type NonEmptyGritCheckPlans = readonly [GritCheckPlan, ...GritCheckPlan[]];
+
+interface GritCheckBatchAcquisition {
+  readonly acquisitions: ReadonlyMap<string, GritDiagnosticAcquisition>;
+  readonly participantRuleIds: ReadonlySet<string>;
+}
+
 interface MaterializedRule {
   readonly kind: "materialized";
   readonly rule: RuleGritFacts;
+  readonly roots: readonly [string, ...string[]];
   readonly pattern: MaterializedGritPattern;
 }
 
@@ -47,8 +60,8 @@ export const runGritCheckAcquisitionEffect = Effect.fn("grit.check.acquire")(fun
   roots: readonly [string, ...string[]],
   options: { readonly repoRoot: string; readonly grit: GritCommandService }
 ) {
-  const acquisitions = yield* runGritCheckAcquisitionsEffect([rule], roots, options);
-  return Option.getOrElse(Option.fromNullable(acquisitions.get(rule.id)), () =>
+  const batch = yield* runGritCheckAcquisitionsEffect([{ rule, roots }], options);
+  return Option.getOrElse(Option.fromNullable(batch.acquisitions.get(rule.id)), () =>
     preCommandFailure(
       "DiagnosticProviderSetupFailed",
       `Grit check produced no acquisition for selected rule ${rule.id}.`
@@ -57,19 +70,20 @@ export const runGritCheckAcquisitionEffect = Effect.fn("grit.check.acquire")(fun
 });
 
 /**
- * Acquires one check report for rules with exactly equal ordered acquisition roots.
- * Asset admission remains per rule; provider execution is shared only by valid peers.
+ * Acquires one check report across the union of selected exact-path rule roots.
+ * Asset admission and observed evidence remain projected independently per rule.
  */
 export const runGritCheckAcquisitionsEffect = Effect.fn("grit.check.acquireBatch")(function* (
-  rules: NonEmptyGritRules,
-  roots: readonly [string, ...string[]],
+  plans: NonEmptyGritCheckPlans,
   options: { readonly repoRoot: string; readonly grit: GritCommandService }
 ) {
   const materializations: readonly RuleMaterialization[] = yield* Effect.forEach(
-    rules,
-    (rule) =>
+    plans,
+    ({ rule, roots }) =>
       materializeGritPatternEffect(rule, options.repoRoot).pipe(
-        Effect.map((pattern): RuleMaterialization => ({ kind: "materialized", rule, pattern })),
+        Effect.map(
+          (pattern): RuleMaterialization => ({ kind: "materialized", rule, roots, pattern })
+        ),
         Effect.catchTag("GritPatternAssetInvalid", (error) =>
           Effect.succeed({
             kind: "failed",
@@ -81,22 +95,25 @@ export const runGritCheckAcquisitionsEffect = Effect.fn("grit.check.acquireBatch
     { concurrency: 1 }
   );
   const valid = materializations.flatMap(materializedRuleEntry);
-  const shared = yield* acquireSharedCheckEffect(nonEmptyMaterializations(valid), roots, options);
-  return new Map(
-    materializations.map((materialization) =>
-      materializationAcquisitionEntry(materialization, shared)
-    )
-  );
+  const shared = yield* acquireSharedCheckEffect(nonEmptyMaterializations(valid), options);
+  return {
+    acquisitions: new Map(
+      materializations.map((materialization) =>
+        materializationAcquisitionEntry(materialization, shared)
+      )
+    ),
+    participantRuleIds: new Set(valid.map(({ rule }) => rule.id)),
+  } satisfies GritCheckBatchAcquisition;
 });
 
 function materializationAcquisitionEntry(
   materialization: RuleMaterialization,
-  shared: Option.Option<GritDiagnosticAcquisition>
+  shared: ReadonlyMap<string, GritDiagnosticAcquisition>
 ): readonly [string, GritDiagnosticAcquisition] {
   const acquisition = Match.value(materialization).pipe(
     Match.when({ kind: "failed" }, ({ acquisition: failure }) => failure),
     Match.when({ kind: "materialized" }, ({ rule }) =>
-      Option.getOrElse(shared, () =>
+      Option.getOrElse(Option.fromNullable(shared.get(rule.id)), () =>
         preCommandFailure(
           "DiagnosticProviderSetupFailed",
           `Grit check produced no acquisition for materialized rule ${rule.id}.`
@@ -110,26 +127,30 @@ function materializationAcquisitionEntry(
 
 const acquireSharedCheckEffect = Effect.fn("grit.check.acquireShared")(function* (
   materializations: Option.Option<readonly [MaterializedRule, ...MaterializedRule[]]>,
-  roots: readonly [string, ...string[]],
   options: { readonly repoRoot: string; readonly grit: GritCommandService }
 ) {
   return yield* Match.value(materializations).pipe(
-    Match.when({ _tag: "None" }, () => Effect.succeed(Option.none<GritDiagnosticAcquisition>())),
-    Match.orElse(({ value }) => acquireMaterializedCheckEffect(value, roots, options))
+    Match.when({ _tag: "None" }, () =>
+      Effect.succeed(new Map<string, GritDiagnosticAcquisition>())
+    ),
+    Match.orElse(({ value }) => acquireMaterializedCheckEffect(value, options))
   );
 });
 
 const acquireMaterializedCheckEffect = Effect.fn("grit.check.acquireMaterialized")(function* (
   materializations: readonly [MaterializedRule, ...MaterializedRule[]],
-  roots: readonly [string, ...string[]],
   options: { readonly repoRoot: string; readonly grit: GritCommandService }
 ) {
-  const acquisition = yield* runMaterializedCheckEffect(materializations, roots, options).pipe(
+  return yield* runMaterializedCheckEffect(materializations, options).pipe(
     Effect.catchTag("GritScopedConfigInvalid", (error) =>
-      Effect.succeed(preCommandFailure("DiagnosticProviderSetupFailed", error.detail))
+      Effect.succeed(
+        sharedAcquisitions(
+          materializations,
+          preCommandFailure("DiagnosticProviderSetupFailed", error.detail)
+        )
+      )
     )
   );
-  return Option.some(acquisition);
 });
 
 function materializedRuleEntry(materialization: RuleMaterialization): readonly MaterializedRule[] {
@@ -155,13 +176,13 @@ function materializedPatterns(
 
 const runMaterializedCheckEffect = Effect.fn("grit.check.runMaterializedBatch")(function* (
   materializations: readonly [MaterializedRule, ...MaterializedRule[]],
-  roots: readonly [string, ...string[]],
   options: { readonly repoRoot: string; readonly grit: GritCommandService }
 ) {
   const workspace = yield* acquireScopedGritCatalogEffect(materializedPatterns(materializations));
   const fs = yield* FileSystem.FileSystem;
   const rules = materializedRules(materializations);
   const patternNames = materializedPatternNames(materializations);
+  const roots = unionRoots(materializations);
   const providerRequest = {
     patternNames,
     scanRoots: roots,
@@ -182,14 +203,39 @@ const runMaterializedCheckEffect = Effect.fn("grit.check.runMaterializedBatch")(
   );
   return yield* Match.value(capture).pipe(
     Match.when({ kind: "command-failed" }, (failure) =>
-      Effect.succeed(commandFailure(nativeRequest, failure))
+      Effect.succeed(sharedAcquisitions(materializations, commandFailure(nativeRequest, failure)))
     ),
     Match.when({ kind: "completed" }, ({ result, command }) =>
-      continueCompletedCheckEffect(rules, roots, result, nativeRequest, command, fs)
+      continueCompletedCheckEffect(
+        materializations,
+        rules,
+        roots,
+        result,
+        nativeRequest,
+        command,
+        fs
+      )
     ),
     Match.exhaustive
   );
 });
+
+function unionRoots(
+  materializations: readonly [MaterializedRule, ...MaterializedRule[]]
+): readonly [string, ...string[]] {
+  const [first, ...rest] = [...new Set(materializations.flatMap(({ roots }) => roots))].sort(
+    (left, right) => left.localeCompare(right)
+  );
+  if (first === undefined) throw new Error("Materialized Grit check batch has no roots.");
+  return [first, ...rest];
+}
+
+function sharedAcquisitions(
+  materializations: readonly MaterializedRule[],
+  acquisition: GritDiagnosticAcquisition
+): ReadonlyMap<string, GritDiagnosticAcquisition> {
+  return new Map(materializations.map(({ rule }) => [rule.id, acquisition]));
+}
 
 function materializedRules(
   materializations: readonly [MaterializedRule, ...MaterializedRule[]]
@@ -206,6 +252,7 @@ function materializedPatternNames(
 }
 
 function continueCompletedCheckEffect(
+  materializations: readonly [MaterializedRule, ...MaterializedRule[]],
   rules: NonEmptyGritRules,
   roots: readonly [string, ...string[]],
   result: Parameters<typeof parseGritCheckCommand>[0],
@@ -214,15 +261,18 @@ function continueCompletedCheckEffect(
   fs: FileSystem.FileSystem
 ) {
   return Match.value(checkAcquisitionEvidence(request, command)).pipe(
-    Match.when({ kind: "failed" }, ({ acquisition }) => Effect.succeed(acquisition)),
+    Match.when({ kind: "failed" }, ({ acquisition }) =>
+      Effect.succeed(sharedAcquisitions(materializations, acquisition))
+    ),
     Match.when({ kind: "accepted" }, ({ evidence }) =>
-      completeCapturedCheckEffect(rules, roots, result, evidence, fs)
+      completeCapturedCheckEffect(materializations, rules, roots, result, evidence, fs)
     ),
     Match.exhaustive
   );
 }
 
 const completeCapturedCheckEffect = Effect.fn("grit.check.completeCapture")(function* (
+  materializations: readonly [MaterializedRule, ...MaterializedRule[]],
   rules: NonEmptyGritRules,
   roots: readonly [string, ...string[]],
   result: Parameters<typeof parseGritCheckCommand>[0],
@@ -236,21 +286,35 @@ const completeCapturedCheckEffect = Effect.fn("grit.check.completeCapture")(func
     Match.when({ kind: "parse-failed" }, ({ failure, detail }) =>
       Effect.succeed({
         kind: "terminal" as const,
-        acquisition: parseAcquisitionFailure(failure, detail, evidence),
+        acquisitions: sharedAcquisitions(
+          materializations,
+          parseAcquisitionFailure(failure, detail, evidence)
+        ),
       })
     ),
     Match.when({ kind: "parsed-incomplete" }, ({ failure, detail }) =>
       Effect.succeed({
         kind: "terminal" as const,
-        acquisition: incompleteAcquisitionFailure(failure, detail, evidence),
+        acquisitions: sharedAcquisitions(
+          materializations,
+          incompleteAcquisitionFailure(failure, detail, evidence)
+        ),
       })
     ),
     Match.exhaustive
   );
   return Match.value(observation).pipe(
-    Match.when({ kind: "terminal" }, ({ acquisition }) => acquisition),
+    Match.when({ kind: "terminal" }, ({ acquisitions }) => acquisitions),
     Match.orElse(({ report, processed, results }) =>
-      reconcileCheckObservation(rules, roots, report, processed, results, evidence)
+      reconcileCheckObservation(
+        materializations,
+        rules,
+        roots,
+        report,
+        processed,
+        results,
+        evidence
+      )
     )
   );
 });
@@ -285,13 +349,14 @@ const canonicalCheckObservationEffect = Effect.fn("grit.check.canonicalize")(fun
 });
 
 function reconcileCheckObservation(
+  materializations: readonly [MaterializedRule, ...MaterializedRule[]],
   rules: NonEmptyGritRules,
   roots: readonly string[],
   report: GritReport,
   processed: CanonicalPaths,
   resultPaths: readonly Option.Option<string>[],
   evidence: GritCheckAcquisitionEvidence
-): GritDiagnosticAcquisition {
+): ReadonlyMap<string, GritDiagnosticAcquisition> {
   const processedPaths = Match.value(processed).pipe(
     Match.when({ kind: "complete" }, ({ paths }) => paths),
     Match.orElse(() => [])
@@ -313,13 +378,6 @@ function reconcileCheckObservation(
         `path-escape: processed path ${processedPath} is outside every admitted root.`
       )
     ),
-    ...roots.flatMap((root) =>
-      validationFailure(
-        !processedPaths.some((processedPath) => pathIsWithinRoot(processedPath, root)),
-        "DiagnosticOutputIncomplete",
-        `unobserved-root: Grit check provided no processed path for ${root}.`
-      )
-    ),
     ...report.results.flatMap((result, index) =>
       resultValidationFailures(
         selectedPatternNames,
@@ -331,11 +389,56 @@ function reconcileCheckObservation(
     ),
   ];
   return Match.value(Option.fromNullable(validationFailures[0])).pipe(
-    Match.when({ _tag: "None" }, () => completeCheckAcquisition(report, evidence)),
+    Match.when(
+      { _tag: "None" },
+      () =>
+        new Map(
+          materializations.map((materialization) => [
+            materialization.rule.id,
+            projectRuleAcquisition(materialization, report, processedPaths, resultPaths, evidence),
+          ])
+        )
+    ),
     Match.orElse(({ value: { failure, detail } }) =>
-      incompleteAcquisitionFailure(failure, detail, evidence)
+      sharedAcquisitions(materializations, incompleteAcquisitionFailure(failure, detail, evidence))
     )
   );
+}
+
+function projectRuleAcquisition(
+  materialization: MaterializedRule,
+  report: GritReport,
+  processedPaths: readonly string[],
+  resultPaths: readonly Option.Option<string>[],
+  evidence: GritCheckAcquisitionEvidence
+): GritDiagnosticAcquisition {
+  const missingRoot = materialization.roots.find(
+    (root) => !processedPaths.some((processedPath) => pathIsWithinRoot(processedPath, root))
+  );
+  if (missingRoot !== undefined) {
+    return incompleteAcquisitionFailure(
+      "DiagnosticOutputIncomplete",
+      `unobserved-root: Grit check provided no processed path for ${missingRoot}.`,
+      evidence
+    );
+  }
+
+  const paths = processedPaths.filter((observed) =>
+    materialization.roots.some((root) => pathIsWithinRoot(observed, root))
+  );
+  const results = report.results.flatMap((result, index) => {
+    const observedPath = resultPaths[index];
+    const observedIdentity = observedGritDiagnosticIdentity(result);
+    const belongsToRule =
+      observedIdentity.kind !== "observed-identity-mismatch" &&
+      observedIdentity.observedPatternIdentity === materialization.rule.patternName &&
+      Option.exists(observedPath, (candidate) =>
+        materialization.roots.some((root) => pathIsWithinRoot(candidate, root))
+      );
+    if (!belongsToRule || Option.isNone(observedPath)) return [];
+    return [{ ...result, path: observedPath.value }];
+  });
+  return completeCheckAcquisition({ paths, results }, evidence);
 }
 
 const canonicalPathsEffect = Effect.fn("grit.check.canonicalPaths")(function* (

--- a/tools/habitat/src/resources/rule-diagnostics/providers/grit/runner.ts
+++ b/tools/habitat/src/resources/rule-diagnostics/providers/grit/runner.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import path from "node:path";
 import type {
   RuleDiagnosticExecutionResult,
@@ -83,6 +84,13 @@ type GritExecutionUnit =
   | { readonly kind: "check-group"; readonly plans: readonly [CheckGritPlan, ...CheckGritPlan[]] }
   | { readonly kind: "single"; readonly plan: PlannedGritRule };
 
+interface ExactCheckGroup {
+  readonly plans: CheckGritPlan[];
+}
+
+/** Caps pattern-by-root expansion while still amortizing native Grit startup. */
+const maximumExactBatchWorkExpansion = 2;
+
 const runGritDiagnosticExecutionsEffect = Effect.fn("grit.diagnosticExecutions.run")(function* (
   selectedRules: readonly RuleGritFacts[],
   options: GritRunOptions
@@ -129,68 +137,52 @@ const executeTimedCheckGroupEffect = Effect.fn("grit.checkGroup.executeTimed")(f
 ) {
   const started = yield* Clock.currentTimeMillis;
   const canonicalOptions = { ...options, repoRoot: plans[0].repoRoot };
-  const acquisitions = yield* runGritCheckAcquisitionsEffect(
-    checkGroupRules(plans),
-    plans[0].roots,
+  const [firstPlan, ...remainingPlans] = plans;
+  const batch = yield* runGritCheckAcquisitionsEffect(
+    [
+      { rule: firstPlan.rule, roots: firstPlan.roots },
+      ...remainingPlans.map(({ rule, roots }) => ({ rule, roots })),
+    ],
     canonicalOptions
   ).pipe(Effect.scoped);
   const durationMs = Math.max(0, (yield* Clock.currentTimeMillis) - started);
-  const timing = sharedCheckTiming(plans, durationMs);
-  const observedRules = plans.flatMap((plan) =>
-    observedCheckRuleEntry(plan, acquisitions.get(plan.rule.id))
-  );
-  const projected = Option.match(Option.fromNullable(observedRules[0]), {
-    onNone: () => new Map<string, DiagnosticRunOutcome>(),
-    onSome: (firstObservation) =>
-      gritDiagnosticOutcomesFromReport(
-        observedRules.map(({ rule }) => rule),
-        firstObservation.report,
-        { repoRoot: canonicalOptions.repoRoot }
-      ),
-  });
+  const participants = plans.filter(({ rule }) => batch.participantRuleIds.has(rule.id));
+  const timing = sharedCheckTiming(participants, durationMs);
   return plans.map((plan) =>
     checkGroupExecution(
       plan,
-      acquisitions,
-      projected,
+      batch.acquisitions,
       canonicalOptions.repoRoot,
-      durationMs,
-      timing
+      batch.participantRuleIds.has(plan.rule.id) ? durationMs : 0,
+      batch.participantRuleIds.has(plan.rule.id) ? timing : undefined
     )
   );
 });
 
 function sharedCheckTiming(
-  plans: readonly [CheckGritPlan, ...CheckGritPlan[]],
+  plans: readonly CheckGritPlan[],
   durationMs: number
 ): RuleDiagnosticExecutionTiming | undefined {
-  return Match.value(plans.length).pipe(
-    Match.when(1, () => undefined),
-    Match.orElse(() => ({
-      kind: "shared" as const,
-      groupId: `rule-diagnostics:${plans.map(({ rule }) => rule.id).join(",")}`,
-      durationMs,
-      ruleCount: plans.length,
-    }))
-  );
+  if (plans.length <= 1) return undefined;
+  return {
+    kind: "shared",
+    groupId: `rule-diagnostics:${plans.map(({ rule }) => rule.id).join(",")}`,
+    durationMs,
+    ruleCount: plans.length,
+  };
 }
 
 function checkGroupExecution(
   plan: CheckGritPlan,
   acquisitions: ReadonlyMap<string, GritDiagnosticAcquisition>,
-  projected: ReadonlyMap<string, DiagnosticRunOutcome>,
   repoRoot: string,
   durationMs: number,
   timing: RuleDiagnosticExecutionTiming | undefined
 ): GritDiagnosticExecution {
-  const fallback = Option.match(Option.fromNullable(acquisitions.get(plan.rule.id)), {
+  const outcome = Option.match(Option.fromNullable(acquisitions.get(plan.rule.id)), {
     onNone: () => missingOutcome(plan.rule),
     onSome: (acquisition) => outcomeFromAcquisition(plan.rule, acquisition, repoRoot),
   });
-  const outcome = Option.getOrElse(
-    Option.fromNullable(projected.get(plan.rule.id)),
-    () => fallback
-  );
   return { outcome, durationMs, ...optionalTiming(timing) };
 }
 
@@ -201,91 +193,91 @@ function optionalTiming(timing: RuleDiagnosticExecutionTiming | undefined) {
   );
 }
 
-function observedCheckRuleEntry(
-  plan: CheckGritPlan,
-  acquisition: GritDiagnosticAcquisition | undefined
-) {
-  return Match.value(acquisition).pipe(
-    Match.when({ kind: "observed-complete", observation: { kind: "check" } }, ({ observation }) => [
-      { rule: plan.rule, report: observation.report },
-    ]),
-    Match.orElse(() => [])
-  );
-}
-
-function checkGroupRules(
-  plans: readonly [CheckGritPlan, ...CheckGritPlan[]]
-): readonly [RuleGritFacts, ...RuleGritFacts[]] {
-  const [first, ...rest] = plans;
-  return [first.rule, ...rest.map(({ rule }) => rule)];
-}
-
 function executionUnits(plans: readonly PlannedGritRule[]): readonly GritExecutionUnit[] {
-  const checkPlans = plans.filter(isCheckPlan);
-  const patternCounts = new Map<string, number>();
-  for (const plan of checkPlans) {
-    const key = plan.rule.patternName;
-    patternCounts.set(key, (patternCounts.get(key) ?? 0) + 1);
+  const occurrenceByPattern = new Map<string, number>();
+  const exactGroupByPlan = new Map<CheckGritPlan, ExactCheckGroup>();
+  const exactGroupsByOccurrence = new Map<number, ExactCheckGroup[]>();
+  const otherCheckPlans = plans.filter(
+    (plan): plan is CheckGritPlan => isCheckPlan(plan) && !hasExactPathCoverage(plan)
+  );
+  const otherPatternCounts = new Map<string, number>();
+  const otherRootGroups = new Map<string, CheckGritPlan[]>();
+  for (const plan of plans) {
+    if (!isCheckPlan(plan) || !hasExactPathCoverage(plan)) continue;
+    const occurrence = occurrenceByPattern.get(plan.rule.patternName) ?? 0;
+    occurrenceByPattern.set(plan.rule.patternName, occurrence + 1);
+    const groups = exactGroupsByOccurrence.get(occurrence) ?? [];
+    const group = groups.find(({ plans: peers }) => canShareExactCheckGroup(peers, plan)) ?? {
+      plans: [],
+    };
+    if (!groups.includes(group)) exactGroupsByOccurrence.set(occurrence, [...groups, group]);
+    group.plans.push(plan);
+    exactGroupByPlan.set(plan, group);
   }
-  const groups = new Map<string, CheckGritPlan[]>();
-  for (const plan of checkPlans) {
-    if ((patternCounts.get(plan.rule.patternName) ?? 0) > 1) continue;
+  for (const plan of otherCheckPlans) {
+    otherPatternCounts.set(
+      plan.rule.patternName,
+      (otherPatternCounts.get(plan.rule.patternName) ?? 0) + 1
+    );
+  }
+  for (const plan of otherCheckPlans) {
+    if ((otherPatternCounts.get(plan.rule.patternName) ?? 0) > 1) continue;
     const key = rootsKey(plan.roots);
-    groups.set(key, [...(groups.get(key) ?? []), plan]);
+    otherRootGroups.set(key, [...(otherRootGroups.get(key) ?? []), plan]);
   }
-  const emittedGroups = new Set<string>();
-  return plans.flatMap((plan) => planExecutionUnits(plan, patternCounts, groups, emittedGroups));
-}
 
-function planExecutionUnits(
-  plan: PlannedGritRule,
-  patternCounts: ReadonlyMap<string, number>,
-  groups: ReadonlyMap<string, readonly CheckGritPlan[]>,
-  emittedGroups: Set<string>
-): readonly GritExecutionUnit[] {
-  return Option.match(Option.liftPredicate(plan, isCheckPlan), {
-    onNone: () => singleExecutionUnit(plan),
-    onSome: (checkPlan) => checkPlanExecutionUnits(checkPlan, patternCounts, groups, emittedGroups),
+  const emittedExactGroups = new Set<ExactCheckGroup>();
+  const emittedOtherGroups = new Set<string>();
+  return plans.flatMap((plan) => {
+    if (!isCheckPlan(plan)) return singleExecutionUnit(plan);
+    if (hasExactPathCoverage(plan)) {
+      const group = exactGroupByPlan.get(plan);
+      if (group === undefined || emittedExactGroups.has(group)) return [];
+      emittedExactGroups.add(group);
+      return checkGroupUnit(group.plans, plan);
+    }
+    if ((otherPatternCounts.get(plan.rule.patternName) ?? 0) > 1) {
+      return singleExecutionUnit(plan);
+    }
+    const key = rootsKey(plan.roots);
+    if (emittedOtherGroups.has(key)) return [];
+    emittedOtherGroups.add(key);
+    return checkGroupUnit(otherRootGroups.get(key), plan);
   });
 }
 
-function checkPlanExecutionUnits(
-  plan: CheckGritPlan,
-  patternCounts: ReadonlyMap<string, number>,
-  groups: ReadonlyMap<string, readonly CheckGritPlan[]>,
-  emittedGroups: Set<string>
-): readonly GritExecutionUnit[] {
-  const duplicatedPattern = (patternCounts.get(plan.rule.patternName) ?? 0) > 1;
-  return Match.value(duplicatedPattern).pipe(
-    Match.when(true, () => singleExecutionUnit(plan)),
-    Match.orElse(() => groupedCheckExecutionUnits(plan, groups, emittedGroups))
+function canShareExactCheckGroup(
+  current: readonly CheckGritPlan[],
+  candidate: CheckGritPlan
+): boolean {
+  if (current.length === 0) return true;
+  const plans = [...current, candidate];
+  const union = uniquePlanRoots(plans);
+  const independentWork = plans.reduce((total, plan) => total + plan.roots.length, 0);
+  const batchedWork = plans.length * union.length;
+  const largestExistingArgv = Math.max(...plans.map(({ roots }) => rootArgumentBytes(roots)));
+  return (
+    rootArgumentBytes(union) <= largestExistingArgv &&
+    batchedWork <= independentWork * maximumExactBatchWorkExpansion
   );
 }
 
-function groupedCheckExecutionUnits(
-  plan: CheckGritPlan,
-  groups: ReadonlyMap<string, readonly CheckGritPlan[]>,
-  emittedGroups: Set<string>
-): readonly GritExecutionUnit[] {
-  const key = rootsKey(plan.roots);
-  return Match.value(emittedGroups.has(key)).pipe(
-    Match.when(true, () => []),
-    Match.orElse(() => emitCheckGroupExecutionUnit(key, plan, groups, emittedGroups))
-  );
+function uniquePlanRoots(plans: readonly CheckGritPlan[]): readonly string[] {
+  return [...new Set(plans.flatMap(({ roots }) => roots))];
 }
 
-function emitCheckGroupExecutionUnit(
-  key: string,
-  plan: CheckGritPlan,
-  groups: ReadonlyMap<string, readonly CheckGritPlan[]>,
-  emittedGroups: Set<string>
+function rootArgumentBytes(roots: readonly string[]): number {
+  return roots.reduce((total, root) => total + Buffer.byteLength(root) + 1, 0);
+}
+
+function checkGroupUnit(
+  plans: readonly CheckGritPlan[] | undefined,
+  fallback: CheckGritPlan
 ): readonly GritExecutionUnit[] {
-  emittedGroups.add(key);
-  const [first, ...rest] = groups.get(key) ?? [];
-  return Option.match(Option.fromNullable(first), {
-    onNone: () => singleExecutionUnit(plan),
-    onSome: (head) => [{ kind: "check-group", plans: [head, ...rest] }],
-  });
+  const [first, ...rest] = plans ?? [];
+  return first === undefined
+    ? singleExecutionUnit(fallback)
+    : [{ kind: "check-group", plans: [first, ...rest] }];
 }
 
 function singleExecutionUnit(plan: PlannedGritRule): readonly GritExecutionUnit[] {
@@ -294,6 +286,10 @@ function singleExecutionUnit(plan: PlannedGritRule): readonly GritExecutionUnit[
 
 function isCheckPlan(plan: PlannedGritRule): plan is CheckGritPlan {
   return plan.kind === "execute" && plan.rule.runner.acquisition.kind === "check";
+}
+
+function hasExactPathCoverage(plan: CheckGritPlan): boolean {
+  return plan.rule.pathCoverage.every(({ kind }) => kind === "exact-path");
 }
 
 function rootsKey(roots: readonly string[]): string {

--- a/tools/habitat/test/lib/grit-provider.test.ts
+++ b/tools/habitat/test/lib/grit-provider.test.ts
@@ -2335,53 +2335,123 @@ describe("Grit generic acquisition and public disposition", () => {
     expect(executions.get("beta")?.timing).toEqual(executions.get("alpha")?.timing);
   });
 
-  test("keeps different roots and duplicate pattern identities in sequential commands", async () => {
-    const cases = [
-      [
-        rule("alpha", "alpha_pattern", providerPattern, [providerRoot]),
-        rule("docs", "docs_pattern", providerPattern, ["docs"]),
-      ],
-      [
-        rule("duplicate-a", "duplicate_pattern", providerPattern, [providerRoot]),
-        rule("duplicate-b", "duplicate_pattern", providerPattern, [providerRoot]),
-      ],
+  test("shares one immutable catalog across compatible exact roots", async () => {
+    const selectedRules = [
+      exactRule("alpha", "alpha_pattern", [providerRoot], [providerFile]),
+      exactRule(
+        "broad",
+        "broad_pattern",
+        [providerRoot, "docs"],
+        [providerFile, "docs/PRODUCT.md"]
+      ),
     ] as const;
-    for (const selectedRules of cases) {
-      const observed: Array<readonly string[]> = [];
-      const catalogs: string[] = [];
+    const observed: Array<readonly string[]> = [];
+    const catalogs: string[] = [];
+    const grit = makeFakeGritCommandService(
+      (request, providerRequest) => {
+        const checkRequest = requireCheckProviderRequest(providerRequest);
+        observed.push([...checkRequest.scanRoots]);
+        catalogs.push(readFileSync(path.join(request.cwd, ".grit/grit.yaml"), "utf8"));
+        return makeHabitatCommandResult(request, {
+          stderr: captureOutput(jsonDocument({ paths: [...checkRequest.scanRoots], results: [] })),
+        });
+      },
+      { repoRoot }
+    );
+
+    const executions = await Effect.runPromise(
+      runGritRulesEffect(selectedRules, { repoRoot, grit }).pipe(Effect.provide(NodeContext.layer))
+    );
+
+    expect([...executions.keys()]).toEqual(selectedRules.map(({ id }) => id));
+    expect(observed).toHaveLength(1);
+    expect(observed[0]).toEqual([...new Set(observed[0])].sort());
+    expect(catalogs).toHaveLength(1);
+    expect(catalogs[0]).toContain("alpha_pattern");
+    expect(catalogs[0]).toContain("broad_pattern");
+  });
+
+  test("splits disjoint exact scopes instead of creating an unbounded cross-product", async () => {
+    const fixture = mkdtempSync(path.join(tmpdir(), "habitat-grit-batch-bounds-"));
+    try {
+      mkdirSync(path.join(fixture, ".habitat"));
+      mkdirSync(path.join(fixture, "alpha"));
+      mkdirSync(path.join(fixture, "beta"));
+      mkdirSync(path.join(fixture, "gamma"));
+      writeFileSync(
+        path.join(fixture, ".habitat/pattern.md"),
+        readFileSync(path.join(repoRoot, providerPattern), "utf8")
+      );
+      for (const directory of ["alpha", "beta", "gamma"]) {
+        writeFileSync(path.join(fixture, directory, "subject.ts"), "const subject = true;\n");
+      }
+      const selectedRules = ["alpha", "beta", "gamma"].map((id) =>
+        exactRule(id, `${id}_pattern`, [id], [`${id}/subject.ts`], ".habitat/pattern.md")
+      );
+      const observedPatternNames: string[][] = [];
       const grit = makeFakeGritCommandService(
         (request, providerRequest) => {
           const checkRequest = requireCheckProviderRequest(providerRequest);
-          observed.push([...checkRequest.scanRoots]);
-          catalogs.push(readFileSync(path.join(request.cwd, ".grit/grit.yaml"), "utf8"));
+          observedPatternNames.push([...checkRequest.patternNames]);
           return makeHabitatCommandResult(request, {
             stderr: captureOutput(
               jsonDocument({ paths: [...checkRequest.scanRoots], results: [] })
             ),
           });
         },
-        { repoRoot }
+        { repoRoot: fixture }
       );
 
-      const executions = await Effect.runPromise(
-        runGritRulesEffect(selectedRules, { repoRoot, grit }).pipe(
+      await Effect.runPromise(
+        runGritRulesEffect(selectedRules, { repoRoot: fixture, grit }).pipe(
           Effect.provide(NodeContext.layer)
         )
       );
 
-      expect([...executions.keys()]).toEqual(selectedRules.map(({ id }) => id));
-      expect(observed).toHaveLength(2);
-      expect(catalogs).toHaveLength(2);
-      expect(catalogs.every((catalog) => catalog.split("  - name:").length === 2)).toBe(true);
+      expect(observedPatternNames).toEqual([
+        ["alpha_pattern"],
+        ["beta_pattern"],
+        ["gamma_pattern"],
+      ]);
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
     }
   });
 
-  test("keeps duplicate pattern identities singleton across different root groups", async () => {
+  test("uses deterministic compatibility batches for duplicate pattern identities", async () => {
     const selectedRules = [
-      rule("duplicate-provider", "duplicate_pattern", providerPattern, [providerRoot]),
-      rule("provider-peer", "provider_peer_pattern", providerPattern, [providerRoot]),
-      rule("duplicate-docs", "duplicate_pattern", providerPattern, ["docs"]),
-      rule("docs-peer", "docs_peer_pattern", providerPattern, ["docs"]),
+      exactRule("duplicate-a", "duplicate_pattern", [providerRoot], [providerFile]),
+      exactRule("duplicate-b", "duplicate_pattern", ["docs"], ["docs/PRODUCT.md"]),
+      exactRule("peer", "peer_pattern", [providerRoot], [providerFile]),
+    ] as const;
+    const observedPatternNames: string[][] = [];
+    const grit = makeFakeGritCommandService(
+      (request, providerRequest) => {
+        const checkRequest = requireCheckProviderRequest(providerRequest);
+        observedPatternNames.push([...checkRequest.patternNames]);
+        return makeHabitatCommandResult(request, {
+          stderr: captureOutput(jsonDocument({ paths: [...checkRequest.scanRoots], results: [] })),
+        });
+      },
+      { repoRoot }
+    );
+
+    await Effect.runPromise(
+      runGritRulesEffect(selectedRules, { repoRoot, grit }).pipe(Effect.provide(NodeContext.layer))
+    );
+
+    expect(observedPatternNames).toEqual([
+      ["duplicate_pattern", "peer_pattern"],
+      ["duplicate_pattern"],
+    ]);
+  });
+
+  test("bounds multiple duplicate identities by maximum multiplicity", async () => {
+    const selectedRules = [
+      exactRule("duplicate-provider", "duplicate_pattern", [providerRoot], [providerFile]),
+      exactRule("provider-peer", "provider_peer_pattern", [providerRoot], [providerFile]),
+      exactRule("duplicate-docs", "duplicate_pattern", ["docs"], ["docs/PRODUCT.md"]),
+      exactRule("docs-peer", "provider_peer_pattern", ["docs"], ["docs/PRODUCT.md"]),
     ] as const;
     const observedPatternNames: string[][] = [];
     const grit = makeFakeGritCommandService(
@@ -2401,11 +2471,160 @@ describe("Grit generic acquisition and public disposition", () => {
 
     expect([...executions.keys()]).toEqual(selectedRules.map(({ id }) => id));
     expect(observedPatternNames).toEqual([
-      ["duplicate_pattern"],
-      ["provider_peer_pattern"],
-      ["duplicate_pattern"],
-      ["docs_peer_pattern"],
+      ["duplicate_pattern", "provider_peer_pattern"],
+      ["duplicate_pattern", "provider_peer_pattern"],
     ]);
+  });
+
+  test("projects cross-scope findings and missing processed roots per rule", async () => {
+    const alpha = exactRule("alpha", "alpha_pattern", [providerRoot], [providerFile]);
+    const broad = exactRule(
+      "broad",
+      "broad_pattern",
+      [providerRoot, "docs"],
+      [providerFile, "docs/PRODUCT.md"]
+    );
+    const docsFile = path.join(repoRoot, "docs/PRODUCT.md");
+    let omitDocsRoot = false;
+    const grit = makeFakeGritCommandService(
+      (request, providerRequest) => {
+        const checkRequest = requireCheckProviderRequest(providerRequest);
+        const paths = omitDocsRoot
+          ? [path.join(repoRoot, providerFile)]
+          : [...checkRequest.scanRoots];
+        return makeHabitatCommandResult(request, {
+          stderr: captureOutput(
+            jsonDocument({
+              paths,
+              results: omitDocsRoot ? [] : checkReport(docsFile, "alpha_pattern").results,
+            })
+          ),
+        });
+      },
+      { repoRoot }
+    );
+
+    const projected = await Effect.runPromise(
+      runGritRulesEffect([alpha, broad], { repoRoot, grit }).pipe(Effect.provide(NodeContext.layer))
+    );
+    expect(projected.get("alpha")).toMatchObject({
+      kind: "executed",
+      result: { diagnostics: [] },
+    });
+    expect(projected.get("broad")).toMatchObject({
+      kind: "executed",
+      result: { diagnostics: [] },
+    });
+
+    omitDocsRoot = true;
+    const incomplete = await Effect.runPromise(
+      runGritRulesEffect([alpha, broad], { repoRoot, grit }).pipe(Effect.provide(NodeContext.layer))
+    );
+    expect(incomplete.get("alpha")).toMatchObject({ kind: "executed" });
+    expect(incomplete.get("broad")).toMatchObject({
+      kind: "failed",
+      failure: "DiagnosticOutputIncomplete",
+    });
+  });
+
+  test("projects canonical paths from an external symlink alias", async () => {
+    const fixture = mkdtempSync(path.join(tmpdir(), "habitat-grit-batch-canonical-"));
+    const outside = mkdtempSync(path.join(tmpdir(), "habitat-grit-batch-alias-"));
+    try {
+      mkdirSync(path.join(fixture, ".habitat"));
+      mkdirSync(path.join(fixture, "scan"));
+      writeFileSync(
+        path.join(fixture, ".habitat/pattern.md"),
+        readFileSync(path.join(repoRoot, providerPattern), "utf8")
+      );
+      const subject = path.join(fixture, "scan/subject.ts");
+      const alias = path.join(outside, "subject.ts");
+      writeFileSync(subject, "const subject = true;\n");
+      symlinkSync(subject, alias);
+      const alpha = exactRule(
+        "alpha",
+        "alpha_pattern",
+        ["scan"],
+        ["scan/**/*.ts"],
+        ".habitat/pattern.md"
+      );
+      const beta = exactRule(
+        "beta",
+        "beta_pattern",
+        ["scan"],
+        ["scan/**/*.ts"],
+        ".habitat/pattern.md"
+      );
+      const grit = makeFakeGritCommandService(
+        (request) =>
+          makeHabitatCommandResult(request, {
+            stderr: captureOutput(jsonDocument(checkReport(alias, "alpha_pattern", [alias]))),
+          }),
+        { repoRoot: fixture }
+      );
+
+      const executions = await Effect.runPromise(
+        runGritRulesEffect([alpha, beta], { repoRoot: fixture, grit }).pipe(
+          Effect.provide(NodeContext.layer)
+        )
+      );
+
+      expect(executions.get("alpha")).toMatchObject({
+        kind: "executed",
+        result: { diagnostics: [{ path: "scan/subject.ts" }] },
+      });
+      expect(executions.get("beta")).toMatchObject({
+        kind: "executed",
+        result: { diagnostics: [] },
+      });
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test("fails shared batch integrity while continuing a later compatibility batch", async () => {
+    const selectedRules = [
+      exactRule("alpha", "duplicate_pattern", [providerRoot], [providerFile]),
+      exactRule("peer", "peer_pattern", [providerRoot], [providerFile]),
+      exactRule("alpha-second", "duplicate_pattern", [providerRoot], [providerFile]),
+    ] as const;
+    let callCount = 0;
+    const grit = makeFakeGritCommandService(
+      (request, providerRequest) => {
+        const checkRequest = requireCheckProviderRequest(providerRequest);
+        callCount += 1;
+        return makeHabitatCommandResult(request, {
+          stderr: captureOutput(
+            callCount === 1
+              ? jsonDocument(
+                  checkReport(
+                    checkRequest.scanRoots[0] ?? path.join(repoRoot, providerFile),
+                    "foreign_pattern",
+                    checkRequest.scanRoots
+                  )
+                )
+              : jsonDocument({ paths: [...checkRequest.scanRoots], results: [] })
+          ),
+        });
+      },
+      { repoRoot }
+    );
+
+    const executions = await Effect.runPromise(
+      runGritRulesEffect(selectedRules, { repoRoot, grit }).pipe(Effect.provide(NodeContext.layer))
+    );
+
+    expect(callCount).toBe(2);
+    expect(executions.get("alpha")).toMatchObject({
+      kind: "failed",
+      failure: "DiagnosticUnexpectedIdentity",
+    });
+    expect(executions.get("peer")).toMatchObject({
+      kind: "failed",
+      failure: "DiagnosticUnexpectedIdentity",
+    });
+    expect(executions.get("alpha-second")).toMatchObject({ kind: "executed" });
   });
 
   test("isolates invalid rule assets before valid peers acquire a shared catalog", async () => {
@@ -2435,8 +2654,11 @@ describe("Grit generic acquisition and public disposition", () => {
     expect(executions.get("invalid")).toMatchObject({
       kind: "failed",
       failure: "DiagnosticRuleMaterializationFailed",
+      durationMs: 0,
     });
+    expect(executions.get("invalid")?.timing).toBeUndefined();
     expect(executions.get("valid")).toMatchObject({ kind: "executed" });
+    expect(executions.get("valid")?.timing).toBeUndefined();
     expect(catalogs).toHaveLength(1);
     expect(catalogs[0]).toContain("valid_pattern");
     expect(catalogs[0]).not.toContain("invalid_pattern");
@@ -3055,8 +3277,18 @@ function exactCheckRule(
   acquisitionRoots: readonly string[],
   patterns: readonly string[]
 ): RuleGritFacts {
+  return exactRule(id, `${id}_pattern`, acquisitionRoots, patterns);
+}
+
+function exactRule(
+  id: string,
+  patternName: string,
+  acquisitionRoots: readonly string[],
+  patterns: readonly string[],
+  pattern = providerPattern
+): RuleGritFacts {
   return {
-    ...rule(id, `${id}_pattern`, providerPattern, acquisitionRoots),
+    ...rule(id, patternName, pattern, acquisitionRoots),
     pathCoverage: [{ kind: "exact-path", patterns: [...patterns] }],
   };
 }


### PR DESCRIPTION
## Outcome

Bounds and shares native Grit acquisition across compatible exact-path rule applications so current portable Habitat consumers do not pay repeated cold-start and catalog setup costs. Per-rule scope, findings, and failures remain isolated.

This is a temporary compatibility patch on the historical Civ7 portable line. RAWR HQ Template remains the Habitat source and release authority; retire this exact pin when its first consumable release provides equivalent aggregate evaluation.

## Proof

- Habitat TypeScript check passed
- Focused Biome check passed
- Grit provider suite: 70 passed, 2 configured skips
- Portable build and pack passed; artifact SHA-256: `0ab9480ecf6557f8c55b819a0a0e207609e9620f935424429401224c997fbb95`
- Full isolated package verifier was stopped when its network install remained idle and retained 1.3 GB; the temporary fixture was removed. Magic will provide the real exact-pinned consumer proof.